### PR TITLE
feat(tenant): SAN-cert correlator for brand-domain discovery

### DIFF
--- a/src/csc/discovery/index.ts
+++ b/src/csc/discovery/index.ts
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Brand-discovery primitives (Phase-4 of the customer-domain expansion roadmap).
+ */
+
+export { correlateSans } from './san-correlator';
+export type { SanCorrelationOptions, SanCorrelationResult } from './san-correlator';

--- a/src/csc/discovery/san-correlator.ts
+++ b/src/csc/discovery/san-correlator.ts
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * SAN-cert correlator (Phase-4 brand-discovery, tier-1 signal).
+ *
+ * Queries crt.sh for a seed domain, extracts every Subject Alternative Name
+ * from the matched certificates, and returns the set of *sibling* co-owned
+ * domains: not the seed itself, not subdomains of the seed (those are the
+ * job of `discover_subdomains`), and not invalid hostnames.
+ *
+ * Adopted from the well-known technique used by `bit4woo/teemo`. Because CT
+ * logs are append-only and global, a single wildcard or multi-domain cert
+ * publicly correlates everything the customer renews together — a near-
+ * deterministic ownership signal at zero query cost.
+ *
+ * Failure modes follow the bv-mcp tool-wrapper convention: this function
+ * MUST NOT throw on network/rate-limit/timeout — only on programmer error
+ * (invalid input). Callers can interrogate `queryStatus` instead.
+ */
+
+import { safeFetch } from '../../lib/safe-fetch';
+import { validateDomain } from '../../lib/sanitize';
+
+/** Default request timeout (ms). */
+const DEFAULT_TIMEOUT_MS = 8_000;
+
+/** Default cap on certs to consider per seed query. */
+const DEFAULT_MAX_CERTS = 50;
+
+/**
+ * Cap on the JSON response body before parsing. crt.sh can return MBs of
+ * SAN data for large issuers; bound it to keep the Worker out of OOM land.
+ */
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+
+export interface SanCorrelationOptions {
+	/** Request timeout in ms. Defaults to 8000. */
+	timeoutMs?: number;
+	/** Cap on the number of crt.sh entries that contribute to the result. Defaults to 50. */
+	maxCertsPerDomain?: number;
+	/** Override the underlying fetch implementation (used for testing). Defaults to `safeFetch`. */
+	fetchFn?: typeof fetch;
+}
+
+export interface SanCorrelationResult {
+	seedDomain: string;
+	/** Deduped, alphabetically sorted, lowercase ASCII sibling domains. */
+	coOwnedDomains: string[];
+	/** crt.sh `id` values of the certs that produced the matches (capped by maxCertsPerDomain). */
+	certIds: number[];
+	queryStatus: 'ok' | 'rate_limited' | 'timeout' | 'error';
+}
+
+/** A single crt.sh JSON response entry (subset we use). */
+interface CrtShEntry {
+	id?: number;
+	name_value?: string;
+	entry_timestamp?: string;
+}
+
+/**
+ * Build the empty/error-shape result. Centralised so the failure paths can't
+ * accidentally diverge on field defaults.
+ */
+function emptyResult(seedDomain: string, status: SanCorrelationResult['queryStatus']): SanCorrelationResult {
+	return { seedDomain, coOwnedDomains: [], certIds: [], queryStatus: status };
+}
+
+/**
+ * Sort entries newest-first. Entries without `entry_timestamp` are pushed to
+ * the end so they don't out-compete dated entries for the cap slots.
+ */
+function sortEntriesNewestFirst(entries: CrtShEntry[]): CrtShEntry[] {
+	const withSortKey = entries.map((entry) => {
+		const t = entry.entry_timestamp ? Date.parse(entry.entry_timestamp) : Number.NaN;
+		return { entry, sortKey: Number.isFinite(t) ? t : Number.NEGATIVE_INFINITY };
+	});
+	withSortKey.sort((a, b) => b.sortKey - a.sortKey);
+	return withSortKey.map((x) => x.entry);
+}
+
+/**
+ * Extract sibling domains from a single SAN string.
+ *
+ * `name_value` is a list of hostnames separated by `\n` or `,` (crt.sh varies
+ * by query). Wildcards (`*.example.com`) become the bare apex. Subdomains
+ * of the seed are dropped — those are `discover_subdomains`' job. The seed
+ * itself is dropped. Hostnames that fail `validateDomain` are silently
+ * filtered (SSRF/sentinel guard).
+ */
+function extractSiblingsFromNameValue(nameValue: string, seedLower: string): string[] {
+	const seedSuffix = `.${seedLower}`;
+	const out: string[] = [];
+	for (const rawSplit of nameValue.split(/[\n,]/)) {
+		let host = rawSplit.trim().toLowerCase();
+		if (!host) continue;
+		// Strip wildcard prefix — the bare apex is what we actually want.
+		if (host.startsWith('*.')) host = host.slice(2);
+		if (!host) continue;
+		// Drop the seed itself.
+		if (host === seedLower) continue;
+		// Drop subdomains of the seed. `endsWith('.' + seed)` so that
+		// `notexample.com` is *not* treated as a subdomain of `example.com`.
+		if (host.endsWith(seedSuffix)) continue;
+		// SSRF / format guard.
+		const validation = validateDomain(host);
+		if (!validation.valid) continue;
+		out.push(host);
+	}
+	return out;
+}
+
+/**
+ * Correlate co-owned sibling domains for a seed via crt.sh SAN clustering.
+ *
+ * @throws Error with the `'Domain validation failed:'` prefix when the seed
+ *   does not pass `validateDomain`. All other failure modes (network error,
+ *   429 rate limit, timeout, oversize body, malformed JSON) are returned as
+ *   `queryStatus: 'rate_limited' | 'timeout' | 'error'` rather than thrown.
+ */
+export async function correlateSans(
+	seedDomain: string,
+	options: SanCorrelationOptions = {},
+): Promise<SanCorrelationResult> {
+	// Validate FIRST — outside the network try/catch — so a bad seed surfaces
+	// to the caller as a thrown error rather than getting swallowed and
+	// returned as `queryStatus: 'error'`. The thrown prefix matches the
+	// project's `SAFE_ERROR_PREFIXES` allowlist.
+	const validation = validateDomain(seedDomain);
+	if (!validation.valid) {
+		throw new Error(`Domain validation failed: ${validation.error ?? 'invalid domain'}`);
+	}
+	const seedLower = seedDomain.trim().toLowerCase().replace(/\.$/, '');
+
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const maxCerts = options.maxCertsPerDomain ?? DEFAULT_MAX_CERTS;
+	const fetchFn = options.fetchFn ?? safeFetch;
+
+	const url = `https://crt.sh/?q=${encodeURIComponent(seedLower)}&output=json`;
+
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+	let response: Response;
+	try {
+		response = await fetchFn(url, { signal: controller.signal, redirect: 'manual' });
+	} catch (err) {
+		clearTimeout(timeoutId);
+		if (err instanceof Error && err.name === 'AbortError') {
+			return emptyResult(seedLower, 'timeout');
+		}
+		return emptyResult(seedLower, 'error');
+	}
+	clearTimeout(timeoutId);
+
+	if (response.status === 429) {
+		return emptyResult(seedLower, 'rate_limited');
+	}
+	if (!response.ok) {
+		return emptyResult(seedLower, 'error');
+	}
+
+	// Pre-flight cap via Content-Length when available to short-circuit
+	// pathologically large responses before parsing.
+	const contentLength = response.headers.get('content-length');
+	if (contentLength) {
+		const declared = Number.parseInt(contentLength, 10);
+		if (Number.isFinite(declared) && declared > MAX_BODY_BYTES) {
+			return emptyResult(seedLower, 'error');
+		}
+	}
+
+	let entries: CrtShEntry[];
+	try {
+		const text = await response.text();
+		if (text.length > MAX_BODY_BYTES) {
+			return emptyResult(seedLower, 'error');
+		}
+		const parsed = JSON.parse(text);
+		if (!Array.isArray(parsed)) {
+			return emptyResult(seedLower, 'error');
+		}
+		entries = parsed as CrtShEntry[];
+	} catch (err) {
+		if (err instanceof Error && err.name === 'AbortError') {
+			return emptyResult(seedLower, 'timeout');
+		}
+		return emptyResult(seedLower, 'error');
+	}
+
+	if (entries.length === 0) {
+		return { seedDomain: seedLower, coOwnedDomains: [], certIds: [], queryStatus: 'ok' };
+	}
+
+	// Sort newest-first, then cap. Without sorting, the cap silently drops
+	// the most-recent (most-relevant) certificate observations.
+	const ranked = sortEntriesNewestFirst(entries).slice(0, Math.max(0, maxCerts));
+
+	const siblings = new Set<string>();
+	const certIds: number[] = [];
+	for (const entry of ranked) {
+		if (typeof entry.id === 'number') certIds.push(entry.id);
+		const nameValue = entry.name_value;
+		if (typeof nameValue !== 'string' || !nameValue) continue;
+		for (const sibling of extractSiblingsFromNameValue(nameValue, seedLower)) {
+			siblings.add(sibling);
+		}
+	}
+
+	const coOwnedDomains = Array.from(siblings).sort();
+	return { seedDomain: seedLower, coOwnedDomains, certIds, queryStatus: 'ok' };
+}

