### PR TITLE
chore(brand-audit): re-run with live BV_WHOIS shim; consolidate 13 prior-Unknown candidates

### DIFF
--- a/reports/CONSOLIDATED_BRAND_AUDIT.md
+++ b/reports/CONSOLIDATED_BRAND_AUDIT.md
@@ -6,9 +6,9 @@
 
 ## Headline
 
-- **23** consolidated (same registrar as target, centrally managed)
-- **17** shadow IT / provider sprawl (high-confidence brand signal on a different or unknown registrar)
-- **4** likely impersonation / low-confidence noise
+- **36** consolidated (same registrar as target, centrally managed)
+- **5** shadow IT / provider sprawl (high-confidence brand signal on a different or unknown registrar)
+- **3** likely impersonation / low-confidence noise
 
 ### Premise check: how many targets actually use CSC?
 
@@ -42,17 +42,17 @@
 | `google.info` | MarkMonitor Inc. | NS | 1 |
 | `google.net` | MarkMonitor Inc. | NS | 1 |
 | `google.org` | MarkMonitor Inc. | NS | 1 |
+| `google.co` | MarkMonitor, Inc. | NS | 1 |
+| `google.io` | MarkMonitor Inc. | NS | 1 |
+| `google.me` | MarkMonitor Inc. | NS | 1 |
+| `google.sh` | MarkMonitor Inc. | NS | 1 |
+| `google.us` | MarkMonitor, Inc. | NS | 1 |
 
 **Shadow IT / Provider Sprawl** (high-confidence, different registrar):
 
 | Domain | Registrar | Evidence | Confidence |
 |---|---|---|---:|
-| `google.co` | Unknown | NS | 1 |
 | `google.de` | Unknown | NS | 1 |
-| `google.io` | Unknown | NS | 1 |
-| `google.me` | Unknown | NS | 1 |
-| `google.sh` | Unknown | NS | 1 |
-| `google.us` | Unknown | NS | 1 |
 
 ### amazon.com — primary: MarkMonitor (1 registrar families across portfolio)
 
@@ -75,16 +75,16 @@ _No candidate domains surfaced by discovery signals._
 | `apple.info` | Nom-iq Ltd. dba COM LAUDE | NS | 1 |
 | `apple.net` | Nom-iq Ltd. dba COM LAUDE | NS | 1 |
 | `apple.uk` | Nom-IQ Limited t/a Com Laude | NS | 1 |
+| `apple.co` | Nom-iq Ltd. dba COM LAUDE | NS | 1 |
+| `apple.me` | Nom-iq Ltd. dba COM LAUDE | NS | 1 |
+| `apple.us` | Nom-iq Ltd. dba COM LAUDE | NS | 1 |
 
 **Shadow IT / Provider Sprawl** (high-confidence, different registrar):
 
 | Domain | Registrar | Evidence | Confidence |
 |---|---|---|---:|
 | `apple.ca` | Tucows.com Co. | NS | 1 |
-| `apple.co` | Unknown | NS | 1 |
 | `apple.de` | Unknown | NS | 1 |
-| `apple.me` | Unknown | NS | 1 |
-| `apple.us` | Unknown | NS | 1 |
 
 ### disney.com — primary: CSC (1 registrar families across portfolio)
 
@@ -109,16 +109,16 @@ _No candidate domains surfaced by discovery signals._
 | `paypal.biz` | MarkMonitor, Inc. | NS | 1 |
 | `paypal.ca` | MarkMonitor International Canada Ltd. | NS | 1 |
 | `paypal.fr` | MARKMONITOR Inc. | NS | 1 |
+| `paypal.co` | MarkMonitor, Inc. | NS | 1 |
+| `paypal.me` | MarkMonitor Inc. | NS | 1 |
 
 **Shadow IT / Provider Sprawl** (high-confidence, different registrar):
 
 | Domain | Registrar | Evidence | Confidence |
 |---|---|---|---:|
-| `paypal.co` | Unknown | NS | 1 |
 | `paypal.de` | Unknown | NS | 1 |
-| `paypal.me` | Unknown | NS | 1 |
 
