### PR TITLE
feat: context-aware scoring profiles for scan_domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,4 @@ docs/plans/
 .dev/
 
 .gemini/
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Added
 
+- Context-aware scoring profiles for `scan_domain`: five named profiles (`mail_enabled`, `enterprise_mail`, `non_mail`, `web_only`, `minimal`) that adapt importance weights based on detected domain purpose. Phase 1: auto-detection runs and is reported in the structured result (`scoringProfile`, `scoringSignals`), but only explicit `profile` parameter values activate different weights. New types `DomainProfile` and `DomainContext` exported from the public package API.
 - `scan_domain` now returns a second content block containing machine-readable structured JSON (`score`, `grade`, `passed`, `maturityStage`, `maturityLabel`, `categoryScores`, `findingCounts`, `timestamp`, `cached`) wrapped in `<!-- STRUCTURED_RESULT -->` delimiters. CI/CD consumers can parse this reliably instead of regex-matching the text report.
 - `buildStructuredScanResult()` and `StructuredScanResult` type exported from `src/tools/scan/format-report.ts` and the public package API.
 - Publishable ESM npm package metadata, bundled public API entrypoint, and `prepack` build flow for consuming the scanner core as `blackveil-dns`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,7 @@ src/tools/explain-finding.ts — Static explanation generator
 src/lib/scoring.ts        — Re-export facade for scoring subsystem
 src/lib/scoring-model.ts  — Types (Finding, CheckResult, ScanScore, CheckCategory, Severity) + buildCheckResult/createFinding
 src/lib/scoring-engine.ts — IMPORTANCE_WEIGHTS, computeScanScore, scoreToGrade
+src/lib/context-profiles.ts — DomainProfile, DomainContext, PROFILE_WEIGHTS, detectDomainContext
 src/lib/json-rpc.ts       — JSON-RPC 2.0 types, error codes, response builders
 src/lib/session.ts        — KV-backed (optional) + in-memory fallback session management
 src/lib/auth.ts           — Bearer token validation (constant-time XOR comparison)
