### PR TITLE
feat: next-gen reliability hardening (8 phases)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3297,9 +3297,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.12",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-			"integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+			"version": "4.12.14",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+			"integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {

--- a/packages/dns-checks/src/types.ts
+++ b/packages/dns-checks/src/types.ts
@@ -120,6 +120,8 @@ export interface CheckResult {
 	checkStatus?: CheckStatus;
 	/** When true, the result is incomplete (e.g. timeout) and should not be cached long-term. */
 	partial?: boolean;
+	/** Optional structured metadata attached to the result by the check wrapper (not the core package). */
+	metadata?: Record<string, unknown>;
 }
 
 export interface ScanScore {

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,7 +629,7 @@ app.get('/mcp/sse', async (c) => {
 		}
 	}
 
-	const legacySessionId = await createSession(c.env.SESSION_STORE);
+	const legacySessionId = await createSession(c.env.SESSION_STORE, createAnalyticsClient(c.env.MCP_ANALYTICS));
 	const endpointUrl = new URL(`/mcp/messages?sessionId=${encodeURIComponent(legacySessionId)}`, c.req.url).toString();
 	return openLegacySseStream(legacySessionId, endpointUrl);
 });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -13,6 +13,64 @@
 import { logError } from './log';
 import type { McpClientType } from './client-detection';
 
+// ---------------------------------------------------------------------------
+// Degradation dedup — isolate-local rolling window (Task 18)
+// ---------------------------------------------------------------------------
+
+const DEGRADATION_SEEN = new Map<string, number>(); // key → insertedAtMs
+const DEGRADATION_WINDOW_MS = 60_000;
+
+function degradationDedupKey(scanId: string | undefined, type: string, component: string): string {
+	return `${scanId ?? ''}|${type}|${component}`;
+}
+
+function shouldEmitDegradation(scanId: string | undefined, type: string, component: string): boolean {
+	if (!scanId) return true; // no dedup when scanId is missing
+	const k = degradationDedupKey(scanId, type, component);
+	const now = Date.now();
+	for (const [existing, t] of DEGRADATION_SEEN) {
+		if (now - t > DEGRADATION_WINDOW_MS) DEGRADATION_SEEN.delete(existing);
+	}
+	if (DEGRADATION_SEEN.has(k)) return false;
+	DEGRADATION_SEEN.set(k, now);
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// FNV-1a collision probe — opportunistic, zero cost on uncontended paths (Task 19)
+// ---------------------------------------------------------------------------
+
+const FNV_HASH_SEEN = new Map<string, string>(); // hash → originalValue
+const FNV_HASH_SEEN_MAX = 10_000;
+let PENDING_COLLISION_FLAG = false;
+
+function recordHash(value: string, hash: string): void {
+	const cached = FNV_HASH_SEEN.get(hash);
+	if (cached !== undefined && cached !== value) {
+		PENDING_COLLISION_FLAG = true;
+	} else if (cached === undefined) {
+		FNV_HASH_SEEN.set(hash, value);
+		if (FNV_HASH_SEEN.size > FNV_HASH_SEEN_MAX) {
+			const firstKey = FNV_HASH_SEEN.keys().next().value;
+			if (firstKey !== undefined) FNV_HASH_SEEN.delete(firstKey);
+		}
+	}
+}
+
+/**
+ * Test-only helper: simulate a hash collision between existingValue and newValue.
+ * Not used in production paths.
+ */
+export function __forceCollisionForTest(existingValue: string, newValue: string): void {
+	for (const [h, v] of FNV_HASH_SEEN) {
+		if (v === existingValue) {
+			// Simulate a collision: a different value hashes to the same slot.
+			recordHash(newValue, h);
+			return;
+		}
+	}
+}
+
 /** Minimal shape used by Cloudflare Analytics Engine dataset bindings. */
 interface AnalyticsDatasetLike {
 	writeDataPoint: (point: {
@@ -65,6 +123,10 @@ export interface AnalyticsClient {
 		degradationType: 'dns_resolver_failure' | 'kv_fallback' | 'provider_detection_failure' | 'partial_result' | 'post_processing_error';
 		component: string;
 		domain?: string;
+		/** Per-scan correlation ID for dedup of parallel check degradations (Task 18). */
+		scanId?: string;
+		/** Override collision flag directly (probe-only, not a migration). */
+		hashCollisionSuspected?: boolean;
 	} & AnalyticsContext): void;
 }
 
@@ -144,16 +206,21 @@ export function createAnalyticsClient(dataset?: AnalyticsDatasetLike): Analytics
 			});
 		},
 		emitDegradationEvent: (event) => {
+			if (!shouldEmitDegradation(event.scanId, event.degradationType, event.component)) return;
+			const collision = PENDING_COLLISION_FLAG || Boolean(event.hashCollisionSuspected);
+			PENDING_COLLISION_FLAG = false;
 			safeWrite(dataset, {
 				indexes: ['degradation'],
 				blobs: [
 					event.degradationType,
 					normalizeIndex(event.component),
 					event.domain ? domainFingerprint(event.domain) : 'none',
+					event.scanId ?? '',
 					event.country ?? 'unknown',
 					event.clientType ?? 'unknown',
 					event.authTier ?? 'anon',
 				],
+				doubles: [collision ? 1 : 0],
 			});
 		},
 	};
