### PR TITLE
fix(test): clear rate-limit KV state in test/index.spec.ts beforeEach

### DIFF
--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -455,6 +455,29 @@ export function resetGlobalDailyLimit(): void {
 	globalDayCount = 0;
 }
 
+/**
+ * Test-only helper. Removes every `rl:*` key from the given KV namespace —
+ * complement to `resetAllRateLimits()` which only clears the per-isolate
+ * Map. Call from `beforeEach` in test files that exercise the public
+ * rate-limit code path; without it the 60s minute-window keys can bleed
+ * across tests on slow CI workers (#96).
+ *
+ * Fail-soft: returns silently on KV errors. Test isolation must never
+ * reject the surrounding beforeEach.
+ */
+export async function resetAllRateLimitsKv(kv: KVNamespace): Promise<void> {
+	try {
+		let cursor: string | undefined;
+		do {
+			const list = await kv.list({ prefix: 'rl:', cursor });
+			await Promise.all(list.keys.map((k) => kv.delete(k.name)));
+			cursor = list.list_complete ? undefined : list.cursor;
+		} while (cursor);
+	} catch {
+		// Best-effort — surfaced via test flake if the helper truly fails.
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Per-tier concurrency limits (best-effort per-isolate fairness)
 // ---------------------------------------------------------------------------

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -2,7 +2,7 @@ import { env, createExecutionContext, waitOnExecutionContext, SELF } from 'cloud
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
 import worker from '../src';
 import { resetQuotaCoordinatorState } from '../src/lib/quota-coordinator';
-import { resetAllRateLimits } from '../src/lib/rate-limiter';
+import { resetAllRateLimits, resetAllRateLimitsKv } from '../src/lib/rate-limiter';
 import { resetLegacySseState } from '../src/lib/legacy-sse';
 import { resetSessions } from '../src/lib/session';
 import { ACTIVE_SESSIONS } from '../src/lib/session-memory';
@@ -84,6 +84,7 @@ describe('DNS Security MCP Server', () => {
 		resetSessions();
 		resetLegacySseState();
 		await resetQuotaCoordinatorState(env.QUOTA_COORDINATOR);
+		await resetAllRateLimitsKv(env.RATE_LIMIT);
 	});
 
 		afterEach(() => {

--- a/test/rate-limiter-kv-reset.test.ts
+++ b/test/rate-limiter-kv-reset.test.ts
@@ -1,0 +1,62 @@
+// #96 fix: rate-limiter KV state must be resettable per-test in addition to
+// the in-memory counter. Pre-fix, `resetAllRateLimits()` only cleared the
+// per-isolate Map but left `rl:min:*`, `rl:hr:*`, `rl:day:tool:*` and
+// `rl:global:day:*` keys in the RATE_LIMIT KV namespace. On slow CI workers
+// where vitest's import phase consumes ~123s, the 60s minute-window TTL
+// hadn't expired by the time the next test ran — earlier tests' counters
+// bled forward and broke `tools/call notifications consume exactly one
+// rate-limit unit per request` (line 1219) and `auto-recovers expired
+// sessions for tools/call by reviving the same session ID` (line 1484) in
+// `test/index.spec.ts`.
+
+import { env } from 'cloudflare:test';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { resetAllRateLimitsKv } from '../src/lib/rate-limiter';
+
+async function listRlKeys(): Promise<string[]> {
+	const list = await env.RATE_LIMIT.list({ prefix: 'rl:' });
+	return list.keys.map((k) => k.name);
+}
+
+beforeEach(async () => {
+	await resetAllRateLimitsKv(env.RATE_LIMIT);
+});
+afterEach(async () => {
+	await resetAllRateLimitsKv(env.RATE_LIMIT);
+});
+
+describe('resetAllRateLimitsKv', () => {
+	it('removes every rl:* key from the namespace', async () => {
+		await env.RATE_LIMIT.put('rl:min:1.2.3.4:200', '50', { expirationTtl: 60 });
+		await env.RATE_LIMIT.put('rl:hr:1.2.3.4:33', '300', { expirationTtl: 3600 });
+		await env.RATE_LIMIT.put('rl:day:tool:scan_domain:abcd:55', '10', { expirationTtl: 86_400 });
+		await env.RATE_LIMIT.put('rl:global:day:55', '500', { expirationTtl: 86_400 });
+		await env.RATE_LIMIT.put('rl:ctl:min:1.2.3.4:200', '5', { expirationTtl: 60 });
+
+		expect((await listRlKeys()).length).toBeGreaterThanOrEqual(5);
+
+		await resetAllRateLimitsKv(env.RATE_LIMIT);
+
+		expect(await listRlKeys()).toEqual([]);
+	});
+
+	it('leaves non-rl keys alone', async () => {
+		await env.RATE_LIMIT.put('tier:abcd', '{"tier":"free"}', { expirationTtl: 60 });
+		await env.RATE_LIMIT.put('rl:min:1.2.3.4:200', '50', { expirationTtl: 60 });
+
+		await resetAllRateLimitsKv(env.RATE_LIMIT);
+
+		expect(await env.RATE_LIMIT.get('tier:abcd')).toBe('{"tier":"free"}');
+		expect(await env.RATE_LIMIT.get('rl:min:1.2.3.4:200')).toBeNull();
+	});
+
+	it('is fail-soft on KV errors (test isolation must not throw)', async () => {
+		const broken = {
+			list: async () => {
+				throw new Error('KV unavailable');
+			},
+		} as unknown as KVNamespace;
+		// Must not throw — caller's beforeEach should never reject because of test infra.
+		await expect(resetAllRateLimitsKv(broken)).resolves.toBeUndefined();
+	});
+});


### PR DESCRIPTION
Closes #96.

## Root cause

`resetAllRateLimits()` only clears the per-isolate `Map`. `rl:*` keys in the `RATE_LIMIT` KV namespace (`rl:min:*`, `rl:hr:*`, `rl:day:tool:*`, `rl:global:day:*`, `rl:ctl:*`) persist with their TTL. On slow CI workers — vitest's import phase is ~123 s vs ~3 s locally — the 60 s minute-window counters from earlier tests in `test/index.spec.ts` bled into:

- **`:1238`** "tools/call notifications consume exactly one rate-limit unit per request" — expected `202`, got `200` (notification rate-limit-rejected with HTTP 200 + `-32029` body).
- **`:1484`** "auto-recovers expired sessions for tools/call by reviving the same session ID" — got `{ code: -32029, message: 'Rate limit exceeded. Retry after 58s' }`.

## Fix

New `resetAllRateLimitsKv(kv: KVNamespace): Promise<void>` in `src/lib/rate-limiter.ts` walks the namespace's `rl:` prefix and deletes every key (paginated via cursor). Wired into the existing `beforeEach` in `test/index.spec.ts` after `resetQuotaCoordinatorState`. Fail-soft on KV errors so test infra never rejects.

## TDD evidence

- `test/rate-limiter-kv-reset.test.ts` — 3 unit tests, RED before implementation, GREEN after:
  - removes every `rl:*` key from the namespace
  - leaves non-`rl:` keys (e.g. `tier:*`) alone
  - fail-soft when KV throws

## Verification

```
npm run typecheck       ✅
npx vitest run          ✅ 208 files / 2670 tests pass (was 2667)
```

The CI run on this PR is the real test — if `build-and-test` passes first time, the flake is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)