### PR TITLE
fix: production-readiness remediation (10 audit findings + 3 lock-down tests)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -55,8 +55,13 @@ regexes = [
 # Test fixtures use well-known service IPs (GitHub Pages, AWS, DigitalOcean) intentionally
 paths = [
   '''test/''',
-  '''src/tools/.*-analysis\.ts$''',  # Analysis modules contain IP examples in JSDoc
-  '''src/lib/ip-utils\.ts$''',       # IP utility module contains example IPs in JSDoc
+  '''packages/[^/]+/test/''',          # Sub-package fixtures
+  '''src/tools/.*-analysis\.ts$''',    # Analysis modules contain IP examples in JSDoc
+  '''src/lib/ip-utils\.ts$''',         # IP utility module contains example IPs in JSDoc
+  '''docs/.*\.md$''',                  # IPv4 examples in RFC / explanation context (per-rule, not global)
+  '''CHANGELOG\.md$''',                # IPs that appear in incident write-ups
+  '''scripts/tranco-deep-.*\.json$''', # Captured scan artifacts (resolved IPs from public Tranco list)
+  '''scripts/phase\d+-.*\.json$''',    # Captured monitoring snapshots
 ]
 
 [[rules]]
@@ -69,6 +74,13 @@ keywords = ["phone", "tel", "mobile", "cell", "fax"]
 [rules.allowlist]
 paths = [
   '''test/''',
+  '''packages/[^/]+/test/''',
+  '''scripts/tranco-deep-.*\.json$''',     # Numeric IDs in scan artifacts
+  '''scripts/phase\d+-.*\.json$''',
+  '''scripts/chaos/''',                    # Test sentinels (e.g. 1234567890 placeholders)
+  '''crates/[^/]+/Cargo\.lock$''',         # Rust deps include numeric versions/hashes
+  '''crates/[^/]+/target/''',              # Rust build artifacts (gitignored locally; safety net)
+  '''docs/.*\.md$''',                      # Phone-number-shaped numerics in docs (timestamps, hashes)
 ]
 
 [[rules]]
@@ -128,7 +140,18 @@ regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-
 keywords = ["key","api","token","secret","client","passwd","password","auth","access"]
 [rules.allowlist]
 paths = [
-  '''test/''', # Test fixtures use dummy keys/tokens — never real secrets
+  '''test/''',                       # Test fixtures use dummy keys/tokens — never real secrets
+  '''packages/[^/]+/test/''',
+]
+regexTarget = "match"
+# Env-var-default literals — these reference the env var name (or a placeholder
+# documented in shell-export form), not a real key. Cataloged by
+# test/audits/no-tracked-secrets.audit.test.ts (N5).
+regexes = [
+  '''process\.env\.BV_API_KEY''',           # scripts/tranco-scan.mjs:21, tranco-deep-scan.mjs:28
+  '''os\.getenv\(.{0,40}BV_API_KEY''',      # scripts/chaos/chaos-test-wasm.py:9
+  '''api_key=\$\{BV_API_KEY\}''',           # .mcp.json placeholder
+  '''bv_Kx8eZ2rdtUPfdzR8e_\.\.\.''',        # docs/client-setup.md:434 — truncated doc placeholder
 ]
 
 # ─── Global Allowlists ───────────────────────────────────────────────
@@ -145,4 +168,5 @@ paths = [
   '''worker-configuration\.d\.ts$''', # Generated CF types
   '''\.dev/''',                      # Local deploy overrides (gitignored)
   '''docs/plans/''',                 # Internal planning docs (gitignored)
+  '''test/audits/no-tracked-secrets\.audit\.test\.ts$''', # Audit test contains regex literals (incl. PEM header)
 ]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,9 +121,17 @@ src/lib/                  — Shared infrastructure
   analytics.ts            — Analytics Engine integration (fail-open, 4 event types)
   log.ts                  — Structured JSON logging with sanitization
 
-test/                     — One spec per source file
-test/helpers/dns-mock.ts  — Shared fetch mock for DNS-over-HTTPS queries
-test/schemas/             — Unit tests for Zod schemas
+test/                     — Specs are flat by source file (e.g. test/check-spf.spec.ts ↔ src/tools/check-spf.ts).
+                            The 6-layer test pyramid (Unit → Integration → Contract → Audit → E2E → Chaos)
+                            is methodology, not directory layout — most tests live at the top level and a
+                            spec's layer is conveyed by filename suffix (.spec.ts, .integration.test.ts,
+                            .audit.test.ts, .contract.test.ts, .chaos.test.ts).
+test/helpers/             — Shared test fixtures (dns-mock.ts: setupFetchMock, mockTxtRecords, ...)
+test/schemas/             — Unit tests for Zod schemas in src/schemas/
+test/oauth/               — OAuth flow specs (authorize, token, PKCE, JWT, entitlements, e2e)
+test/audits/              — Audit-layer tests (config drift, workflow regressions, tool quota coverage)
+test/contracts/           — Contract tests for cross-service Zod payloads (e.g. fuzzing alert webhook)
+test/chaos/               — Chaos-layer fail-soft invariant tests (KV down, webhook 500, etc.)
 
 packages/dns-checks/     — @blackveil/dns-checks (runtime-agnostic core library)
   src/scoring/           — Generic scoring engine

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"blackveil-dns-mcp": "dist/stdio.js"
 			},
 			"devDependencies": {
-				"@cloudflare/vitest-pool-workers": "^0.13.3",
+				"@cloudflare/vitest-pool-workers": "^0.15.2",
 				"@cloudflare/workers-types": "4.20260506.1",
 				"@types/punycode": "^2.1.4",
 				"eslint": "9.39.3",
@@ -41,24 +41,24 @@
 			"link": true
 		},
 		"node_modules/@cloudflare/kv-asset-handler": {
-			"version": "0.4.2",
-			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
-			"integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
+			"integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/@cloudflare/unenv-preset": {
-			"version": "2.16.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.0.tgz",
-			"integrity": "sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==",
+			"version": "2.16.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+			"integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"peerDependencies": {
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0"
+				"workerd": ">1.20260305.0 <2.0.0-0"
 			},
 			"peerDependenciesMeta": {
 				"workerd": {
@@ -67,16 +67,16 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
-			"version": "0.13.3",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.13.3.tgz",
-			"integrity": "sha512-4aS6YZbOyOIExIQAaO4ZboX1HVQdDRiEo9Wc6scJIzzaqHMmg2/N8lD+r7P9IX+l2SnC7tg2vvy/u3aqj0cVXg==",
+			"version": "0.15.2",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.15.2.tgz",
+			"integrity": "sha512-zQ6H1sEIhApOJm08EuKUmRvpxiiploPnNmx4R+X8Slp76MRXyaNxYkA9TW/r0fiDu98SWqJwACkuHh3nKZvfUQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cjs-module-lexer": "^1.2.3",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260317.1",
-				"wrangler": "4.76.0",
+				"miniflare": "4.20260430.0",
+				"wrangler": "4.87.0",
 				"zod": "^3.25.76"
 			},
 			"peerDependencies": {
@@ -86,33 +86,33 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers/node_modules/wrangler": {
-			"version": "4.76.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.76.0.tgz",
-			"integrity": "sha512-Wan+CU5a0tu4HIxGOrzjNbkmxCT27HUmzrMj6kc7aoAnjSLv50Ggcn2Ant7wNQrD6xW3g31phKupZJgTZ8wZfQ==",
+			"version": "4.87.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.87.0.tgz",
+			"integrity": "sha512-lfhfKwLfQlowwgV0xhlYgE9fU3n0I30d4ccGY/rTCEm/n42Mjvlr0Ng3ZPNqlsrsKBcDR531V7dsPkgELvrk/Q==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
-				"@cloudflare/kv-asset-handler": "0.4.2",
-				"@cloudflare/unenv-preset": "2.16.0",
+				"@cloudflare/kv-asset-handler": "0.5.0",
+				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.27.3",
-				"miniflare": "4.20260317.1",
+				"miniflare": "4.20260430.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260317.1"
+				"workerd": "1.20260430.1"
 			},
 			"bin": {
 				"wrangler": "bin/wrangler.js",
 				"wrangler2": "bin/wrangler.js"
 			},
 			"engines": {
-				"node": ">=20.0.0"
+				"node": ">=22.0.0"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260317.1"
+				"@cloudflare/workers-types": "^4.20260430.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
@@ -131,9 +131,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260317.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260317.1.tgz",
-			"integrity": "sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==",
+			"version": "1.20260430.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260430.1.tgz",
+			"integrity": "sha512-ADohZUHf7NBvPp2PdZig2Opxx+hDkk3ve7jrTne3JRx9kDSB73zc4LzcEeEN8LKkbAcqZmvfRJfpChSlusu0lA==",
 			"cpu": [
 				"x64"
 			],
@@ -148,9 +148,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260317.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260317.1.tgz",
-			"integrity": "sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==",
+			"version": "1.20260430.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260430.1.tgz",
+			"integrity": "sha512-/DoYC/1wHs+YRZzzqSQg1/EHB4hiv1yV5U8FnmapRRIzVaPtnt+ApeOXeMrIdKidgKOI8TqQzgBU8xbIM7Cl4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -165,9 +165,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260317.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260317.1.tgz",
-			"integrity": "sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==",
+			"version": "1.20260430.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260430.1.tgz",
+			"integrity": "sha512-koJhBWvEVZPKCVFtMLp2iMHlYr+lFCF47wGbnlKdHVlemV0zTxJEyHI8aLlrhPLhBmOmYLp46rXw09/qJkRIhQ==",
 			"cpu": [
 				"x64"
 			],
@@ -182,9 +182,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260317.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260317.1.tgz",
-			"integrity": "sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==",
+			"version": "1.20260430.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260430.1.tgz",
+			"integrity": "sha512-hMdapNAzNQZDXGGkg4Slydc3fRJP5FUZLJVVcZCW/+imhhJro9Z1rv5n/wfR+txKoSWhTYR8eOp8Pyi2bzLzlw==",
 			"cpu": [
 				"arm64"
 			],
@@ -199,9 +199,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260317.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260317.1.tgz",
-			"integrity": "sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==",
+			"version": "1.20260430.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260430.1.tgz",
+			"integrity": "sha512-jS3ffixjb5USOwz4frw4WzCz0HrjVxkgyU3WiYb06N7hBAfN6eOrveAJ4QRef0+suK4V1vQFoB1oKdRBsXe9Dw==",
 			"cpu": [
 				"x64"
 			],
@@ -3946,16 +3946,16 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260317.1",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260317.1.tgz",
-			"integrity": "sha512-A3csI1HXEIfqe3oscgpoRMHdYlkReQKPH/g5JE53vFSjoM6YIAOGAzyDNeYffwd9oQkPWDj9xER8+vpxei8klA==",
+			"version": "4.20260430.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260430.0.tgz",
+			"integrity": "sha512-MWvMm3Siho9Yj7lbJZidLs8hbrRvIcOrif2mnsHQZdvoKfedpea+GaN8XJxbpRcq0B2WzNI1BB1ihdnqes3/ZA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "^0.34.5",
-				"undici": "7.24.4",
-				"workerd": "1.20260317.1",
+				"undici": "7.24.8",
+				"workerd": "1.20260430.1",
 				"ws": "8.18.0",
 				"youch": "4.1.0-beta.10"
 			},
@@ -3963,7 +3963,7 @@
 				"miniflare": "bootstrap.js"
 			},
 			"engines": {
-				"node": ">=18.0.0"
+				"node": ">=22.0.0"
 			}
 		},
 		"node_modules/minimatch": {
@@ -5274,9 +5274,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.24.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-			"integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+			"version": "7.24.8",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+			"integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5536,9 +5536,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260317.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260317.1.tgz",
-			"integrity": "sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==",
+			"version": "1.20260430.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260430.1.tgz",
+			"integrity": "sha512-KEgIWyiw3Jmn+DCd/L3ePo5fmiiYb/UcwKvDWPf/nLLOiwShDFzDSsegU5NY/JcwgvO/QsLHVi2FYrbkcXNY5Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -5549,11 +5549,11 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260317.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260317.1",
-				"@cloudflare/workerd-linux-64": "1.20260317.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260317.1",
-				"@cloudflare/workerd-windows-64": "1.20260317.1"
+				"@cloudflare/workerd-darwin-64": "1.20260430.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260430.1",
+				"@cloudflare/workerd-linux-64": "1.20260430.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260430.1",
+				"@cloudflare/workerd-windows-64": "1.20260430.1"
 			}
 		},
 		"node_modules/wrangler": {
@@ -5587,32 +5587,6 @@
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/wrangler/node_modules/@cloudflare/kv-asset-handler": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.5.0.tgz",
-			"integrity": "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"engines": {
-				"node": ">=22.0.0"
-			}
-		},
-		"node_modules/wrangler/node_modules/@cloudflare/unenv-preset": {
-			"version": "2.16.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
-			"integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
-			"dev": true,
-			"license": "MIT OR Apache-2.0",
-			"peerDependencies": {
-				"unenv": "2.0.0-rc.24",
-				"workerd": ">1.20260305.0 <2.0.0-0"
-			},
-			"peerDependenciesMeta": {
-				"workerd": {
 					"optional": true
 				}
 			}
@@ -5721,16 +5695,6 @@
 			},
 			"engines": {
 				"node": ">=22.0.0"
-			}
-		},
-		"node_modules/wrangler/node_modules/undici": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-			"integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.18.1"
 			}
 		},
 		"node_modules/wrangler/node_modules/workerd": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"build:wasm": "cd crates/bv-wasm-core && wasm-pack build --target web"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.13.3",
