### PR TITLE
fix(audit): glob workflows so renames don't break workflow-secret-check audit

### DIFF
--- a/test/audits/workflow-secret-check.audit.test.ts
+++ b/test/audits/workflow-secret-check.audit.test.ts
@@ -17,27 +17,20 @@
 // Per testing-methodology.md principle 4 — audit tests replace review checklists.
 
 import { describe, it, expect } from 'vitest';
-import autoDeployMain from '../../.github/workflows/auto-deploy-main.yml?raw';
-import ciContract from '../../.github/workflows/ci-contract.yml?raw';
-import ci from '../../.github/workflows/ci.yml?raw';
-import deployHook from '../../.github/workflows/deploy-hook.yml?raw';
-import dnsSecurity from '../../.github/workflows/dns-security.yml?raw';
-import publishYml from '../../.github/workflows/publish.yml?raw';
-import repoHygiene from '../../.github/workflows/repo-hygiene.yml?raw';
-import securityYml from '../../.github/workflows/security.yml?raw';
-import triageIssues from '../../.github/workflows/triage-issues.yml?raw';
 
-const WORKFLOWS: ReadonlyArray<readonly [string, string]> = [
-	['auto-deploy-main.yml', autoDeployMain],
-	['ci-contract.yml', ciContract],
-	['ci.yml', ci],
-	['deploy-hook.yml', deployHook],
-	['dns-security.yml', dnsSecurity],
-	['publish.yml', publishYml],
-	['repo-hygiene.yml', repoHygiene],
-	['security.yml', securityYml],
-	['triage-issues.yml', triageIssues],
-];
+// Glob `*.yml` only — disabled workflows (`*.yml.disabled`) don't run, so
+// auditing their secret-check patterns is irrelevant. Renaming to
+// `.disabled` (operational pause) or back to `.yml` (re-enable) just shifts
+// which files get scanned, no static-import edits required.
+const workflowModules = import.meta.glob('../../.github/workflows/*.yml', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>;
+
+const WORKFLOWS: ReadonlyArray<readonly [string, string]> = Object.entries(workflowModules)
+	.map(([path, content]) => [path.split('/').pop()!, content] as const)
+	.sort(([a], [b]) => a.localeCompare(b));
 
 describe('workflow secret-check audit', () => {
 	it('no workflow uses the warn-and-skip anti-pattern (`skip=true` written to $GITHUB_ENV)', () => {


### PR DESCRIPTION
PR #86 renamed `auto-deploy-main.yml` → `auto-deploy-main.yml.disabled`. The audit at `test/audits/workflow-secret-check.audit.test.ts` had a hard `import` of that exact filename, so the rename broke the audit at module-resolve time. Caught by `publish.yml` failing on the v2.10.8 tag push.

This PR refactors to `import.meta.glob('../../.github/workflows/*.yml', ?raw, eager: true)` so file enumeration is dynamic. Renames between `.yml` and `.yml.disabled` no longer require editing the audit. The glob's `*.yml` pattern naturally excludes `.disabled` files — disabled workflows don't run, so their content is moot for this audit.

## Local verification
- Audit alone: 2/2 pass
- Full suite: 196 files / 2602 tests pass

## Self-note for the prompt operator
Admin-merging trivial CI changes is fine, but run `npm test` locally first if the change touches files that audit tests reference. PR #86 was admin-merged before its `build-and-test` gate finished — that gate would have caught this regression. The new `feedback_admin_merge_trivial_ci.md` memory will be updated to add that nuance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)