### PR TITLE
fix: improve scan finding accuracy for DMARC, MTA-STS, and maturity staging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
 				"@types/punycode": "^2.1.4",
 				"@vitest/coverage-istanbul": "^3.2.4",
 				"eslint": "^10.0.2",
-				"hono": "^4.12.2",
+				"hono": "^4.12.7",
 				"tsup": "^8.5.0",
 				"typescript": "^5.5.2",
 				"typescript-eslint": "^8.56.1",
@@ -3358,9 +3358,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.5",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-			"integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+			"version": "4.12.7",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.7.tgz",
+			"integrity": "sha512-jq9l1DM0zVIvsm3lv9Nw9nlJnMNPOcAtsbsgiUhWcFzPE99Gvo6yRTlszSLLYacMeQ6quHD6hMfId8crVHvexw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
 		"@types/punycode": "^2.1.4",
 		"@vitest/coverage-istanbul": "^3.2.4",
 		"eslint": "^10.0.2",
-		"hono": "^4.12.2",
+		"hono": "^4.12.7",
 		"tsup": "^8.5.0",
 		"typescript": "^5.5.2",
 		"typescript-eslint": "^8.56.1",

--- a/src/tools/explain-finding-data.ts
+++ b/src/tools/explain-finding-data.ts
@@ -1421,7 +1421,7 @@ export const SPECIFIC_IMPACT_RULES: SpecificImpactRule[] = [
 	},
 	{
 		checkType: 'DMARC',
-		titleIncludes: ['no forensic reporting', 'forensic reporting'],
+		titleIncludes: ['no forensic reporting', 'ruf= absent'],
 		impact: 'You only see aggregate summaries — individual failure details are not reported, making troubleshooting harder.',
 		adverseConsequences: 'Legitimate email delivery issues take longer to diagnose, and targeted spoofing attempts are harder to trace.',
 	},

