### PR TITLE
fix: downgrade SPF ~all finding when DMARC enforcement is active

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4766,7 +4766,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.3.6"

--- a/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
@@ -66,6 +66,15 @@ describe('checkSPF', () => {
 		expect(result.findings.some((f) => f.title === 'SPF soft fail (~all) with DMARC enforcement' && f.severity === 'info')).toBe(true);
 	});
 
+	it('downgrades ~all to info when DMARC p=reject with pct parameter', async () => {
+		const queryDNS = createMockDNS({
+			'example.com': ['v=spf1 include:_spf.google.com ~all'],
+			'_dmarc.example.com': ['v=DMARC1; p=reject; pct=50'],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings.some((f) => f.title === 'SPF soft fail (~all) with DMARC enforcement' && f.severity === 'info')).toBe(true);
+	});
+
 	it('flags ~all as low when DMARC record is completely absent', async () => {
 		const queryDNS = createMockDNS({
 			'example.com': ['v=spf1 include:_spf.google.com ~all'],

--- a/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
@@ -39,13 +39,40 @@ describe('checkSPF', () => {
 		expect(result.findings.find((f) => f.title.includes('Permissive SPF'))?.severity).toBe('critical');
 	});
 
-	it('flags ~all as low', async () => {
+	it('flags ~all as low when DMARC is not enforcing', async () => {
+		const queryDNS = createMockDNS({
+			'example.com': ['v=spf1 include:_spf.google.com ~all'],
+			'_dmarc.example.com': ['v=DMARC1; p=none'],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings.some((f) => f.title === 'SPF soft fail (~all)' && f.severity === 'low')).toBe(true);
+	});
+
+	it('downgrades ~all to info when DMARC p=reject is active', async () => {
 		const queryDNS = createMockDNS({
 			'example.com': ['v=spf1 include:_spf.google.com ~all'],
 			'_dmarc.example.com': ['v=DMARC1; p=reject; aspf=s; adkim=s'],
 		});
 		const result = await checkSPF('example.com', queryDNS);
-		expect(result.findings.some((f) => f.title === 'SPF soft fail (~all)')).toBe(true);
+		expect(result.findings.some((f) => f.title === 'SPF soft fail (~all) with DMARC enforcement' && f.severity === 'info')).toBe(true);
+	});
+
+	it('downgrades ~all to info when DMARC p=quarantine is active', async () => {
+		const queryDNS = createMockDNS({
+			'example.com': ['v=spf1 include:_spf.google.com ~all'],
+			'_dmarc.example.com': ['v=DMARC1; p=quarantine'],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings.some((f) => f.title === 'SPF soft fail (~all) with DMARC enforcement' && f.severity === 'info')).toBe(true);
+	});
+
+	it('flags ~all as low when DMARC record is completely absent', async () => {
+		const queryDNS = createMockDNS({
+			'example.com': ['v=spf1 include:_spf.google.com ~all'],
+			'_dmarc.example.com': [],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings.some((f) => f.title === 'SPF soft fail (~all)' && f.severity === 'low')).toBe(true);
 	});
 
 	it('returns info for properly configured SPF with -all', async () => {

--- a/packages/dns-checks/src/checks/check-spf.ts
+++ b/packages/dns-checks/src/checks/check-spf.ts
@@ -106,6 +106,11 @@ export async function checkSPF(
 		return buildCheckResult('spf', findings);
 	}
 
+	// Pre-fetch DMARC context once — reused by both ~all severity and trust surface analysis
+	const trustSurfaceContext = await getTrustSurfaceDmarcContext(domain, queryDNS, timeout);
+	const dmarcEnforcing =
+		trustSurfaceContext.dmarcPolicy === 'reject' || trustSurfaceContext.dmarcPolicy === 'quarantine';
+
 	if (spfRecords.length > 1) {
 		findings.push(
 			createFinding(
@@ -148,15 +153,30 @@ export async function checkSPF(
 				),
 			);
 		} else if (qualifier.toLowerCase() === '~all') {
-			findings.push(
-				createFinding(
-					'spf',
-					'SPF soft fail (~all)',
-					'low',
-					`SPF record uses "~all" (soft fail). Consider upgrading to "-all" (hard fail) for stricter enforcement once you've verified all legitimate senders are included.`,
-					spfMetadata,
-				),
-			);
+			// ~all is the recommended setting when DMARC enforcement is active.
+			// -all causes rejection at SMTP level before DMARC can verify DKIM.
+			// See RFC 7489 §10.1, https://www.mailhardener.com/kb/spf
+			if (dmarcEnforcing) {
+				findings.push(
+					createFinding(
+						'spf',
+						'SPF soft fail (~all) with DMARC enforcement',
+						'info',
+						`SPF record uses "~all" (soft fail) which is the recommended setting when DMARC enforcement is active. The DMARC policy ensures unauthorized mail is rejected after DKIM verification, while ~all avoids premature rejection at the SMTP level.`,
+						spfMetadata,
+					),
+				);
+			} else {
+				findings.push(
+					createFinding(
+						'spf',
+						'SPF soft fail (~all)',
+						'low',
+						`SPF record uses "~all" (soft fail). Consider upgrading to "-all" (hard fail) for stricter enforcement, or deploy DMARC with p=reject to handle authentication via DKIM alignment.`,
+						spfMetadata,
+					),
+				);
+			}
 		}
 		// -all is the recommended setting, no finding needed
 	} else if (!hasRedirect) {
@@ -224,7 +244,6 @@ export async function checkSPF(
 	}
 
 	// Trust surface analysis — flag multi-tenant SaaS platform includes
-	const trustSurfaceContext = await getTrustSurfaceDmarcContext(domain, queryDNS, timeout);
 	const trustSurfaceFindings = analyzeTrustSurface(spf, trustSurfaceContext);
 	findings.push(...trustSurfaceFindings);
 

--- a/packages/dns-checks/src/checks/check-spf.ts
+++ b/packages/dns-checks/src/checks/check-spf.ts
@@ -108,8 +108,8 @@ export async function checkSPF(
 
 	// Pre-fetch DMARC context once — reused by both ~all severity and trust surface analysis
 	const trustSurfaceContext = await getTrustSurfaceDmarcContext(domain, queryDNS, timeout);
-	const dmarcEnforcing =
-		trustSurfaceContext.dmarcPolicy === 'reject' || trustSurfaceContext.dmarcPolicy === 'quarantine';
+	const dmarcPolicyToken = trustSurfaceContext.dmarcPolicy?.split(';')[0].trim();
+	const dmarcEnforcing = dmarcPolicyToken === 'reject' || dmarcPolicyToken === 'quarantine';
 
 	if (spfRecords.length > 1) {
 		findings.push(


### PR DESCRIPTION
## Summary

When a domain has DMARC with `p=reject` or `p=quarantine`, SPF `~all` (softfail) is the recommended setting per RFC 7489 and industry best practices. Using `-all` (hardfail) can cause message rejection at SMTP level **before** DMARC can evaluate DKIM, breaking legitimate forwarded/relayed mail.

This PR:
- Downgrades the SPF `~all` finding from `low` to `info` when DMARC enforcement is detected
- Keeps `low` severity when DMARC is absent or `p=none`
- Consolidates duplicate DMARC DNS lookups (was queried twice, now once after the no-SPF early return)

### References

- **RFC 7489 §10.1**: *"a '-' prefix on a sender's SPF mechanism, such as '-all', could cause that rejection to go into effect early in handling, causing message rejection before any DMARC processing takes place"*
- **RFC 7489 §6.7**: *"DMARC-compliant Mail Receivers typically disregard any mail-handling directive discovered as part of [SPF]"*
- **RFC 7208 §8.5**: softfail — *"Receiving software SHOULD NOT reject the message based solely on this result"*
- **Google Workspace docs**: *"Google recommends you use ~all in your SPF record"*
- **M3AAWG Best Practices** (Sept 2020): *"Start with a softfail option for non-matching senders (~all)"*
- **Valimail**: *"Since DMARC is calling the shots anyway, there's no benefit to using -all"*
- **Mailhardener**: *"SPF hard fail, softfail and even neutral have the exact same effect when using DMARC"* — https://www.mailhardener.com/kb/spf

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Security fix
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / tooling

## Security impact

None. This change only affects the severity classification of an informational finding. No auth, validation, rate limiting, or sanitization changes.

## Test plan

- [x] Unit tests added / updated (4 new cases: DMARC none/reject/quarantine/absent)
- [x] Manual testing performed
- [x] `npm test` passes
- [x] `npm run typecheck` passes

## Checklist

- [x] Changes follow existing code conventions
- [x] No secrets, credentials, or internal references included
- [x] Error messages follow the safe-prefix convention (see CLAUDE.md)
- [ ] New tool? Followed the "Adding a New Tool" checklist in CLAUDE.md — N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SPF soft-fail (tilde ~all) findings now reflect DMARC context: when DMARC enforcement is active the finding is marked informational and guidance updates accordingly; when DMARC is not enforcing or absent the finding remains low severity with advice to tighten SPF or deploy DMARC. Tests updated to cover these DMARC-aware scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->