@@ -191,9 +258,15 @@ function sanitizeNumber(value: number): number {
 /**
  * Computes a stable 32-bit fingerprint for aggregate grouping.
  * Not a privacy control — FNV-1a is trivially reversible for known domain sets.
+ *
+ * Also exported as `hashDomain` for opportunistic collision probing (Task 19).
  */
-function domainFingerprint(domain: string): string {
+export function hashDomain(domain: string): string {
 	return fnv1aHash(domain, 'd_');
+}
+
+function domainFingerprint(domain: string): string {
+	return hashDomain(domain);
 }
 
 /**
@@ -204,7 +277,7 @@ export function hashForAnalytics(value: string): string {
 	return fnv1aHash(value, 's_');
 }
 
-/** Shared FNV-1a hash with configurable prefix. */
+/** Shared FNV-1a hash with configurable prefix. Records result for collision probing (Task 19). */
 function fnv1aHash(value: string, prefix: string): string {
 	let hash = 0x811c9dc5;
 	const normalized = value.trim().toLowerCase();
@@ -212,5 +285,7 @@ function fnv1aHash(value: string, prefix: string): string {
 		hash ^= normalized.charCodeAt(i);
 		hash = Math.imul(hash, 0x01000193);
 	}
-	return `${prefix}${(hash >>> 0).toString(16)}`;
+	const result = `${prefix}${(hash >>> 0).toString(16)}`;
+	recordHash(normalized, result);
+	return result;
 }

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -226,6 +226,12 @@ export const SCAN_TIMEOUT_MS = 12_000;
 /** Default per-check timeout (ms). */
 export const PER_CHECK_TIMEOUT_MS = 8_000;
 
+/** TTL for the best-effort cross-isolate per-IP advisory lock. */
+export const IP_LOCK_TTL_MS = 500;
+
+/** Single-retry delay when advisory lock is held by another isolate. */
+export const IP_LOCK_RETRY_MS = 200;
+
 /** Helper: parse an env var as a clamped integer, returning defaultVal on invalid/out-of-range input. */
 function parseClampedInt(envValue: string | undefined, defaultVal: number, min: number, max: number): number {
 	if (!envValue) return defaultVal;

--- a/src/lib/dns-transport.ts
+++ b/src/lib/dns-transport.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { DNS_TIMEOUT_MS, DNS_RETRIES, DNS_CONFIRM_WITH_SECONDARY_ON_EMPTY, DOH_EDGE_CACHE_TTL, DNS_RETRY_BASE_DELAY_MS } from './config';
-import { type DohResponse, type QueryDnsOptions, RecordType, type RecordTypeName } from './dns-types';
+import { type DohResponse, type DohOutcome, type QueryDnsOptions, RecordType, type RecordTypeName, toNullable } from './dns-types';
 import { DohResponseSchema } from '../schemas/dns';
 import { logError } from './log';
 import type { Semaphore } from './semaphore';
@@ -28,31 +28,47 @@ function retryDelay(attempt: number): Promise<void> {
 }
 
 /**
- * Fetch a DoH response from a URL.
+ * Fetch a DoH response and classify the outcome. Existing callers that want
+ * the legacy `DohResponse | null` shape use `fetchDohResponse` (below).
  *
  * @param token - Optional auth token sent as `X-BV-Token` (for custom secondary resolvers).
  * @param useEdgeCache - If true, attaches Cloudflare `cf` cache directive. Omit for external origins.
  */
-async function fetchDohResponse(
+export async function fetchDohOutcome(
 	url: string,
 	timeoutMs: number,
 	opts?: { token?: string; useEdgeCache?: boolean; semaphore?: Semaphore },
-): Promise<DohResponse | null> {
+): Promise<DohOutcome> {
 	try {
 		const headers: Record<string, string> = { Accept: 'application/dns-json' };
 		if (opts?.token) headers['X-BV-Token'] = opts.token;
-		const doFetch = () => fetch(url, {
-			method: 'GET',
-			headers,
-			signal: AbortSignal.timeout(timeoutMs),
-			...(opts?.useEdgeCache ? { cf: { cacheTtl: DOH_EDGE_CACHE_TTL, cacheEverything: true } } : {}),
-		});
+		const doFetch = () =>
+			fetch(url, {
+				method: 'GET',
+				headers,
+				signal: AbortSignal.timeout(timeoutMs),
+				...(opts?.useEdgeCache ? { cf: { cacheTtl: DOH_EDGE_CACHE_TTL, cacheEverything: true } } : {}),
+			});
 		const response = opts?.semaphore ? await opts.semaphore.run(doFetch) : await doFetch();
-		if (!response.ok) return null;
+		if (!response.ok) {
+			logError('DNS fetch non-2xx', {
+				severity: 'warn',
+				category: 'dns-transport',
+				details: { url: url.replace(/name=[^&]+/, 'name=<domain>'), status: response.status },
+			});
+			return { kind: 'error', reason: 'http' };
+		}
 		const data = await response.json();
 		const parsed = DohResponseSchema.safeParse(data);
-		if (!parsed.success) return null;
-		return parsed.data as DohResponse;
+		if (!parsed.success) {
+			logError('DNS parse failure', {
+				severity: 'warn',
+				category: 'dns-transport',
+				details: { url: url.replace(/name=[^&]+/, 'name=<domain>') },
+			});
+			return { kind: 'error', reason: 'parse' };
+		}
+		return { kind: 'ok', response: parsed.data as DohResponse };
 	} catch (err) {
 		const isTimeout = err instanceof DOMException && err.name === 'TimeoutError';
 		logError(isTimeout ? 'DNS fetch timeout' : 'DNS fetch failed', {
@@ -60,8 +76,16 @@ async function fetchDohResponse(
 			category: 'dns-transport',
 			details: { url: url.replace(/name=[^&]+/, 'name=<domain>'), errorType: isTimeout ? 'timeout' : 'network' },
 		});
-		return null;
+		return { kind: 'error', reason: isTimeout ? 'timeout' : 'network' };
 	}
+}
+
+async function fetchDohResponse(
+	url: string,
+	timeoutMs: number,
+	opts?: { token?: string; useEdgeCache?: boolean; semaphore?: Semaphore },
+): Promise<DohResponse | null> {
+	return toNullable(await fetchDohOutcome(url, timeoutMs, opts));
 }
 
 /** Error thrown when a DNS query fails */

--- a/src/lib/dns-transport.ts
+++ b/src/lib/dns-transport.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { DNS_TIMEOUT_MS, DNS_RETRIES, DNS_CONFIRM_WITH_SECONDARY_ON_EMPTY, DOH_EDGE_CACHE_TTL, DNS_RETRY_BASE_DELAY_MS } from './config';
-import { type DohResponse, type DohOutcome, type QueryDnsOptions, RecordType, type RecordTypeName, toNullable } from './dns-types';
+import { type DohResponse, type DohOutcome, type QueryDnsOptions, RecordType, type RecordTypeName } from './dns-types';
 import { DohResponseSchema } from '../schemas/dns';
 import { logError } from './log';
 import type { Semaphore } from './semaphore';
@@ -78,14 +78,6 @@ export async function fetchDohOutcome(
 		});
 		return { kind: 'error', reason: isTimeout ? 'timeout' : 'network' };
 	}
-}
-
-async function fetchDohResponse(
-	url: string,
-	timeoutMs: number,
-	opts?: { token?: string; useEdgeCache?: boolean; semaphore?: Semaphore },
-): Promise<DohResponse | null> {
-	return toNullable(await fetchDohOutcome(url, timeoutMs, opts));
 }
 
 /** Error thrown when a DNS query fails */
@@ -183,8 +175,18 @@ async function queryDnsUncached(domain: string, type: RecordTypeName, dnssecChec
 		const data = validated.data as DohResponse;
 
 		if (confirmWithSecondaryOnEmpty && !opts?.skipSecondaryConfirmation && !hasTypedAnswers(data, type)) {
-			const secondaryResult = await confirmWithSecondaryResolvers(domain, type, dnssecCheck, timeoutMs, sem, opts);
-			if (secondaryResult) return secondaryResult;
+			const secondaryOpts = opts?.secondaryDoh
+				? { secondaryDoh: { url: opts.secondaryDoh.endpoint, token: opts.secondaryDoh.token } }
+				: undefined;
+			const secondaryResult = await confirmWithSecondaryResolvers(domain, type, dnssecCheck, timeoutMs, sem, secondaryOpts);
+			if ('kind' in secondaryResult && secondaryResult.kind === 'unconfirmed') {
+				// Secondary confirmation unavailable — keep the primary result as-is.
+				// (Do NOT change primary to empty; primary is authoritative when we can't verify.)
+				return data;
+			}
+			// secondaryResult is DohResponse here
+			const confirmedResponse = secondaryResult as DohResponse;
+			return confirmedResponse;
 		}
 
 		return data;
@@ -195,51 +197,40 @@ async function queryDnsUncached(domain: string, type: RecordTypeName, dnssecChec
 
 /**
  * Confirm empty primary results with secondary resolvers.
- * When both bv-dns and Google are available, races them in parallel (max 3s)
- * — first responder with typed answers wins. Falls back to sequential when
- * only Google is configured.
+ * Races bv-dns (when configured) and Google DoH in parallel — first responder
+ * with a successful response wins. Returns `{ kind: 'unconfirmed' }` when all
+ * secondaries fail, so callers can distinguish "both resolvers down" from
+ * "confirmed absent."
  */
-async function confirmWithSecondaryResolvers(
+export async function confirmWithSecondaryResolvers(
 	domain: string,
 	type: RecordTypeName,
 	dnssecCheck: boolean,
 	timeoutMs: number,
-	sem: Semaphore | undefined,
-	opts?: QueryDnsOptions,
-): Promise<DohResponse | null> {
-	const hasBvDns = !!opts?.secondaryDoh?.endpoint;
+	sem?: Semaphore,
+	opts?: { secondaryDoh?: { url: string; token?: string } },
+): Promise<DohResponse | { kind: 'unconfirmed' }> {
+	const bvDnsUrl = opts?.secondaryDoh ? buildDohUrl(opts.secondaryDoh.url, domain, type, dnssecCheck) : null;
 	const googleUrl = buildDohUrl(GOOGLE_DOH_ENDPOINT, domain, type, dnssecCheck);
-
-	if (hasBvDns) {
-		const bvDnsUrl = buildDohUrl(opts!.secondaryDoh!.endpoint, domain, type, dnssecCheck);
-
-		// Race bv-dns and Google in parallel — first with typed answers wins
-		const candidates = [
-			fetchDohResponse(bvDnsUrl, timeoutMs, { token: opts!.secondaryDoh!.token, semaphore: sem }),
-			fetchDohResponse(googleUrl, timeoutMs, { useEdgeCache: true, semaphore: sem }),
-		];
-
-		const results = await Promise.allSettled(candidates);
-		for (const r of results) {
-			if (r.status === 'fulfilled' && r.value && hasTypedAnswers(r.value, type)) {
-				return r.value;
-			}
-		}
-		const allFailed = results.every((r) => r.status === 'rejected' || !r.value);
-		if (allFailed) {
-			logError('All secondary DNS resolvers failed', {
-				severity: 'warn',
-				category: 'dns-transport',
-				details: { domain, type },
-			});
-		}
-		return null;
+	const candidates = [
+		bvDnsUrl
+			? fetchDohOutcome(bvDnsUrl, timeoutMs, { token: opts!.secondaryDoh!.token, semaphore: sem })
+			: Promise.resolve({ kind: 'error', reason: 'network' } as const),
+		fetchDohOutcome(googleUrl, timeoutMs, { useEdgeCache: true, semaphore: sem }),
+	];
+	const results = await Promise.allSettled(candidates);
+	for (const r of results) {
+		if (r.status === 'fulfilled' && r.value.kind === 'ok' && hasTypedAnswers(r.value.response, type)) return r.value.response;
 	}
-
-	// Only Google available
-	const google = await fetchDohResponse(googleUrl, timeoutMs, { useEdgeCache: true, semaphore: sem });
-	if (google && hasTypedAnswers(google, type)) {
-		return google;
+	// No secondary returned typed answers — return the first successful response if any,
+	// so callers get a valid (possibly empty) DohResponse instead of unconfirmed.
+	for (const r of results) {
+		if (r.status === 'fulfilled' && r.value.kind === 'ok') return r.value.response;
 	}
-	return null;
+	logError('All secondary resolvers failed', {
+		severity: 'warn',
+		category: 'dns-transport',
+		details: { type },
+	});
+	return { kind: 'unconfirmed' };
 }

--- a/src/lib/dns-transport.ts
+++ b/src/lib/dns-transport.ts
@@ -28,8 +28,9 @@ function retryDelay(attempt: number): Promise<void> {
 }
 
 /**
- * Fetch a DoH response and classify the outcome. Existing callers that want
- * the legacy `DohResponse | null` shape use `fetchDohResponse` (below).
+ * Fetch a DoH response and classify the outcome. The discriminated return
+ * type lets callers distinguish transport-level failures (timeout, network,
+ * parse, http) from "no records" results (a valid `ok` with empty Answer[]).
  *
  * @param token - Optional auth token sent as `X-BV-Token` (for custom secondary resolvers).
  * @param useEdgeCache - If true, attaches Cloudflare `cf` cache directive. Omit for external origins.

--- a/src/lib/dns-types.ts
+++ b/src/lib/dns-types.ts
@@ -72,3 +72,20 @@ export interface QueryDnsOptions {
 	/** Semaphore for capping concurrent outbound DoH fetches per isolate. */
 	dnsSemaphore?: import('./semaphore').Semaphore;
 }
+
+/**
+ * Outcome of a single DoH fetch attempt. `ok` includes 200-OK responses with
+ * empty `Answer[]` — a valid "no records" result. `error` is reserved for
+ * failures that make the outcome ambiguous to the caller.
+ */
+export type DohOutcome =
+	| { kind: 'ok'; response: DohResponse }
+	| { kind: 'error'; reason: 'timeout' | 'network' | 'parse' | 'http' };
+
+/**
+ * Back-compat adapter: maps `DohOutcome` to the legacy `DohResponse | null`
+ * return shape. `ok` → response, `error` → null.
+ */
+export function toNullable(outcome: DohOutcome): DohResponse | null {
+	return outcome.kind === 'ok' ? outcome.response : null;
+}

--- a/src/lib/profile-accumulator.ts
+++ b/src/lib/profile-accumulator.ts
@@ -16,6 +16,7 @@
 import { DurableObject } from 'cloudflare:workers';
 import { and, asc, count, desc, eq, gte, inArray, type InferSelectModel, sql } from 'drizzle-orm';
 import { drizzle, type DrizzleSqliteDODatabase } from 'drizzle-orm/durable-sqlite';
+import { logError } from './log';
 import {
 	EMA_ALPHA,
 	MATURITY_THRESHOLD,
@@ -770,5 +771,54 @@ export class ProfileAccumulator extends DurableObject<Env> {
 			periodAvgScore: Math.round(weightedAvg * 10) / 10,
 			snapshots,
 		});
+	}
+}
+
+// ─── KV-backed cross-isolate convergence helpers ────────────────────────────
+
+const ADAPTIVE_WEIGHT_KV_TTL_SECONDS = 60;
+
+function awKey(profile: string, provider: string): string {
+	return `aw:${profile}:${provider}`;
+}
+
+/**
+ * Publish a cross-isolate-visible summary of adaptive weights to KV.
+ * Called opportunistically (via waitUntil) after telemetry updates to converge
+ * scoring across isolates within one TTL window.
+ */
+export async function publishAdaptiveWeightSummary(
+	profile: string,
+	provider: string,
+	weights: Record<string, number>,
+	kv: KVNamespace,
+): Promise<void> {
+	try {
+		await kv.put(awKey(profile, provider), JSON.stringify(weights), {
+			expirationTtl: ADAPTIVE_WEIGHT_KV_TTL_SECONDS,
+		});
+	} catch {
+		logError('[profile-accumulator] KV publish failed', {
+			severity: 'warn',
+			category: 'profile-accumulator',
+		});
+	}
+}
+
+/**
+ * Read a cross-isolate adaptive-weight summary from KV. Returns null on cache
+ * miss or KV error — caller falls back to the DO call or static weights.
+ */
+export async function getAdaptiveWeights(
+	profile: string,
+	provider: string,
+	kv: KVNamespace,
+): Promise<Record<string, number> | null> {
+	try {
+		const raw = await kv.get(awKey(profile, provider));
+		if (!raw) return null;
+		return JSON.parse(raw) as Record<string, number>;
+	} catch {
+		return null;
 	}
 }

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -227,7 +227,8 @@ export async function checkScopedRateLimitKVWithAdvisory(
 	try {
 		return await withIpKvAdvisoryLock(ip, kv, () => checkScopedRateLimitKV(ip, scope, minuteLimit, hourLimit, kv));
 	} catch {
-		// KV outage — fall back to in-memory
+		// KV outage — log warning and fall back to in-memory
+		logError('[rate-limiter] KV error, falling back to in-memory');
 		return checkScopedRateLimitInMemory(ip, scope, minuteLimit, hourLimit);
 	}
 }

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -29,6 +29,7 @@ import {
 } from './quota-coordinator';
 import { CircuitBreaker, CircuitBreakerOpen } from './circuit-breaker';
 import { logError } from './log';
+import { IP_LOCK_TTL_MS, IP_LOCK_RETRY_MS } from './config';
 
 export interface RateLimitResult {
 	allowed: boolean;
@@ -159,7 +160,7 @@ async function checkScopedRateLimitKV(
 }
 
 async function checkRateLimitKV(ip: string, kv: KVNamespace): Promise<RateLimitResult> {
-	return checkScopedRateLimitKV(ip, 'tools', MINUTE_LIMIT, HOUR_LIMIT, kv);
+	return checkScopedRateLimitKVWithAdvisory(ip, 'tools', MINUTE_LIMIT, HOUR_LIMIT, kv);
 }
 
 async function checkControlPlaneRateLimitKV(ip: string, kv: KVNamespace): Promise<RateLimitResult> {
@@ -187,6 +188,47 @@ export async function withIpKvLock<T>(ip: string, work: () => Promise<T>): Promi
 		if (KV_IP_LOCK_TAILS.get(ip) === tail) {
 			KV_IP_LOCK_TAILS.delete(ip);
 		}
+	}
+}
+
+/**
+ * Best-effort cross-isolate per-IP advisory lock. Activates only when the
+ * in-memory KV_IP_LOCK_TAILS already has a tail for this IP (indicating
+ * contention on this isolate). On uncontended paths, skips the KV read
+ * entirely — zero added latency.
+ *
+ * KV outage → falls through to `work()` without the advisory layer.
+ */
+async function withIpKvAdvisoryLock<T>(ip: string, kv: KVNamespace, work: () => Promise<T>): Promise<T> {
+	const contended = KV_IP_LOCK_TAILS.has(ip);
+	if (!contended) return work();
+	const advisoryKey = `lk:ip:${ip}`;
+	try {
+		const held = await kv.get(advisoryKey);
+		if (held) await new Promise((r) => setTimeout(r, IP_LOCK_RETRY_MS));
+		await kv.put(advisoryKey, String(Date.now()), { expirationTtl: Math.max(1, Math.ceil(IP_LOCK_TTL_MS / 1000)) });
+	} catch {
+		// KV outage → best-effort fallback to in-memory lock only.
+	}
+	try {
+		return await work();
+	} finally {
+		try { await kv.delete(advisoryKey); } catch { /* best-effort */ }
+	}
+}
+
+export async function checkScopedRateLimitKVWithAdvisory(
+	ip: string,
+	scope: RateLimitScope,
+	minuteLimit: number,
+	hourLimit: number,
+	kv: KVNamespace,
+): Promise<RateLimitResult> {
+	try {
+		return await withIpKvAdvisoryLock(ip, kv, () => checkScopedRateLimitKV(ip, scope, minuteLimit, hourLimit, kv));
+	} catch {
+		// KV outage — fall back to in-memory
+		return checkScopedRateLimitInMemory(ip, scope, minuteLimit, hourLimit);
 	}
 }
 

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -29,6 +29,7 @@ import { withIpKvLock } from './rate-limiter';
 import { logError } from './log';
 import { SessionRecordSchema } from '../schemas/session';
 import { SessionIdSchema } from '../schemas/primitives';
+import type { AnalyticsClient } from './analytics';
 
 export { ACTIVE_SESSIONS, resetSessions, SESSION_REFRESH_INTERVAL_MS, SESSION_TTL_MS };
 
@@ -136,7 +137,7 @@ export function generateSessionId(): string {
 }
 
 /** Create a new session and return its ID */
-export async function createSession(kv?: KVNamespace): Promise<string> {
+export async function createSession(kv?: KVNamespace, analytics?: AnalyticsClient): Promise<string> {
 	const id = generateSessionId();
 	const now = Date.now();
 	const record: SessionRecord = { createdAt: now, lastAccessedAt: now };
@@ -153,6 +154,7 @@ export async function createSession(kv?: KVNamespace): Promise<string> {
 			// continue working. No retry — KV failures are typically transient and the next
 			// session creation will succeed.
 			logError('[session] KV create failed, in-memory fallback active', { category: 'session' });
+			analytics?.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session' });
 		}
 	}
 

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -87,7 +87,7 @@ export async function dispatchMcpMethod(options: DispatchMcpMethodOptions): Prom
 				// requests with the old session ID get a 404. Old sessions
 				// expire naturally via TTL (2 hours) and are cleaned up by
 				// periodic in-memory pruning + KV expirationTtl.
-				const sessionId = createSessionOnInitialize ? await createSession(options.sessionStore) : options.existingSessionId;
+				const sessionId = createSessionOnInitialize ? await createSession(options.sessionStore, options.analytics) : options.existingSessionId;
 				if (createSessionOnInitialize && sessionId) {
 					auditSessionCreated(options.ip, sessionId);
 					options.analytics?.emitSessionEvent({

--- a/src/tools/check-dnssec.ts
+++ b/src/tools/check-dnssec.ts
@@ -6,7 +6,7 @@
  */
 
 import { checkDNSSEC } from '@blackveil/dns-checks';
-import { DnsQueryError, queryDns, queryDnsRecords } from '../lib/dns';
+import { queryDns, queryDnsRecords } from '../lib/dns';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { buildCheckResult, createFinding } from '../lib/scoring';
@@ -105,6 +105,14 @@ export async function checkDnssec(domain: string, dnsOptions?: QueryDnsOptions):
 		},
 	) as CheckResult;
 
+	// If the inner check returned a transport-error sentinel finding, surface checkStatus='error'.
+	// checkDNSSEC catches transport failures internally and returns a 'DNSSEC check failed' finding
+	// rather than throwing — we detect this to distinguish transport errors from "no DNSSEC deployed".
+	const isDnsTransportError = baseResult.findings.some((f) => f.title === 'DNSSEC check failed');
+	if (isDnsTransportError) {
+		return { ...baseResult, checkStatus: 'error' as const };
+	}
+
 	// Skip augmentation when DNSSEC is definitively absent, failed, or misconfigured at the domain level.
 	// 'DNSSEC chain of trust incomplete' means the domain has DNSKEY but no DS — it is domain-operator-configured
 	// (just broken), not TLD-inherited.
@@ -143,16 +151,20 @@ export async function checkDnssec(domain: string, dnsOptions?: QueryDnsOptions):
 
 	return augmentWithSource(domain, baseResult, dnsOptions);
 	} catch (err) {
-		if (err instanceof DnsQueryError) {
-			return buildCheckResult('dnssec', [
-				createFinding(
-					'dnssec',
-					'DNSSEC check could not complete',
-					'info',
-					`Unable to verify DNSSEC for ${domain} — DNS query failed: ${err.message}`,
-					{ checkStatus: 'error' },
-				),
-			]);
+		if (err instanceof Error) {
+			const message = err.message;
+			return {
+				...buildCheckResult('dnssec', [
+					createFinding(
+						'dnssec',
+						'DNSSEC check could not be completed',
+						'info',
+						`DNS lookup failed (${message}). DNSSEC posture unknown.`,
+						{ dnsError: message },
+					),
+				]),
+				checkStatus: 'error' as const,
+			};
 		}
 		throw err;
 	}

--- a/src/tools/check-dnssec.ts
+++ b/src/tools/check-dnssec.ts
@@ -6,7 +6,7 @@
  */
 
 import { checkDNSSEC } from '@blackveil/dns-checks';
-import { queryDns, queryDnsRecords } from '../lib/dns';
+import { queryDns, queryDnsRecords, DnsQueryError } from '../lib/dns';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { buildCheckResult, createFinding } from '../lib/scoring';
@@ -151,16 +151,16 @@ export async function checkDnssec(domain: string, dnsOptions?: QueryDnsOptions):
 
 	return augmentWithSource(domain, baseResult, dnsOptions);
 	} catch (err) {
-		if (err instanceof Error) {
+		if (err instanceof DnsQueryError) {
 			const message = err.message;
 			return {
 				...buildCheckResult('dnssec', [
 					createFinding(
 						'dnssec',
-						'DNSSEC check could not be completed',
+						'DNSSEC check could not complete',
 						'info',
-						`DNS lookup failed (${message}). DNSSEC posture unknown.`,
-						{ dnsError: message },
+						`DNS query failed (${message}). DNSSEC posture unknown.`,
+						{ dnsError: message, checkStatus: 'error' },
 					),
 				]),
 				checkStatus: 'error' as const,

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -245,7 +245,7 @@ export async function checkHttpSecurity(domain: string): Promise<CheckResult> {
 				{ wafChallenge: wafName, inconclusive: true },
 			);
 			const base = buildCheckResult('http_security', [finding]);
-			return { ...base, checkStatus: 'error' };
+			return { ...base, score: 0, passed: false, checkStatus: 'error' };
 		}
 	}
 

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -13,11 +13,44 @@
 
 import { checkHTTPSecurity } from '@blackveil/dns-checks';
 import type { CheckResult } from '../lib/scoring';
-import { createFinding } from '../lib/scoring';
+import { buildCheckResult, createFinding } from '../lib/scoring';
 import { HTTPS_TIMEOUT_MS } from '../lib/config';
 
 /** User-Agent for outbound probes — matches the package's scanner UA. */
 const SCANNER_USER_AGENT = 'Mozilla/5.0 (compatible; BlackVeilDNSScanner/1.0; +https://blackveilsecurity.com)';
+
+/** WAF/CDN challenge page fingerprints. Matched against response headers (and optionally body). */
+const WAF_CHALLENGE_FINGERPRINTS: Array<{
+	name: string;
+	matchHeaders: (h: Headers) => boolean;
+	matchBody?: (body: string) => boolean;
+}> = [
+	{
+		name: 'cloudflare',
+		// cf-ray header is conclusive on its own; body title is a belt-and-suspenders signal
+		matchHeaders: (h) =>
+			!!(h.get('cf-ray') && (h.get('server') ?? '').toLowerCase().includes('cloudflare')),
+		matchBody: (body) => /just a moment/i.test(body),
+	},
+	{
+		name: 'akamai',
+		matchHeaders: (h) => (h.get('server') ?? '').toLowerCase().includes('akamaighost'),
+	},
+];
+
+/**
+ * Detect a WAF/CDN challenge page from response headers and optional body.
+ * Returns the WAF provider name if matched, null otherwise.
+ */
+function detectWafChallenge(headers: Headers, body?: string): string | null {
+	for (const fp of WAF_CHALLENGE_FINGERPRINTS) {
+		if (!fp.matchHeaders(headers)) continue;
+		// If a body matcher is defined, at least one of headers or body must match
+		if (fp.matchBody && body !== undefined && !fp.matchBody(body)) continue;
+		return fp.name;
+	}
+	return null;
+}
 
 /** Security headers to merge (union) across dual fetches. */
 const MERGE_HEADERS = [
@@ -160,6 +193,24 @@ async function dualFetchHeaders(
 }
 
 /**
+ * Fetch the page body for WAF challenge fingerprinting.
+ * Returns an empty string on error (fail-open — WAF detection should not block normal analysis).
+ */
+async function fetchBodyForWafDetection(url: string, timeoutMs: number): Promise<string> {
+	try {
+		const response = await fetch(url, {
+			method: 'GET',
+			redirect: 'manual',
+			headers: { 'User-Agent': SCANNER_USER_AGENT },
+			signal: AbortSignal.timeout(timeoutMs),
+		});
+		return await response.text();
+	} catch {
+		return '';
+	}
+}
+
+/**
  * Check HTTP security headers for a domain.
  *
  * Strategy: fire two parallel HEAD fetches, union the security headers, then
@@ -171,9 +222,32 @@ async function dualFetchHeaders(
  *
  * Also detects CDN provider from the analyzed headers and adds an info
  * finding when a CDN is fronting the origin.
+ *
+ * WAF/CDN challenge pages are fingerprinted early (after the dual-fetch)
+ * and short-circuit the header analysis — returning checkStatus='error'
+ * with a single info finding instead of misleading header-missing findings.
  */
 export async function checkHttpSecurity(domain: string): Promise<CheckResult> {
 	const dualResult = await dualFetchHeaders(domain, HTTPS_TIMEOUT_MS);
+
+	// WAF/CDN challenge detection — short-circuit before header analysis
+	if (dualResult) {
+		const headersForWaf = dualResult.headers;
+		const needsBody = WAF_CHALLENGE_FINGERPRINTS.some((fp) => fp.matchHeaders(headersForWaf) && fp.matchBody);
+		const body = needsBody ? await fetchBodyForWafDetection(`https://${domain}`, HTTPS_TIMEOUT_MS) : undefined;
+		const wafName = detectWafChallenge(headersForWaf, body);
+		if (wafName) {
+			const finding = createFinding(
+				'http_security',
+				`${wafName.charAt(0).toUpperCase() + wafName.slice(1)} WAF challenge intercepted`,
+				'info',
+				`The fetched response appears to be a WAF/CDN challenge page, not the real site. Header analysis is inconclusive.`,
+				{ wafChallenge: wafName, inconclusive: true },
+			);
+			const base = buildCheckResult('http_security', [finding]);
+			return { ...base, checkStatus: 'error' };
+		}
+	}
 
 	let capturedHeaders: Headers | null = null;
 

--- a/src/tools/check-mx.ts
+++ b/src/tools/check-mx.ts
@@ -41,6 +41,7 @@ export async function checkMx(domain: string, options?: CheckMxOptions, dnsOptio
 
 	// Provider detection post-processing
 	const findings = [...baseResult.findings];
+	let providerDetectionFailed = false;
 
 	try {
 		// Re-query MX records to get raw strings for provider matching
@@ -76,6 +77,7 @@ export async function checkMx(domain: string, options?: CheckMxOptions, dnsOptio
 			}
 
 			if (providerSignatures.degraded) {
+				providerDetectionFailed = true;
 				findings.push(
 					createFinding(
 						'mx',
@@ -95,6 +97,7 @@ export async function checkMx(domain: string, options?: CheckMxOptions, dnsOptio
 		}
 	} catch (err) {
 		// Provider detection failure is non-critical — return base result with warning log
+		providerDetectionFailed = true;
 		logEvent({
 			timestamp: new Date().toISOString(),
 			severity: 'warn',
@@ -106,5 +109,9 @@ export async function checkMx(domain: string, options?: CheckMxOptions, dnsOptio
 		});
 	}
 
-	return { ...baseResult, findings };
+	return {
+		...baseResult,
+		findings,
+		...(providerDetectionFailed ? { metadata: { providerDetectionFailed: true } } : {}),
+	};
 }

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -172,6 +172,9 @@ async function runCheckRetry(
  * @returns Full scan result with score, individual check results, and metadata
  */
 export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOptions?: ScanRuntimeOptions): Promise<ScanDomainResult> {
+	// scanId: generated once per scan for threading to analytics degradation events.
+	// Currently unused here — callers will pass it when emitDegradationEvent sites migrate.
+	const _scanId = crypto.randomUUID();
 	const scanStartTime = Date.now();
 	const explicitProfile = runtimeOptions?.profile;
 	const isExplicit = explicitProfile && explicitProfile !== 'auto';

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -25,6 +25,7 @@ import {
 import {
 	adaptiveWeightsToContext,
 	generateScoringNote,
+	MATURITY_THRESHOLD,
 	type AdaptiveWeightsResponse,
 	type ScanTelemetry,
 } from '../lib/adaptive-weights';
@@ -51,6 +52,7 @@ import { checkSubdomailing } from './check-subdomailing';
 import { applyScanPostProcessing } from './scan/post-processing';
 import type { ScanRuntimeOptions } from './scan/post-processing';
 import { logError } from '../lib/log';
+import { getAdaptiveWeights, publishAdaptiveWeightSummary } from '../lib/profile-accumulator';
 import { capMaturityStage, computeMaturityStage } from './scan/maturity-staging';
 import type { MaturityStage } from './scan/maturity-staging';
 export { formatScanReport, buildStructuredScanResult } from './scan/format-report';
@@ -356,14 +358,39 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 		// uses the default weights (identical to pre-profile behavior).
 		const scoringContext = isExplicit ? domainContext : undefined;
 
-		// Attempt to fetch adaptive weights from the ProfileAccumulator DO
+		// Attempt to fetch adaptive weights — KV first for cross-isolate convergence,
+		// then fall through to the ProfileAccumulator DO on miss.
 		let adaptiveResponse: AdaptiveWeightsResponse | null = null;
-		if (runtimeOptions?.profileAccumulator) {
+		const adaptiveProvider = domainContext.detectedProvider ?? '';
+
+		if (kv && adaptiveProvider) {
+			const kvWeights = await getAdaptiveWeights(domainContext.profile, adaptiveProvider, kv);
+			if (kvWeights) {
+				// Synthesise a minimal AdaptiveWeightsResponse from KV data so the
+				// downstream code path is unchanged.
+				adaptiveResponse = {
+					profile: domainContext.profile,
+					provider: adaptiveProvider,
+					sampleCount: MATURITY_THRESHOLD,
+					blendFactor: 1,
+					weights: kvWeights,
+					boundHits: [],
+				};
+			}
+		}
+
+		if (!adaptiveResponse && runtimeOptions?.profileAccumulator) {
 			adaptiveResponse = await fetchAdaptiveWeights(
 				runtimeOptions.profileAccumulator,
 				domainContext.profile,
 				domainContext.detectedProvider,
 			);
+			// Publish to KV so other isolates can converge within the TTL window.
+			if (adaptiveResponse && adaptiveProvider && kv && runtimeOptions.waitUntil) {
+				runtimeOptions.waitUntil(
+					publishAdaptiveWeightSummary(domainContext.profile, adaptiveProvider, adaptiveResponse.weights, kv),
+				);
+			}
 		}
 
 		// Add bound hits to signals if present

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -100,6 +100,14 @@ function upsertCheckResult(results: CheckResult[], updated: CheckResult): CheckR
 }
 
 async function addOutboundProviderInference(results: CheckResult[], runtimeOptions?: ScanRuntimeOptions): Promise<CheckResult[]> {
+	// If the MX provider detection failed, skip provider-informed DKIM/SPF adjustments
+	// to avoid false inferences based on incomplete or degraded provider data.
+	const mxResult = results.find((result) => result.category === 'mx');
+	const providerDetectionFailed = Boolean(
+		(mxResult?.metadata as { providerDetectionFailed?: boolean } | undefined)?.providerDetectionFailed,
+	);
+	if (providerDetectionFailed) return results;
+
 	const spfResult = results.find((result) => result.category === 'spf');
 	const dkimResult = results.find((result) => result.category === 'dkim');
 

--- a/test/adaptive-weights.spec.ts
+++ b/test/adaptive-weights.spec.ts
@@ -316,3 +316,44 @@ describe('adaptive-weights', () => {
 		});
 	});
 });
+
+describe('adaptive weight KV convergence', () => {
+	function makeKv() {
+		const store = new Map<string, string>();
+		return {
+			kv: {
+				async get(key: string) { return store.get(key) ?? null; },
+				async put(key: string, value: string, _opts?: { expirationTtl?: number }) { store.set(key, value); },
+				async delete(key: string) { store.delete(key); },
+			} as unknown as KVNamespace,
+			store,
+		};
+	}
+
+	it('publishAdaptiveWeightSummary + getAdaptiveWeights round-trip via KV', async () => {
+		const { kv } = makeKv();
+		const { publishAdaptiveWeightSummary, getAdaptiveWeights } = await import('../src/lib/profile-accumulator');
+		const weights = { spf: 10.5, dmarc: 16.2 };
+		await publishAdaptiveWeightSummary('mail_enabled', 'google', weights, kv);
+		const a = await getAdaptiveWeights('mail_enabled', 'google', kv);
+		const b = await getAdaptiveWeights('mail_enabled', 'google', kv);
+		expect(a).toEqual(b);
+		expect(a).toEqual(weights);
+	});
+
+	it('getAdaptiveWeights returns null on cache miss (caller falls back to static)', async () => {
+		const { kv } = makeKv();
+		const { getAdaptiveWeights } = await import('../src/lib/profile-accumulator');
+		expect(await getAdaptiveWeights('mail_enabled', 'unknown', kv)).toBeNull();
+	});
+
+	it('getAdaptiveWeights returns null on KV error (graceful fallback)', async () => {
+		const kv = {
+			async get() { throw new Error('KV down'); },
+			async put() {},
+			async delete() {},
+		} as unknown as KVNamespace;
+		const { getAdaptiveWeights } = await import('../src/lib/profile-accumulator');
+		expect(await getAdaptiveWeights('mail_enabled', 'google', kv)).toBeNull();
+	});
+});

--- a/test/analytics.spec.ts
+++ b/test/analytics.spec.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createAnalyticsClient } from '../src/lib/analytics';
 import type { AnalyticsContext } from '../src/lib/analytics';
 
@@ -116,9 +118,12 @@ describe('createAnalyticsClient', () => {
 		expect(point.indexes).toEqual(['degradation']);
 		expect(point.blobs[0]).toBe('dns_resolver_failure');
 		expect(point.blobs[1]).toBe('fetchdohresponse');
-		expect(point.blobs[3]).toBe('NZ');
-		expect(point.blobs[4]).toBe('claude_code');
-		expect(point.blobs[5]).toBe('agent');
+		// blobs[2] = domain fingerprint, blobs[3] = scanId (''), blobs[4] = country
+		expect(point.blobs[4]).toBe('NZ');
+		expect(point.blobs[5]).toBe('claude_code');
+		expect(point.blobs[6]).toBe('agent');
+		// doubles[0] = hashCollisionSuspected flag (0 = no collision)
+		expect(point.doubles?.[0]).toBe(0);
 	});
 
 	it('emitDegradationEvent handles missing optional fields', () => {
@@ -133,6 +138,68 @@ describe('createAnalyticsClient', () => {
 		expect(point.indexes).toEqual(['degradation']);
 		expect(point.blobs[0]).toBe('kv_fallback');
 		expect(point.blobs[2]).toBe('none');
-		expect(point.blobs[3]).toBe('unknown');
+		expect(point.blobs[3]).toBe(''); // no scanId
+		expect(point.blobs[4]).toBe('unknown'); // country
+	});
+});
+
+describe('analytics degradation dedup + collision probe', () => {
+	function makeClient() {
+		const writes: Array<{ indexes?: string[]; blobs?: string[]; doubles?: number[] }> = [];
+		const dataset = {
+			writeDataPoint: (p: { indexes?: string[]; blobs?: string[]; doubles?: number[] }) => writes.push(p),
+		};
+		return { dataset, writes };
+	}
+
+	beforeEach(() => {
+		// Clear any module-level state between tests.
+		vi.resetModules();
+	});
+
+	it('dedups identical (scanId, degradationType, component) within the rolling window', async () => {
+		const { dataset, writes } = makeClient();
+		const { createAnalyticsClient } = await import('../src/lib/analytics');
+		const client = createAnalyticsClient(dataset as never);
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'A' });
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'A' });
+		// Same (scanId, type, component) → only one write.
+		const degWrites = writes.filter((w) => w.indexes?.[0] === 'degradation');
+		expect(degWrites.length).toBe(1);
+	});
+
+	it('does NOT dedup across different scanIds', async () => {
+		const { dataset, writes } = makeClient();
+		const { createAnalyticsClient } = await import('../src/lib/analytics');
+		const client = createAnalyticsClient(dataset as never);
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'A' });
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'B' });
+		const degWrites = writes.filter((w) => w.indexes?.[0] === 'degradation');
+		expect(degWrites.length).toBe(2);
+	});
+
+	it('does NOT dedup when scanId is undefined (each call is independent)', async () => {
+		const { dataset, writes } = makeClient();
+		const { createAnalyticsClient } = await import('../src/lib/analytics');
+		const client = createAnalyticsClient(dataset as never);
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session' });
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session' });
+		const degWrites = writes.filter((w) => w.indexes?.[0] === 'degradation');
+		expect(degWrites.length).toBe(2);
+	});
+
+	it('emits hashCollisionSuspected when two different domains hash identically', async () => {
+		const { dataset, writes } = makeClient();
+		const { createAnalyticsClient, hashDomain, __forceCollisionForTest } = await import('../src/lib/analytics');
+		const client = createAnalyticsClient(dataset as never);
+		// Prime the collision cache so the next hash call sees a collision.
+		hashDomain('example.com');
+		// Force-inject a collision for different.com → same hash as example.com.
+		(__forceCollisionForTest as ((a: string, b: string) => void) | undefined)?.('example.com', 'different.com');
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'probe-emit' });
+		const degWrites = writes.filter((w) => w.indexes?.[0] === 'degradation');
+		expect(degWrites.length).toBeGreaterThanOrEqual(1);
+		// hashCollisionSuspected is the 0th double.
+		expect(degWrites[0].doubles?.[0]).toBe(1);
 	});
 });

--- a/test/cache.spec.ts
+++ b/test/cache.spec.ts
@@ -363,3 +363,59 @@ describe('runWithCache — cross-isolate dedup', () => {
 		expect(run).toHaveBeenCalledOnce();
 	});
 });
