### PR TITLE
chore(brand-audit): add 4th 'indeterminate' bucket for DENIC-redacted candidates

### DIFF
--- a/reports/CONSOLIDATED_BRAND_AUDIT.md
+++ b/reports/CONSOLIDATED_BRAND_AUDIT.md
@@ -2,12 +2,13 @@
 
 **Generated:** 2026-05-14  
 **Scope:** 11 targets, lookalike TLD variants discovered via SAN / NS / DMARC RUA / DKIM key reuse signals  
-**Classification:** same-registrar-family-as-target = consolidated; different-or-unknown + high confidence = shadow IT / sprawl; low confidence = impersonation.
+**Classification:** same-registrar-family-as-target = consolidated; different registrar + high confidence = shadow IT / sprawl; registry refuses to disclose (e.g. DENIC) = indeterminate; low confidence = impersonation.
 
 ## Headline
 
 - **36** consolidated (same registrar as target, centrally managed)
-- **5** shadow IT / provider sprawl (high-confidence brand signal on a different or unknown registrar)
+- **2** shadow IT / provider sprawl (high-confidence brand signal on a different registrar)
+- **3** indeterminate (registry redacts registrar by policy — e.g. DENIC)
 - **3** likely impersonation / low-confidence noise
 
 ### Premise check: how many targets actually use CSC?
@@ -30,7 +31,7 @@
 
 ## Per-target detail
 
-### google.com — primary: MarkMonitor (2 registrar families across portfolio)
+### google.com — primary: MarkMonitor (1 registrar families across portfolio)
 
 **Consolidated** (same registrar family as target):
 
@@ -48,11 +49,11 @@
 | `google.sh` | MarkMonitor Inc. | NS | 1 |
 | `google.us` | MarkMonitor, Inc. | NS | 1 |
 
-**Shadow IT / Provider Sprawl** (high-confidence, different registrar):
+**Indeterminate** (registry refuses to disclose registrar — registrar may still be the same family):
 
-| Domain | Registrar | Evidence | Confidence |
+| Domain | Source | Evidence | Confidence |
 |---|---|---|---:|
-| `google.de` | Unknown | NS | 1 |
+| `google.de` | redacted | NS | 1 |
 
 ### amazon.com — primary: MarkMonitor (1 registrar families across portfolio)
 
@@ -62,7 +63,7 @@ _No candidate domains surfaced by discovery signals._
 
 _No candidate domains surfaced by discovery signals._
 
-### apple.com — primary: Com Laude (3 registrar families across portfolio)
+### apple.com — primary: Com Laude (2 registrar families across portfolio)
 
 **Consolidated** (same registrar family as target):
 
@@ -84,7 +85,12 @@ _No candidate domains surfaced by discovery signals._
 | Domain | Registrar | Evidence | Confidence |
 |---|---|---|---:|
 | `apple.ca` | Tucows.com Co. | NS | 1 |
-| `apple.de` | Unknown | NS | 1 |
+
+**Indeterminate** (registry refuses to disclose registrar — registrar may still be the same family):
+
+| Domain | Source | Evidence | Confidence |
+|---|---|---|---:|
+| `apple.de` | redacted | NS | 1 |
 
 ### disney.com — primary: CSC (1 registrar families across portfolio)
 
@@ -99,7 +105,7 @@ _No candidate domains surfaced by discovery signals._
 
 _No candidate domains surfaced by discovery signals._
 
-### paypal.com — primary: MarkMonitor (2 registrar families across portfolio)
+### paypal.com — primary: MarkMonitor (1 registrar families across portfolio)
 
 **Consolidated** (same registrar family as target):
 
@@ -112,11 +118,11 @@ _No candidate domains surfaced by discovery signals._
 | `paypal.co` | MarkMonitor, Inc. | NS | 1 |
 | `paypal.me` | MarkMonitor Inc. | NS | 1 |
 
