### PR TITLE
fix(cache): don't cache partial results (F5 — bv-web 2026-05-14 analytics)

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -2,7 +2,7 @@
 
 import type { CheckResult } from '../lib/scoring';
 import type { QueryDnsOptions, SecondaryDohConfig } from '../lib/dns-types';
-import { runWithCacheTracked, cacheDelete } from '../lib/cache';
+import { runWithCacheTracked } from '../lib/cache';
 import { sanitizeErrorMessage } from '../lib/json-rpc';
 import { checkSpf } from '../tools/check-spf';
 import { checkDmarc } from '../tools/check-dmarc';
@@ -258,11 +258,17 @@ export async function handleToolsCall(
 			if (registeredTool) {
 				const checkName = registeredTool.cacheKey(validatedArgs);
 				const cacheKey = `cache:${validDomain}:check:${checkName}`;
-				const { data: result, cacheStatus } = await runWithCacheTracked(cacheKey, () => registeredTool.execute(validDomain, validatedArgs, runtimeOptions), scanCacheKV, registeredTool.cacheTtlSeconds);
-				// Don't cache partial results (e.g. lookalike timeout) — evict what runWithCacheTracked just stored
-				if (result.partial) {
-					await cacheDelete(cacheKey, scanCacheKV);
-				}
+				// Don't cache partial results (e.g. lookalike timeout). The predicate skips the
+				// kv.put entirely instead of the old put-then-delete anti-pattern that drove
+				// ~13M wasted SCAN_CACHE writes/week (bv-web 2026-05-14 analytics, cluster F5).
+				const { data: result, cacheStatus } = await runWithCacheTracked(
+					cacheKey,
+					() => registeredTool.execute(validDomain, validatedArgs, runtimeOptions),
+					scanCacheKV,
+					registeredTool.cacheTtlSeconds,
+					/* skipCache */ undefined,
+					(r) => !r.partial,
+				);
 				runtimeOptions?.resultCapture?.(result);
 				logResult = result.passed ? 'pass' : 'fail';
 				logDetails = result;

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -207,9 +207,13 @@ export async function cacheSet(key: string, value: unknown, kv?: KVNamespace, tt
  * @param kv - Optional KV namespace for persistent caching
  * @param ttlSeconds - Cache TTL in seconds (default: 300 = 5 minutes)
  * @param skipCache - When true, bypass cache lookup and always execute the function (result is still cached)
+ * @param shouldCache - Optional predicate. When provided and returns false for the computed
+ *   result, the result is NOT written to KV / in-memory cache. Sentinel cleanup still runs.
+ *   Used to suppress caching of partial results (e.g. lookalike timeouts) without the
+ *   put-then-delete anti-pattern. See bv-web 2026-05-14 analytics remediation (cluster F5).
  * @returns The cached or freshly computed result
  */
-export async function runWithCache<T>(key: string, run: () => Promise<T>, kv?: KVNamespace, ttlSeconds?: number, skipCache?: boolean): Promise<T> {
+export async function runWithCache<T>(key: string, run: () => Promise<T>, kv?: KVNamespace, ttlSeconds?: number, skipCache?: boolean, shouldCache?: (result: T) => boolean): Promise<T> {
 	if (!skipCache) {
 		const cached = await cacheGet<T>(key, kv);
 		if (cached !== undefined) return cached;
@@ -241,8 +245,12 @@ export async function runWithCache<T>(key: string, run: () => Promise<T>, kv?: K
 	const cleanup = setTimeout(() => INFLIGHT.delete(key), INFLIGHT_CLEANUP_MS);
 	const promise = run()
 		.then(async (result) => {
-			await cacheSet(key, result, kv, ttlSeconds);
-			// Clean up sentinel
+			// Only persist if the caller's predicate accepts the result.
+			// Default (no predicate) is to cache everything.
+			if (!shouldCache || shouldCache(result)) {
+				await cacheSet(key, result, kv, ttlSeconds);
+			}
+			// Clean up sentinel regardless — we still claimed the computation slot.
 			if (kv) {
 				try { await kv.delete(`${key}:computing`); } catch { /* best-effort */ }
 			}
@@ -272,6 +280,9 @@ export interface CacheResult<T> {
 /**
  * Like `runWithCache`, but returns cache hit/miss metadata alongside the result.
  * Used where callers need to report cache status (e.g. analytics).
+ *
+ * @param shouldCache - Optional predicate. When provided and returns false, the
+ *   freshly-computed result is NOT written to KV. See {@link runWithCache} for context.
  */
 export async function runWithCacheTracked<T>(
 	key: string,
@@ -279,13 +290,14 @@ export async function runWithCacheTracked<T>(
 	kv?: KVNamespace,
 	ttlSeconds?: number,
 	skipCache?: boolean,
+	shouldCache?: (result: T) => boolean,
 ): Promise<CacheResult<T>> {
 	if (!skipCache) {
 		const cached = await cacheGet<T>(key, kv);
 		if (cached !== undefined) return { data: cached, cacheStatus: 'hit' };
 	}
 
-	const data = await runWithCache(key, run, kv, ttlSeconds, true);
+	const data = await runWithCache(key, run, kv, ttlSeconds, true, shouldCache);
 	return { data, cacheStatus: 'miss' };
 }
 

--- a/test/cache-should-cache.spec.ts
+++ b/test/cache-should-cache.spec.ts
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the `shouldCache` predicate on runWithCache / runWithCacheTracked.
+ *
+ * Regression gate for bv-web 2026-05-14 analytics remediation (cluster F5):
+ * the call site in src/handlers/tools.ts used to kv.put every result and then
+ * kv.delete partial ones — driving ~13M wasted SCAN_CACHE writes/week. The
+ * shouldCache predicate skips the put entirely.
+ *
+ * Layer: unit. Uses real IN_MEMORY_CACHE (sociable); KV is mocked only where
+ * verifying the kv.put side-effect is the point.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { runWithCache, runWithCacheTracked, IN_MEMORY_CACHE } from '../src/lib/cache';
+
+const notPartial = (r: { partial?: boolean }) => !r.partial;
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	IN_MEMORY_CACHE.clear();
+});
+
+describe('runWithCache — shouldCache predicate', () => {
+	it('skips cache write when predicate returns false (no-KV / in-memory path)', async () => {
+		await runWithCache(
+			'inmem:partial',
+			async () => ({ partial: true, value: 'x' }),
+			undefined,
+			undefined,
+			undefined,
+			notPartial,
+		);
+		expect(IN_MEMORY_CACHE.get('inmem:partial')).toBeUndefined();
+	});
+
+	it('still writes cache when predicate returns true (no-KV / in-memory path)', async () => {
+		await runWithCache(
+			'inmem:complete',
+			async () => ({ partial: false, value: 'y' }),
+			undefined,
+			undefined,
+			undefined,
+			notPartial,
+		);
+		expect(IN_MEMORY_CACHE.get('inmem:complete')).toEqual({ partial: false, value: 'y' });
+	});
+
+	it('does not invoke kv.put on the result key when predicate returns false', async () => {
+		// KV is the external boundary; mocking it is principle-8 compliant.
+		const mockKV = {
+			get: vi.fn().mockResolvedValue(null),
+			put: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+		await runWithCache(
+			'kv:partial',
+			async () => ({ partial: true }),
+			mockKV as unknown as KVNamespace,
+			300,
+			undefined,
+			notPartial,
+		);
+		const resultPut = mockKV.put.mock.calls.find(
+			(c) => (c[0] as string) === 'kv:partial',
+		);
+		// The whole point of the F5 fix: no result-key put for partial results.
+		expect(resultPut).toBeUndefined();
+		// Sentinel cleanup must still run so future callers don't poll a stale lock.
+		expect(mockKV.delete).toHaveBeenCalledWith('kv:partial:computing');
+	});
+
+	it('runWithCacheTracked threads the predicate through', async () => {
+		const { data, cacheStatus } = await runWithCacheTracked(
+			'tracked:partial',
+			async () => ({ partial: true, value: 'z' }),
+			undefined,
+			undefined,
+			undefined,
+			notPartial,
+		);
+		expect(data).toEqual({ partial: true, value: 'z' });
+		expect(cacheStatus).toBe('miss');
+		expect(IN_MEMORY_CACHE.get('tracked:partial')).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

- **Cluster F5** of the bv-web 2026-05-14 Cloudflare analytics remediation. `bv-dns-security-mcp-SCAN_CACHE` was showing 27M puts alongside 13M deletes over a 7-day window — a put-then-delete anti-pattern where `runWithCacheTracked` cached every result, then partial results (e.g. lookalike timeouts) were immediately `kv.delete()`'d at the callsite in `src/handlers/tools.ts:261-264`.
- **Fix**: add an optional `shouldCache?: (result: T) => boolean` predicate to `runWithCache` and thread it through `runWithCacheTracked`. The callsite now passes `(r) => !r.partial`, so partial results skip the put entirely. Chose Approach B over caller-side caching (Approach A) to preserve the cross-isolate KV sentinel dedup and the per-isolate `INFLIGHT` stampede guard that Approach A would have silently dropped.
- **Side benefit**: closes a sub-millisecond consistency window where a partial result was cached between `put` and `delete` and could leak to a concurrent reader.

## Test plan

- [x] New unit suite `test/cache-should-cache.spec.ts` — RED before the fix (3/4 fail), GREEN after (4/4 pass)
- [x] `test/cache.spec.ts` + `test/handlers-tools.spec.ts` still pass (104/104)
- [x] `tsc --noEmit` clean
- [ ] Reviewer: confirm no production caller relies on the ~1ms eviction window for any other purpose (only known caller is the F5 path)

## Cross-repo context

Parent task: `bv-web docs/plans/2026-05-14-cloudflare-analytics-remediation-tdd-plan.md`. Plan + analytics evidence live in the bv-web worktree `chore/cf-analytics-remediation-2026-05-14`.