### PR TITLE
fix: add WASM build steps to deploy workflows, document v2.4.0

### DIFF
--- a/.github/workflows/deploy-hook.yml
+++ b/.github/workflows/deploy-hook.yml
@@ -49,11 +49,18 @@ jobs:
       - name: Build workspace package
         run: npm -w packages/dns-checks run build
 
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        run: npm run build:wasm
+
       - name: Typecheck
         run: npx tsc --noEmit
 
       - name: Test
         run: npm test
+
 
   deploy:
     name: Deploy to Cloudflare Workers
@@ -83,8 +90,15 @@ jobs:
       - name: Build workspace package
         run: npm -w packages/dns-checks run build
 
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        run: npm run build:wasm
+
       - name: Deploy
         run: npx wrangler deploy -c wrangler.jsonc
+
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -205,9 +205,18 @@ jobs:
         if: env.skip != 'true'
         run: npm -w packages/dns-checks run build
 
+      - name: Install wasm-pack
+        if: env.skip != 'true'
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - name: Build WASM
+        if: env.skip != 'true'
+        run: npm run build:wasm
+
       - name: Deploy
         if: env.skip != 'true'
         run: npx wrangler deploy -c wrangler.jsonc
+
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-04-07
+
+### Added
+- **Structured JSON output for all 44 tools** — all tools now return a `<!-- STRUCTURED_RESULT -->` JSON block when `format=full` (non-interactive clients). Previously only `scan_domain` returned structured data. Compact mode (interactive LLM clients: Claude Code, Cursor, etc.) is unaffected.
+
 ## [2.3.5] - 2026-04-07
 
 ### Fixed


### PR DESCRIPTION
## Summary

- **`publish.yml` deploy-cloudflare job**: add `wasm-pack` install + `npm run build:wasm` before `wrangler deploy` — each job runs on a fresh runner with no `pkg/` artifacts (gitignored via `crates/bv-wasm-core/pkg/.gitignore`)
- **`deploy-hook.yml` validate job**: add WASM build before `npm test` — `test/wasm-integration.test.ts` was failing without the `pkg/` directory
- **`deploy-hook.yml` deploy job**: add WASM build before `wrangler deploy` — same reason as publish.yml
- **`CHANGELOG.md`**: add missing `[2.4.0]` entry documenting structured JSON output for all 44 tools

`ci.yml` and `ci-contract.yml` already had the WASM build steps — this brings the release and manual deploy workflows into parity.

## Test plan

- [ ] Verify `deploy-hook.yml` validate job passes `npm test` (including `wasm-integration.test.ts`)
- [ ] Verify `deploy-hook.yml` deploy job completes wrangler deploy without missing `pkg/` error
- [ ] Verify `publish.yml` deploy-cloudflare job completes on next tag release
- [ ] Confirm CHANGELOG `[2.4.0]` entry appears in next GitHub Release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * All 44 tools now generate structured JSON output when requested in non-interactive client mode, enabling improved data export and integration capabilities.

* **Chores**
  * WebAssembly build process is now integrated into deployment pipelines for consistent artifact generation across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->