### PR TITLE
fix: explicit Finding type annotations for CI typecheck

### DIFF
--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Build workspace packages
+        run: npm run build --workspace=packages/dns-checks
+
       - name: Internal dependency policy
         run: npm run validate:internal-deps
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npm run build --workspace=packages/dns-checks
       - run: npx tsc --noEmit
       - run: npm run lint
       - run: npm test

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -202,7 +202,7 @@ export async function handleToolsCall(
 	const args = params.arguments ?? {};
 	const startTime = Date.now();
 	let domain: string | undefined;
-	let logResult: string | undefined;
+	let logResult = 'unknown';
 	let logDetails: unknown;
 	try {
 		const validatedArgs = validateToolArgs(name, args);

--- a/src/tools/compare-baseline.ts
+++ b/src/tools/compare-baseline.ts
@@ -6,7 +6,7 @@
  */
 
 import type { OutputFormat } from '../handlers/tool-args';
-import type { CheckCategory } from '../lib/scoring';
+import type { CheckCategory, Finding } from '../lib/scoring';
 import type { ScanDomainResult } from './scan-domain';
 
 const GRADE_ORDER = ['A+', 'A', 'B+', 'B', 'C+', 'C', 'D+', 'D', 'E', 'F'] as const;
@@ -67,7 +67,7 @@ function dmarcEnforced(scan: ScanDomainResult): boolean {
 	const dmarcCheck = scan.checks.find((value) => value.category === 'dmarc');
 	if (!dmarcCheck) return false;
 
-	const hasNonePolicyFinding = dmarcCheck.findings.some((finding) => {
+	const hasNonePolicyFinding = dmarcCheck.findings.some((finding: Finding) => {
 		const text = `${finding.title} ${finding.detail}`.toLowerCase();
 		return finding.severity !== 'info' && (text.includes('p=none') || text.includes('policy is none'));
 	});
@@ -132,7 +132,7 @@ export function compareBaseline(scan: ScanDomainResult, baseline: PolicyBaseline
 
 	if (baseline.max_critical_findings !== undefined) {
 		checkedRules++;
-		const criticalCount = scan.score.findings.filter((finding) => finding.severity === 'critical').length;
+		const criticalCount = scan.score.findings.filter((finding: Finding) => finding.severity === 'critical').length;
 		if (criticalCount > baseline.max_critical_findings) {
 			violations.push({
 				rule: 'max_critical_findings',
@@ -145,7 +145,7 @@ export function compareBaseline(scan: ScanDomainResult, baseline: PolicyBaseline
 
 	if (baseline.max_high_findings !== undefined) {
 		checkedRules++;
-		const highCount = scan.score.findings.filter((finding) => finding.severity === 'high').length;
+		const highCount = scan.score.findings.filter((finding: Finding) => finding.severity === 'high').length;
 		if (highCount > baseline.max_high_findings) {
 			violations.push({
 				rule: 'max_high_findings',

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-import { type CheckCategory, type CheckResult, buildCheckResult, createFinding } from '../../lib/scoring';
+import { type CheckCategory, type CheckResult, type Finding, buildCheckResult, createFinding } from '../../lib/scoring';
 import { queryTxtRecords } from '../../lib/dns';
 import { detectProviderMatches, detectProviderMatchesBySelectors, loadProviderSignatures } from '../../lib/provider-signatures';
 import { parseDmarcTags } from '../check-dmarc';
@@ -28,7 +28,7 @@ export async function applyScanPostProcessing(
 ): Promise<CheckResult[]> {
 	let results = checkResults;
 	const mxResult = results.find((result) => result.category === 'mx');
-	const hasNoMx = mxResult ? mxResult.findings.some((finding) => finding.title === 'No MX records found') : false;
+	const hasNoMx = mxResult ? mxResult.findings.some((finding: Finding) => finding.title === 'No MX records found') : false;
 
 	if (hasNoMx) {
 		const apexCovers = await checkApexDmarcPolicy(domain);
@@ -40,7 +40,7 @@ export async function applyScanPostProcessing(
 
 	// Detect no-send SPF policy (v=spf1 -all with no authorizing mechanisms)
 	const spfResult = results.find((result) => result.category === 'spf');
-	const hasNoSendPolicy = spfResult?.findings.some((f) => f.metadata?.noSendPolicy === true) ?? false;
+	const hasNoSendPolicy = spfResult?.findings.some((f: Finding) => f.metadata?.noSendPolicy === true) ?? false;
 	if (hasNoSendPolicy && !hasNoMx) {
 		results = adjustForNoSendDomain(results);
 	}
@@ -196,7 +196,7 @@ function isMissingRecordFinding(finding: { title: string; detail: string }): boo
 function clarifyMtaStsForMailDomain(domain: string, results: CheckResult[]): CheckResult[] {
 	return results.map((result) => {
 		if (result.category !== 'mta_sts') return result;
-		const adjusted = result.findings.map((finding) => {
+		const adjusted = result.findings.map((finding: Finding) => {
 			if (finding.title === 'No MTA-STS or TLS-RPT records found') {
 				return {
 					...finding,
@@ -213,7 +213,7 @@ function adjustForNonMailDomain(results: CheckResult[], apexDmarcCovers: boolean
 	const emailCategories: CheckCategory[] = ['spf', 'dmarc', 'dkim', 'mta_sts'];
 	return results.map((result) => {
 		if (!emailCategories.includes(result.category)) return result;
-		const adjusted = result.findings.map((finding) => {
+		const adjusted = result.findings.map((finding: Finding) => {
 			if ((finding.severity === 'critical' || finding.severity === 'high') && isMissingRecordFinding(finding)) {
 				const reason = apexDmarcCovers
 					? 'expected — no MX records and parent domain DMARC policy covers subdomains'
@@ -229,7 +229,7 @@ function adjustForNonMailDomain(results: CheckResult[], apexDmarcCovers: boolean
 function adjustBimiForNonMailDomain(results: CheckResult[]): CheckResult[] {
 	return results.map((result) => {
 		if (result.category !== 'bimi') return result;
-		const adjusted = result.findings.map((finding) => {
+		const adjusted = result.findings.map((finding: Finding) => {
 			if (finding.title === 'No BIMI record found' && finding.detail.includes('eligible for BIMI')) {
 				const bimiDomain = finding.detail.match(/at (default\._bimi\.\S+)/)?.[1] ?? `default._bimi.unknown`;
 				return {
@@ -247,7 +247,7 @@ function adjustForNoSendDomain(results: CheckResult[]): CheckResult[] {
 	const noSendCategories: CheckCategory[] = ['dkim', 'mta_sts', 'bimi'];
 	return results.map((result) => {
 		if (!noSendCategories.includes(result.category)) return result;
-		const adjusted = result.findings.map((finding) => {
+		const adjusted = result.findings.map((finding: Finding) => {
 			if ((finding.severity === 'critical' || finding.severity === 'high') && isMissingRecordFinding(finding)) {
 				return {
 					...finding,


### PR DESCRIPTION
## Summary
- Adds explicit `Finding` type annotations to `.filter()`/`.some()`/`.map()` callbacks in `compare-baseline.ts` (3 sites) and `post-processing.ts` (6 sites)
- CI lacks `worker-configuration.d.ts` (wrangler-generated, gitignored), causing `Finding` to be unresolvable in callback parameters
- Fixes the `build-and-test` and `contract` workflow failures on main

## Test plan
- [ ] CI `build-and-test` passes (typecheck + tests)
- [ ] CI `contract` passes (typecheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety in the codebase by adding explicit type annotations to enhance code reliability and maintainability. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->