### PR TITLE
fix: resolve Claude Desktop MCP tool errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -662,9 +662,18 @@ app.delete('/mcp', async (c) => {
 
 app.route('/internal', internalRoutes);
 
+// OAuth well-known endpoints — return valid JSON so mcp-remote doesn't crash
+// parsing plain-text 404 responses during OAuth discovery probes.
+app.get('/.well-known/oauth-authorization-server', (c) => {
+	return c.json({ error: 'not_supported', error_description: 'This server does not support OAuth' }, 404);
+});
+app.get('/.well-known/oauth-protected-resource', (c) => {
+	return c.json({ error: 'not_supported', error_description: 'This server does not support OAuth' }, 404);
+});
+
 app.all('*', (c) => {
-	// Plain text — JSON `{"error":"..."}` is misinterpreted as an OAuth error by mcp-remote,
-	// which breaks Claude Desktop connections to servers that don't implement OAuth.
+	// Plain text — avoids mcp-remote misinterpreting JSON as an OAuth error.
+	// OAuth well-known paths are handled explicitly above.
 	return c.text('Not found', 404);
 });
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -56,7 +56,7 @@ export interface AnalyticsClient {
 		remaining: number;
 	} & AnalyticsContext): void;
 	emitSessionEvent(event: {
-		action: 'created' | 'terminated';
+		action: 'created' | 'terminated' | 'revived';
 	} & AnalyticsContext): void;
 }
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -147,8 +147,14 @@ export async function createSession(kv?: KVNamespace): Promise<string> {
  * Unlike `createSession()` which generates a new ID, this preserves the
  * existing session ID so clients that cannot learn a new ID (e.g. mcp-remote)
  * can continue using their cached session ID after expiry recovery.
+ *
+ * Security: relies on session IDs being 256-bit cryptographic random values
+ * (validated via `isValidSessionIdFormat`), making brute-force infeasible.
+ * The session-create rate limit (30/min) also applies to revival attempts.
  */
 export async function reviveSession(id: string, kv?: KVNamespace): Promise<boolean> {
+	if (!isValidSessionIdFormat(id)) return false;
+
 	const now = Date.now();
 	const record: SessionRecord = { createdAt: now, lastAccessedAt: now };
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -141,6 +141,30 @@ export async function createSession(kv?: KVNamespace): Promise<string> {
 	return id;
 }
 
+/**
+ * Revive an expired session by re-creating its record with the same ID.
+ *
+ * Unlike `createSession()` which generates a new ID, this preserves the
+ * existing session ID so clients that cannot learn a new ID (e.g. mcp-remote)
+ * can continue using their cached session ID after expiry recovery.
+ */
+export async function reviveSession(id: string, kv?: KVNamespace): Promise<boolean> {
+	const now = Date.now();
+	const record: SessionRecord = { createdAt: now, lastAccessedAt: now };
+
+	createSessionInMemory(id);
+
+	if (kv) {
+		try {
+			await createSessionKVRecord(id, kv, record);
+		} catch {
+			logError('[session] KV revive failed, in-memory fallback active', { category: 'session' });
+		}
+	}
+
+	return true;
+}
+
 /** Check whether a session ID exists in the active sessions store */
 export async function validateSession(id: string, kv?: KVNamespace): Promise<boolean> {
 	// Reject malformed session IDs before any storage lookup

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -358,19 +358,21 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 
 				if (recoveryAllowed) {
 					sessionRevived = await reviveSession(options.sessionId!, options.sessionStore);
-					options.analytics?.emitSessionEvent({
-						action: 'revived',
-						country: options.country,
-						clientType: options.clientType as import('../lib/client-detection').McpClientType,
-						authTier: options.authTier,
-					});
-					logEvent({
-						timestamp: new Date().toISOString(),
-						category: 'session',
-						result: 'recovered',
-						ip: options.ip,
-						details: { method, clientType: options.clientType },
-					});
+					if (sessionRevived) {
+						options.analytics?.emitSessionEvent({
+							action: 'revived',
+							country: options.country,
+							clientType: options.clientType as import('../lib/client-detection').McpClientType,
+							authTier: options.authTier,
+						});
+						logEvent({
+							timestamp: new Date().toISOString(),
+							category: 'session',
+							result: 'recovered',
+							ip: options.ip,
+							details: { method, clientType: options.clientType },
+						});
+					}
 				}
 			}
 

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -9,7 +9,7 @@ import { normalizeToolName } from '../handlers/tool-args';
 import { acceptsSSE } from '../lib/sse';
 import { dispatchMcpMethod } from './dispatch';
 import { validateJsonRpcRequest } from './request';
-import { checkSessionCreateRateLimit, createSession } from '../lib/session';
+import { checkSessionCreateRateLimit, reviveSession } from '../lib/session';
 import type { JsonRpcRequest } from '../lib/json-rpc';
 import type { AnalyticsClient } from '../lib/analytics';
 
@@ -333,7 +333,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 		}
 	}
 
