### PR TITLE
feat: add 7 intelligence tools

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -56,6 +56,7 @@ regexes = [
 paths = [
   '''test/''',
   '''src/tools/.*-analysis\.ts$''',  # Analysis modules contain IP examples in JSDoc
+  '''src/lib/ip-utils\.ts$''',       # IP utility module contains example IPs in JSDoc
 ]
 
 [[rules]]

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"cf-typegen": "wrangler types",
 		"lint": "eslint .",
 		"lint:fix": "eslint . --fix",
-		"build:wasm": "cd crates/bv-wasm-core && /Users/adam/.cargo/bin/wasm-pack build --target web"
+		"build:wasm": "cd crates/bv-wasm-core && wasm-pack build --target web"
 	},
 	"devDependencies": {
 		"@cloudflare/vitest-pool-workers": "^0.13.3",

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -43,6 +43,7 @@ import { resolveSpfChain, formatSpfChain } from '../tools/resolve-spf-chain';
 import { discoverSubdomains, formatSubdomainDiscovery } from '../tools/discover-subdomains';
 import { mapCompliance, formatCompliance } from '../tools/map-compliance';
 import { simulateAttackPaths, formatAttackPaths } from '../tools/simulate-attack-paths';
+import { checkDbl } from '../tools/check-dbl';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -144,6 +145,7 @@ const TOOL_REGISTRY: Record<
 	check_srv: { cacheKey: () => 'srv', execute: (d, _args, ro) => checkSrv(d, buildDnsOptions(ro)) },
 	check_zone_hygiene: { cacheKey: () => 'zone_hygiene', execute: (d, _args, ro) => checkZoneHygiene(d, buildDnsOptions(ro)) },
 	check_subdomailing: { cacheKey: () => 'subdomailing', execute: (d, _args, ro) => checkSubdomailing(d, buildDnsOptions(ro)) },
+	check_dbl: { cacheKey: () => 'dbl', execute: (d, _args, ro) => checkDbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
@@ -468,7 +470,7 @@ export async function handleToolsCall(
 					}
 					default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 44 available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 45 available tools.`);
 			}
 		};
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -45,6 +45,7 @@ import { mapCompliance, formatCompliance } from '../tools/map-compliance';
 import { simulateAttackPaths, formatAttackPaths } from '../tools/simulate-attack-paths';
 import { checkDbl } from '../tools/check-dbl';
 import { checkRbl } from '../tools/check-rbl';
+import { checkCymruAsn } from '../tools/check-cymru-asn';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -148,6 +149,7 @@ const TOOL_REGISTRY: Record<
 	check_subdomailing: { cacheKey: () => 'subdomailing', execute: (d, _args, ro) => checkSubdomailing(d, buildDnsOptions(ro)) },
 	check_dbl: { cacheKey: () => 'dbl', execute: (d, _args, ro) => checkDbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	check_rbl: { cacheKey: () => 'rbl', execute: (d, _args, ro) => checkRbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
+	cymru_asn: { cacheKey: () => 'asn', execute: (d, _args, ro) => checkCymruAsn(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
@@ -472,7 +474,7 @@ export async function handleToolsCall(
 					}
 					default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 46 available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 47 available tools.`);
 			}
 		};
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -48,6 +48,7 @@ import { checkRbl } from '../tools/check-rbl';
 import { checkCymruAsn } from '../tools/check-cymru-asn';
 import { checkRdapLookup } from '../tools/check-rdap-lookup';
 import { checkNsecWalkability } from '../tools/check-nsec-walkability';
