### PR TITLE
fix(publish): mcp-publisher asset has no version in filename

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -263,7 +263,7 @@ jobs:
         env:
           MCP_PUBLISHER_VERSION: '1.7.8'
         run: |
-          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_${MCP_PUBLISHER_VERSION}_linux_amd64.tar.gz" \
+          curl -fsSL "https://github.com/modelcontextprotocol/registry/releases/download/v${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz" \
             | sudo tar -xz -C /usr/local/bin mcp-publisher
           mcp-publisher --version
 


### PR DESCRIPTION
One-line follow-up to #90. The actual GitHub release asset is `mcp-publisher_<os>_<arch>.tar.gz` — no version in the filename. PR #90 wrongly added `${MCP_PUBLISHER_VERSION}` to the asset path, which 404'd publish.yml's MCP Registry job on every release (caught by run #25497985880 on v2.10.9). Verified the corrected URL with `curl -fsSLI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)