-	let recoveredSessionId: string | undefined;
+	let sessionRevived = false;
 
 	if (options.validateSession && method !== 'initialize' && !method.startsWith('notifications/')) {
 		const sessionError = await validateSessionRequest(
@@ -357,29 +357,37 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 				}
 
 				if (recoveryAllowed) {
-					recoveredSessionId = await createSession(options.sessionStore);
+					sessionRevived = await reviveSession(options.sessionId!, options.sessionStore);
 					options.analytics?.emitSessionEvent({
 						action: 'created',
 						country: options.country,
 						clientType: options.clientType as import('../lib/client-detection').McpClientType,
 						authTier: options.authTier,
 					});
+					logEvent({
+						timestamp: new Date().toISOString(),
+						category: 'session',
+						result: 'recovered',
+						ip: options.ip,
+						details: { method, clientType: options.clientType },
+					});
 				}
 			}
 
-			if (recoveredSessionId) {
-				// Continue request execution with a fresh session to prevent stale-session loops
-				// in clients that do not auto-reinitialize after a 404 session response.
+			if (sessionRevived) {
+				// Continue request execution with the revived session to prevent stale-session
+				// loops in clients (e.g. mcp-remote) that do not learn new session IDs from
+				// response headers and cannot auto-reinitialize after a 404.
 			} else {
-			emitRequestAnalytics(options, method, 'error', true);
-			return {
-				kind: 'response',
-				payload: sessionError.payload,
-				headers: {},
-				httpStatus: sessionError.status,
-				useErrorEnvelope: true,
-				eventId,
-			};
+				emitRequestAnalytics(options, method, 'error', true);
+				return {
+					kind: 'response',
+					payload: sessionError.payload,
+					headers: {},
+					httpStatus: sessionError.status,
+					useErrorEnvelope: true,
+					eventId,
+				};
 			}
 		}
 	}
@@ -448,7 +456,6 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			payload: null,
 			headers: {
 				...rateHeaders,
-				...(recoveredSessionId ? { 'mcp-session-id': recoveredSessionId } : {}),
 			},
 			httpStatus: 200,
 			useErrorEnvelope: false,
@@ -500,9 +507,6 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 		}
 
 		const headers: Record<string, string> = {};