--- a/src/tools/explain-finding-data.ts
+++ b/src/tools/explain-finding-data.ts
@@ -1414,6 +1414,30 @@ export const SPECIFIC_IMPACT_RULES: SpecificImpactRule[] = [
 		adverseConsequences: 'Problems go unnoticed longer, and scammers operate freely because you have no visibility.',
 	},
 	{
+		checkType: 'DMARC',
+		titleIncludes: ['no subdomain policy'],
+		impact: 'Subdomains inherit the parent policy, but without an explicit sp= tag, future changes may unintentionally leave subdomains unprotected.',
+		adverseConsequences: 'Attackers can spoof email from subdomains if the inherited policy is weakened or removed.',
+	},
+	{
+		checkType: 'DMARC',
+		titleIncludes: ['no forensic reporting', 'forensic reporting'],
+		impact: 'You only see aggregate summaries — individual failure details are not reported, making troubleshooting harder.',
+		adverseConsequences: 'Legitimate email delivery issues take longer to diagnose, and targeted spoofing attempts are harder to trace.',
+	},
+	{
+		checkType: 'DMARC',
+		titleIncludes: ['relaxed dkim alignment'],
+		impact: 'Relaxed DKIM alignment allows organizational domain matches, so a compromised subdomain could pass DKIM checks.',
+		adverseConsequences: 'An attacker controlling any subdomain can send DKIM-aligned email that passes DMARC for your main domain.',
+	},
+	{
+		checkType: 'DMARC',
+		titleIncludes: ['relaxed spf alignment'],
+		impact: 'Relaxed SPF alignment allows organizational domain matches, so email from any subdomain can pass SPF checks.',
+		adverseConsequences: 'An attacker using a subdomain SPF record can send SPF-aligned email that passes DMARC for your main domain.',
+	},
+	{
 		checkType: 'MX',
 		titleIncludes: ['no mx records found', 'mx configuration error'],
 		impact: 'Incoming email delivery is broken or unreliable — messages may not arrive at all.',

--- a/src/tools/scan/maturity-staging.ts
+++ b/src/tools/scan/maturity-staging.ts
@@ -22,12 +22,27 @@ export interface MaturityStage {
 export function computeMaturityStage(checks: CheckResult[]): MaturityStage {
 	const byCategory = new Map(checks.map((c) => [c.category, c]));
 
+	const mxCheck = byCategory.get('mx');
 	const spfCheck = byCategory.get('spf');
 	const dmarcCheck = byCategory.get('dmarc');
 	const dkimCheck = byCategory.get('dkim');
 	const mtaStsCheck = byCategory.get('mta_sts');
 	const dnssecCheck = byCategory.get('dnssec');
 	const bimiCheck = byCategory.get('bimi');
+
+	// Non-mail domains should not receive email maturity stages
+	const hasNoMx = mxCheck != null && mxCheck.findings.some((f) => /No MX records found/i.test(f.title));
+	if (hasNoMx) {
+		const hasDnssec = dnssecCheck?.passed ?? false;
+		return {
+			stage: hasDnssec ? 1 : 0,
+			label: hasDnssec ? 'DNS-Only' : 'Unprotected',
+			description: hasDnssec
+				? 'This domain does not accept email. DNS security (DNSSEC) is in place.'
+				: 'This domain does not accept email and has no DNSSEC.',
+			nextStep: hasDnssec ? '' : 'Enable DNSSEC to protect DNS resolution integrity.',
+		};
+	}
 
 	// Determine SPF presence
 	const hasSpf = spfCheck != null && !spfCheck.findings.some((f) => /No SPF record/i.test(f.title));

--- a/src/tools/scan/maturity-staging.ts
+++ b/src/tools/scan/maturity-staging.ts
@@ -30,8 +30,12 @@ export function computeMaturityStage(checks: CheckResult[]): MaturityStage {
 	const dnssecCheck = byCategory.get('dnssec');
 	const bimiCheck = byCategory.get('bimi');
 
-	// Non-mail domains should not receive email maturity stages
-	const hasNoMx = mxCheck != null && mxCheck.findings.some((f) => /No MX records found/i.test(f.title));
+	// Non-mail domains should not receive email maturity stages.
+	// The numeric stage values here (0 = "Unprotected", 1 = "DNS-Only") intentionally
+	// reuse the same numbers as the mail-domain scale. This is safe because `stage` is
+	// only ever rendered as a display value alongside `label` — it is never used as a
+	// numeric index or compared against mail-domain stages in any downstream logic.
+	const hasNoMx = mxCheck != null && mxCheck.findings.some((f) => f.title === 'No MX records found');
 	if (hasNoMx) {
 		const hasDnssec = dnssecCheck?.passed ?? false;
 		return {

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -23,6 +23,8 @@ export async function applyScanPostProcessing(
 	if (hasNoMx) {
 		const apexCovers = await checkApexDmarcPolicy(domain);
 		results = adjustForNonMailDomain(results, apexCovers);
+	} else if (mxResult) {
+		results = clarifyMtaStsForMailDomain(domain, results);
 	}
 
 	return addOutboundProviderInference(results, runtimeOptions);
@@ -164,6 +166,22 @@ async function checkApexDmarcPolicy(domain: string): Promise<boolean> {
 function isMissingRecordFinding(finding: { title: string; detail: string }): boolean {
 	const text = `${finding.title} ${finding.detail}`.toLowerCase();
 	return /(no\s+.+\s+record|missing|not\s+found|no\s+mta-sts|no\s+dkim)/.test(text);
+}
+
+function clarifyMtaStsForMailDomain(domain: string, results: CheckResult[]): CheckResult[] {
+	return results.map((result) => {
+		if (result.category !== 'mta_sts') return result;
+		const adjusted = result.findings.map((finding) => {
+			if (finding.title === 'No MTA-STS or TLS-RPT records found') {
+				return {
+					...finding,
+					detail: `Neither MTA-STS nor TLS-RPT records are present for ${domain}. Since this domain has MX records and accepts email, adding MTA-STS and TLS-RPT is recommended to protect inbound email in transit.`,
+				};
+			}
+			return finding;
+		});
+		return buildCheckResult(result.category, adjusted);
+	});
 }
 
 function adjustForNonMailDomain(results: CheckResult[], apexDmarcCovers: boolean): CheckResult[] {

--- a/test/explain-finding.spec.ts
+++ b/test/explain-finding.spec.ts
@@ -525,7 +525,7 @@ describe('resolveImpactNarrative', () => {
 		const narrative = resolveImpactNarrative({
 			category: 'dmarc',
 			severity: 'low',
-			title: 'Forensic reporting (ruf=) is not configured',
+			title: 'No forensic reporting configured (ruf= absent)',
 			detail: 'No ruf= tag present',
 		});
 		expect(narrative.impact).toContain('aggregate summaries');

--- a/test/explain-finding.spec.ts
+++ b/test/explain-finding.spec.ts
@@ -507,4 +507,52 @@ describe('resolveImpactNarrative', () => {
 		expect(narrative.impact).toContain('big picture');
 		expect(narrative.adverseConsequences).toContain('unnoticed');
 	});
+
+	it('returns distinct narrative for DMARC no subdomain policy', async () => {
+		const { resolveImpactNarrative } = await getModule();
+		const narrative = resolveImpactNarrative({
+			category: 'dmarc',
+			severity: 'low',
+			title: 'No subdomain policy (sp=) specified',
+			detail: 'Subdomains inherit the parent domain policy',
+		});
+		expect(narrative.impact).toContain('sp=');
+		expect(narrative.adverseConsequences).toContain('subdomain');
+	});
+
+	it('returns distinct narrative for DMARC no forensic reporting', async () => {
+		const { resolveImpactNarrative } = await getModule();
+		const narrative = resolveImpactNarrative({
+			category: 'dmarc',
+			severity: 'low',
+			title: 'Forensic reporting (ruf=) is not configured',
+			detail: 'No ruf= tag present',
+		});
+		expect(narrative.impact).toContain('aggregate summaries');
+		expect(narrative.adverseConsequences).toContain('diagnose');
+	});
+
+	it('returns distinct narrative for DMARC relaxed DKIM alignment', async () => {
+		const { resolveImpactNarrative } = await getModule();
+		const narrative = resolveImpactNarrative({
+			category: 'dmarc',
+			severity: 'low',
+			title: 'Relaxed DKIM alignment (adkim=r)',
+			detail: 'DKIM alignment mode is relaxed',
+		});
+		expect(narrative.impact).toContain('organizational domain');
+		expect(narrative.adverseConsequences).toContain('subdomain');
+	});
+
+	it('returns distinct narrative for DMARC relaxed SPF alignment', async () => {
+		const { resolveImpactNarrative } = await getModule();
+		const narrative = resolveImpactNarrative({
+			category: 'dmarc',
+			severity: 'low',
+			title: 'Relaxed SPF alignment (aspf=r)',
+			detail: 'SPF alignment mode is relaxed',
+		});
+		expect(narrative.impact).toContain('organizational domain');
+		expect(narrative.adverseConsequences).toContain('subdomain');
+	});
 });

--- a/test/maturity-staging.spec.ts
+++ b/test/maturity-staging.spec.ts
@@ -57,8 +57,8 @@ describe('computeMaturityStage', () => {
 			buildCheckResult('spf', [createFinding('spf', 'SPF record configured', 'info', 'ok')]),
 			buildCheckResult('dkim', [createFinding('dkim', 'DKIM configured', 'info', 'Found selectors')]),
 			buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
-			{ category: 'mta_sts', passed: true, score: 100, findings: [createFinding('mta_sts', 'MTA-STS configured', 'info', 'ok')] },
-			{ category: 'dnssec', passed: true, score: 100, findings: [createFinding('dnssec', 'DNSSEC validated', 'info', 'ok')] },
+			buildCheckResult('mta_sts', [createFinding('mta_sts', 'MTA-STS configured', 'info', 'ok')]),
+			buildCheckResult('dnssec', [createFinding('dnssec', 'DNSSEC validated', 'info', 'ok')]),
 		];
 		const stage = computeMaturityStage(checks);
 		expect(stage.stage).toBe(4);
@@ -72,7 +72,7 @@ describe('computeMaturityStage', () => {
 			buildCheckResult('dkim', [createFinding('dkim', 'DKIM configured', 'info', 'Found selectors')]),
 			buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC policy set to quarantine', 'low', 'Policy is quarantine')]),
 			buildCheckResult('bimi', [createFinding('bimi', 'BIMI record configured', 'info', 'BIMI valid')]),
-			{ category: 'dnssec', passed: true, score: 100, findings: [createFinding('dnssec', 'DNSSEC validated', 'info', 'ok')] },
+			buildCheckResult('dnssec', [createFinding('dnssec', 'DNSSEC validated', 'info', 'ok')]),
 		];
 		const stage = computeMaturityStage(checks);
 		expect(stage.stage).toBe(4);
@@ -114,7 +114,7 @@ describe('computeMaturityStage', () => {
 		const checks: CheckResult[] = [
 			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'Domain has no MX')]),
 			buildCheckResult('spf', [createFinding('spf', 'No SPF record found', 'critical', 'Missing SPF')]),
-			{ category: 'dnssec', passed: true, score: 100, findings: [createFinding('dnssec', 'DNSSEC validated', 'info', 'ok')] },
+			buildCheckResult('dnssec', [createFinding('dnssec', 'DNSSEC validated', 'info', 'ok')]),
 		];
 		const stage = computeMaturityStage(checks);
 		expect(stage.stage).toBe(1);

--- a/test/maturity-staging.spec.ts
+++ b/test/maturity-staging.spec.ts
@@ -95,4 +95,44 @@ describe('computeMaturityStage', () => {
 		expect(stage.stage).toBe(0);
 		expect(stage.label).toBe('Unprotected');
 	});
+
+	it('returns Unprotected for non-mail domain without DNSSEC', () => {
+		const checks: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'Domain has no MX')]),
+			buildCheckResult('spf', [createFinding('spf', 'No SPF record found', 'critical', 'Missing SPF')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'No DMARC record found', 'critical', 'Missing DMARC')]),
+			{ category: 'dnssec', passed: false, score: 0, findings: [createFinding('dnssec', 'No DNSKEY records', 'high', 'No DNSSEC')] },
+		];
+		const stage = computeMaturityStage(checks);
+		expect(stage.stage).toBe(0);
+		expect(stage.label).toBe('Unprotected');
+		expect(stage.description).toContain('does not accept email');
+		expect(stage.nextStep).toContain('DNSSEC');
+	});
+
+	it('returns DNS-Only for non-mail domain with DNSSEC', () => {
+		const checks: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'Domain has no MX')]),
+			buildCheckResult('spf', [createFinding('spf', 'No SPF record found', 'critical', 'Missing SPF')]),
+			{ category: 'dnssec', passed: true, score: 100, findings: [createFinding('dnssec', 'DNSSEC validated', 'info', 'ok')] },
+		];
+		const stage = computeMaturityStage(checks);
+		expect(stage.stage).toBe(1);
+		expect(stage.label).toBe('DNS-Only');
+		expect(stage.description).toContain('does not accept email');
+		expect(stage.description).toContain('DNSSEC');
+		expect(stage.nextStep).toBe('');
+	});
+
+	it('does not short-circuit to non-mail path when MX records exist', () => {
+		const checks: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 MX records')]),
+			buildCheckResult('spf', [createFinding('spf', 'SPF record configured', 'info', 'ok')]),
+			buildCheckResult('dkim', [createFinding('dkim', 'DKIM configured', 'info', 'Found selectors')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+		];
+		const stage = computeMaturityStage(checks);
+		expect(stage.stage).toBe(3);
+		expect(stage.label).toBe('Enforcing');
+	});
 });

