### PR TITLE
docs: refresh CLAUDE.md / README / AS-BUILT for v2.10.9

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Blackveil DNS — open-source DNS & email security scanner, built as a Cloudflare Worker.
 Exposes 51 tools via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`.
 An additional check (`check_subdomain_takeover`) runs only inside `scan_domain` and is not directly callable by clients.
-**Version**: 2.10.7 — keep `SERVER_VERSION` in `src/lib/server-version.ts` and `version` in `package.json` in sync. Listed on the [MCP Registry](https://registry.modelcontextprotocol.io) as `com.blackveilsecurity/dns`.
+**Version**: 2.10.9 — keep `SERVER_VERSION` (`src/lib/server-version.ts`), `version` (`package.json`, `package-lock.json`), `version` AND `packages[0].version` (`server.json` — known foot-gun, both fields), and the `[X.Y.Z]` heading in `CHANGELOG.md` in sync. Listed on the [MCP Registry](https://registry.modelcontextprotocol.io) as `com.blackveilsecurity/dns`.
 
 ## Commands
 
@@ -523,7 +523,7 @@ npm run deploy:private     # uses .dev/wrangler.deploy.jsonc
 | `ENABLE_OAUTH` | var | Set to `true` to expose OAuth discovery/register/authorize/token routes. Defaults disabled so clients do not auto-open owner-key browser consent. |
 | `ENABLE_OWNER_OAUTH` | var | Set to `true` only for operator/admin deployments that should render the legacy owner `BV_API_KEY` consent page. Defaults disabled; paid customer OAuth uses bv-web/Stripe entitlements instead. |
 | `OWNER_ALLOW_IPS` | var | Comma-separated IPs allowed for `owner` tier (key + wrong IP → `partner`). Also enforced at `/oauth/authorize` consent step. |
-| `OAUTH_SIGNING_SECRET` | Secret | HS256 signing key (≥32 bytes). Upload via `wrangler secret put`. `/oauth/token` returns `server_error` 500 until set. |
+| `OAUTH_SIGNING_SECRET` | Secret | HS256 signing key (≥32 bytes). Upload via `wrangler secret put`. **Required when `ENABLE_OAUTH=true`** — v2.10.9 added a route-layer gate (`oauthAvailability` in `src/index.ts`) that returns `service_unavailable` 503 from every OAuth route (`/.well-known/oauth-*`, `/oauth/{register,authorize,token}`) until the secret is set. The inner `/oauth/token` 500 path is preserved as defense in depth. Pre-v2.10.9 the failure surfaced only after user consent; the v2.10.8 incident drove the hardening. Codified by `test/chaos/oauth-misconfiguration.chaos.test.ts` and `test/audits/oauth-readiness-gate.audit.test.ts`. |
 | `OAUTH_ISSUER` | var | Optional issuer override (e.g. `https://dns-mcp.blackveilsecurity.com`). Falls back to request Host — set in prod to harden against Host-header spoofing of discovery metadata. |
 | `ALLOWED_ORIGINS` | var | Comma-separated allowed Origins |
 | `RATE_LIMIT` | KV | Per-IP rate counters (**required prod**) |

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Open-source DNS & email security scanner for Claude, Cursor, VS Code, and MCP cl
 [![GitHub stars](https://img.shields.io/github/stars/MadaBurns/bv-mcp?style=flat&logo=github)](https://github.com/MadaBurns/bv-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
-[![Tests](https://img.shields.io/badge/Tests-2587-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
+[![Tests](https://img.shields.io/badge/Tests-2610-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![Coverage](https://img.shields.io/badge/Coverage-~90%25-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-blue)](https://modelcontextprotocol.io/)

--- a/docs/AS-BUILT.md
+++ b/docs/AS-BUILT.md
@@ -1,9 +1,9 @@
 # Blackveil DNS OAuth Integration — As-Built Documentation
 
-**Version**: 2.10.7
+**Version**: 2.10.9
 **Status**: Production Live
-**Date**: May 7, 2026
-**Build Duration**: 8 phases over 2 weeks (Phase 1-8); v2.10.2-v2.10.7 hardening releases
+**Date**: May 8, 2026
+**Build Duration**: 8 phases over 2 weeks (Phase 1-8); v2.10.2-v2.10.9 hardening releases
 
 ---
 
@@ -22,13 +22,13 @@
 | Rate Limiting | Per-tier enforcement | ✅ |
 | Production Status | Live | ✅ |
 | Rollback Time | <5 minutes | ✅ |
-| Test Suite | 2587 tests across 6 pyramid layers | ✅ |
+| Test Suite | 2610 tests across 6 pyramid layers | ✅ |
 
 ---
 
-## Post-Launch Hardening (v2.10.2 → v2.10.7)
+## Post-Launch Hardening (v2.10.2 → v2.10.9)
 
-Eight phases delivered the system to v2.10.1 production. Five subsequent releases hardened the system against findings from operational use and security review:
+Eight phases delivered the system to v2.10.1 production. Eight subsequent releases hardened the system against findings from operational use and security review:
 
 | Version | Theme | Key changes |
 |---------|-------|-------------|
@@ -38,6 +38,8 @@ Eight phases delivered the system to v2.10.1 production. Five subsequent release
 | **v2.10.5** | Dependency hygiene | Hono 4.12.14 → 4.12.18 (advisories GHSA-9vqf-7f2p-gf9v + GHSA-69xw-7hcm-h432, neither exploitable in our codebase) |
 | **v2.10.6** | Fuzzing detection | KV-backed sliding-window detector for unknown-tool / unknown-method / zod-arg / auth-fail patterns; alerts via existing 15-min cron; principals identified by `keyHash` or `ipHash`, never raw IP. 28 new tests across all 6 pyramid layers |
 | **v2.10.7** | CI integrity | `publish.yml` switched from warn-and-skip to fail-fast on missing secrets; new audit test scans every `.github/workflows/*.yml` for the silent-skip anti-pattern. Root-cause: v2.10.2-v2.10.6 npm + Cloudflare publishes had silently dropped because secrets were missing and the workflow exited green |
+| **v2.10.8** | Production-readiness audit + secret rotation | Removed leaked `BV_API_KEY` fallback defaults from two committed scripts; rotated and `git filter-repo --replace-text` purged 4 hex tokens from history (main + branches + 79 tags force-pushed); per-rule `.gitleaks.toml` allowlists dropped repo leak count 10,161 → ~108. Three new TDD-driven invariants: `tool-quota-coverage` audit, exact-value `FUZZ_THRESHOLDS` audit lock, `oauth-tier` contract narrowing `CustomerOAuthTierSchema` to `developer \| enterprise`. Bumped `@cloudflare/vitest-pool-workers` 0.13.3 → 0.15.2 to clear the compat-date fallback warning |
+| **v2.10.9** | OAuth fail-fast hardening | `oauthAvailability` 3-state route gate added in `src/index.ts` — `'misconfigured'` (ENABLE_OAUTH=true but `OAUTH_SIGNING_SECRET` missing/<32B) returns 503 service_unavailable from every OAuth route at first RTT, rather than luring the user through register/authorize/consent and failing opaquely at /oauth/token. `'disabled'` (feature off) preserves 404, semantically distinct from "broken". Driven by the v2.10.8 incident: prod was deployed without `OAUTH_SIGNING_SECRET`; Claude Desktop showed "Couldn't connect" only after consent. Locked by `test/chaos/oauth-misconfiguration.chaos.test.ts` (6 routes × 3 env states) and `test/audits/oauth-readiness-gate.audit.test.ts` (forbids bare `isOAuthEnabled` checks at the route layer). Constant `OAUTH_SIGNING_SECRET_MIN_BYTES` and helper `isValidOAuthSigningSecret()` shared between route gate and signer (`src/lib/config.ts`). Inner-handler 500 path preserved as defense-in-depth |
 
 **TDD discipline:** Every behaviour change in v2.10.3 onwards landed through RED→GREEN→REFACTOR with the failing test watched before implementation. New tests by layer:
 - Unit: 17 (fuzzing-detector, internal-guard, oauth/pkce, oauth/jwt alg-pin)


### PR DESCRIPTION
Pure documentation. Brings CLAUDE.md, README test-count badge, and AS-BUILT.md in sync with v2.10.9 — including the new OAuth fail-fast route gate, the updated 5-file version-bump lock-step, and v2.10.8/v2.10.9 hardening rows in the post-launch table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)