### PR TITLE
chore(security): post-rewrite gitleaks allowlists + brochure cleanup

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,6 +14,12 @@ description = "Real email address (not example/test domain)"
 regex = '''[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}'''
 keywords = ["@"]
 [rules.allowlist]
+# Test fixtures and clearly-fictional domains live in these paths.
+paths = [
+  '''^test/''',
+  '''/test/''',
+  '''^packages/[^/]+/test/''',
+]
 regexTarget = "match"
 regexes = [
   '''@([a-zA-Z0-9.\-]+\.)?example\.(com|org|net)''',
@@ -24,6 +30,8 @@ regexes = [
   '''@(dmarcian|valimail|agari|dmarcadvisors)\.com''',        # Known DMARC vendor domains in test fixtures
   '''@(internal-company|thirdparty|yourdomain)\.com''',       # Test/placeholder domains
   '''mailto:[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]''', # mailto: in DMARC/TLSRPT test records
+  '''support@smithery\.ai''',                                  # Smithery's public business contact
+  '''oldmail@retail\.com''',                                   # Fictional narrative example in older docs/MARKETING-BROCHURE.md commits
 ]
 
 [[rules]]
@@ -78,6 +86,7 @@ paths = [
   '''scripts/tranco-deep-.*\.json$''',     # Numeric IDs in scan artifacts
   '''scripts/phase\d+-.*\.json$''',
   '''scripts/chaos/''',                    # Test sentinels (e.g. 1234567890 placeholders)
+  '''^chaos-test-.*\.py$''',                # Old root-level path before scripts/chaos/ reshuffle
   '''crates/[^/]+/Cargo\.lock$''',         # Rust deps include numeric versions/hashes
   '''crates/[^/]+/target/''',              # Rust build artifacts (gitignored locally; safety net)
   '''docs/.*\.md$''',                      # Phone-number-shaped numerics in docs (timestamps, hashes)
@@ -115,14 +124,23 @@ keywords = ["harlan"]
 [[rules]]
 id = "customer-name"
 description = "Customer/tenant name leaked"
-regex = '''(?i)\bredacted-tenant\b'''
-keywords = ["redacted-tenant"]
+# History was scrubbed of csc-global on 2026-05-08 via filter-repo --replace-text;
+# this rule keeps the literal `csc-global` pattern so future commits attempting
+# to reintroduce the name are caught by the pre-commit hook.
+regex = '''(?i)\bcsc-global\b'''
+keywords = ["csc-global"]
 
 [[rules]]
 id = "internal-org-team"
 description = "Internal GitHub organization team name leaked"
 regex = '''@blackveil-security/'''
 keywords = ["blackveil-security"]
+[rules.allowlist]
+# CODEOWNERS legitimately requires GitHub team handles to function.
+paths = [
+  '''^\.github/CODEOWNERS$''',
+  '''/\.github/CODEOWNERS$''',
+]
 
 [[rules]]
 id = "enterprise-architecture"

--- a/docs/MARKETING-BROCHURE.md
+++ b/docs/MARKETING-BROCHURE.md
@@ -246,7 +246,7 @@ Scan Results:
 Attack Path:
   1. Attacker registers discontinued provider domain
   2. Attacker sets MX to IP relinquished by provider
-  3. Attacker receives all mail sent to oldmail@retail.com
+  3. Attacker receives all mail sent to oldmail@example.com
   4. Attacker can access customer communications, reset passwords
 
 Remediation:


### PR DESCRIPTION
## Summary
Follow-up to the **2026-05-08 history rewrite** (which scrubbed `tenant-global`, `harlan.blackveilsecurity.com`, and 3 dead BV API keys from all 1,933 commits). The text-replace also rewrote the `customer-name` rule's literal in `.gitleaks.toml` — this PR restores it and adds allowlists for the remaining false positives.

## Changes

### `.gitleaks.toml`
- **`customer-name` rule:** restore the redacted customer-slug literal so the pre-commit hook still catches future re-introduction.
- **`real-email-address` rule:** add `paths` allowlist for `^test/`, `/test/`, `^packages/[^/]+/test/` (the 6 test-fixture emails like `tls@force-refresh.com` were genuine false positives). Add `support@smithery.ai` (Smithery's public business contact) and `oldmail@retail.com` (fictional narrative example) to regex allowlist.
- **`internal-org-team` rule:** allowlist `.github/CODEOWNERS` (CODEOWNERS legitimately requires `@org/team` handles).
- **`phone-number` rule:** add `^chaos-test-.*\.py$` to allowlist (the file used to be at repo root before being moved to `scripts/chaos/`).

### `docs/MARKETING-BROCHURE.md`
- Replace `oldmail@retail.com` with `oldmail@example.com` in the attack-narrative example (clearly fictional, already allowlisted).

## Verification

```bash
$ gitleaks detect --config .gitleaks.toml
0 findings
```

(Was 103 before the rewrite + this PR.)

## Companion to the history rewrite

The history rewrite force-pushed `main` and 79 tags from a fresh mirror clone. Anyone with a local clone of bv-mcp will see "diverged history" and needs to run:
```bash
git fetch origin --prune --prune-tags --tags --force
git reset --hard origin/main
```

Local `.worktrees/` will need refresh too. PR #95's old SHA (`a568424`) is now orphaned but still linkable for historical reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)