### PR TITLE
docs(claude-md): add BV_WHOIS row to Bindings table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -539,6 +539,7 @@ To maintain the public/private architectural split, this repository uses an auto
 | `BV_DOH_ENDPOINT` | var | Custom secondary DoH URL (fallback: Google) |
 | `BV_DOH_TOKEN` | Secret | Auth for bv-dns (`X-BV-Token` header) |
 | `BV_CERTSTREAM` | Service | CT log subdomain cache (optional, falls back to crt.sh) |
+| `BV_WHOIS` | Service | WHOIS-over-TCP/43 shim Worker (`bv-whois`) — optional; `check_rdap_lookup` falls back to RDAP-only when unset. KV-cached IANA referrals, 15 hardcoded fast-path TLDs. v2.15.0+ |
 | `SCORING_CONFIG` | var | JSON scoring overrides (optional) |
 | `CF_ACCOUNT_ID` | var | Cloudflare account ID (alerting) |
 | `CF_ANALYTICS_TOKEN` | Secret | Analytics Engine read token (alerting) |


### PR DESCRIPTION
Follow-up to v2.15.0 (PR #116). One-line addition to the CLAUDE.md `Bindings` table documenting the new optional service binding to the bv-whois shim Worker.

When unset: `check_rdap_lookup` remains RDAP-only (same as v2.14.x — no regression). When set: enables ccTLD coverage (`.me/.us/.co/.io/.sh`) that have no public RDAP servers.

Deferred from PR #116 to avoid rebase conflicts with #115 (CLAUDE.md cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)