### PR TITLE
chore: remove explain_finding rejection telemetry (closes #77)

### DIFF
--- a/src/handlers/tool-args.ts
+++ b/src/handlers/tool-args.ts
@@ -2,36 +2,8 @@
 
 import { ZodError } from 'zod';
 import { validateDomain, sanitizeDomain } from '../lib/sanitize';
-import { logEvent } from '../lib/log';
 import { TOOL_SCHEMA_MAP } from '../schemas/tool-args';
 import type { OutputFormat, Profile } from '../schemas/primitives';
-
-/**
- * Time-boxed telemetry: record what inputs clients send that get rejected.
- * Added 2026-04-25 to diagnose explain_finding's 27% error rate (10/37 calls).
- * Remove once 7 days of data has been reviewed and the root cause is known.
- */
-function logExplainFindingRejection(args: Record<string, unknown>, err: ZodError): void {
-	const issue = err.issues[0];
-	const path = issue.path.join('.');
-	const received = args[path];
-	let rejectedValue: string;
-	if (received === undefined) rejectedValue = '<missing>';
-	else if (received === null) rejectedValue = '<null>';
-	else if (typeof received === 'string') rejectedValue = received.replace(/[\x00-\x1F\x7F]/g, '?').slice(0, 64);
-	else rejectedValue = typeof received;
-	logEvent({
-		timestamp: new Date().toISOString(),
-		severity: 'info',
-		tool: 'explain_finding',
-		result: 'explain_finding_rejected',
-		details: {
-			rejectedField: path,
-			rejectedValue,
-			issueCode: issue.code,
-		},
-	});
-}
 
 export type { OutputFormat };
 
@@ -91,9 +63,6 @@ export function validateToolArgs(toolName: string, args: Record<string, unknown>
 		return schema.parse(args) as Record<string, unknown>;
 	} catch (err) {
 		if (err instanceof ZodError) {
-			if (toolName === 'explain_finding') {
-				logExplainFindingRejection(args, err);
-			}
 			throw new Error(formatZodError(err, toolName));
 		}
 		throw err;

--- a/test/tool-args.spec.ts
+++ b/test/tool-args.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import {
 	extractAndValidateDomain,
 	extractDkimSelector,

--- a/test/tool-args.spec.ts
+++ b/test/tool-args.spec.ts
@@ -57,61 +57,6 @@ describe('tool-args helpers', () => {
 		expect(() => validateToolArgs('explain_finding', { checkType: 'SPF' })).toThrow('Missing required parameters');
 	});
 
-	describe('explain_finding rejection telemetry', () => {
-		let logSpy: ReturnType<typeof vi.spyOn>;
-
-		afterEach(() => {
-			logSpy?.mockRestore();
-		});
-
-		it('emits a structured log event when explain_finding is rejected by Zod', () => {
-			logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-
-			expect(() =>
-				validateToolArgs('explain_finding', { checkType: 'SPF', status: 'unexpected_value_xyz' }),
-			).toThrow();
-
-			const telemetryCall = logSpy.mock.calls.find((args) => {
-				const msg = args[0];
-				return typeof msg === 'string' && msg.includes('explain_finding_rejected');
-			});
-			expect(telemetryCall).toBeDefined();
-			const payload = JSON.parse(telemetryCall![0] as string);
-			expect(payload.result).toBe('explain_finding_rejected');
-			expect(payload.tool).toBe('explain_finding');
-			expect(payload.details.rejectedField).toBe('status');
-			expect(payload.details.rejectedValue).toContain('unexpected_value_xyz');
-			expect((payload.details.rejectedValue as string).length).toBeLessThanOrEqual(64);
-		});
-
-		it('truncates long or unusual rejected values', () => {
-			logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-
-			const longValue = 'x'.repeat(500);
-			expect(() => validateToolArgs('explain_finding', { checkType: 'SPF', status: longValue })).toThrow();
-
-			const telemetryCall = logSpy.mock.calls.find((args) => {
-				const msg = args[0];
-				return typeof msg === 'string' && msg.includes('explain_finding_rejected');
-			});
-			expect(telemetryCall).toBeDefined();
-			const payload = JSON.parse(telemetryCall![0] as string);
-			expect((payload.details.rejectedValue as string).length).toBeLessThanOrEqual(64);
-		});
-
-		it('does not emit telemetry for other tools when Zod rejects', () => {
-			logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
-
-			expect(() => validateToolArgs('check_spf', {})).toThrow();
-
-			const telemetryCall = logSpy.mock.calls.find((args) => {
-				const msg = args[0];
-				return typeof msg === 'string' && msg.includes('explain_finding_rejected');
-			});
-			expect(telemetryCall).toBeUndefined();
-		});
-	});
-
 	it('validateToolArgs passes through unknown tool names', () => {
 		const args = { foo: 'bar' };
 		expect(validateToolArgs('unknown_tool', args)).toBe(args);


### PR DESCRIPTION
Closes #77.

## Decision: Category C — close as expected noise

The temporary `logExplainFindingRejection` hook was added 2026-04-25 to diagnose a **27% error rate** in `explain_finding` (10/37 calls over 30 days).

### 30-day analytics review (2026-05-08)

| day        | calls | errors |
|------------|-------|--------|
| 2026-05-06 |   3   |   **0** |
| 2026-04-25 |   3   |   **0** |
| 2026-04-19 |   2   |   **0** |
| 2026-04-16 |   9   |   **0** |

**Total: 17 calls, 0 errors.** The 27% rate has fully resolved — likely a transient client-side mismatch around the time the issue was filed. Schema (`ExplainStatusSchema`) accepts `pass | fail | warning | critical | high | medium | low | info` with `.trim().toLowerCase()` normalization, which is already broad. No broadening needed.

## Changes (86 lines removed)

- `logExplainFindingRejection()` and its call site in `src/handlers/tool-args.ts`
- Now-unused `logEvent` import
- `describe('explain_finding rejection telemetry', ...)` block in `test/tool-args.spec.ts` (3 tests)

Schema validation tests in `test/schemas/tool-args.spec.ts` retained — they cover the actual contract per testing-methodology principle 2 (push down, then delete).

## Verification

- `npm run typecheck` ✅
- `npx vitest run` ✅ 207 files / 2664 tests pass
- `grep -rn logExplainFindingRejection src/ test/` → no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)