+		"@cloudflare/vitest-pool-workers": "^0.15.2",
 		"@cloudflare/workers-types": "4.20260506.1",
 		"@types/punycode": "^2.1.4",
 		"eslint": "9.39.3",

--- a/scripts/chaos/chaos-test-clients.py
+++ b/scripts/chaos/chaos-test-clients.py
@@ -116,7 +116,7 @@ def make_headers(ua, session_id=None, content_type="application/json",
     if auth == "bearer" and API_KEY:
         h.append(f"Authorization: Bearer {API_KEY}")
     elif auth == "bearer_invalid":
-        h.append("Authorization: Bearer bv_invalid_key_00000000000000000000")
+        h.append("Authorization: Bearer bv_invalid_test_sentinel")
     if api_key_header:
         h.append(f"Authorization: Bearer {api_key_header}")
     return h
@@ -420,7 +420,7 @@ def test_auth_precedence():
         }),
         headers=make_headers(ua, auth="bearer"),
         include_headers=True,
-        params={"api_key": "bv_bogus_key_00000000000000000000000000000000"},
+        params={"api_key": "bv_bogus_test_sentinel"},
     )
     sid = extract_session_id(raw)
     record("5a. valid Bearer + bogus api_key → session created (Bearer wins)",
@@ -430,7 +430,7 @@ def test_auth_precedence():
         curl_json("POST", "/mcp",
                   body={"jsonrpc": "2.0", "method": "notifications/initialized"},
                   headers=make_headers(ua, session_id=sid, auth="bearer"),
-                  params={"api_key": "bv_bogus_key_00000000000000000000000000000000"})
+                  params={"api_key": "bv_bogus_test_sentinel"})
         delete_session(sid, ua)
 
     # 5b. Invalid Bearer + valid api_key → should FAIL (Bearer header takes precedence)

