### PR TITLE
feat(brand-discovery): v2.16.0 — SAN retry + bv-certstream /sans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.16.0] - 2026-05-15
+
+### Added
+- **bv-certstream `/sans` integration for SAN-sibling discovery**: `discover_brand_domains`'s SAN signal (`correlateSans`) now prefers the `BV_CERTSTREAM` service binding when present, falling back to direct crt.sh on failure. Mirrors the existing `/enumerate` pattern used by `discoverSubdomains` but with a distinct `/sans?domain=X` endpoint — different crt.sh query shape (`?q=X` apex vs `?q=%.X` subdomain) and different consumer-side filter (siblings keep cross-brand names; subdomains strip them). Threaded `certstream` through `DiscoverBrandDomainsOptions` and the `discover_brand_domains` tool registry. Routes traffic through Cloudflare egress (less IP-throttled than direct user-side calls) with the worker's 30s timeout cap (vs bv-mcp's 15s). Companion worker change: `bv-web/cloudflare/certstream-worker` (`/sans` route + `queryCrtShSans` handler).
+
+### Fixed
+- **SAN-correlator silently dropped tier-1 brand candidates under crt.sh throttling**: `correlateSans` was single-shot — one fetch attempt, error/timeout/429 silently returned an empty SAN bucket. Surfaced by the CSC brand audit where amazon.com, microsoft.com, nike.com returned **zero candidates** despite high-confidence brand asserts; investigation showed `signalStatus.san: 'error'` for all three while ns/dmarc_rua/dkim_key_reuse succeeded. crt.sh is heavily IP-throttled and intermittently 5xx's on tier-1 brand queries (verified: direct `curl --max-time 20` to crt.sh timed out for 4 of 5 sampled brands during the audit run). Added jittered exponential-backoff retry (default 2 retries, 500ms base × 2^attempt with ±50% jitter) inside `correlateSans` — only on transient `error`/`rate_limited`/`timeout` results; partial-success (stream cap hit) is `ok` and not retried. New `maxRetries`/`initialBackoffMs`/`sleepFn` options for test override.
+
 ## [2.15.0] - 2026-05-15
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -538,7 +538,7 @@ To maintain the public/private architectural split, this repository uses an auto
 | `PROVIDER_SIGNATURES_URL` | var | Runtime provider signatures URL |
 | `BV_DOH_ENDPOINT` | var | Custom secondary DoH URL (fallback: Google) |
 | `BV_DOH_TOKEN` | Secret | Auth for bv-dns (`X-BV-Token` header) |
-| `BV_CERTSTREAM` | Service | CT log subdomain cache (optional, falls back to crt.sh) |
+| `BV_CERTSTREAM` | Service | CT log access via bv-certstream-worker. Two endpoints consumed: `/enumerate?domain=X` for subdomain discovery (`discover_subdomains`, scan path); `/sans?domain=X` (v2.16.0+) for cross-brand SAN sibling discovery (`discover_brand_domains` via `correlateSans`). Optional — direct-crt.sh fallback runs in both paths if binding is unset or fails. The SAN path's fallback has jittered exponential-backoff retry (default 2 retries). |
 | `BV_WHOIS` | Service | WHOIS-over-TCP/43 shim Worker (`bv-whois`) — optional; `check_rdap_lookup` falls back to RDAP-only when unset. KV-cached IANA referrals, 15 hardcoded fast-path TLDs. v2.15.0+ |
 | `SCORING_CONFIG` | var | JSON scoring overrides (optional) |
 | `CF_ACCOUNT_ID` | var | Cloudflare account ID (alerting) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.15.0",
+	"version": "2.16.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "2.15.0",
+			"version": "2.16.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.15.0",
+	"version": "2.16.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "2.15.0",
+	"version": "2.16.0",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "2.15.0",
+			"version": "2.16.0",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -168,12 +168,13 @@ const TOOL_REGISTRY: Record<
 			const candHash = candDomains.length === 0 ? '0' : `${candDomains.length}:${candDomains.slice().sort().join('|').slice(0, 64)}`;
 			return `discover_brand:${signals}:c${candHash}:m${minConf}`;
 		},