-### stripe.com — primary: SafeNames (2 registrar families across portfolio)
+### stripe.com — primary: SafeNames (1 registrar families across portfolio)
 
 **Consolidated** (same registrar family as target):
 
@@ -127,15 +127,10 @@ _No candidate domains surfaced by discovery signals._
 | `stripe.fr` | SAFENAMES LTD | NS | 1 |
 | `stripe.net` | SafeNames Ltd. | NS | 1 |
 | `stripe.uk` | Safenames Ltd | NS | 1 |
+| `stripe.me` | SafeNames Ltd. | NS | 1 |
+| `stripe.sh` | SafeNames Ltd. | NS | 1 |
 
-**Shadow IT / Provider Sprawl** (high-confidence, different registrar):
-
-| Domain | Registrar | Evidence | Confidence |
-|---|---|---|---:|
-| `stripe.me` | Unknown | NS | 1 |
-| `stripe.sh` | Unknown | NS | 1 |
-
-### walmart.com — primary: CSC (3 registrar families across portfolio)
+### walmart.com — primary: CSC (2 registrar families across portfolio)
 
 **Shadow IT / Provider Sprawl** (high-confidence, different registrar):
 
@@ -148,16 +143,16 @@ _No candidate domains surfaced by discovery signals._
 | Domain | Registrar | Evidence | Confidence |
 |---|---|---|---:|
 | `walmart.app` | MarkMonitor Inc. | NS | 0.5 |
-| `walmart.io` | Unknown | NS | 0.5 |
+| `walmart.io` | MarkMonitor Inc. | NS | 0.5 |
 | `walmart.org` | MarkMonitor Inc. | NS | 0.5 |
 
-### github.com — primary: MarkMonitor (2 registrar families across portfolio)
+### github.com — primary: MarkMonitor (1 registrar families across portfolio)
 
-**Impersonation / Low Confidence**:
+**Consolidated** (same registrar family as target):
 
 | Domain | Registrar | Evidence | Confidence |
 |---|---|---|---:|
-| `github.me` | Unknown | NS | 0.5 |
+| `github.me` | MarkMonitor Inc. | NS | 0.5 |
 
 ### blackveilsecurity.com — primary: Cloudflare (1 registrar families across portfolio)
 
@@ -173,11 +168,12 @@ Across all 44 candidate domains:
 
 | Registrar | Candidates |
 |---|---:|
-| Unknown | 17 |
-| MarkMonitor Inc. | 6 |
-| Nom-iq Ltd. dba COM LAUDE | 4 |
+| MarkMonitor Inc. | 12 |
+| Nom-iq Ltd. dba COM LAUDE | 7 |
+| MarkMonitor, Inc. | 5 |
 | MarkMonitor International Canada Ltd. | 3 |
-| MarkMonitor, Inc. | 2 |
+| Unknown | 3 |
+| SafeNames Ltd. | 3 |
 | MARKMONITOR Inc. | 2 |
 | CSC Corporate Domains, Inc. | 2 |
 | Nom-IQ Limited dba Com Laude | 1 |
@@ -185,7 +181,6 @@ Across all 44 candidate domains:
 | Nom-IQ Limited t/a Com Laude | 1 |
 | Tucows.com Co. | 1 |
 | SAFENAMES LTD | 1 |
-| SafeNames Ltd. | 1 |
 | Safenames Ltd | 1 |
 | Cloudflare, Inc | 1 |
 

--- a/reports/csc-audit-results.json
+++ b/reports/csc-audit-results.json
@@ -37,41 +37,41 @@
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
         "confidence": 1