-**Shadow IT / Provider Sprawl** (high-confidence, different registrar):
+**Indeterminate** (registry refuses to disclose registrar — registrar may still be the same family):
 
-| Domain | Registrar | Evidence | Confidence |
+| Domain | Source | Evidence | Confidence |
 |---|---|---|---:|
-| `paypal.de` | Unknown | NS | 1 |
+| `paypal.de` | redacted | NS | 1 |
 
 ### stripe.com — primary: SafeNames (1 registrar families across portfolio)
 
@@ -186,8 +192,8 @@ Across all 44 candidate domains:
 
 ## Methodology notes & caveats
 
-- **17 of 44 candidates returned `Unknown` registrar** — all ccTLDs (`.me/.de/.co/.us/.sh/.io`) where RDAP either lacks a server or returned 404. These get bucketed as shadow IT by default. Manual WHOIS would resolve them.
-- **MarkMonitor appears under 4 legal entities** (`Inc.`, `MARKMONITOR Inc.`, `MarkMonitor, Inc.`, `MarkMonitor International Canada Ltd.`) — normalized to one family.
-- **Com Laude appears under 4 string variants** (`Nom-iq Ltd. dba COM LAUDE`, `COM LAUDE (NOM IQ LIMITED)`, etc.) — normalized to one family.
+- **ccTLDs without RDAP** (`.me/.co/.us/.sh/.io/.uk/.fr/.ca/...`) resolved via the bv-whois shim Worker (WHOIS-over-TCP/43 with IANA referral cache).
+- **`.de` (DENIC) is short-circuited as redacted** — German law (BDSG) requires the registry to withhold the registrar field, and DENIC blocks Cloudflare Workers' egress IPs at port 43. The shim returns `source: redacted` instantly without contacting the network.
+- **MarkMonitor / Com Laude / SafeNames** each appear under multiple string variants (case, regional subsidiary, dba); normalized to one family per provider.
 - **Confidence threshold for shadow IT = 0.7** matches the original spec. Defensive registrations at conf=0.5 (e.g., `walmart.app/io/org`) fall into the impersonation bucket despite being likely Walmart-owned. Threshold tuning is a follow-up.
 - **Candidate set is `<base>.<TLD>` for 15 hardcoded TLDs.** Subdomains under target (e.g., `mail.apple.com`) come from discovery signals separately.

--- a/reports/csc-audit-results.json
+++ b/reports/csc-audit-results.json
@@ -6,75 +6,88 @@
         "domain": "google.biz",
         "registrar": "MarkMonitor, Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "google.ca",
         "registrar": "MarkMonitor International Canada Ltd.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "google.fr",
         "registrar": "MARKMONITOR Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "google.info",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "google.net",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "google.org",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "google.co",
         "registrar": "MarkMonitor, Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "google.io",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "google.me",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "google.sh",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "google.us",
         "registrar": "MarkMonitor, Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       }
     ],
-    "shadowIt": [
+    "shadowIt": [],
+    "indeterminate": [
       {
         "domain": "google.de",
         "registrar": "Unknown",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "redacted"
       }
     ],
     "impersonation": []
@@ -83,12 +96,14 @@
     "target": "amazon.com",
     "consolidated": [],
     "shadowIt": [],
+    "indeterminate": [],
     "impersonation": []
   },
   {
     "target": "microsoft.com",
     "consolidated": [],
     "shadowIt": [],
+    "indeterminate": [],
     "impersonation": []
   },
   {
@@ -98,61 +113,71 @@
         "domain": "apple.ai",
         "registrar": "Nom-iq Ltd. dba COM LAUDE",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "apple.app",
         "registrar": "Nom-IQ Limited dba Com Laude",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "apple.biz",
         "registrar": "Nom-iq Ltd. dba COM LAUDE",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "apple.fr",
         "registrar": "COM LAUDE (NOM IQ LIMITED)",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "apple.info",
         "registrar": "Nom-iq Ltd. dba COM LAUDE",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "apple.net",
         "registrar": "Nom-iq Ltd. dba COM LAUDE",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "apple.uk",
         "registrar": "Nom-IQ Limited t/a Com Laude",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "apple.co",
         "registrar": "Nom-iq Ltd. dba COM LAUDE",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "apple.me",
         "registrar": "Nom-iq Ltd. dba COM LAUDE",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "apple.us",
         "registrar": "Nom-iq Ltd. dba COM LAUDE",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       }
     ],
     "shadowIt": [
@@ -160,13 +185,17 @@
         "domain": "apple.ca",
         "registrar": "Tucows.com Co.",
         "evidence": "NS",
-        "confidence": 1
-      },
+        "confidence": 1,
+        "source": "rdap"
+      }
+    ],
+    "indeterminate": [
       {
         "domain": "apple.de",
         "registrar": "Unknown",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "redacted"
       }
     ],
     "impersonation": []