-		if (recoveredSessionId) {
-			headers['mcp-session-id'] = recoveredSessionId;
-		}
 		if (dispatchResult.newSessionId) {
 			headers['mcp-session-id'] = dispatchResult.newSessionId;
 		}

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -359,7 +359,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 				if (recoveryAllowed) {
 					sessionRevived = await reviveSession(options.sessionId!, options.sessionStore);
 					options.analytics?.emitSessionEvent({
-						action: 'created',
+						action: 'revived',
 						country: options.country,
 						clientType: options.clientType as import('../lib/client-detection').McpClientType,
 						authTier: options.authTier,

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1401,7 +1401,7 @@ describe('DNS Security MCP Server', () => {
 			expect(response.status).toBe(404);
 		});
 
-		it('auto-recovers expired sessions for tools/call and returns a fresh session header', async () => {
+		it('auto-recovers expired sessions for tools/call by reviving the same session ID', async () => {
 			const sessionId = await initSession();
 			await terminateSession(sessionId);
 
@@ -1426,9 +1426,10 @@ describe('DNS Security MCP Server', () => {
 			await waitOnExecutionContext(toolCtx);
 
 			expect(toolResponse.status).toBe(200);
+			// No new session ID header — the original session ID is revived in-place
+			// so clients (e.g. mcp-remote) that ignore response headers keep working
 			const recoveredSessionId = toolResponse.headers.get('mcp-session-id');
-			expect(recoveredSessionId).toBeTruthy();
-			expect(recoveredSessionId).not.toBe(sessionId);
+			expect(recoveredSessionId).toBeNull();
 
 			const toolBody = (await toolResponse.json()) as {
 				result?: { content?: Array<{ type: string; text: string }> };
@@ -1437,11 +1438,12 @@ describe('DNS Security MCP Server', () => {
 			expect(toolBody.error).toBeUndefined();
 			expect(Array.isArray(toolBody.result?.content)).toBe(true);
 
+			// Follow-up request with the SAME original session ID succeeds
 			const followupRequest = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
 				method: 'POST',
 				headers: {
 					'Content-Type': 'application/json',
-					'Mcp-Session-Id': recoveredSessionId!,
+					'Mcp-Session-Id': sessionId,
 				},
 				body: JSON.stringify({ jsonrpc: '2.0', id: 102, method: 'tools/list', params: {} }),
 			});
@@ -1598,6 +1600,41 @@ describe('DNS Security MCP Server', () => {
 			const response = await worker.fetch(request, env, ctx);
 			await waitOnExecutionContext(ctx);
 			expect(response.status).toBe(404);
+		});
+	});
+
+	describe('OAuth well-known endpoints', () => {
+		it('returns valid JSON 404 for /.well-known/oauth-authorization-server', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/.well-known/oauth-authorization-server');
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(404);
+			expect(response.headers.get('content-type')).toContain('application/json');
+			const body = (await response.json()) as { error: string; error_description: string };
+			expect(body.error).toBe('not_supported');
+		});
+
+		it('returns valid JSON 404 for /.well-known/oauth-protected-resource', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/.well-known/oauth-protected-resource');
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(404);
+			expect(response.headers.get('content-type')).toContain('application/json');
+			const body = (await response.json()) as { error: string; error_description: string };
+			expect(body.error).toBe('not_supported');
+		});
+
+		it('returns parseable JSON bodies (no SyntaxError for mcp-remote)', async () => {
+			for (const path of ['/.well-known/oauth-authorization-server', '/.well-known/oauth-protected-resource']) {
+				const request = new Request<unknown, IncomingRequestCfProperties>(`http://example.com${path}`);
+				const ctx = createExecutionContext();
+				const response = await worker.fetch(request, env, ctx);
+				await waitOnExecutionContext(ctx);
+				const text = await response.clone().text();
+				expect(() => JSON.parse(text)).not.toThrow();
+			}
 		});
 	});
 });

--- a/test/session-recovery.spec.ts
+++ b/test/session-recovery.spec.ts
@@ -64,7 +64,7 @@ describe('Session expiration recovery', () => {
 				jsonrpc: '2.0',
 				id: 1,
 				method: 'tools/call',
-				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+				params: { name: 'explain_finding', arguments: { finding_id: 'spf_softfail' } },
 			}),
 		});
 		const ctx = createExecutionContext();
@@ -95,7 +95,7 @@ describe('Session expiration recovery', () => {
 				jsonrpc: '2.0',
 				id: 2,
 				method: 'tools/call',
-				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+				params: { name: 'explain_finding', arguments: { finding_id: 'spf_softfail' } },
 			}),
 		});
 		const ctx = createExecutionContext();
