### PR TITLE
feat(dkim): probe Cloudflare Email Routing selector (cf2024-1)

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/check-dkim.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dkim.test.ts
@@ -51,4 +51,12 @@ describe('checkDKIM', () => {
 		const result = await checkDKIM('example.com', queryDNS);
 		expect(result.findings.some((f) => f.title.includes('testing mode'))).toBe(true);
 	});
+
+	it('detects Cloudflare Email Routing DKIM selector (cf2024-1)', async () => {
+		const queryDNS = createMockDNS({
+			'cf2024-1._domainkey.example.com': ['v=DKIM1; k=rsa; p=' + 'A'.repeat(600)],
+		});
+		const result = await checkDKIM('example.com', queryDNS);
+		expect(result.findings.some((f) => f.title === 'DKIM configured')).toBe(true);
+	});
 });

--- a/packages/dns-checks/src/checks/check-dkim.ts
+++ b/packages/dns-checks/src/checks/check-dkim.ts
@@ -26,6 +26,7 @@ const COMMON_SELECTORS = [
 	'dkim',
 	'amazonses', // Amazon SES
 	'zoho', // Zoho Mail
+	'cf2024-1', // Cloudflare Email Routing
 ];
 
 /**
@@ -147,8 +148,7 @@ export async function checkDKIM(
 										? 'below recommended'
 										: 'strong';
 						const descriptions: Record<string, string> = {
-							critical:
-								`DKIM RSA key for "${result.selector}" is ${severityMsg} (~${keyAnalysis.bits} bits). Upgrade to 2048-bit RSA or use Ed25519 for better security.`,
+							critical: `DKIM RSA key for "${result.selector}" is ${severityMsg} (~${keyAnalysis.bits} bits). Upgrade to 2048-bit RSA or use Ed25519 for better security.`,
 							high: `DKIM RSA key for "${result.selector}" is ${severityMsg} (${keyAnalysis.bits} bits). Consider upgrading to 2048-bit RSA or Ed25519.`,
 							medium: `DKIM RSA key for "${result.selector}" is ${severityMsg} (${keyAnalysis.bits} bits). Major providers recommend 4096-bit RSA or Ed25519.`,
 							info: `DKIM RSA key for "${result.selector}" is strong (${keyAnalysis.bits} bits).`,
@@ -190,7 +190,10 @@ export async function checkDKIM(
 				// If only sha1 is listed (no sha256), the key cannot verify modern DKIM signatures.
 				const hashTag = getDkimTagValue(record, 'h');
 				if (hashTag) {
-					const hashAlgs = hashTag.split(':').map((h) => h.trim().toLowerCase()).filter(Boolean);
+					const hashAlgs = hashTag
+						.split(':')
+						.map((h) => h.trim().toLowerCase())
+						.filter(Boolean);
 					if (hashAlgs.length > 0 && !hashAlgs.includes('sha256') && hashAlgs.includes('sha1')) {
 						findings.push(
 							createFinding(

--- a/packages/dns-checks/src/scoring/config.ts
+++ b/packages/dns-checks/src/scoring/config.ts
@@ -108,6 +108,7 @@ export const DEFAULT_SCORING_CONFIG: ScoringConfig = {
 	providerDkimConfidence: {
 		amazonses: 0.8, sendgrid: 0.8, mailgun: 0.8, postmark: 0.8,
 		google: 0.9, microsoft365: 0.9, proofpoint: 0.6, mimecast: 0.6,
+		cloudflare: 0.9, // Cloudflare Email Routing
 	},
 	thresholds: {
 		emailBonusImportance: 8,


### PR DESCRIPTION
## Summary

Cloudflare Email Routing automatically publishes a DKIM TXT record at `cf2024-1._domainkey.<domain>` when Email Routing is enabled on a zone. The default DKIM selector list in `check-dkim.ts` did not include `cf2024-1`, so domains using CF Email Routing get a false-positive **HIGH** finding `No DKIM records found among tested selectors`, even though DKIM is correctly published and signing outbound forwarded mail.

This PR adds `cf2024-1` to the common selectors probed by the DKIM check, and adds a `cloudflare: 0.9` entry to `providerDkimConfidence` for parity with the other major hosted-mail providers (Google Workspace, Microsoft 365 at 0.9).

## Changes

- `packages/dns-checks/src/checks/check-dkim.ts` — `COMMON_SELECTORS` now includes `cf2024-1` (commented).
- `packages/dns-checks/src/scoring/config.ts` — `providerDkimConfidence` gains `cloudflare: 0.9`.
- `packages/dns-checks/src/__tests__/checks/check-dkim.test.ts` — new test asserting `DKIM configured` finding for a domain publishing only the `cf2024-1` selector.

Diff size: **3 files changed, +15 / -3**.

## Verification

Two production zones using Cloudflare Email Routing were tested live and both publish DKIM at `cf2024-1._domainkey.<domain>`. Before this PR, both produced a high-severity finding `No DKIM records found among tested selectors`. After this PR, both correctly yield `DKIM configured`.

## Test plan

- [x] DKIM-specific tests: 6/6 pass (5 existing + 1 new for cf2024-1)
- [x] Full dns-checks package: 260/260 pass
- [x] Verified live on two production CF Email Routing zones
- [x] No type changes, no public API changes — purely additive to the probing set

## Why `cf2024-1` specifically

Cloudflare Email Routing rotates DKIM keys periodically. The currently-published selector (as of 2026-05) is `cf2024-1` across all Email-Routing-enabled zones, which corresponds to Cloudflare's annual key rotation scheme. Future rotations (`cf2025-1`, etc.) can be added incrementally — happy to follow up with a separate PR or to keep this one as a single canonical selector now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)