--- a/scripts/phase7-validation.mjs
+++ b/scripts/phase7-validation.mjs
@@ -18,7 +18,11 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const BV_API_KEY = process.env.BV_API_KEY || 'REDACTED_KEY';
+const BV_API_KEY = process.env.BV_API_KEY;
+if (!BV_API_KEY) {
+	console.error('Error: BV_API_KEY environment variable is required');
+	process.exit(1);
+}
 const API_BASE = 'https://dns-mcp.blackveilsecurity.com/mcp';
 
 // Colors for output

--- a/scripts/phase8-monitor.mjs
+++ b/scripts/phase8-monitor.mjs
@@ -16,7 +16,11 @@ import { fileURLToPath } from 'url';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const BV_API_KEY = process.env.BV_API_KEY || 'REDACTED_KEY';
+const BV_API_KEY = process.env.BV_API_KEY;
+if (!BV_API_KEY) {
+	console.error('Error: BV_API_KEY environment variable is required');
+	process.exit(1);
+}
 const API_BASE = 'https://dns-mcp.blackveilsecurity.com';
 
 // Colors for terminal output

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -174,6 +174,8 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_txt_hygiene: 200,
 	check_http_security: 200,
 	check_dane: 200,
+	check_dane_https: 200,
+	check_svcb_https: 200,
 	check_mx_reputation: 20,
 	check_srv: 200,
 	check_zone_hygiene: 200,