-		execute: (d, args) =>
+		execute: (d, args, ro) =>
 			discoverBrandDomains(d, {
 				signals: args.signals as Parameters<typeof discoverBrandDomains>[1] extends infer O ? (O extends { signals?: infer S } ? S : undefined) : undefined,
 				candidate_domains: args.candidate_domains as string[] | undefined,
 				dkim_selectors: args.dkim_selectors as string[] | undefined,
 				min_confidence: args.min_confidence as number | undefined,
+				certstream: ro?.certstream,
 			}),
 		cacheTtlSeconds: 3600,
 	},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '2.15.0';
+export const SERVER_VERSION = '2.16.0';

--- a/src/tenants/discovery/san-correlator.ts
+++ b/src/tenants/discovery/san-correlator.ts
@@ -39,13 +39,49 @@ const SATURATION_THRESHOLD = 100;
  */
 const MAX_STREAM_BYTES = 25 * 1024 * 1024;
 
+/**
+ * Default retries on transient failures (error / rate_limited / timeout).
+ * crt.sh is throttled per-IP and intermittently 5xx's on tier-1 brand queries;
+ * 2 retries with backoff is enough to absorb a single throttle window without
+ * blowing the SAN signal's contribution to the orchestrator.
+ */
+const DEFAULT_MAX_RETRIES = 2;
+
+/** Default initial backoff in ms; doubles each retry with ±50% jitter. */
+const DEFAULT_INITIAL_BACKOFF_MS = 500;
+
 export interface SanCorrelationOptions {
-	/** Request timeout in ms. Defaults to 15000. */
+	/** Request timeout in ms (per attempt). Defaults to 15000. */
 	timeoutMs?: number;
 	/** Cap on the number of crt.sh entries that contribute to the result. Defaults to 200. */
 	maxCertsPerDomain?: number;
 	/** Override the underlying fetch implementation (used for testing). Defaults to `safeFetch`. */
 	fetchFn?: typeof fetch;
+	/** Max retry attempts on transient failures (error/rate_limited/timeout). Default 2 (3 total attempts). Set to 0 to disable. */
+	maxRetries?: number;
+	/** Initial backoff in ms; doubles each retry with ±50% jitter. Default 500. */
+	initialBackoffMs?: number;
+	/** Sleep function override (test hook to skip real timers). */
+	sleepFn?: (ms: number) => Promise<void>;
+	/**
+	 * Optional bv-certstream-worker service binding. When provided, queries are
+	 * routed through the worker's `/sans` endpoint (Cloudflare egress + cache)
+	 * before falling back to direct crt.sh. Mirrors the pattern in
+	 * `discover-subdomains.ts` (which uses the `/enumerate` endpoint for
+	 * subdomain enumeration). Distinct endpoint because subdomain vs sibling
+	 * discovery use different crt.sh query shapes and different result filters.
+	 */
+	certstream?: { fetch: typeof fetch };
+}
+
+/** Response shape from bv-certstream-worker `/sans` endpoint. */
+interface CertstreamSansResponse {
+	domain: string;
+	names: string[];
+	certificateCount: number;
+	timedOut: boolean;
+	cached: boolean;
+	error?: string;
 }
 
 export interface SanCorrelationResult {
@@ -91,26 +127,86 @@ function extractSiblingsFromNameValue(nameValue: string, seedLower: string): str
 	return out;
 }
 
