### PR TITLE
fix(test): add OAUTH_SIGNING_SECRET to vitest bindings

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -6,7 +6,19 @@ export default defineConfig({
 		cloudflareTest({
 			isolatedStorage: false,
 			wrangler: { configPath: './wrangler.jsonc' },
-			miniflare: { kvNamespaces: ['SESSION_STORE', 'RATE_LIMIT'], bindings: { ENABLE_OAUTH: 'true', ENABLE_OWNER_OAUTH: 'true' } },
+			miniflare: {
+				kvNamespaces: ['SESSION_STORE', 'RATE_LIMIT'],
+				bindings: {
+					ENABLE_OAUTH: 'true',
+					ENABLE_OWNER_OAUTH: 'true',
+					// v2.10.9 route gate requires `OAUTH_SIGNING_SECRET >= 32 bytes` for OAuth
+					// routes to serve (otherwise 503 service_unavailable). Tests that override
+					// env (chaos/e2e/token specs) explicitly unset it. Without this binding,
+					// CI ran without .dev.vars and SELF.fetch tests against OAuth routes 503'd
+					// instead of hitting the handler — caught by publish.yml v2.10.9 run #25497389714.
+					OAUTH_SIGNING_SECRET: 'a'.repeat(32),
+				},
+			},
 		}),
 	],
 	test: {


### PR DESCRIPTION
Test-infra follow-up to #91. The new route gate 503s when OAUTH_SIGNING_SECRET is missing; CI test env didn't have it (.dev.vars is gitignored), so SELF.fetch tests on OAuth routes failed. This adds the secret to miniflare bindings. Production is already on v2.10.9 via manual deploy — this just unblocks publish.yml so npm publish + MCP Registry can run for v2.10.9 once the tag is moved forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)