+
+describe('runWithCache sentinel lifecycle', () => {
+	function makeMockKv() {
+		const store = new Map<string, { value: string; expiresAt?: number }>();
+		const writeLog: Array<{ key: string; value: string; ttl?: number; op: 'put' | 'delete' }> = [];
+		const kv = {
+			async get(key: string) {
+				const e = store.get(key);
+				if (!e) return null;
+				if (e.expiresAt && Date.now() > e.expiresAt) {
+					store.delete(key);
+					return null;
+				}
+				return e.value;
+			},
+			async put(key: string, value: string, opts?: { expirationTtl?: number }) {
+				const expiresAt = opts?.expirationTtl ? Date.now() + opts.expirationTtl * 1000 : undefined;
+				store.set(key, { value, expiresAt });
+				writeLog.push({ key, value, ttl: opts?.expirationTtl, op: 'put' });
+			},
+			async delete(key: string) {
+				store.delete(key);
+				writeLog.push({ key, value: '', op: 'delete' });
+			},
+		} as unknown as KVNamespace;
+		return { kv, writeLog, store };
+	}
+
+	it('sentinel TTL is <= 10 seconds', async () => {
+		const { kv, writeLog } = makeMockKv();
+		const { runWithCache } = await import('../src/lib/cache');
+		await runWithCache('sentinel-ttl-key', async () => ({ ok: true }), kv);
+		const sentinelWrite = writeLog.find((e) => e.op === 'put' && e.key === 'sentinel-ttl-key:computing');
+		expect(sentinelWrite).toBeDefined();
+		expect(sentinelWrite!.ttl).toBeDefined();
+		expect(sentinelWrite!.ttl!).toBeLessThanOrEqual(10);
+	});
+
+	it('sentinel is deleted in finally even when run() throws', async () => {
+		const { kv, store } = makeMockKv();
+		const { runWithCache } = await import('../src/lib/cache');
+		await expect(runWithCache('sentinel-throw-key', async () => { throw new Error('boom'); }, kv)).rejects.toThrow('boom');
+		expect(store.get('sentinel-throw-key:computing')).toBeUndefined();
+	});
+
+	it('sentinel delete happens AFTER result put (racing poller sees result first)', async () => {
+		const { kv, writeLog } = makeMockKv();
+		const { runWithCache } = await import('../src/lib/cache');
+		await runWithCache('sentinel-order-key', async () => ({ hit: true }), kv);
+		const putResultIdx = writeLog.findIndex((e) => e.op === 'put' && e.key === 'sentinel-order-key');
+		const deleteSentinelIdx = writeLog.findIndex((e) => e.op === 'delete' && e.key === 'sentinel-order-key:computing');
+		expect(putResultIdx).toBeGreaterThanOrEqual(0);
+		expect(deleteSentinelIdx).toBeGreaterThanOrEqual(0);
+		expect(deleteSentinelIdx).toBeGreaterThan(putResultIdx);
+	});
+});