+import { checkDnssecChain } from '../tools/check-dnssec-chain';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -154,6 +155,7 @@ const TOOL_REGISTRY: Record<
 	cymru_asn: { cacheKey: () => 'asn', execute: (d, _args, ro) => checkCymruAsn(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	rdap_lookup: { cacheKey: () => 'rdap', execute: (d) => checkRdapLookup(d), cacheTtlSeconds: 3600 },
 	check_nsec_walkability: { cacheKey: () => 'nsec_walkability', execute: (d, _args, ro) => checkNsecWalkability(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
+	check_dnssec_chain: { cacheKey: () => 'dnssec_chain', execute: (d, _args, ro) => checkDnssecChain(d, buildDnsOptions(ro)) },
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
@@ -478,7 +480,7 @@ export async function handleToolsCall(
 					}
 					default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 49 available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 50 available tools.`);
 			}
 		};
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -46,6 +46,7 @@ import { simulateAttackPaths, formatAttackPaths } from '../tools/simulate-attack
 import { checkDbl } from '../tools/check-dbl';
 import { checkRbl } from '../tools/check-rbl';
 import { checkCymruAsn } from '../tools/check-cymru-asn';
+import { checkRdapLookup } from '../tools/check-rdap-lookup';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -150,6 +151,7 @@ const TOOL_REGISTRY: Record<
 	check_dbl: { cacheKey: () => 'dbl', execute: (d, _args, ro) => checkDbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	check_rbl: { cacheKey: () => 'rbl', execute: (d, _args, ro) => checkRbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	cymru_asn: { cacheKey: () => 'asn', execute: (d, _args, ro) => checkCymruAsn(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
+	rdap_lookup: { cacheKey: () => 'rdap', execute: (d) => checkRdapLookup(d), cacheTtlSeconds: 3600 },
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
@@ -474,7 +476,7 @@ export async function handleToolsCall(
 					}
 					default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 47 available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 48 available tools.`);
 			}
 		};
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -47,6 +47,7 @@ import { checkDbl } from '../tools/check-dbl';
 import { checkRbl } from '../tools/check-rbl';
 import { checkCymruAsn } from '../tools/check-cymru-asn';
 import { checkRdapLookup } from '../tools/check-rdap-lookup';
+import { checkNsecWalkability } from '../tools/check-nsec-walkability';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -152,6 +153,7 @@ const TOOL_REGISTRY: Record<
 	check_rbl: { cacheKey: () => 'rbl', execute: (d, _args, ro) => checkRbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	cymru_asn: { cacheKey: () => 'asn', execute: (d, _args, ro) => checkCymruAsn(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	rdap_lookup: { cacheKey: () => 'rdap', execute: (d) => checkRdapLookup(d), cacheTtlSeconds: 3600 },
+	check_nsec_walkability: { cacheKey: () => 'nsec_walkability', execute: (d, _args, ro) => checkNsecWalkability(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
@@ -476,7 +478,7 @@ export async function handleToolsCall(
 					}
 					default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 48 available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 49 available tools.`);
 			}
 		};
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -49,6 +49,7 @@ import { checkCymruAsn } from '../tools/check-cymru-asn';
 import { checkRdapLookup } from '../tools/check-rdap-lookup';
 import { checkNsecWalkability } from '../tools/check-nsec-walkability';
 import { checkDnssecChain } from '../tools/check-dnssec-chain';
+import { checkFastFlux } from '../tools/check-fast-flux';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -156,6 +157,7 @@ const TOOL_REGISTRY: Record<
 	rdap_lookup: { cacheKey: () => 'rdap', execute: (d) => checkRdapLookup(d), cacheTtlSeconds: 3600 },
 	check_nsec_walkability: { cacheKey: () => 'nsec_walkability', execute: (d, _args, ro) => checkNsecWalkability(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	check_dnssec_chain: { cacheKey: () => 'dnssec_chain', execute: (d, _args, ro) => checkDnssecChain(d, buildDnsOptions(ro)) },
+	check_fast_flux: { cacheKey: () => 'fast_flux', execute: (d, args, ro) => checkFastFlux(d, (args.rounds as number | undefined) ?? 3, buildDnsOptions(ro)) },
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
@@ -480,7 +482,7 @@ export async function handleToolsCall(
 					}
 					default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 50 available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 51 available tools.`);
 			}
 		};
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -44,6 +44,7 @@ import { discoverSubdomains, formatSubdomainDiscovery } from '../tools/discover-
 import { mapCompliance, formatCompliance } from '../tools/map-compliance';
 import { simulateAttackPaths, formatAttackPaths } from '../tools/simulate-attack-paths';
 import { checkDbl } from '../tools/check-dbl';
+import { checkRbl } from '../tools/check-rbl';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -146,6 +147,7 @@ const TOOL_REGISTRY: Record<
 	check_zone_hygiene: { cacheKey: () => 'zone_hygiene', execute: (d, _args, ro) => checkZoneHygiene(d, buildDnsOptions(ro)) },
 	check_subdomailing: { cacheKey: () => 'subdomailing', execute: (d, _args, ro) => checkSubdomailing(d, buildDnsOptions(ro)) },
 	check_dbl: { cacheKey: () => 'dbl', execute: (d, _args, ro) => checkDbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
+	check_rbl: { cacheKey: () => 'rbl', execute: (d, _args, ro) => checkRbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
@@ -470,7 +472,7 @@ export async function handleToolsCall(
 					}
 					default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 45 available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all 46 available tools.`);
 			}
 		};
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -179,6 +179,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	map_compliance: 75,
 	simulate_attack_paths: 75,
 	check_dbl: 30,
+	check_rbl: 20,
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -180,6 +180,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	simulate_attack_paths: 75,
 	check_dbl: 30,
 	check_rbl: 20,
+	cymru_asn: 30,
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -183,6 +183,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	cymru_asn: 30,
 	rdap_lookup: 20,
 	check_nsec_walkability: 30,
+	check_dnssec_chain: 30,
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -184,6 +184,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	rdap_lookup: 20,
 	check_nsec_walkability: 30,
 	check_dnssec_chain: 30,
+	check_fast_flux: 10,
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -178,6 +178,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	discover_subdomains: 50,
 	map_compliance: 75,
 	simulate_attack_paths: 75,
+	check_dbl: 30,
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -182,6 +182,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_rbl: 20,
 	cymru_asn: 30,
 	rdap_lookup: 20,
+	check_nsec_walkability: 30,
 };
 
 /**

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -181,6 +181,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_dbl: 30,
 	check_rbl: 20,
 	cymru_asn: 30,
+	rdap_lookup: 20,
 };
 
 /**

--- a/src/lib/dns-types.ts
+++ b/src/lib/dns-types.ts
@@ -14,6 +14,7 @@ export const RecordType = {
 	DNSKEY: 48,
 	DS: 43,
 	RRSIG: 46,
+	NSEC3PARAM: 51,
 	PTR: 12,
 	SRV: 33,
 	HTTPS: 65,

--- a/src/lib/ip-utils.ts
+++ b/src/lib/ip-utils.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Reverse the octets of an IPv4 address.
+ * Used for DNSBL and PTR queries (e.g., "1.2.3.4" → "4.3.2.1").
+ */
+export function reverseIPv4(ip: string): string {
+	return ip.split('.').reverse().join('.');
+}
+
+/**
+ * Expand a possibly-compressed IPv6 address to its full 32-nibble form,
+ * reverse the nibbles, and join with dots.
+ * Used for Cymru ASN lookups and ip6.arpa PTR queries.
+ *
+ * @example reverseIPv6("2001:0db8::1") → "1.0.0.0...8.b.d.0.1.0.0.2"
+ */
+export function reverseIPv6(ip: string): string {
+	// Expand :: shorthand to full 8 groups
+	const halves = ip.split('::');
+	let groups: string[];
+
+	if (halves.length === 2) {
+		const left = halves[0] ? halves[0].split(':') : [];
+		const right = halves[1] ? halves[1].split(':') : [];
+		const missing = 8 - left.length - right.length;
+		groups = [...left, ...Array(missing).fill('0000'), ...right];
+	} else {
+		groups = ip.split(':');
+	}
+
+	// Pad each group to 4 hex digits, concatenate all 32 nibbles, reverse, dot-join
+	const nibbles = groups.map((g) => g.padStart(4, '0')).join('');
+	return nibbles.split('').reverse().join('.');
+}
+
+/**
+ * Check whether an IP address is in a private/reserved range.
+ * Covers RFC 1918, loopback, link-local, and IPv6 ULA.
+ */
+export function isPrivateIP(ip: string): boolean {
+	// IPv6 check
+	if (ip.includes(':')) {
+		if (ip === '::1') return true;
+		const lower = ip.toLowerCase();
+		// Link-local fe80::/10
+		if (lower.startsWith('fe80:')) return true;
+		// ULA fc00::/7 — first byte is fc or fd (binary 1111110x)
+		if (lower.startsWith('fc') || lower.startsWith('fd')) return true;
+		return false;
+	}
+
+	// IPv4 check
+	const parts = ip.split('.').map(Number);
+	if (parts.length !== 4) return false;
+
+	const [a, b] = parts;
+	// 10.0.0.0/8
+	if (a === 10) return true;
+	// 172.16.0.0/12
+	if (a === 172 && b >= 16 && b <= 31) return true;
+	// 192.168.0.0/16
+	if (a === 192 && b === 168) return true;
+	// 127.0.0.0/8 (loopback)
+	if (a === 127) return true;
+	// 169.254.0.0/16 (link-local)
+	if (a === 169 && b === 254) return true;
+
+	return false;
+}

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -221,4 +221,5 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	check_dbl: BaseDomainArgs,
 	check_rbl: BaseDomainArgs,
 	cymru_asn: BaseDomainArgs,
+	rdap_lookup: BaseDomainArgs,
 };

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -218,4 +218,5 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	discover_subdomains: BaseDomainArgs,
 	map_compliance: BaseDomainArgs,
 	simulate_attack_paths: BaseDomainArgs,
+	check_dbl: BaseDomainArgs,
 };

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -223,4 +223,5 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	cymru_asn: BaseDomainArgs,
 	rdap_lookup: BaseDomainArgs,
 	check_nsec_walkability: BaseDomainArgs,
+	check_dnssec_chain: BaseDomainArgs,
 };

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -222,4 +222,5 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	check_rbl: BaseDomainArgs,
 	cymru_asn: BaseDomainArgs,
 	rdap_lookup: BaseDomainArgs,
+	check_nsec_walkability: BaseDomainArgs,
 };

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -220,4 +220,5 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	simulate_attack_paths: BaseDomainArgs,
 	check_dbl: BaseDomainArgs,
 	check_rbl: BaseDomainArgs,
+	cymru_asn: BaseDomainArgs,
 };

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -169,6 +169,13 @@ export const GenerateRolloutPlanArgs = z.object({
 	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 }).passthrough();
 
+/** check_fast_flux — domain + rounds + format */
+export const CheckFastFluxArgs = z.object({
+	domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
+	rounds: z.number().int().min(3).max(5).optional().describe('Number of query rounds (3-5, default 3).'),
+	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+}).passthrough();
+
 /**
  * Map of every tool name to its Zod argument schema.
  * Used for runtime validation in tools.ts and for inputSchema generation.
@@ -224,4 +231,5 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	rdap_lookup: BaseDomainArgs,
 	check_nsec_walkability: BaseDomainArgs,
 	check_dnssec_chain: BaseDomainArgs,
+	check_fast_flux: CheckFastFluxArgs,
 };

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -219,4 +219,5 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	map_compliance: BaseDomainArgs,
 	simulate_attack_paths: BaseDomainArgs,
 	check_dbl: BaseDomainArgs,
+	check_rbl: BaseDomainArgs,
 };

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -59,7 +59,7 @@ interface ToolDef {
 }
 
 /** DNS/security acronyms that should be uppercased in human-readable tool titles. */
-const KNOWN_ACRONYMS = new Set(['mx', 'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta', 'sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http', 'https', 'dane', 'svcb', 'srv', 'txt', 'doh', 'rpm', 'dbl']);
+const KNOWN_ACRONYMS = new Set(['mx', 'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta', 'sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http', 'https', 'dane', 'svcb', 'srv', 'txt', 'doh', 'rpm', 'dbl', 'rdap']);
 
 /** Convert a snake_case tool name to a human-readable title. e.g. "check_mta_sts" → "Check MTA STS" */
 function toolNameToTitle(name: string): string {
@@ -390,6 +390,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	cymru_asn: {
 		description:
 			'Map domain IPs to Autonomous System Numbers via Team Cymru DNS. Returns ASN, prefix, country, registry, and organization for each IP. Flags high-risk hosting ASNs.',
+		schema: BaseDomainArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
+	rdap_lookup: {
+		description:
+			'Fetch domain registration data via RDAP (modern WHOIS replacement). Returns registrar, creation/expiration dates, EPP status, registrant info, and domain age.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -59,7 +59,7 @@ interface ToolDef {
 }
 
 /** DNS/security acronyms that should be uppercased in human-readable tool titles. */
-const KNOWN_ACRONYMS = new Set(['mx', 'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta', 'sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http', 'https', 'dane', 'svcb', 'srv', 'txt', 'doh', 'rpm', 'dbl', 'rdap']);
+const KNOWN_ACRONYMS = new Set(['mx', 'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta', 'sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http', 'https', 'dane', 'svcb', 'srv', 'txt', 'doh', 'rpm', 'dbl', 'rdap', 'nsec']);
 
 /** Convert a snake_case tool name to a human-readable title. e.g. "check_mta_sts" → "Check MTA STS" */
 function toolNameToTitle(name: string): string {
@@ -85,7 +85,7 @@ function toInputSchema(schema: z.ZodTypeAny): McpTool['inputSchema'] {
 	return jsonSchema as McpTool['inputSchema'];
 }
 
-/** All 45 MCP tool definitions. */
+/** All 49 MCP tool definitions. */
 const TOOL_DEFS: Record<string, ToolDef> = {
 	check_mx: {
 		description: 'Look up MX records for a domain. Shows mail servers, email provider detection, and validates configuration.',
@@ -397,6 +397,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	rdap_lookup: {
 		description:
 			'Fetch domain registration data via RDAP (modern WHOIS replacement). Returns registrar, creation/expiration dates, EPP status, registrant info, and domain age.',
+		schema: BaseDomainArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
+	check_nsec_walkability: {
+		description:
+			'Assess zone walkability risk by analyzing NSEC3PARAM configuration. Detects plain NSEC zones, weak NSEC3 parameters, and opt-out flags.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -380,6 +380,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		group: 'intelligence',
 		scanIncluded: false,
 	},
+	check_rbl: {
+		description:
+			'Check MX server IP reputation against 8 DNS-based Real-time Blocklists (Spamhaus ZEN, SpamCop, UCEProtect, Mailspike, Barracuda, PSBL, SORBS). Resolves MX hosts to IPs first.',
+		schema: BaseDomainArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
 };
 
 export const TOOLS: McpTool[] = Object.entries(TOOL_DEFS).map(([name, def]) => ({

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -59,7 +59,7 @@ interface ToolDef {
 }
 
 /** DNS/security acronyms that should be uppercased in human-readable tool titles. */
-const KNOWN_ACRONYMS = new Set(['mx', 'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta', 'sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http', 'https', 'dane', 'svcb', 'srv', 'txt', 'doh', 'rpm']);
+const KNOWN_ACRONYMS = new Set(['mx', 'spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta', 'sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http', 'https', 'dane', 'svcb', 'srv', 'txt', 'doh', 'rpm', 'dbl']);
 
 /** Convert a snake_case tool name to a human-readable title. e.g. "check_mta_sts" → "Check MTA STS" */
 function toolNameToTitle(name: string): string {
@@ -85,7 +85,7 @@ function toInputSchema(schema: z.ZodTypeAny): McpTool['inputSchema'] {
 	return jsonSchema as McpTool['inputSchema'];
 }
 
-/** All 44 MCP tool definitions. */
+/** All 45 MCP tool definitions. */
 const TOOL_DEFS: Record<string, ToolDef> = {
 	check_mx: {
 		description: 'Look up MX records for a domain. Shows mail servers, email provider detection, and validates configuration.',
@@ -370,6 +370,12 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	simulate_attack_paths: {
 		description: 'Analyze current DNS posture and enumerate specific attack paths an adversary could exploit, with severity, feasibility, steps, and mitigations.',
+		schema: BaseDomainArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
+	check_dbl: {
+		description: 'Check domain reputation against DNS-based Domain Block Lists (Spamhaus DBL, URIBL, SURBL). Returns listing status with decoded return codes.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -85,7 +85,7 @@ function toInputSchema(schema: z.ZodTypeAny): McpTool['inputSchema'] {
 	return jsonSchema as McpTool['inputSchema'];
 }
 
-/** All 49 MCP tool definitions. */
+/** All 50 MCP tool definitions. */
 const TOOL_DEFS: Record<string, ToolDef> = {
 	check_mx: {
 		description: 'Look up MX records for a domain. Shows mail servers, email provider detection, and validates configuration.',
@@ -404,6 +404,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	check_nsec_walkability: {
 		description:
 			'Assess zone walkability risk by analyzing NSEC3PARAM configuration. Detects plain NSEC zones, weak NSEC3 parameters, and opt-out flags.',
+		schema: BaseDomainArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
+	check_dnssec_chain: {
+		description:
+			'Walk the DNSSEC chain of trust from root to target domain. Reports DS/DNSKEY records, algorithm usage, and linkage status at each zone level.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -20,6 +20,7 @@ import {
 	MapSupplyChainArgs,
 	AnalyzeDriftArgs,
 	GenerateRolloutPlanArgs,
+	CheckFastFluxArgs,
 	TOOL_SCHEMA_MAP,
 } from './tool-args';
 
@@ -85,7 +86,7 @@ function toInputSchema(schema: z.ZodTypeAny): McpTool['inputSchema'] {
 	return jsonSchema as McpTool['inputSchema'];
 }
 
-/** All 50 MCP tool definitions. */
+/** All 51 MCP tool definitions. */
 const TOOL_DEFS: Record<string, ToolDef> = {
 	check_mx: {
 		description: 'Look up MX records for a domain. Shows mail servers, email provider detection, and validates configuration.',
@@ -412,6 +413,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		description:
 			'Walk the DNSSEC chain of trust from root to target domain. Reports DS/DNSKEY records, algorithm usage, and linkage status at each zone level.',
 		schema: BaseDomainArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
+	check_fast_flux: {
+		description:
+			'Detect fast-flux DNS behavior by performing multiple rounds of A/AAAA queries with delays. Compares IP answer sets and TTLs across rounds to identify rotating infrastructure.',
+		schema: CheckFastFluxArgs,
 		group: 'intelligence',
 		scanIncluded: false,
 	},

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -387,6 +387,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		group: 'intelligence',
 		scanIncluded: false,
 	},
+	cymru_asn: {
+		description:
+			'Map domain IPs to Autonomous System Numbers via Team Cymru DNS. Returns ASN, prefix, country, registry, and organization for each IP. Flags high-risk hosting ASNs.',
+		schema: BaseDomainArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
 };
 
 export const TOOLS: McpTool[] = Object.entries(TOOL_DEFS).map(([name, def]) => ({

--- a/src/tools/check-cymru-asn.ts
+++ b/src/tools/check-cymru-asn.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ASN Lookup tool via Team Cymru DNS.
+ * Maps domain A-record IPs to Autonomous System Numbers (ASNs) using
+ * Team Cymru's DNS-based ASN service (origin.asn.cymru.com / asn.cymru.com).
+ */
+
+import { queryDnsRecords, queryTxtRecords } from '../lib/dns';
+import type { QueryDnsOptions } from '../lib/dns-types';
+import { reverseIPv4 } from '../lib/ip-utils';
+import { buildCheckResult, createFinding } from '../lib/scoring';
+import type { CheckResult, CheckCategory } from '../lib/scoring';
+
+const CATEGORY = 'asn' as CheckCategory;
+
+/**
+ * ASNs associated with hosting providers commonly used for malicious infrastructure.
+ * Presence is not inherently bad, but warrants awareness in a security context.
+ */
+const HIGH_RISK_ASNS = new Set([
+	9009, // M247
+	53667, // Frantech/BuyVM
+	36352, // ColoCrossing
+	20473, // Vultr
+	14061, // DigitalOcean
+	63949, // Linode/Akamai
+]);
+
+interface AsnOrigin {
+	asn: number;
+	prefix: string;
+	cc: string;
+	registry: string;
+	allocated: string;
+}
+
+/** Parse a Cymru origin TXT response: "ASN | prefix | CC | registry | allocated" */
+function parseOriginTxt(txt: string): AsnOrigin | null {
+	const parts = txt.split('|').map((p) => p.trim());
+	if (parts.length < 5) return null;
+	const asn = parseInt(parts[0], 10);
+	if (!Number.isFinite(asn) || asn <= 0) return null;
+	return {
+		asn,
+		prefix: parts[1],
+		cc: parts[2],
+		registry: parts[3],
+		allocated: parts[4],
+	};
+}
+
+/** Parse a Cymru org TXT response: "ASN | CC | registry | allocated | org name" */
+function parseOrgTxt(txt: string): string | null {
+	const parts = txt.split('|').map((p) => p.trim());
+	if (parts.length < 5) return null;
+	return parts[4] || null;
+}
+
+/**
+ * Look up ASN information for a domain's A-record IPs via Team Cymru DNS.
+ *
+ * For each resolved IPv4 address:
+ * 1. Queries `{reversed}.origin.asn.cymru.com` TXT for ASN/prefix/CC
+ * 2. Queries `AS{asn}.asn.cymru.com` TXT for the organization name
+ *
+ * Flags high-risk ASNs (commonly abused hosting providers) as medium severity.
+ *
+ * @param domain - The domain to look up
+ * @param dnsOptions - Optional DNS query options
+ * @returns CheckResult with ASN findings
+ */
+export async function checkCymruAsn(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
+	const findings: ReturnType<typeof createFinding>[] = [];
+
+	// Step 1: Resolve domain A records
+	let ips: string[] = [];
+	try {
+		ips = await queryDnsRecords(domain, 'A', dnsOptions);
+	} catch {
+		// A resolution failed
+	}
+
+	if (ips.length === 0) {
+		findings.push(
+			createFinding(CATEGORY, 'No A records found', 'info', `Could not resolve any A records for ${domain}. ASN lookup requires IPv4 addresses.`, {
+				domain,
+			}),
+		);
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	// Deduplicate IPs
+	ips = [...new Set(ips)];
+
+	// Step 2: Query Cymru origin for each IP
+	const seenAsns = new Set<number>();
+
+	for (const ip of ips) {
+		// Only handle IPv4
+		if (!/^(\d{1,3}\.){3}\d{1,3}$/.test(ip)) continue;
+
+		const reversed = reverseIPv4(ip);
+		const originName = `${reversed}.origin.asn.cymru.com`;
+
+		let originTxts: string[] = [];
+		try {
+			originTxts = await queryTxtRecords(originName, dnsOptions);
+		} catch {
+			// Origin lookup failed for this IP
+		}
+
+		if (originTxts.length === 0) {
+			findings.push(
+				createFinding(CATEGORY, `No ASN data for ${ip}`, 'info', `No ASN data returned from Team Cymru for ${ip}.`, {
+					ip,
+				}),
+			);
+			continue;
+		}
+
+		const origin = parseOriginTxt(originTxts[0]);
+		if (!origin) {
+			findings.push(
+				createFinding(CATEGORY, `Unparseable ASN response for ${ip}`, 'info', `Team Cymru returned an unparseable response for ${ip}.`, {
+					ip,
+					raw: originTxts[0],
+				}),
+			);
+			continue;
+		}
+
+		// Step 3: Query org name (deduplicate by ASN to avoid redundant lookups)
+		let orgName: string | null = null;
+		if (!seenAsns.has(origin.asn)) {
+			try {
+				const orgTxts = await queryTxtRecords(`AS${origin.asn}.asn.cymru.com`, dnsOptions);
+				if (orgTxts.length > 0) {
+					orgName = parseOrgTxt(orgTxts[0]);
+				}
+			} catch {
+				// Org lookup failed — continue with ASN number only
+			}
+		}
+		seenAsns.add(origin.asn);
+
+		// Step 4: Build findings
+		const isHighRisk = HIGH_RISK_ASNS.has(origin.asn);
+		const orgLabel = orgName ? ` (${orgName})` : '';
+
+		if (isHighRisk) {
+			findings.push(
+				createFinding(
+					CATEGORY,
+					`High-risk ASN ${origin.asn} detected`,
+					'medium',
+					`${ip} is announced by high-risk ASN ${origin.asn}${orgLabel} in prefix ${origin.prefix} (${origin.cc}, ${origin.registry}).`,
+					{ ip, asn: origin.asn, prefix: origin.prefix, cc: origin.cc, registry: origin.registry, orgName, highRisk: true },
+				),
+			);
+		}
+
+		findings.push(
+			createFinding(
+				CATEGORY,
+				`ASN ${origin.asn} for ${ip}`,
+				'info',
+				`${ip} → AS${origin.asn}${orgLabel}, prefix ${origin.prefix}, country ${origin.cc}, registry ${origin.registry}, allocated ${origin.allocated}.`,
+				{ ip, asn: origin.asn, prefix: origin.prefix, cc: origin.cc, registry: origin.registry, allocated: origin.allocated, orgName },
+			),
+		);
+	}
+
+	return buildCheckResult(CATEGORY, findings) as CheckResult;
+}

--- a/src/tools/check-dbl.ts
+++ b/src/tools/check-dbl.ts
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Domain Blocklist (DBL) check tool.
+ * Queries a domain against DNS-based Domain Block Lists:
+ * - Spamhaus DBL (dbl.spamhaus.org)
+ * - URIBL (multi.uribl.com)
+ * - SURBL (multi.surbl.org)
+ *
+ * Workers-compatible: uses fetch API only (DNS-over-HTTPS).
+ */
+
+import type { CheckCategory, CheckResult, Finding } from '../lib/scoring';
+import { buildCheckResult, createFinding } from '../lib/scoring';
+import { queryDnsRecords } from '../lib/dns';
+import type { QueryDnsOptions } from '../lib/dns-types';
+
+/** Cast category — 'dbl' is not in the scoring CheckCategory union (intelligence-only tool). */
+const CATEGORY = 'dbl' as CheckCategory;
+
+// ---------------------------------------------------------------------------
+// DBL zone definitions
+// ---------------------------------------------------------------------------
+
+interface DblZone {
+	name: string;
+	zone: string;
+	decode: (ip: string) => DblDecodeResult | null;
+	/** Default severity for a listing on this zone. */
+	severity: 'high' | 'medium';
+}
+
+interface DblDecodeResult {
+	label: string;
+	detail: string;
+}
+
+// -- Spamhaus DBL return codes ------------------------------------------------
+
+const SPAMHAUS_CODES: Record<string, string> = {
+	'127.0.1.2': 'Spam domain',
+	'127.0.1.4': 'Phishing domain',
+	'127.0.1.5': 'Malware domain',
+	'127.0.1.6': 'Botnet C&C domain',
+	'127.0.1.102': 'Abused legit spam domain',
+	'127.0.1.103': 'Abused legit spammed redirector',
+	'127.0.1.104': 'Abused legit phishing domain',
+	'127.0.1.105': 'Abused legit malware domain',
+	'127.0.1.106': 'Abused legit botnet C&C domain',
+};
+
+function decodeSpamhaus(ip: string): DblDecodeResult | null {
+	// 127.255.255.x = quota/rate limit error — NOT a listing
+	if (/^127\.255\.255\./.test(ip)) return null;
+
+	const label = SPAMHAUS_CODES[ip];
+	if (label) {
+		return { label, detail: `Spamhaus DBL return code ${ip}: ${label}` };
+	}
+	// Unknown but valid listing in the 127.0.1.x range
+	if (/^127\.0\.1\./.test(ip)) {
+		return { label: 'Listed (unknown code)', detail: `Spamhaus DBL return code ${ip}: unknown listing type` };
+	}
+	return null;
+}
+
+// -- URIBL bitmask flags ------------------------------------------------------
+
+const URIBL_FLAGS: Array<{ mask: number; label: string }> = [
+	{ mask: 0x01, label: 'Black' },
+	{ mask: 0x02, label: 'Grey' },
+	{ mask: 0x04, label: 'Red' },
+	{ mask: 0x08, label: 'Multi' },
+];
+
+function decodeUribl(ip: string): DblDecodeResult | null {
+	const octet = parseInt(ip.split('.')[3], 10);
+	if (!Number.isFinite(octet) || octet === 0) return null;
+
+	const matched = URIBL_FLAGS.filter((f) => (octet & f.mask) !== 0).map((f) => f.label);
+	if (matched.length === 0) return null;
+
+	const labels = matched.join(', ');
+	return { label: labels, detail: `URIBL flags: ${labels} (return code ${ip})` };
+}
+
+// -- SURBL bitmask flags ------------------------------------------------------
+
+const SURBL_FLAGS: Array<{ mask: number; label: string }> = [
+	{ mask: 0x02, label: 'SC (SpamCop)' },
+	{ mask: 0x04, label: 'WS (sa-blacklist)' },
+	{ mask: 0x08, label: 'AB (AbuseButler)' },
+	{ mask: 0x10, label: 'Phishing' },
+	{ mask: 0x40, label: 'Malware' },
+	{ mask: 0x80, label: 'CRX (Cracked/compromised)' },
+];
+
+function decodeSurbl(ip: string): DblDecodeResult | null {
+	const octet = parseInt(ip.split('.')[3], 10);
+	if (!Number.isFinite(octet) || octet === 0) return null;
+
+	const matched = SURBL_FLAGS.filter((f) => (octet & f.mask) !== 0).map((f) => f.label);
+	if (matched.length === 0) return null;
+
+	const labels = matched.join(', ');
+	return { label: labels, detail: `SURBL flags: ${labels} (return code ${ip})` };
+}
+
+// -- Zone registry ------------------------------------------------------------
+
+const DBL_ZONES: DblZone[] = [
+	{ name: 'Spamhaus DBL', zone: 'dbl.spamhaus.org', decode: decodeSpamhaus, severity: 'high' },
+	{ name: 'URIBL', zone: 'multi.uribl.com', decode: decodeUribl, severity: 'medium' },
+	{ name: 'SURBL', zone: 'multi.surbl.org', decode: decodeSurbl, severity: 'medium' },
+];
+
+// ---------------------------------------------------------------------------
+// Main check function
+// ---------------------------------------------------------------------------
+
+/**
+ * Check a domain against DNS-based Domain Block Lists.
+ *
+ * Queries the domain against Spamhaus DBL, URIBL, and SURBL. Returns listing
+ * status with decoded return codes. NXDOMAIN (empty response) means the domain
+ * is not listed. Spamhaus 127.255.255.x responses are treated as quota errors,
+ * not listings.
+ *
+ * @param domain - The domain to check (used as-is, subdomains not stripped)
+ * @param dnsOptions - Optional DNS query options
+ * @returns CheckResult with DBL findings
+ */
+export async function checkDbl(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
+	const findings: Finding[] = [];
+
+	// Query all zones in parallel
+	const results = await Promise.allSettled(
+		DBL_ZONES.map(async (zone) => {
+			const queryName = `${domain}.${zone.zone}`;
+			const answers = await queryDnsRecords(queryName, 'A', dnsOptions);
+			return { zone, answers };
+		}),
+	);
+
+	let listedCount = 0;
+	let checkedCount = 0;
+
+	for (const result of results) {
+		if (result.status === 'rejected') {
+			// DNS error for this zone — report and continue with partial results
+			const zoneIndex = results.indexOf(result);
+			const zone = DBL_ZONES[zoneIndex];
+			findings.push(
+				createFinding(
+					CATEGORY,
+					`${zone.name} lookup error`,
+					'low',
+					`DNS query error for ${domain} on ${zone.name} (${zone.zone}). Partial results may be available from other blocklists.`,
+					{ zone: zone.zone, error: true },
+				),
+			);
+			continue;
+		}
+
+		checkedCount++;
+		const { zone, answers } = result.value;
+
+		if (answers.length === 0) {
+			// Not listed on this zone (NXDOMAIN / empty)
+			continue;
+		}
+
+		const ip = answers[0];
+
+		// Spamhaus quota/error detection
+		if (zone.zone === 'dbl.spamhaus.org' && /^127\.255\.255\./.test(ip)) {
+			findings.push(
+				createFinding(
+					CATEGORY,
+					`${zone.name} query rate-limited`,
+					'low',
+					`Spamhaus DBL returned ${ip}, indicating a query quota or rate limit. This is not a listing. Results from this zone are unavailable.`,
+					{ zone: zone.zone, returnCode: ip, quotaError: true },
+				),
+			);
+			continue;
+		}
+
+		// Decode the return code
+		const decoded = zone.decode(ip);
+		if (decoded) {
+			listedCount++;
+			findings.push(
+				createFinding(
+					CATEGORY,
+					`Listed on ${zone.name}`,
+					zone.severity,
+					`${domain} is listed on ${zone.name}: ${decoded.detail}`,
+					{ zone: zone.zone, returnCode: ip, labels: decoded.label },
+				),
+			);
+		}
+	}
+
+	// If no listings and no errors produced findings, add a clean summary
+	if (listedCount === 0 && findings.length === 0) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Domain not listed on any blocklist',
+				'info',
+				`${domain} is not listed on any of the ${checkedCount} checked DNS-based domain blocklists (Spamhaus DBL, URIBL, SURBL).`,
+				{ zonesChecked: checkedCount },
+			),
+		);
+	} else if (listedCount === 0 && findings.every((f) => f.severity === 'low')) {
+		// Only errors/quota — add an info note that no actual listings were found
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Domain not listed on any blocklist',
+				'info',
+				`${domain} was not found on any of the successfully queried blocklists.`,
+				{ zonesChecked: checkedCount },
+			),
+		);
+	}
+
+	return buildCheckResult(CATEGORY, findings) as CheckResult;
+}

--- a/src/tools/check-dbl.ts
+++ b/src/tools/check-dbl.ts
@@ -65,17 +65,20 @@ function decodeSpamhaus(ip: string): DblDecodeResult | null {
 }
 
 // -- URIBL bitmask flags ------------------------------------------------------
+// Reference: https://uribl.com — 0x01 means the querier is rate-limited/blocked.
 
 const URIBL_FLAGS: Array<{ mask: number; label: string }> = [
-	{ mask: 0x01, label: 'Black' },
-	{ mask: 0x02, label: 'Grey' },
-	{ mask: 0x04, label: 'Red' },
-	{ mask: 0x08, label: 'Multi' },
+	{ mask: 0x02, label: 'Black' },
+	{ mask: 0x04, label: 'Grey' },
+	{ mask: 0x08, label: 'Red' },
 ];
 
 function decodeUribl(ip: string): DblDecodeResult | null {
 	const octet = parseInt(ip.split('.')[3], 10);
 	if (!Number.isFinite(octet) || octet === 0) return null;
+
+	// 0x01 = querier rate-limited/blocked by URIBL — NOT a listing
+	if ((octet & 0x01) !== 0 && (octet & ~0x01) === 0) return null;
 
 	const matched = URIBL_FLAGS.filter((f) => (octet & f.mask) !== 0).map((f) => f.label);
 	if (matched.length === 0) return null;
@@ -89,10 +92,11 @@ function decodeUribl(ip: string): DblDecodeResult | null {
 const SURBL_FLAGS: Array<{ mask: number; label: string }> = [
 	{ mask: 0x02, label: 'SC (SpamCop)' },
 	{ mask: 0x04, label: 'WS (sa-blacklist)' },
-	{ mask: 0x08, label: 'AB (AbuseButler)' },
-	{ mask: 0x10, label: 'Phishing' },
-	{ mask: 0x40, label: 'Malware' },
-	{ mask: 0x80, label: 'CRX (Cracked/compromised)' },
+	{ mask: 0x08, label: 'PH (Phishing)' },
+	{ mask: 0x10, label: 'MW (Malware)' },
+	{ mask: 0x20, label: 'AB (AbuseButler)' },
+	{ mask: 0x40, label: 'JP' },
+	{ mask: 0x80, label: 'CR (Cracked)' },
 ];
 
 function decodeSurbl(ip: string): DblDecodeResult | null {
@@ -184,6 +188,23 @@ export async function checkDbl(domain: string, dnsOptions?: QueryDnsOptions): Pr
 				),
 			);
 			continue;
+		}
+
+		// URIBL rate-limit/blocked detection (last octet == 1, i.e. only 0x01 set)
+		if (zone.zone === 'multi.uribl.com') {
+			const uriblOctet = parseInt(ip.split('.')[3], 10);
+			if (uriblOctet === 1) {
+				findings.push(
+					createFinding(
+						CATEGORY,
+						`${zone.name} query rate-limited`,
+						'info',
+						`URIBL returned ${ip}, indicating the querier is rate-limited or blocked. This is not a listing. Results from this zone are unavailable.`,
+						{ zone: zone.zone, returnCode: ip, quotaError: true },
+					),
+				);
+				continue;
+			}
 		}
 
 		// Decode the return code

--- a/src/tools/check-dnssec-chain.ts
+++ b/src/tools/check-dnssec-chain.ts
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DNSSEC Chain-of-Trust Walk tool.
+ * Walks the DNSSEC chain from root to target domain via DoH, reporting
+ * DS/DNSKEY records and linkage at each zone level.
+ *
+ * Limitations (disclosed in output):
+ * - No cryptographic RRSIG verification. Reports structure and linkage only.
+ *
+ * Workers-compatible: uses fetch API only (DNS-over-HTTPS).
+ */
+
+import { queryDns, queryDnsRecords } from '../lib/dns';
+import type { QueryDnsOptions } from '../lib/dns-types';
+import { buildCheckResult, createFinding } from '../lib/scoring';
+import type { CheckResult, CheckCategory } from '../lib/scoring';
+
+const CATEGORY = 'dnssec_chain' as CheckCategory;
+
+/** DNSSEC signing algorithm names (IANA registry). */
+const DNSSEC_ALGORITHMS: Record<number, string> = {
+	1: 'RSA-MD5',
+	3: 'DSA-SHA1',
+	5: 'RSA-SHA1',
+	6: 'DSA-NSEC3-SHA1',
+	7: 'RSA-SHA1-NSEC3',
+	8: 'RSA-SHA256',
+	10: 'RSA-SHA512',
+	12: 'ECC-GOST',
+	13: 'ECDSAP256SHA256',
+	14: 'ECDSAP384SHA384',
+	15: 'Ed25519',
+	16: 'Ed448',
+};
+
+/** Algorithms considered weak / deprecated. */
+const WEAK_ALGORITHMS = new Set([1, 3, 5, 6, 7]);
+
+/** DS digest type names. */
+const DIGEST_TYPES: Record<number, string> = { 1: 'SHA-1', 2: 'SHA-256', 4: 'SHA-384' };
+
+/** Linkage status between DS and DNSKEY at a zone. */
+type LinkageStatus = 'linked' | 'no_ds' | 'no_dnskey' | 'broken';
+
+/** Parsed DS record fields. */
+interface ParsedDs {
+	keyTag: number;
+	algorithm: number;
+	digestType: number;
+	digest: string;
+}
+
+/** Parsed DNSKEY record fields. */
+interface ParsedDnskey {
+	flags: number;
+	protocol: number;
+	algorithm: number;
+	pubkey: string;
+	isKsk: boolean;
+}
+
+/** Per-zone walk result. */
+interface ZoneResult {
+	zone: string;
+	dsRecords: ParsedDs[];
+	dnskeyRecords: ParsedDnskey[];
+	linkage: LinkageStatus;
+	algorithms: string[];
+	weakAlgorithms: string[];
+}
+
+// ---------------------------------------------------------------------------
+// Parsers
+// ---------------------------------------------------------------------------
+
+function parseDsRecord(data: string): ParsedDs | null {
+	const parts = data.trim().split(/\s+/);
+	if (parts.length < 4) return null;
+	const keyTag = parseInt(parts[0], 10);
+	const algorithm = parseInt(parts[1], 10);
+	const digestType = parseInt(parts[2], 10);
+	const digest = parts.slice(3).join('');
+	if (!Number.isFinite(keyTag) || !Number.isFinite(algorithm) || !Number.isFinite(digestType)) return null;
+	return { keyTag, algorithm, digestType, digest };
+}
+
+function parseDnskeyRecord(data: string): ParsedDnskey | null {
+	const parts = data.trim().split(/\s+/);
+	if (parts.length < 4) return null;
+	const flags = parseInt(parts[0], 10);
+	const protocol = parseInt(parts[1], 10);
+	const algorithm = parseInt(parts[2], 10);
+	const pubkey = parts.slice(3).join('');
+	if (!Number.isFinite(flags) || !Number.isFinite(protocol) || !Number.isFinite(algorithm)) return null;
+	return { flags, protocol, algorithm, pubkey, isKsk: flags === 257 };
+}
+
+// ---------------------------------------------------------------------------
+// Linkage determination
+// ---------------------------------------------------------------------------
+
+function determineLinkage(dsRecords: ParsedDs[], dnskeyRecords: ParsedDnskey[]): LinkageStatus {
+	if (dsRecords.length === 0) return 'no_ds';
+	if (dnskeyRecords.length === 0) return 'no_dnskey';
+
+	// Check if any DS algorithm matches any DNSKEY algorithm
+	const dsAlgs = new Set(dsRecords.map((ds) => ds.algorithm));
+	const keyAlgs = new Set(dnskeyRecords.map((k) => k.algorithm));
+	for (const alg of dsAlgs) {
+		if (keyAlgs.has(alg)) return 'linked';
+	}
+	return 'broken';
+}
+
+// ---------------------------------------------------------------------------
+// Zone hierarchy builder
+// ---------------------------------------------------------------------------
+
+/** Build zone hierarchy: "sub.example.com" → [".", "com", "example.com", "sub.example.com"] */
+function buildZoneHierarchy(domain: string): string[] {
+	const labels = domain.split('.');
+	const zones: string[] = ['.'];
+	for (let i = labels.length - 1; i >= 0; i--) {
+		zones.push(labels.slice(i).join('.'));
+	}
+	return zones;
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk the DNSSEC chain of trust from root to the target domain.
+ * Queries DS and DNSKEY records at each zone level and reports linkage.
+ *
+ * @param domain - The domain to check (must already be validated and sanitized)
+ * @param dnsOptions - Optional DNS query options
+ * @returns CheckResult with chain-of-trust findings
+ */
+export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
+	const findings: ReturnType<typeof createFinding>[] = [];
+	const zones = buildZoneHierarchy(domain);
+	const zoneResults: ZoneResult[] = [];
+	let chainBroken = false;
+	const weakAlgsFound: string[] = [];
+
+	for (const zone of zones) {
+		// Query DS (skip for root — root has no parent to hold DS)
+		let dsRecords: ParsedDs[] = [];
+		if (zone !== '.') {
+			try {
+				const rawDs = await queryDnsRecords(zone, 'DS', dnsOptions);
+				dsRecords = rawDs.map(parseDsRecord).filter((r): r is ParsedDs => r !== null);
+			} catch {
+				// DS query failed — treat as no DS
+			}
+		}
+
+		// Query DNSKEY
+		let dnskeyRecords: ParsedDnskey[] = [];
+		try {
+			const rawDnskey = await queryDnsRecords(zone, 'DNSKEY', dnsOptions);
+			dnskeyRecords = rawDnskey.map(parseDnskeyRecord).filter((r): r is ParsedDnskey => r !== null);
+		} catch {
+			// DNSKEY query failed — treat as no DNSKEY
+		}
+
+		// Determine linkage (root always has no_ds since we skip DS query)
+		const linkage = zone === '.' ? (dnskeyRecords.length > 0 ? 'linked' : 'no_dnskey') : determineLinkage(dsRecords, dnskeyRecords);
+
+		// Collect algorithm names
+		const allAlgs = new Set<number>();
+		for (const ds of dsRecords) allAlgs.add(ds.algorithm);
+		for (const key of dnskeyRecords) allAlgs.add(key.algorithm);
+		const algorithms = [...allAlgs].map((a) => DNSSEC_ALGORITHMS[a] ?? `Unknown(${a})`);
+		const weakAlgorithms = [...allAlgs].filter((a) => WEAK_ALGORITHMS.has(a)).map((a) => DNSSEC_ALGORITHMS[a] ?? `Unknown(${a})`);
+		weakAlgsFound.push(...weakAlgorithms);
+
+		zoneResults.push({
+			zone,
+			dsRecords,
+			dnskeyRecords,
+			linkage,
+			algorithms,
+			weakAlgorithms,
+		});
+
+		if (linkage === 'no_dnskey' || linkage === 'broken') {
+			chainBroken = true;
+		}
+
+		// Stop walking if zone has no DS and no DNSKEY (unsigned from here down)
+		if (zone !== '.' && dsRecords.length === 0 && dnskeyRecords.length === 0) {
+			break;
+		}
+	}
+
+	// Check AD flag on target domain
+	let adFlag = false;
+	try {
+		const adResp = await queryDns(domain, 'A', true, dnsOptions);
+		adFlag = adResp.AD === true;
+	} catch {
+		// AD check failed — leave as false
+	}
+
+	// Determine chain completeness
+	const lastZone = zoneResults[zoneResults.length - 1];
+	const reachedTarget = lastZone?.zone === domain;
+	// Chain is complete only if we reached the target AND it's not broken AND the target zone is actually signed
+	const targetSigned = reachedTarget && (lastZone.dsRecords.length > 0 || lastZone.dnskeyRecords.length > 0);
+	const chainComplete = reachedTarget && !chainBroken && targetSigned;
+
+	// --- Findings ---
+
+	// Broken chain finding (high severity)
+	if (chainBroken) {
+		const brokenZones = zoneResults.filter((z) => z.linkage === 'no_dnskey' || z.linkage === 'broken');
+		for (const bz of brokenZones) {
+			const reason = bz.linkage === 'no_dnskey' ? 'DS record exists but no DNSKEY found' : 'DS and DNSKEY algorithm mismatch';
+			findings.push(
+				createFinding(
+					CATEGORY,
+					`Broken DNSSEC chain at ${bz.zone}`,
+					'high',
+					`DNSSEC chain is broken at ${bz.zone}: ${reason}. Resolvers that validate DNSSEC will return SERVFAIL for this zone.`,
+					{ zone: bz.zone, linkage: bz.linkage },
+				),
+			);
+		}
+	}
+
+	// Weak algorithm finding (medium severity)
+	if (weakAlgsFound.length > 0) {
+		const uniqueWeak = [...new Set(weakAlgsFound)];
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Weak DNSSEC algorithm in chain',
+				'medium',
+				`DNSSEC chain uses deprecated/weak algorithm(s): ${uniqueWeak.join(', ')}. These are considered cryptographically weak and should be migrated to RSA-SHA256 (algorithm 8) or ECDSA (algorithm 13/14).`,
+				{ weakAlgorithms: uniqueWeak },
+			),
+		);
+	}
+
+	// Chain summary (always present — info severity)
+	const zonesSummary = zoneResults.map((z) => ({
+		zone: z.zone,
+		dsCount: z.dsRecords.length,
+		dnskeyCount: z.dnskeyRecords.length,
+		kskCount: z.dnskeyRecords.filter((k) => k.isKsk).length,
+		zskCount: z.dnskeyRecords.filter((k) => !k.isKsk).length,
+		linkage: z.linkage,
+		algorithms: z.algorithms,
+		dsDigestTypes: [...new Set(z.dsRecords.map((ds) => DIGEST_TYPES[ds.digestType] ?? `Unknown(${ds.digestType})`))],
+	}));
+
+	const stoppedEarly = !reachedTarget;
+	let summaryStatus: string;
+	if (stoppedEarly) {
+		summaryStatus = `stopped at ${lastZone?.zone ?? '.'} — zone has no DS and no DNSKEY (not signed)`;
+	} else if (!targetSigned) {
+		summaryStatus = `${domain} has no DS and no DNSKEY — domain is not signed`;
+	} else if (chainComplete) {
+		summaryStatus = 'complete chain from root to target';
+	} else {
+		summaryStatus = 'chain broken';
+	}
+	const summaryDetail = `DNSSEC chain walk for ${domain}: ${summaryStatus}. Zones walked: ${zoneResults.map((z) => z.zone).join(' → ')}. AD flag: ${adFlag}. Limitation: no cryptographic RRSIG verification; reports structure and linkage only.`;
+
+	findings.push(
+		createFinding(CATEGORY, 'DNSSEC chain summary', 'info', summaryDetail, {
+			chainComplete,
+			adFlag,
+			zonesWalked: zoneResults.length,
+			zones: zonesSummary,
+		}),
+	);
+
+	return buildCheckResult(CATEGORY, findings) as CheckResult;
+}

--- a/src/tools/check-fast-flux.ts
+++ b/src/tools/check-fast-flux.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Fast-Flux Detection tool (DoH-adapted).
+ * Performs multiple rounds of A/AAAA queries with delays between them,
+ * comparing IP answer sets and TTLs across rounds to detect fast-flux behavior.
+ *
+ * Limitations: DoH resolver caching may mask rotation. Lower fidelity than
+ * direct UDP probing.
+ *
+ * Workers-compatible: uses fetch API only (DNS-over-HTTPS).
+ */
+
+import { queryDns } from '../lib/dns';
+import type { DnsAnswer, QueryDnsOptions } from '../lib/dns-types';
+import { buildCheckResult, createFinding } from '../lib/scoring';
+import type { CheckResult, CheckCategory, Finding } from '../lib/scoring';
+
+const CATEGORY = 'fast_flux' as CheckCategory;
+
+/** A-record type code */
+const TYPE_A = 1;
+/** AAAA-record type code */
+const TYPE_AAAA = 28;
+
+interface RoundResult {
+	ips: string[];
+	minTtl: number;
+}
+
+/**
+ * Detect fast-flux DNS behavior by querying A/AAAA records across multiple rounds.
+ *
+ * @param domain - The domain to check (must already be validated and sanitized)
+ * @param rounds - Number of query rounds (3-5, default 3)
+ * @param dnsOptions - Optional DNS query options
+ * @param delayMs - Delay between rounds in ms (default 2000; tests can pass 0)
+ * @returns CheckResult with fast-flux findings
+ */
+export async function checkFastFlux(
+	domain: string,
+	rounds?: number,
+	dnsOptions?: QueryDnsOptions,
+	delayMs = 2000,
+): Promise<CheckResult> {
+	const effectiveRounds = Math.max(3, Math.min(5, rounds ?? 3));
+	const roundResults: RoundResult[] = [];
+
+	for (let i = 0; i < effectiveRounds; i++) {
+		// Delay between rounds (not before the first)
+		if (i > 0 && delayMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+
+		try {
+			// Query A + AAAA in parallel
+			const [aResult, aaaaResult] = await Promise.allSettled([
+				queryDns(domain, 'A', false, dnsOptions),
+				queryDns(domain, 'AAAA', false, dnsOptions),
+			]);
+
+			const answers: DnsAnswer[] = [];
+
+			if (aResult.status === 'fulfilled' && aResult.value.Answer) {
+				answers.push(...aResult.value.Answer.filter((a) => a.type === TYPE_A));
+			}
+			if (aaaaResult.status === 'fulfilled' && aaaaResult.value.Answer) {
+				answers.push(...aaaaResult.value.Answer.filter((a) => a.type === TYPE_AAAA));
+			}
+
+			const ips = answers.map((a) => a.data).sort();
+			const minTtl = answers.length > 0 ? Math.min(...answers.map((a) => a.TTL)) : Infinity;
+
+			roundResults.push({ ips, minTtl });
+		} catch {
+			// Round failed entirely — record empty result
+			roundResults.push({ ips: [], minTtl: Infinity });
+		}
+	}
+
+	// Check if all rounds failed
+	const successfulRounds = roundResults.filter((r) => r.ips.length > 0);
+	if (successfulRounds.length === 0) {
+		const findings: Finding[] = [
+			createFinding(
+				CATEGORY,
+				'DNS queries failed',
+				'medium',
+				`All ${effectiveRounds} query rounds failed for ${domain}. Unable to assess fast-flux behavior.`,
+			),
+		];
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	// Collect all unique IPs across all rounds
+	const allUniqueIps = new Set<string>();
+	for (const round of roundResults) {
+		for (const ip of round.ips) {
+			allUniqueIps.add(ip);
+		}
+	}
+
+	// Count IP set changes between consecutive rounds
+	let ipSetChanges = 0;
+	for (let i = 1; i < roundResults.length; i++) {
+		const prev = roundResults[i - 1].ips.join(',');
+		const curr = roundResults[i].ips.join(',');
+		if (prev !== curr && roundResults[i - 1].ips.length > 0 && roundResults[i].ips.length > 0) {
+			ipSetChanges++;
+		}
+	}
+
+	// Find minimum TTL across all rounds
+	const overallMinTtl = Math.min(...successfulRounds.map((r) => r.minTtl));
+
+	// Detect flux: low TTL AND IP changes
+	const fluxDetected = overallMinTtl < 300 && ipSetChanges > 0;
+
+	const findings: Finding[] = [];
+
+	if (fluxDetected) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Fast-flux behavior detected',
+				'high',
+				`${domain} shows fast-flux indicators: ${allUniqueIps.size} unique IPs observed across ${effectiveRounds} rounds with ${ipSetChanges} IP set change(s) and minimum TTL of ${overallMinTtl}s. Rotating IPs with low TTLs are characteristic of fast-flux networks used to evade takedowns.`,
+				{
+					domain,
+					flux_detected: true,
+					unique_ips: allUniqueIps.size,
+					ip_set_changes: ipSetChanges,
+					min_ttl: overallMinTtl,
+					rounds: effectiveRounds,
+				},
+			),
+		);
+	} else {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Stable resolution — no fast-flux indicators',
+				'info',
+				`${domain} resolved consistently across ${effectiveRounds} rounds: ${allUniqueIps.size} unique IP(s), ${ipSetChanges} IP set change(s), minimum TTL ${overallMinTtl === Infinity ? 'N/A' : `${overallMinTtl}s`}. No fast-flux behavior detected.`,
+				{
+					domain,
+					flux_detected: false,
+					unique_ips: allUniqueIps.size,
+					ip_set_changes: ipSetChanges,
+					min_ttl: overallMinTtl === Infinity ? null : overallMinTtl,
+					rounds: effectiveRounds,
+				},
+			),
+		);
+	}
+
+	// Disclosure about limitations
+	findings.push(
+		createFinding(
+			CATEGORY,
+			'Detection limitations',
+			'info',
+			'DoH resolver caching may mask IP rotation. This check has lower fidelity than direct UDP probing against authoritative nameservers.',
+		),
+	);
+
+	return buildCheckResult(CATEGORY, findings) as CheckResult;
+}

--- a/src/tools/check-nsec-walkability.ts
+++ b/src/tools/check-nsec-walkability.ts
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * NSEC3 Parameter Analysis tool.
+ * Assesses zone walkability risk by analyzing NSEC3PARAM configuration via DoH.
+ *
+ * Workers-compatible: uses fetch API only (DNS-over-HTTPS).
+ */
+
+import { queryDnsRecords } from '../lib/dns';
+import type { QueryDnsOptions } from '../lib/dns-types';
+import { buildCheckResult, createFinding } from '../lib/scoring';
+import type { CheckResult, CheckCategory } from '../lib/scoring';
+
+const CATEGORY = 'nsec_walkability' as CheckCategory;
+
+/** NSEC3 hash algorithm names (RFC 5155 §11). Only algorithm 1 is defined. */
+const NSEC3_HASH_ALGORITHMS: Record<number, string> = {
+	1: 'SHA-1',
+};
+
+/** Parsed NSEC3PARAM fields. */
+interface Nsec3Params {
+	algorithm: number;
+	algorithmName: string;
+	flags: number;
+	iterations: number;
+	salt: string; // "-" means empty
+}
+
+/**
+ * Parse an NSEC3PARAM data string: "algorithm flags iterations salt"
+ * Salt of "-" indicates an empty salt (RFC 5155 §4.2).
+ */
+function parseNsec3Param(data: string): Nsec3Params | null {
+	const parts = data.trim().split(/\s+/);
+	if (parts.length < 4) return null;
+
+	const algorithm = parseInt(parts[0], 10);
+	const flags = parseInt(parts[1], 10);
+	const iterations = parseInt(parts[2], 10);
+	const salt = parts[3];
+
+	if (!Number.isFinite(algorithm) || !Number.isFinite(flags) || !Number.isFinite(iterations)) {
+		return null;
+	}
+
+	return {
+		algorithm,
+		algorithmName: NSEC3_HASH_ALGORITHMS[algorithm] ?? `Unknown (${algorithm})`,
+		flags,
+		iterations,
+		salt,
+	};
+}
+
+/**
+ * Assess NSEC3 zone walkability risk by analyzing NSEC3PARAM records.
+ *
+ * Limitations (disclosed in findings):
+ * - Cannot probe for actual NSEC/NSEC3 denial records via DoH
+ * - Cannot definitively confirm plain NSEC vs. absent NSEC3PARAM
+ * - Analyzes configuration parameters only
+ *
+ * @param domain - The domain to check (must already be validated and sanitized)
+ * @param dnsOptions - Optional DNS query options
+ * @returns CheckResult with NSEC3 walkability findings
+ */
+export async function checkNsecWalkability(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
+	const findings: ReturnType<typeof createFinding>[] = [];
+
+	let nsec3Records: string[] = [];
+	try {
+		nsec3Records = await queryDnsRecords(domain, 'NSEC3PARAM', dnsOptions);
+	} catch {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'NSEC3PARAM query failed',
+				'info',
+				`DNS query for NSEC3PARAM records at ${domain} failed. Unable to assess zone walkability. Note: this analysis cannot probe for actual NSEC/NSEC3 denial records via DoH and analyzes configuration parameters only.`,
+				{ domain },
+			),
+		);
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	if (nsec3Records.length === 0) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'No NSEC3PARAM record found',
+				'high',
+				`No NSEC3PARAM record was found for ${domain}. The zone likely uses plain NSEC, which makes it fully walkable — an attacker can enumerate all zone contents by following NSEC chain links. Limitation: DoH cannot probe for actual NSEC/NSEC3 denial-of-existence records, so this assessment is based on the absence of NSEC3PARAM configuration only.`,
+				{ domain, walkable: true },
+			),
+		);
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	// Parse the first NSEC3PARAM record (zones should have exactly one)
+	const params = parseNsec3Param(nsec3Records[0]);
+
+	if (!params) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Unparseable NSEC3PARAM',
+				'info',
+				`NSEC3PARAM record for ${domain} could not be parsed: ${nsec3Records[0]}`,
+				{ domain, raw: nsec3Records[0] },
+			),
+		);
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	const hasSalt = params.salt !== '-';
+	const hasIterations = params.iterations > 0;
+
+	// Check opt-out flag (bit 0 of flags)
+	if (params.flags & 1) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'NSEC3 opt-out enabled',
+				'low',
+				`NSEC3PARAM for ${domain} has the opt-out flag set (flags=${params.flags}). Opt-out allows unsigned delegations to be omitted from the NSEC3 chain, which may leave some subdomains without denial-of-existence protection.`,
+				{ domain, flags: params.flags, optOut: true },
+			),
+		);
+	}
+
+	// Assess walkability risk based on parameters
+	if (!hasIterations && !hasSalt) {
+		// RFC 9276 default: 0 iterations, no salt — low enumeration cost
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'NSEC3 with minimal parameters',
+				'medium',
+				`NSEC3PARAM for ${domain} uses 0 iterations and no salt (RFC 9276 recommended defaults). While NSEC3 prevents trivial zone walking, the low enumeration cost means offline dictionary attacks against the hashed names are feasible. Algorithm: ${params.algorithmName}. Note: this tool analyzes NSEC3PARAM configuration only and cannot probe for actual NSEC3 denial records via DoH.`,
+				{
+					domain,
+					algorithm: params.algorithmName,
+					algorithmId: params.algorithm,
+					iterations: params.iterations,
+					salt: params.salt,
+					hasSalt: false,
+				},
+			),
+		);
+	} else {
+		// Has salt and/or iterations > 0 — standard NSEC3 configuration
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'NSEC3 parameters configured',
+				'info',
+				`NSEC3PARAM for ${domain}: algorithm ${params.algorithmName}, ${params.iterations} iteration${params.iterations !== 1 ? 's' : ''}, salt ${hasSalt ? params.salt : 'none'}. Zone uses NSEC3 hashed denial-of-existence, which mitigates trivial zone walking. Note: this tool analyzes configuration parameters only.`,
+				{
+					domain,
+					algorithm: params.algorithmName,
+					algorithmId: params.algorithm,
+					iterations: params.iterations,
+					salt: params.salt,
+					hasSalt,
+				},
+			),
+		);
+	}
+
+	return buildCheckResult(CATEGORY, findings) as CheckResult;
+}

--- a/src/tools/check-rbl.ts
+++ b/src/tools/check-rbl.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Real-time Blocklist (RBL) check tool.
+ * Resolves MX IPs for a domain and checks against 8 DNS-based blocklists.
+ */
+
+import { queryDnsRecords, queryMxRecords } from '../lib/dns';
+import type { QueryDnsOptions } from '../lib/dns-types';
+import { reverseIPv4, isPrivateIP } from '../lib/ip-utils';
+import { buildCheckResult, createFinding } from '../lib/scoring';
+import type { CheckResult, CheckCategory } from '../lib/scoring';
+
+interface RblZone {
+	name: string;
+	zone: string;
+}
+
+const RBL_ZONES: RblZone[] = [
+	{ name: 'Spamhaus ZEN', zone: 'zen.spamhaus.org' },
+	{ name: 'SpamCop', zone: 'bl.spamcop.net' },
+	{ name: 'UCEProtect L1', zone: 'dnsbl-1.uceprotect.net' },
+	{ name: 'UCEProtect L2', zone: 'dnsbl-2.uceprotect.net' },
+	{ name: 'Mailspike', zone: 'bl.mailspike.net' },
+	{ name: 'Barracuda', zone: 'b.barracudacentral.org' },
+	{ name: 'PSBL', zone: 'psbl.surriel.com' },
+	{ name: 'SORBS', zone: 'dnsbl.sorbs.net' },
+];
+
+const CATEGORY = 'rbl' as CheckCategory;
+const MAX_MX_IPS = 4;
+
+/** Spamhaus ZEN return code descriptions (keyed by last two octets). */
+const SPAMHAUS_CODES: Record<string, string> = {
+	'0.2': 'SBL — direct spam source',
+	'0.3': 'SBL CSS — spam support service',
+	'0.4': 'XBL CBL — exploited host',
+	'0.5': 'XBL — exploited host (NJABL)',
+	'0.9': 'SBL DROP — hijacked netblock',
+	'0.10': 'PBL ISP — end-user IP',
+	'0.11': 'PBL ISP — end-user IP',
+};
+
+/** Decode Spamhaus ZEN return code. Returns null for quota codes. */
+function decodeSpamhausCode(ip: string): string | null {
+	if (ip.startsWith('127.255.255.')) return null; // quota
+	const lastTwo = ip.split('.').slice(2).join('.');
+	return SPAMHAUS_CODES[lastTwo] ?? `Listed (${ip})`;
+}
+
+/** Mailspike positive reputation codes: 127.0.0.10 through 127.0.0.14. */
+function isMailspikePositive(ip: string): boolean {
+	const last = parseInt(ip.split('.').pop() ?? '0', 10);
+	return last >= 10 && last <= 14;
+}
+
+/**
+ * Check MX server IPs against 8 DNS-based Real-time Blocklists.
+ * Falls back to domain A records if no MX records exist.
+ */
+export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
+	const findings: ReturnType<typeof createFinding>[] = [];
+
+	// Step 1: Resolve MX → hosts → IPs. Fall back to domain A records.
+	let ips: string[] = [];
+	let usedFallback = false;
+
+	try {
+		const mxRecords = await queryMxRecords(domain, dnsOptions);
+		if (mxRecords.length > 0) {
+			const mxHosts = mxRecords.map((r) => r.exchange).filter(Boolean);
+			const ipResults = await Promise.allSettled(
+				mxHosts.slice(0, MAX_MX_IPS).map((host) => queryDnsRecords(host, 'A', dnsOptions)),
+			);
+			for (const r of ipResults) {
+				if (r.status === 'fulfilled') ips.push(...r.value);
+			}
+		}
+	} catch {
+		// MX resolution failed
+	}
+
+	if (ips.length === 0) {
+		try {
+			ips = await queryDnsRecords(domain, 'A', dnsOptions);
+			if (ips.length > 0) usedFallback = true;
+		} catch {
+			// A resolution also failed
+		}
+	}
+
+	if (ips.length === 0) {
+		findings.push(
+			createFinding(CATEGORY, 'No IP addresses found', 'info', `Could not resolve any IP addresses for ${domain} (no MX or A records).`, {
+				domain,
+			}),
+		);
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	if (usedFallback) {
+		findings.push(
+			createFinding(CATEGORY, 'No MX records — using A record fallback', 'info', `${domain} has no MX records. Using A record IP(s) for RBL checks.`, {
+				domain,
+				fallback: true,
+			}),
+		);
+	}
+
+	// Deduplicate and limit
+	ips = [...new Set(ips)].slice(0, MAX_MX_IPS);
+
+	// Step 2: Check each IP against all RBL zones
+	let totalListings = 0;
+
+	for (const ip of ips) {
+		// Only check IPv4
+		if (!/^(\d{1,3}\.){3}\d{1,3}$/.test(ip)) continue;
+
+		if (isPrivateIP(ip)) {
+			findings.push(
+				createFinding(CATEGORY, `Private IP detected: ${ip}`, 'info', `MX resolves to private IP ${ip} — RBL checks skipped for this address.`, {
+					ip,
+					private: true,
+				}),
+			);
+			continue;
+		}
+
+		const reversed = reverseIPv4(ip);
+		let ipListingCount = 0;
+		let hasSpamhausListing = false;
+		const ipListingIndices: number[] = [];
+
+		const rblResults = await Promise.allSettled(
+			RBL_ZONES.map(async (rbl) => {
+				const queryName = `${reversed}.${rbl.zone}`;
+				try {
+					const answers = await queryDnsRecords(queryName, 'A', dnsOptions);
+					if (answers.length === 0) return { rbl, listed: false };
+
+					const returnIp = answers[0];
+
+					// Spamhaus quota codes
+					if (rbl.zone === 'zen.spamhaus.org' && returnIp.startsWith('127.255.255.')) {
+						return { rbl, listed: false, quota: true };
+					}
+
+					// Mailspike positive reputation
+					if (rbl.zone === 'bl.mailspike.net' && isMailspikePositive(returnIp)) {
+						return { rbl, listed: false, positiveRep: true };
+					}
+
+					return { rbl, listed: true, returnIp };
+				} catch {
+					return { rbl, listed: false, error: true };
+				}
+			}),
+		);
+
+		for (const settled of rblResults) {
+			if (settled.status === 'rejected') continue;
+			const result = settled.value;
+
+			if (result.quota) {
+				findings.push(
+					createFinding(CATEGORY, `${result.rbl.name} quota exceeded`, 'info', `Spamhaus returned a quota/rate-limit response for ${ip}. Use a DQS key for reliable results.`, {
+						ip,
+						zone: result.rbl.zone,
+						quota: true,
+					}),
+				);
+				continue;
+			}
+
+			if (result.positiveRep) {
+				findings.push(
+					createFinding(CATEGORY, `Positive Mailspike reputation for ${ip}`, 'info', `${ip} has positive reputation on Mailspike.`, {
+						ip,
+						zone: result.rbl.zone,
+						positiveReputation: true,
+					}),
+				);
+				continue;
+			}
+
+			if (result.error || !result.listed) continue;
+
+			ipListingCount++;
+			totalListings++;
+			if (result.rbl.zone === 'zen.spamhaus.org') hasSpamhausListing = true;
+
+			const severity = result.rbl.zone === 'zen.spamhaus.org' ? 'high' : 'low';
+			const detail =
+				result.rbl.zone === 'zen.spamhaus.org'
+					? `${ip} is listed on ${result.rbl.name}: ${decodeSpamhausCode(result.returnIp!) ?? result.returnIp}.`
+					: `${ip} is listed on ${result.rbl.name}.`;
+
+			ipListingIndices.push(findings.length);
+			findings.push(
+				createFinding(CATEGORY, `Listed on ${result.rbl.name}`, severity as 'high' | 'low', detail, {
+					ip,
+					zone: result.rbl.zone,
+					returnCode: result.returnIp,
+				}),
+			);
+		}
+
+		// Elevate severity if 2+ non-Spamhaus RBLs list the same IP
+		if (!hasSpamhausListing && ipListingCount >= 2) {
+			const firstLowIdx = ipListingIndices.find((idx) => findings[idx]?.severity === 'low');
+			if (firstLowIdx !== undefined) {
+				const f = findings[firstLowIdx];
+				findings[firstLowIdx] = createFinding(
+					CATEGORY,
+					f.title,
+					'medium',
+					f.detail + ` (elevated: listed on ${ipListingCount} RBLs)`,
+					f.metadata,
+				);
+			}
+		}
+	}
+
+	if (totalListings === 0 && !findings.some((f) => f.title.includes('Listed'))) {
+		findings.push(
+			createFinding(CATEGORY, 'IP reputation clean — not listed on any RBL', 'info', `All checked IPs for ${domain} are clean on ${RBL_ZONES.length} RBLs.`, {
+				ips,
+				zones: RBL_ZONES.map((z) => z.zone),
+			}),
+		);
+	}
+
+	return buildCheckResult(CATEGORY, findings) as CheckResult;
+}

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * RDAP Lookup tool — Domain Registration Data.
+ * Fetches domain registration data via RDAP (modern WHOIS replacement).
+ * Uses only HTTP fetch (no DNS queries).
+ */
+
+import { buildCheckResult, createFinding } from '../lib/scoring';
+import type { CheckResult, CheckCategory } from '../lib/scoring';
+
+const CATEGORY = 'rdap' as CheckCategory;
+
+/** RDAP bootstrap URL (IANA). */
+const IANA_BOOTSTRAP_URL = 'https://data.iana.org/rdap/dns.json';
+
+/** Hardcoded RDAP server fallbacks for common TLDs. */
+const FALLBACK_RDAP_SERVERS: Record<string, string> = {
+	com: 'https://rdap.verisign.com/com/v1/',
+	net: 'https://rdap.verisign.com/net/v1/',
+	org: 'https://rdap.org/',
+	info: 'https://rdap.afilias.net/rdap/info/',
+	io: 'https://rdap.nic.io/',
+};
+
+/** Module-level bootstrap cache (per isolate lifetime). */
+let bootstrapCache: Record<string, string> | null = null;
+
+/** Reset bootstrap cache — exported for test isolation. */
+export function _resetBootstrapCache(): void {
+	bootstrapCache = null;
+}
+
+/** Timeout for all outbound RDAP fetches (ms). */
+const RDAP_TIMEOUT_MS = 10_000;
+
+interface RdapEvent {
+	eventAction: string;
+	eventDate: string;
+}
+
+interface RdapVcardProperty {
+	0: string;  // property name
+	1: Record<string, unknown>;  // parameters
+	2: string;  // type
+	3: unknown;  // value
+}
+
+interface RdapEntity {
+	objectClassName?: string;
+	roles?: string[];
+	vcardArray?: ['vcard', RdapVcardProperty[]];
+	entities?: RdapEntity[];
+}
+
+interface RdapDomainResponse {
+	ldhName?: string;
+	status?: string[];
+	events?: RdapEvent[];
+	entities?: RdapEntity[];
+}
+
+/**
+ * Fetch and parse the IANA RDAP bootstrap file.
+ * Caches result in module-level variable for isolate lifetime.
+ * Returns a TLD → RDAP server URL map.
+ */
+async function fetchBootstrap(): Promise<Record<string, string>> {
+	if (bootstrapCache) return bootstrapCache;
+
+	try {
+		const resp = await fetch(IANA_BOOTSTRAP_URL, {
+			redirect: 'manual',
+			signal: AbortSignal.timeout(RDAP_TIMEOUT_MS),
+			headers: { Accept: 'application/json' },
+		});
+		if (!resp.ok) return {};
+
+		const data = (await resp.json()) as { services?: [string[], string[]][] };
+		const map: Record<string, string> = {};
+
+		if (Array.isArray(data.services)) {
+			for (const [tlds, urls] of data.services) {
+				if (!Array.isArray(tlds) || !Array.isArray(urls) || urls.length === 0) continue;
+				const serverUrl = urls[0];
+				for (const tld of tlds) {
+					if (typeof tld === 'string' && typeof serverUrl === 'string') {
+						map[tld.toLowerCase()] = serverUrl;
+					}
+				}
+			}
+		}
+
+		bootstrapCache = map;
+		return map;
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Resolve the RDAP server URL for a given TLD.
+ * Tries IANA bootstrap first, then hardcoded fallbacks.
+ */
+async function resolveRdapServer(tld: string): Promise<string | null> {
+	const normalizedTld = tld.toLowerCase();
+
+	// Try bootstrap
+	const bootstrap = await fetchBootstrap();
+	if (bootstrap[normalizedTld]) return bootstrap[normalizedTld];
+
+	// Fallback to hardcoded map
+	return FALLBACK_RDAP_SERVERS[normalizedTld] ?? null;
+}
+
+/** Extract the full name from a vCard array for a given role. */
+function extractVcardName(entity: RdapEntity): string | null {
+	if (!entity.vcardArray || entity.vcardArray[0] !== 'vcard') return null;
+	const properties = entity.vcardArray[1];
+	if (!Array.isArray(properties)) return null;
+
+	for (const prop of properties) {
+		if (Array.isArray(prop) && prop[0] === 'fn' && typeof prop[3] === 'string') {
+			return prop[3];
+		}
+	}
+	return null;
+}
+
+/** Extract country from a vCard adr property. */
+function extractVcardCountry(entity: RdapEntity): string | null {
+	if (!entity.vcardArray || entity.vcardArray[0] !== 'vcard') return null;
+	const properties = entity.vcardArray[1];
+	if (!Array.isArray(properties)) return null;
+
+	for (const prop of properties) {
+		if (Array.isArray(prop) && prop[0] === 'adr') {
+			const value = prop[3];
+			if (Array.isArray(value) && value.length > 0) {
+				const country = value[value.length - 1];
+				return typeof country === 'string' && country.length > 0 ? country : null;
+			}
+		}
+	}
+	return null;
+}
+
+/** Find an entity with the given role. Searches top-level and nested entities. */
+function findEntityByRole(entities: RdapEntity[] | undefined, role: string): RdapEntity | null {
+	if (!Array.isArray(entities)) return null;
+	for (const entity of entities) {
+		if (Array.isArray(entity.roles) && entity.roles.includes(role)) {
+			return entity;
+		}
+		// Search nested entities
+		if (Array.isArray(entity.entities)) {
+			const nested = findEntityByRole(entity.entities, role);
+			if (nested) return nested;
+		}
+	}
+	return null;
+}
+
+/** Find an event by action name. */
+function findEvent(events: RdapEvent[] | undefined, action: string): RdapEvent | null {
+	if (!Array.isArray(events)) return null;
+	return events.find((e) => e.eventAction === action) ?? null;
+}
+
+/**
+ * Look up domain registration data via RDAP.
+ *
+ * @param domain - The domain to look up
+ * @returns CheckResult with registration findings
+ */
+export async function checkRdapLookup(domain: string): Promise<CheckResult> {
+	const findings: ReturnType<typeof createFinding>[] = [];
+
+	// Extract TLD
+	const labels = domain.split('.');
+	const tld = labels[labels.length - 1];
+
+	// Resolve RDAP server
+	const rdapServerUrl = await resolveRdapServer(tld);
+	if (!rdapServerUrl) {
+		findings.push(
+			createFinding(CATEGORY, 'No RDAP server found', 'info', `No RDAP server found for TLD ".${tld}". RDAP data unavailable for this domain.`, {
+				domain,
+				tld,
+			}),
+		);
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	// Fetch RDAP domain data
+	let rdapData: RdapDomainResponse;
+	try {
+		const baseUrl = rdapServerUrl.endsWith('/') ? rdapServerUrl : `${rdapServerUrl}/`;
+		const rdapUrl = `${baseUrl}domain/${domain}`;
+		const resp = await fetch(rdapUrl, {
+			redirect: 'manual',
+			signal: AbortSignal.timeout(RDAP_TIMEOUT_MS),
+			headers: { Accept: 'application/rdap+json, application/json' },
+		});
+
+		if (!resp.ok) {
+			findings.push(
+				createFinding(CATEGORY, 'RDAP lookup failed', 'info', `RDAP server returned HTTP ${resp.status} for ${domain}. Registration data unavailable.`, {
+					domain,
+					httpStatus: resp.status,
+				}),
+			);
+			return buildCheckResult(CATEGORY, findings) as CheckResult;
+		}
+
+		rdapData = (await resp.json()) as RdapDomainResponse;
+	} catch (err) {
+		const message = err instanceof Error ? err.message : 'Unknown error';
+		findings.push(
+			createFinding(CATEGORY, 'RDAP lookup failed', 'info', `RDAP lookup failed for ${domain}: ${message}`, {
+				domain,
+				error: message,
+			}),
+		);
+		return buildCheckResult(CATEGORY, findings) as CheckResult;
+	}
+
+	// Parse registrar
+	const registrarEntity = findEntityByRole(rdapData.entities, 'registrar');
+	const registrarName = registrarEntity ? extractVcardName(registrarEntity) : null;
+
+	// Parse registrant
+	const registrantEntity = findEntityByRole(rdapData.entities, 'registrant');
+	const registrantName = registrantEntity ? extractVcardName(registrantEntity) : null;
+	const registrantCountry = registrantEntity ? extractVcardCountry(registrantEntity) : null;
+
+	// Parse events
+	const registrationEvent = findEvent(rdapData.events, 'registration');
+	const expirationEvent = findEvent(rdapData.events, 'expiration');
+	const lastChangedEvent = findEvent(rdapData.events, 'last changed');
+
+	// Calculate domain age
+	let domainAgeDays: number | null = null;
+	if (registrationEvent?.eventDate) {
+		const creationTime = new Date(registrationEvent.eventDate).getTime();
+		if (Number.isFinite(creationTime)) {
+			domainAgeDays = Math.floor((Date.now() - creationTime) / (1000 * 60 * 60 * 24));
+		}
+	}
+
+	// Calculate days until expiration
+	let daysUntilExpiration: number | null = null;
+	if (expirationEvent?.eventDate) {
+		const expirationTime = new Date(expirationEvent.eventDate).getTime();
+		if (Number.isFinite(expirationTime)) {
+			daysUntilExpiration = Math.floor((expirationTime - Date.now()) / (1000 * 60 * 60 * 24));
+		}
+	}
+
+	// EPP status
+	const eppStatus = Array.isArray(rdapData.status) ? rdapData.status : [];
+
+	// Build metadata
+	const metadata: Record<string, unknown> = {
+		domain,
+		registrar: registrarName,
+		registrant: registrantName,
+		registrantCountry,
+		creationDate: registrationEvent?.eventDate ?? null,
+		expirationDate: expirationEvent?.eventDate ?? null,
+		lastChanged: lastChangedEvent?.eventDate ?? null,
+		eppStatus,
+		rdapServer: rdapServerUrl,
+	};
+
+	if (domainAgeDays !== null) {
+		metadata.domainAgeDays = domainAgeDays;
+	}
+	if (daysUntilExpiration !== null) {
+		metadata.daysUntilExpiration = daysUntilExpiration;
+	}
+
+	// Findings
+
+	// Medium: newly registered (< 30 days)
+	if (domainAgeDays !== null && domainAgeDays < 30) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Newly registered domain',
+				'medium',
+				`${domain} was registered ${domainAgeDays} day${domainAgeDays !== 1 ? 's' : ''} ago (${registrationEvent!.eventDate}). Newly registered domains are commonly used for phishing and spam.`,
+				metadata,
+			),
+		);
+	}
+
+	// Low: expiring within 30 days
+	if (daysUntilExpiration !== null && daysUntilExpiration <= 30 && daysUntilExpiration >= 0) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Domain expiring soon',
+				'low',
+				`${domain} expires in ${daysUntilExpiration} day${daysUntilExpiration !== 1 ? 's' : ''} (${expirationEvent!.eventDate}). Expired domains can be re-registered by attackers.`,
+				metadata,
+			),
+		);
+	}
+
+	// Info: standard registration details (always present)
+	const parts: string[] = [];
+	if (registrarName) parts.push(`Registrar: ${registrarName}`);
+	if (registrantName) parts.push(`Registrant: ${registrantName}`);
+	if (registrantCountry) parts.push(`Country: ${registrantCountry}`);
+	if (registrationEvent?.eventDate) parts.push(`Created: ${registrationEvent.eventDate.split('T')[0]}`);
+	if (expirationEvent?.eventDate) parts.push(`Expires: ${expirationEvent.eventDate.split('T')[0]}`);
+	if (lastChangedEvent?.eventDate) parts.push(`Updated: ${lastChangedEvent.eventDate.split('T')[0]}`);
+	if (eppStatus.length > 0) parts.push(`Status: ${eppStatus.join(', ')}`);
+	if (domainAgeDays !== null) parts.push(`Age: ${domainAgeDays} days`);
+
+	findings.push(
+		createFinding(
+			CATEGORY,
+			'Registration details',
+			'info',
+			parts.length > 0 ? parts.join('. ') + '.' : `RDAP data retrieved for ${domain} but no structured fields found.`,
+			metadata,
+		),
+	);
+
+	return buildCheckResult(CATEGORY, findings) as CheckResult;
+}

--- a/src/tools/explain-finding-data.ts
+++ b/src/tools/explain-finding-data.ts
@@ -491,6 +491,71 @@ export const EXPLANATIONS: Record<string, ExplanationTemplate> = {
 		recommendation: 'No action required. Consider adding ECH for enhanced privacy.',
 		references: ['https://datatracker.ietf.org/doc/html/rfc9460'],
 	},
+	// --- Intelligence tools (mclose parity) ---
+	DBL_LISTED: {
+		title: 'Domain Listed on Blocklist',
+		severity: 'high',
+		explanation:
+			'The domain appears on one or more DNS-based Domain Block Lists (DBLs), indicating it has been flagged for spam, phishing, or malware distribution.',
+		impact: 'Listed domains may have email deliverability issues and are often blocked by recipient mail servers.',
+		adverseConsequences: 'Legitimate email from this domain may be silently dropped or quarantined.',
+		recommendation:
+			'Investigate the listing reason. For Spamhaus DBL, check https://check.spamhaus.org/. Request delisting after resolving the underlying issue.',
+		references: ['https://www.spamhaus.org/dbl/', 'https://uribl.com/', 'https://www.surbl.org/'],
+	},
+	RBL_LISTED: {
+		title: 'IP Listed on Real-time Blocklist',
+		severity: 'high',
+		explanation:
+			'One or more mail server IPs are listed on DNS-based Real-time Blocklists, indicating the IP has been flagged for sending spam or malicious traffic.',
+		impact: 'Email from listed IPs is likely to be rejected or quarantined by recipient servers.',
+		adverseConsequences: 'Significant email deliverability degradation. May require IP change or delisting process.',
+		recommendation:
+			'Check Spamhaus at https://check.spamhaus.org/. For shared hosting, contact your provider. For dedicated IPs, resolve the abuse issue and request delisting.',
+		references: ['https://www.spamhaus.org/zen/', 'https://www.spamcop.net/'],
+	},
+	ASN_HIGH_RISK: {
+		title: 'High-Risk ASN Detected',
+		severity: 'medium',
+		explanation:
+			'The domain resolves to IP addresses in an Autonomous System commonly associated with abuse infrastructure (bulletproof hosting, botnets).',
+		recommendation:
+			'Verify the hosting choice is intentional. High-risk ASNs are not inherently malicious but are statistically over-represented in abuse reports.',
+		references: ['https://www.team-cymru.com/ip-asn-mapping'],
+	},
+	FAST_FLUX_DETECTED: {
+		title: 'Fast-Flux Behavior Detected',
+		severity: 'high',
+		explanation:
+			'The domain shows rapidly rotating IP addresses with very low TTLs, a technique commonly used by botnets and phishing operations to evade takedown.',
+		impact: 'Fast-flux domains are a strong indicator of malicious infrastructure.',
+		adverseConsequences: 'Associating with fast-flux infrastructure damages domain reputation and may trigger automated blocking.',
+		recommendation:
+			'Investigate immediately. If this is a CDN or legitimate load balancer, TTLs are typically higher and rotation patterns are predictable.',
+		references: ['https://en.wikipedia.org/wiki/Fast_flux'],
+	},
+	DNSSEC_CHAIN_BROKEN: {
+		title: 'DNSSEC Chain of Trust Broken',
+		severity: 'high',
+		explanation:
+			'The DNSSEC chain of trust has a gap — a DS record exists at the parent zone but the corresponding DNSKEY is missing or mismatched at the child zone.',
+		impact: 'DNSSEC-validating resolvers will return SERVFAIL for this domain, causing complete resolution failure for security-conscious clients.',
+		adverseConsequences: 'Domain may be unreachable for users behind DNSSEC-validating resolvers.',
+		recommendation:
+			'Ensure the DS record at the parent matches a DNSKEY at the child zone. Use `delv +vtrace` for detailed chain debugging.',
+		references: ['https://datatracker.ietf.org/doc/html/rfc4033'],
+	},
+	NSEC_WALKABLE: {
+		title: 'Zone Walkable (No NSEC3)',
+		severity: 'high',
+		explanation:
+			'The zone does not appear to use NSEC3, meaning it likely uses plain NSEC records which allow full zone enumeration (zone walking).',
+		impact: 'Attackers can discover all hostnames in the zone without brute-forcing, exposing internal infrastructure.',
+		adverseConsequences: 'Complete zone enumeration reveals the attack surface — internal hosts, staging environments, and service names.',
+		recommendation:
+			'Deploy NSEC3 with at least algorithm 1 (SHA-1) and consider using salt. RFC 9276 recommends 0 iterations with no salt as the minimum.',
+		references: ['https://datatracker.ietf.org/doc/html/rfc5155', 'https://datatracker.ietf.org/doc/html/rfc9276'],
+	},
 };
 
 export const DEFAULT_EXPLANATION: ExplanationTemplate = {
@@ -569,6 +634,26 @@ export const CATEGORY_FALLBACK_IMPACT: Record<string, ImpactNarrative> = {
 	SVCB_HTTPS: {
 		impact: 'Modern transport capabilities (ALPN, ECH) cannot be advertised via DNS, reducing connection efficiency and privacy.',
 		adverseConsequences: 'Clients require additional round-trips to negotiate protocols, and ECH-based privacy is unavailable.',
+	},
+	RBL: {
+		impact: 'Mail server IPs are listed on one or more DNS blocklists, likely degrading email deliverability.',
+		adverseConsequences: 'Outbound email may be silently dropped or quarantined by recipient servers.',
+	},
+	DBL: {
+		impact: 'Domain is flagged on DNS-based domain blocklists, indicating prior spam or abuse association.',
+		adverseConsequences: 'Domain reputation is damaged. Email and web traffic may be blocked by security tools.',
+	},
+	FAST_FLUX: {
+		impact: 'DNS resolution shows fast-flux patterns — rapidly rotating IPs with low TTLs.',
+		adverseConsequences: 'Strong indicator of botnet or phishing infrastructure. Domain reputation will be severely impacted.',
+	},
+	DNSSEC_CHAIN: {
+		impact: 'DNSSEC chain structure has gaps or uses weak algorithms, reducing trust in DNS responses.',
+		adverseConsequences: 'DNSSEC-validating resolvers may fail to resolve the domain or accept spoofed responses.',
+	},
+	NSEC_WALKABILITY: {
+		impact: 'Zone denial-of-existence parameters allow enumeration of zone contents.',
+		adverseConsequences: 'Attackers can map the full attack surface by walking the zone without brute-forcing.',
 	},
 };
 

--- a/test/check-cymru-asn.spec.ts
+++ b/test/check-cymru-asn.spec.ts
@@ -1,0 +1,239 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a DoH A-record response. */
+function aResponse(name: string, ips: string[]) {
+	return createDohResponse(
+		[{ name, type: 1 }],
+		ips.map((ip) => ({ name, type: 1, TTL: 300, data: ip })),
+	);
+}
+
+/** Build a DoH TXT-record response (data values are double-quoted per DNS wire format). */
+function txtResponse(name: string, values: string[]) {
+	return createDohResponse(
+		[{ name, type: 16 }],
+		values.map((v) => ({ name, type: 16, TTL: 300, data: `"${v}"` })),
+	);
+}
+
+/** Build an empty DoH response (NXDOMAIN / no answers). */
+function emptyResponse(name: string) {
+	return createDohResponse([{ name, type: 1 }], []);
+}
+
+/**
+ * Build a fetch mock that routes A-record and Cymru TXT queries.
+ *
+ * @param domainAIps - A records returned for the domain
+ * @param originTxt - Map of IP to origin TXT response (e.g. "15169 | 93.184.216.0/24 | US | arin | 2007-03-19")
+ * @param orgTxt - Map of ASN to org TXT response (e.g. "15169 | US | arin | 2007-03-19 | GOOGLE - Google LLC, US")
+ * @param originErrors - Set of IPs whose origin queries should fail
+ * @param orgErrors - Set of ASNs whose org queries should fail
+ */
+function buildFetchMock(opts: {
+	domain?: string;
+	domainAIps?: string[];
+	originTxt?: Record<string, string>;
+	orgTxt?: Record<string, string>;
+	originErrors?: Set<string>;
+	orgErrors?: Set<string>;
+}) {
+	const domain = opts.domain ?? 'example.com';
+	const domainAIps = opts.domainAIps ?? [];
+	const originTxt = opts.originTxt ?? {};
+	const orgTxt = opts.orgTxt ?? {};
+	const originErrors = opts.originErrors ?? new Set();
+	const orgErrors = opts.orgErrors ?? new Set();
+
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+		// A record query for domain
+		if (url.includes(`name=${domain}`) && url.includes('type=A')) {
+			return Promise.resolve(aResponse(domain, domainAIps));
+		}
+		if (url.includes(`name=${encodeURIComponent(domain)}`) && url.includes('type=A')) {
+			return Promise.resolve(aResponse(domain, domainAIps));
+		}
+
+		// Origin TXT queries (must check before general asn.cymru.com)
+		if (url.includes('origin.asn.cymru.com') && url.includes('type=TXT')) {
+			// Check for error IPs
+			for (const ip of originErrors) {
+				const parts = ip.split('.').reverse().join('.');
+				if (url.includes(parts)) {
+					return Promise.reject(new Error('DNS timeout'));
+				}
+			}
+
+			// Check for matching origin records
+			for (const [ip, txt] of Object.entries(originTxt)) {
+				const reversed = ip.split('.').reverse().join('.');
+				if (url.includes(reversed)) {
+					const queryName = `${reversed}.origin.asn.cymru.com`;
+					return Promise.resolve(txtResponse(queryName, [txt]));
+				}
+			}
+
+			return Promise.resolve(emptyResponse('origin-query'));
+		}
+
+		// Org name TXT queries (AS{asn}.asn.cymru.com)
+		if (url.includes('asn.cymru.com') && url.includes('type=TXT')) {
+			// Check for error ASNs
+			for (const asn of orgErrors) {
+				if (url.includes(`AS${asn}.asn.cymru.com`) || url.includes(`AS${asn}.asn.cymru.com`)) {
+					return Promise.reject(new Error('DNS timeout'));
+				}
+			}
+
+			// Check for matching org records
+			for (const [asn, txt] of Object.entries(orgTxt)) {
+				if (url.includes(`AS${asn}.asn.cymru.com`)) {
+					const queryName = `AS${asn}.asn.cymru.com`;
+					return Promise.resolve(txtResponse(queryName, [txt]));
+				}
+			}
+
+			return Promise.resolve(emptyResponse('org-query'));
+		}
+
+		// Default empty response
+		return Promise.resolve(emptyResponse('unknown'));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('checkCymruAsn', () => {
+	async function run(domain = 'example.com') {
+		const { checkCymruAsn } = await import('../src/tools/check-cymru-asn');
+		return checkCymruAsn(domain);
+	}
+
+	it('should parse standard IPv4 ASN lookup with org name', async () => {
+		buildFetchMock({
+			domainAIps: ['93.184.216.34'],
+			originTxt: {
+				'93.184.216.34': '15169 | 93.184.216.0/24 | US | arin | 2007-03-19',
+			},
+			orgTxt: {
+				'15169': '15169 | US | arin | 2007-03-19 | GOOGLE - Google LLC, US',
+			},
+		});
+
+		const result = await run();
+		expect(result.category).toBe('asn');
+		expect(result.findings.length).toBeGreaterThanOrEqual(1);
+
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.detail.includes('15169'));
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.detail).toContain('93.184.216.0/24');
+		expect(infoFinding!.detail).toContain('GOOGLE');
+	});
+
+	it('should flag high-risk ASN with medium severity', async () => {
+		buildFetchMock({
+			domainAIps: ['104.236.128.1'],
+			originTxt: {
+				'104.236.128.1': '14061 | 104.236.0.0/16 | US | arin | 2012-01-01',
+			},
+			orgTxt: {
+				'14061': '14061 | US | arin | 2012-01-01 | DIGITALOCEAN-ASN - DigitalOcean LLC, US',
+			},
+		});
+
+		const result = await run();
+		expect(result.category).toBe('asn');
+
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.detail).toMatch(/high-risk/i);
+		expect(mediumFinding!.detail).toContain('14061');
+	});
+
+	it('should report info when no origin record found (no ASN data)', async () => {
+		buildFetchMock({
+			domainAIps: ['198.51.100.1'],
+			// No originTxt — Cymru returns empty
+		});
+
+		const result = await run();
+		expect(result.category).toBe('asn');
+
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && (f.detail.includes('no ASN') || f.detail.includes('No ASN')));
+		expect(infoFinding).toBeDefined();
+	});
+
+	it('should still report ASN when org name lookup fails', async () => {
+		buildFetchMock({
+			domainAIps: ['93.184.216.34'],
+			originTxt: {
+				'93.184.216.34': '15169 | 93.184.216.0/24 | US | arin | 2007-03-19',
+			},
+			orgErrors: new Set(['15169']),
+		});
+
+		const result = await run();
+		expect(result.category).toBe('asn');
+
+		// Should still have the ASN finding even without org name
+		const asnFinding = result.findings.find((f) => f.detail.includes('15169'));
+		expect(asnFinding).toBeDefined();
+		expect(asnFinding!.detail).toContain('93.184.216.0/24');
+	});
+
+	it('should handle multiple A record IPs with different ASNs', async () => {
+		buildFetchMock({
+			domainAIps: ['93.184.216.34', '104.236.128.1'],
+			originTxt: {
+				'93.184.216.34': '15169 | 93.184.216.0/24 | US | arin | 2007-03-19',
+				'104.236.128.1': '14061 | 104.236.0.0/16 | US | arin | 2012-01-01',
+			},
+			orgTxt: {
+				'15169': '15169 | US | arin | 2007-03-19 | GOOGLE - Google LLC, US',
+				'14061': '14061 | US | arin | 2012-01-01 | DIGITALOCEAN-ASN - DigitalOcean LLC, US',
+			},
+		});
+
+		const result = await run();
+		expect(result.category).toBe('asn');
+
+		// Should have findings for both IPs
+		const googleFinding = result.findings.find((f) => f.detail.includes('15169'));
+		const doFinding = result.findings.find((f) => f.detail.includes('14061'));
+		expect(googleFinding).toBeDefined();
+		expect(doFinding).toBeDefined();
+
+		// DigitalOcean is high-risk
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.detail).toContain('14061');
+	});
+
+	it('should report info when domain has no A records', async () => {
+		buildFetchMock({
+			domainAIps: [], // No A records
+		});
+
+		const result = await run();
+		expect(result.category).toBe('asn');
+
+		const infoFinding = result.findings.find((f) => f.severity === 'info');
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.detail).toMatch(/no.*A record|no.*IP|Could not resolve/i);
+	});
+});

--- a/test/check-dbl.spec.ts
+++ b/test/check-dbl.spec.ts
@@ -52,14 +52,14 @@ describe('checkDbl', () => {
 		expect(highFinding!.detail).toContain('Spam');
 	});
 
-	it('should decode URIBL bitmask (127.0.0.2 = Grey)', async () => {
+	it('should decode URIBL bitmask (127.0.0.2 = Black)', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
 			if (url.includes('dbl.spamhaus.org')) {
 				return Promise.resolve(emptyResponse('example.com.dbl.spamhaus.org'));
 			}
-			// URIBL: listed as Grey (bitmask 0x02 → 127.0.0.2)
+			// URIBL: listed as Black (bitmask 0x02 → 127.0.0.2)
 			if (url.includes('multi.uribl.com')) {
 				return Promise.resolve(aResponse('example.com.multi.uribl.com', ['127.0.0.2']));
 			}
@@ -74,10 +74,10 @@ describe('checkDbl', () => {
 		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
 		expect(mediumFinding).toBeDefined();
 		expect(mediumFinding!.title).toMatch(/URIBL/i);
-		expect(mediumFinding!.detail).toContain('Grey');
+		expect(mediumFinding!.detail).toContain('Black');
 	});
 
-	it('should decode SURBL bitmask (127.0.0.16 = Phishing)', async () => {
+	it('should decode SURBL bitmask (127.0.0.8 = PH Phishing)', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
@@ -87,9 +87,9 @@ describe('checkDbl', () => {
 			if (url.includes('multi.uribl.com')) {
 				return Promise.resolve(emptyResponse('example.com.multi.uribl.com'));
 			}
-			// SURBL: listed as Phishing (bitmask 0x10 → 127.0.0.16)
+			// SURBL: listed as Phishing (bitmask 0x08 → 127.0.0.8)
 			if (url.includes('multi.surbl.org')) {
-				return Promise.resolve(aResponse('example.com.multi.surbl.org', ['127.0.0.16']));
+				return Promise.resolve(aResponse('example.com.multi.surbl.org', ['127.0.0.8']));
 			}
 			return Promise.resolve(emptyResponse('example.com'));
 		});
@@ -99,7 +99,7 @@ describe('checkDbl', () => {
 		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
 		expect(mediumFinding).toBeDefined();
 		expect(mediumFinding!.title).toMatch(/SURBL/i);
-		expect(mediumFinding!.detail).toContain('Phishing');
+		expect(mediumFinding!.detail).toContain('PH (Phishing)');
 	});
 
 	it('should report info finding when clean on all zones (NXDOMAIN)', async () => {

--- a/test/check-dbl.spec.ts
+++ b/test/check-dbl.spec.ts
@@ -1,0 +1,214 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/** Build a DoH A-record response for a given query name. */
+function aResponse(name: string, ips: string[]) {
+	return createDohResponse(
+		[{ name, type: 1 }],
+		ips.map((ip) => ({ name, type: 1, TTL: 300, data: ip })),
+	);
+}
+
+/** Build an empty DoH response (NXDOMAIN / no answers). */
+function emptyResponse(name: string) {
+	return createDohResponse([{ name, type: 1 }], []);
+}
+
+describe('checkDbl', () => {
+	async function run(domain = 'example.com') {
+		const { checkDbl } = await import('../src/tools/check-dbl');
+		return checkDbl(domain);
+	}
+
+	it('should report high finding when listed on Spamhaus DBL', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			// Spamhaus DBL: listed as spam domain (127.0.1.2)
+			if (url.includes('dbl.spamhaus.org')) {
+				return Promise.resolve(aResponse('example.com.dbl.spamhaus.org', ['127.0.1.2']));
+			}
+			// URIBL and SURBL: clean
+			if (url.includes('multi.uribl.com')) {
+				return Promise.resolve(emptyResponse('example.com.multi.uribl.com'));
+			}
+			if (url.includes('multi.surbl.org')) {
+				return Promise.resolve(emptyResponse('example.com.multi.surbl.org'));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dbl');
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.title).toMatch(/Spamhaus DBL/i);
+		expect(highFinding!.detail).toContain('Spam');
+	});
+
+	it('should decode URIBL bitmask (127.0.0.2 = Grey)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('dbl.spamhaus.org')) {
+				return Promise.resolve(emptyResponse('example.com.dbl.spamhaus.org'));
+			}
+			// URIBL: listed as Grey (bitmask 0x02 → 127.0.0.2)
+			if (url.includes('multi.uribl.com')) {
+				return Promise.resolve(aResponse('example.com.multi.uribl.com', ['127.0.0.2']));
+			}
+			if (url.includes('multi.surbl.org')) {
+				return Promise.resolve(emptyResponse('example.com.multi.surbl.org'));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dbl');
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.title).toMatch(/URIBL/i);
+		expect(mediumFinding!.detail).toContain('Grey');
+	});
+
+	it('should decode SURBL bitmask (127.0.0.16 = Phishing)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('dbl.spamhaus.org')) {
+				return Promise.resolve(emptyResponse('example.com.dbl.spamhaus.org'));
+			}
+			if (url.includes('multi.uribl.com')) {
+				return Promise.resolve(emptyResponse('example.com.multi.uribl.com'));
+			}
+			// SURBL: listed as Phishing (bitmask 0x10 → 127.0.0.16)
+			if (url.includes('multi.surbl.org')) {
+				return Promise.resolve(aResponse('example.com.multi.surbl.org', ['127.0.0.16']));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dbl');
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.title).toMatch(/SURBL/i);
+		expect(mediumFinding!.detail).toContain('Phishing');
+	});
+
+	it('should report info finding when clean on all zones (NXDOMAIN)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('dbl.spamhaus.org')) {
+				return Promise.resolve(emptyResponse('example.com.dbl.spamhaus.org'));
+			}
+			if (url.includes('multi.uribl.com')) {
+				return Promise.resolve(emptyResponse('example.com.multi.uribl.com'));
+			}
+			if (url.includes('multi.surbl.org')) {
+				return Promise.resolve(emptyResponse('example.com.multi.surbl.org'));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dbl');
+		expect(result.passed).toBe(true);
+		const infoFinding = result.findings.find((f) => f.severity === 'info');
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.title).toMatch(/not listed/i);
+	});
+
+	it('should treat Spamhaus 127.255.255.x as quota error, not a listing', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			// Spamhaus returns quota/error response
+			if (url.includes('dbl.spamhaus.org')) {
+				return Promise.resolve(aResponse('example.com.dbl.spamhaus.org', ['127.255.255.254']));
+			}
+			if (url.includes('multi.uribl.com')) {
+				return Promise.resolve(emptyResponse('example.com.multi.uribl.com'));
+			}
+			if (url.includes('multi.surbl.org')) {
+				return Promise.resolve(emptyResponse('example.com.multi.surbl.org'));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dbl');
+		// Should NOT have a high finding — quota error is not a listing
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeUndefined();
+		// Should have a low/info finding about the quota error
+		const quotaFinding = result.findings.find((f) => f.detail.includes('quota') || f.detail.includes('rate'));
+		expect(quotaFinding).toBeDefined();
+	});
+
+	it('should return partial results when one zone has DNS error', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			// Spamhaus: DNS error
+			if (url.includes('dbl.spamhaus.org')) {
+				return Promise.reject(new Error('DNS timeout'));
+			}
+			// URIBL: listed
+			if (url.includes('multi.uribl.com')) {
+				return Promise.resolve(aResponse('example.com.multi.uribl.com', ['127.0.0.2']));
+			}
+			// SURBL: clean
+			if (url.includes('multi.surbl.org')) {
+				return Promise.resolve(emptyResponse('example.com.multi.surbl.org'));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dbl');
+		// Should have findings from URIBL (medium) even though Spamhaus failed
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.title).toMatch(/URIBL/i);
+		// Should also have an error finding for the failed zone
+		const errorFinding = result.findings.find((f) => f.title.includes('Spamhaus') && f.detail.includes('error'));
+		expect(errorFinding).toBeDefined();
+	});
+
+	it('should use domain as-is without stripping subdomains', async () => {
+		const queriedNames = new Set<string>();
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			queriedNames.add(url);
+
+			if (url.includes('dbl.spamhaus.org')) {
+				return Promise.resolve(emptyResponse('sub.example.com.dbl.spamhaus.org'));
+			}
+			if (url.includes('multi.uribl.com')) {
+				return Promise.resolve(emptyResponse('sub.example.com.multi.uribl.com'));
+			}
+			if (url.includes('multi.surbl.org')) {
+				return Promise.resolve(emptyResponse('sub.example.com.multi.surbl.org'));
+			}
+			return Promise.resolve(emptyResponse('sub.example.com'));
+		});
+
+		const result = await run('sub.example.com');
+		expect(result.category).toBe('dbl');
+
+		// Verify the full subdomain was queried, not just example.com
+		const urls = Array.from(queriedNames);
+		const dblQueries = urls.filter((u) => u.includes('dbl.spamhaus.org'));
+		expect(dblQueries.length).toBeGreaterThan(0);
+		expect(dblQueries[0]).toContain('sub.example.com.dbl.spamhaus.org');
+	});
+});

--- a/test/check-dnssec-chain.spec.ts
+++ b/test/check-dnssec-chain.spec.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+import { RecordType } from '../src/lib/dns-types';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a DoH response containing DS records for a zone. */
+function dsResponse(zone: string, records: string[]) {
+	return createDohResponse(
+		[{ name: zone, type: RecordType.DS }],
+		records.map((data) => ({ name: zone, type: RecordType.DS, TTL: 300, data })),
+	);
+}
+
+/** Build a DoH response containing DNSKEY records for a zone. */
+function dnskeyResponse(zone: string, records: string[]) {
+	return createDohResponse(
+		[{ name: zone, type: RecordType.DNSKEY }],
+		records.map((data) => ({ name: zone, type: RecordType.DNSKEY, TTL: 300, data })),
+	);
+}
+
+/** Build an empty DoH response for a given type. */
+function emptyDsResponse(zone: string) {
+	return createDohResponse([{ name: zone, type: RecordType.DS }], []);
+}
+
+function emptyDnskeyResponse(zone: string) {
+	return createDohResponse([{ name: zone, type: RecordType.DNSKEY }], []);
+}
+
+/** Build an A-record response with AD flag. */
+function adResponse(domain: string, ad: boolean) {
+	return createDohResponse([{ name: domain, type: RecordType.A }], [{ name: domain, type: RecordType.A, TTL: 300, data: '93.184.216.34' }], { ad });
+}
+
+/**
+ * Create a fetch mock that routes by URL query params (name + type).
+ * `routeMap` keys are "name:type" (e.g. "com:DS", "example.com:DNSKEY", "example.com:A").
+ */
+function mockDnsFetch(routeMap: Record<string, Response>) {
+	globalThis.fetch = vi.fn().mockImplementation((url: string | URL | Request) => {
+		const u = new URL(typeof url === 'string' ? url : url instanceof Request ? url.url : url.toString());
+		const name = u.searchParams.get('name') ?? '';
+		const type = u.searchParams.get('type') ?? '';
+		const key = `${name}:${type}`;
+		const resp = routeMap[key];
+		if (resp) return Promise.resolve(resp);
+		// Default: empty response
+		return Promise.resolve(createDohResponse([{ name, type: 1 }], []));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('checkDnssecChain', () => {
+	async function run(domain = 'example.com') {
+		const { checkDnssecChain } = await import('../src/tools/check-dnssec-chain');
+		return checkDnssecChain(domain);
+	}
+
+	it('fully signed chain reports chainComplete=true', async () => {
+		mockDnsFetch({
+			// Root zone — DNSKEY only (no DS for root)
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			// com zone
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			// example.com zone
+			'example.com:DS': dsResponse('example.com', ['54321 8 2 DDEEFF00']),
+			'example.com:DNSKEY': dnskeyResponse('example.com', ['257 3 8 AwEAAexample...']),
+			// AD flag query
+			'example.com:A': adResponse('example.com', true),
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dnssec_chain');
+
+		// Should have at least an info finding with chain summary
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.metadata?.chainComplete === true);
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.metadata!.adFlag).toBe(true);
+	});
+
+	it('unsigned domain reports no DS', async () => {
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			// example.com has no DS and no DNSKEY → unsigned
+			'example.com:DS': emptyDsResponse('example.com'),
+			'example.com:DNSKEY': emptyDnskeyResponse('example.com'),
+			'example.com:A': adResponse('example.com', false),
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dnssec_chain');
+
+		// Chain stops at unsigned zone — detail should mention "no DS" or "unsigned"
+		const infoFinding = result.findings.find((f) => f.severity === 'info');
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.detail).toMatch(/no DS|unsigned|not signed/i);
+	});
+
+	it('broken linkage (DS exists but no DNSKEY) produces high severity', async () => {
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			// example.com has DS but NO DNSKEY → broken
+			'example.com:DS': dsResponse('example.com', ['54321 8 2 DDEEFF00']),
+			'example.com:DNSKEY': emptyDnskeyResponse('example.com'),
+			'example.com:A': adResponse('example.com', false),
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dnssec_chain');
+
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.detail).toMatch(/broken|no DNSKEY|mismatch/i);
+	});
+
+	it('maps algorithm 8 to RSA-SHA256', async () => {
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			'example.com:DS': dsResponse('example.com', ['54321 8 2 DDEEFF00']),
+			'example.com:DNSKEY': dnskeyResponse('example.com', ['257 3 8 AwEAAexample...']),
+			'example.com:A': adResponse('example.com', true),
+		});
+
+		const result = await run();
+
+		// At least one zone should have RSA-SHA256 in its metadata
+		const chainFinding = result.findings.find((f) => f.severity === 'info' && f.metadata?.zones);
+		expect(chainFinding).toBeDefined();
+		const zones = chainFinding!.metadata!.zones as Array<{ algorithms?: string[] }>;
+		const allAlgs = zones.flatMap((z) => z.algorithms ?? []);
+		expect(allAlgs).toContain('RSA-SHA256');
+	});
+
+	it('weak algorithm (algo 5 → RSA-SHA1) produces medium severity', async () => {
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 5 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 5 1 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 5 AwEAAcom...']),
+			'example.com:DS': dsResponse('example.com', ['54321 5 1 DDEEFF00']),
+			'example.com:DNSKEY': dnskeyResponse('example.com', ['257 3 5 AwEAAexample...']),
+			'example.com:A': adResponse('example.com', true),
+		});
+
+		const result = await run();
+		expect(result.category).toBe('dnssec_chain');
+
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.detail).toMatch(/weak|RSA-SHA1|deprecated/i);
+	});
+
+	it('deep subdomain walks root→com→example.com→sub.example.com', async () => {
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			'example.com:DS': dsResponse('example.com', ['54321 8 2 DDEEFF00']),
+			'example.com:DNSKEY': dnskeyResponse('example.com', ['257 3 8 AwEAAexample...']),
+			'sub.example.com:DS': dsResponse('sub.example.com', ['11111 8 2 11223344']),
+			'sub.example.com:DNSKEY': dnskeyResponse('sub.example.com', ['257 3 8 AwEAAsub...']),
+			'sub.example.com:A': adResponse('sub.example.com', true),
+		});
+
+		const result = await run('sub.example.com');
+		expect(result.category).toBe('dnssec_chain');
+
+		const chainFinding = result.findings.find((f) => f.severity === 'info' && f.metadata?.zones);
+		expect(chainFinding).toBeDefined();
+		const zones = chainFinding!.metadata!.zones as Array<{ zone: string }>;
+		const zoneNames = zones.map((z) => z.zone);
+		expect(zoneNames).toContain('.');
+		expect(zoneNames).toContain('com');
+		expect(zoneNames).toContain('example.com');
+		expect(zoneNames).toContain('sub.example.com');
+	});
+});

--- a/test/check-fast-flux.spec.ts
+++ b/test/check-fast-flux.spec.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/** Build a DoH A-record response for a domain with given IPs and TTL. */
+function aResponse(domain: string, ips: string[], ttl = 300) {
+	return createDohResponse(
+		[{ name: domain, type: 1 }],
+		ips.map((ip) => ({ name: domain, type: 1, TTL: ttl, data: ip })),
+	);
+}
+
+/** Build a DoH AAAA-record response for a domain with given IPs and TTL. */
+function aaaaResponse(domain: string, ips: string[], ttl = 300) {
+	return createDohResponse(
+		[{ name: domain, type: 28 }],
+		ips.map((ip) => ({ name: domain, type: 28, TTL: ttl, data: ip })),
+	);
+}
+
+/** Build an empty DoH response (no answers). */
+function emptyResponse(domain: string, type = 1) {
+	return createDohResponse([{ name: domain, type }], []);
+}
+
+/** Extract the primary (non-limitation) finding from results. */
+function primaryFinding(findings: Array<{ title: string; metadata?: Record<string, unknown> }>) {
+	return findings.find((f) => !f.title.includes('limitations'));
+}
+
+describe('checkFastFlux', () => {
+	async function run(domain = 'example.com', rounds = 3) {
+		const { checkFastFlux } = await import('../src/tools/check-fast-flux');
+		return checkFastFlux(domain, rounds, undefined, 0);
+	}
+
+	it('should report info for stable domain (same IPs every round, high TTL)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('type=AAAA')) {
+				return Promise.resolve(aaaaResponse('example.com', ['2606:2800:220:1:248:1893:25c8:1946'], 3600));
+			}
+			if (url.includes('type=A')) {
+				return Promise.resolve(aResponse('example.com', ['93.184.216.34'], 3600));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('fast_flux');
+		expect(result.passed).toBe(true);
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.title.includes('Stable'));
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.title).toMatch(/stable/i);
+		// Check finding metadata for flux_detected
+		const primary = primaryFinding(result.findings);
+		expect(primary?.metadata?.flux_detected).toBe(false);
+	});
+
+	it('should report high finding for rotating IPs with low TTL', async () => {
+		let aCallCount = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('type=AAAA')) {
+				return Promise.resolve(emptyResponse('flux.example.com', 28));
+			}
+			if (url.includes('type=A')) {
+				aCallCount++;
+				// Each round returns different IPs
+				const roundIps = [
+					['1.2.3.4', '5.6.7.8'],
+					['9.10.11.12', '13.14.15.16'],
+					['17.18.19.20', '21.22.23.24'],
+				];
+				const idx = Math.min(aCallCount - 1, roundIps.length - 1);
+				return Promise.resolve(aResponse('flux.example.com', roundIps[idx], 60));
+			}
+			return Promise.resolve(emptyResponse('flux.example.com'));
+		});
+
+		const result = await run('flux.example.com');
+		expect(result.category).toBe('fast_flux');
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.title).toMatch(/fast.flux/i);
+		expect(highFinding!.metadata?.flux_detected).toBe(true);
+	});
+
+	it('should NOT flag low TTL with stable IPs (TTL alone is not flux)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('type=AAAA')) {
+				return Promise.resolve(emptyResponse('example.com', 28));
+			}
+			if (url.includes('type=A')) {
+				return Promise.resolve(aResponse('example.com', ['1.2.3.4'], 30));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		const result = await run();
+		const primary = primaryFinding(result.findings);
+		expect(primary?.metadata?.flux_detected).toBe(false);
+		expect(result.findings.find((f) => f.severity === 'high')).toBeUndefined();
+	});
+
+	it('should NOT flag changing IPs with high TTL (CDN behavior)', async () => {
+		let aCallCount = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('type=AAAA')) {
+				return Promise.resolve(emptyResponse('cdn.example.com', 28));
+			}
+			if (url.includes('type=A')) {
+				aCallCount++;
+				const roundIps = [
+					['1.2.3.4'],
+					['5.6.7.8'],
+					['9.10.11.12'],
+				];
+				const idx = Math.min(aCallCount - 1, roundIps.length - 1);
+				return Promise.resolve(aResponse('cdn.example.com', roundIps[idx], 3600));
+			}
+			return Promise.resolve(emptyResponse('cdn.example.com'));
+		});
+
+		const result = await run('cdn.example.com');
+		const primary = primaryFinding(result.findings);
+		expect(primary?.metadata?.flux_detected).toBe(false);
+		expect(result.findings.find((f) => f.severity === 'high')).toBeUndefined();
+	});
+
+	it('should handle DNS errors gracefully', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('DNS timeout'));
+
+		const result = await run('error.example.com');
+		expect(result.category).toBe('fast_flux');
+		// Should have findings but not crash
+		expect(result.findings.length).toBeGreaterThan(0);
+	});
+
+	it('should respect the rounds parameter (verify correct number of query rounds)', async () => {
+		let aQueryCount = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('type=AAAA')) {
+				return Promise.resolve(emptyResponse('example.com', 28));
+			}
+			if (url.includes('type=A')) {
+				aQueryCount++;
+				return Promise.resolve(aResponse('example.com', ['1.2.3.4'], 300));
+			}
+			return Promise.resolve(emptyResponse('example.com'));
+		});
+
+		await run('example.com', 5);
+		// 5 rounds, each round queries A once (AAAA checked first to avoid substring match)
+		expect(aQueryCount).toBe(5);
+	});
+
+	it('should include AAAA records in detection (IPv6 IPs tracked)', async () => {
+		let aaaaCallCount = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			if (url.includes('type=AAAA')) {
+				aaaaCallCount++;
+				// Rotating AAAA records
+				const roundIps = [
+					['2001:db8::1'],
+					['2001:db8::2'],
+					['2001:db8::3'],
+				];
+				const idx = Math.min(aaaaCallCount - 1, roundIps.length - 1);
+				return Promise.resolve(aaaaResponse('v6flux.example.com', roundIps[idx], 60));
+			}
+			if (url.includes('type=A')) {
+				// Same A records every round
+				return Promise.resolve(aResponse('v6flux.example.com', ['1.2.3.4'], 60));
+			}
+			return Promise.resolve(emptyResponse('v6flux.example.com'));
+		});
+
+		const result = await run('v6flux.example.com');
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.metadata?.flux_detected).toBe(true);
+		// Verify IPv6 IPs are included in the unique IP set
+		expect((highFinding!.metadata?.unique_ips as number)).toBeGreaterThan(1);
+	});
+});

--- a/test/check-nsec-walkability.spec.ts
+++ b/test/check-nsec-walkability.spec.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a DoH NSEC3PARAM response (type 51). */
+function nsec3paramResponse(domain: string, records: string[]) {
+	return createDohResponse(
+		[{ name: domain, type: 51 }],
+		records.map((data) => ({ name: domain, type: 51, TTL: 300, data })),
+	);
+}
+
+/** Build an empty DoH response (no answers). */
+function emptyResponse(domain: string) {
+	return createDohResponse([{ name: domain, type: 51 }], []);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('checkNsecWalkability', () => {
+	async function run(domain = 'example.com') {
+		const { checkNsecWalkability } = await import('../src/tools/check-nsec-walkability');
+		return checkNsecWalkability(domain);
+	}
+
+	it('should parse NSEC3PARAM with salt and iterations as info', async () => {
+		// "1 0 10 AABBCCDD" → algorithm=1 (SHA-1), flags=0, iterations=10, salt=AABBCCDD
+		globalThis.fetch = vi.fn().mockResolvedValue(nsec3paramResponse('example.com', ['1 0 10 AABBCCDD']));
+
+		const result = await run();
+		expect(result.category).toBe('nsec_walkability');
+
+		// Standard NSEC3 with salt + iterations → info
+		const paramFinding = result.findings.find((f) => f.severity === 'info' && f.detail.includes('NSEC3'));
+		expect(paramFinding).toBeDefined();
+		expect(paramFinding!.metadata?.algorithm).toBe('SHA-1');
+		expect(paramFinding!.metadata?.iterations).toBe(10);
+		expect(paramFinding!.metadata?.salt).toBe('AABBCCDD');
+	});
+
+	it('should flag 0 iterations with no salt as medium severity', async () => {
+		// "1 0 0 -" → RFC 9276 default params: 0 iterations, no salt
+		globalThis.fetch = vi.fn().mockResolvedValue(nsec3paramResponse('example.com', ['1 0 0 -']));
+
+		const result = await run();
+		expect(result.category).toBe('nsec_walkability');
+
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.detail).toMatch(/low enumeration cost|RFC 9276/i);
+	});
+
+	it('should flag missing NSEC3PARAM as high severity', async () => {
+		// No NSEC3PARAM → zone likely uses plain NSEC (fully walkable)
+		globalThis.fetch = vi.fn().mockResolvedValue(emptyResponse('example.com'));
+
+		const result = await run();
+		expect(result.category).toBe('nsec_walkability');
+
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.detail).toMatch(/walkable|plain NSEC/i);
+	});
+
+	it('should report opt-out flag when set', async () => {
+		// "1 1 5 AABB" → flags=1 (opt-out bit set)
+		globalThis.fetch = vi.fn().mockResolvedValue(nsec3paramResponse('example.com', ['1 1 5 AABB']));
+
+		const result = await run();
+		expect(result.category).toBe('nsec_walkability');
+
+		const optOutFinding = result.findings.find((f) => f.detail.includes('opt-out') || f.detail.includes('Opt-out'));
+		expect(optOutFinding).toBeDefined();
+		expect(optOutFinding!.severity).toBe('low');
+	});
+
+	it('should map algorithm ID 1 to SHA-1', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue(nsec3paramResponse('example.com', ['1 0 10 AABBCCDD']));
+
+		const result = await run();
+		const finding = result.findings.find((f) => f.metadata?.algorithm);
+		expect(finding).toBeDefined();
+		expect(finding!.metadata!.algorithm).toBe('SHA-1');
+	});
+
+	it('should handle DNS error gracefully', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('DNS timeout'));
+
+		const result = await run();
+		expect(result.category).toBe('nsec_walkability');
+
+		// Should not throw — return info finding about the error
+		const infoFinding = result.findings.find((f) => f.severity === 'info');
+		expect(infoFinding).toBeDefined();
+	});
+});

--- a/test/check-rbl.spec.ts
+++ b/test/check-rbl.spec.ts
@@ -1,0 +1,283 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a DoH A-record response. */
+function aResponse(name: string, ips: string[]) {
+	return createDohResponse(
+		[{ name, type: 1 }],
+		ips.map((ip) => ({ name, type: 1, TTL: 300, data: ip })),
+	);
+}
+
+/** Build a DoH MX-record response. */
+function mxResponse(domain: string, entries: Array<{ priority: number; exchange: string }>) {
+	return createDohResponse(
+		[{ name: domain, type: 15 }],
+		entries.map((e) => ({ name: domain, type: 15, TTL: 300, data: `${e.priority} ${e.exchange}.` })),
+	);
+}
+
+/** Build an empty DoH response (NXDOMAIN / no answers). */
+function emptyResponse(name: string) {
+	return createDohResponse([{ name, type: 1 }], []);
+}
+
+/** The 8 RBL zones used by check_rbl. */
+const RBL_ZONES = [
+	'zen.spamhaus.org',
+	'bl.spamcop.net',
+	'dnsbl-1.uceprotect.net',
+	'dnsbl-2.uceprotect.net',
+	'bl.mailspike.net',
+	'b.barracudacentral.org',
+	'psbl.surriel.com',
+	'dnsbl.sorbs.net',
+];
+
+/**
+ * Build a fetch mock that routes MX, A, and RBL queries.
+ *
+ * @param mxEntries - MX records returned for the domain
+ * @param mxIps - Map of MX hostname to IP addresses
+ * @param rblAnswers - Map of "reversed.zone" to RBL response IPs (empty = clean)
+ * @param domainAIps - Fallback A records for domain itself (when no MX)
+ * @param dnsErrors - Set of zone names that should return DNS errors
+ */
+function buildFetchMock(opts: {
+	domain?: string;
+	mxEntries?: Array<{ priority: number; exchange: string }>;
+	mxIps?: Record<string, string[]>;
+	rblAnswers?: Record<string, string[]>;
+	domainAIps?: string[];
+	dnsErrors?: Set<string>;
+}) {
+	const domain = opts.domain ?? 'example.com';
+	const mxEntries = opts.mxEntries ?? [];
+	const mxIps = opts.mxIps ?? {};
+	const rblAnswers = opts.rblAnswers ?? {};
+	const domainAIps = opts.domainAIps ?? [];
+	const dnsErrors = opts.dnsErrors ?? new Set();
+
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+		// MX query for the domain
+		if (url.includes(`name=${domain}`) && url.includes('type=MX')) {
+			return Promise.resolve(mxResponse(domain, mxEntries));
+		}
+		// Also match URL-encoded MX query
+		if (url.includes(`name=${encodeURIComponent(domain)}`) && url.includes('type=MX')) {
+			return Promise.resolve(mxResponse(domain, mxEntries));
+		}
+
+		// A record queries for MX hostnames
+		for (const [host, ips] of Object.entries(mxIps)) {
+			if (url.includes(`name=${host}`) && url.includes('type=A')) {
+				return Promise.resolve(aResponse(host, ips));
+			}
+		}
+
+		// A record query for domain itself (fallback when no MX)
+		if (url.includes(`name=${domain}`) && url.includes('type=A')) {
+			return Promise.resolve(aResponse(domain, domainAIps));
+		}
+
+		// RBL queries — check for reversed IP + zone patterns
+		for (const zone of RBL_ZONES) {
+			if (url.includes(zone)) {
+				// Check DNS error zones
+				if (dnsErrors.has(zone)) {
+					return Promise.reject(new Error('DNS timeout'));
+				}
+
+				// Find matching rbl answer
+				for (const [key, ips] of Object.entries(rblAnswers)) {
+					if (url.includes(key)) {
+						const queryName = key;
+						return Promise.resolve(aResponse(queryName, ips));
+					}
+				}
+
+				// Default: not listed (empty)
+				return Promise.resolve(emptyResponse('rbl-query'));
+			}
+		}
+
+		// Default empty response
+		return Promise.resolve(emptyResponse('unknown'));
+	});
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('checkRbl', () => {
+	async function run(domain = 'example.com') {
+		const { checkRbl } = await import('../src/tools/check-rbl');
+		return checkRbl(domain);
+	}
+
+	it('should report high finding when listed on Spamhaus ZEN', async () => {
+		buildFetchMock({
+			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
+			mxIps: { 'mail.example.com': ['203.0.113.1'] },
+			rblAnswers: {
+				// 203.0.113.1 reversed = 1.113.0.203
+				'1.113.0.203.zen.spamhaus.org': ['127.0.0.2'],
+			},
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.title).toMatch(/Spamhaus/i);
+		expect(highFinding!.detail).toContain('SBL');
+	});
+
+	it('should report multiple listing findings when listed on multiple RBLs', async () => {
+		buildFetchMock({
+			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
+			mxIps: { 'mail.example.com': ['203.0.113.1'] },
+			rblAnswers: {
+				'1.113.0.203.bl.spamcop.net': ['127.0.0.2'],
+				'1.113.0.203.dnsbl-1.uceprotect.net': ['127.0.0.2'],
+				'1.113.0.203.b.barracudacentral.org': ['127.0.0.2'],
+			},
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		// 3 non-Spamhaus listings for same IP → first should be elevated to medium (2+ rule)
+		const listingFindings = result.findings.filter((f) => f.title.match(/Listed on/i));
+		expect(listingFindings.length).toBeGreaterThanOrEqual(3);
+		// At least one should be medium (severity escalation for 2+ non-Spamhaus)
+		const mediumFindings = listingFindings.filter((f) => f.severity === 'medium');
+		expect(mediumFindings.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it('should report info finding when clean on all RBLs', async () => {
+		buildFetchMock({
+			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
+			mxIps: { 'mail.example.com': ['203.0.113.1'] },
+			// No rblAnswers = clean on all
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		expect(result.passed).toBe(true);
+		const infoFinding = result.findings.find((f) => f.severity === 'info');
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.title).toMatch(/clean|not listed/i);
+	});
+
+	it('should treat Spamhaus 127.255.255.x as quota error, not a listing', async () => {
+		buildFetchMock({
+			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
+			mxIps: { 'mail.example.com': ['203.0.113.1'] },
+			rblAnswers: {
+				'1.113.0.203.zen.spamhaus.org': ['127.255.255.254'],
+			},
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		// Should NOT have a high finding
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeUndefined();
+		// Should have an info finding about quota
+		const quotaFinding = result.findings.find((f) => f.detail.includes('quota') || f.detail.includes('rate'));
+		expect(quotaFinding).toBeDefined();
+		expect(quotaFinding!.severity).toBe('info');
+	});
+
+	it('should treat Mailspike 127.0.0.10 as positive reputation (info, clean)', async () => {
+		buildFetchMock({
+			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
+			mxIps: { 'mail.example.com': ['203.0.113.1'] },
+			rblAnswers: {
+				'1.113.0.203.bl.mailspike.net': ['127.0.0.10'],
+			},
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		// No high/medium/low finding for Mailspike positive reputation
+		const negativeFinding = result.findings.find(
+			(f) => (f.severity === 'high' || f.severity === 'medium' || f.severity === 'low') && f.title.includes('Mailspike'),
+		);
+		expect(negativeFinding).toBeUndefined();
+		// Should have info finding about positive reputation
+		const positiveFinding = result.findings.find((f) => f.detail.includes('positive') || f.detail.includes('Mailspike'));
+		expect(positiveFinding).toBeDefined();
+		expect(positiveFinding!.severity).toBe('info');
+	});
+
+	it('should return partial results when one RBL has DNS error', async () => {
+		buildFetchMock({
+			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
+			mxIps: { 'mail.example.com': ['203.0.113.1'] },
+			rblAnswers: {
+				'1.113.0.203.bl.spamcop.net': ['127.0.0.2'],
+			},
+			dnsErrors: new Set(['zen.spamhaus.org']),
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		// Should still have SpamCop finding despite Spamhaus failure
+		const spamcopFinding = result.findings.find((f) => f.title.includes('SpamCop'));
+		expect(spamcopFinding).toBeDefined();
+	});
+
+	it('should fall back to domain A records when no MX records', async () => {
+		buildFetchMock({
+			mxEntries: [], // No MX records
+			domainAIps: ['198.51.100.1'],
+			// All clean
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		// Should have a finding about using A record fallback
+		const fallbackFinding = result.findings.find((f) => f.detail.includes('A record') || f.detail.includes('fallback') || f.detail.includes('No MX'));
+		expect(fallbackFinding).toBeDefined();
+	});
+
+	it('should report info finding when no MX and no A records', async () => {
+		buildFetchMock({
+			mxEntries: [], // No MX
+			domainAIps: [], // No A records either
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		const infoFinding = result.findings.find((f) => f.severity === 'info');
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.detail).toMatch(/no.*IP|no.*address|unable/i);
+	});
+
+	it('should warn about private MX IP', async () => {
+		buildFetchMock({
+			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
+			mxIps: { 'mail.example.com': ['192.168.1.1'] },
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rbl');
+		const privateFinding = result.findings.find((f) => f.detail.includes('private') || f.detail.includes('192.168'));
+		expect(privateFinding).toBeDefined();
+		expect(privateFinding!.severity).toBe('info');
+	});
+});

--- a/test/check-rdap-lookup.spec.ts
+++ b/test/check-rdap-lookup.spec.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+/** Build a minimal IANA RDAP bootstrap JSON response. */
+function makeBootstrap(services: [string[], string[]][] = [[['com'], ['https://rdap.verisign.com/com/v1/']]]) {
+	return {
+		version: '1.0',
+		publication: '2024-01-01T00:00:00Z',
+		services,
+	};
+}
+
+/** Build a minimal RDAP domain response. */
+function makeRdapResponse(overrides: Record<string, unknown> = {}) {
+	return {
+		objectClassName: 'domain',
+		ldhName: 'example.com',
+		handle: 'D12345-COM',
+		status: ['clientTransferProhibited', 'serverDeleteProhibited'],
+		events: [
+			{ eventAction: 'registration', eventDate: '2020-01-15T00:00:00Z' },
+			{ eventAction: 'expiration', eventDate: '2027-06-15T00:00:00Z' },
+			{ eventAction: 'last changed', eventDate: '2024-03-01T12:00:00Z' },
+		],
+		entities: [
+			{
+				objectClassName: 'entity',
+				roles: ['registrar'],
+				vcardArray: ['vcard', [
+					['version', {}, 'text', '4.0'],
+					['fn', {}, 'text', 'Example Registrar Inc.'],
+				]],
+			},
+			{
+				objectClassName: 'entity',
+				roles: ['registrant'],
+				vcardArray: ['vcard', [
+					['version', {}, 'text', '4.0'],
+					['fn', {}, 'text', 'ACME Corporation'],
+					['adr', {}, 'text', ['', '', '123 Main St', 'Springfield', 'IL', '62704', 'US']],
+				]],
+			},
+		],
+		...overrides,
+	};
+}
+
+/** Route fetch calls by URL pattern. */
+function mockFetchRouter(routes: Record<string, () => unknown>) {
+	return vi.fn().mockImplementation((input: string | URL | Request, _init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		for (const [pattern, handler] of Object.entries(routes)) {
+			if (url.includes(pattern)) {
+				return Promise.resolve(new Response(JSON.stringify(handler()), {
+					status: 200,
+					headers: { 'Content-Type': 'application/rdap+json' },
+				}));
+			}
+		}
+		return Promise.resolve(new Response('Not Found', { status: 404 }));
+	});
+}
+
+describe('checkRdapLookup', () => {
+	async function run(domain = 'example.com') {
+		const mod = await import('../src/tools/check-rdap-lookup');
+		mod._resetBootstrapCache();
+		return mod.checkRdapLookup(domain);
+	}
+
+	it('should parse registrar and creation date from standard .com domain', async () => {
+		globalThis.fetch = mockFetchRouter({
+			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
+			'rdap.verisign.com': () => makeRdapResponse(),
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rdap');
+		expect(result.findings.length).toBeGreaterThanOrEqual(1);
+
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.title.toLowerCase().includes('registration'));
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.detail).toContain('Example Registrar Inc.');
+		expect(infoFinding!.detail).toContain('2020-01-15');
+	});
+
+	it('should handle privacy-redacted registrant', async () => {
+		const redactedResponse = makeRdapResponse({
+			entities: [
+				{
+					objectClassName: 'entity',
+					roles: ['registrar'],
+					vcardArray: ['vcard', [
+						['version', {}, 'text', '4.0'],
+						['fn', {}, 'text', 'Namecheap Inc.'],
+					]],
+				},
+				{
+					objectClassName: 'entity',
+					roles: ['registrant'],
+					vcardArray: ['vcard', [
+						['version', {}, 'text', '4.0'],
+						['fn', {}, 'text', 'REDACTED FOR PRIVACY'],
+						['adr', {}, 'text', ['', '', 'REDACTED FOR PRIVACY', '', '', '', 'REDACTED FOR PRIVACY']],
+					]],
+				},
+			],
+		});
+
+		globalThis.fetch = mockFetchRouter({
+			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
+			'rdap.verisign.com': () => redactedResponse,
+		});
+
+		const result = await run();
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.title.toLowerCase().includes('registration'));
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.detail).toContain('REDACTED');
+	});
+
+	it('should flag newly registered domain (< 30 days) as medium severity', async () => {
+		const now = new Date();
+		const recentDate = new Date(now.getTime() - 10 * 24 * 60 * 60 * 1000); // 10 days ago
+
+		const newDomainResponse = makeRdapResponse({
+			events: [
+				{ eventAction: 'registration', eventDate: recentDate.toISOString() },
+				{ eventAction: 'expiration', eventDate: '2027-06-15T00:00:00Z' },
+			],
+		});
+
+		globalThis.fetch = mockFetchRouter({
+			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
+			'rdap.verisign.com': () => newDomainResponse,
+		});
+
+		const result = await run();
+		const mediumFinding = result.findings.find((f) => f.severity === 'medium');
+		expect(mediumFinding).toBeDefined();
+		expect(mediumFinding!.title).toMatch(/newly registered/i);
+		// domainAgeDays lives in finding metadata
+		const infoFinding = result.findings.find((f) => f.severity === 'info' || f.severity === 'medium');
+		expect(infoFinding?.metadata?.domainAgeDays).toBeLessThanOrEqual(15);
+	});
+
+	it('should handle RDAP server timeout gracefully', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('data.iana.org/rdap/dns.json')) {
+				return Promise.resolve(new Response(JSON.stringify(makeBootstrap()), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}));
+			}
+			// Simulate timeout on RDAP domain lookup
+			return Promise.reject(new DOMException('The operation was aborted', 'AbortError'));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('rdap');
+		const errorFinding = result.findings.find((f) => f.severity === 'info' && f.title.toLowerCase().includes('failed'));
+		expect(errorFinding).toBeDefined();
+	});
+
+	it('should use redirect: manual for all fetch calls', async () => {
+		const fetchSpy = vi.fn().mockImplementation((input: string | URL | Request, _init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('data.iana.org/rdap/dns.json')) {
+				return Promise.resolve(new Response(JSON.stringify(makeBootstrap()), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}));
+			}
+			if (url.includes('rdap.verisign.com')) {
+				return Promise.resolve(new Response(JSON.stringify(makeRdapResponse()), {
+					status: 200,
+					headers: { 'Content-Type': 'application/rdap+json' },
+				}));
+			}
+			return Promise.resolve(new Response('Not Found', { status: 404 }));
+		});
+		globalThis.fetch = fetchSpy;
+
+		await run();
+
+		// Verify every fetch call used redirect: 'manual'
+		for (const call of fetchSpy.mock.calls) {
+			const init = call[1] as RequestInit | undefined;
+			expect(init?.redirect, `Fetch to ${call[0]} missing redirect:manual`).toBe('manual');
+		}
+	});
+
+	it('should calculate domain age correctly in metadata', async () => {
+		const creationDate = new Date('2023-06-01T00:00:00Z');
+		const expectedAgeDays = Math.floor((Date.now() - creationDate.getTime()) / (1000 * 60 * 60 * 24));
+
+		const response = makeRdapResponse({
+			events: [
+				{ eventAction: 'registration', eventDate: '2023-06-01T00:00:00Z' },
+				{ eventAction: 'expiration', eventDate: '2030-06-01T00:00:00Z' },
+			],
+		});
+
+		globalThis.fetch = mockFetchRouter({
+			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
+			'rdap.verisign.com': () => response,
+		});
+
+		const result = await run();
+		// domainAgeDays lives in finding metadata
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.title.toLowerCase().includes('registration'));
+		expect(infoFinding?.metadata?.domainAgeDays).toBeDefined();
+		// Allow 1 day tolerance for test timing
+		expect(Math.abs((infoFinding!.metadata!.domainAgeDays as number) - expectedAgeDays)).toBeLessThanOrEqual(1);
+	});
+
+	it('should use hardcoded fallback when bootstrap has no matching TLD', async () => {
+		// Bootstrap returns empty services → should fall back to hardcoded map
+		globalThis.fetch = mockFetchRouter({
+			'data.iana.org/rdap/dns.json': () => makeBootstrap([]),
+			'rdap.verisign.com': () => makeRdapResponse(),
+		});
+
+		const result = await run('example.com');
+		expect(result.category).toBe('rdap');
+		// Should still get results via hardcoded fallback for .com
+		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.title.toLowerCase().includes('registration'));
+		expect(infoFinding).toBeDefined();
+	});
+});

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -463,7 +463,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(48);
+		expect(result.tools).toHaveLength(49);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -463,7 +463,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(46);
+		expect(result.tools).toHaveLength(47);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -463,7 +463,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(45);
+		expect(result.tools).toHaveLength(46);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -463,7 +463,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(44);
+		expect(result.tools).toHaveLength(45);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -463,7 +463,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(47);
+		expect(result.tools).toHaveLength(48);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -463,7 +463,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(49);
+		expect(result.tools).toHaveLength(50);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -463,7 +463,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(50);
+		expect(result.tools).toHaveLength(51);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -352,7 +352,7 @@ describe('DNS Security MCP Server', () => {
 			const response = await worker.fetch(request, env, ctx);
 			await waitOnExecutionContext(ctx);
 			const body = (await response.json()) as { result: { tools: Array<{ name: string }> } };
-			expect(body.result.tools).toHaveLength(44);
+			expect(body.result.tools).toHaveLength(51);
 			const toolNames = body.result.tools.map((t) => t.name);
 			expect(toolNames).toContain('check_spf');
 			expect(toolNames).toContain('check_dmarc');

--- a/test/ip-utils.spec.ts
+++ b/test/ip-utils.spec.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+
+describe('ip-utils', () => {
+	describe('reverseIPv4', () => {
+		it('reverses simple octets', async () => {
+			const { reverseIPv4 } = await import('../src/lib/ip-utils');
+			expect(reverseIPv4('1.2.3.4')).toBe('4.3.2.1');
+		});
+
+		it('reverses a public IP', async () => {
+			const { reverseIPv4 } = await import('../src/lib/ip-utils');
+			expect(reverseIPv4('198.51.100.25')).toBe('25.100.51.198');
+		});
+
+		it('reverses loopback', async () => {
+			const { reverseIPv4 } = await import('../src/lib/ip-utils');
+			expect(reverseIPv4('127.0.0.1')).toBe('1.0.0.127');
+		});
+	});
+
+	describe('reverseIPv6', () => {
+		it('reverses a compressed IPv6 address', async () => {
+			const { reverseIPv6 } = await import('../src/lib/ip-utils');
+			expect(reverseIPv6('2001:0db8::1')).toBe(
+				'1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2',
+			);
+		});
+
+		it('reverses a fully expanded IPv6 address', async () => {
+			const { reverseIPv6 } = await import('../src/lib/ip-utils');
+			expect(reverseIPv6('2001:0db8:85a3:0000:0000:8a2e:0370:7334')).toBe(
+				'4.3.3.7.0.7.3.0.e.2.a.8.0.0.0.0.0.0.0.0.3.a.5.8.8.b.d.0.1.0.0.2',
+			);
+		});
+
+		it('reverses ::1 (loopback)', async () => {
+			const { reverseIPv6 } = await import('../src/lib/ip-utils');
+			expect(reverseIPv6('::1')).toBe(
+				'1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0',
+			);
+		});
+
+		it('reverses :: (all zeros)', async () => {
+			const { reverseIPv6 } = await import('../src/lib/ip-utils');
+			expect(reverseIPv6('::')).toBe(
+				'0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0',
+			);
+		});
+
+		it('reverses fe80::1 (link-local)', async () => {
+			const { reverseIPv6 } = await import('../src/lib/ip-utils');
+			// fe80:0000:0000:0000:0000:0000:0000:0001 → nibbles reversed
+			expect(reverseIPv6('fe80::1')).toBe(
+				'1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.e.f',
+			);
+		});
+	});
+
+	describe('isPrivateIP', () => {
+		// RFC 1918 ranges
+		it('detects 10.x.x.x as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('10.0.0.1')).toBe(true);
+			expect(isPrivateIP('10.255.255.255')).toBe(true);
+		});
+
+		it('detects 172.16-31.x.x as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('172.16.0.1')).toBe(true);
+			expect(isPrivateIP('172.31.255.255')).toBe(true);
+			expect(isPrivateIP('172.15.0.1')).toBe(false);
+			expect(isPrivateIP('172.32.0.1')).toBe(false);
+		});
+
+		it('detects 192.168.x.x as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('192.168.0.1')).toBe(true);
+			expect(isPrivateIP('192.168.255.255')).toBe(true);
+		});
+
+		// Loopback
+		it('detects IPv4 loopback as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('127.0.0.1')).toBe(true);
+			expect(isPrivateIP('127.255.255.255')).toBe(true);
+		});
+
+		it('detects IPv6 loopback as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('::1')).toBe(true);
+		});
+
+		// Link-local
+		it('detects IPv4 link-local as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('169.254.1.1')).toBe(true);
+		});
+
+		it('detects IPv6 link-local as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('fe80::1')).toBe(true);
+		});
+
+		// ULA (fc00::/7 = fc00:: through fdff::)
+		it('detects IPv6 ULA as private', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('fd00::1')).toBe(true);
+			expect(isPrivateIP('fc00::1')).toBe(true);
+		});
+
+		// Public IPs should return false
+		it('returns false for public IPv4', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('8.8.8.8')).toBe(false);
+			expect(isPrivateIP('1.1.1.1')).toBe(false);
+			expect(isPrivateIP('198.51.100.25')).toBe(false);
+		});
+
+		it('returns false for public IPv6', async () => {
+			const { isPrivateIP } = await import('../src/lib/ip-utils');
+			expect(isPrivateIP('2001:4860:4860::8888')).toBe(false);
+			expect(isPrivateIP('2606:4700:4700::1111')).toBe(false);
+		});
+	});
+});

--- a/test/rate-limit-chaos.spec.ts
+++ b/test/rate-limit-chaos.spec.ts
@@ -331,7 +331,7 @@ describe('rate-limit chaos tests', () => {
 	describe('config consistency', () => {
 		it('all check_* tools in config have the same daily limit (200)', () => {
 			const checkTools = Object.entries(FREE_TOOL_DAILY_LIMITS).filter(
-				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl' && name !== 'check_rbl' && name !== 'check_nsec_walkability',
+				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl' && name !== 'check_rbl' && name !== 'check_nsec_walkability' && name !== 'check_dnssec_chain',
 			);
 			for (const [name, limit] of checkTools) {
 				expect(limit, `${name} should have limit 200`).toBe(200);

--- a/test/rate-limit-chaos.spec.ts
+++ b/test/rate-limit-chaos.spec.ts
@@ -331,7 +331,7 @@ describe('rate-limit chaos tests', () => {
 	describe('config consistency', () => {
 		it('all check_* tools in config have the same daily limit (200)', () => {
 			const checkTools = Object.entries(FREE_TOOL_DAILY_LIMITS).filter(
-				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl' && name !== 'check_rbl' && name !== 'check_nsec_walkability' && name !== 'check_dnssec_chain',
+				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl' && name !== 'check_rbl' && name !== 'check_nsec_walkability' && name !== 'check_dnssec_chain' && name !== 'check_fast_flux',
 			);
 			for (const [name, limit] of checkTools) {
 				expect(limit, `${name} should have limit 200`).toBe(200);

--- a/test/rate-limit-chaos.spec.ts
+++ b/test/rate-limit-chaos.spec.ts
@@ -331,7 +331,7 @@ describe('rate-limit chaos tests', () => {
 	describe('config consistency', () => {
 		it('all check_* tools in config have the same daily limit (200)', () => {
 			const checkTools = Object.entries(FREE_TOOL_DAILY_LIMITS).filter(
-				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl' && name !== 'check_rbl',
+				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl' && name !== 'check_rbl' && name !== 'check_nsec_walkability',
 			);
 			for (const [name, limit] of checkTools) {
 				expect(limit, `${name} should have limit 200`).toBe(200);

--- a/test/rate-limit-chaos.spec.ts
+++ b/test/rate-limit-chaos.spec.ts
@@ -331,7 +331,7 @@ describe('rate-limit chaos tests', () => {
 	describe('config consistency', () => {
 		it('all check_* tools in config have the same daily limit (200)', () => {
 			const checkTools = Object.entries(FREE_TOOL_DAILY_LIMITS).filter(
-				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency',
+				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl',
 			);
 			for (const [name, limit] of checkTools) {
 				expect(limit, `${name} should have limit 200`).toBe(200);

--- a/test/rate-limit-chaos.spec.ts
+++ b/test/rate-limit-chaos.spec.ts
@@ -331,7 +331,7 @@ describe('rate-limit chaos tests', () => {
 	describe('config consistency', () => {
 		it('all check_* tools in config have the same daily limit (200)', () => {
 			const checkTools = Object.entries(FREE_TOOL_DAILY_LIMITS).filter(
-				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl',
+				([name]) => name.startsWith('check_') && name !== 'check_lookalikes' && name !== 'check_shadow_domains' && name !== 'check_mx_reputation' && name !== 'check_resolver_consistency' && name !== 'check_dbl' && name !== 'check_rbl',
 			);
 			for (const [name, limit] of checkTools) {
 				expect(limit, `${name} should have limit 200`).toBe(200);

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -147,7 +147,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 38 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(48);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(49);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -147,7 +147,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 38 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(45);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(46);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -147,7 +147,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 38 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(44);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(45);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -147,7 +147,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 38 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(46);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(47);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -147,7 +147,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 38 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(49);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(50);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -147,7 +147,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 38 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(50);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(51);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -147,7 +147,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 38 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(47);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(48);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 39 tools', () => {
-		expect(TOOLS).toHaveLength(45);
+		expect(TOOLS).toHaveLength(46);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 39 tools', () => {
-		expect(TOOLS).toHaveLength(44);
+		expect(TOOLS).toHaveLength(45);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 39 tools', () => {
-		expect(TOOLS).toHaveLength(47);
+		expect(TOOLS).toHaveLength(48);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 39 tools', () => {
-		expect(TOOLS).toHaveLength(48);
+		expect(TOOLS).toHaveLength(49);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 39 tools', () => {
-		expect(TOOLS).toHaveLength(46);
+		expect(TOOLS).toHaveLength(47);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 39 tools', () => {
-		expect(TOOLS).toHaveLength(49);
+		expect(TOOLS).toHaveLength(50);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 39 tools', () => {
-		expect(TOOLS).toHaveLength(50);
+		expect(TOOLS).toHaveLength(51);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -33,11 +33,12 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'check_dbl',
 	'check_rbl',
 	'cymru_asn',
+	'rdap_lookup',
 ]);
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 42 tools', () => {
-		expect(TOOLS).toHaveLength(47);
+		expect(TOOLS).toHaveLength(48);
 	});
 
 	it('all tool names are unique', () => {

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -34,11 +34,12 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'check_rbl',
 	'cymru_asn',
 	'rdap_lookup',
+	'check_nsec_walkability',
 ]);
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 42 tools', () => {
-		expect(TOOLS).toHaveLength(48);
+		expect(TOOLS).toHaveLength(49);
 	});
 
 	it('all tool names are unique', () => {

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -32,11 +32,12 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'resolve_spf_chain', 'discover_subdomains', 'map_compliance', 'simulate_attack_paths',
 	'check_dbl',
 	'check_rbl',
+	'cymru_asn',
 ]);
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 42 tools', () => {
-		expect(TOOLS).toHaveLength(46);
+		expect(TOOLS).toHaveLength(47);
 	});
 
 	it('all tool names are unique', () => {

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -31,11 +31,12 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'map_supply_chain', 'analyze_drift', 'validate_fix', 'generate_rollout_plan',
 	'resolve_spf_chain', 'discover_subdomains', 'map_compliance', 'simulate_attack_paths',
 	'check_dbl',
+	'check_rbl',
 ]);
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 42 tools', () => {
-		expect(TOOLS).toHaveLength(45);
+		expect(TOOLS).toHaveLength(46);
 	});
 
 	it('all tool names are unique', () => {
@@ -80,7 +81,7 @@ describe('tool-schemas metadata', () => {
 	});
 
 	it('all scoring check tools have a tier (except check_resolver_consistency)', () => {
-		const checkTools = TOOLS.filter((t) => t.name.startsWith('check_') && t.name !== 'check_resolver_consistency' && t.name !== 'check_dbl');
+		const checkTools = TOOLS.filter((t) => t.name.startsWith('check_') && t.name !== 'check_resolver_consistency' && t.group !== 'intelligence');
 		for (const tool of checkTools) {
 			expect(tool.tier, `${tool.name} is a scoring check but is missing a tier`).toBeDefined();
 		}

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -35,11 +35,12 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'cymru_asn',
 	'rdap_lookup',
 	'check_nsec_walkability',
+	'check_dnssec_chain',
 ]);
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 42 tools', () => {
-		expect(TOOLS).toHaveLength(49);
+		expect(TOOLS).toHaveLength(50);
 	});
 
 	it('all tool names are unique', () => {

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -30,11 +30,12 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'get_benchmark', 'get_provider_insights', 'assess_spoofability', 'explain_finding',
 	'map_supply_chain', 'analyze_drift', 'validate_fix', 'generate_rollout_plan',
 	'resolve_spf_chain', 'discover_subdomains', 'map_compliance', 'simulate_attack_paths',
+	'check_dbl',
 ]);
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 42 tools', () => {
-		expect(TOOLS).toHaveLength(44);
+		expect(TOOLS).toHaveLength(45);
 	});
 
 	it('all tool names are unique', () => {
@@ -79,7 +80,7 @@ describe('tool-schemas metadata', () => {
 	});
 
 	it('all scoring check tools have a tier (except check_resolver_consistency)', () => {
-		const checkTools = TOOLS.filter((t) => t.name.startsWith('check_') && t.name !== 'check_resolver_consistency');
+		const checkTools = TOOLS.filter((t) => t.name.startsWith('check_') && t.name !== 'check_resolver_consistency' && t.name !== 'check_dbl');
 		for (const tool of checkTools) {
 			expect(tool.tier, `${tool.name} is a scoring check but is missing a tier`).toBeDefined();
 		}

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -36,11 +36,12 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'rdap_lookup',
 	'check_nsec_walkability',
 	'check_dnssec_chain',
+	'check_fast_flux',
 ]);
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 42 tools', () => {
-		expect(TOOLS).toHaveLength(50);
+		expect(TOOLS).toHaveLength(51);
 	});
 
 	it('all tool names are unique', () => {


### PR DESCRIPTION
## Summary

- **7 new intelligence tools** for Cloudflare Workers (DoH/HTTP only)
- **4 full implementations**: `check_rbl` (8 RBLs), `check_dbl` (3 domain blocklists), `cymru_asn` (Team Cymru ASN lookup), `rdap_lookup` (RDAP registration data)
- **3 Workers-adapted versions**: `check_fast_flux` (multi-round DoH flux detection), `check_dnssec_chain` (DS/DNSKEY chain walk), `check_nsec_walkability` (NSEC3PARAM analysis)
- All tools registered as `group: 'intelligence'`, `scanIncluded: false` — no scoring impact, callable standalone
- Shared `ip-utils.ts` for IPv4/IPv6 reversal and private IP detection
- 66 new tests across 8 test files, explanation templates for all categories

## Design decisions

- **No scoring integration**: These are investigation/context tools, not pass/fail controls. Blocklist status is a symptom, ASN/RDAP is context data, adapted tools have lower fidelity.
- **3 tools not implemented**: `dns_query_dot` (IS the transport), `check_zone_transfer` (AXFR needs raw TCP), `detect_hijacking` (needs arbitrary resolver access) — all require raw sockets impossible on Workers.
- **URIBL/SURBL bitmask mappings** verified against authoritative sources (Rspamd docs, URIBL.com).

## Test plan

- [x] 66 new unit tests across 8 spec files (ip-utils, check-dbl, check-rbl, cymru-asn, rdap-lookup, nsec-walkability, dnssec-chain, fast-flux)
- [x] All existing tests pass (no regressions)
- [x] Typecheck clean
- [x] Lint clean
- [ ] Manual smoke test via `npm run dev` against real domains

🤖 Generated with [Claude Code](https://claude.com/claude-code)