### PR TITLE
fix: enable MCP session recovery after expiry

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ import { checkRateLimit, checkToolDailyRateLimit } from './lib/rate-limiter';
 import { logEvent, logError, sanitizeHeadersForLog } from './lib/log';
 import { jsonRpcError, JSON_RPC_ERRORS } from './lib/json-rpc';
 import { normalizeHeaders, parseJsonRpcRequest, readRequestBody } from './mcp/request';
-import { createSession, deleteSession } from './lib/session';
+import { createSession, deleteSession, validateSession } from './lib/session';
 import { isAuthorizedRequest, unauthorizedResponse } from './lib/auth';
 import { sseEvent, acceptsSSE, createSseStream, sseErrorResponse, createStreamingSseResponse } from './lib/sse';
 import { createAnalyticsClient } from './lib/analytics';
@@ -400,6 +400,16 @@ app.post('/mcp/messages', async (c) => {
 
 	if (!sessionId) {
 		return c.json(jsonRpcError(null, JSON_RPC_ERRORS.INVALID_REQUEST, 'Bad Request: missing session'), 400);
+	}
+
+	// Early session validation — return HTTP 404 directly for expired/terminated sessions
+	// so legacy SSE clients see the error instead of getting 202 with an undeliverable SSE message
+	if (!(await validateSession(sessionId, c.env.SESSION_STORE))) {
+		closeLegacyStream(sessionId);
+		return c.json(
+			jsonRpcError(null, JSON_RPC_ERRORS.INVALID_REQUEST, 'Not Found: session expired or terminated'),
+			404,
+		);
 	}
 
 	const bodyReadResult = await readRequestBody(c.req.raw, MAX_REQUEST_BODY_BYTES);

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -28,6 +28,9 @@ export function acceptsSSE(accept: string | undefined): boolean {
  * Build a Response for an error payload, using SSE format when the client
  * sent `Accept: text/event-stream` so that SSE-only transports (e.g. mcp-remote)
  * receive the error instead of hanging.
+ *
+ * Uses the actual HTTP status code so MCP clients can detect session expiry (404)
+ * and other errors at the HTTP level, as required by the MCP spec.
  */
 export function sseErrorResponse(
 	payload: unknown,
@@ -39,7 +42,7 @@ export function sseErrorResponse(
 	if (acceptsSSE(accept)) {
 		const body = sseEvent(payload, eventId);
 		return new Response(body, {
-			status: 200,
+			status,
 			headers: {
 				'Content-Type': 'text/event-stream',
 				'Cache-Control': 'no-cache',

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -235,7 +235,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 		}
 	}
 
-	if (options.validateSession && method !== 'initialize') {
+	if (options.validateSession && method !== 'initialize' && !method.startsWith('notifications/')) {
 		const sessionError = await validateSessionRequest(
 			options.sessionId,
 			options.sessionStore,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1291,6 +1291,179 @@ describe('DNS Security MCP Server', () => {
 		});
 	});
 
+	describe('Session recovery', () => {
+		/** Helper: terminate a session via DELETE so subsequent requests see it as expired */
+		async function terminateSession(sessionId: string): Promise<void> {
+			const delReq = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'DELETE',
+				headers: { 'Mcp-Session-Id': sessionId },
+			});
+			const ctx = createExecutionContext();
+			const delRes = await worker.fetch(delReq, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(delRes.status).toBe(204);
+		}
+
+		it('returns HTTP 404 (not 200) for expired sessions when client accepts SSE', async () => {
+			const sessionId = await initSession();
+			await terminateSession(sessionId);
+
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					'Mcp-Session-Id': sessionId,
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+
+			// Must be HTTP 404 so MCP clients detect session expiry and re-initialize
+			expect(response.status).toBe(404);
+		});
+
+		it('allows notifications/initialized without a valid session', async () => {
+			// Notifications are fire-and-forget per MCP spec — no session required
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+
+			// Notifications return 202 (accepted, no response body)
+			expect(response.status).toBe(202);
+		});
+
+		it('allows notifications with terminated session ID', async () => {
+			const sessionId = await initSession();
+			await terminateSession(sessionId);
+
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Mcp-Session-Id': sessionId,
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+
+			expect(response.status).toBe(202);
+		});
+
+		it('completes full re-initialization after session termination (Claude Desktop flow)', async () => {
+			// Step 1: Initialize and get session
+			const sessionId = await initSession();
+
+			// Step 2: Terminate the session (simulates expiry)
+			await terminateSession(sessionId);
+
+			// Step 3: tools/list with terminated session → 404
+			const expiredRequest = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					'Mcp-Session-Id': sessionId,
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', id: 10, method: 'tools/list', params: {} }),
+			});
+			const ctx1 = createExecutionContext();
+			const expiredResponse = await worker.fetch(expiredRequest, env, ctx1);
+			await waitOnExecutionContext(ctx1);
+			expect(expiredResponse.status).toBe(404);
+
+			// Step 4: Re-initialize with fresh session
+			const reInitRequest = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', id: 11, method: 'initialize', params: {} }),
+			});
+			const ctx2 = createExecutionContext();
+			const reInitResponse = await worker.fetch(reInitRequest, env, ctx2);
+			await waitOnExecutionContext(ctx2);
+			expect(reInitResponse.status).toBe(200);
+			const newSessionId = reInitResponse.headers.get('mcp-session-id');
+			expect(newSessionId).toBeTruthy();
+			expect(newSessionId).not.toBe(sessionId);
+
+			// Step 5: notifications/initialized with new session → 202
+			const notifRequest = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					'Mcp-Session-Id': newSessionId!,
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+			});
+			const ctx3 = createExecutionContext();
+			const notifResponse = await worker.fetch(notifRequest, env, ctx3);
+			await waitOnExecutionContext(ctx3);
+			expect(notifResponse.status).toBe(202);
+
+			// Step 6: tools/list with new session → 200
+			const toolsRequest = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Accept: 'application/json, text/event-stream',
+					'Mcp-Session-Id': newSessionId!,
+				},
+				body: JSON.stringify({ jsonrpc: '2.0', id: 12, method: 'tools/list', params: {} }),
+			});
+			const ctx4 = createExecutionContext();
+			const toolsResponse = await worker.fetch(toolsRequest, env, ctx4);
+			await waitOnExecutionContext(ctx4);
+			expect(toolsResponse.status).toBe(200);
+		});
+
+		it('returns HTTP 404 for legacy SSE POST with terminated session', async () => {
+			// Open legacy SSE stream
+			const openRequest = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp/sse', {
+				method: 'GET',
+				headers: { Accept: 'text/event-stream' },
+			});
+			const openCtx = createExecutionContext();
+			const streamResponse = await worker.fetch(openRequest, env, openCtx);
+			await waitOnExecutionContext(openCtx);
+			const endpointChunk = await readSseChunk(streamResponse);
+			const endpoint = parseSseEvent(endpointChunk, 'endpoint');
+			const sessionId = streamResponse.headers.get('mcp-session-id');
+			expect(sessionId).toBeTruthy();
+
+			// Terminate the session
+			await terminateSession(sessionId!);
+
+			// POST to legacy endpoint with terminated session → must get HTTP 404 directly
+			const request = new Request<unknown, IncomingRequestCfProperties>(endpoint, {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+
+			// Must be HTTP 404 directly, not HTTP 202 with undeliverable SSE message
+			expect(response.status).toBe(404);
+			const body = (await response.json()) as { error: { message: string } };
+			expect(body.error.message).toContain('session expired or terminated');
+		});
+	});
+
 	describe('404 fallback', () => {
 		it('returns 404 for unknown routes', async () => {
 			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/unknown');

--- a/test/sse.spec.ts
+++ b/test/sse.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { sseErrorResponse } from '../src/lib/sse';
+import { jsonRpcError, JSON_RPC_ERRORS } from '../src/lib/json-rpc';
+
+describe('sseErrorResponse', () => {
+	it('returns the actual HTTP status code for SSE clients instead of 200', () => {
+		const payload = jsonRpcError(1, JSON_RPC_ERRORS.INVALID_REQUEST, 'Not Found: session expired or terminated');
+		const response = sseErrorResponse(payload, 404, 'text/event-stream');
+
+		expect(response.status).toBe(404);
+		expect(response.headers.get('content-type')).toBe('text/event-stream');
+	});
+
+	it('returns 429 status for rate-limited SSE clients', () => {
+		const payload = jsonRpcError(1, JSON_RPC_ERRORS.RATE_LIMITED, 'Rate limit exceeded');
+		const response = sseErrorResponse(payload, 429, 'text/event-stream', { 'retry-after': '5' });
+
+		expect(response.status).toBe(429);
+		expect(response.headers.get('retry-after')).toBe('5');
+	});
+
+	it('returns 400 status for missing session SSE clients', () => {
+		const payload = jsonRpcError(1, JSON_RPC_ERRORS.INVALID_REQUEST, 'Bad Request: missing session');
+		const response = sseErrorResponse(payload, 400, 'text/event-stream');
+
+		expect(response.status).toBe(400);
+	});
+
+	it('still returns JSON with actual status for non-SSE clients', () => {
+		const payload = jsonRpcError(1, JSON_RPC_ERRORS.INVALID_REQUEST, 'Not Found: session expired or terminated');
+		const response = sseErrorResponse(payload, 404, 'application/json');
+
+		expect(response.status).toBe(404);
+	});
+
+	it('includes SSE event body when client accepts SSE', async () => {
+		const payload = jsonRpcError(1, JSON_RPC_ERRORS.INVALID_REQUEST, 'session expired');
+		const response = sseErrorResponse(payload, 404, 'text/event-stream');
+
+		const body = await response.text();
+		expect(body).toContain('event: message');
+		expect(body).toContain('session expired');
+	});
+});


### PR DESCRIPTION
## Summary

- **`sseErrorResponse` was masking HTTP 404 with HTTP 200** for SSE clients, preventing Claude Desktop and other MCP clients from detecting session expiry and triggering re-initialization
- **`notifications/*` methods now skip session validation** — they're fire-and-forget per MCP spec and were already exempted from control plane rate limits
- **Legacy SSE POST `/mcp/messages` now returns HTTP 404 directly** for expired sessions instead of HTTP 202 with an undeliverable enqueued SSE message

## Test plan

- [x] 5 new unit tests for `sseErrorResponse` status code preservation (`test/sse.spec.ts`)
- [x] 5 new integration tests for session recovery flows (`test/index.spec.ts`)
- [x] Full end-to-end Claude Desktop re-initialization lifecycle test (init → expire → 404 → re-init → notify → use)
- [x] 907/907 tests pass, typecheck clean, lint clean
- [ ] Deploy to staging and verify Claude Desktop can recover from session expiry without restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed incorrect HTTP status codes in error responses for SSE clients—now returns actual status instead of always 200.
  * Improved session validation to properly detect expired or terminated sessions earlier, returning 404 immediately to prevent undeliverable messages.
  * Notification methods can now execute without requiring an active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->