--- a/test/chaos/invariants.spec.ts
+++ b/test/chaos/invariants.spec.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Regression spine for next-gen-reliability invariants. Each test corresponds
+// to one phase's production fix. If the fix is reverted, exactly one test
+// here should fail. Flakiness is not tolerated: fault injection is
+// deterministic (synchronous throws), not timing-based.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+describe('invariants: P1 — DohOutcome discrimination', () => {
+	const savedFetch = globalThis.fetch;
+	afterEach(() => { globalThis.fetch = savedFetch; vi.restoreAllMocks(); });
+
+	it('fetchDohOutcome distinguishes timeout from ok (empty Answer)', async () => {
+		const { fetchDohOutcome } = await import('../../src/lib/dns-transport');
+
+		globalThis.fetch = vi.fn().mockRejectedValue(new DOMException('t', 'TimeoutError')) as unknown as typeof fetch;
+		const timedOut = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 50);
+		expect(timedOut.kind).toBe('error');
+		if (timedOut.kind === 'error') expect(timedOut.reason).toBe('timeout');
+
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ Status: 0, Answer: [] }),
+		}) as unknown as typeof fetch;
+		const empty = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 3000);
+		expect(empty.kind).toBe('ok');
+	});
+});
+
+describe('invariants: P2 — secondary unconfirmed sentinel', () => {
+	const savedFetch = globalThis.fetch;
+	afterEach(() => { globalThis.fetch = savedFetch; vi.restoreAllMocks(); });
+
+	it('both secondaries fail → { kind: "unconfirmed" }', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('net')) as unknown as typeof fetch;
+		const { confirmWithSecondaryResolvers } = await import('../../src/lib/dns-transport');
+		const result = await confirmWithSecondaryResolvers('example.com', 'TXT', false, 1000);
+		expect((result as { kind?: string }).kind).toBe('unconfirmed');
+	});
+});
+
+describe('invariants: P3 — sentinel lifecycle', () => {
+	function makeMockKv() {
+		const store = new Map<string, string>();
+		const writeLog: Array<{ key: string; value: string; op: 'put' | 'delete'; ttl?: number }> = [];
+		const kv = {
+			async get(key: string) { return store.get(key) ?? null; },
+			async put(key: string, value: string, opts?: { expirationTtl?: number }) {
+				store.set(key, value);
+				writeLog.push({ key, value, op: 'put', ttl: opts?.expirationTtl });
+			},
+			async delete(key: string) { store.delete(key); writeLog.push({ key, value: '', op: 'delete' }); },
+		} as unknown as KVNamespace;
+		return { kv, store, writeLog };
+	}
+
+	it('sentinel is deleted even when run() throws', async () => {
+		const { kv, store } = makeMockKv();
+		const { runWithCache } = await import('../../src/lib/cache');
+		await expect(runWithCache('inv-key', async () => { throw new Error('x'); }, kv)).rejects.toThrow('x');
+		expect(store.get('inv-key:computing')).toBeUndefined();
+	});
+
+	it('sentinel TTL is <= 10 seconds', async () => {
+		const { kv, writeLog } = makeMockKv();
+		const { runWithCache } = await import('../../src/lib/cache');
+		await runWithCache('inv-ttl-key', async () => ({ ok: true }), kv);
+		const sentinel = writeLog.find((e) => e.op === 'put' && e.key === 'inv-ttl-key:computing');
+		expect(sentinel?.ttl).toBeDefined();
+		expect(sentinel!.ttl!).toBeLessThanOrEqual(10);
+	});
+});
+
+describe('invariants: P4 — session KV failure → degradation event', () => {
+	it('KV put failure triggers kv_fallback degradation event', async () => {
+		const events: Array<{ degradationType: string; component: string }> = [];
+		const fakeAnalytics = {
+			enabled: true,
+			emitRequestEvent: vi.fn(),
+			emitToolEvent: vi.fn(),
+			emitRateLimitEvent: vi.fn(),
+			emitSessionEvent: vi.fn(),
+			emitDegradationEvent: (e: { degradationType: string; component: string }) =>
+				events.push({ degradationType: e.degradationType, component: e.component }),
+		};
+		const kv = {
+			async get() { return null; },
+			async put() { throw new Error('KV down'); },
+			async delete() {},
+			async list() { return { keys: [] }; },
+		} as unknown as KVNamespace;
+		const { createSession } = await import('../../src/lib/session');
+		await createSession(kv, fakeAnalytics as never);
+		expect(events).toEqual([{ degradationType: 'kv_fallback', component: 'session' }]);
+	});
+});
+
+describe('invariants: P5 — rate-limiter KV advisory lock is contention-gated', () => {
+	it('uncontended call does not attempt advisory KV writes', async () => {
+		let advisoryKeyReads = 0;
+		const store = new Map<string, string>();
+		const kv = {
+			async get(key: string) {
+				if (key.startsWith('lk:ip:')) advisoryKeyReads += 1;
+				return store.get(key) ?? null;
+			},
+			async put(key: string, value: string) { store.set(key, value); },
+			async delete(key: string) { store.delete(key); },
+		} as unknown as KVNamespace;
+		const { checkScopedRateLimitKVWithAdvisory } = await import('../../src/lib/rate-limiter');
+		await checkScopedRateLimitKVWithAdvisory!('9.9.9.9', 'tools', 50, 300, kv);
+		expect(advisoryKeyReads).toBe(0); // contention-gated — no advisory read on uncontended path
+	});
+});
+
+describe('invariants: P6 — adaptive-weight KV round-trip', () => {
+	it('publish then get returns the same weights', async () => {
+		const store = new Map<string, string>();
+		const kv = {
+			async get(k: string) { return store.get(k) ?? null; },
+			async put(k: string, v: string, _o?: { expirationTtl?: number }) { store.set(k, v); },
+			async delete(k: string) { store.delete(k); },
+		} as unknown as KVNamespace;
+		const { publishAdaptiveWeightSummary, getAdaptiveWeights } = await import('../../src/lib/profile-accumulator');
+		await publishAdaptiveWeightSummary('mail_enabled', 'google', { spf: 10, dmarc: 16 }, kv);
+		const got = await getAdaptiveWeights('mail_enabled', 'google', kv);
+		expect(got).toEqual({ spf: 10, dmarc: 16 });
+	});
+
+	it('missing summary returns null (static fallback signal)', async () => {
+		const kv = {
+			async get() { return null; },
+			async put() {},
+			async delete() {},
+		} as unknown as KVNamespace;
+		const { getAdaptiveWeights } = await import('../../src/lib/profile-accumulator');
+		expect(await getAdaptiveWeights('mail_enabled', 'unknown', kv)).toBeNull();
+	});
+});
+
+describe('invariants: P7c — DNSSEC transport failure → checkStatus=error', () => {
+	const savedFetch = globalThis.fetch;
+	afterEach(() => { globalThis.fetch = savedFetch; vi.restoreAllMocks(); });
+
+	it('DNS fetch failure produces checkStatus=error, not "not configured"', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('net')) as unknown as typeof fetch;
+		const { checkDnssec } = await import('../../src/tools/check-dnssec');
+		const result = await checkDnssec('example.com');
+		expect(result.checkStatus).toBe('error');
+		const hasMisclassification = result.findings.some(
+			(f: { title?: string }) => (f.title ?? '').toLowerCase().includes('not configured'),
+		);
+		expect(hasMisclassification).toBe(false);
+	});
+});
+
+describe('invariants: P8 — analytics degradation dedup', () => {
+	it('same (scanId, type, component) emits exactly once', async () => {
+		const writes: Array<{ indexes?: string[] }> = [];
+		const dataset = { writeDataPoint: (p: { indexes?: string[] }) => writes.push(p) };
+		const { createAnalyticsClient } = await import('../../src/lib/analytics');
+		const client = createAnalyticsClient(dataset as never);
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'X' });
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'X' });
+		const degWrites = writes.filter((w) => w.indexes?.[0] === 'degradation');
+		expect(degWrites.length).toBe(1);
+	});
+
+	it('different scanIds produce separate emits', async () => {
+		const writes: Array<{ indexes?: string[] }> = [];
+		const dataset = { writeDataPoint: (p: { indexes?: string[] }) => writes.push(p) };
+		const { createAnalyticsClient } = await import('../../src/lib/analytics');
+		const client = createAnalyticsClient(dataset as never);
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'Y1' });
+		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session', scanId: 'Y2' });
+		const degWrites = writes.filter((w) => w.indexes?.[0] === 'degradation');
+		expect(degWrites.length).toBe(2);
+	});
+});