@@ -124,7 +124,7 @@ describe('Session expiration recovery', () => {
 				jsonrpc: '2.0',
 				id: 3,
 				method: 'tools/call',
-				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+				params: { name: 'explain_finding', arguments: { finding_id: 'spf_softfail' } },
 			}),
 		});
 		const ctx1 = createExecutionContext();
@@ -143,7 +143,7 @@ describe('Session expiration recovery', () => {
 				jsonrpc: '2.0',
 				id: 4,
 				method: 'tools/call',
-				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+				params: { name: 'explain_finding', arguments: { finding_id: 'spf_softfail' } },
 			}),
 		});
 		const ctx2 = createExecutionContext();
@@ -191,7 +191,7 @@ describe('Session expiration recovery', () => {
 				jsonrpc: '2.0',
 				id: 6,
 				method: 'tools/call',
-				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+				params: { name: 'explain_finding', arguments: { finding_id: 'spf_softfail' } },
 			}),
 		});
 		const ctx = createExecutionContext();

--- a/test/session-recovery.spec.ts
+++ b/test/session-recovery.spec.ts
@@ -1,0 +1,182 @@
+import { describe, it, expect, vi, afterEach, beforeEach } from 'vitest';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import worker from '../src';
+import { resetAllRateLimits } from '../src/lib/rate-limiter';
+import { resetSessions } from '../src/lib/session';
+import { resetLegacySseState } from '../src/lib/legacy-sse';
+import { ACTIVE_SESSIONS } from '../src/lib/session-memory';
+
+beforeEach(async () => {
+	resetAllRateLimits();
+	resetSessions();
+	resetLegacySseState();
+});
+
+afterEach(() => {
+	vi.useRealTimers();
+	vi.restoreAllMocks();
+});
+
+/** Helper: initialize a session and return the Mcp-Session-Id */
+async function initSession(): Promise<string> {
+	const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+		method: 'POST',
+		headers: { 'Content-Type': 'application/json' },
+		body: JSON.stringify({ jsonrpc: '2.0', id: 0, method: 'initialize', params: {} }),
+	});
+	const ctx = createExecutionContext();
+	const response = await worker.fetch(request, env, ctx);
+	await waitOnExecutionContext(ctx);
+	const sessionId = response.headers.get('mcp-session-id');
+	if (!sessionId) throw new Error('initSession: no Mcp-Session-Id returned');
+	return sessionId;
+}
+
+/** Helper: delete a session to simulate expiry */
+async function deleteSession(sessionId: string): Promise<void> {
+	const delReq = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+		method: 'DELETE',
+		headers: { 'Mcp-Session-Id': sessionId },
+	});
+	const delCtx = createExecutionContext();
+	await worker.fetch(delReq, env, delCtx);
+	await waitOnExecutionContext(delCtx);
+}
+
+describe('Session expiration recovery', () => {
+	it('revives expired session on tools/call using the same session ID', async () => {
+		const sessionId = await initSession();
+
+		// Terminate the session to simulate expiry
+		await deleteSession(sessionId);
+
+		// Confirm session is expired
+		expect(ACTIVE_SESSIONS.has(sessionId)).toBe(false);
+
+		// Send a tools/call with the expired session — should auto-recover
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Mcp-Session-Id': sessionId,
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+			}),
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		// Should succeed (not 404)
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { result?: { content: Array<{ text: string }> }; error?: unknown };
+		expect(body.error).toBeUndefined();
+		expect(body.result).toBeDefined();
+
+		// The session should be revived in memory with the SAME ID
+		expect(ACTIVE_SESSIONS.has(sessionId)).toBe(true);
+	});
+
+	it('does not return a new session ID header on recovery', async () => {
+		const sessionId = await initSession();
+		await deleteSession(sessionId);
+
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Mcp-Session-Id': sessionId,
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 2,
+				method: 'tools/call',
+				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+			}),
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		expect(res.status).toBe(200);
+
+		// No mcp-session-id header should be returned (client already has it)
+		const returnedSessionId = res.headers.get('mcp-session-id');
+		expect(returnedSessionId).toBeNull();
+	});
+
+	it('subsequent requests with the same session ID succeed after recovery', async () => {
+		const sessionId = await initSession();
+		await deleteSession(sessionId);
+
+		// First tools/call triggers recovery
+		const req1 = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Mcp-Session-Id': sessionId,
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 3,
+				method: 'tools/call',
+				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+			}),
+		});
+		const ctx1 = createExecutionContext();
+		const res1 = await worker.fetch(req1, env, ctx1);
+		await waitOnExecutionContext(ctx1);
+		expect(res1.status).toBe(200);
+
+		// Second request with the same session ID should also succeed
+		const req2 = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Mcp-Session-Id': sessionId,
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 4,
+				method: 'tools/call',
+				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+			}),
+		});
+		const ctx2 = createExecutionContext();
+		const res2 = await worker.fetch(req2, env, ctx2);
+		await waitOnExecutionContext(ctx2);
+		expect(res2.status).toBe(200);
+		const body2 = (await res2.json()) as { result?: unknown; error?: unknown };
+		expect(body2.error).toBeUndefined();
+		expect(body2.result).toBeDefined();
+	});
+
+	it('does not recover expired sessions for tools/list (only tools/call)', async () => {
+		const sessionId = await initSession();
+		await deleteSession(sessionId);
+
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Mcp-Session-Id': sessionId,
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 5,
+				method: 'tools/list',
+				params: {},
+			}),
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		// tools/list should NOT trigger recovery — returns 404
+		expect(res.status).toBe(404);
+	});
+});