@@ -178,22 +207,26 @@
         "domain": "disney.org",
         "registrar": "CSC Corporate Domains, Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "maildisney.com",
         "registrar": "CSC Corporate Domains, Inc.",
         "evidence": "MARKOV GEN, NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       }
     ],
     "shadowIt": [],
+    "indeterminate": [],
     "impersonation": []
   },
   {
     "target": "nike.com",
     "consolidated": [],
     "shadowIt": [],
+    "indeterminate": [],
     "impersonation": []
   },
   {
@@ -203,45 +236,53 @@
         "domain": "paypal.ai",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "paypal.biz",
         "registrar": "MarkMonitor, Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "paypal.ca",
         "registrar": "MarkMonitor International Canada Ltd.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "paypal.fr",
         "registrar": "MARKMONITOR Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "paypal.co",
         "registrar": "MarkMonitor, Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "paypal.me",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       }
     ],
-    "shadowIt": [
+    "shadowIt": [],
+    "indeterminate": [
       {
         "domain": "paypal.de",
         "registrar": "Unknown",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "redacted"
       }
     ],
     "impersonation": []
@@ -253,34 +294,40 @@
         "domain": "stripe.fr",
         "registrar": "SAFENAMES LTD",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "stripe.net",
         "registrar": "SafeNames Ltd.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "stripe.uk",
         "registrar": "Safenames Ltd",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       },
       {
         "domain": "stripe.me",
         "registrar": "SafeNames Ltd.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       },
       {
         "domain": "stripe.sh",
         "registrar": "SafeNames Ltd.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "whois"
       }
     ],
     "shadowIt": [],
+    "indeterminate": [],
     "impersonation": []
   },
   {
@@ -291,27 +338,32 @@
         "domain": "walmart.ca",
         "registrar": "MarkMonitor International Canada Ltd.",
         "evidence": "NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       }
     ],
+    "indeterminate": [],
     "impersonation": [
       {
         "domain": "walmart.app",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 0.5
+        "confidence": 0.5,
+        "source": "rdap"
       },
       {
         "domain": "walmart.io",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 0.5
+        "confidence": 0.5,
+        "source": "whois"
       },
       {
         "domain": "walmart.org",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 0.5
+        "confidence": 0.5,
+        "source": "rdap"
       }
     ]
   },
@@ -322,10 +374,12 @@
         "domain": "github.me",
         "registrar": "MarkMonitor Inc.",
         "evidence": "NS",
-        "confidence": 0.5
+        "confidence": 0.5,
+        "source": "whois"
       }
     ],
     "shadowIt": [],
+    "indeterminate": [],
     "impersonation": []
   },
   {
@@ -335,10 +389,12 @@
         "domain": "blackveilsecurity.ai",
         "registrar": "Cloudflare, Inc",
         "evidence": "DMARC RUA, NS",
-        "confidence": 1
+        "confidence": 1,
+        "source": "rdap"
       }
     ],
     "shadowIt": [],
+    "indeterminate": [],
     "impersonation": []
   }
 ]