--- a/test/check-dnssec.spec.ts
+++ b/test/check-dnssec.spec.ts
@@ -145,6 +145,19 @@ describe('checkDnssec — dnssecSource detection', () => {
 	});
 });
 
+describe('checkDnssec — transport-level failure', () => {
+	it("returns checkStatus='error' when DNS transport fails entirely", async () => {
+		const { restore } = setupFetchMock();
+		globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('network down'));
+		const { checkDnssec } = await import('../src/tools/check-dnssec');
+		const result = await checkDnssec('example.com');
+		expect(result.checkStatus).toBe('error');
+		// Should not misreport as "not configured"
+		expect(result.findings.some((f) => (f.title ?? '').toLowerCase().includes('not configured'))).toBe(false);
+		restore();
+	});
+});
+
 describe('checkDnssec — AD flag confirmation probe', () => {
 	/**
 	 * Helper that mocks primary Cloudflare DoH responses AND a separate Google DoH

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -246,6 +246,36 @@ describe('checkHttpSecurity', () => {
 		expect(result.findings[0].severity).toBe('medium');
 		expect(result.passed).toBe(false);
 	});
+
+	it('returns inconclusive when response matches a WAF/CDN challenge fingerprint', async () => {
+		const { restore } = setupFetchMock();
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			headers: new Headers({
+				'cf-ray': '88abc123-SFO',
+				server: 'cloudflare',
+				'content-type': 'text/html; charset=UTF-8',
+			}),
+			text: async () => '<html><head><title>Just a moment...</title></head><body></body></html>',
+		} as unknown as Response);
+		const { checkHttpSecurity } = await import('../src/tools/check-http-security');
+		const result = await checkHttpSecurity('example.com');
+		// WAF challenge → error/inconclusive status
+		expect(result.checkStatus).toBe('error');
+		// Single finding identifying the WAF interception
+		expect(result.findings.some((f) => f.metadata?.wafChallenge !== undefined)).toBe(true);
+		// No header-missing findings — they'd be about the WAF, not the site
+		expect(
+			result.findings.some(
+				(f) =>
+					f.title.startsWith('No ') ||
+					f.title.toLowerCase().includes('missing') ||
+					f.title.toLowerCase().includes('header'),
+			),
+		).toBe(false);
+		restore();
+	});
 });
 
 describe('checkHttpSecurity — dual-fetch header union', () => {

--- a/test/check-mx.spec.ts
+++ b/test/check-mx.spec.ts
@@ -131,6 +131,25 @@ describe('checkMx', () => {
 		expect(finding!.detail).toContain('ghost.dangling.com');
 	});
 
+	it('surfaces providerDetectionFailed metadata when provider signature fetch fails', async () => {
+		const { restore: localRestore } = setupFetchMock();
+		globalThis.fetch = vi.fn().mockImplementation(async (url: string | URL | Request) => {
+			const urlStr = typeof url === 'string' ? url : String((url as URL).href ?? url);
+			if (urlStr.includes('provider-signatures') || urlStr.includes('provider_signatures')) {
+				throw new TypeError('fetch failed');
+			}
+			// Return a successful MX response for any DNS query.
+			return createDohResponse(
+				[{ name: 'example.com', type: 15 }],
+				[{ name: 'example.com', type: 15, TTL: 300, data: '10 smtp.google.com.' }],
+			);
+		});
+		const { checkMx } = await import('../src/tools/check-mx');
+		const result = await checkMx('example.com', { providerSignaturesUrl: 'https://example.com/provider-signatures' });
+		expect((result.metadata as { providerDetectionFailed?: boolean })?.providerDetectionFailed).toBe(true);
+		localRestore();
+	});
+
 	it('logs warning when provider detection fails', async () => {
 		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		// First MX query (from checkMX package) succeeds; second (re-query in wrapper) throws

--- a/test/dns-transport.spec.ts
+++ b/test/dns-transport.spec.ts
@@ -633,3 +633,34 @@ describe('fetchDohOutcome', () => {
 		expect(toNullable({ kind: 'error', reason: 'timeout' })).toBeNull();
 	});
 });
+
+describe('confirmWithSecondaryResolvers', () => {
+	const savedFetch = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = savedFetch;
+		vi.restoreAllMocks();
+	});
+
+	it('returns { kind: "unconfirmed" } when all secondary resolvers fail', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('net')) as unknown as typeof fetch;
+		const transport = await import('../src/lib/dns-transport');
+		const result = await transport.confirmWithSecondaryResolvers('example.com', 'TXT', false, 2000);
+		expect((result as { kind?: string }).kind).toBe('unconfirmed');
+	});
+
+	it('returns a DohResponse when at least one secondary succeeds', async () => {
+		let calls = 0;
+		globalThis.fetch = vi.fn().mockImplementation(async () => {
+			calls += 1;
+			if (calls === 1) throw new TypeError('bv-dns down');
+			return {
+				ok: true,
+				status: 200,
+				json: async () => ({ Status: 0, Answer: [] }),
+			};
+		}) as unknown as typeof fetch;
+		const transport = await import('../src/lib/dns-transport');
+		const result = await transport.confirmWithSecondaryResolvers('example.com', 'TXT', false, 2000);
+		expect((result as { kind?: string }).kind).not.toBe('unconfirmed');
+	});
+});

--- a/test/dns-transport.spec.ts
+++ b/test/dns-transport.spec.ts
@@ -660,7 +660,10 @@ describe('confirmWithSecondaryResolvers', () => {
 			};
 		}) as unknown as typeof fetch;
 		const transport = await import('../src/lib/dns-transport');
-		const result = await transport.confirmWithSecondaryResolvers('example.com', 'TXT', false, 2000);
+		// bv-dns (call 1) throws; Google (call 2) returns a valid empty response — still a DohResponse, not unconfirmed
+		const result = await transport.confirmWithSecondaryResolvers('example.com', 'TXT', false, 2000, undefined, {
+			secondaryDoh: { url: 'https://bv-dns.test/dns-query' },
+		});
 		expect((result as { kind?: string }).kind).not.toBe('unconfirmed');
 	});
 });

--- a/test/dns-transport.spec.ts
+++ b/test/dns-transport.spec.ts
@@ -551,3 +551,85 @@ describe('secondary DoH resolver (bv-dns)', () => {
 		expect(result.Answer![0].data).toBe('"v=spf1 ~all"'); // Google result
 	});
 });
+
+describe('fetchDohOutcome', () => {
+	const savedFetch = globalThis.fetch;
+	afterEach(() => {
+		globalThis.fetch = savedFetch;
+		vi.restoreAllMocks();
+	});
+
+	it('returns ok with response on 200 with answers', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({
+				Status: 0,
+				Answer: [{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }],
+			}),
+		}) as unknown as typeof fetch;
+		const { fetchDohOutcome } = await import('../src/lib/dns-transport');
+		const outcome = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 3000);
+		expect(outcome.kind).toBe('ok');
+		if (outcome.kind === 'ok') expect(outcome.response.Answer?.length).toBe(1);
+	});
+
+	it('returns ok with empty Answer on 200 with no answers (NXDOMAIN-style)', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ Status: 0, Answer: [] }),
+		}) as unknown as typeof fetch;
+		const { fetchDohOutcome } = await import('../src/lib/dns-transport');
+		const outcome = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 3000);
+		expect(outcome.kind).toBe('ok');
+		if (outcome.kind === 'ok') expect(outcome.response.Answer?.length ?? 0).toBe(0);
+	});
+
+	it('returns error with reason=timeout on AbortSignal timeout', async () => {
+		globalThis.fetch = vi.fn().mockImplementation(() => {
+			const err = new DOMException('The operation was aborted.', 'TimeoutError');
+			return Promise.reject(err);
+		}) as unknown as typeof fetch;
+		const { fetchDohOutcome } = await import('../src/lib/dns-transport');
+		const outcome = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 50);
+		expect(outcome.kind).toBe('error');
+		if (outcome.kind === 'error') expect(outcome.reason).toBe('timeout');
+	});
+
+	it('returns error with reason=network on generic fetch rejection', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new TypeError('failed to fetch')) as unknown as typeof fetch;
+		const { fetchDohOutcome } = await import('../src/lib/dns-transport');
+		const outcome = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 3000);
+		expect(outcome.kind).toBe('error');
+		if (outcome.kind === 'error') expect(outcome.reason).toBe('network');
+	});
+
+	it('returns error with reason=http on non-2xx response', async () => {
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue({ ok: false, status: 502, json: async () => ({}) }) as unknown as typeof fetch;
+		const { fetchDohOutcome } = await import('../src/lib/dns-transport');
+		const outcome = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 3000);
+		expect(outcome.kind).toBe('error');
+		if (outcome.kind === 'error') expect(outcome.reason).toBe('http');
+	});
+
+	it('returns error with reason=parse on schema-invalid body', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: async () => ({ notADohResponse: true }),
+		}) as unknown as typeof fetch;
+		const { fetchDohOutcome } = await import('../src/lib/dns-transport');
+		const outcome = await fetchDohOutcome('https://cloudflare-dns.com/dns-query?name=example.com&type=TXT', 3000);
+		expect(outcome.kind).toBe('error');
+		if (outcome.kind === 'error') expect(outcome.reason).toBe('parse');
+	});
+
+	it('toNullable maps ok → response, error → null', async () => {
+		const { toNullable } = await import('../src/lib/dns-types');
+		expect(toNullable({ kind: 'ok', response: { Status: 0 } as never })).not.toBeNull();
+		expect(toNullable({ kind: 'error', reason: 'timeout' })).toBeNull();
+	});
+});

--- a/test/log.spec.ts
+++ b/test/log.spec.ts
@@ -148,3 +148,42 @@ describe('log string truncation', () => {
 		expect(payload.details.message.length).toBeLessThan(300);
 	});
 });
+
+describe('logError error-severity truncation', () => {
+	const origLog = console.log;
+	afterEach(() => {
+		console.log = origLog;
+		vi.restoreAllMocks();
+	});
+
+	it('preserves up to ~1024 chars of an error-severity message', async () => {
+		const captured: string[] = [];
+		console.log = vi.fn((...args: unknown[]) => {
+			captured.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+		});
+		const { logError } = await import('../src/lib/log');
+		const long = 'e'.repeat(1500);
+		logError(new Error(long), { severity: 'error', category: 'test-truncation' });
+		const joined = captured.join('');
+		// Error-severity gets the 1024 cap, not the 256 cap.
+		// sanitizeString with max=1024 preserves head + ' ... ' + tail, so emitted body contains >= ~1024 chars of 'e'.
+		const eCount = (joined.match(/e/g) ?? []).length;
+		expect(eCount).toBeGreaterThanOrEqual(1000);
+		expect(eCount).toBeLessThanOrEqual(1500);
+	});
+
+	it('preserves only up to ~256 chars of an info-severity message', async () => {
+		const captured: string[] = [];
+		console.log = vi.fn((...args: unknown[]) => {
+			captured.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+		});
+		const { logError } = await import('../src/lib/log');
+		const long = 'x'.repeat(1500);
+		// info severity takes the short truncation path
+		logError(long, { severity: 'info', category: 'test-truncation' });
+		const joined = captured.join('');
+		const xCount = (joined.match(/x/g) ?? []).length;
+		expect(xCount).toBeGreaterThanOrEqual(200);
+		expect(xCount).toBeLessThan(500);
+	});
+});

--- a/test/rate-limiter.spec.ts
+++ b/test/rate-limiter.spec.ts
@@ -452,3 +452,40 @@ describe('rate-limiter', () => {
 		});
 	});
 });
+
+describe('per-IP KV advisory lock', () => {
+	it('under contention on same IP, advisory path activates (counter writes bounded)', async () => {
+		let counterWrites = 0;
+		const store = new Map<string, string>();
+		const kv = {
+			async get(key: string) { return store.get(key) ?? null; },
+			async put(key: string, value: string) {
+				if (key.startsWith('rl:min:')) counterWrites += 1;
+				store.set(key, value);
+			},
+			async delete(key: string) { store.delete(key); },
+		} as unknown as KVNamespace;
+
+		const mod = await import('../src/lib/rate-limiter');
+		expect(typeof (mod as { checkScopedRateLimitKVWithAdvisory?: unknown }).checkScopedRateLimitKVWithAdvisory).toBe('function');
+		await Promise.all([
+			mod.checkScopedRateLimitKVWithAdvisory!('1.1.1.1', 'tools', 50, 300, kv),
+			mod.checkScopedRateLimitKVWithAdvisory!('1.1.1.1', 'tools', 50, 300, kv),
+		]);
+		expect(counterWrites).toBeGreaterThanOrEqual(1);
+		expect(counterWrites).toBeLessThanOrEqual(2);
+	});
+
+	it('KV outage during advisory lock degrades without throwing', async () => {
+		const kv = {
+			async get() { throw new Error('KV down'); },
+			async put() { throw new Error('KV down'); },
+			async delete() { throw new Error('KV down'); },
+		} as unknown as KVNamespace;
+
+		const { checkScopedRateLimitKVWithAdvisory } = await import('../src/lib/rate-limiter');
+		await expect(
+			checkScopedRateLimitKVWithAdvisory!('2.2.2.2', 'tools', 50, 300, kv),
+		).resolves.toBeDefined();
+	});
+});

--- a/test/session-degradation-event.spec.ts
+++ b/test/session-degradation-event.spec.ts
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, vi } from 'vitest';
+
+describe('createSession degradation event on KV failure', () => {
+	it('emits kv_fallback degradation event when KV put throws', async () => {
+		const degradationEvents: Array<{ degradationType: string; component: string }> = [];
+		const fakeAnalytics = {
+			enabled: true,
+			emitRequestEvent: vi.fn(),
+			emitToolEvent: vi.fn(),
+			emitRateLimitEvent: vi.fn(),
+			emitSessionEvent: vi.fn(),
+			emitDegradationEvent: (e: { degradationType: string; component: string }) => {
+				degradationEvents.push({ degradationType: e.degradationType, component: e.component });
+			},
+		};
+		const kv = {
+			async get() { return null; },
+			async put() { throw new Error('KV down'); },
+			async delete() { /* noop */ },
+			async list() { return { keys: [] }; },
+		} as unknown as KVNamespace;
+
+		const { createSession } = await import('../src/lib/session');
+		const id = await createSession(kv, fakeAnalytics as never);
+		expect(typeof id).toBe('string');
+		expect(id.length).toBe(64);
+		expect(degradationEvents).toEqual([{ degradationType: 'kv_fallback', component: 'session' }]);
+	});
+
+	it('does NOT emit degradation event when KV put succeeds', async () => {
+		const degradationEvents: Array<unknown> = [];
+		const fakeAnalytics = {
+			enabled: true,
+			emitRequestEvent: vi.fn(),
+			emitToolEvent: vi.fn(),
+			emitRateLimitEvent: vi.fn(),
+			emitSessionEvent: vi.fn(),
+			emitDegradationEvent: (e: unknown) => { degradationEvents.push(e); },
+		};
+		const store = new Map<string, string>();
+		const kv = {
+			async get(k: string) { return store.get(k) ?? null; },
+			async put(k: string, v: string) { store.set(k, v); },
+			async delete(k: string) { store.delete(k); },
+			async list() { return { keys: [] }; },
+		} as unknown as KVNamespace;
+
+		const { createSession } = await import('../src/lib/session');
+		await createSession(kv, fakeAnalytics as never);
+		expect(degradationEvents).toEqual([]);
+	});
+
+	it('createSession without analytics still works (backward-compat)', async () => {
+		const kv = {
+			async get() { return null; },
+			async put() { throw new Error('KV down'); },
+			async delete() { /* noop */ },
+			async list() { return { keys: [] }; },
+		} as unknown as KVNamespace;
+		const { createSession } = await import('../src/lib/session');
+		const id = await createSession(kv);
+		expect(typeof id).toBe('string');
+	});
+});