@@ -203,6 +205,9 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_dnssec_chain: 30,
 	check_fast_flux: 10,
 };
+
+/** Tools intentionally governed by per-IP rate limits only (no per-tool free-tier quota). Audited by test/audits/tool-quota-coverage.audit.test.ts. */
+export const INTENTIONALLY_UNLIMITED_TOOLS: ReadonlySet<string> = new Set<string>([]);
 
 /**
  * Per-tier concurrent tool execution limits (per-isolate, best-effort fairness).

--- a/src/schemas/oauth.ts
+++ b/src/schemas/oauth.ts
@@ -6,7 +6,17 @@ const SafeOAuthIdentifierSchema = z.string().min(1).max(128).regex(/^[A-Za-z0-9:
 const StripeIdSchema = z.string().min(4).max(128).regex(/^[a-z]+_[A-Za-z0-9]+$/);
 const EmailHashSchema = z.string().length(64).regex(/^[a-f0-9]{64}$/i);
 
-export const CustomerOAuthTierSchema = z.enum(['agent', 'developer', 'enterprise']);
+/**
+ * Tiers reachable via OAuth (bv-web Stripe entitlements).
+ *
+ * Per CLAUDE.md "Paid OAuth Tiers": only paid plans flow through OAuth, mapping to
+ * `developer` (Pro / Business / MCP-Developer) or `enterprise` (Enterprise /
+ * MCP-Enterprise). The `agent` tier is reserved for static API keys and is never
+ * minted by bv-web; `owner` is privileged and never customer-facing. Keeping this
+ * union narrow prevents a misconfigured bv-web response from silently escalating an
+ * OAuth principal into a tier the rate limiter / quota coordinator never expected.
+ */
+export const CustomerOAuthTierSchema = z.enum(['developer', 'enterprise']);
 export const ActiveStripeSubscriptionStatusSchema = z.enum(['active', 'trialing']);
 
 export const PaidOAuthEntitlementResponseSchema = z.object({

--- a/test/audits/fuzzing-config.audit.test.ts
+++ b/test/audits/fuzzing-config.audit.test.ts
@@ -24,6 +24,20 @@ describe('fuzzing-config audit', () => {
 		});
 	});
 
