### PR TITLE
perf: two-phase DNS probing for check_lookalikes and check_shadow_domains

### DIFF
--- a/docs/superpowers/plans/2026-03-16-two-phase-dns-probing.md
+++ b/docs/superpowers/plans/2026-03-16-two-phase-dns-probing.md
@@ -1,0 +1,617 @@
+# Two-Phase DNS Probing Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut check_lookalikes P95 from 20s to 4-6s and check_shadow_domains P95 from 14s to 3-5s by filtering unregistered variants with a fast NS existence check before detailed probing.
+
+**Architecture:** Two-phase probing — Phase 1 queries NS records for all variants in parallel with lean DNS settings (2s timeout, no retries, no secondary confirmation). Only variants with NS records proceed to Phase 2 for full detail queries. This eliminates ~90% of wasted queries on non-existent domains.
+
+**Tech Stack:** TypeScript, Cloudflare Workers runtime, DNS-over-HTTPS (Cloudflare DoH), Vitest
+
+**Spec:** `docs/superpowers/specs/2026-03-16-dns-probe-performance-design.md`
+
+---
+
+## Chunk 1: check_lookalikes Two-Phase Probing
+
+### Task 1: Add NS mock to existing lookalike positive-case tests
+
+All existing tests that expect findings for specific domains (high/medium severity) currently mock A and MX records but not NS. Phase 1 filters on NS, so these tests must also return NS records for those domains to pass after the implementation.
+
+**Files:**
+- Modify: `test/check-lookalikes.spec.ts`
+
+- [ ] **Step 1: Add NS responses to the "high finding for lookalike with MX" test mock**
+
+In the fetch mock at line 38, add NS responses for the domains that should be detected. The mock should return NS records for any query with `type === 'NS' || type === '2'` for the target domains (`twst.com`, `tst.com`, `tes.com`, `testt.com`):
+
+```typescript
+if (name === 'twst.com' || name === 'tst.com' || name === 'tes.com' || name === 'testt.com') {
+	if (type === 'NS' || type === '2') {
+		return Promise.resolve(
+			createDohResponse(
+				[{ name, type: 2 }],
+				[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+			),
+		);
+	}
+	if (type === 'MX' || type === '15') {
+		// ... existing MX mock
+```
+
+- [ ] **Step 2: Add NS responses to the "medium finding for lookalike with A but no MX" test mock**
+
+Same pattern — line 70 mock. Add NS records for `tst.com` and `tes.com`:
+
+```typescript
+if (name === 'tst.com' || name === 'tes.com') {
+	if (type === 'NS' || type === '2') {
+		return Promise.resolve(
+			createDohResponse(
+				[{ name, type: 2 }],
+				[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+			),
+		);
+	}
+	if (type === 'A' || type === '1') {
+		// ... existing A mock
+```
+
+- [ ] **Step 3: Add NS responses to null MX filtering tests**
+
+Both null MX tests (lines 137, 172) mock A/MX for `tst.com`, `tes.com`, `testt.com`. Add NS records for these domains in the same `if` blocks.
+
+- [ ] **Step 4: Add NS responses to wildcard DNS tests**
+
+The "keep dot-insertion permutations" test (line 278) mocks `te.st.com` with A records. Add NS record for `te.st.com`. The "non-dot-insertion" test (line 305) mocks `tst.com` — add NS record for it too.
+
+- [ ] **Step 5: Run existing tests to verify they still pass (before implementation)**
+
+Run: `npx vitest run test/check-lookalikes.spec.ts`
+Expected: All 11 tests PASS (NS mocks are harmless before Phase 1 is implemented — they're just extra responses that nothing queries yet)
+
+- [ ] **Step 6: Commit**
+
+```
+git add test/check-lookalikes.spec.ts
+git commit -m "test: add NS mocks to lookalike positive-case tests for two-phase probing"
+```
+
+---
+
+### Task 2: Write failing tests for lookalike Phase 1 behavior
+
+**Files:**
+- Modify: `test/check-lookalikes.spec.ts`
+
+- [ ] **Step 1: Write test — Phase 1 filters out variants without NS records**
+
+Add to the main `checkLookalikes` describe block. This test verifies that a domain with A + MX but NO NS records is filtered out by Phase 1:
+
+```typescript
+it('should not report lookalikes that have no NS records (Phase 1 filter)', async () => {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const { name, type } = parseDohQuery(input);
+
+		// tst.com has A and MX but NO NS records — should be filtered by Phase 1
+		if (name === 'tst.com') {
+			if (type === 'MX' || type === '15') {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type: 15 }],
+						[{ name, type: 15, TTL: 300, data: '10 mail.evil.com.' }],
+					),
+				);
+			}
+			if (type === 'A' || type === '1') {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type: 1 }],
+						[{ name, type: 1, TTL: 300, data: '1.2.3.4' }],
+					),
+				);
+			}
+		}
+		return Promise.resolve(createDohResponse([], []));
+	});
+	const result = await run('test.com');
+	// tst.com should NOT appear in findings — Phase 1 NS check eliminates it
+	const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+	expect(tstFinding).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Write test — Phase 1 passes variants with NS records to Phase 2**
+
+```typescript
+it('should report lookalikes that pass Phase 1 NS check', async () => {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const { name, type } = parseDohQuery(input);
+
+		if (name === 'tst.com') {
+			// Has NS → passes Phase 1
+			if (type === 'NS' || type === '2') {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type: 2 }],
+						[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+					),
+				);
+			}
+			if (type === 'A' || type === '1') {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type: 1 }],
+						[{ name, type: 1, TTL: 300, data: '1.2.3.4' }],
+					),
+				);
+			}
+		}
+		return Promise.resolve(createDohResponse([], []));
+	});
+	const result = await run('test.com');
+	const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+	expect(tstFinding).toBeDefined();
+	expect(tstFinding!.severity).toBe('medium');
+});
+```
+
+- [ ] **Step 3: Run tests to verify new tests fail**
+
+Run: `npx vitest run test/check-lookalikes.spec.ts`
+Expected: The Phase 1 filter test FAILS (tst.com is still detected because Phase 1 isn't implemented yet). The NS-passing test PASSES (NS mock is present, A mock returns data, existing code detects it).
+
+- [ ] **Step 4: Commit**
+
+```
+git add test/check-lookalikes.spec.ts
+git commit -m "test(red): add failing tests for lookalike Phase 1 NS filtering"
+```
+
+---
+
+### Task 3: Implement two-phase probing in check_lookalikes
+
+**Files:**
+- Modify: `src/tools/check-lookalikes.ts`
+
+- [ ] **Step 1: Add Phase 1 NS existence filter function**
+
+Add after the `detectWildcardParents` function (after line 98). This function takes a list of domains and returns only those with NS records, using lean DNS options:
+
+```typescript
+import type { QueryDnsOptions } from '../lib/dns-types';
+
+/** Lean DNS options for Phase 1 existence checks — fast, no retries, no secondary confirmation. */
+const PHASE1_DNS_OPTS: QueryDnsOptions = {
+	timeoutMs: 2000,
+	retries: 0,
+	skipSecondaryConfirmation: true,
+};
+
+/**
+ * Phase 1: Fast NS existence check for all domains in parallel.
+ * Returns only domains that have NS records (i.e., are registered).
+ */
+async function filterByNsExistence(domains: string[]): Promise<string[]> {
+	const results = await Promise.allSettled(
+		domains.map(async (domain) => {
+			const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
+			return { domain, hasNs: ns.length > 0 };
+		}),
+	);
+	return results
+		.filter((r): r is PromiseFulfilledResult<{ domain: string; hasNs: boolean }> =>
+			r.status === 'fulfilled' && r.value.hasNs)
+		.map((r) => r.value.domain);
+}
+```
+
+- [ ] **Step 2: Insert Phase 1 between wildcard filtering and adaptive batching**
+
+In `checkLookalikesCore`, replace the direct `probeWithAdaptiveBatching(permsToProbe)` call (line 209) with a Phase 1 filter:
+
+```typescript
+	// Phase 1: Fast NS existence check — filter out unregistered domains
+	const registeredPerms = await filterByNsExistence(permsToProbe);
+
+	if (registeredPerms.length === 0) {
+		findings.push(
+			createFinding(
+				'lookalikes',
+				'No active lookalike domains detected',
+				'info',
+				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations detected.`,
+			),
+		);
+		return buildCheckResult('lookalikes', findings);
+	}
+
+	// Phase 2: Detail probe only registered domains
+	const probeResults = await probeWithAdaptiveBatching(registeredPerms);
+```
+
+- [ ] **Step 3: Run tests to verify Phase 1 filter test passes**
+
+Run: `npx vitest run test/check-lookalikes.spec.ts`
+Expected: ALL tests PASS including the new Phase 1 filter test
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/tools/check-lookalikes.ts
+git commit -m "perf: add Phase 1 NS existence filter to check_lookalikes"
+```
+
+---
+
+### Task 4: Export Phase 1 DNS opts constant for test verification
+
+**Files:**
+- Modify: `src/tools/check-lookalikes.ts`
+- Modify: `test/check-lookalikes.spec.ts`
+
+- [ ] **Step 1: Export the PHASE1_DNS_OPTS constant**
+
+Change `const PHASE1_DNS_OPTS` to `export const PHASE1_DNS_OPTS` in check-lookalikes.ts.
+
+- [ ] **Step 2: Write test verifying Phase 1 DNS options**
+
+```typescript
+it('exports Phase 1 lean DNS options', async () => {
+	const mod = await import('../src/tools/check-lookalikes');
+	expect(mod.PHASE1_DNS_OPTS).toEqual({
+		timeoutMs: 2000,
+		retries: 0,
+		skipSecondaryConfirmation: true,
+	});
+});
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `npx vitest run test/check-lookalikes.spec.ts`
+Expected: ALL tests PASS
+
+- [ ] **Step 4: Commit**
+
+```
+git add src/tools/check-lookalikes.ts test/check-lookalikes.spec.ts
+git commit -m "test: verify Phase 1 lean DNS options are exported correctly"
+```
+
+---
+
+## Chunk 2: check_shadow_domains Two-Phase Probing
+
+### Task 5: Write failing tests for shadow domains Phase 1 behavior
+
+**Files:**
+- Modify: `test/check-shadow-domains.spec.ts`
+
+- [ ] **Step 1: Write test — Phase 1 filters variants without NS records**
+
+Add to the main `checkShadowDomains` describe block. A variant with MX but no NS should be classified as "unregistered" (info), not probed for detailed records:
+
+```typescript
+it('should classify variant as unregistered when it has no NS records (Phase 1 filter)', async () => {
+	const target = 'example.com';
+
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const q = parseDohQuery(input);
+		if (!q) return Promise.resolve(emptyResponse());
+		const { name, type } = q;
+
+		if (name === target && (type === 'MX' || type === '15')) {
+			return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+		}
+
+		// example.net has MX infrastructure but NO NS records — should not be detail-probed
+		if (name === 'example.net') {
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.shadow.com.']));
+			if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['1.2.3.4']));
+			if (type === 'TXT' || type === '16') return Promise.resolve(emptyResponse());
+		}
+		if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
+			return Promise.resolve(emptyResponse());
+		}
+
+		return Promise.resolve(emptyResponse());
+	});
+
+	const result = await run(target);
+	// Without NS, example.net should be classified as "unregistered" (info), not critical
+	const critical = result.findings.find(
+		(f) => f.severity === 'critical' && f.detail.includes('example.net'),
+	);
+	expect(critical).toBeUndefined();
+
+	const unregistered = result.findings.find(
+		(f) => f.severity === 'info' && f.detail.includes('example.net') && /unregistered/i.test(f.title),
+	);
+	expect(unregistered).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run test/check-shadow-domains.spec.ts -t "Phase 1 filter"`
+Expected: FAIL — currently example.net gets probed and classified as critical (it has MX, no SPF, no DMARC)
+
+- [ ] **Step 3: Commit**
+
+```
+git add test/check-shadow-domains.spec.ts
+git commit -m "test(red): add failing test for shadow domains Phase 1 NS filtering"
+```
+
+---
+
+### Task 6: Implement two-phase probing in check_shadow_domains
+
+**Files:**
+- Modify: `src/tools/check-shadow-domains.ts`
+
+- [ ] **Step 1: Add Phase 1 constants and NS existence filter**
+
+Add after the `BACKOFF_DELAY_MS` constant (line 22) and export `FAILURE_THRESHOLD`:
+
+```typescript
+export const FAILURE_THRESHOLD = 0;
+
+/** Lean DNS options for Phase 1 existence checks. */
+export const PHASE1_DNS_OPTS: QueryDnsOptions = {
+	timeoutMs: 2000,
+	retries: 0,
+	skipSecondaryConfirmation: true,
+};
+```
+
+Add the Phase 1 filter function (after `probeVariant`):
+
+```typescript
+/**
+ * Phase 1: Fast NS existence check for all variants in parallel.
+ * Returns a Map of variant → NS records for registered domains.
+ */
+async function filterByNsExistence(
+	variants: string[],
+	dnsOpts: QueryDnsOptions,
+): Promise<Map<string, string[]>> {
+	const registered = new Map<string, string[]>();
+	const results = await Promise.allSettled(
+		variants.map(async (variant) => {
+			const ns = await queryDnsRecords(variant, 'NS', { ...dnsOpts, ...PHASE1_DNS_OPTS });
+			return { variant, ns };
+		}),
+	);
+	for (const result of results) {
+		if (result.status === 'fulfilled' && result.value.ns.length > 0) {
+			registered.set(result.value.variant, result.value.ns);
+		}
+	}
+	return registered;
+}
+```
+
+- [ ] **Step 2: Modify probeVariant to accept pre-fetched NS records**
+
+Change the `probeVariant` signature and implementation to optionally skip the NS query:
+
+```typescript
+async function probeVariant(
+	variant: string,
+	dnsOpts: QueryDnsOptions,
+	prefetchedNs?: string[],
+): Promise<VariantProbeResult> {
+	const queries: Promise<unknown>[] = [
+		prefetchedNs ? Promise.resolve(prefetchedNs) : queryDnsRecords(variant, 'NS', dnsOpts),
+		queryDnsRecords(variant, 'A', dnsOpts),
+		queryMxRecords(variant, dnsOpts),
+		queryTxtRecords(variant, dnsOpts),
+		queryTxtRecords(`_dmarc.${variant}`, dnsOpts),
+	];
+
+	const [nsResult, aResult, mxResult, txtResult, dmarcResult] = await Promise.allSettled(queries);
+
+	const ns = nsResult.status === 'fulfilled' ? (nsResult.value as string[]) : [];
+	const hasA = aResult.status === 'fulfilled' && (aResult.value as string[]).length > 0;
+	const mx = mxResult.status === 'fulfilled'
+		? (mxResult.value as Array<{ exchange: string }>).map((r) => r.exchange)
+		: [];
+
+	const txtValues = txtResult.status === 'fulfilled' ? (txtResult.value as string[]) : [];
+	const hasSpf = txtValues.some((r) => r.toLowerCase().startsWith('v=spf1'));
+
+	let dmarcPolicy: string | null = null;
+	const dmarcValues = dmarcResult.status === 'fulfilled' ? (dmarcResult.value as string[]) : [];
+	const dmarcRecord = dmarcValues.find((r) => r.toLowerCase().startsWith('v=dmarc1'));
+	if (dmarcRecord) {
+		const pMatch = dmarcRecord.match(/;\s*p=([^;\s]+)/i);
+		dmarcPolicy = pMatch ? pMatch[1].toLowerCase() : 'none';
+	}
+
+	return { variant, ns, hasA, mx, hasSpf, dmarcPolicy };
+}
+```
+
+- [ ] **Step 3: Replace single-phase batching with two-phase in checkShadowDomains**
+
+In the `checkShadowDomains` function, replace the adaptive batching loop (lines 339-378) with:
+
+```typescript
+	// Phase 1: Fast NS existence check
+	const registeredVariants = await filterByNsExistence(variants, dnsOpts);
+
+	// Classify unregistered variants as info findings
+	for (const variant of variants) {
+		if (!registeredVariants.has(variant)) {
+			findings.push(
+				createFinding(
+					'shadow_domains',
+					'Brand variant unregistered',
+					'info',
+					`${variant} does not appear to be registered. Consider defensive registration to prevent brand abuse.`,
+					{ variant, ns: [], mx: [], hasSpf: false, dmarcPolicy: null },
+				),
+			);
+		}
+	}
+
+	// Phase 2: Detail probe only registered variants with NS passthrough
+	const registeredList = [...registeredVariants.entries()];
+	let batchSize = INITIAL_BATCH_SIZE;
+	let delayMs = 0;
+	const completedProbes: VariantProbeResult[] = [];
+	let timedOut = false;
+
+	for (let i = 0; i < registeredList.length; i += batchSize) {
+		if (Date.now() >= deadline) {
+			timedOut = true;
+			break;
+		}
+
+		if (delayMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+
+		const batch = registeredList.slice(i, i + batchSize);
+		const batchResults = await Promise.allSettled(
+			batch.map(([variant, ns]) => probeVariant(variant, dnsOpts, ns)),
+		);
+
+		let failures = 0;
+		for (const result of batchResults) {
+			if (result.status === 'fulfilled') {
+				completedProbes.push(result.value);
+			} else {
+				failures++;
+			}
+		}
+
+		if (failures > FAILURE_THRESHOLD) {
+			batchSize = Math.max(MIN_BATCH_SIZE, Math.floor(batchSize / 2));
+			delayMs = BACKOFF_DELAY_MS;
+		} else if (delayMs > 0) {
+			batchSize = Math.min(INITIAL_BATCH_SIZE, batchSize + 1);
+			delayMs = 0;
+		}
+	}
+
+	let variantsChecked = registeredList.length;
+```
+
+Keep the rest of the function (classify probes, detectSharedNs, timeout finding, sorting) unchanged.
+
+- [ ] **Step 4: Run all shadow domain tests**
+
+Run: `npx vitest run test/check-shadow-domains.spec.ts`
+Expected: ALL tests PASS including the new Phase 1 filter test
+
+- [ ] **Step 5: Commit**
+
+```
+git add src/tools/check-shadow-domains.ts
+git commit -m "perf: add Phase 1 NS existence filter to check_shadow_domains with NS passthrough"
+```
+
+---
+
+### Task 7: Export shadow domains Phase 1 constant and add verification test
+
+**Files:**
+- Modify: `test/check-shadow-domains.spec.ts`
+
+- [ ] **Step 1: Write test verifying Phase 1 DNS options and FAILURE_THRESHOLD export**
+
+```typescript
+it('exports Phase 1 lean DNS options and FAILURE_THRESHOLD', async () => {
+	const mod = await import('../src/tools/check-shadow-domains');
+	expect(mod.PHASE1_DNS_OPTS).toEqual({
+		timeoutMs: 2000,
+		retries: 0,
+		skipSecondaryConfirmation: true,
+	});
+	expect(mod.FAILURE_THRESHOLD).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `npx vitest run test/check-shadow-domains.spec.ts`
+Expected: ALL tests PASS
+
+- [ ] **Step 3: Commit**
+
+```
+git add test/check-shadow-domains.spec.ts
+git commit -m "test: verify shadow domains Phase 1 constants are exported"
+```
+
+---
+
+## Chunk 3: Full Verification and Deployment
+
+### Task 8: Run complete test suite and quality checks
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `npm test`
+Expected: All 907+ tests PASS, no regressions
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: Clean (no errors)
+
+- [ ] **Step 3: Run lint**
+
+Run: `npm run lint`
+Expected: Clean (no errors)
+
+- [ ] **Step 4: Verify no unintended changes**
+
+Run: `git diff --stat HEAD~N` (where N = number of commits in this branch)
+Expected: Only `src/tools/check-lookalikes.ts`, `src/tools/check-shadow-domains.ts`, `test/check-lookalikes.spec.ts`, `test/check-shadow-domains.spec.ts` modified
+
+---
+
+### Task 9: Create branch, push, and PR
+
+- [ ] **Step 1: Create feature branch (if not already on one)**
+
+```bash
+git checkout -b perf/two-phase-dns-probing
+```
+
+- [ ] **Step 2: Push and create PR**
+
+```bash
+git push -u origin perf/two-phase-dns-probing
+gh pr create --title "perf: two-phase DNS probing for check_lookalikes and check_shadow_domains" --body "..."
+```
+
+---
+
+### Task 10: Deploy and validate with production metrics
+
+- [ ] **Step 1: Merge and deploy**
+
+```bash
+gh pr merge --merge --admin
+git checkout main && git pull
+npm run deploy:private
+```
+
+- [ ] **Step 2: Run production validation**
+
+Call `check_lookalikes` and `check_shadow_domains` via MCP tools against real domains. Verify:
+- Responses complete in <5s (vs previous 7-20s)
+- Findings are correct (no false negatives for known registered variants)
+- No errors
+
+- [ ] **Step 3: Check analytics after 24 hours**
+
+Query Analytics Engine for `check_lookalikes` and `check_shadow_domains` P50/P95 and compare against pre-deploy baseline.

--- a/docs/superpowers/specs/2026-03-16-dns-probe-performance-design.md
+++ b/docs/superpowers/specs/2026-03-16-dns-probe-performance-design.md
@@ -1,0 +1,132 @@
+# Two-Phase DNS Probing for check_lookalikes and check_shadow_domains
+
+**Date:** 2026-03-16
+**Status:** Approved
+**Problem:** check_lookalikes P95=20s/72% fail rate, check_shadow_domains P95=14s/62% fail rate
+
+## Context
+
+Both tools make 70-130 DNS queries per invocation, probing every variant with full record types regardless of whether the domain exists. Production analytics (7 days ending 2026-03-16) show:
+
+- `check_lookalikes`: 18 calls, avg 6.8s, P50 4.5s (fail), P95 20s (timeout)
+- `check_shadow_domains`: 29 calls, avg 3.5s, P50 4.7s (fail), P95 14s
+
+Most variants (~90%) are unregistered. Querying MX, TXT, DMARC records for non-existent domains wastes time and triggers adaptive backoff (halved concurrency + 500ms delays per batch), compounding the latency.
+
+## Design
+
+### Two-Phase Probing
+
+Replace single-phase "query everything for every variant" with two phases:
+
+**Phase 1 — Existence (fast, lean):**
+- Query NS records for all variants with aggressive settings:
+  - `retries: 0` (no retry on timeout — non-existence is expected)
+  - `skipSecondaryConfirmation: true` (don't double-check empty results)
+  - `timeoutMs: 2000` (reduced from 3000 — if NS doesn't resolve in 2s, domain likely unregistered or unreachable)
+- High concurrency: all variants in a single `Promise.allSettled` (no adaptive batching — these are lightweight single-record queries that return NXDOMAIN quickly for non-existent domains)
+- Result: a set of "registered" variants (those with NS records)
+
+**Phase 2 — Detail (only registered variants):**
+- For variants that passed Phase 1, run the existing full probe:
+  - `check_lookalikes`: A + MX records
+  - `check_shadow_domains`: A + MX + TXT + DMARC records (NS result from Phase 1 is passed through — no re-query)
+- Normal DNS settings (3s timeout, 1 retry) — these are real domains worth accurate probing
+- Existing adaptive batching applies here with current thresholds
+
+### Why NS for Existence
+
+NS records are the most reliable existence indicator:
+- Every registered domain has NS records (delegated by the registrar)
+- A domain can have NS but no A/MX (parked, email-only, etc.)
+- NS queries are fast — authoritative nameservers are cached aggressively
+- Using A records would miss MX-only or NS-only domains
+
+### DNS Options
+
+`QueryDnsOptions` in `src/lib/dns-types.ts` already supports `timeoutMs`, `retries`, `skipSecondaryConfirmation`, and `confirmWithSecondaryOnEmpty`. No changes needed to the DNS transport layer.
+
+Both tools pass lean options for Phase 1:
+```typescript
+const leanDnsOpts: QueryDnsOptions = {
+  timeoutMs: 2000,
+  retries: 0,
+  skipSecondaryConfirmation: true,
+};
+```
+
+### check_lookalikes Changes
+
+**Before:** 50 permutations × (A + MX) = 100+ queries, adaptive batches of 10
+**After:**
+1. Wildcard detection runs first (unchanged — canary probes for dot-insertion parent domains)
+2. Phase 1: NS queries for all non-wildcard permutations in parallel (single `Promise.allSettled`, lean DNS) → ~300-500ms
+3. Phase 2: ~2-5 resolved domains × (A + MX) = 4-10 queries, adaptive batching with existing `FAILURE_THRESHOLD = 2`
+4. Total: ~55-65 queries (50 NS + canary probes + resolved × 2), ~1-2s typical
+
+Additional: skip secondary DNS confirmation entirely (was enabled, unlike scan_domain checks). Lookalike domains that don't resolve on Cloudflare DoH won't resolve for attackers either.
+
+**Wildcard detection ordering:** Wildcard canary probes (`_bv-wc-probe.<parent>` A queries) run before Phase 1, as they do today. Dot-insertion permutations under wildcard parents are filtered out before Phase 1 NS queries run. This prevents wildcard DNS from inflating the "registered" set.
+
+### check_shadow_domains Changes
+
+**Before:** 14-19 variants × 5 records = 71-96 queries, adaptive batches of 4 (backoff at >0 failures)
+**After:**
+1. Phase 1: 14-19 NS queries in parallel (single `Promise.allSettled`, lean DNS) → ~300-500ms
+2. Phase 2: ~2-4 registered variants × 4 records (A + MX + TXT + DMARC) = 8-16 queries. NS result from Phase 1 is passed into the detail probe to avoid re-querying.
+3. Total: ~25-35 queries, ~1-2s typical
+
+Extract a `FAILURE_THRESHOLD` constant (currently inline `failures > 0`) to match the `check_lookalikes` pattern.
+
+Note: `check_shadow_domains` already skips secondary confirmation. The main win is Phase 1 existence filtering.
+
+### Phase 1 NS Result Passthrough (check_shadow_domains)
+
+Phase 1 collects NS records for each variant. For `check_shadow_domains`, NS data is needed by `classifyVariant()` and `detectSharedNs()` in Phase 2. To avoid re-querying:
+- Phase 1 returns `Map<string, DnsRecord[]>` mapping variant → NS records
+- `probeVariant()` accepts optional pre-fetched NS records; if provided, it runs 4 queries (A, MX, TXT, DMARC) instead of 5
+- This saves 1 query per registered variant (small but free)
+
+For `check_lookalikes`, Phase 1 NS results are used only for filtering (exists/doesn't exist). Phase 2 queries A + MX independently — no passthrough needed since lookalikes don't use NS data in their analysis.
+
+## Query Budget Estimates
+
+| Scenario | check_lookalikes | check_shadow_domains |
+|---|---|---|
+| **Before (current)** | 100-130 queries | 71-96 queries |
+| **After (0 variants exist)** | 50 + ~5 canary = ~55 queries | 14-19 queries |
+| **After (3 variants exist)** | ~55 + 6 = ~61 queries | 14-19 + 12 = ~28-31 queries |
+| **After (5 variants exist)** | ~55 + 10 = ~65 queries | 14-19 + 20 = ~34-39 queries |
+
+## Expected Performance Impact
+
+| Metric | check_lookalikes before | after (est.) | check_shadow_domains before | after (est.) |
+|---|---|---|---|---|
+| P50 | 4.5s | **1-2s** | 4.7s | **1-2s** |
+| P95 | 20s | **4-6s** | 14s | **3-5s** |
+| Fail rate | 72% | **<20%** | 62% | **<20%** |
+| Queries/call | 100-130 | 55-65 | 71-96 | 25-35 |
+
+## Files Modified
+
+| File | Change |
+|---|---|
+| `src/tools/check-lookalikes.ts` | Two-phase probing: wildcard detection → Phase 1 NS filter → Phase 2 detail probe. Skip secondary DNS confirmation. |
+| `src/tools/check-shadow-domains.ts` | Two-phase probing: Phase 1 NS filter → Phase 2 detail probe with NS passthrough. Extract `FAILURE_THRESHOLD` constant. |
+| `test/check-lookalikes.spec.ts` | Add NS record mocks to all positive-case tests (Phase 1 filter requires NS). Add tests for two-phase behavior and lean DNS options. |
+| `test/check-shadow-domains.spec.ts` | Add NS record mocks to positive-case tests. Add tests for two-phase behavior and NS passthrough. |
+
+**No changes needed to:** `src/lib/dns-transport.ts`, `src/lib/dns-records.ts`, `src/lib/dns.ts`, `src/lib/dns-types.ts` — `QueryDnsOptions` already supports all required overrides.
+
+## Non-Goals
+
+- Reducing permutation count (50 is correct for thoroughness)
+- Changing the scoring/severity of findings
+- Changing the output format or MCP response structure
+- Adding these tools to scan_domain (they remain standalone due to query volume)
+
+## Risks
+
+- **False negatives on NS-only check**: A domain could theoretically be registered without NS records (broken delegation). This is extremely rare and such domains can't receive email or serve web content, so missing them has no security impact.
+- **Stale NXDOMAIN in edge cache**: Cloudflare's edge cache (`DOH_EDGE_CACHE_TTL = 300s`) may serve a cached NXDOMAIN for a recently registered domain. With `retries: 0`, there's no recovery path until the edge cache TTL expires. Risk is low (5-minute window) and affects only brand-new domain registrations. The 60-minute tool-level result cache means a subsequent call after edge cache refresh will pick up the domain.
+- **Wildcard false positives**: Wildcard DNS parents could cause Phase 1 to mark a non-existent subdomain as "registered" (NS records inherited from parent). Mitigation: wildcard detection runs before Phase 1, filtering these out.

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -8,6 +8,7 @@
  */
 
 import { queryDnsRecords } from '../lib/dns';
+import type { QueryDnsOptions } from '../lib/dns-types';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { generateLookalikes } from './lookalike-analysis';
@@ -23,6 +24,13 @@ const LOOKALIKE_TIMEOUT_MS = 20_000;
 
 /** Canary label used for wildcard detection on parent domains */
 export const WILDCARD_CANARY_LABEL = '_bv-wc-probe';
+
+/** Lean DNS options for Phase 1 existence checks — fast, no retries, no secondary confirmation. */
+export const PHASE1_DNS_OPTS: QueryDnsOptions = {
+	timeoutMs: 2000,
+	retries: 0,
+	skipSecondaryConfirmation: true,
+};
 
 interface LookalikeResult {
 	domain: string;
@@ -95,6 +103,25 @@ async function detectWildcardParents(parentDomains: string[]): Promise<Set<strin
 	});
 	await Promise.allSettled(probes);
 	return wildcardParents;
+}
+
+/**
+ * Phase 1: Fast NS existence check for all domains in parallel.
+ * Returns only domains that have NS records (i.e., are registered).
+ */
+async function filterByNsExistence(domains: string[]): Promise<string[]> {
+	const results = await Promise.allSettled(
+		domains.map(async (domain) => {
+			const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
+			return { domain, hasNs: ns.length > 0 };
+		}),
+	);
+	return results
+		.filter(
+			(r): r is PromiseFulfilledResult<{ domain: string; hasNs: boolean }> =>
+				r.status === 'fulfilled' && r.value.hasNs,
+		)
+		.map((r) => r.value.domain);
 }
 
 /**
@@ -205,8 +232,23 @@ async function checkLookalikesCore(domain: string): Promise<CheckResult> {
 
 	const permsToProbe = [...nonDotInsertionPerms, ...filteredDotInsertionPerms];
 
-	// Process with adaptive batching to avoid overwhelming the DoH endpoint
-	const probeResults = await probeWithAdaptiveBatching(permsToProbe);
+	// Phase 1: Fast NS existence check — filter out unregistered domains
+	const registeredPerms = await filterByNsExistence(permsToProbe);
+
+	if (registeredPerms.length === 0) {
+		findings.push(
+			createFinding(
+				'lookalikes',
+				'No active lookalike domains detected',
+				'info',
+				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations detected.`,
+			),
+		);
+		return buildCheckResult('lookalikes', findings);
+	}
+
+	// Phase 2: Detail probe only registered domains
+	const probeResults = await probeWithAdaptiveBatching(registeredPerms);
 	const results: LookalikeResult[] = [];
 	for (const result of probeResults) {
 		if (result.status === 'fulfilled') {

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -398,7 +398,7 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 	let batchSize = INITIAL_BATCH_SIZE;
 	let delayMs = 0;
 	const completedProbes: VariantProbeResult[] = [];
-	let variantsChecked = registeredList.length;
+	const variantsChecked = registeredList.length;
 	let timedOut = false;
 
 	for (let i = 0; i < registeredList.length; i += batchSize) {

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -21,6 +21,15 @@ const INITIAL_BATCH_SIZE = 4;
 const MIN_BATCH_SIZE = 2;
 const BACKOFF_DELAY_MS = 500;
 
+export const FAILURE_THRESHOLD = 0;
+
+/** Lean DNS options for Phase 1 existence checks. */
+export const PHASE1_DNS_OPTS: QueryDnsOptions = {
+	timeoutMs: 2000,
+	retries: 0,
+	skipSecondaryConfirmation: true,
+};
+
 /** Global ccTLD set always appended. */
 const GLOBAL_TLDS = [
 	'.com', '.net', '.org', '.io', '.ai', '.co',
@@ -93,9 +102,16 @@ export function generateVariants(brand: string, effectiveTld: string, primaryDom
  * Probe a single variant domain for NS, A, MX, SPF, and DMARC records.
  * All 5 DNS queries run in parallel with skipSecondaryConfirmation.
  */
-async function probeVariant(variant: string, dnsOpts: QueryDnsOptions): Promise<VariantProbeResult> {
+async function probeVariant(
+	variant: string,
+	dnsOpts: QueryDnsOptions,
+	prefetchedNs?: string[],
+): Promise<VariantProbeResult> {
+	const nsPromise: Promise<string[]> =
+		prefetchedNs !== undefined ? Promise.resolve(prefetchedNs) : queryDnsRecords(variant, 'NS', dnsOpts);
+
 	const [nsResult, aResult, mxResult, txtResult, dmarcResult] = await Promise.allSettled([
-		queryDnsRecords(variant, 'NS', dnsOpts),
+		nsPromise,
 		queryDnsRecords(variant, 'A', dnsOpts),
 		queryMxRecords(variant, dnsOpts),
 		queryTxtRecords(variant, dnsOpts),
@@ -120,6 +136,29 @@ async function probeVariant(variant: string, dnsOpts: QueryDnsOptions): Promise<
 	}
 
 	return { variant, ns, hasA, mx, hasSpf, dmarcPolicy };
+}
+
+/**
+ * Phase 1: Fast NS existence check for all variants in parallel.
+ * Returns a Map of variant -> NS records for registered domains.
+ */
+async function filterByNsExistence(
+	variants: string[],
+	dnsOpts: QueryDnsOptions,
+): Promise<Map<string, string[]>> {
+	const registered = new Map<string, string[]>();
+	const results = await Promise.allSettled(
+		variants.map(async (variant) => {
+			const ns = await queryDnsRecords(variant, 'NS', { ...dnsOpts, ...PHASE1_DNS_OPTS });
+			return { variant, ns };
+		}),
+	);
+	for (const result of results) {
+		if (result.status === 'fulfilled' && result.value.ns.length > 0) {
+			registered.set(result.value.variant, result.value.ns);
+		}
+	}
+	return registered;
 }
 
 /**
@@ -336,15 +375,33 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 		// Primary MX query failure — continue with empty set
 	}
 
-	// Adaptive batching
+	// Phase 1: Fast NS existence check — filter out unregistered variants
+	const registeredVariants = await filterByNsExistence(variants, dnsOpts);
+
+	// Classify unregistered variants immediately as info findings
+	for (const variant of variants) {
+		if (!registeredVariants.has(variant)) {
+			findings.push(
+				createFinding(
+					'shadow_domains',
+					'Brand variant unregistered',
+					'info',
+					`${variant} does not appear to be registered. Consider defensive registration to prevent brand abuse.`,
+					{ variant, ns: [], mx: [], hasSpf: false, dmarcPolicy: null },
+				),
+			);
+		}
+	}
+
+	// Phase 2: Detail probe only registered variants with NS passthrough
+	const registeredList = [...registeredVariants.entries()];
 	let batchSize = INITIAL_BATCH_SIZE;
 	let delayMs = 0;
 	const completedProbes: VariantProbeResult[] = [];
-	let variantsChecked = 0;
+	let variantsChecked = registeredList.length;
 	let timedOut = false;
 
-	for (let i = 0; i < variants.length; i += batchSize) {
-		// Cooperative timeout check between batches
+	for (let i = 0; i < registeredList.length; i += batchSize) {
 		if (Date.now() >= deadline) {
 			timedOut = true;
 			break;
@@ -354,8 +411,10 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 			await new Promise((resolve) => setTimeout(resolve, delayMs));
 		}
 
-		const batch = variants.slice(i, i + batchSize);
-		const batchResults = await Promise.allSettled(batch.map((v) => probeVariant(v, dnsOpts)));
+		const batch = registeredList.slice(i, i + batchSize);
+		const batchResults = await Promise.allSettled(
+			batch.map(([variant, ns]) => probeVariant(variant, dnsOpts, ns)),
+		);
 
 		let failures = 0;
 		for (const result of batchResults) {
@@ -365,10 +424,9 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 				failures++;
 			}
 		}
-		variantsChecked += batch.length;
 
 		// Adaptive batch sizing
-		if (failures > 0) {
+		if (failures > FAILURE_THRESHOLD) {
 			batchSize = Math.max(MIN_BATCH_SIZE, Math.floor(batchSize / 2));
 			delayMs = BACKOFF_DELAY_MS;
 		} else if (delayMs > 0) {

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -141,6 +141,67 @@ describe('checkLookalikes', () => {
 		expect(mod.BACKOFF_DELAY_MS).toBe(500);
 		expect(mod.FAILURE_THRESHOLD).toBe(2);
 	});
+
+	it('should not report lookalikes that have no NS records (Phase 1 filter)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+
+			// tst.com has A + MX but NO NS records — should be filtered by Phase 1
+			if (name === 'tst.com') {
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 15 }],
+							[{ name, type: 15, TTL: 300, data: '10 mail.tst.com.' }],
+						),
+					);
+				}
+				if (type === 'A' || type === '1') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 1 }],
+							[{ name, type: 1, TTL: 300, data: '1.2.3.4' }],
+						),
+					);
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeUndefined();
+	});
+
+	it('should report lookalikes that pass Phase 1 NS check', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+
+			// tst.com has NS + A records (no MX) — should pass Phase 1 and be reported as medium
+			if (name === 'tst.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
+				if (type === 'A' || type === '1') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 1 }],
+							[{ name, type: 1, TTL: 300, data: '1.2.3.4' }],
+						),
+					);
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeDefined();
+		expect(tstFinding!.severity).toBe('medium');
+	});
 });
 
 describe('checkLookalikes - null MX filtering', () => {

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -40,6 +40,14 @@ describe('checkLookalikes', () => {
 
 			// Make one specific lookalike have MX records
 			if (name === 'twst.com' || name === 'tst.com' || name === 'tes.com' || name === 'testt.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
 				if (type === 'MX' || type === '15') {
 					return Promise.resolve(
 						createDohResponse(
@@ -72,6 +80,14 @@ describe('checkLookalikes', () => {
 
 			// One lookalike with A record but no MX
 			if (name === 'tst.com' || name === 'tes.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
 				if (type === 'A' || type === '1') {
 					return Promise.resolve(
 						createDohResponse(
@@ -139,6 +155,14 @@ describe('checkLookalikes - null MX filtering', () => {
 
 			// Make a lookalike resolve with A + null MX
 			if (name === 'tst.com' || name === 'tes.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
 				if (type === 'MX' || type === '15') {
 					return Promise.resolve(
 						createDohResponse(
@@ -174,6 +198,14 @@ describe('checkLookalikes - null MX filtering', () => {
 			const { name, type } = parseDohQuery(input);
 
 			if (name === 'testt.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
 				// This domain has a real MX record → HIGH
 				if (type === 'MX' || type === '15') {
 					return Promise.resolve(
@@ -193,6 +225,14 @@ describe('checkLookalikes - null MX filtering', () => {
 				}
 			}
 			if (name === 'tes.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
 				// This domain has null MX → should NOT be flagged as HIGH
 				if (type === 'MX' || type === '15') {
 					return Promise.resolve(
@@ -281,6 +321,14 @@ describe('checkLookalikes - wildcard DNS filtering', () => {
 
 			// Only the actual dot-insertion domain resolves, canary does NOT
 			if (name === 'te.st.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
 				if (type === 'A' || type === '1') {
 					return Promise.resolve(
 						createDohResponse(
@@ -308,6 +356,14 @@ describe('checkLookalikes - wildcard DNS filtering', () => {
 
 			// tst.com (character omission, not dot-insertion) resolves
 			if (name === 'tst.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }],
+						),
+					);
+				}
 				if (type === 'A' || type === '1') {
 					return Promise.resolve(
 						createDohResponse(

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -142,6 +142,15 @@ describe('checkLookalikes', () => {
 		expect(mod.FAILURE_THRESHOLD).toBe(2);
 	});
 
+	it('exports Phase 1 lean DNS options', async () => {
+		const mod = await import('../src/tools/check-lookalikes');
+		expect(mod.PHASE1_DNS_OPTS).toEqual({
+			timeoutMs: 2000,
+			retries: 0,
+			skipSecondaryConfirmation: true,
+		});
+	});
+
 	it('should not report lookalikes that have no NS records (Phase 1 filter)', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -597,3 +597,15 @@ describe('checkShadowDomains — classification edge cases', () => {
 		expect(divergent).toBeUndefined();
 	});
 });
+
+describe('checkShadowDomains — Phase 1 constants', () => {
+	it('exports Phase 1 lean DNS options and FAILURE_THRESHOLD', async () => {
+		const mod = await import('../src/tools/check-shadow-domains');
+		expect(mod.PHASE1_DNS_OPTS).toEqual({
+			timeoutMs: 2000,
+			retries: 0,
+			skipSecondaryConfirmation: true,
+		});
+		expect(mod.FAILURE_THRESHOLD).toBe(0);
+	});
+});

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -347,6 +347,44 @@ describe('checkShadowDomains', () => {
 		);
 		expect(sharedNsFinding).toBeDefined();
 	});
+
+	it('should classify variant as unregistered when it has no NS records (Phase 1 filter)', async () => {
+		const target = 'example.com';
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+
+			if (name === target && (type === 'MX' || type === '15')) {
+				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			}
+
+			// example.net has MX but NO NS records — should not be detail-probed
+			if (name === 'example.net') {
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.shadow.com.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['1.2.3.4']));
+				if (type === 'TXT' || type === '16') return Promise.resolve(emptyResponse());
+			}
+			if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
+				return Promise.resolve(emptyResponse());
+			}
+
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		// Without NS, example.net should NOT be critical
+		const critical = result.findings.find(
+			(f) => f.severity === 'critical' && f.detail.includes('example.net'),
+		);
+		expect(critical).toBeUndefined();
+
+		const unregistered = result.findings.find(
+			(f) => f.severity === 'info' && f.detail.includes('example.net') && /unregistered/i.test(f.title),
+		);
+		expect(unregistered).toBeDefined();
+	});
 });
 
 describe('generateVariants', () => {


### PR DESCRIPTION
## Summary

- **check_lookalikes** (P95=20s, 72% fail rate): Added Phase 1 NS existence filter before detail probing. Queries reduced from 100-130 to ~55-65 per invocation.
- **check_shadow_domains** (P95=14s, 62% fail rate): Added Phase 1 NS existence filter with NS result passthrough. Queries reduced from 71-96 to ~25-35 per invocation.
- Both tools now use lean DNS options for Phase 1 (2s timeout, 0 retries, no secondary confirmation) — most non-existent domains return NXDOMAIN in <300ms
- Expected P95 improvement: 20s → 4-6s (lookalikes), 14s → 3-5s (shadow domains)

## How it works

**Phase 1 (fast):** Query NS records for all variants in a single parallel batch with aggressive settings. ~90% of variants are unregistered and return NXDOMAIN quickly.

**Phase 2 (accurate):** Only variants that passed Phase 1 (have NS records = are registered) proceed to full detail probing (A, MX, TXT, DMARC). Normal DNS settings apply here.

## Test plan

- [x] 912/912 tests pass, typecheck clean, lint clean
- [x] NS mocks added to all existing positive-case tests (required for Phase 1 filter)
- [x] New tests verify Phase 1 filters out domains without NS records
- [x] New tests verify Phase 1 constants are exported correctly
- [ ] Deploy and validate P95 latency improvement via Analytics Engine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented two-phase DNS probing for lookalike and shadow domain detection tools, improving performance by filtering unregistered domains before detailed analysis.

* **Performance Improvements**
  * Reduced query overhead and timeout occurrences through optimized DNS probing strategy.

* **Tests**
  * Added comprehensive test coverage for two-phase probing workflow and phase-specific configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->