### PR TITLE
chore(ci): disable auto-deploy-main while in manual-deploy mode

### DIFF
--- a/.github/workflows/auto-deploy-main.yml.disabled
+++ b/.github/workflows/auto-deploy-main.yml.disabled
@@ -1,5 +1,12 @@
 name: Auto Deploy Main
 
+# DISABLED 2026-05-07 — operating in manual-deploy mode (`npm run deploy:private`).
+# Re-enable: rename this file back to `auto-deploy-main.yml` AFTER uploading
+# `CLOUDFLARE_API_TOKEN` (Workers Edit + Account Read) to the GitHub
+# `production` environment. Without that secret, the deploy job fails fast
+# on every main push (per the v2.10.6 fail-fast guards). See CLAUDE.md
+# "Manual release fallback" for the manual deploy procedure.
+
 on:
   workflow_run:
     workflows:


### PR DESCRIPTION
Renames `.github/workflows/auto-deploy-main.yml` → `auto-deploy-main.yml.disabled` so GitHub Actions stops picking it up.

## Why

Production is currently shipped via `npm run deploy:private` from local (operator's wrangler OAuth, no GH secret needed). `CLOUDFLARE_API_TOKEN` is intentionally not in the `production` environment.

With the v2.10.6 fail-fast guards (`exit 1` on missing secrets), every main push was turning the deploy job red. This stops the noise without weakening the guard — re-enabling is one `git mv` away once the token is uploaded.

## Re-enable steps (also in the file's header comment)

1. Mint a Cloudflare API token at https://dash.cloudflare.com/profile/api-tokens with template **Edit Cloudflare Workers**.
2. `gh secret set CLOUDFLARE_API_TOKEN --env production --body "..." --repo MadaBurns/bv-mcp`
3. `git mv .github/workflows/auto-deploy-main.yml.disabled .github/workflows/auto-deploy-main.yml`
4. Commit + PR.

## Test plan
- [ ] CI passes (no functional code changed)
- [ ] After merge: next main push does NOT trigger Auto Deploy Main

🤖 Generated with [Claude Code](https://claude.com/claude-code)