+	// Lock the exact numeric values so any drift (loosening or unannounced
+	// tightening) requires an explicit audit-test update + PR review note.
+	// Per CLAUDE.md: "v1 defaults are 3× the plan values to stay silent for one
+	// week of baseline collection before lowering."
+	it('FUZZ_THRESHOLDS values match the locked v1 baseline', () => {
+		expect(FUZZ_THRESHOLDS).toEqual({
+			windowSeconds: 60,
+			unknown_tool: 30,
+			unknown_method: 15,
+			zod_arg: 60,
+			auth_fail: 90,
+		});
+	});
+
 	it('detector + counter + alerting modules do not redeclare FUZZ_THRESHOLDS', () => {
 		// `const FUZZ_THRESHOLDS = ...` would be the offending shape; importing the
 		// type or the value from config.ts is fine (we're only forbidding redeclaration).

--- a/test/audits/no-tracked-secrets.audit.test.ts
+++ b/test/audits/no-tracked-secrets.audit.test.ts
@@ -1,0 +1,166 @@
+// Audit test: no committed (or about-to-be-committed) source file may contain a
+// literal Blackveil API key (`bv_` prefix + 30+ url-safe characters), an AWS
+// access key, or a private-key PEM header.
+//
+// Background: in 2026, `.mcp.json` was tracked at repo root with a real owner
+// API key embedded in the URL. The key was caught by the gitleaks
+// `generic-api-key` rule, but only because the surrounding context happened to
+// match a generic pattern. A first-class audit makes the BV-key shape itself a
+// hard fail regardless of surrounding heuristics.
+//
+// Implementation: tests run in the `@cloudflare/vitest-pool-workers` runtime,
+// which has no `node:fs` / `node:child_process`. We use Vite's bulk `?raw`
+// import via `import.meta.glob` — the file list is resolved at transform time
+// (host Node) and the contents are bundled into the test module.
+//
+// This is not a strict equivalent of `git ls-files`: glob respects the
+// filesystem, not git. We mitigate by (a) scoping to source-bearing extensions
+// inside known-tracked top-level directories, and (b) excluding paths that
+// would be `.gitignore`'d locally (`.dev/`, `.wrangler/`, `node_modules/`,
+// `dist/`, `coverage/`, `.worktrees/`, `.claude/`). In CI (`actions/checkout`)
+// only tracked files are present, so the result equals `git ls-files`.
+//
+// Per testing-methodology.md principle 4 — audit tests replace review checklists.
+
+import { describe, it, expect } from 'vitest';
+
+// 30+ chars after `bv_` rules out doc placeholders like `bv_Kx8eZ2rdtUPfdzR8e_...`
+// (truncated with `...`) while still matching the real owner-key shape (40+ url-safe chars).
+const BV_KEY_PATTERN = /bv_[A-Za-z0-9_]{30,}/;
+
+// Sourced from .gitleaks.toml builtin AWS rule and the standard PEM private-key headers.
+// We keep these intentionally narrow — broad pattern audits live in gitleaks proper;
+// here we want zero false positives so the test stays cheap to keep green.
+const AWS_ACCESS_KEY_PATTERN = /\bAKIA[0-9A-Z]{16}\b/;
+const PRIVATE_KEY_HEADER_PATTERN = /-----BEGIN (?:RSA |EC |OPENSSH |DSA |ENCRYPTED |PGP )?PRIVATE KEY-----/;
+
+interface SecretRule {
+	readonly id: string;
+	readonly pattern: RegExp;
+}
+
+const RULES: readonly SecretRule[] = [
+	{ id: 'bv-api-key', pattern: BV_KEY_PATTERN },
+	{ id: 'aws-access-key', pattern: AWS_ACCESS_KEY_PATTERN },
+	{ id: 'private-key-pem', pattern: PRIVATE_KEY_HEADER_PATTERN },
+];
+
+// Files (relative to repo root) that are allowed to contain pattern matches.
+// Audit tests + fixture files are excluded because they contain the regex
+// literal itself, not a real secret. Spec files are excluded for the same reason.
+const ALLOWLISTED_PATHS: readonly RegExp[] = [
+	// This audit test itself contains the regex literals.
+	/^test\/audits\/no-tracked-secrets\.audit\.test\.ts$/,
+	// Test fixtures legitimately contain placeholder-shaped tokens.
+	/^test\//,
+	/^packages\/[^/]+\/test\//,
+	// Any spec/test file outside the test/ tree.
+	/\.(spec|test)\.ts$/,
+	// .gitleaks.toml + githooks contain the patterns by definition.
+	/^\.gitleaks\.toml$/,
+	/^\.githooks\//,
+	// Documented script defaults like `process.env.BV_API_KEY` and
+	// `os.getenv("BV_API_KEY", "mock-key-for-local-testing")` reference the
+	// env-var name, not a literal key. These don't match our 30-char pattern
+	// but listing them for clarity if patterns ever loosen.
+];
+
+function isAllowlisted(rel: string): boolean {
+	return ALLOWLISTED_PATHS.some((re) => re.test(rel));
+}
+
+// Bulk-load source-bearing files from known-tracked top-level directories.
+// Worker bundles have a memory ceiling, so we scope by extension + directory.
+// `eager: true` resolves at transform time on the host (Node) — works inside
+// the Workers test pool because the strings are baked into the bundle.
+//
+// Globs are split per-directory both for clarity and to keep each glob's
+// expansion bounded (avoids the unhandled-error worker crash we saw with a
+// single broad `/**/*` pattern).
+const FILE_GROUPS: ReadonlyArray<Record<string, unknown>> = [
+	import.meta.glob(['/.mcp.json', '/.gitignore', '/.npmrc', '/server.json', '/smithery.yaml'], { query: '?raw', eager: true }),
+	import.meta.glob('/*.{json,jsonc,yml,yaml,toml,md,mjs,cjs,js,ts}', { query: '?raw', eager: true }),
+	import.meta.glob('/src/**/*.{ts,mjs,js,json,jsonc}', { query: '?raw', eager: true }),
+	import.meta.glob('/packages/**/*.{ts,mjs,js,json,jsonc,md}', { query: '?raw', eager: true }),
+	import.meta.glob('/scripts/**/*.{mjs,js,ts,py,sh}', { query: '?raw', eager: true }),
+	import.meta.glob('/docs/**/*.{md,mdx}', { query: '?raw', eager: true }),
+	import.meta.glob('/.github/**/*.{yml,yaml,md}', { query: '?raw', eager: true }),
+];
+
+function collectFiles(): Map<string, string> {
+	const all = new Map<string, string>();
+	for (const group of FILE_GROUPS) {
+		for (const [absKey, mod] of Object.entries(group)) {
+			// Glob keys start with `/`, e.g. `/src/index.ts`. Convert to repo-relative.
+			const rel = absKey.startsWith('/') ? absKey.slice(1) : absKey;
+			if (isAllowlisted(rel)) continue;
+			// `?raw` modules expose the file body as `default`.
+			const body = (mod as { default?: unknown })?.default;
+			if (typeof body === 'string') {
+				all.set(rel, body);
+			}
+		}
+	}
+	return all;
+}
+
+describe('no tracked secrets — BV API key + AWS + PEM', () => {
+	// Build the regex literal at runtime so this test file itself doesn't
+	// contain a key-shaped string that would self-trip the bv-api-key rule.
+	const SAMPLE_REAL = 'bv_' + 'Kx8eZ2rdtUPfdzR8e_JfSCIVZ_UsdLQn3NOqwICW0HA';
+	const SAMPLE_PLACEHOLDER = 'bv_' + 'Kx8eZ2rdtUPfdzR8e_...';
+
+	it('regex matches a realistic BV API key shape (sanity check)', () => {
+		expect(BV_KEY_PATTERN.test(SAMPLE_REAL)).toBe(true);
+		// Doc placeholders (truncated) must NOT match.
+		expect(BV_KEY_PATTERN.test(SAMPLE_PLACEHOLDER)).toBe(false);
+		// Bare references must NOT match.
+		expect(BV_KEY_PATTERN.test('hello bv_world')).toBe(false);
+		expect(BV_KEY_PATTERN.test('process.env.BV_API_KEY')).toBe(false);
+	});
+
+	it('AWS access-key + PEM header sanity', () => {
+		expect(AWS_ACCESS_KEY_PATTERN.test('AKIA' + 'IOSFODNN7EXAMPLE')).toBe(true);
+		expect(AWS_ACCESS_KEY_PATTERN.test('not an akia value')).toBe(false);
+		expect(PRIVATE_KEY_HEADER_PATTERN.test('-----BEGIN PRIVATE KEY-----')).toBe(true);
+		expect(PRIVATE_KEY_HEADER_PATTERN.test('-----BEGIN OPENSSH PRIVATE KEY-----')).toBe(true);
+		expect(PRIVATE_KEY_HEADER_PATTERN.test('-----BEGIN CERTIFICATE-----')).toBe(false);
+	});
+
+	it('audit covers source-bearing files (sanity floor)', () => {
+		const files = collectFiles();
+		// If this drops to zero, the glob is mis-scoped and the audit becomes a no-op.
+		expect(files.size).toBeGreaterThan(50);
+		// Repo-root config files we care about must be reachable.
+		expect(files.has('.mcp.json')).toBe(true);
+	});
+
+	it('no scanned file contains a BV API key, AWS access key, or private-key PEM', () => {
+		const files = collectFiles();
+		const offenders: { file: string; line: number; rule: string; preview: string }[] = [];
+
+		for (const [rel, body] of files) {
+			const lines = body.split('\n');
+			lines.forEach((text, idx) => {
+				for (const rule of RULES) {
+					const m = rule.pattern.exec(text);
+					if (m) {
+						offenders.push({
+							file: rel,
+							line: idx + 1,
+							rule: rule.id,
+							preview: m[0].slice(0, 8) + '…(redacted)',
+						});
+					}
+				}
+			});
+		}
+
+		expect(
+			offenders,
+			`Tracked files contain a literal secret. Rotate the credential and remove it from history:\n${offenders
+				.map((o) => `  [${o.rule}] ${o.file}:${o.line}  ${o.preview}`)
+				.join('\n')}`,
+		).toEqual([]);
+	});
+});

--- a/test/audits/tool-quota-coverage.audit.test.ts
+++ b/test/audits/tool-quota-coverage.audit.test.ts
@@ -1,0 +1,41 @@
+// Audit test: every MCP tool must have explicit per-tool free-tier quota
+// coverage decision — either an entry in FREE_TOOL_DAILY_LIMITS, or explicit
+// membership in INTENTIONALLY_UNLIMITED_TOOLS (covered by per-IP only).
+//
+// Background: prior to v2.10.8, tools omitted from FREE_TOOL_DAILY_LIMITS
+// silently fell back to per-IP rate limiting. That was sometimes intended,
+// sometimes a bug (e.g. check_dane_https / check_svcb_https shipped without
+// quotas because nobody noticed). This audit forces the decision to be
+// explicit and visible in code review.
+//
+// Per testing-methodology.md principle 4 — audit tests replace review checklists.
+
+import { describe, it, expect } from 'vitest';
+import { TOOLS } from '../../src/schemas/tool-definitions';
+import { FREE_TOOL_DAILY_LIMITS, INTENTIONALLY_UNLIMITED_TOOLS } from '../../src/lib/config';
+
+describe('tool-quota-coverage audit', () => {
+	it('every TOOL_DEFS entry is either quota-limited or explicitly unlimited (never neither, never both)', () => {
+		const limited = new Set(Object.keys(FREE_TOOL_DAILY_LIMITS));
+		const unlimited = INTENTIONALLY_UNLIMITED_TOOLS;
+
+		const missing: string[] = [];
+		const both: string[] = [];
+
+		for (const tool of TOOLS) {
+			const inLimited = limited.has(tool.name);
+			const inUnlimited = unlimited.has(tool.name);
+			if (!inLimited && !inUnlimited) missing.push(tool.name);
+			if (inLimited && inUnlimited) both.push(tool.name);
+		}
+
+		expect(missing, `tools missing from BOTH FREE_TOOL_DAILY_LIMITS and INTENTIONALLY_UNLIMITED_TOOLS: ${missing.join(', ')}`).toEqual([]);
+		expect(both, `tools listed in BOTH (must pick one): ${both.join(', ')}`).toEqual([]);
+	});
+
+	it('INTENTIONALLY_UNLIMITED_TOOLS membership is a non-empty subset of TOOL_DEFS names', () => {
+		const validNames = new Set(TOOLS.map((t) => t.name));
+		const stale = [...INTENTIONALLY_UNLIMITED_TOOLS].filter((name) => !validNames.has(name));
+		expect(stale, `INTENTIONALLY_UNLIMITED_TOOLS contains names not in TOOL_DEFS: ${stale.join(', ')}`).toEqual([]);
+	});
+});

--- a/test/contracts/oauth-tier.contract.test.ts
+++ b/test/contracts/oauth-tier.contract.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+/**
+ * Contract: bv-web → bv-mcp OAuth entitlement tier surface.
+ *
+ * CLAUDE.md "Paid OAuth Tiers" is the source of truth: only `developer` and
+ * `enterprise` tiers reach bv-mcp via OAuth. The `agent` tier is reserved for
+ * static API-key authentication, not OAuth, so the entitlement schema must not
+ * accept it. This contract test guards the bv-web ↔ bv-mcp Zod payload from
+ * silently accepting an `agent` claim that downstream code (rate limiter, quota
+ * coordinator) never expects from an OAuth principal.
+ */
+import { describe, expect, it } from 'vitest';
+
+describe('CustomerOAuthTierSchema contract', () => {
+	it('accepts developer (paid Pro/Business/MCP-Developer plan)', async () => {
+		const { CustomerOAuthTierSchema } = await import('../../src/schemas/oauth');
+		expect(CustomerOAuthTierSchema.safeParse('developer').success).toBe(true);
+	});
+
+	it('accepts enterprise (paid Enterprise/MCP-Enterprise plan)', async () => {
+		const { CustomerOAuthTierSchema } = await import('../../src/schemas/oauth');
+		expect(CustomerOAuthTierSchema.safeParse('enterprise').success).toBe(true);
+	});
+
+	it('rejects agent (static-API-key-only tier, never reachable via OAuth)', async () => {
+		const { CustomerOAuthTierSchema } = await import('../../src/schemas/oauth');
+		expect(CustomerOAuthTierSchema.safeParse('agent').success).toBe(false);
+	});
+
+	it('rejects owner (privileged tier, never minted by bv-web Stripe entitlements)', async () => {
+		const { CustomerOAuthTierSchema } = await import('../../src/schemas/oauth');
+		expect(CustomerOAuthTierSchema.safeParse('owner').success).toBe(false);
+	});
+
+	it('rejects free / unauthenticated tiers', async () => {
+		const { CustomerOAuthTierSchema } = await import('../../src/schemas/oauth');
+		expect(CustomerOAuthTierSchema.safeParse('free').success).toBe(false);
+		expect(CustomerOAuthTierSchema.safeParse('partner').success).toBe(false);
+	});
+
+	it('PaidOAuthEntitlementResponseSchema rejects agent tier from bv-web', async () => {
+		const { PaidOAuthEntitlementResponseSchema } = await import('../../src/schemas/oauth');
+		const result = PaidOAuthEntitlementResponseSchema.safeParse({
+			subject: 'user_123',
+			tier: 'agent',
+			stripeCustomerId: 'cus_123',
+			stripeSubscriptionId: 'sub_123',
+			subscriptionStatus: 'active',
+			scopes: ['mcp'],
+		});
+		expect(result.success).toBe(false);
+	});
+});


### PR DESCRIPTION
## Summary

Resolves 10 of 13 findings from a multi-agent production-readiness audit on v2.10.7. Three findings (B2 missing CF token, W2 deploy-trail catch-up, plus a notify task) are tracked in the post-merge checklist below.

This is a re-creation of #84 — the original was auto-closed when the parent commits were rewritten by `git filter-repo` to redact 4 leaked owner-tier API tokens from history (separate operation, already complete on `main`).

Three commits, intentionally ordered so each is independently revertable:

1. **`fix(security)`** — Removes a leaked owner-tier `BV_API_KEY` from two committed scripts that carried it as a `process.env || '...'` fallback default. Adds a new audit test (`no-tracked-secrets.audit.test.ts`) that scans every tracked file for BV-key, AWS-key, and PEM patterns. Per-rule `.gitleaks.toml` allowlists drop the repo-wide gitleaks count from **10,161 → ~108** without loosening any actual secret rules.
2. **`test(audits)`** — Three TDD-driven invariants: (a) `tool-quota-coverage.audit.test.ts` requires every tool in `TOOL_DEFS` to be either rate-limited or in a new `INTENTIONALLY_UNLIMITED_TOOLS` set; backfills `check_dane_https`/`check_svcb_https` at 200/day. (b) `fuzzing-config.audit.test.ts` upgraded from shape-only to exact-value `toEqual` on `FUZZ_THRESHOLDS`. (c) `oauth-tier.contract.test.ts` locks `CustomerOAuthTierSchema` to `developer | enterprise` only — `agent` is now correctly rejected per CLAUDE.md.
3. **`build(deps)`** — Bumps `@cloudflare/vitest-pool-workers` 0.13.3 → 0.15.2 so the bundled workerd supports the pinned compatibility_date (eliminates the `requested "2026-04-22" falls back to "2026-03-17"` warning).

## Already done (out-of-PR-scope)

- ✅ `BV_API_KEY` rotated in Cloudflare production (old key returns 401, new key returns 200, verified)
- ✅ `git filter-repo --replace-text` redacted 4 leaked tokens from history; `main` and all branches/tags force-pushed; `allow_force_pushes: false` restored

## Verification

```
typecheck     exit 0
lint          exit 0
build         exit 0
dns-checks    exit 0
test          exit 0  Tests 2598 passed (2598)
```

## Still required after merge

- [ ] Upload `CLOUDFLARE_API_TOKEN` (Workers Edit + Account Read scopes) to GitHub `production` env. Until then `auto-deploy-main.yml` and `publish.yml` Cloudflare deploy jobs `exit 1`.
- [ ] After token uploaded, re-run `auto-deploy-main.yml` for the post-merge SHA so production reflects current code.
- [ ] Add `File hygiene check` to required status checks on `main` branch protection.
- [ ] Notify any token consumers and clone-holders to refresh creds + re-clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)