+function defaultSleep(ms: number): Promise<void> {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 /**
- * Correlate co-owned sibling domains for a seed via crt.sh SAN clustering.
- * Uses a streaming JSON parser to handle large certificate histories (Tier-1 brands).
+ * Try the bv-certstream-worker `/sans` endpoint. Returns null on failure so the
+ * outer fallback can switch to direct crt.sh.
+ *
+ * Failure modes folded into null: non-OK status, fetch throw, malformed JSON,
+ * `error` field set, or `timedOut: true`. The worker handles its own crt.sh
+ * timeout (default 30s, longer than bv-mcp's 15s) — we apply a single
+ * outer timeout here matching the caller's budget.
  */
-export async function correlateSans(
-	seedDomain: string,
-	options: SanCorrelationOptions = {},
-): Promise<SanCorrelationResult> {
-	const validation = validateDomain(seedDomain);
-	if (!validation.valid) {
-		throw new Error(`Domain validation failed: ${validation.error ?? 'invalid domain'}`);
+async function attemptCertstreamSans(
+	seedLower: string,
+	timeoutMs: number,
+	certstream: { fetch: typeof fetch },
+): Promise<SanCorrelationResult | null> {
+	const controller = new AbortController();
+	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+	let response: Response;
+	try {
+		response = await certstream.fetch(
+			`https://certstream/sans?domain=${encodeURIComponent(seedLower)}`,
+			{ signal: controller.signal },
+		);
+	} catch {
+		clearTimeout(timeoutId);
+		return null;
 	}
-	const seedLower = seedDomain.trim().toLowerCase().replace(/\.$/, '');
+	clearTimeout(timeoutId);
 
-	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
-	const maxCerts = options.maxCertsPerDomain ?? DEFAULT_MAX_CERTS;
-	const fetchFn = options.fetchFn ?? safeFetch;
+	if (!response.ok) return null;
 
-	const url = `https://crt.sh/?q=${encodeURIComponent(seedLower)}&output=json`;
+	let data: CertstreamSansResponse;
+	try {
+		data = (await response.json()) as CertstreamSansResponse;
+	} catch {
+		return null;
+	}
+	if (data.error || data.timedOut || !Array.isArray(data.names)) return null;
 
+	// Apply the same sibling filter as the direct crt.sh path: drop the seed,
+	// drop subdomains of the seed, drop wildcards (`*.foo.com` → `foo.com`),
+	// drop invalid hostnames. The worker doesn't pre-filter — sibling-vs-subdomain
+	// semantics live in the consumer.
+	const seedSuffix = `.${seedLower}`;
+	const siblings = new Set<string>();
+	for (const raw of data.names) {
+		let host = String(raw).trim().toLowerCase();
+		if (!host) continue;
+		if (host.startsWith('*.')) host = host.slice(2);
+		if (!host) continue;
+		if (host === seedLower) continue;
+		if (host.endsWith(seedSuffix)) continue;
+		if (!validateDomain(host).valid) continue;
+		siblings.add(host);
+	}
+
+	return {
+		seedDomain: seedLower,
+		coOwnedDomains: Array.from(siblings).sort(),
+		certIds: [],
+		queryStatus: 'ok',
+	};
+}
+
+/**
+ * Single fetch+parse attempt against crt.sh. Never throws on transient
+ * failures — the outer `correlateSans` decides whether to retry based on
+ * the returned `queryStatus`.
+ */
+async function attemptCorrelation(
+	seedLower: string,
+	url: string,
+	timeoutMs: number,
+	maxCerts: number,
+	fetchFn: typeof fetch,
+): Promise<SanCorrelationResult> {
 	const controller = new AbortController();
 	const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -135,64 +231,58 @@ export async function correlateSans(
 	let certsProcessed = 0;
 	let certsSinceNewDomain = 0;
 	let bytesProcessed = 0;
-// Initialize streaming parser for a flat array of objects
-const parser = new JSONParser({ paths: ['$.*'] });
+	const parser = new JSONParser({ paths: ['$.*'] });
 
-// Byte counter to enforce safety cap
-const byteCounter = new TransformStream<Uint8Array, Uint8Array>({
-	transform(chunk, ctrl) {
-		bytesProcessed += chunk.length;
-		if (bytesProcessed > MAX_STREAM_BYTES) {
-			ctrl.error(new Error('Stream size limit exceeded'));
-		} else {
-			ctrl.enqueue(chunk);
-		}
-	},
-});
+	const byteCounter = new TransformStream<Uint8Array, Uint8Array>({
+		transform(chunk, ctrl) {
+			bytesProcessed += chunk.length;
+			if (bytesProcessed > MAX_STREAM_BYTES) {
+				ctrl.error(new Error('Stream size limit exceeded'));
+			} else {
+				ctrl.enqueue(chunk);
+			}
+		},
+	});
 
-const reader = body.pipeThrough(byteCounter).pipeThrough(parser).getReader();
+	const reader = body.pipeThrough(byteCounter).pipeThrough(parser).getReader();
 
-try {
-	while (true) {
-		const { done, value } = await reader.read();
-		if (done) break;
+	try {
+		while (true) {
+			const { done, value } = await reader.read();
+			if (done) break;
 
-		// value is a StackElement from @streamparser/json
-		// Handle both individual objects and arrays (just in case)
-		const entries = Array.isArray(value.value) ? value.value : [value.value];
+			const entries = Array.isArray(value.value) ? value.value : [value.value];
 
-		for (const entryRaw of entries) {
-			const entry = entryRaw as CrtShEntry;
-			if (!entry) continue;
-			certsProcessed++;
+			for (const entryRaw of entries) {
+				const entry = entryRaw as CrtShEntry;
+				if (!entry) continue;
+				certsProcessed++;
 
-			let foundNew = false;
-			if (typeof entry.id === 'number') certIds.push(entry.id);
-			const nameValue = entry.name_value;
-			if (typeof nameValue === 'string' && nameValue) {
-				for (const sibling of extractSiblingsFromNameValue(nameValue, seedLower)) {
-					if (!siblings.has(sibling)) {
-						siblings.add(sibling);
-						foundNew = true;
+				let foundNew = false;
+				if (typeof entry.id === 'number') certIds.push(entry.id);
+				const nameValue = entry.name_value;
+				if (typeof nameValue === 'string' && nameValue) {
+					for (const sibling of extractSiblingsFromNameValue(nameValue, seedLower)) {
+						if (!siblings.has(sibling)) {
+							siblings.add(sibling);
+							foundNew = true;
+						}
 					}
 				}
-			}
 
-			if (foundNew) {
-				certsSinceNewDomain = 0;
-			} else {
-				certsSinceNewDomain++;
-			}
+				if (foundNew) {
+					certsSinceNewDomain = 0;
+				} else {
+					certsSinceNewDomain++;
+				}
 
-			// Stop if we hit the hard cap or signal saturation
-			if (certsProcessed >= maxCerts || certsSinceNewDomain >= SATURATION_THRESHOLD) {
-				await reader.cancel();
-				break;
+				if (certsProcessed >= maxCerts || certsSinceNewDomain >= SATURATION_THRESHOLD) {
+					await reader.cancel();
+					break;
+				}
 			}
 		}
-	}
-} catch (err) {
-		// If it's the stream limit error, we return what we have so far as partial success
+	} catch (err) {
 		if (err instanceof Error && err.message === 'Stream size limit exceeded') {
 			return {
 				seedDomain: seedLower,
@@ -201,7 +291,6 @@ try {
 				queryStatus: 'ok',
 			};
 		}
-		// Any other error (malformed JSON, network drop mid-stream)
 		return emptyResult(seedLower, 'error');
 	}
 
@@ -211,4 +300,55 @@ try {
 		certIds,
 		queryStatus: 'ok',
 	};
+}
+
+/**
+ * Correlate co-owned sibling domains for a seed via crt.sh SAN clustering.
+ * Uses a streaming JSON parser to handle large certificate histories (Tier-1 brands).
+ *
+ * Retries on transient `error` / `rate_limited` / `timeout` statuses with
+ * jittered exponential backoff (default: 2 retries, 500ms base). crt.sh is
+ * IP-throttled and intermittently 5xx's on tier-1 brand queries; without
+ * retry, a single throttle window silently drops the SAN signal for that
+ * target. Partial-success (stream cap hit) is `ok` and never retried.
+ */
+export async function correlateSans(
+	seedDomain: string,
+	options: SanCorrelationOptions = {},
+): Promise<SanCorrelationResult> {
+	const validation = validateDomain(seedDomain);
+	if (!validation.valid) {
+		throw new Error(`Domain validation failed: ${validation.error ?? 'invalid domain'}`);
+	}
+	const seedLower = seedDomain.trim().toLowerCase().replace(/\.$/, '');
+
+	const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+	const maxCerts = options.maxCertsPerDomain ?? DEFAULT_MAX_CERTS;
+	const fetchFn = options.fetchFn ?? safeFetch;
+	const maxRetries = Math.max(0, options.maxRetries ?? DEFAULT_MAX_RETRIES);
+	const initialBackoffMs = Math.max(0, options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS);
+	const sleepFn = options.sleepFn ?? defaultSleep;
+
+	// Path A: prefer the bv-certstream service binding when available. Single
+	// attempt because the worker has its own cache + crt.sh-side timeout; if
+	// it fails we drop straight to direct crt.sh (which has its own retry).
+	if (options.certstream) {
+		const csResult = await attemptCertstreamSans(seedLower, timeoutMs, options.certstream);
+		if (csResult !== null) return csResult;
+	}
+
+	// Path B: direct crt.sh with jittered exponential-backoff retry.
+	const url = `https://crt.sh/?q=${encodeURIComponent(seedLower)}&output=json`;
+
+	let result: SanCorrelationResult = emptyResult(seedLower, 'error');
+	for (let attempt = 0; attempt <= maxRetries; attempt++) {
+		result = await attemptCorrelation(seedLower, url, timeoutMs, maxCerts, fetchFn);
+		if (result.queryStatus === 'ok') return result;
+		if (attempt < maxRetries) {
+			const base = initialBackoffMs * Math.pow(2, attempt);
+			const jitterFactor = 0.5 + Math.random();
+			await sleepFn(Math.floor(base * jitterFactor));
+		}
+	}
+	return result;
 }

--- a/src/tools/discover-brand-domains.ts
+++ b/src/tools/discover-brand-domains.ts
@@ -105,6 +105,13 @@ export interface DiscoverBrandDomainsOptions {
 	candidate_domains?: string[];
 	dkim_selectors?: string[];
 	min_confidence?: number;
+	/**
+	 * Optional bv-certstream-worker service binding. Threaded into the SAN
+	 * correlator's primary path — sidesteps crt.sh per-IP throttling and
+	 * benefits from the worker's cache when available. Falls back to direct
+	 * crt.sh (with retry) if the binding fails.
+	 */
+	certstream?: { fetch: typeof fetch };
 }
 
 /** Combine independent-event confidences: P(any signal correct). */
@@ -239,7 +246,9 @@ export async function discoverBrandDomains(
 
 	if (signals.includes('san')) {
 		jobs.push(async () => {
-			const out = await runSignal<SanCorrelationResult>(() => d.correlateSans(seedDomain));
+			const out = await runSignal<SanCorrelationResult>(() =>
+				d.correlateSans(seedDomain, options.certstream ? { certstream: options.certstream } : {}),
+			);
 			if (!out.ok) {
 				signalStatus.san = { status: 'failed', error: out.error };
 				return;

--- a/test/tenants/discovery/san-correlator.test.ts
+++ b/test/tenants/discovery/san-correlator.test.ts
@@ -106,7 +106,7 @@ describe('correlateSans', () => {
 
 	it('returns rate_limited status on 429 without throwing', async () => {
 		const fetchFn = vi.fn().mockResolvedValue(new Response('rate', { status: 429 })) as unknown as typeof fetch;
-		const result = await correlateSans('foo.com', { fetchFn });
+		const result = await correlateSans('foo.com', { fetchFn, maxRetries: 0 });
 		expect(result.queryStatus).toBe('rate_limited');
 		expect(result.coOwnedDomains).toEqual([]);
 	});
@@ -115,14 +115,14 @@ describe('correlateSans', () => {
 		const abortErr = new Error('aborted');
 		abortErr.name = 'AbortError';
 		const fetchFn = vi.fn().mockRejectedValue(abortErr) as unknown as typeof fetch;
-		const result = await correlateSans('foo.com', { fetchFn });
+		const result = await correlateSans('foo.com', { fetchFn, maxRetries: 0 });
 		expect(result.queryStatus).toBe('timeout');
 		expect(result.coOwnedDomains).toEqual([]);
 	});
 
 	it('returns error status on a generic network failure without throwing', async () => {
 		const fetchFn = vi.fn().mockRejectedValue(new TypeError('network down')) as unknown as typeof fetch;
-		const result = await correlateSans('foo.com', { fetchFn });
+		const result = await correlateSans('foo.com', { fetchFn, maxRetries: 0 });
 		expect(result.queryStatus).toBe('error');
 		expect(result.coOwnedDomains).toEqual([]);
 	});
@@ -143,5 +143,100 @@ describe('correlateSans', () => {
 		const result = await correlateSans('foo.com', { fetchFn });
 		expect(result.queryStatus).toBe('ok');
 		expect(result.coOwnedDomains).toEqual(['bar.com']);
+	});
+
+	it('retries on transient error and surfaces eventual success', async () => {
+		const okResponse = jsonResponse([{ id: 1, name_value: 'foo.com\nbar.com' }]);
+		const fetchFn = vi
+			.fn<typeof fetch>()
+			.mockRejectedValueOnce(new TypeError('network down'))
+			.mockResolvedValueOnce(new Response('boom', { status: 503 }))
+			.mockResolvedValueOnce(okResponse);
+		const sleepFn = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+		const result = await correlateSans('foo.com', { fetchFn, sleepFn, maxRetries: 2, initialBackoffMs: 1 });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['bar.com']);
+		expect(fetchFn).toHaveBeenCalledTimes(3);
+		expect(sleepFn).toHaveBeenCalledTimes(2);
+	});
+
+	it('retries on rate_limited (429) before giving up', async () => {
+		const fetchFn = vi
+			.fn<typeof fetch>()
+			.mockResolvedValue(new Response('rate', { status: 429 }));
+		const sleepFn = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+		const result = await correlateSans('foo.com', { fetchFn, sleepFn, maxRetries: 2, initialBackoffMs: 1 });
+		expect(result.queryStatus).toBe('rate_limited');
+		expect(fetchFn).toHaveBeenCalledTimes(3);
+		expect(sleepFn).toHaveBeenCalledTimes(2);
+	});
+
+	it('returns last attempt status after exhausting retries', async () => {
+		const fetchFn = vi
+			.fn<typeof fetch>()
+			.mockRejectedValueOnce(new TypeError('first'))
+			.mockResolvedValueOnce(new Response('rate', { status: 429 }))
+			.mockRejectedValueOnce(new TypeError('third'));
+		const sleepFn = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+		const result = await correlateSans('foo.com', { fetchFn, sleepFn, maxRetries: 2, initialBackoffMs: 1 });
+		// Last attempt rejected → 'error' status
+		expect(result.queryStatus).toBe('error');
+		expect(fetchFn).toHaveBeenCalledTimes(3);
+	});
+
+	it('uses bv-certstream service binding when provided and returns siblings', async () => {
+		const csFetch = vi.fn<typeof fetch>().mockResolvedValue(
+			Response.json({
+				domain: 'foo.com',
+				names: ['bar.com', 'baz.com', '*.foo.com', 'foo.com', 'shop.foo.com', 'not a domain', 'alpha.com'],
+				certificateCount: 5,
+				timedOut: false,
+				cached: true,
+			}),
+		);
+		const directFetch = vi.fn() as unknown as typeof fetch;
+		const result = await correlateSans('foo.com', {
+			certstream: { fetch: csFetch },
+			fetchFn: directFetch,
+			maxRetries: 0,
+		});
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['alpha.com', 'bar.com', 'baz.com']);
+		expect(csFetch).toHaveBeenCalledTimes(1);
+		const callUrl = (csFetch.mock.calls[0][0] as string);
+		expect(callUrl).toContain('/sans?domain=foo.com');
+		// Direct crt.sh fallback must not have been invoked.
+		expect(directFetch).not.toHaveBeenCalled();
+	});
+
+	it('falls back to direct crt.sh when certstream binding fails', async () => {
+		const csFetch = vi.fn<typeof fetch>().mockResolvedValue(new Response('boom', { status: 503 }));
+		const directFetch = mockFetchOk([{ id: 7, name_value: 'foo.com\nfallback-sibling.com' }]);
+		const sleepFn = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+		const result = await correlateSans('foo.com', {
+			certstream: { fetch: csFetch },
+			fetchFn: directFetch,
+			sleepFn,
+			maxRetries: 0,
+		});
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['fallback-sibling.com']);
+		expect(csFetch).toHaveBeenCalledTimes(1);
+		expect(directFetch).toHaveBeenCalledTimes(1);
+	});
+
+	it('falls back when certstream response sets error or timedOut', async () => {
+		const csFetch = vi.fn<typeof fetch>().mockResolvedValue(
+			Response.json({ domain: 'foo.com', names: [], certificateCount: 0, timedOut: true, cached: false }),
+		);
+		const directFetch = mockFetchOk([{ id: 1, name_value: 'foo.com\nrecovered.com' }]);
+		const result = await correlateSans('foo.com', {
+			certstream: { fetch: csFetch },
+			fetchFn: directFetch,
+			maxRetries: 0,
+		});
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['recovered.com']);
+		expect(directFetch).toHaveBeenCalledTimes(1);
 	});
 });


### PR DESCRIPTION
## Summary

Two complementary changes to `discover_brand_domains`' SAN signal (`correlateSans`). Bumps to **2.16.0**.

1. **Jittered exponential-backoff retry** on transient crt.sh failures (default 2 retries, 500ms × 2^attempt with ±50% jitter). `correlateSans` was single-shot — any error/rate_limited/timeout silently dropped to an empty SAN bucket.
2. **Optional bv-certstream `BV_CERTSTREAM` binding** via new `/sans` endpoint (companion: MadaBurns/bv-web#389). When bound, prefer the worker (Cloudflare egress + 30s cap) before falling back to direct crt.sh with retry.

## Why

The corporate-registrar brand audit returned **zero candidates** for amazon.com, microsoft.com, nike.com despite valid signals. Probe-confirmed `signalStatus.san: 'error'` for all three while ns/dmarc_rua/dkim_key_reuse succeeded. Direct `curl --max-time 20` to crt.sh timed out for 4 of 5 tier-1 brands during the audit window — crt.sh is heavily IP-throttled.

## Test plan

- [x] 6 new `correlateSans` tests (3 retry + 3 certstream-path). 17/17 san-correlator tests pass.
- [x] 39/39 brand-discovery surface (incl. discover-brand-domains specs).
- [x] `npm run typecheck` clean.
- [x] Live probe: retry alone recovered microsoft.com's SAN signal (`error` → `ok`) on a re-run.

## Backwards compatibility

- `certstream` option is gated; missing binding → direct-crt.sh path (existing + new retry).
- Without bv-web#389 deployed, `attemptCertstreamSans` returns null on 404 → fallback runs. Safe to ship in either order.

## Deploy / release

This branch will tag `v2.16.0` and trigger `publish.yml`. Per the known fail-fast on missing production secrets, manual fallback may be needed:
- `npm publish` (NPM_KEY from `.dev.vars`)
- `npm run deploy:prod` (operator wrangler OAuth)
- `mcp-publisher publish`

Version sync verified across 5 sites: `package.json`, `package-lock.json` (×2), `server.json` (×2), `src/lib/server-version.ts`, `CHANGELOG.md` `[2.16.0]` heading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)