@@ -154,6 +155,16 @@ Only `IMPORTANCE_WEIGHTS` drives `computeScanScore()` (the `CATEGORY_DISPLAY_WEI
 **`passed` flag**: `score >= 50` in `buildCheckResult`.
 
 **Grades**: A+ (90+), A (85–89), B+ (80–84), B (75–79), C+ (70–74), C (65–69), D+ (60–64), D (55–59), E (50–54), F (<50).
+
+### Scoring Profiles
+
+`computeScanScore()` accepts an optional `DomainContext` that adapts weights based on domain purpose. Five profiles exist: `mail_enabled` (default/today's weights), `enterprise_mail`, `non_mail`, `web_only`, `minimal`. Defined in `src/lib/context-profiles.ts`.
+
+**Phase 1 (current):** `scan_domain` auto-detects the profile from check results (MX presence, provider detection, SSL/CAA) and reports it in the structured result (`scoringProfile`, `scoringSignals`), but `auto` mode uses `mail_enabled` weights (identical to pre-profile behavior). Only explicit `profile` parameter values activate different weights and cache keys (`cache:<domain>:profile:<profile>`).
+
+**Detection priority:** `non_mail`/`web_only` (no MX) → `enterprise_mail` (MX + known provider + hardening signal) → `mail_enabled` (MX, default) → `minimal` (>50% checks failed).
+
+**Profile-aware scoring:** When context is provided, `computeScanScore` uses `context.weights` instead of `IMPORTANCE_WEIGHTS`, `PROFILE_CRITICAL_CATEGORIES[profile]` for gap ceiling, and `PROFILE_EMAIL_BONUS_ELIGIBLE[profile]` for email bonus eligibility.
 
 ## Security
 

--- a/src/handlers/tool-args.ts
+++ b/src/handlers/tool-args.ts
@@ -34,6 +34,22 @@ export function extractDkimSelector(args: Record<string, unknown>): string | und
 	return selector;
 }
 
+const VALID_PROFILES = ['auto', 'mail_enabled', 'enterprise_mail', 'non_mail', 'web_only', 'minimal'] as const;
+
+/** Extract and validate the optional scoring profile parameter. */
+export function extractScanProfile(args: Record<string, unknown>): typeof VALID_PROFILES[number] | undefined {
+	const profile = args.profile;
+	if (profile === undefined || profile === null) return undefined;
+	if (typeof profile !== 'string') {
+		throw new Error('Invalid profile: must be a string');
+	}
+	const normalized = profile.trim().toLowerCase();
+	if (!(VALID_PROFILES as readonly string[]).includes(normalized)) {
+		throw new Error(`Invalid profile: must be one of ${VALID_PROFILES.join(', ')}`);
+	}
+	return normalized as typeof VALID_PROFILES[number];
+}
+
 export function extractExplainFindingArgs(args: Record<string, unknown>): {
 	checkType: string;
 	status: string;

--- a/src/handlers/tool-schemas.ts
+++ b/src/handlers/tool-schemas.ts
@@ -118,7 +118,22 @@ export const TOOLS: McpTool[] = [
 		name: 'scan_domain',
 		description:
 			'Run a comprehensive DNS security scan on a domain. Executes all checks (SPF, DMARC, DKIM, DNSSEC, SSL, MTA-STS, NS, CAA, MX, Subdomain Takeover) in parallel and returns an overall security score and grade.',
-		inputSchema: DOMAIN_INPUT_SCHEMA,
+		inputSchema: {
+			type: 'object' as const,
+			properties: {
+				domain: {
+					type: 'string',
+					description: 'The domain name to check (e.g., example.com)',
+				},
+				profile: {
+					type: 'string',
+					enum: ['auto', 'mail_enabled', 'enterprise_mail', 'non_mail', 'web_only', 'minimal'],
+					description:
+						'Scoring profile to apply. "auto" (default) detects the profile from scan results. Explicit values override detection and change scoring weights.',
+				},
+			},
+			required: ['domain'],
+		},
 	},
 	{
 		name: 'compare_baseline',

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -19,7 +19,7 @@ import { explainFinding, formatExplanation } from '../tools/explain-finding';
 import { compareBaseline, formatBaselineResult } from '../tools/compare-baseline';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
-import { extractAndValidateDomain, extractDkimSelector, extractExplainFindingArgs, normalizeToolName } from './tool-args';
+import { extractAndValidateDomain, extractDkimSelector, extractExplainFindingArgs, extractScanProfile, normalizeToolName } from './tool-args';
 import { logToolFailure, logToolSuccess } from './tool-execution';
 import { formatCheckResult, mcpError, mcpText } from './tool-formatters';
 import type { McpContent } from './tool-formatters';
@@ -165,7 +165,9 @@ export async function handleToolsCall(
 
 			switch (name) {
 				case 'scan_domain': {
-					const result = await scanDomain(validDomain, scanCacheKV, runtimeOptions);
+					const profile = extractScanProfile(args);
+					const scanOptions = profile ? { ...runtimeOptions, profile } : runtimeOptions;
+					const result = await scanDomain(validDomain, scanCacheKV, scanOptions);
 					logResult = result.score.grade;
 					logDetails = result;
 					logToolSuccess({

--- a/src/lib/context-profiles.ts
+++ b/src/lib/context-profiles.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: MIT
+
+/**
+ * Context-aware scoring profiles for scan_domain.
+ *
+ * Adapts importance weights based on detected domain purpose (mail-enabled,
+ * enterprise mail, non-mail, web-only, minimal infrastructure).
+ *
+ * Phase 1: Auto-detection runs and reports the detected profile in the
+ * structured result, but `auto` uses `mail_enabled` weights (identical to
+ * today). Only explicit profile selection activates different weights.
+ */
+
+import type { CheckCategory, CheckResult } from './scoring-model';
+
+export type DomainProfile = 'mail_enabled' | 'enterprise_mail' | 'non_mail' | 'web_only' | 'minimal';
+
+export interface DomainContext {
+	profile: DomainProfile;
+	signals: string[];
+	weights: Record<CheckCategory, ImportanceProfile>;
+}
+
+interface ImportanceProfile {
+	importance: number;
+}
+
+/** Per-profile importance weights. */
+export const PROFILE_WEIGHTS: Record<DomainProfile, Record<CheckCategory, ImportanceProfile>> = {
+	mail_enabled: {
+		dmarc: { importance: 22 },
+		dkim: { importance: 16 },
+		spf: { importance: 10 },
+		ssl: { importance: 5 },
+		subdomain_takeover: { importance: 3 },
+		dnssec: { importance: 2 },
+		mta_sts: { importance: 2 },
+		mx: { importance: 2 },
+		tlsrpt: { importance: 1 },
+		caa: { importance: 0 },
+		ns: { importance: 0 },
+		bimi: { importance: 0 },
+		lookalikes: { importance: 0 },
+	},
+	enterprise_mail: {
+		dmarc: { importance: 24 },
+		dkim: { importance: 18 },
+		spf: { importance: 12 },
+		ssl: { importance: 5 },
+		subdomain_takeover: { importance: 3 },
+		dnssec: { importance: 3 },
+		mta_sts: { importance: 4 },
+		mx: { importance: 2 },
+		tlsrpt: { importance: 2 },
+		caa: { importance: 0 },
+		ns: { importance: 0 },
+		bimi: { importance: 1 },
+		lookalikes: { importance: 0 },
+	},
+	non_mail: {
+		ssl: { importance: 8 },
+		subdomain_takeover: { importance: 5 },
+		dnssec: { importance: 5 },
+		caa: { importance: 3 },
+		dmarc: { importance: 2 },
+		ns: { importance: 2 },
+		dkim: { importance: 1 },
+		spf: { importance: 1 },
+		mx: { importance: 0 },
+		mta_sts: { importance: 0 },
+		tlsrpt: { importance: 0 },
+		bimi: { importance: 0 },
+		lookalikes: { importance: 0 },
+	},
+	web_only: {
+		ssl: { importance: 12 },
+		subdomain_takeover: { importance: 5 },
+		dnssec: { importance: 5 },
+		caa: { importance: 5 },
+		dmarc: { importance: 2 },
+		ns: { importance: 2 },
+		dkim: { importance: 1 },
+		spf: { importance: 1 },
+		mx: { importance: 0 },
+		mta_sts: { importance: 0 },
+		tlsrpt: { importance: 0 },
+		bimi: { importance: 0 },
+		lookalikes: { importance: 0 },
+	},
+	minimal: {
+		dmarc: { importance: 5 },
+		ssl: { importance: 5 },
+		dnssec: { importance: 5 },
+		dkim: { importance: 3 },
+		spf: { importance: 3 },
+		subdomain_takeover: { importance: 3 },
+		ns: { importance: 2 },
+		mx: { importance: 1 },
+		caa: { importance: 1 },
+		mta_sts: { importance: 0 },
+		tlsrpt: { importance: 0 },
+		bimi: { importance: 0 },
+		lookalikes: { importance: 0 },
+	},
+};
+
+/** Which categories trigger the critical gap ceiling per profile. */
+export const PROFILE_CRITICAL_CATEGORIES: Record<DomainProfile, CheckCategory[]> = {
+	mail_enabled: ['spf', 'dmarc', 'dkim', 'ssl', 'dnssec', 'subdomain_takeover'],
+	enterprise_mail: ['spf', 'dmarc', 'dkim', 'ssl', 'dnssec', 'subdomain_takeover'],
+	non_mail: ['ssl', 'dnssec', 'subdomain_takeover'],
+	web_only: ['ssl', 'dnssec', 'subdomain_takeover'],
+	minimal: ['ssl', 'dnssec', 'subdomain_takeover'],
+};
+
+/** Whether a profile is eligible for the email bonus. */
+export const PROFILE_EMAIL_BONUS_ELIGIBLE: Record<DomainProfile, boolean> = {
+	mail_enabled: true,
+	enterprise_mail: true,
+	non_mail: false,
+	web_only: false,
+	minimal: false,
+};
+
+/** Known enterprise mail providers detected via MX record patterns. */
+const ENTERPRISE_PROVIDERS = [
+	'google workspace',
+	'microsoft 365',
+	'proofpoint',
+	'mimecast',
+	'barracuda',
+];
+
+/**
+ * Detect domain context from completed check results.
+ * Pure function — reads findings metadata only, no DNS queries.
+ */
+export function detectDomainContext(results: CheckResult[]): DomainContext {
+	const signals: string[] = [];
+
+	const mxResult = results.find((r) => r.category === 'mx');
+	const sslResult = results.find((r) => r.category === 'ssl');
+	const caaResult = results.find((r) => r.category === 'caa');
+	const dkimResult = results.find((r) => r.category === 'dkim');
+	const mtaStsResult = results.find((r) => r.category === 'mta_sts');
+	const bimiResult = results.find((r) => r.category === 'bimi');
+
+	// Detect MX presence
+	const hasNoMx = mxResult
+		? mxResult.findings.some((f) => f.title === 'No MX records found')
+		: false;
+	const hasMx = mxResult && !hasNoMx;
+
+	if (hasMx) signals.push('MX present');
+	if (hasNoMx) signals.push('No MX records');
+
+	// Detect enterprise provider from MX findings
+	let hasEnterpriseProvider = false;
+	if (mxResult) {
+		for (const finding of mxResult.findings) {
+			const text = `${finding.title} ${finding.detail}`.toLowerCase();
+			const providerName = finding.metadata?.provider;
+			const providerStr = typeof providerName === 'string' ? providerName.toLowerCase() : '';
+			for (const provider of ENTERPRISE_PROVIDERS) {
+				if (text.includes(provider) || providerStr.includes(provider)) {
+					hasEnterpriseProvider = true;
+					signals.push(`${provider} provider`);
+					break;
+				}
+			}
+			if (hasEnterpriseProvider) break;
+		}
+	}
+
+	// Detect hardening signals (DKIM present, MTA-STS present, BIMI present)
+	const dkimPresent = dkimResult
+		? !dkimResult.findings.some((f) => {
+				const text = `${f.title} ${f.detail}`.toLowerCase();
+				return /(no\s+dkim|not\s+found|missing)/.test(text) && f.severity !== 'info';
+			})
+		: false;
+	if (dkimPresent && hasMx) signals.push('DKIM present');
+
+	const mtaStsPresent = mtaStsResult ? mtaStsResult.passed : false;
+	if (mtaStsPresent) signals.push('MTA-STS present');
+
+	const bimiPresent = bimiResult ? bimiResult.passed : false;
+	if (bimiPresent) signals.push('BIMI present');
+
+	const hasHardeningSignal = dkimPresent || mtaStsPresent || bimiPresent;
+
+	// Detect web indicators
+	const sslPass = sslResult ? sslResult.passed : false;
+	const caaPass = caaResult ? caaResult.passed : false;
+	if (sslPass) signals.push('SSL valid');
+	if (caaPass) signals.push('CAA present');
+
+	// Count failed/timed-out checks
+	const totalChecks = results.length;
+	const failedChecks = results.filter((r) => !r.passed).length;
+	const failureRatio = totalChecks > 0 ? failedChecks / totalChecks : 0;
+	if (failureRatio > 0.5) signals.push(`>${Math.round(failureRatio * 100)}% checks failed`);
+
+	// Detection priority
+	let profile: DomainProfile;
+
+	if (hasNoMx || !hasMx) {
+		if (caaPass || sslPass) {
+			profile = 'web_only';
+		} else {
+			profile = 'non_mail';
+		}
+	} else if (hasMx && hasEnterpriseProvider && hasHardeningSignal) {
+		profile = 'enterprise_mail';
+	} else {
+		profile = 'mail_enabled';
+	}
+
+	// Override to minimal if most checks failed
+	if (failureRatio > 0.5) {
+		profile = 'minimal';
+	}
+
+	return {
+		profile,
+		signals,
+		weights: PROFILE_WEIGHTS[profile],
+	};
+}
+
+/** Look up the weight table for a given profile. */
+export function getProfileWeights(profile: DomainProfile): Record<CheckCategory, ImportanceProfile> {
+	return PROFILE_WEIGHTS[profile];
+}

--- a/src/lib/scoring-engine.ts
+++ b/src/lib/scoring-engine.ts
@@ -8,6 +8,8 @@ import {
 	inferFindingConfidence,
 	type ScanScore,
 } from './scoring-model';
+import type { DomainContext } from './context-profiles';
+import { PROFILE_CRITICAL_CATEGORIES, PROFILE_EMAIL_BONUS_ELIGIBLE } from './context-profiles';
 
 interface ImportanceProfile {
 	importance: number;
@@ -80,11 +82,17 @@ export function scoreToGrade(score: number): string {
 	return 'F';
 }
 
+/** Default critical categories used when no context is provided. */
+const DEFAULT_CRITICAL_CATEGORIES: CheckCategory[] = ['spf', 'dmarc', 'dkim', 'ssl', 'dnssec', 'subdomain_takeover'];
+
 /**
  * Compute the overall scan score from individual check results.
  * Uses weighted average of category scores.
+ *
+ * When a `DomainContext` is provided, uses profile-specific weights,
+ * critical gap categories, and email bonus eligibility instead of defaults.
  */
-export function computeScanScore(results: CheckResult[]): ScanScore {
+export function computeScanScore(results: CheckResult[], context?: DomainContext): ScanScore {
 	const partialScores: Partial<Record<CheckCategory, number>> = {};
 	const allFindings: Finding[] = [];
 
@@ -114,9 +122,12 @@ export function computeScanScore(results: CheckResult[]): ScanScore {
 	let earnedPoints = 0;
 	let maxPoints = 0;
 
-	// IMPORTANCE_WEIGHTS is Record<CheckCategory, ImportanceProfile> — Object.keys returns string[], cast is safe
-	for (const category of Object.keys(IMPORTANCE_WEIGHTS) as CheckCategory[]) {
-		const { importance } = IMPORTANCE_WEIGHTS[category];
+	// Use context-specific weights when provided, otherwise fall back to static defaults
+	const activeWeights = context ? context.weights : IMPORTANCE_WEIGHTS;
+
+	// activeWeights is Record<CheckCategory, ImportanceProfile> — Object.keys returns string[], cast is safe
+	for (const category of Object.keys(activeWeights) as CheckCategory[]) {
+		const { importance } = activeWeights[category];
 		maxPoints += importance;
 		if (importance === 0) continue;
 
@@ -126,6 +137,9 @@ export function computeScanScore(results: CheckResult[]): ScanScore {
 		earnedPoints += (effectiveScore / 100) * importance;
 	}
 
+	// Email bonus: only awarded for profiles that are eligible (or when no context is provided)
+	const emailBonusEligible = context ? PROFILE_EMAIL_BONUS_ELIGIBLE[context.profile] : true;
+
 	const spfResult = results.find((result) => result.category === 'spf');
 	const dkimResult = results.find((result) => result.category === 'dkim');
 	const dmarcResult = results.find((result) => result.category === 'dmarc');
@@ -134,7 +148,7 @@ export function computeScanScore(results: CheckResult[]): ScanScore {
 	const dmarcPresent = !!dmarcResult && !scoreIndicatesMissingControl(dmarcResult.findings);
 
 	let emailBonus = 0;
-	if (spfStrong && dkimPresent && dmarcPresent && dmarcResult) {
+	if (emailBonusEligible && spfStrong && dkimPresent && dmarcPresent && dmarcResult) {
 		if (dmarcResult.score >= 90) {
 			emailBonus = EMAIL_BONUS_IMPORTANCE;
 		} else if (dmarcResult.score >= 70) {
@@ -160,8 +174,10 @@ export function computeScanScore(results: CheckResult[]): ScanScore {
 
 	// Critical gap ceiling: cap score when foundational controls are missing
 	const CRITICAL_GAP_CEILING = 64;
-	const CRITICAL_CATEGORIES: CheckCategory[] = ['spf', 'dmarc', 'dkim', 'ssl', 'dnssec', 'subdomain_takeover'];
-	const hasCriticalGap = CRITICAL_CATEGORIES.some((cat) => {
+	const criticalCategories = context
+		? PROFILE_CRITICAL_CATEGORIES[context.profile]
+		: DEFAULT_CRITICAL_CATEGORIES;
+	const hasCriticalGap = criticalCategories.some((cat) => {
 		const result = results.find((r) => r.category === cat);
 		return result && scoreIndicatesMissingControl(result.findings);
 	});

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -22,3 +22,5 @@ export {
 } from './scoring-model';
 
 export { computeScanScore, scoreToGrade } from './scoring-engine';
+
+export { detectDomainContext, getProfileWeights, type DomainContext, type DomainProfile } from './context-profiles';

--- a/src/package.ts
+++ b/src/package.ts
@@ -32,6 +32,10 @@ export {
 	type FindingConfidence,
 	type ScanScore,
 	type Severity,
+	detectDomainContext,
+	getProfileWeights,
+	type DomainContext,
+	type DomainProfile,
 } from './lib/scoring';
 
 export { sanitizeDomain, sanitizeInput, validateDomain } from './lib/sanitize';

--- a/src/tools/compare-baseline.ts
+++ b/src/tools/compare-baseline.ts
@@ -32,6 +32,7 @@ export interface BaselineResult {
 	passed: boolean;
 	violations: BaselineViolation[];
 	checkedRules: number;
+	scoringProfile?: string;
 	timestamp: string;
 }
 
@@ -159,6 +160,7 @@ export function compareBaseline(scan: ScanDomainResult, baseline: PolicyBaseline
 		passed: violations.length === 0,
 		violations,
 		checkedRules,
+		scoringProfile: scan.context?.profile,
 		timestamp: new Date().toISOString(),
 	};
 }

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -10,7 +10,18 @@
  * Compatible with Cloudflare Workers runtime (no Node.js APIs).
  */
 
-import { type CheckCategory, type CheckResult, type ScanScore, buildCheckResult, computeScanScore, createFinding } from '../lib/scoring';
+import {
+	type CheckCategory,
+	type CheckResult,
+	type DomainContext,
+	type DomainProfile,
+	type ScanScore,
+	buildCheckResult,
+	computeScanScore,
+	createFinding,
+	detectDomainContext,
+	getProfileWeights,
+} from '../lib/scoring';
 import { cacheGet, cacheSet, runWithCache } from '../lib/cache';
 import { checkSpf } from './check-spf';
 import { checkDmarc } from './check-dmarc';
@@ -47,6 +58,7 @@ export interface ScanDomainResult {
 	score: ScanScore;
 	checks: CheckResult[];
 	maturity: MaturityStage;
+	context: DomainContext;
 	cached: boolean;
 	timestamp: string;
 }
@@ -60,7 +72,11 @@ export interface ScanDomainResult {
  * @returns Full scan result with score, individual check results, and metadata
  */
 export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOptions?: ScanRuntimeOptions): Promise<ScanDomainResult> {
-	const cacheKey = `${CACHE_PREFIX}${domain}`;
+	const explicitProfile = runtimeOptions?.profile;
+	const isExplicit = explicitProfile && explicitProfile !== 'auto';
+	const cacheKey = isExplicit
+		? `${CACHE_PREFIX}${domain}:profile:${explicitProfile}`
+		: `${CACHE_PREFIX}${domain}`;
 
 	// Check cache first
 	const cached = await cacheGet<ScanDomainResult>(cacheKey, kv);
@@ -147,7 +163,24 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 	try {
 		checkResults = await applyScanPostProcessing(domain, checkResults, runtimeOptions);
 
-		const score = computeScanScore(checkResults);
+		// Detect domain context from check results
+		let domainContext = detectDomainContext(checkResults);
+
+		// If an explicit profile was requested, override detection
+		if (isExplicit) {
+			domainContext = {
+				profile: explicitProfile as DomainProfile,
+				signals: [...domainContext.signals, `explicit profile override: ${explicitProfile}`],
+				weights: getProfileWeights(explicitProfile as DomainProfile),
+			};
+		}
+
+		// Phase 1: only pass context to scoring when an explicit profile is set.
+		// For 'auto' (or unset), detection runs and is reported but scoring
+		// uses the default weights (identical to pre-profile behavior).
+		const scoringContext = isExplicit ? domainContext : undefined;
+
+		const score = computeScanScore(checkResults, scoringContext);
 		const maturity = computeMaturityStage(checkResults);
 
 		result = {
@@ -155,11 +188,13 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 			score,
 			checks: checkResults,
 			maturity,
+			context: domainContext,
 			cached: false,
 			timestamp: new Date().toISOString(),
 		};
 	} catch {
 		// Post-processing or scoring failed — return whatever we have
+		const domainContext = detectDomainContext(checkResults);
 		const score = computeScanScore(checkResults);
 		const maturity = computeMaturityStage(checkResults);
 		result = {
@@ -167,6 +202,7 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 			score,
 			checks: checkResults,
 			maturity,
+			context: domainContext,
 			cached: false,
 			timestamp: new Date().toISOString(),
 		};

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -14,6 +14,8 @@ export interface StructuredScanResult {
 	maturityLabel: string | null;
 	categoryScores: Record<string, number>;
 	findingCounts: { critical: number; high: number; medium: number; low: number };
+	scoringProfile: string;
+	scoringSignals: string[];
 	timestamp: string;
 	cached: boolean;
 }
@@ -34,6 +36,8 @@ export function buildStructuredScanResult(result: ScanDomainResult): StructuredS
 			medium: result.score.findings.filter((f) => f.severity === 'medium').length,
 			low: result.score.findings.filter((f) => f.severity === 'low').length,
 		},
+		scoringProfile: result.context?.profile ?? 'mail_enabled',
+		scoringSignals: result.context?.signals ?? [],
 		timestamp: result.timestamp,
 		cached: result.cached,
 	};
@@ -54,6 +58,12 @@ export function formatScanReport(result: ScanDomainResult): string {
 		if (result.maturity.nextStep) {
 			lines.push(`Next step: ${result.maturity.nextStep}`);
 		}
+		lines.push('');
+	}
+
+	if (result.context) {
+		const signalSummary = result.context.signals.length > 0 ? result.context.signals.join(', ') : 'default';
+		lines.push(`Scoring Profile: ${result.context.profile} (${signalSummary})`);
 		lines.push('');
 	}
 

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -9,6 +9,7 @@ export interface ScanRuntimeOptions {
 	providerSignaturesUrl?: string;
 	providerSignaturesAllowedHosts?: string[];
 	providerSignaturesSha256?: string;
+	profile?: 'mail_enabled' | 'enterprise_mail' | 'non_mail' | 'web_only' | 'minimal' | 'auto';
 }
 
 export async function applyScanPostProcessing(

--- a/test/context-profiles.spec.ts
+++ b/test/context-profiles.spec.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'vitest';
+import {
+	detectDomainContext,
+	getProfileWeights,
+	PROFILE_WEIGHTS,
+	PROFILE_CRITICAL_CATEGORIES,
+	PROFILE_EMAIL_BONUS_ELIGIBLE,
+	type DomainProfile,
+} from '../src/lib/context-profiles';
+import { buildCheckResult, createFinding, type CheckCategory } from '../src/lib/scoring-model';
+
+function makeCheckResult(category: CheckCategory, score: number, findings: ReturnType<typeof createFinding>[] = []) {
+	if (findings.length === 0) {
+		if (score === 100) {
+			findings = [createFinding(category, `${category} OK`, 'info', 'Check passed')];
+		} else {
+			findings = [createFinding(category, `${category} issue`, 'medium', 'Issue detected')];
+		}
+	}
+	return buildCheckResult(category, findings);
+}
+
+function fullPassingResults(overrides?: Partial<Record<CheckCategory, ReturnType<typeof buildCheckResult>>>) {
+	const categories: CheckCategory[] = [
+		'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta_sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'subdomain_takeover', 'mx',
+	];
+	return categories.map((cat) => overrides?.[cat] ?? makeCheckResult(cat, 100));
+}
+
+describe('context-profiles', () => {
+	describe('detectDomainContext', () => {
+		it('detects enterprise_mail when MX + Google Workspace provider + DKIM present', () => {
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
+				]),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('enterprise_mail');
+			expect(ctx.signals).toContain('MX present');
+			expect(ctx.signals.some((s) => s.includes('google workspace'))).toBe(true);
+		});
+
+		it('detects mail_enabled when MX present but no enterprise provider', () => {
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'MX records found', 'info', 'mail.example.com'),
+				]),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('mail_enabled');
+			expect(ctx.signals).toContain('MX present');
+		});
+
+		it('detects web_only when no MX but CAA present', () => {
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'No MX records found', 'high', 'No MX records found for domain'),
+				]),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('web_only');
+			expect(ctx.signals).toContain('No MX records');
+			expect(ctx.signals).toContain('CAA present');
+		});
+
+		it('detects non_mail when no MX and no web indicators', () => {
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'No MX records found', 'high', 'No MX records found for domain'),
+				]),
+				caa: buildCheckResult('caa', [
+					createFinding('caa', 'No CAA records', 'critical', 'No CAA records found'),
+					createFinding('caa', 'CAA missing', 'high', 'CAA is required'),
+				]),
+				ssl: buildCheckResult('ssl', [
+					createFinding('ssl', 'SSL check failed', 'critical', 'No valid certificate found'),
+					createFinding('ssl', 'SSL required', 'high', 'Certificate is required'),
+				]),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('non_mail');
+			expect(ctx.signals).toContain('No MX records');
+		});
+
+		it('detects minimal when >50% checks failed', () => {
+			const categories: CheckCategory[] = [
+				'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta_sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'subdomain_takeover', 'mx',
+			];
+			// Make 7 of 12 checks fail (score < 50 => not passed) by using critical+high findings
+			const results = categories.map((cat, i) => {
+				if (i < 7) {
+					return buildCheckResult(cat, [
+						createFinding(cat, `${cat} check error`, 'critical', 'Check failed critically'),
+						createFinding(cat, `${cat} also broken`, 'high', 'Additional failure'),
+					]);
+				}
+				return makeCheckResult(cat, 100);
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('minimal');
+		});
+
+		it('explicit profile override replaces detected profile in signals', () => {
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'MX records found', 'info', 'mail.example.com'),
+				]),
+			});
+			const ctx = detectDomainContext(results);
+			// Detection should give mail_enabled
+			expect(ctx.profile).toBe('mail_enabled');
+			// An explicit override would be applied in scan-domain.ts, not in detectDomainContext itself
+		});
+	});
+
+	describe('getProfileWeights', () => {
+		it('returns the correct weight table for each profile', () => {
+			const profiles: DomainProfile[] = ['mail_enabled', 'enterprise_mail', 'non_mail', 'web_only', 'minimal'];
+			for (const profile of profiles) {
+				const weights = getProfileWeights(profile);
+				expect(weights).toEqual(PROFILE_WEIGHTS[profile]);
+			}
+		});
+
+		it('each profile has non-zero total weight', () => {
+			const profiles: DomainProfile[] = ['mail_enabled', 'enterprise_mail', 'non_mail', 'web_only', 'minimal'];
+			for (const profile of profiles) {
+				const weights = getProfileWeights(profile);
+				const total = Object.values(weights).reduce((sum, w) => sum + w.importance, 0);
+				expect(total).toBeGreaterThan(0);
+			}
+		});
+	});
+
+	describe('PROFILE_CRITICAL_CATEGORIES', () => {
+		it('non_mail and web_only do not include email categories', () => {
+			for (const profile of ['non_mail', 'web_only'] as DomainProfile[]) {
+				const cats = PROFILE_CRITICAL_CATEGORIES[profile];
+				expect(cats).not.toContain('spf');
+				expect(cats).not.toContain('dmarc');
+				expect(cats).not.toContain('dkim');
+				expect(cats).toContain('ssl');
+				expect(cats).toContain('dnssec');
+			}
+		});
+
+		it('mail_enabled and enterprise_mail include email categories', () => {
+			for (const profile of ['mail_enabled', 'enterprise_mail'] as DomainProfile[]) {
+				const cats = PROFILE_CRITICAL_CATEGORIES[profile];
+				expect(cats).toContain('spf');
+				expect(cats).toContain('dmarc');
+				expect(cats).toContain('dkim');
+			}
+		});
+	});
+
+	describe('PROFILE_EMAIL_BONUS_ELIGIBLE', () => {
+		it('only mail profiles are eligible for email bonus', () => {
+			expect(PROFILE_EMAIL_BONUS_ELIGIBLE.mail_enabled).toBe(true);
+			expect(PROFILE_EMAIL_BONUS_ELIGIBLE.enterprise_mail).toBe(true);
+			expect(PROFILE_EMAIL_BONUS_ELIGIBLE.non_mail).toBe(false);
+			expect(PROFILE_EMAIL_BONUS_ELIGIBLE.web_only).toBe(false);
+			expect(PROFILE_EMAIL_BONUS_ELIGIBLE.minimal).toBe(false);
+		});
+	});
+});

--- a/test/format-scan-report.spec.ts
+++ b/test/format-scan-report.spec.ts
@@ -127,6 +127,9 @@ describe('format-scan-report', () => {
 		expect(structured.findingCounts).toEqual({ critical: 1, high: 1, medium: 1, low: 1 });
 		expect(structured.timestamp).toBe('2026-03-12T00:00:00.000Z');
 		expect(structured.cached).toBe(false);
+		// New profile fields default gracefully when context is absent
+		expect(structured.scoringProfile).toBe('mail_enabled');
+		expect(structured.scoringSignals).toEqual([]);
 	});
 
 	it('buildStructuredScanResult handles missing maturity', () => {

--- a/test/scoring-profiles.spec.ts
+++ b/test/scoring-profiles.spec.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import { computeScanScore } from '../src/lib/scoring-engine';
+import { buildCheckResult, createFinding, type CheckCategory, type CheckResult } from '../src/lib/scoring-model';
+import { getProfileWeights, type DomainContext } from '../src/lib/context-profiles';
+
+function makeResult(category: CheckCategory, score: number, title?: string, severity?: 'info' | 'low' | 'medium' | 'high' | 'critical'): CheckResult {
+	const findings = [];
+	if (score === 100) {
+		findings.push(createFinding(category, title ?? `${category} OK`, 'info', 'Check passed'));
+	} else if (score === 0) {
+		findings.push(createFinding(category, title ?? `No ${category} record found`, severity ?? 'critical', `Missing ${category} record`));
+		findings.push(createFinding(category, `${category} required`, severity ?? 'high', `${category} is required but not found`));
+	} else {
+		findings.push(createFinding(category, title ?? `${category} issue`, severity ?? 'medium', 'Issue detected'));
+	}
+	return buildCheckResult(category, findings);
+}
+
+function buildFullResults(overrides: Partial<Record<CheckCategory, CheckResult>> = {}): CheckResult[] {
+	const defaults: Record<CheckCategory, CheckResult> = {
+		spf: makeResult('spf', 100),
+		dmarc: makeResult('dmarc', 100),
+		dkim: makeResult('dkim', 100),
+		dnssec: makeResult('dnssec', 100),
+		ssl: makeResult('ssl', 100),
+		mta_sts: makeResult('mta_sts', 100),
+		ns: makeResult('ns', 100),
+		caa: makeResult('caa', 100),
+		bimi: makeResult('bimi', 100),
+		tlsrpt: makeResult('tlsrpt', 100),
+		subdomain_takeover: makeResult('subdomain_takeover', 100),
+		mx: makeResult('mx', 100),
+		lookalikes: makeResult('lookalikes', 100),
+	};
+	return Object.values({ ...defaults, ...overrides });
+}
+
+function makeNonMailContext(): DomainContext {
+	return {
+		profile: 'non_mail',
+		signals: ['No MX records'],
+		weights: getProfileWeights('non_mail'),
+	};
+}
+
+function makeEnterpriseContext(): DomainContext {
+	return {
+		profile: 'enterprise_mail',
+		signals: ['MX present', 'google workspace provider', 'DKIM present'],
+		weights: getProfileWeights('enterprise_mail'),
+	};
+}
+
+describe('scoring-profiles', () => {
+	describe('regression: computeScanScore without context', () => {
+		it('returns identical results to pre-profile behavior', () => {
+			const results = buildFullResults();
+			const withoutContext = computeScanScore(results);
+			const withUndefined = computeScanScore(results, undefined);
+			expect(withoutContext.overall).toBe(withUndefined.overall);
+			expect(withoutContext.grade).toBe(withUndefined.grade);
+		});
+
+		it('empty results still return 100', () => {
+			const score = computeScanScore([]);
+			expect(score.overall).toBe(100);
+		});
+	});
+
+	describe('non_mail context', () => {
+		it('does NOT cap score at 64 when SPF/DMARC are missing', () => {
+			const results = buildFullResults({
+				spf: makeResult('spf', 0, 'No SPF record found', 'critical'),
+				dmarc: makeResult('dmarc', 0, 'No DMARC record found', 'critical'),
+			});
+			const nonMailCtx = makeNonMailContext();
+			const withContext = computeScanScore(results, nonMailCtx);
+			// SPF/DMARC are NOT in non_mail critical categories, so no ceiling
+			expect(withContext.overall).toBeGreaterThan(64);
+		});
+
+		it('DOES cap score at 64 when SSL is missing (critical for non_mail)', () => {
+			const results = buildFullResults({
+				ssl: makeResult('ssl', 0, 'No valid certificate found', 'critical'),
+			});
+			const nonMailCtx = makeNonMailContext();
+			const withContext = computeScanScore(results, nonMailCtx);
+			expect(withContext.overall).toBeLessThanOrEqual(64);
+		});
+
+		it('does NOT award email bonus', () => {
+			// All email checks pass — but non_mail profile should skip bonus
+			const results = buildFullResults();
+			const nonMailCtx = makeNonMailContext();
+			const withContext = computeScanScore(results, nonMailCtx);
+			const withoutContext = computeScanScore(results);
+			// Without context, email bonus applies. With non_mail, it doesn't.
+			// Both should be high scores but may differ slightly due to bonus
+			expect(withContext.overall).toBeLessThanOrEqual(withoutContext.overall);
+		});
+	});
+
+	describe('enterprise_mail context', () => {
+		it('elevates MTA-STS importance', () => {
+			// With enterprise profile, MTA-STS weight is 4 vs 2 for mail_enabled
+			const results = buildFullResults({
+				mta_sts: makeResult('mta_sts', 0, 'No MTA-STS record found', 'high'),
+			});
+			const enterpriseCtx = makeEnterpriseContext();
+			const withEnterprise = computeScanScore(results, enterpriseCtx);
+			const withoutContext = computeScanScore(results);
+			// Enterprise should penalize MTA-STS absence more
+			expect(withEnterprise.overall).toBeLessThan(withoutContext.overall);
+		});
+
+		it('awards email bonus when eligible', () => {
+			const results = buildFullResults();
+			const enterpriseCtx = makeEnterpriseContext();
+			const score = computeScanScore(results, enterpriseCtx);
+			// With all checks passing, email bonus should be awarded
+			expect(score.overall).toBeGreaterThanOrEqual(90);
+		});
+	});
+
+	describe('snapshot: known result sets with expected scores per profile', () => {
+		const allPassing = buildFullResults();
+
+		it('all passing with mail_enabled (default) profile', () => {
+			const score = computeScanScore(allPassing);
+			expect(score.overall).toBe(100);
+			expect(score.grade).toBe('A+');
+		});
+
+		it('all passing with enterprise_mail profile', () => {
+			const score = computeScanScore(allPassing, makeEnterpriseContext());
+			expect(score.overall).toBe(100);
+			expect(score.grade).toBe('A+');
+		});
+
+		it('all passing with non_mail profile', () => {
+			const score = computeScanScore(allPassing, makeNonMailContext());
+			expect(score.overall).toBe(100);
+			expect(score.grade).toBe('A+');
+		});
+
+		it('missing SPF+DMARC: non_mail scores higher than default', () => {
+			const results = buildFullResults({
+				spf: makeResult('spf', 0, 'No SPF record found', 'critical'),
+				dmarc: makeResult('dmarc', 0, 'No DMARC record found', 'critical'),
+			});
+			const defaultScore = computeScanScore(results);
+			const nonMailScore = computeScanScore(results, makeNonMailContext());
+			expect(nonMailScore.overall).toBeGreaterThan(defaultScore.overall);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Adds five named scoring profiles (`mail_enabled`, `enterprise_mail`, `non_mail`, `web_only`, `minimal`) that adapt importance weights based on detected domain purpose
- Auto-detection runs using signals already collected during the scan (MX presence, enterprise provider, DKIM/MTA-STS/BIMI hardening, SSL/CAA) — no extra DNS queries
- **Phase 1**: `auto` mode reports the detected profile but uses `mail_enabled` weights (identical to today). Only explicit `profile` parameter activates different weights and cache keys. This lets us validate detection accuracy in production before scores change.
- Structured result now includes `scoringProfile` and `scoringSignals` fields (additive, backward-compatible)

### Files changed
- **New**: `src/lib/context-profiles.ts` — profile types, weight tables, detection logic
- **New**: `test/context-profiles.spec.ts`, `test/scoring-profiles.spec.ts` — 22 new tests
- **Modified**: `scoring-engine.ts` (optional `DomainContext` param), `scan-domain.ts` (detection + profile routing), `format-report.ts` (structured result fields + text report line), `tool-schemas.ts` / `tool-args.ts` / `tools.ts` (profile parameter), `compare-baseline.ts` (scoringProfile field), `scoring.ts` + `package.ts` (exports), `CLAUDE.md`, `CHANGELOG.md`

## Test plan
- [x] 735 tests pass (22 new + 713 existing)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [ ] Manual: `scan_domain` with no profile returns same score as before, structured result shows `scoringProfile`
- [ ] Manual: `scan_domain` with `profile: "non_mail"` returns different score for mail-heavy domain
- [ ] Verify `blackveil-dns-action` still parses structured result (new fields are additive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* Added optional `profile` parameter to scan_domain for context-aware scoring calibrated to domain purpose
* Automatic domain-type detection (mail-enabled, enterprise, non-mail, web-only, minimal) with explicit override support
* Scan results now include detected scoring profile and detection signals for transparency

**Documentation**
* Updated CHANGELOG with new context-aware scoring capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->