### PR TITLE
fix(whois-transport): sequence write fully before read; don't close writer

### DIFF
--- a/packages/bv-whois/src/__tests__/transport.test.ts
+++ b/packages/bv-whois/src/__tests__/transport.test.ts
@@ -111,6 +111,37 @@ describe('whoisQuery', () => {
 		).rejects.toThrow(/invalid|numeric/i);
 	});
 
+	it('does NOT call writer.close() — regression: 100-domain chaos run showed 98/98 zero-byte reads', async () => {
+		// cloudflare:sockets has no half-close: calling `writer.close()` shuts down the
+		// entire socket and the server never sees our query before the FIN. The prior
+		// async-fire-and-forget pattern called writer.close() and produced 100% empty reads.
+		// Invariant: our transport must release the writer's lock, not close it.
+		let writerCloseCalled = false;
+
+		const factory: SocketFactory = {
+			async connect() {
+				return {
+					writable: new WritableStream({
+						write() {},
+						close() { writerCloseCalled = true; },
+					}),
+					readable: new ReadableStream({
+						start(controller) {
+							controller.enqueue(new TextEncoder().encode('Registrar: TestReg\n'));
+							controller.close();
+						},
+					}),
+					close: () => Promise.resolve(),
+				};
+			},
+		};
+
+		const result = await whoisQuery('whois.example.com', 'q', { socketFactory: factory });
+
+		expect(writerCloseCalled).toBe(false);
+		expect(result).toContain('Registrar: TestReg');
+	});
+
 	it('concatenates multi-chunk reads into a single response string', async () => {
 		const factory: SocketFactory = {
 			async connect() {

--- a/packages/bv-whois/src/transport.ts
+++ b/packages/bv-whois/src/transport.ts
@@ -13,6 +13,8 @@ export interface SocketLike {
 	writable: WritableStream<Uint8Array>;
 	readable: ReadableStream<Uint8Array>;
 	close(): Promise<void>;
+	/** Promise that resolves when the TCP handshake completes (or rejects on connection failure). */
+	opened?: Promise<unknown>;
 }
 
 /** Pluggable socket factory — production uses `cloudflare:sockets`. */
@@ -87,12 +89,23 @@ export async function whoisQuery(
 
 	const socket = await factory.connect({ hostname: server, port: WHOIS_PORT });
 
-	// Fire-and-await the write, but don't let it pin the whole budget.
+	// Wait for the TCP handshake to complete before writing. cloudflare:sockets'
+	// `connect()` returns a Socket immediately but the connection isn't actually
+	// open yet.
+	if (socket.opened) {
+		await socket.opened;
+	}
+
+	// Write the query AND complete the write before starting to read.
+	// `cloudflare:sockets` has no half-close: calling `writer.close()` closes
+	// the entire socket. We must NOT call it — the WHOIS server signals
+	// end-of-response by closing its side, which gives us EOF on read.
+	// 100-domain chaos run with the previous async-write-fire-and-forget pattern
+	// produced 98/98 zero-byte reads because the read loop started before the
+	// write flushed and the socket closure raced the data.
 	const writer = socket.writable.getWriter();
-	const writePromise = (async () => {
-		await writer.write(new TextEncoder().encode(`${query}\r\n`));
-		await writer.close();
-	})().catch(() => { /* socket errors will surface on read */ });
+	await writer.write(new TextEncoder().encode(`${query}\r\n`));
+	writer.releaseLock();
 
 	const reader = socket.readable.getReader();
 	const decoder = new TextDecoder();
@@ -128,7 +141,6 @@ export async function whoisQuery(
 	} finally {
 		try { reader.releaseLock(); } catch { /* ignore */ }
 		try { await socket.close(); } catch { /* ignore */ }
-		await writePromise;
 	}
 
 	const full = chunks.join('');


### PR DESCRIPTION
## Summary

100-domain chaos test on the freshly-deployed v2.15.0 shim showed **98/98 zero-byte reads** — uniform across 10 different TLDs and registry servers, so not a server-side issue.

### Root cause

`cloudflare:sockets` has no half-close. The merged transport called `writer.close()` in a fire-and-forget async block:

```ts
const writePromise = (async () => {
    await writer.write(...);
    await writer.close();   // ← closes the ENTIRE socket
})().catch(() => {});
// reader.read() starts immediately, races the write
```

When `writer.close()` ran, both socket halves shut down. The server saw FIN before our query bytes flushed, sent no response, and our read returned EOF with 0 bytes.

### Fix

- `await writer.write()` synchronously before getting the reader
- `writer.releaseLock()` instead of `writer.close()` — release the lock but keep the socket open so the server can stream its response
- WHOIS servers terminate naturally by closing their side; our reader sees EOF without us closing the write half

### Verification — 100-domain chaos run post-fix

| TLD | Result |
|---|---|
| `.com` | 10/10 ✓ |
| `.us` | 10/10 ✓ |
| `.co` | 9/10 |
| `.me` | 9/10 (resolves the original brand-audit ccTLD gap) |
| `.io` | 9/10 |
| `.ca` | 8/10 |
| `.sh` | 6/10 |
| `.fr` | 5/10 |
| `.de` | 0/10 — needs DENIC redaction parser follow-up |
| `.uk` | 0/10 — needs Nominet format parser follow-up |

**66% overall success** (was 0%). Remaining failures are TLD-specific parser gaps, not transport issues — tracked as separate follow-ups.

### Regression test

Added a direct invariant test: `writer.close()` must NOT be called by the transport. Catches any future regression of the cloudflare:sockets quirk.

bv-whois tests: 34 → 35 passing.

## Test plan
- [x] Local unit tests pass (`npm -w packages/bv-whois test` → 35/35)
- [x] Deployed + verified live: `curl POST /lookup {"domain":"google.me"}` returns `MarkMonitor Inc.`
- [x] 100-domain chaos run: 66 whois / 33 error / 1 notfound (vs. 0 / 100 / 0 pre-fix)
- [ ] Post-merge: `.de` and `.uk` parser improvements (separate PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)