--- a/test/csc/discovery/san-correlator.test.ts
+++ b/test/csc/discovery/san-correlator.test.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the SAN-cert correlator (Phase-4 brand-discovery, tier-1 signal).
+ *
+ * The correlator queries crt.sh for a seed domain, extracts every Subject
+ * Alternative Name from the returned certificates, and filters to sibling
+ * co-owned domains (not the seed itself, not subdomains, not invalid hosts).
+ *
+ * Tests inject a `fetchFn` rather than spying on `safeFetch` — the implementation
+ * exposes the dependency for exactly this reason.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { correlateSans } from '../../../src/csc/discovery/san-correlator';
+
+interface CrtShFixtureEntry {
+	id?: number;
+	name_value: string;
+	entry_timestamp?: string;
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+	const text = JSON.stringify(body);
+	return new Response(text, {
+		status: 200,
+		headers: { 'content-type': 'application/json', 'content-length': String(text.length) },
+		...init,
+	});
+}
+
+function mockFetchOk(entries: CrtShFixtureEntry[]): typeof fetch {
+	return vi.fn().mockResolvedValue(jsonResponse(entries)) as unknown as typeof fetch;
+}
+
+describe('correlateSans', () => {
+	it('returns sibling SANs from a single cert (happy path)', async () => {
+		const fetchFn = mockFetchOk([
+			{ id: 1, name_value: 'foo.com\nbar.com\nbaz.com' },
+		]);
+		const result = await correlateSans('foo.com', { fetchFn });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['bar.com', 'baz.com']);
+		expect(result.seedDomain).toBe('foo.com');
+	});
+
+	it('drops wildcards and subdomains of the seed', async () => {
+		const fetchFn = mockFetchOk([
+			{ id: 1, name_value: '*.example.com\nexample.com\nshop.example.com' },
+		]);
+		const result = await correlateSans('example.com', { fetchFn });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+
+	it('deduplicates SANs across multiple certs and sorts the result', async () => {
+		const fetchFn = mockFetchOk([
+			{ id: 1, name_value: 'foo.com\nbar.com\ncharlie.com' },
+			{ id: 2, name_value: 'foo.com\nbar.com\nalpha.com' },
+		]);
+		const result = await correlateSans('foo.com', { fetchFn });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['alpha.com', 'bar.com', 'charlie.com']);
+	});
+
+	it('caps the cert count via maxCertsPerDomain', async () => {
+		const entries: CrtShFixtureEntry[] = [];
+		for (let i = 0; i < 100; i++) {
+			entries.push({
+				id: i,
+				name_value: `foo.com\nsibling${i}.com`,
+				entry_timestamp: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+			});
+		}
+		const fetchFn = mockFetchOk(entries);
+		const result = await correlateSans('foo.com', { fetchFn, maxCertsPerDomain: 10 });
+		expect(result.queryStatus).toBe('ok');
+		// Most-recent first ⇒ siblings 90..99 (10 items)
+		expect(result.coOwnedDomains.length).toBe(10);
+		const sortedExpected = Array.from({ length: 10 }, (_, k) => `sibling${90 + k}.com`).sort();
+		expect(result.coOwnedDomains).toEqual(sortedExpected);
+	});
+
+	it('throws on invalid seed input with the expected error prefix', async () => {
+		await expect(correlateSans('not a domain')).rejects.toThrow(/^Domain validation failed:/);
+	});
+
+	it('returns rate_limited status on 429 without throwing', async () => {
+		const fetchFn = vi.fn().mockResolvedValue(new Response('rate', { status: 429 })) as unknown as typeof fetch;
+		const result = await correlateSans('foo.com', { fetchFn });
+		expect(result.queryStatus).toBe('rate_limited');
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+
+	it('returns timeout status when fetch throws an AbortError', async () => {
+		const abortErr = new Error('aborted');
+		abortErr.name = 'AbortError';
+		const fetchFn = vi.fn().mockRejectedValue(abortErr) as unknown as typeof fetch;
+		const result = await correlateSans('foo.com', { fetchFn });
+		expect(result.queryStatus).toBe('timeout');
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+
+	it('returns error status on a generic network failure without throwing', async () => {
+		const fetchFn = vi.fn().mockRejectedValue(new TypeError('network down')) as unknown as typeof fetch;
+		const result = await correlateSans('foo.com', { fetchFn });
+		expect(result.queryStatus).toBe('error');
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+
+	it('silently drops invalid SAN entries while keeping valid ones', async () => {
+		const fetchFn = mockFetchOk([
+			{ id: 1, name_value: 'valid.com\nnot a domain\nfoo.com' },
+		]);
+		const result = await correlateSans('foo.com', { fetchFn });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['valid.com']);
+	});
+
+	it('drops the seed itself even when present in SAN list', async () => {
+		const fetchFn = mockFetchOk([
+			{ id: 1, name_value: 'foo.com\nFoo.com\nbar.com' },
+		]);
+		const result = await correlateSans('foo.com', { fetchFn });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['bar.com']);
+	});
+});


### PR DESCRIPTION
## Summary
Tier-1 signal in the brand-discovery pipeline: query crt.sh for a seed domain, extract every Subject Alternative Name from the returned certs, filter to sibling domains (not seed, not subdomain), validate. Result is a near-deterministic list of co-owned domains.

Adopted from technique used by [bit4woo/teemo](https://github.com/bit4woo/teemo) (1k⭐). High-confidence signal at near-zero query cost — CT logs are free and public.

## Files
- \`src/tenant/discovery/san-correlator.ts\` — \`correlateSans(seedDomain, options?)\` returns \`{ seedDomain, coOwnedDomains[], certIds[], queryStatus }\`
- \`src/tenant/discovery/index.ts\` — barrel re-export
- \`test/tenant/discovery/san-correlator.test.ts\` — 10 unit tests

## Notable design
- Uses \`safeFetch\` (existing SSRF guard) — seedDomain comes from caller, crt.sh URL is constant.
- \`fetchFn\` injection for the test seam (no \`vi.spyOn(safeFetch)\`).
- Subdomain filter: \`endsWith('.' + seed)\` so \`notexample.com\` isn't dropped when seed is \`example.com\`.
- \`name_value\` split on both \`\\n\` and \`,\` (crt.sh varies by query type).
- Sort certs by \`entry_timestamp\` desc before applying \`maxCertsPerDomain\` cap.
- 5MB body cap with content-length pre-flight + post-read guard.
- Status: 429 → \`rate_limited\`, AbortError → \`timeout\`, else → \`error\`. Doesn't throw on network/rate-limit/timeout.

## TDD evidence
RED: 10 failed (\`Error: not implemented\`). GREEN: 10/10 pass.

## Verification
- \`npx vitest run test/tenant/discovery/\` ✅ 10/10
- \`npm run typecheck\` clean
- Standalone — no dependency on the other 3 tenant PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)