### PR TITLE
feat(quota): raise partner.scan_domain to 2.5M for tenant-class customers

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -124,8 +124,8 @@ export const TIER_DAILY_LIMITS: Record<McpApiKeyTier, number> = {
  */
 export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string, number>>> = {
 	partner: {
-		scan_domain: 100_000,
-		scan: 100_000,
+		scan_domain: 2_500_000,
+		scan: 2_500_000,
 		compare_baseline: 100_000,
 		check_spf: 500_000,
 		check_dmarc: 500_000,

--- a/test/audits/csc-scale-quota.audit.test.ts
+++ b/test/audits/csc-scale-quota.audit.test.ts
@@ -1,0 +1,35 @@
+// Audit test: partner-tier scan_domain quota must support CSC-class
+// enterprise customers (one-shot 2.5M-domain portfolio audits).
+//
+// Background: Phase 0 of the CSC enterprise enablement plan. CSC's headline
+// customer has 2.5M-domain portfolios; the prior 100K/day partner-tier cap
+// blocked one-shot audits. This audit locks the floor so a future regression
+// toward the lower number trips CI.
+//
+// Per testing-methodology.md principle 4 — audit tests replace review checklists.
+
+import { describe, it, expect } from 'vitest';
+import { TIER_TOOL_DAILY_LIMITS } from '../../src/lib/config';
+
+const CSC_FLOOR = 2_500_000;
+
+describe('csc-scale-quota audit', () => {
+	it('partner.scan_domain meets CSC-class one-shot portfolio audit floor (>= 2.5M)', () => {
+		const limit = TIER_TOOL_DAILY_LIMITS.partner?.scan_domain;
+		expect(limit, 'TIER_TOOL_DAILY_LIMITS.partner.scan_domain must be defined').toBeDefined();
+		expect(limit).toBeGreaterThanOrEqual(CSC_FLOOR);
+	});
+
+	it('partner.scan alias meets CSC-class one-shot portfolio audit floor (>= 2.5M)', () => {
+		// `tools/call` resolves `scan` → `scan_domain`, so the alias must match.
+		const limit = TIER_TOOL_DAILY_LIMITS.partner?.scan;
+		expect(limit, 'TIER_TOOL_DAILY_LIMITS.partner.scan must be defined').toBeDefined();
+		expect(limit).toBeGreaterThanOrEqual(CSC_FLOOR);
+	});
+
+	it('partner.scan_domain and partner.scan stay in sync', () => {
+		const scanDomain = TIER_TOOL_DAILY_LIMITS.partner?.scan_domain;
+		const scan = TIER_TOOL_DAILY_LIMITS.partner?.scan;
+		expect(scan, 'partner.scan must equal partner.scan_domain (alias)').toBe(scanDomain);
+	});
+});

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -69,7 +69,7 @@ describe('partner tier', () => {
 	it('has per-tool daily limits', () => {
 		const partnerLimits = TIER_TOOL_DAILY_LIMITS.partner;
 		expect(partnerLimits).toBeDefined();
-		expect(partnerLimits!.scan_domain).toBe(100_000);
+		expect(partnerLimits!.scan_domain).toBe(2_500_000);
 		expect(partnerLimits!.check_spf).toBe(500_000);
 		expect(partnerLimits!.check_lookalikes).toBe(50_000);
 	});


### PR DESCRIPTION
## Summary
Phase 0 of the tenant enterprise enablement plan. tenant's headline customer has 2.5M-domain portfolios; the prior `100K/day` `partner` cap blocked one-shot audits.

- `src/lib/config.ts:127-128` — `scan_domain` and `scan` aliases bumped from `100_000` → `2_500_000`
- `test/config.spec.ts:72` — pre-existing test that hardcoded the old value, updated to the new floor
- `test/audits/tenant-scale-quota.audit.test.ts` — new audit-layer test (TDD red→green) that locks the 2.5M floor so a future regression toward the lower number trips CI

## Verification
- `npx vitest run test/audits/tenant-scale-quota.audit.test.ts` ✅ 3/3
- `npm run typecheck` clean
- `npm run lint` clean
- Full suite (210 files / 2673 tests) passes (per agent-A worktree run)

## Other
- No production behaviour change for tiers other than `partner`.
- No version bump (separate PR).
- Standalone — no dependency on the other 3 tenant PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)