--- a/test/session-recovery.spec.ts
+++ b/test/session-recovery.spec.ts
@@ -179,4 +179,27 @@ describe('Session expiration recovery', () => {
 		// tools/list should NOT trigger recovery — returns 404
 		expect(res.status).toBe(404);
 	});
+
+	it('rejects recovery for malformed session IDs', async () => {
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Mcp-Session-Id': 'not-a-valid-hex-id',
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 6,
+				method: 'tools/call',
+				params: { name: 'check_spf', arguments: { domain: 'example.com' } },
+			}),
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, env, ctx);
+		await waitOnExecutionContext(ctx);
+
+		// Malformed session IDs should NOT trigger recovery
+		expect(res.status).toBe(404);
+		expect(ACTIVE_SESSIONS.has('not-a-valid-hex-id')).toBe(false);
+	});
 });


### PR DESCRIPTION
## Summary
- **Session recovery**: revive expired sessions with the same ID instead of creating new ones. `mcp-remote` ignores new session IDs in response headers, causing permanent "session expired" error loops after 2hr idle TTL.
- **OAuth well-known routes**: return valid JSON 404 for `/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource` so `mcp-remote` doesn't crash parsing plain-text responses during OAuth discovery probes.
- **Security hardening**: `reviveSession()` validates session ID format before writing, preventing arbitrary strings from polluting KV/memory. Analytics distinguishes `revived` from `created` sessions.

## Test plan
- [x] 1923 tests pass (142 files)
- [x] TypeScript typecheck clean
- [x] New `test/session-recovery.spec.ts` — 5 tests covering recovery, header behavior, tools/list exclusion, malformed ID rejection
- [x] New OAuth well-known tests in `test/index.spec.ts` — 3 tests for JSON response parsing
- [x] Security review completed — critical finding (missing format validation) fixed before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sessions can be revived in-place after expiry, restoring continuity without issuing a new session ID and without returning a new mcp-session-id header.

* **Bug Fixes**
  * OAuth well-known endpoints now return HTTP 404 with JSON error details.

* **Tests**
  * Added tests covering session recovery behavior and the OAuth well-known endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->