-      }
-    ],
-    "shadowIt": [
-      {
-        "domain": "google.co",
-        "registrar": "Unknown",
-        "evidence": "NS",
-        "confidence": 1
       },
       {
-        "domain": "google.de",
-        "registrar": "Unknown",
+        "domain": "google.co",
+        "registrar": "MarkMonitor, Inc.",
         "evidence": "NS",
         "confidence": 1
       },
       {
         "domain": "google.io",
-        "registrar": "Unknown",
+        "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
         "confidence": 1
       },
       {
         "domain": "google.me",
-        "registrar": "Unknown",
+        "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
         "confidence": 1
       },
       {
         "domain": "google.sh",
-        "registrar": "Unknown",
+        "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
         "confidence": 1
       },
       {
         "domain": "google.us",
+        "registrar": "MarkMonitor, Inc.",
+        "evidence": "NS",
+        "confidence": 1
+      }
+    ],
+    "shadowIt": [
+      {
+        "domain": "google.de",
         "registrar": "Unknown",
         "evidence": "NS",
         "confidence": 1
@@ -135,6 +135,24 @@
         "registrar": "Nom-IQ Limited t/a Com Laude",
         "evidence": "NS",
         "confidence": 1
+      },
+      {
+        "domain": "apple.co",
+        "registrar": "Nom-iq Ltd. dba COM LAUDE",
+        "evidence": "NS",
+        "confidence": 1
+      },
+      {
+        "domain": "apple.me",
+        "registrar": "Nom-iq Ltd. dba COM LAUDE",
+        "evidence": "NS",
+        "confidence": 1
+      },
+      {
+        "domain": "apple.us",
+        "registrar": "Nom-iq Ltd. dba COM LAUDE",
+        "evidence": "NS",
+        "confidence": 1
       }
     ],
     "shadowIt": [
@@ -145,25 +163,7 @@
         "confidence": 1
       },
       {
-        "domain": "apple.co",
-        "registrar": "Unknown",
-        "evidence": "NS",
-        "confidence": 1
-      },
-      {
         "domain": "apple.de",
-        "registrar": "Unknown",
-        "evidence": "NS",
-        "confidence": 1
-      },
-      {
-        "domain": "apple.me",
-        "registrar": "Unknown",
-        "evidence": "NS",
-        "confidence": 1
-      },
-      {
-        "domain": "apple.us",
         "registrar": "Unknown",
         "evidence": "NS",
         "confidence": 1
@@ -222,23 +222,23 @@
         "registrar": "MARKMONITOR Inc.",
         "evidence": "NS",
         "confidence": 1
-      }
-    ],
-    "shadowIt": [
-      {
-        "domain": "paypal.co",
-        "registrar": "Unknown",
-        "evidence": "NS",
-        "confidence": 1
       },
       {
-        "domain": "paypal.de",
-        "registrar": "Unknown",
+        "domain": "paypal.co",
+        "registrar": "MarkMonitor, Inc.",
         "evidence": "NS",
         "confidence": 1
       },
       {
         "domain": "paypal.me",
+        "registrar": "MarkMonitor Inc.",
+        "evidence": "NS",
+        "confidence": 1
+      }
+    ],
+    "shadowIt": [
+      {
+        "domain": "paypal.de",
         "registrar": "Unknown",
         "evidence": "NS",
         "confidence": 1
@@ -266,22 +266,21 @@
         "registrar": "Safenames Ltd",
         "evidence": "NS",
         "confidence": 1
-      }
-    ],
-    "shadowIt": [
+      },
       {
         "domain": "stripe.me",
-        "registrar": "Unknown",
+        "registrar": "SafeNames Ltd.",
         "evidence": "NS",
         "confidence": 1
       },
       {
         "domain": "stripe.sh",
-        "registrar": "Unknown",
+        "registrar": "SafeNames Ltd.",
         "evidence": "NS",
         "confidence": 1
       }
     ],
+    "shadowIt": [],
     "impersonation": []
   },
   {
@@ -304,7 +303,7 @@
       },
       {
         "domain": "walmart.io",
-        "registrar": "Unknown",
+        "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
         "confidence": 0.5
       },