--- a/test/scan-post-processing.spec.ts
+++ b/test/scan-post-processing.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import type { CheckResult } from '../src/lib/scoring';
+import { type CheckResult, buildCheckResult, createFinding } from '../src/lib/scoring';
 
 describe('scan-post-processing helpers', () => {
 	it('downgrades missing email findings for non-mail domains when no MX records exist', async () => {
@@ -9,18 +9,8 @@ describe('scan-post-processing helpers', () => {
 		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
 
 		const results: CheckResult[] = [
-			{
-				category: 'spf',
-				passed: false,
-				score: 0,
-				findings: [{ category: 'spf', title: 'No SPF record found', severity: 'critical', detail: 'No SPF record found for example.com.' }],
-			},
-			{
-				category: 'mx',
-				passed: true,
-				score: 100,
-				findings: [{ category: 'mx', title: 'No MX records found', severity: 'info', detail: 'No inbound mail is configured.' }],
-			},
+			buildCheckResult('spf', [createFinding('spf', 'No SPF record found', 'critical', 'No SPF record found for example.com.')]),
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'No inbound mail is configured.')]),
 		];
 
 		const updated = await applyScanPostProcessing('app.example.com', results);
@@ -33,25 +23,10 @@ describe('scan-post-processing helpers', () => {
 		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
 
 		const results: CheckResult[] = [
-			{
-				category: 'mx',
-				passed: true,
-				score: 100,
-				findings: [{ category: 'mx', title: 'MX records found', severity: 'info', detail: '2 MX records configured.' }],
-			},
-			{
-				category: 'mta_sts',
-				passed: false,
-				score: 0,
-				findings: [
-					{
-						category: 'mta_sts',
-						title: 'No MTA-STS or TLS-RPT records found',
-						severity: 'medium',
-						detail: 'Neither MTA-STS nor TLS-RPT DNS records were found.',
-					},
-				],
-			},
+			buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 MX records configured.')]),
+			buildCheckResult('mta_sts', [
+				createFinding('mta_sts', 'No MTA-STS or TLS-RPT records found', 'medium', 'Neither MTA-STS nor TLS-RPT DNS records were found.'),
+			]),
 		];
 
 		const updated = await applyScanPostProcessing('example.com', results);
@@ -67,25 +42,10 @@ describe('scan-post-processing helpers', () => {
 		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
 
 		const results: CheckResult[] = [
-			{
-				category: 'mx',
-				passed: true,
-				score: 100,
-				findings: [{ category: 'mx', title: 'No MX records found', severity: 'info', detail: 'No inbound mail.' }],
-			},
-			{
-				category: 'mta_sts',
-				passed: false,
-				score: 0,
-				findings: [
-					{
-						category: 'mta_sts',
-						title: 'No MTA-STS or TLS-RPT records found',
-						severity: 'medium',
-						detail: 'Neither MTA-STS nor TLS-RPT DNS records were found.',
-					},
-				],
-			},
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'No inbound mail.')]),
+			buildCheckResult('mta_sts', [
+				createFinding('mta_sts', 'No MTA-STS or TLS-RPT records found', 'medium', 'Neither MTA-STS nor TLS-RPT DNS records were found.'),
+			]),
 		];
 
 		const updated = await applyScanPostProcessing('no-mail.example.com', results);
@@ -99,32 +59,9 @@ describe('scan-post-processing helpers', () => {
 		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
 
 		const results: CheckResult[] = [
-			{
-				category: 'spf',
-				passed: true,
-				score: 100,
-				findings: [
-					{
-						category: 'spf',
-						title: 'SPF record configured',
-						severity: 'info',
-						detail: 'Healthy SPF',
-						metadata: { includeDomains: ['google.com'] },
-					},
-				],
-			},
-			{
-				category: 'dkim',
-				passed: true,
-				score: 100,
-				findings: [],
-			},
-			{
-				category: 'mx',
-				passed: true,
-				score: 100,
-				findings: [],
-			},
+			buildCheckResult('spf', [createFinding('spf', 'SPF record configured', 'info', 'Healthy SPF', { includeDomains: ['google.com'] })]),
+			buildCheckResult('dkim', []),
+			buildCheckResult('mx', []),
 		];
 
 		const updated = await applyScanPostProcessing('example.com', results);

--- a/test/scan-post-processing.spec.ts
+++ b/test/scan-post-processing.spec.ts
@@ -29,6 +29,72 @@ describe('scan-post-processing helpers', () => {
 		vi.doUnmock('../src/lib/dns');
 	});
 
+	it('clarifies MTA-STS text for mail domains with MX records', async () => {
+		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+		const results: CheckResult[] = [
+			{
+				category: 'mx',
+				passed: true,
+				score: 100,
+				findings: [{ category: 'mx', title: 'MX records found', severity: 'info', detail: '2 MX records configured.' }],
+			},
+			{
+				category: 'mta_sts',
+				passed: false,
+				score: 0,
+				findings: [
+					{
+						category: 'mta_sts',
+						title: 'No MTA-STS or TLS-RPT records found',
+						severity: 'medium',
+						detail: 'Neither MTA-STS nor TLS-RPT DNS records were found.',
+					},
+				],
+			},
+		];
+
+		const updated = await applyScanPostProcessing('example.com', results);
+		const mtaSts = updated.find((r) => r.category === 'mta_sts');
+		expect(mtaSts?.findings[0].detail).toContain('has MX records and accepts email');
+		expect(mtaSts?.findings[0].detail).toContain('recommended');
+	});
+
+	it('does not clarify MTA-STS text when no MX records exist', async () => {
+		vi.doMock('../src/lib/dns', () => ({
+			queryTxtRecords: vi.fn().mockResolvedValue([]),
+		}));
+		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+		const results: CheckResult[] = [
+			{
+				category: 'mx',
+				passed: true,
+				score: 100,
+				findings: [{ category: 'mx', title: 'No MX records found', severity: 'info', detail: 'No inbound mail.' }],
+			},
+			{
+				category: 'mta_sts',
+				passed: false,
+				score: 0,
+				findings: [
+					{
+						category: 'mta_sts',
+						title: 'No MTA-STS or TLS-RPT records found',
+						severity: 'medium',
+						detail: 'Neither MTA-STS nor TLS-RPT DNS records were found.',
+					},
+				],
+			},
+		];
+
+		const updated = await applyScanPostProcessing('no-mail.example.com', results);
+		const mtaSts = updated.find((r) => r.category === 'mta_sts');
+		// For non-mail domains, severity gets downgraded to info (not clarified)
+		expect(mtaSts?.findings[0].detail).not.toContain('has MX records and accepts email');
+		vi.doUnmock('../src/lib/dns');
+	});
+
 	it('adds outbound provider inference when SPF include domains match provider signatures', async () => {
 		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
 


### PR DESCRIPTION
## Summary

- **DMARC sub-finding impact rules**: Added 4 new `SPECIFIC_IMPACT_RULES` entries so "no subdomain policy", "no forensic reporting", "relaxed DKIM alignment", and "relaxed SPF alignment" findings get distinct impact/adverse-consequence narratives instead of falling through to the generic DMARC category fallback
- **MTA-STS context awareness**: When a domain has MX records (accepts email), the "No MTA-STS or TLS-RPT records found" detail text now explicitly notes that MTA-STS is recommended — previously it was silent about whether the domain accepts mail
- **Maturity staging MX gate**: Non-mail domains (no MX records) now receive "DNS-Only" (stage 1, with DNSSEC) or "Unprotected" (stage 0, without) instead of misleading email maturity stages like "Hardened"

## Test plan

- [x] 4 new `resolveImpactNarrative` tests verify DMARC sub-finding rules return distinct narratives
- [x] 2 new post-processing tests verify MTA-STS text clarification for mail vs non-mail domains
- [x] 3 new maturity staging tests verify non-mail domain gating and MX-present passthrough
- [x] Full suite passes: 711 tests, typecheck clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced DMARC findings with detailed explanations covering subdomain policy configurations, forensic reporting settings, and alignment mode restrictions.
  * Improved handling and classification of domains without MX records into appropriate maturity stages.
  * Refined MTA-STS recommendations for mail domains with active MX records.

* **Tests**
  * Added comprehensive test coverage for DMARC narratives, maturity stage computation, and MTA-STS clarifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->