### PR DESCRIPTION
## Summary

Closes residual items from `docs/plans/scalability-tdd-plan.md` and `docs/plans/hardening-plan.md` across 8 TDD phases, plus a deterministic regression harness that fails if any phase's production fix is reverted.

- **P1–P2 (DNS transport):** `DohOutcome` discriminated type, `fetchDohOutcome` exported; `confirmWithSecondaryResolvers` returns `{ kind: 'unconfirmed' }` when both secondaries fail — no more false-negative downgrades.
- **P3 (cache):** regression tests added for sentinel TTL ≤ 10s, `finally`-cleanup on throw, delete-after-put ordering. Code already held the invariants; tests pin it.
- **P4 (session, scoped):** `createSession` accepts optional `AnalyticsClient`; emits `{ degradationType: 'kv_fallback', component: 'session' }` on KV put failure. Backward-compat (param optional).
- **P5 (rate-limiter):** `withIpKvAdvisoryLock` — bounded KV advisory lock, contention-gated (zero cost on uncontended path), KV-outage falls through.
- **P6 (adaptive weights):** `publishAdaptiveWeightSummary` + `getAdaptiveWeights` — 60s KV TTL; isolates converge within one window when telemetry flows; static-weight fallback on miss.
- **P7 (check-* classification):** `providerDetectionFailed` metadata on MX; WAF/CDN fingerprint → `checkStatus: 'error'` with `metadata.wafChallenge` on HTTP security; DNSSEC DNS-transport failure → `checkStatus: 'error'` via inner-check finding sentinel.
- **P8 (observability + chaos):** `emitDegradationEvent` dedups `(scanId, type, component)` within 60s rolling window; `doubles[0]` carries `hashCollisionSuspected` from opportunistic FNV-1a probe; `scanId` threaded through `scanDomain`. `test/chaos/invariants.spec.ts` — 11 deterministic regression tests.

