### PR TITLE
fix(release): mcp-publisher is a Go binary, not an npm package

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -256,9 +256,20 @@ jobs:
       # CLAUDE.md "MCP Registry DNS auth"). The previous design used a
       # long-lived JWT in MCP_REGISTRY_TOKEN, which expired silently and went
       # unnoticed because publish.yml warn-and-skipped on missing secrets.
+      # `mcp-publisher` is a Go binary distributed via GitHub releases at
+      # modelcontextprotocol/registry — NOT an npm package. `npx mcp-publisher`
+      # 404s. Pin to a known-good version; bump deliberately.
+      - name: Install mcp-publisher
+        env:
+          MCP_PUBLISHER_VERSION: '1.7.8'
+        run: |
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_${MCP_PUBLISHER_VERSION}_linux_amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin mcp-publisher
+          mcp-publisher --version
+
       - name: Login + publish to registry
         env:
           MCP_PUBLISHER_KEY: ${{ secrets.MCP_PUBLISHER_KEY }}
         run: |
-          npx mcp-publisher login dns --domain blackveilsecurity.com --private-key "$MCP_PUBLISHER_KEY"
-          npx mcp-publisher publish
+          mcp-publisher login dns --domain blackveilsecurity.com --private-key "$MCP_PUBLISHER_KEY"
+          mcp-publisher publish

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -459,8 +459,12 @@ rm /tmp/.npmrc-bv
 npm run deploy:private
 
 # 3. MCP Registry — DNS-based auth (see "MCP Registry DNS auth" below)
-npx mcp-publisher login dns --domain blackveilsecurity.com --private-key <ed25519-hex>
-npx mcp-publisher publish
+# `mcp-publisher` is a Go binary, NOT an npm package. Install via homebrew
+# (`brew install mcp-publisher`) or download from
+# https://github.com/modelcontextprotocol/registry/releases — `npx
+# mcp-publisher` will 404 on the npm registry.
+mcp-publisher login dns --domain blackveilsecurity.com --private-key <ed25519-hex>
+mcp-publisher publish
 
 # 4. Verify
 curl -s "https://registry.npmjs.org/-/package/blackveil-dns/dist-tags"


### PR DESCRIPTION
The MCP Registry job in publish.yml ran \`npx mcp-publisher\` — but \`mcp-publisher\` was never published to npm. The actual tool is a Go binary distributed at github.com/modelcontextprotocol/registry/releases. \`npx mcp-publisher\` resolves to E404 every time.

Surfaced when v2.10.8 tag-pushed publish.yml: 5 of 6 jobs ran, the MCP Registry job failed at \`npx mcp-publisher login dns ...\` with \`'mcp-publisher@*' is not in this registry\`. Net effect over the last release cycle: the registry stayed at v2.10.7 while npm + Worker advanced to 2.10.8 (registry caught up via local manual publish from your shell).

This PR:
1. \`publish.yml\`: downloads the pinned binary (\`mcp-publisher 1.7.8\`) into \`/usr/local/bin\` before invoking \`login dns\` + \`publish\`. Same DNS-auth flow, real executable.
2. \`CLAUDE.md\` "Manual release fallback": drops the \`npx\`, points at homebrew / GitHub releases.

Memory files (\`reference_release_publish_paths.md\`, \`reference_mcp_registry_dns_auth.md\`) updated separately.

## Test plan
- [ ] CI passes file-hygiene + secret-scan + dep-audit (no test changes — workflow only)
- [ ] Next tag (v2.10.9 or later) triggers publish.yml; MCP Registry job succeeds end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)