--- a/scripts/csc-rdap-fill.spec.ts
+++ b/scripts/csc-rdap-fill.spec.ts
@@ -62,18 +62,40 @@ function isSubdomainOf(cand: string, target: string) {
 	return cand === target || cand.endsWith('.' + target);
 }
 
-interface Candidate { domain: string; registrar: string; evidence: string; confidence: number; note?: string }
-interface TargetResult { target: string; consolidated: Candidate[]; shadowIt: Candidate[]; impersonation: Candidate[] }
+type RegistrarSource = 'rdap' | 'whois' | 'redacted' | 'notfound' | 'unknown';
 
-async function lookupRegistrar(domain: string): Promise<string> {
+interface Candidate { domain: string; registrar: string; source?: RegistrarSource; evidence: string; confidence: number; note?: string }
+interface TargetResult {
+	target: string;
+	consolidated: Candidate[];
+	shadowIt: Candidate[];
+	/** Registry refuses to disclose registrar (e.g. DENIC by German law). Genuinely
+	 *  unknowable from WHOIS — separate signal from "we couldn't reach the server". */
+	indeterminate: Candidate[];
+	impersonation: Candidate[];
+}
+
+interface LookupResult { registrar: string; source: RegistrarSource }
+
+/**
+ * Look up the registrar AND its provenance. The source field discriminates:
+ *   - 'rdap' / 'whois' = we have a real registrar string
+ *   - 'redacted' = registry exists but won't tell us (e.g. DENIC)
+ *   - 'notfound' = registry says domain doesn't exist
+ *   - 'unknown' = we couldn't reach the registry or shim failed
+ */
+async function lookupRegistrar(domain: string): Promise<LookupResult> {
 	try {
 		const rdap = await checkRdapLookup(domain, { whoisBinding: LIVE_WHOIS_BINDING });
-		const rFind = rdap.findings.find(
-			f => typeof f.metadata?.registrar === 'string' && (f.metadata.registrar as string).length > 0,
-		);
-		return rFind ? (rFind.metadata!.registrar as string) : 'Unknown';
+		// Prefer findings that carry registrarSource metadata (set by the WHOIS fallback path).
+		const find = rdap.findings.find(f => f.metadata?.registrarSource) ?? rdap.findings.find(f => f.metadata?.registrar);
+		const source = (find?.metadata?.registrarSource as RegistrarSource | undefined) ?? 'unknown';
+		const registrar = typeof find?.metadata?.registrar === 'string' && (find.metadata.registrar as string).length > 0
+			? (find.metadata.registrar as string)
+			: 'Unknown';
+		return { registrar, source };
 	} catch {
-		return 'Unknown';
+		return { registrar: 'Unknown', source: 'unknown' };
 	}
 }
 
@@ -86,53 +108,71 @@ describe('CSC RDAP fill', () => {
 		const targetRegistrarRaw: Record<string, string> = {};
 		const targetRegistrarFamily: Record<string, string> = {};
 		for (const target of TARGETS) {
-			const raw = await lookupRegistrar(target);
+			const { registrar: raw } = await lookupRegistrar(target);
 			targetRegistrarRaw[target] = raw;
 			targetRegistrarFamily[target] = normalizeRegistrar(raw);
 			console.log(`  ${target.padEnd(28)} ${targetRegistrarFamily[target].padEnd(20)} (${raw})`);
 		}
 
-		// Dedupe candidate domains across all buckets
+		// Dedupe candidate domains across all buckets — includes new `indeterminate` bucket if present.
 		const uniqueCandidates = new Set<string>();
 		for (const t of existing) {
-			for (const bucket of [t.consolidated, t.shadowIt, t.impersonation]) {
+			for (const bucket of [t.consolidated, t.shadowIt, t.indeterminate ?? [], t.impersonation]) {
 				for (const c of bucket) uniqueCandidates.add(c.domain);
 			}
 		}
 		console.log(`\n=== Re-RDAPing ${uniqueCandidates.size} unique candidates ===`);
 
-		const registrarCache = new Map<string, string>();
+		const lookupCache = new Map<string, LookupResult>();
 		for (const domain of uniqueCandidates) {
-			registrarCache.set(domain, await lookupRegistrar(domain));
+			lookupCache.set(domain, await lookupRegistrar(domain));
 		}
 
-		// Re-classify: same-family-as-target = consolidated; conf≥0.7 + different family = shadowIt; else impersonation
+		// Re-classify:
+		//   - source=redacted → indeterminate (registry hides the answer by policy; e.g. DENIC)
+		//   - same-family-as-target → consolidated
+		//   - subdomain of target → consolidated (org subdomain)
+		//   - confidence ≥ 0.7 + different family → shadow IT / sprawl
+		//   - else → impersonation
 		const fixed: TargetResult[] = existing.map(t => {
 			const targetFamily = targetRegistrarFamily[t.target];
-			const allCandidates = [...t.consolidated, ...t.shadowIt, ...t.impersonation];
+			const allCandidates = [
+				...t.consolidated,
+				...t.shadowIt,
+				...(t.indeterminate ?? []),
+				...t.impersonation,
+			];
 			const newConsolidated: Candidate[] = [];
 			const newShadowIt: Candidate[] = [];
+			const newIndeterminate: Candidate[] = [];
 			const newImpersonation: Candidate[] = [];
 
 			for (const c of allCandidates) {
-				const registrarRaw = registrarCache.get(c.domain) ?? 'Unknown';
-				const candFamily = normalizeRegistrar(registrarRaw);
-				const enriched: Candidate = { ...c, registrar: registrarRaw };
+				const lookup = lookupCache.get(c.domain) ?? { registrar: 'Unknown', source: 'unknown' as const };
+				const candFamily = normalizeRegistrar(lookup.registrar);
+				const enriched: Candidate = { ...c, registrar: lookup.registrar, source: lookup.source };
 
-				// Same registrar family as target (and not Unknown==Unknown coincidence) → consolidated
-				if (candFamily !== 'Unknown' && targetFamily !== 'Unknown' && candFamily === targetFamily) {
+				// Registry refuses to disclose by policy — separate from "we couldn't find out".
+				if (lookup.source === 'redacted') {
+					newIndeterminate.push(enriched);
+				} else if (candFamily !== 'Unknown' && targetFamily !== 'Unknown' && candFamily === targetFamily) {
 					newConsolidated.push(enriched);
 				} else if (isSubdomainOf(c.domain, t.target)) {
 					newConsolidated.push({ ...enriched, note: 'Organizational Subdomain' });
 				} else if (c.confidence >= 0.7) {
-					// High-confidence brand signal on a different/unknown registrar = provider sprawl / shadow IT
 					newShadowIt.push(enriched);
 				} else {
 					newImpersonation.push(enriched);
 				}
 			}
 
-			return { target: t.target, consolidated: newConsolidated, shadowIt: newShadowIt, impersonation: newImpersonation };
+			return {
+				target: t.target,
+				consolidated: newConsolidated,
+				shadowIt: newShadowIt,
+				indeterminate: newIndeterminate,
+				impersonation: newImpersonation,
+			};
 		});
 
 		writeFileSync('reports/csc-audit-results.json', JSON.stringify(fixed, null, 2));
@@ -145,7 +185,7 @@ describe('CSC RDAP fill', () => {
 		for (const t of fixed) {
 			const family = targetRegistrarFamily[t.target];
 			console.log(
-				`  ${t.target.padEnd(28)} [${family.padEnd(14)}] consolidated=${t.consolidated.length} shadow=${t.shadowIt.length} imp=${t.impersonation.length}`,
+				`  ${t.target.padEnd(28)} [${family.padEnd(14)}] consolidated=${t.consolidated.length} shadow=${t.shadowIt.length} indet=${t.indeterminate.length} imp=${t.impersonation.length}`,
 			);
 		}
 	}, 1_800_000);

--- a/scripts/generate-consolidated-report.mjs
+++ b/scripts/generate-consolidated-report.mjs
@@ -13,17 +13,19 @@ lines.push('# Brand Audit: Shadow IT & Provider Sprawl');
 lines.push('');
 lines.push(`**Generated:** ${dateStr}  `);
 lines.push('**Scope:** 11 targets, lookalike TLD variants discovered via SAN / NS / DMARC RUA / DKIM key reuse signals  ');
-lines.push('**Classification:** same-registrar-family-as-target = consolidated; different-or-unknown + high confidence = shadow IT / sprawl; low confidence = impersonation.');
+lines.push('**Classification:** same-registrar-family-as-target = consolidated; different registrar + high confidence = shadow IT / sprawl; registry refuses to disclose (e.g. DENIC) = indeterminate; low confidence = impersonation.');
 lines.push('');
 
 // Aggregate sprawl: how many distinct registrar families exist across each target's domains
 lines.push('## Headline');
 lines.push('');
-let totalConsolidated = 0, totalShadow = 0, totalImp = 0;
+let totalConsolidated = 0, totalShadow = 0, totalIndet = 0, totalImp = 0;
 const sprawlPerTarget = {};
 for (const t of results) {
+	const indet = t.indeterminate ?? [];
 	totalConsolidated += t.consolidated.length;
 	totalShadow += t.shadowIt.length;
+	totalIndet += indet.length;
 	totalImp += t.impersonation.length;
 	const families = new Set();
 	families.add(targetRegs.family[t.target]);
@@ -41,7 +43,8 @@ for (const t of results) {
 	sprawlPerTarget[t.target] = families;
 }
 lines.push(`- **${totalConsolidated}** consolidated (same registrar as target, centrally managed)`);
-lines.push(`- **${totalShadow}** shadow IT / provider sprawl (high-confidence brand signal on a different or unknown registrar)`);
+lines.push(`- **${totalShadow}** shadow IT / provider sprawl (high-confidence brand signal on a different registrar)`);
+lines.push(`- **${totalIndet}** indeterminate (registry redacts registrar by policy — e.g. DENIC)`);
 lines.push(`- **${totalImp}** likely impersonation / low-confidence noise`);
 lines.push('');
 lines.push('### Premise check: how many targets actually use CSC?');
@@ -88,6 +91,18 @@ for (const t of results) {
 		lines.push('');
 	}
 
+	const indet = t.indeterminate ?? [];
+	if (indet.length > 0) {
+		lines.push('**Indeterminate** (registry refuses to disclose registrar — registrar may still be the same family):');
+		lines.push('');
+		lines.push('| Domain | Source | Evidence | Confidence |');
+		lines.push('|---|---|---|---:|');
+		for (const c of indet) {
+			lines.push(`| \`${c.domain}\` | ${c.source ?? 'redacted'} | ${c.evidence} | ${c.confidence} |`);
+		}
+		lines.push('');
+	}
+
 	if (t.impersonation.length > 0) {
 		lines.push('**Impersonation / Low Confidence**:');
 		lines.push('');
@@ -99,7 +114,7 @@ for (const t of results) {
 		lines.push('');
 	}
 
-	if (t.consolidated.length === 0 && t.shadowIt.length === 0 && t.impersonation.length === 0) {
+	if (t.consolidated.length === 0 && t.shadowIt.length === 0 && indet.length === 0 && t.impersonation.length === 0) {
 		lines.push('_No candidate domains surfaced by discovery signals._');
 		lines.push('');
 	}
@@ -112,7 +127,7 @@ lines.push('Across all 44 candidate domains:');
 lines.push('');
 const tally = {};
 for (const t of results) {
-	for (const c of [...t.consolidated, ...t.shadowIt, ...t.impersonation]) {
+	for (const c of [...t.consolidated, ...t.shadowIt, ...(t.indeterminate ?? []), ...t.impersonation]) {
 		const reg = c.registrar || 'Unknown';
 		tally[reg] = (tally[reg] || 0) + 1;
 	}
@@ -127,9 +142,9 @@ lines.push('');
 
 lines.push('## Methodology notes & caveats');
 lines.push('');
-lines.push('- **17 of 44 candidates returned `Unknown` registrar** — all ccTLDs (`.me/.de/.co/.us/.sh/.io`) where RDAP either lacks a server or returned 404. These get bucketed as shadow IT by default. Manual WHOIS would resolve them.');
-lines.push('- **MarkMonitor appears under 4 legal entities** (`Inc.`, `MARKMONITOR Inc.`, `MarkMonitor, Inc.`, `MarkMonitor International Canada Ltd.`) — normalized to one family.');
-lines.push('- **Com Laude appears under 4 string variants** (`Nom-iq Ltd. dba COM LAUDE`, `COM LAUDE (NOM IQ LIMITED)`, etc.) — normalized to one family.');
+lines.push('- **ccTLDs without RDAP** (`.me/.co/.us/.sh/.io/.uk/.fr/.ca/...`) resolved via the bv-whois shim Worker (WHOIS-over-TCP/43 with IANA referral cache).');
+lines.push('- **`.de` (DENIC) is short-circuited as redacted** — German law (BDSG) requires the registry to withhold the registrar field, and DENIC blocks Cloudflare Workers\' egress IPs at port 43. The shim returns `source: redacted` instantly without contacting the network.');
+lines.push('- **MarkMonitor / Com Laude / SafeNames** each appear under multiple string variants (case, regional subsidiary, dba); normalized to one family per provider.');
 lines.push('- **Confidence threshold for shadow IT = 0.7** matches the original spec. Defensive registrations at conf=0.5 (e.g., `walmart.app/io/org`) fall into the impersonation bucket despite being likely Walmart-owned. Threshold tuning is a follow-up.');
 lines.push('- **Candidate set is `<base>.<TLD>` for 15 hardcoded TLDs.** Subdomains under target (e.g., `mail.apple.com`) come from discovery signals separately.');
 


### PR DESCRIPTION
## Summary

Previously, `.de` candidates returned `source: redacted` from the shim but the spec's classifier mapped `null` registrar → "Unknown" → shadow IT, which implied "rogue defensive registration" when the truth was simply "registry refuses to disclose by law".

Adds a 4th `indeterminate` bucket and routes `source: redacted` there. Also captures full WHOIS provenance (`source` field on each Candidate) so downstream consumers can distinguish:
- `rdap` / `whois` — known registrar
- `redacted` — registry hides by policy (DENIC, future privacy ccTLDs)
- `notfound` — domain doesn't exist
- `unknown` — couldn't reach the registry

### Headline

| Bucket | Pre-refinement | **Post-refinement** |
|---|---:|---:|
| Consolidated | 36 | 36 |
| Shadow IT / sprawl | 5 | **2** |
| Indeterminate (new) | — | **3** |
| Impersonation | 3 | 3 |

The 3 `.de` candidates (`google.de`, `apple.de`, `paypal.de`) moved out of shadow into indeterminate. Remaining 2 shadow findings are now true sprawl:
- `apple.ca` on Tucows (Apple's primary is Com Laude)
- `walmart.ca` on MarkMonitor Canada (Walmart's primary is the corporate registrar under audit)

### Schema change

The audit-results JSON under `reports/` adds an `indeterminate` array per target. Each `Candidate` now carries a `source` field. Backward-compatible: readers that don't know about the field will ignore it; classifier handles missing `indeterminate` field gracefully.

## Test plan

- [x] `npm run typecheck` clean
- [x] Audit spec runs end-to-end (~29s)
- [x] 3 `.de` candidates land in indeterminate; 2 real sprawl cases stay in shadow
- [x] Generated markdown report renders the new bucket section

🤖 Generated with [Claude Code](https://claude.com/claude-code)