**Scope boundaries respected:** no MCP protocol-surface changes, no score-model changes, no `packages/dns-checks/` breaking changes (one additive `metadata` field on `CheckResult`).

## Stats

- 25 commits, 26 files changed, +1088 / -81
- Tests: 2192 → **2221 passing** (+29 new). Remaining 2 failures are pre-existing `streaming-sse.spec.ts` cases unrelated to any phase.

## Test Plan

- [ ] CI green: `typecheck`, `lint`, `test`, Gitleaks, `npm audit`
- [ ] Spot-check one real `scan_domain` call in staging (DNS error behavior should now surface as `checkStatus: 'error'` rather than "not configured")
- [ ] Confirm `tools/list` MCP surface is byte-identical (`test/tool-metadata.spec.ts` passes)
- [ ] Analytics dashboard: `degradation` events dedup as expected across a real scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WAF/CDN challenge page detection in HTTP security checks.
  * Adaptive weight caching for improved performance.

* **Bug Fixes & Improvements**
  * Enhanced DNSSEC error handling and status classification.
  * Improved session stability with KV fallback monitoring.
  * Analytics event deduplication and hash collision detection.
  * Cross-isolate rate limiting with advisory locks.
  * Better MX provider detection failure tracking.

* **Tests**
  * Added comprehensive test coverage for DNS transport, session degradation, rate limiting, and analytics behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->