### PR TITLE
chore: post-rewrite cleanup — stale ref + drift gitignore

### DIFF
--- a/.github/instructions/scan-orchestration.instructions.md
+++ b/.github/instructions/scan-orchestration.instructions.md
@@ -53,4 +53,4 @@ All checks are **static imports** — no dynamic imports in scan context (unlike
 ## Reference docs
 
 - Scoring model: [docs/scoring.md](../../docs/scoring.md)
-- Architecture diagrams: [docs/architecture.md](../../docs/architecture.md)
+- Request flow: `src/index.ts` (Hono app) → `src/mcp/dispatch.ts` (JSON-RPC routing) → `src/handlers/tools.ts` (TOOL_REGISTRY) → individual checks under `src/tools/`. Trace the imports directly; the standalone architecture-diagram doc was removed in 2026-05-08 to keep this open-source repo focused on customer-facing material.

--- a/.gitignore
+++ b/.gitignore
@@ -89,6 +89,22 @@ plan-*.md
 .github/agents/
 .github/prompts/
 
+# Internal reports / call prep — never commit (drift catchers)
+/BENCHMARK_REPORT.md
+/BENCHMARK_*.md
+/CAPACITY_ANALYSIS.md
+/CAPACITY_*.md
+/CSC-*.md
+/*-Call-Prep.md
+/AS-BUILT.md
+/phase*-golive.md
+/OAUTH_LOCAL_DEBUG.md
+/MCP.md
+/GEMINI.md
+/docs/architecture.md
+/docs/AS-BUILT.md
+/docs/phase*-golive.md
+
 # Dev output files
 *.out
 out.txt


### PR DESCRIPTION
## Summary
Follow-up to the **2026-05-08 second history rewrite** that removed 6 internal docs (`architecture.md`, `AS-BUILT.md`, `phase8-golive.md`, `OAUTH_LOCAL_DEBUG.md`, `MCP.md`, `GEMINI.md`) from all 1,933 commits and 82 tags.

## Changes

1. **`.github/instructions/scan-orchestration.instructions.md`** — replace the now-broken link to `docs/architecture.md` with an inline pointer to the actual request-flow files (`src/index.ts` → `src/mcp/dispatch.ts` → `src/handlers/tools.ts`). Trace imports directly.

2. **`.gitignore`** — catch the recurring drift pattern of internal reports landing at the repo root:
   - `BENCHMARK_REPORT.md` / `BENCHMARK_*.md`
   - `CAPACITY_ANALYSIS.md` / `CAPACITY_*.md`
   - `tenant-*.md` / `*-Call-Prep.md`
   - The 6 docs we just removed (so regeneration can't silently re-track them)

## Test plan
- [x] `git check-ignore` now matches all 4 drift files (`BENCHMARK_REPORT.md`, `CAPACITY_ANALYSIS.md`, `tenant-Global-Call-Prep.md`, `PLAN.md`)
- [x] No remaining `git grep` references to the 6 removed docs in tracked files
- [ ] CI: 4 required checks (build-and-test, Secret & PII scan, Dependency audit, File hygiene check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)