@@ -318,16 +317,16 @@
   },
   {
     "target": "github.com",
-    "consolidated": [],
-    "shadowIt": [],
-    "impersonation": [
+    "consolidated": [
       {
         "domain": "github.me",
-        "registrar": "Unknown",
+        "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
         "confidence": 0.5
       }
-    ]
+    ],
+    "shadowIt": [],
+    "impersonation": []
   },
   {
     "target": "blackveilsecurity.com",

--- a/scripts/csc-rdap-fill.spec.ts
+++ b/scripts/csc-rdap-fill.spec.ts
@@ -17,6 +17,25 @@ import { describe, it } from 'vitest';
 import { readFileSync, writeFileSync } from 'fs';
 import { checkRdapLookup } from '../src/tools/check-rdap-lookup';
 
+/**
+ * Production-shaped Fetcher that targets the live bv-whois shim Worker. This is
+ * what the `BV_WHOIS` service binding does at runtime; in node env we just hit
+ * the public URL so the audit exercises the same end-to-end fallback path.
+ */
+const LIVE_WHOIS_BINDING: { fetch: typeof fetch } = {
+	async fetch(input: RequestInfo, init?: RequestInit) {
+		// Rewrite the "internal" hostname (https://bv-whois/lookup) to the live shim.
+		const req = typeof input === 'string' ? new Request(input, init) : input;
+		const path = new URL(req.url).pathname;
+		const target = `https://bv-whois.bv-edge.workers.dev${path}`;
+		return fetch(target, {
+			method: req.method,
+			headers: req.headers,
+			body: req.method === 'GET' || req.method === 'HEAD' ? undefined : await req.clone().text(),
+		});
+	},
+};
+
 const TARGETS = [
 	'google.com', 'amazon.com', 'microsoft.com', 'apple.com', 'disney.com',
 	'nike.com', 'paypal.com', 'stripe.com', 'walmart.com', 'github.com',
@@ -48,7 +67,7 @@ interface TargetResult { target: string; consolidated: Candidate[]; shadowIt: Ca
 
 async function lookupRegistrar(domain: string): Promise<string> {
 	try {
-		const rdap = await checkRdapLookup(domain);
+		const rdap = await checkRdapLookup(domain, { whoisBinding: LIVE_WHOIS_BINDING });
 		const rFind = rdap.findings.find(
 			f => typeof f.metadata?.registrar === 'string' && (f.metadata.registrar as string).length > 0,
 		);


### PR DESCRIPTION
## Summary

Re-ran the corporate-registrar brand audit after shipping the full WHOIS fallback path (#116, #117, #119). The shim now resolves ccTLD candidates that returned `Unknown` registrar in the v2.15.0 baseline, so the classifier correctly recognizes defensive registrations on the target's primary registrar instead of mis-bucketing them as shadow IT.

### Change

- The rdap-fill calibration spec — inject a `LIVE_WHOIS_BINDING` Fetcher that targets `https://bv-whois.bv-edge.workers.dev`. Mirrors what the `BV_WHOIS` service binding does at runtime; in node env we hit the public URL. Spec now exercises the same fallback path as production.
- The audit-results JSON under `reports/` — re-classified output.
- `reports/CONSOLIDATED_BRAND_AUDIT.md` — regenerated.

### Headline shift

| Bucket | Pre-WHOIS | Post-WHOIS | Δ |
|---|---:|---:|---:|
| Consolidated | 23 | **36** | +13 |
| Shadow IT / sprawl | 17 | **5** | −12 |
| Impersonation | 4 | **3** | −1 |

Per-target moves (consolidated count, after / before):
- `google.com` 11 / 6 — five `.{biz,ca,co,fr,info,...}` variants resolved on MarkMonitor
- `apple.com` 10 / 7 — three more on Com Laude
- `paypal.com` 6 / 4
- `stripe.com` 5 / 3 — all four on SafeNames now visible
- `github.com` 1 / 0
- `walmart.com` 0 / 0 — defensive registrations are on MarkMonitor (sprawl) not the target's primary registrar, correctly stays in shadow

### Remaining shadow IT (5 — all real findings or DENIC redacted)

| Candidate | Registrar | Why still in shadow |
|---|---|---|
| `google.de`, `apple.de`, `paypal.de` | DENIC-redacted (null) | Shim returns `source: redacted` but the spec's classifier maps `null` registrar → "Unknown" → shadow. Refinement: 4th "indeterminate" bucket or redacted-aware classifier. |
| `apple.ca` | Tucows.com Co. | Real sprawl — Apple's primary is Com Laude |
| `walmart.ca` | MarkMonitor Canada | Real sprawl — Walmart's primary is the corporate registrar under audit |

## Test plan

- [x] Audit spec runs end-to-end (~29s, 1 RDAP + 0/1 WHOIS calls per candidate)
- [x] Re-classification yields expected per-target shifts
- [x] All existing dns-checks / bv-whois / bv-mcp tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)