### PR TITLE
feat(brand-audit): v2.19.0 — async batch via queue + D1 state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.19.0] - 2026-05-15
+
+### Added — Brand audit Phase 2: async batch via queue + D1 state
+- **`brand_audit_batch_start` MCP tool** — async producer for up to 50 targets per call. Validates + deduplicates the domain list, writes the parent `brand_audits` row to D1, enqueues one `{ auditId, target, format, min_confidence? }` message per target to `BRAND_AUDIT_QUEUE`. Returns `{ auditId, queuedAt, targetCount, etaSeconds, format, targets }` immediately so the caller can poll instead of holding a multi-minute connection open. **Quota model in v2.19.0 is daily** via `TIER_TOOL_DAILY_LIMITS` (developer=50/day, partner=200/day, enterprise=500/day; free/agent=0). The `BRAND_AUDIT_QUOTAS` constant + `enforceBrandAuditQuota` helper (shipped in v2.18.0 as a Phase-1 building block) describe a monthly window and remain a Phase 4 follow-up — the orchestrator accepts an injectable `enforceQuota` dep already, but the dispatcher wires only the daily gate today.
+- **`brand_audit_status` MCP tool** — read-only D1 lookup that returns audit-level status, progress (`'N/M'`), and per-target statuses. Owner-scoped (someone else's auditId surfaces as `notFound`, never `accessDenied` — ID-enumeration defense). 10s cache to absorb tight polling loops without lying about progress.
+- **`brand_audit_get_report` MCP tool** — fetches the result JSON for a completed audit. With `target` set, returns the per-target `CheckResult`; without, returns the audit-level aggregate. Returns `notReady` when polling against an in-flight audit. 60s cache. Phase 3 will add R2 signed-URL PDF retrieval; this v2.19.0 version returns inline JSON only.
+- **`src/queue/brand-audit-consumer.ts`** — Cloudflare Queue consumer. For each `{ auditId, target }` message: idempotency check (SELECT status FROM brand_audit_targets — duplicate delivery of a completed/failed target acks without re-running brandAuditSingle, preserving budget under at-least-once delivery), status flip → `'running'`, run `brandAuditSingle`, persist result_json + final status, atomic counter tick. Marks audit `completed` when `completed_targets === total_targets`. Per-message timeout `BRAND_AUDIT_MESSAGE_TIMEOUT_MS = 300_000` (5 min, distinct from the scan-queue's 20s). Wire-format validated by Zod (`BrandAuditQueueMessageSchema`) as defense in depth.
+- **D1 schema** (`src/lib/db/brand-audit-schema.ts`) — two tables: `brand_audits` (parent, status state-machine, total/completed counters, format, aggregate `results_json`) + `brand_audit_targets` (children, composite PK on `audit_id+target`, per-target `result_json` + `pdf_r2_key` for Phase 3). Index on `(owner_id, created_at)` for owner audit-list queries.
+- **`docs/provisioning/brand-audit-bindings.md`** — operator runbook for one-time provisioning: `wrangler d1 create brand-audit-v1`, `wrangler queues create brand-audit-queue`, schema apply via `wrangler d1 execute --file=-`, plus the `.dev/wrangler.deploy.jsonc` snippet (private binding declarations).
+- **Per-tier daily overrides** for the three new tools in `TIER_TOOL_DAILY_LIMITS` matching `BRAND_AUDIT_QUOTAS` (free/agent=0, developer=50 batch + 5000 polls, partner=200/10000, enterprise=500/25000). Free/agent blocked by `FREE_TOOL_DAILY_LIMITS.brand_audit_{*}=0`.
+- **Chaos test** (`test/chaos/brand-audit-consumer.chaos.test.ts`) — locks the idempotency invariant: a duplicate delivery of a terminal-state target row must ack without re-running brandAuditSingle and without mutating D1.
+- **Contract test** (`test/contracts/brand-audit-status.contract.test.ts`) — Zod-validated response shapes for batch-start, status, and get-report (target + aggregate modes).
+
+### Changed
+- **`brand_audit_single` candidate-fanout cap** (`src/tools/brand-audit-single.ts`) — applies the 5-line defensive cap flagged in the v2.18.0 security audit. Discovery output is sliced to `MAX_CANDIDATES_PER_AUDIT = 200`; the summary now carries `{ truncated: boolean, truncatedAt: number, discoveredTotal: number }` so callers can detect a capped audit. Bounds outbound RDAP fanout regardless of how wide discovery's SAN/NS coverage grows.
+- **Queue dispatch** (`src/index.ts`) — the Worker's `queue:` handler now routes by `batch.queue` between `bv-scanner-queue` (tenant scans) and `brand-audit-queue` (Phase 2). Existing scanner-queue path unchanged. Switched the existing `console.log` to structured `logEvent` per project logging convention.
+- **`ToolRuntimeOptions`** (`src/handlers/tools.ts`) — plumbing-only: added `brandAuditDb?: D1Database`, `brandAuditQueue?: BrandAuditQueueProducer`, `rateLimitKv?: KVNamespace`, `principalId?: string` for the three new tools.
+
+### Operator action required (deploy)
+- Provision `brand-audit-v1` D1, `brand-audit-queue` queue, and `bv-brand-reports` R2 bucket per `docs/provisioning/brand-audit-bindings.md`. Apply the schema (SQL inlined in the doc). Add the binding declarations to `.dev/wrangler.deploy.jsonc`. Then `npm run deploy:prod`. **Until these are provisioned, the three new tools return a `{ unprovisioned: true }` error finding rather than 500-ing**, so the surface is safe to ship before infrastructure is in place.
+
 ## [2.18.0] - 2026-05-15
 
 ### Added

--- a/docs/provisioning/brand-audit-bindings.md
+++ b/docs/provisioning/brand-audit-bindings.md
@@ -1,0 +1,122 @@
+# Brand-Audit Bindings (v2.19.0+)
+
+The `brand_audit_batch_start` async path needs production-only resources: one D1
+database, one Cloudflare Queue, and one R2 bucket (R2 actually consumed by Phase
+3 PDF rendering — declared now for forward-compat).
+
+These bindings live in `.dev/wrangler.deploy.jsonc` (gitignored) and are merged
+into `wrangler.production.jsonc` at deploy time by `scripts/inject-private-config.cjs`.
+The public `wrangler.jsonc` template intentionally omits all production resource
+bindings (KV, D1, queues, R2) — see CLAUDE.md "Production Injection Workflow".
+
+## Resources to provision (one-time)
+
+```bash
+# D1 — single global database, not per-tenant
+npx wrangler d1 create brand-audit-v1
+
+# Queue
+npx wrangler queues create brand-audit-queue
+
+# R2 (forward-compat; only Phase 3 PDF rendering writes to it)
+npx wrangler r2 bucket create bv-brand-reports
+```
+
+Capture the D1 `database_id` from the create-output and insert below.
+
+## `.dev/wrangler.deploy.jsonc` snippet
+
+Add to the existing private deploy config under the same shape as `BV_SCANNER_QUEUE`:
+
+```jsonc
+{
+  "d1_databases": [
+    // ... existing TENANT_REGISTRY_DB, TENANT_DB_TENANT_PILOT_1 entries ...
+    {
+      "binding": "BRAND_AUDIT_DB",
+      "database_name": "brand-audit-v1",
+      "database_id": "<from-create-output>"
+    }
+  ],
+  "queues": {
+    "producers": [
+      // ... existing BV_SCANNER_QUEUE entry ...
+      { "binding": "BRAND_AUDIT_QUEUE", "queue": "brand-audit-queue" }
+    ],
+    "consumers": [
+      // ... existing bv-scanner-queue consumer ...
+      {
+        "queue": "brand-audit-queue",
+        "max_batch_size": 5,
+        "max_batch_timeout": 30,
+        "max_retries": 3
+      }
+    ]
+  },
+  "r2_buckets": [
+    { "binding": "BRAND_REPORTS", "bucket_name": "bv-brand-reports" }
+  ]
+}
+```
+
+## Schema apply (one-time, after D1 create)
+
+The Drizzle schema in `src/lib/db/brand-audit-schema.ts` is the source of truth.
+The repo does not commit migration SQL — apply the schema manually:
+
+```sql
+-- brand-audit-v1 schema (v2.19.0)
+CREATE TABLE IF NOT EXISTS brand_audits (
+  id TEXT PRIMARY KEY,
+  owner_id TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('queued','running','completed','failed')),
+  total_targets INTEGER NOT NULL,
+  completed_targets INTEGER NOT NULL DEFAULT 0,
+  format TEXT NOT NULL CHECK (format IN ('json','markdown','both')),
+  results_json TEXT,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL,
+  completed_at INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_brand_audits_owner ON brand_audits(owner_id, created_at);
+
+CREATE TABLE IF NOT EXISTS brand_audit_targets (
+  audit_id TEXT NOT NULL REFERENCES brand_audits(id),
+  target TEXT NOT NULL,
+  status TEXT NOT NULL CHECK (status IN ('queued','running','completed','failed')),
+  result_json TEXT,
+  pdf_r2_key TEXT,
+  error TEXT,
+  created_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  PRIMARY KEY (audit_id, target)
+);
+```
+
+Apply via:
+
+```bash
+npx wrangler d1 execute brand-audit-v1 --file=- --remote <<'SQL'
+<paste above>
+SQL
+```
+
+## Verification post-deploy
+
+```bash
+# Confirm tables exist
+npx wrangler d1 execute brand-audit-v1 --remote --command \
+  "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+
+# Confirm queue exists
+npx wrangler queues list | grep brand-audit-queue
+
+# Smoke test the producer (after deploy)
+curl -sX POST https://dns-mcp.blackveilsecurity.com/mcp \
+  -H 'Authorization: Bearer <DEV_KEY>' \
+  -H 'Content-Type: application/json' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"brand_audit_batch_start","arguments":{"domains":["apple.com"]}}}'
+```
+
+The first call should return `{ auditId, queuedAt, targetCount: 1, etaSeconds: ~180 }`.
+Poll with `brand_audit_status` until `status: 'completed'`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.18.0",
+	"version": "2.19.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "2.18.0",
+			"version": "2.19.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.18.0",
+	"version": "2.19.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "2.18.0",
+	"version": "2.19.0",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "2.18.0",
+			"version": "2.19.0",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -52,6 +52,9 @@ import { checkDnssecChain } from '../tools/check-dnssec-chain';
 import { checkFastFlux } from '../tools/check-fast-flux';
 import { discoverBrandDomains } from '../tools/discover-brand-domains';
 import { brandAuditSingle } from '../tools/brand-audit-single';
+import { brandAuditBatchStart } from '../tools/brand-audit-batch-start';
+import { brandAuditStatus } from '../tools/brand-audit-status';
+import { brandAuditGetReport } from '../tools/brand-audit-get-report';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
 import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
@@ -97,6 +100,14 @@ interface ToolRuntimeOptions {
 	keyHash?: string;
 	certstream?: { fetch: typeof fetch };
 	whoisBinding?: { fetch: typeof fetch };
+	/** D1 binding for the brand-audit DB. Used by brand_audit_{batch_start,status,get_report}. Undefined if the operator hasn't provisioned brand-audit-v1 yet (see docs/provisioning/brand-audit-bindings.md). */
+	brandAuditDb?: D1Database;
+	/** Cloudflare Queue producer for the brand-audit batch path. Undefined if unprovisioned. */
+	brandAuditQueue?: { send(message: unknown, options?: { contentType?: 'json' }): Promise<void> };
+	/** RATE_LIMIT KV — also used by enforceBrandAuditQuota for the per-tier monthly window. */
+	rateLimitKv?: KVNamespace;
+	/** principalId of the calling user — required for enforceBrandAuditQuota. Key hash for auth, IP hash for unauth. */
+	principalId?: string;
 }
 
 /** Build QueryDnsOptions for individual check calls from runtime options. */
@@ -121,7 +132,8 @@ async function dynamicCheckMx(domain: string, runtimeOptions?: ToolRuntimeOption
 const TOOL_REGISTRY: Record<
 	string,
 	{
-		cacheKey: (args: Record<string, unknown>) => string;
+		/** cacheKey may consult runtimeOptions to bind principal (defense against owner-scoped IDOR via cache). */
+		cacheKey: (args: Record<string, unknown>, runtimeOptions?: ToolRuntimeOptions) => string;
 		execute: (domain: string, args: Record<string, unknown>, runtimeOptions?: ToolRuntimeOptions) => Promise<CheckResult>;
 		cacheTtlSeconds?: number;
 	}
@@ -194,6 +206,87 @@ const TOOL_REGISTRY: Record<
 				whoisBinding: ro?.whoisBinding,
 			}),
 		cacheTtlSeconds: 3600,
+	},
+	brand_audit_batch_start: {
+		// Async producer — not cacheable. Each invocation enqueues fresh work.
+		// Random UUID keeps every call a cache-miss; brief KV write churn is the cost.
+		cacheKey: () => `__nocache__:brand_audit_batch_start:${crypto.randomUUID()}`,
+		execute: async (_domain, args, ro) => {
+			const db = ro?.brandAuditDb;
+			const queue = ro?.brandAuditQueue;
+			const principalId = ro?.principalId ?? ro?.keyHash ?? 'anonymous';
+			if (!db || !queue) {
+				const { buildCheckResult, createFinding } = await import('../lib/scoring');
+				return buildCheckResult('brand_discovery', [
+					createFinding(
+						'brand_discovery',
+						'Brand audit batch unavailable',
+						'high',
+						'BRAND_AUDIT_DB or BRAND_AUDIT_QUEUE binding is not provisioned. See docs/provisioning/brand-audit-bindings.md.',
+						{ unprovisioned: true },
+					),
+				]);
+			}
+			return brandAuditBatchStart(
+				args.domains as string[],
+				{
+					format: args.format as 'json' | 'markdown' | 'both' | undefined,
+					min_confidence: args.min_confidence as number | undefined,
+				},
+				principalId,
+				{ db, queue },
+			);
+		},
+		cacheTtlSeconds: 0,
+	},
+	brand_audit_status: {
+		// Owner-scoped read — cacheKey MUST bind principalId, else Owner B sees Owner A's
+		// cached status for the same auditId (IDOR-via-cache). Short TTL on top.
+		cacheKey: (args, ro) => `brand_audit_status:${ro?.principalId ?? ro?.keyHash ?? 'anon'}:${String(args.auditId ?? '')}`,
+		execute: async (_domain, args, ro) => {
+			const db = ro?.brandAuditDb;
+			const principalId = ro?.principalId ?? ro?.keyHash ?? 'anonymous';
+			if (!db) {
+				const { buildCheckResult, createFinding } = await import('../lib/scoring');
+				return buildCheckResult('brand_discovery', [
+					createFinding(
+						'brand_discovery',
+						'Brand audit status unavailable',
+						'high',
+						'BRAND_AUDIT_DB binding is not provisioned.',
+						{ unprovisioned: true },
+					),
+				]);
+			}
+			return brandAuditStatus(String(args.auditId ?? ''), principalId, { db });
+		},
+		cacheTtlSeconds: 10,
+	},
+	brand_audit_get_report: {
+		// Same owner-scoped IDOR defense as brand_audit_status — bind principalId.
+		cacheKey: (args, ro) => `brand_audit_report:${ro?.principalId ?? ro?.keyHash ?? 'anon'}:${String(args.auditId ?? '')}:${String(args.target ?? '')}`,
+		execute: async (_domain, args, ro) => {
+			const db = ro?.brandAuditDb;
+			const principalId = ro?.principalId ?? ro?.keyHash ?? 'anonymous';
+			if (!db) {
+				const { buildCheckResult, createFinding } = await import('../lib/scoring');
+				return buildCheckResult('brand_discovery', [
+					createFinding(
+						'brand_discovery',
+						'Brand audit get-report unavailable',
+						'high',
+						'BRAND_AUDIT_DB binding is not provisioned.',
+						{ unprovisioned: true },
+					),
+				]);
+			}
+			return brandAuditGetReport(
+				{ auditId: String(args.auditId ?? ''), target: args.target as string | undefined },
+				principalId,
+				{ db },
+			);
+		},
+		cacheTtlSeconds: 60,
 	},
 };
 
@@ -275,7 +368,7 @@ export async function handleToolsCall(
 			// Dispatch to the appropriate tool — check registry first, then special cases
 			const registeredTool = TOOL_REGISTRY[name];
 			if (registeredTool) {
-				const checkName = registeredTool.cacheKey(validatedArgs);
+				const checkName = registeredTool.cacheKey(validatedArgs, runtimeOptions);
 				const cacheKey = `cache:${validDomain}:check:${checkName}`;
 				// Don't cache partial results (e.g. lookalike timeout). The predicate skips the
 				// kv.put entirely instead of the old put-then-delete anti-pattern that drove

--- a/src/index.ts
+++ b/src/index.ts
@@ -768,6 +768,7 @@ app.all('*', (c) => {
 import { handleScheduled, handleDailyDigest, handleFuzzingScan } from './scheduled';
 import type { ScheduledEnv } from './scheduled';
 import { handleScanQueue, type ScanQueueConsumerEnv } from './tenants/queue-consumer';
+import { handleBrandAuditQueue, type BrandAuditConsumerDeps } from './queue/brand-audit-consumer';
 import { handleTenantCycleAlerts, handleTenantWeeklyRescan, type TenantScheduledEnv } from './tenants/scheduled-handlers';
 
 export default {
@@ -787,12 +788,24 @@ export default {
 		}
 	},
 	/**
-	 * Phase 2 scanner-queue consumer. Routes `BV_SCANNER_QUEUE` deliveries to
-	 * `handleScanQueue`. Per-message ack/retry with idempotency + DLQ-after-3.
-	 * See `src/tenants/queue-consumer.ts` for the full processing contract.
+	 * Queue consumer dispatch. Routes by `batch.queue` since both
+	 * `bv-scanner-queue` (tenant scans) and `brand-audit-queue` (brand-audit
+	 * async path, v2.19.0+) share the same Worker entrypoint.
 	 */
 	queue: async (batch: MessageBatch<unknown>, env: Record<string, unknown>, ctx: ExecutionContext) => {
-		console.log(`Received queue batch with ${batch.messages.length} messages.`);
+		logEvent({ timestamp: new Date().toISOString(), category: 'queue', result: 'batch_received', severity: 'info', details: { queue: batch.queue, messageCount: batch.messages.length } });
+		if (batch.queue === 'brand-audit-queue') {
+			const db = (env as Record<string, unknown>).BRAND_AUDIT_DB as D1Database | undefined;
+			if (!db) {
+				// Binding missing — ack every message to avoid hot-looping. Operator
+				// must provision per docs/provisioning/brand-audit-bindings.md.
+				for (const m of batch.messages) m.ack();
+				return;
+			}
+			const deps: BrandAuditConsumerDeps = { db };
+			await handleBrandAuditQueue(batch, deps);
+			return;
+		}
 		await handleScanQueue(batch, env as ScanQueueConsumerEnv, ctx);
 	},
 };

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -169,15 +169,27 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		explain_finding: 500_000,
 		discover_brand_domains: 50_000,
 		brand_audit_single: 200,
+		brand_audit_batch_start: 200,
+		brand_audit_status: 10_000,
+		brand_audit_get_report: 10_000,
 	},
 	developer: {
 		brand_audit_single: 50,
+		brand_audit_batch_start: 50,
+		brand_audit_status: 5_000,
+		brand_audit_get_report: 5_000,
 	},
 	enterprise: {
 		brand_audit_single: 500,
+		brand_audit_batch_start: 500,
+		brand_audit_status: 25_000,
+		brand_audit_get_report: 25_000,
 	},
 	agent: {
 		brand_audit_single: 0,
+		brand_audit_batch_start: 0,
+		brand_audit_status: 0,
+		brand_audit_get_report: 0,
 	},
 };
 
@@ -236,6 +248,9 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_fast_flux: 3,
 	discover_brand_domains: 1,
 	brand_audit_single: 0,
+	brand_audit_batch_start: 0,
+	brand_audit_status: 0,
+	brand_audit_get_report: 0,
 };
 
 /** Tools intentionally governed by per-IP rate limits only (no per-tool free-tier quota). Audited by test/audits/tool-quota-coverage.audit.test.ts. */

--- a/src/lib/db/brand-audit-schema.ts
+++ b/src/lib/db/brand-audit-schema.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Drizzle ORM schema for the **brand-audit D1** (`brand-audit-v1`).
+ *
+ * Two-table model:
+ *   - `brand_audits` — parent row per batch, written by `brand_audit_batch_start`
+ *     before enqueueing per-target queue messages. `total_targets` is locked at
+ *     enqueue time; `completed_targets` advances as the consumer drains.
+ *   - `brand_audit_targets` — child row per (auditId, target) pair. Holds the
+ *     per-target result JSON (full CheckResult from `brandAuditSingle`) and,
+ *     once Phase 3 lands, the R2 key for the rendered PDF.
+ *
+ * `owner_id` stores the caller's principalId — same shape used by
+ * `lib/rate-limiter.ts`: an API-key hash for authenticated callers, an IP hash
+ * (`i_<fnv1a>`) for unauthenticated. Free/agent tiers can't reach this surface
+ * (quota=0), so in practice owner_id is always a key hash, but the column is
+ * permissive to match the existing principalId contract.
+ *
+ * Provisioning (not committed as a migration file — see CHANGELOG):
+ *   wrangler d1 create brand-audit-v1
+ *   wrangler d1 execute brand-audit-v1 --file docs/provisioning/brand-audit-v1.sql --remote
+ *
+ * Status state machine: queued → running → completed | failed.
+ * Idempotency: consumer must SELECT status before re-running brandAuditSingle —
+ * Cloudflare Queues can deliver a message N times on retry.
+ */
+
+import { index, integer, primaryKey, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+/** State machine for both audits and targets. */
+export type BrandAuditStatus = 'queued' | 'running' | 'completed' | 'failed';
+
+/** Output format requested at enqueue time. */
+export type BrandAuditFormat = 'json' | 'markdown' | 'both';
+
+export const brandAudits = sqliteTable(
+	'brand_audits',
+	{
+		id: text('id').primaryKey(),
+		owner_id: text('owner_id').notNull(),
+		status: text('status', { enum: ['queued', 'running', 'completed', 'failed'] as const }).notNull(),
+		total_targets: integer('total_targets').notNull(),
+		completed_targets: integer('completed_targets').notNull().default(0),
+		format: text('format', { enum: ['json', 'markdown', 'both'] as const }).notNull(),
+		/** Aggregate per-audit summary JSON, populated by the consumer on final-target completion. */
+		results_json: text('results_json'),
+		created_at: integer('created_at').notNull(),
+		updated_at: integer('updated_at').notNull(),
+		completed_at: integer('completed_at'),
+	},
+	(t) => [index('idx_brand_audits_owner').on(t.owner_id, t.created_at)],
+);
+
+export const brandAuditTargets = sqliteTable(
+	'brand_audit_targets',
+	{
+		audit_id: text('audit_id')
+			.notNull()
+			.references(() => brandAudits.id),
+		target: text('target').notNull(),
+		status: text('status', { enum: ['queued', 'running', 'completed', 'failed'] as const }).notNull(),
+		/** Full per-target CheckResult JSON from `brandAuditSingle`. Null until status=completed. */
+		result_json: text('result_json'),
+		/** R2 object key for the rendered PDF. Populated in Phase 3 by the PDF queue consumer. */
+		pdf_r2_key: text('pdf_r2_key'),
+		/** Error message when status=failed. Sanitized — should not leak internal infra. */
+		error: text('error'),
+		created_at: integer('created_at').notNull(),
+		completed_at: integer('completed_at'),
+	},
+	(t) => [primaryKey({ columns: [t.audit_id, t.target] })],
+);
+
+export type BrandAuditRow = typeof brandAudits.$inferSelect;
+export type BrandAuditInsert = typeof brandAudits.$inferInsert;
+export type BrandAuditTargetRow = typeof brandAuditTargets.$inferSelect;
+export type BrandAuditTargetInsert = typeof brandAuditTargets.$inferInsert;

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '2.18.0';
+export const SERVER_VERSION = '2.19.0';

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -1,0 +1,211 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Cloudflare Queue consumer for the brand-audit batch flow.
+ *
+ * Each message is `{ auditId, target, format, min_confidence? }` (produced by
+ * `brand_audit_batch_start`). For each message we:
+ *
+ *   1. **Idempotency check** — SELECT status FROM brand_audit_targets WHERE
+ *      audit_id=? AND target=?. If already 'completed' or 'failed', ack the
+ *      message and return — Cloudflare Queues can deliver the same message N
+ *      times on retry, so re-running brandAuditSingle would double-count and
+ *      waste budget.
+ *   2. **Status flip → 'running'** with started_at timestamp.
+ *   3. Call `brandAuditSingle(target, ...)` — the same orchestrator that powers
+ *      the sync surface. Wall time per target ≈ 3 min for tier-1 brands.
+ *   4. **Status flip → 'completed'** with result_json + completed_at, OR
+ *      `'failed'` with error string. Use a transient-error guard so a D1 hiccup
+ *      mid-write maps to `retry`, not `ack` (Cloudflare will redeliver).
+ *   5. **Counter tick** — atomic UPDATE brand_audits SET completed_targets =
+ *      completed_targets + 1. If post-tick completed_targets === total_targets,
+ *      mark the audit `completed` and stamp completed_at.
+ *
+ * Phase 3 will additionally enqueue to the PDF queue on completion when
+ * `format ∈ {markdown, both}` requests a PDF rendering. v2.19.0 only stores the
+ * result_json blob.
+ */
+
+import { z } from 'zod';
+import { brandAuditSingle as defaultBrandAuditSingle } from '../tools/brand-audit-single';
+import type { CheckResult } from '../lib/scoring';
+
+/** Cloudflare Queues redelivery budget: keep messages alive for at most 5 min total. */
+export const BRAND_AUDIT_MESSAGE_TIMEOUT_MS = 300_000;
+
+/** Wire format for a brand-audit queue message. Validated on the consumer side as defense in depth. */
+export const BrandAuditQueueMessageSchema = z.object({
+	auditId: z.string().min(1).max(64),
+	target: z.string().min(1).max(253),
+	format: z.enum(['json', 'markdown', 'both']),
+	min_confidence: z.number().min(0).max(1).optional(),
+});
+
+export type BrandAuditQueueMessage = z.infer<typeof BrandAuditQueueMessageSchema>;
+
+export interface BrandAuditConsumerDeps {
+	db: D1Database;
+	/** Injectable for tests. */
+	brandAuditSingle?: (target: string, options: { format?: 'json' | 'markdown' | 'both'; min_confidence?: number }) => Promise<CheckResult>;
+	/** Clock override for tests. */
+	now?: () => number;
+}
+
+interface TargetStatusRow {
+	status: 'queued' | 'running' | 'completed' | 'failed';
+	completed_at: number | null;
+}
+
+interface AuditCounterRow {
+	completed_targets: number;
+	total_targets: number;
+}
+
+/**
+ * Process a single message body. Returns:
+ *   - `'ack'` — message handled (success, idempotent skip, or unrecoverable error)
+ *   - `'retry'` — transient infrastructure failure; Cloudflare should redeliver
+ */
+export async function processBrandAuditMessage(
+	rawBody: unknown,
+	deps: BrandAuditConsumerDeps,
+): Promise<'ack' | 'retry'> {
+	const parsed = BrandAuditQueueMessageSchema.safeParse(rawBody);
+	if (!parsed.success) {
+		// Malformed payload — never recoverable by retry. Drop.
+		return 'ack';
+	}
+	const message = parsed.data;
+	const now = (deps.now ?? Date.now)();
+	const single = deps.brandAuditSingle ?? defaultBrandAuditSingle;
+
+	// 1. Idempotency check.
+	let existing: TargetStatusRow | null;
+	try {
+		existing = (await deps.db
+			.prepare(
+				'SELECT status, completed_at FROM brand_audit_targets WHERE audit_id = ? AND target = ? LIMIT 1',
+			)
+			.bind(message.auditId, message.target)
+			.first()) as TargetStatusRow | null;
+	} catch {
+		return 'retry';
+	}
+
+	if (!existing) {
+		// Target row missing — producer should have inserted it. Treat as
+		// unrecoverable (don't loop the queue) but don't fan out work either.
+		return 'ack';
+	}
+
+	if (existing.status === 'completed' || existing.status === 'failed') {
+		// Duplicate delivery of a terminal-state row. Ack without re-running.
+		return 'ack';
+	}
+
+	// 2. Status flip → 'running'.
+	try {
+		await deps.db
+			.prepare(
+				"UPDATE brand_audit_targets SET status = 'running' WHERE audit_id = ? AND target = ? AND status = 'queued'",
+			)
+			.bind(message.auditId, message.target)
+			.run();
+	} catch {
+		return 'retry';
+	}
+
+	// 3. Run the orchestrator with a hard timeout. Tier-1 brands average ~3 min
+	// per target; we cap at BRAND_AUDIT_MESSAGE_TIMEOUT_MS (5 min) so a single
+	// stuck WHOIS / RDAP chain can't ride out the Worker's full retry budget.
+	// On timeout the target row flips to `failed` with a structured error rather
+	// than mysteriously remaining in `running`.
+	let result: CheckResult | null = null;
+	let runtimeError: string | null = null;
+	try {
+		result = await Promise.race([
+			single(message.target, {
+				format: message.format,
+				min_confidence: message.min_confidence,
+			}),
+			new Promise<never>((_, reject) =>
+				setTimeout(
+					() => reject(new Error(`brand_audit_single timed out after ${BRAND_AUDIT_MESSAGE_TIMEOUT_MS}ms`)),
+					BRAND_AUDIT_MESSAGE_TIMEOUT_MS,
+				),
+			),
+		]);
+	} catch (err) {
+		runtimeError = err instanceof Error ? err.message : String(err);
+	}
+
+	// 4. Status flip → 'completed' | 'failed'. Treat D1 write failure here as
+	// retryable (Cloudflare redelivers; idempotency check up top short-circuits).
+	const finalStatus = runtimeError ? 'failed' : 'completed';
+	const resultJson = result ? JSON.stringify(result) : null;
+	const errorString = runtimeError ? sanitizeErrorString(runtimeError) : null;
+
+	try {
+		await deps.db
+			.prepare(
+				'UPDATE brand_audit_targets SET status = ?, result_json = ?, error = ?, completed_at = ? WHERE audit_id = ? AND target = ?',
+			)
+			.bind(finalStatus, resultJson, errorString, now, message.auditId, message.target)
+			.run();
+	} catch {
+		return 'retry';
+	}
+
+	// 5. Counter tick — bump completed_targets and check finalization.
+	try {
+		await deps.db
+			.prepare(
+				'UPDATE brand_audits SET completed_targets = completed_targets + 1, updated_at = ? WHERE id = ?',
+			)
+			.bind(now, message.auditId)
+			.run();
+
+		const counter = (await deps.db
+			.prepare(
+				'SELECT completed_targets, total_targets FROM brand_audits WHERE id = ? LIMIT 1',
+			)
+			.bind(message.auditId)
+			.first()) as AuditCounterRow | null;
+
+		if (counter && counter.completed_targets >= counter.total_targets) {
+			await deps.db
+				.prepare(
+					"UPDATE brand_audits SET status = 'completed', completed_at = ?, updated_at = ? WHERE id = ?",
+				)
+				.bind(now, now, message.auditId)
+				.run();
+		}
+	} catch {
+		// Counter-tick failure leaves the audit row stale but the target row is
+		// already terminal — manual reconciliation via a scheduled cleanup
+		// (Phase 4). We still ack to avoid re-running brandAuditSingle.
+		return 'ack';
+	}
+
+	return 'ack';
+}
+
+/** Strip newlines / runaway-length from error strings before persisting. */
+function sanitizeErrorString(raw: string): string {
+	return raw.replace(/[\r\n\t]+/g, ' ').slice(0, 500);
+}
+
+/** Cloudflare Queue consumer entrypoint — fans out to `processBrandAuditMessage` per message. */
+export async function handleBrandAuditQueue(
+	batch: MessageBatch<unknown>,
+	deps: BrandAuditConsumerDeps,
+): Promise<void> {
+	for (const message of batch.messages) {
+		const verdict = await processBrandAuditMessage(message.body, deps);
+		if (verdict === 'retry') {
+			message.retry();
+		} else {
+			message.ack();
+		}
+	}
+}

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -238,6 +238,38 @@ export const BrandAuditSingleArgs = z.object({
 		.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
 }).passthrough();
 
+/** brand_audit_batch_start — enqueue async brand audits for up to 50 targets. */
+export const BrandAuditBatchStartArgs = z.object({
+	domains: z
+		.array(z.string().min(1).max(253))
+		.min(1)
+		.max(50)
+		.describe('Domains to audit (max 50 per batch). Duplicates are merged.'),
+	format: BrandAuditFormatSchema.optional().describe('Inline output mode. Defaults to "both".'),
+	min_confidence: z
+		.number()
+		.min(0)
+		.max(1)
+		.optional()
+		.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
+}).passthrough();
+
+/** brand_audit_status — poll status of an enqueued audit. */
+export const BrandAuditStatusArgs = z.object({
+	auditId: z.string().min(1).max(64).describe('Audit ID returned by brand_audit_batch_start.'),
+}).passthrough();
+
+/** brand_audit_get_report — fetch result JSON for an audit or single target. */
+export const BrandAuditGetReportArgs = z.object({
+	auditId: z.string().min(1).max(64).describe('Audit ID returned by brand_audit_batch_start.'),
+	target: z
+		.string()
+		.min(1)
+		.max(253)
+		.optional()
+		.describe('Specific target domain. Omit for audit-level aggregate.'),
+}).passthrough();
+
 /**
  * Map of every tool name to its Zod argument schema.
  * Used for runtime validation in tools.ts and for inputSchema generation.
@@ -296,4 +328,7 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	check_fast_flux: CheckFastFluxArgs,
 	discover_brand_domains: DiscoverBrandDomainsArgs,
 	brand_audit_single: BrandAuditSingleArgs,
+	brand_audit_batch_start: BrandAuditBatchStartArgs,
+	brand_audit_status: BrandAuditStatusArgs,
+	brand_audit_get_report: BrandAuditGetReportArgs,
 };

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -23,6 +23,9 @@ import {
 	CheckFastFluxArgs,
 	DiscoverBrandDomainsArgs,
 	BrandAuditSingleArgs,
+	BrandAuditBatchStartArgs,
+	BrandAuditStatusArgs,
+	BrandAuditGetReportArgs,
 	TOOL_SCHEMA_MAP,
 } from './tool-args';
 
@@ -436,6 +439,27 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		description:
 			"Run a full brand audit on a single target: discover brand-related domains via all 8 discovery signals, look up registrar + registrant for each candidate, and classify each into one of four buckets (consolidated, shadowIt, indeterminate, impersonation). Returns a per-candidate classification with summary counts. Gated tier-wide by monthly BRAND_AUDIT_QUOTAS (free/agent=0, developer=50, partner=200, enterprise=500, owner=unlimited).",
 		schema: BrandAuditSingleArgs,
+		group: 'discovery',
+		scanIncluded: false,
+	},
+	brand_audit_batch_start: {
+		description:
+			"Enqueue an async brand audit across up to 50 target domains. Returns { auditId, queuedAt, targetCount, etaSeconds } immediately; poll with brand_audit_status and fetch results with brand_audit_get_report once complete. Each target consumes 1 unit of the monthly BRAND_AUDIT_QUOTAS budget (consumed atomically at enqueue — partial-failure batches don't refund).",
+		schema: BrandAuditBatchStartArgs,
+		group: 'discovery',
+		scanIncluded: false,
+	},
+	brand_audit_status: {
+		description:
+			"Poll the status of an enqueued brand audit. Returns audit-level status (queued | running | completed | failed), progress 'N/M', and per-target statuses. Owner-scoped — auditIds owned by other principals surface as notFound.",
+		schema: BrandAuditStatusArgs,
+		group: 'discovery',
+		scanIncluded: false,
+	},
+	brand_audit_get_report: {
+		description:
+			"Fetch the result JSON for a completed brand audit. With `target` set, returns the per-target CheckResult; without, returns the audit-level aggregate. Returns notReady when polling against an in-flight audit. Phase 3 will add R2 signed-URL PDF retrieval; this v2.19.0 version returns inline JSON only.",
+		schema: BrandAuditGetReportArgs,
 		group: 'discovery',
 		scanIncluded: false,
 	},

--- a/src/tools/brand-audit-batch-start.ts
+++ b/src/tools/brand-audit-batch-start.ts
@@ -1,0 +1,237 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * brand_audit_batch_start — producer for the async brand-audit flow.
+ *
+ * Validates the domain list (max 50, deduplicated, non-empty), optionally consumes
+ * per-tier monthly quota atomically at enqueue time (so a partial-failure batch
+ * can't refund quota), writes the parent `brand_audits` row to D1, then enqueues
+ * one `{ auditId, target }` message per target onto BRAND_AUDIT_QUEUE.
+ *
+ * Returns a `CheckResult` whose summary metadata carries `{ auditId, queuedAt,
+ * targetCount, etaSeconds }`. The caller polls with `brand_audit_status` and
+ * fetches results with `brand_audit_get_report` once status → 'completed'.
+ *
+ * Failure modes:
+ *   - Empty/invalid domain list → `invalidInput` finding, no quota consumed
+ *   - Over 50 domains → `batchTooLarge` finding, no quota consumed
+ *   - Quota exceeded (when enforceQuota dep is wired) → `quotaExceeded` finding,
+ *     no D1 write
+ *   - D1 parent or child insert fails → `persistenceFailure` finding, no queue.send
+ *     fires (caller can safely retry — no half-written state visible to consumers)
+ *   - queue.send fails for SOME targets mid-loop → `partialEnqueue` finding listing
+ *     `failedToEnqueue: [{ target, error }]`. The audit row's status is flipped to
+ *     `'failed'` so the polling tool stops claiming progress against targets that
+ *     no consumer will pick up.
+ */
+
+import { buildCheckResult, createFinding, type CheckResult } from '../lib/scoring';
+import type { BrandAuditFormat } from '../lib/db/brand-audit-schema';
+
+const CATEGORY = 'brand_discovery';
+
+/** Hard cap on targets per batch. Aligns with Phase 2 plan §scope. */
+const MAX_TARGETS_PER_BATCH = 50;
+
+/**
+ * ETA per target. Tier-1 brand audits average ~3 min wall clock (40+ candidates
+ * × RDAP fanout). Used for the response so the caller can poll at a reasonable
+ * interval rather than tight-looping.
+ */
+const ETA_SECONDS_PER_TARGET = 180;
+
+export interface BrandAuditBatchStartOptions {
+	format?: BrandAuditFormat;
+	min_confidence?: number;
+}
+
+export type EnforceBrandAuditQuota = (count: number) => Promise<{
+	allowed: boolean;
+	remaining?: number;
+	limit?: number;
+	retryAfterMs?: number;
+}>;
+
+export interface BrandAuditQueueMessage {
+	auditId: string;
+	target: string;
+	format: BrandAuditFormat;
+	min_confidence?: number;
+}
+
+export interface BrandAuditQueueProducer {
+	send(message: BrandAuditQueueMessage, options?: { contentType?: 'json' }): Promise<void>;
+}
+
+/** Injectable deps. Production wiring threads env bindings; tests pass mocks. */
+export interface BrandAuditBatchStartDeps {
+	db: D1Database;
+	queue: BrandAuditQueueProducer;
+	enforceQuota?: EnforceBrandAuditQuota;
+	/** UUID generator override for deterministic tests. */
+	generateId?: () => string;
+	/** Clock override for deterministic tests. */
+	now?: () => number;
+}
+
+function buildErrorResult(
+	flag: 'invalidInput' | 'batchTooLarge' | 'quotaExceeded' | 'persistenceFailure',
+	message: string,
+	extra: Record<string, unknown> = {},
+): CheckResult {
+	return buildCheckResult(CATEGORY, [
+		createFinding(CATEGORY, `Brand audit batch start: ${flag}`, 'high', message, {
+			[flag]: true,
+			...extra,
+		}),
+	]);
+}
+
+function normaliseDomains(input: readonly string[]): string[] {
+	const seen = new Set<string>();
+	const out: string[] = [];
+	for (const raw of input) {
+		if (typeof raw !== 'string') continue;
+		const norm = raw.trim().toLowerCase().replace(/\.$/, '');
+		if (!norm || seen.has(norm)) continue;
+		seen.add(norm);
+		out.push(norm);
+	}
+	return out;
+}
+
+export async function brandAuditBatchStart(
+	domains: readonly string[],
+	options: BrandAuditBatchStartOptions,
+	ownerId: string,
+	deps: BrandAuditBatchStartDeps,
+): Promise<CheckResult> {
+	if (!Array.isArray(domains) || domains.length === 0) {
+		return buildErrorResult('invalidInput', 'Empty or invalid domain list.');
+	}
+
+	if (domains.length > MAX_TARGETS_PER_BATCH) {
+		return buildErrorResult(
+			'batchTooLarge',
+			`Batch size ${domains.length} exceeds the per-call cap of ${MAX_TARGETS_PER_BATCH}.`,
+			{ submittedCount: domains.length, cap: MAX_TARGETS_PER_BATCH },
+		);
+	}
+
+	const targets = normaliseDomains(domains);
+	if (targets.length === 0) {
+		return buildErrorResult('invalidInput', 'No usable targets after normalisation.');
+	}
+
+	const enforce = deps.enforceQuota;
+	if (enforce) {
+		const verdict = await enforce(targets.length);
+		if (!verdict.allowed) {
+			const retryHint =
+				typeof verdict.retryAfterMs === 'number'
+					? ` retry after ${Math.ceil(verdict.retryAfterMs / 1000)}s`
+					: '';
+			return buildErrorResult(
+				'quotaExceeded',
+				`Monthly quota of ${verdict.limit ?? 0} targets reached for this principal.${retryHint}`,
+				{
+					target: ownerId,
+					limit: verdict.limit ?? 0,
+					remaining: verdict.remaining ?? 0,
+					retryAfterMs: verdict.retryAfterMs,
+					requested: targets.length,
+				},
+			);
+		}
+	}
+
+	const auditId = (deps.generateId ?? defaultGenerateId)();
+	const now = (deps.now ?? Date.now)();
+	const format: BrandAuditFormat = options.format ?? 'both';
+
+	try {
+		await deps.db
+			.prepare(
+				'INSERT INTO brand_audits (id, owner_id, status, total_targets, completed_targets, format, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+			)
+			.bind(auditId, ownerId, 'queued', targets.length, 0, format, now, now)
+			.run();
+
+		for (const target of targets) {
+			await deps.db
+				.prepare(
+					'INSERT INTO brand_audit_targets (audit_id, target, status, created_at) VALUES (?, ?, ?, ?)',
+				)
+				.bind(auditId, target, 'queued', now)
+				.run();
+		}
+	} catch (err) {
+		return buildErrorResult(
+			'persistenceFailure',
+			`Failed to persist brand audit row: ${err instanceof Error ? err.message : String(err)}`,
+			{ auditId },
+		);
+	}
+
+	const enqueued: string[] = [];
+	const failedToEnqueue: { target: string; error: string }[] = [];
+	for (const target of targets) {
+		try {
+			await deps.queue.send(
+				{ auditId, target, format, min_confidence: options.min_confidence },
+				{ contentType: 'json' },
+			);
+			enqueued.push(target);
+		} catch (err) {
+			failedToEnqueue.push({
+				target,
+				error: err instanceof Error ? err.message : String(err),
+			});
+		}
+	}
+
+	// On any enqueue failure, mark the audit `failed` so the polling tool stops
+	// claiming progress against targets that no consumer will ever pick up.
+	// The audit row + per-target rows already exist; we flip parent.status only.
+	if (failedToEnqueue.length > 0) {
+		try {
+			await deps.db
+				.prepare("UPDATE brand_audits SET status = 'failed', updated_at = ? WHERE id = ?")
+				.bind(now, auditId)
+				.run();
+		} catch {
+			// Best-effort — the partialEnqueue finding still surfaces the truth to the caller.
+		}
+	}
+
+	const etaSeconds = ETA_SECONDS_PER_TARGET * Math.max(1, Math.ceil(enqueued.length / 5));
+	const isPartial = failedToEnqueue.length > 0;
+	return buildCheckResult(CATEGORY, [
+		createFinding(
+			CATEGORY,
+			isPartial
+				? `Brand audit batch partially queued: ${enqueued.length}/${targets.length} target(s)`
+				: `Brand audit batch queued: ${targets.length} target(s)`,
+			isPartial ? 'medium' : 'info',
+			`auditId=${auditId} queuedAt=${new Date(now).toISOString()} etaSeconds=${etaSeconds}`,
+			{
+				summary: true,
+				auditId,
+				queuedAt: now,
+				targetCount: enqueued.length,
+				etaSeconds,
+				format,
+				targets: enqueued,
+				...(isPartial && {
+					partialEnqueue: true,
+					failedToEnqueue,
+					requestedCount: targets.length,
+				}),
+			},
+		),
+	]);
+}
+
+function defaultGenerateId(): string {
+	return crypto.randomUUID();
+}

--- a/src/tools/brand-audit-get-report.ts
+++ b/src/tools/brand-audit-get-report.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * brand_audit_get_report — fetch a per-target or audit-aggregate result.
+ *
+ * Read-only D1 lookup. Owner-scoped — someone else's auditId surfaces as
+ * `notFound`, never `accessDenied` (ID-enumeration defense, same as
+ * brand_audit_status).
+ *
+ * Modes:
+ *   - `{ auditId, target }` → per-target CheckResult JSON from `brand_audit_targets.result_json`.
+ *     Returns `notReady` when the target row status is queued/running, `notFound`
+ *     when the row doesn't exist, and the parsed JSON when status=completed.
+ *   - `{ auditId }` (no target) → audit-level aggregate JSON from
+ *     `brand_audits.results_json`. Same ready/notReady gating against the audit
+ *     row's status.
+ *
+ * R2 PDF mode lands in Phase 3 — this tool returns inline JSON only.
+ */
+
+import { buildCheckResult, createFinding, type CheckResult } from '../lib/scoring';
+import type { BrandAuditStatus } from '../lib/db/brand-audit-schema';
+
+const CATEGORY = 'brand_discovery';
+
+export interface BrandAuditGetReportArgs {
+	auditId: string;
+	target?: string;
+}
+
+export interface BrandAuditGetReportDeps {
+	db: D1Database;
+}
+
+interface AuditRowSlim {
+	id: string;
+	owner_id: string;
+	status: BrandAuditStatus;
+	results_json: string | null;
+	format: string;
+}
+
+interface TargetRowSlim {
+	audit_id: string;
+	target: string;
+	status: BrandAuditStatus;
+	result_json: string | null;
+	error: string | null;
+	completed_at: number | null;
+}
+
+function errorResult(flag: string, message: string, extra: Record<string, unknown> = {}): CheckResult {
+	return buildCheckResult(CATEGORY, [
+		createFinding(CATEGORY, `Brand audit get report: ${flag}`, 'high', message, { [flag]: true, ...extra }),
+	]);
+}
+
+function safeParse(json: string | null): unknown {
+	if (!json) return null;
+	try {
+		return JSON.parse(json);
+	} catch {
+		return null;
+	}
+}
+
+export async function brandAuditGetReport(
+	args: BrandAuditGetReportArgs,
+	ownerId: string,
+	deps: BrandAuditGetReportDeps,
+): Promise<CheckResult> {
+	const { auditId, target } = args;
+	if (typeof auditId !== 'string' || auditId.trim().length === 0) {
+		return errorResult('invalidInput', 'auditId is required.');
+	}
+
+	const auditRow = (await deps.db
+		.prepare(
+			'SELECT id, owner_id, status, results_json, format FROM brand_audits WHERE id = ? LIMIT 1',
+		)
+		.bind(auditId)
+		.first()) as AuditRowSlim | null;
+
+	if (!auditRow || auditRow.owner_id !== ownerId) {
+		return errorResult('notFound', `No brand audit found with id ${auditId}.`, { auditId });
+	}
+
+	if (target) {
+		const targetRow = (await deps.db
+			.prepare(
+				'SELECT audit_id, target, status, result_json, error, completed_at FROM brand_audit_targets WHERE audit_id = ? AND target = ? LIMIT 1',
+			)
+			.bind(auditId, target.trim().toLowerCase())
+			.first()) as TargetRowSlim | null;
+
+		if (!targetRow) {
+			return errorResult('notFound', `Target ${target} not in audit ${auditId}.`, { auditId, target });
+		}
+
+		if (targetRow.status !== 'completed' && targetRow.status !== 'failed') {
+			return errorResult(
+				'notReady',
+				`Target ${target} is currently ${targetRow.status}. Poll again with brand_audit_status.`,
+				{ auditId, target, currentStatus: targetRow.status },
+			);
+		}
+
+		const parsed = safeParse(targetRow.result_json);
+		return buildCheckResult(CATEGORY, [
+			createFinding(
+				CATEGORY,
+				`Brand audit ${auditId} target ${target}: ${targetRow.status}`,
+				'info',
+				`status=${targetRow.status} completedAt=${targetRow.completed_at ? new Date(targetRow.completed_at).toISOString() : '—'}`,
+				{
+					summary: true,
+					auditId,
+					target: targetRow.target,
+					status: targetRow.status,
+					result: parsed,
+					error: targetRow.error,
+				},
+			),
+		]);
+	}
+
+	if (auditRow.status !== 'completed' && auditRow.status !== 'failed') {
+		return errorResult(
+			'notReady',
+			`Audit ${auditId} is currently ${auditRow.status}. Poll again with brand_audit_status.`,
+			{ auditId, currentStatus: auditRow.status },
+		);
+	}
+
+	const aggregate = safeParse(auditRow.results_json);
+	return buildCheckResult(CATEGORY, [
+		createFinding(
+			CATEGORY,
+			`Brand audit ${auditId} aggregate: ${auditRow.status}`,
+			'info',
+			`status=${auditRow.status} format=${auditRow.format}`,
+			{
+				summary: true,
+				auditId,
+				status: auditRow.status,
+				format: auditRow.format,
+				aggregate,
+			},
+		),
+	]);
+}

--- a/src/tools/brand-audit-single.ts
+++ b/src/tools/brand-audit-single.ts
@@ -46,6 +46,16 @@ const CATEGORY = 'brand_discovery';
 /** Concurrency cap for parallel RDAP lookups across candidates. */
 const RDAP_CONCURRENCY = 10;
 
+/**
+ * Defensive cap on per-audit candidate count. A pathological discovery output
+ * (e.g. a seed that triggers wide crt.sh SAN matches on a multi-tenant CDN)
+ * could otherwise fan out to thousands of RDAP fetches. 200 comfortably
+ * accommodates the tier-1 brand baseline (~40 candidates per CLAUDE.md's
+ * Known Constraints) with 5× headroom; over that, the consumer ack()s with
+ * `truncated: true` rather than spending Workers CPU + outbound budget.
+ */
+const MAX_CANDIDATES_PER_AUDIT = 200;
+
 const BUCKET_SEVERITY: Record<Bucket, Severity> = {
 	consolidated: 'info',
 	indeterminate: 'low',
@@ -161,7 +171,9 @@ export async function brandAuditSingle(
 	};
 
 	const discovery = await discover(seedDomain, discoveryOpts);
-	const candidateFindings = discovery.findings.filter((f) => typeof f.metadata?.candidate === 'string');
+	const allCandidateFindings = discovery.findings.filter((f) => typeof f.metadata?.candidate === 'string');
+	const truncated = allCandidateFindings.length > MAX_CANDIDATES_PER_AUDIT;
+	const candidateFindings = truncated ? allCandidateFindings.slice(0, MAX_CANDIDATES_PER_AUDIT) : allCandidateFindings;
 
 	// Look up the target's own registrar first — drives Rule 4 (same registrar family corroboration).
 	const targetLookup = await safeRegistrarLookup(seedDomain, deps);
@@ -262,6 +274,9 @@ export async function brandAuditSingle(
 			targetRegistrarSource: targetLookup.registrarSource,
 			targetRegistrant: targetLookup.registrant,
 			minConfidence: options.min_confidence ?? 0.5,
+			truncated,
+			truncatedAt: truncated ? MAX_CANDIDATES_PER_AUDIT : undefined,
+			discoveredTotal: allCandidateFindings.length,
 		},
 	);
 

--- a/src/tools/brand-audit-status.ts
+++ b/src/tools/brand-audit-status.ts
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * brand_audit_status — read-only progress check for an enqueued brand audit.
+ *
+ * Reads `brand_audits` + `brand_audit_targets` from BRAND_AUDIT_DB. Owner-scoped:
+ * an audit row is only visible to its owner (owner_id === principalId). A request
+ * for someone else's auditId returns `notFound`, NOT `accessDenied` — defending
+ * against ID enumeration. Worker code never confirms the existence of an audit
+ * the caller doesn't own.
+ *
+ * Returns a `CheckResult` whose summary metadata carries:
+ *   { auditId, status, progress: 'N/M', completed, total, targets: [{ target, status, error? }] }
+ */
+
+import { buildCheckResult, createFinding, type CheckResult } from '../lib/scoring';
+import type { BrandAuditStatus } from '../lib/db/brand-audit-schema';
+
+const CATEGORY = 'brand_discovery';
+
+export interface BrandAuditStatusDeps {
+	db: D1Database;
+}
+
+interface BrandAuditRow {
+	id: string;
+	owner_id: string;
+	status: BrandAuditStatus;
+	total_targets: number;
+	completed_targets: number;
+	format: string;
+	created_at: number;
+	updated_at: number;
+	completed_at: number | null;
+}
+
+interface BrandAuditTargetRow {
+	audit_id: string;
+	target: string;
+	status: BrandAuditStatus;
+	created_at: number;
+	completed_at: number | null;
+	error: string | null;
+	pdf_r2_key: string | null;
+}
+
+function errorResult(flag: string, message: string, extra: Record<string, unknown> = {}): CheckResult {
+	return buildCheckResult(CATEGORY, [
+		createFinding(CATEGORY, `Brand audit status: ${flag}`, 'high', message, { [flag]: true, ...extra }),
+	]);
+}
+
+export async function brandAuditStatus(
+	auditId: string,
+	ownerId: string,
+	deps: BrandAuditStatusDeps,
+): Promise<CheckResult> {
+	if (typeof auditId !== 'string' || auditId.trim().length === 0) {
+		return errorResult('invalidInput', 'auditId is required.');
+	}
+
+	let audit: BrandAuditRow | null = null;
+	let targets: BrandAuditTargetRow[] = [];
+	try {
+		audit = (await deps.db
+			.prepare(
+				'SELECT id, owner_id, status, total_targets, completed_targets, format, created_at, updated_at, completed_at FROM brand_audits WHERE id = ? LIMIT 1',
+			)
+			.bind(auditId)
+			.first()) as BrandAuditRow | null;
+
+		if (audit && audit.owner_id === ownerId) {
+			const all = await deps.db
+				.prepare(
+					'SELECT audit_id, target, status, created_at, completed_at, error, pdf_r2_key FROM brand_audit_targets WHERE audit_id = ? ORDER BY created_at ASC, target ASC',
+				)
+				.bind(auditId)
+				.all<BrandAuditTargetRow>();
+			targets = all.results ?? [];
+		}
+	} catch (err) {
+		return errorResult(
+			'readFailure',
+			`Failed to read brand audit row: ${err instanceof Error ? err.message : String(err)}`,
+			{ auditId },
+		);
+	}
+
+	if (!audit || audit.owner_id !== ownerId) {
+		return errorResult('notFound', `No brand audit found with id ${auditId}.`, { auditId });
+	}
+
+	const progress = `${audit.completed_targets}/${audit.total_targets}`;
+	const summary = createFinding(
+		CATEGORY,
+		`Brand audit ${auditId}: ${audit.status} (${progress})`,
+		'info',
+		`status=${audit.status} progress=${progress} format=${audit.format} created=${new Date(audit.created_at).toISOString()}`,
+		{
+			summary: true,
+			auditId: audit.id,
+			status: audit.status,
+			progress,
+			completed: audit.completed_targets,
+			total: audit.total_targets,
+			format: audit.format,
+			createdAt: audit.created_at,
+			updatedAt: audit.updated_at,
+			completedAt: audit.completed_at,
+			targets: targets.map((t) => ({
+				target: t.target,
+				status: t.status,
+				createdAt: t.created_at,
+				completedAt: t.completed_at,
+				error: t.error,
+				hasPdf: t.pdf_r2_key !== null,
+			})),
+		},
+	);
+
+	return buildCheckResult(CATEGORY, [summary]);
+}

--- a/test/brand-audit-batch-start.integration.test.ts
+++ b/test/brand-audit-batch-start.integration.test.ts
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the brand_audit_batch_start MCP tool.
+ *
+ * Producer-side of the async brand-audit flow:
+ *   1. Validate the domain list (max 50, deduplicate, non-empty)
+ *   2. Consume `domains.length` units from the per-tier monthly quota
+ *      (atomic at enqueue — not per-target as messages drain)
+ *   3. Write the parent `brand_audits` row to D1 (status='queued')
+ *   4. Enqueue one `{ auditId, target }` message per target
+ *   5. Return `{ auditId, queuedAt, targetCount, etaSeconds }` to the caller
+ *
+ * All side effects (D1, queue, quota) are injected as deps so tests stay offline.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { BrandAuditBatchStartDeps } from '../src/tools/brand-audit-batch-start';
+
+interface D1Call {
+	sql: string;
+	binds: unknown[];
+}
+
+function makeMockD1(opts: { throwOnRun?: boolean } = {}) {
+	const calls: D1Call[] = [];
+	const db = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					return stmt;
+				},
+				async run() {
+					calls.push({ sql, binds });
+					if (opts.throwOnRun) throw new Error('d1_run_failed');
+					return { success: true, meta: { changes: 1, last_row_id: 0, duration: 0, rows_read: 0, rows_written: 1, size_after: 0 } };
+				},
+				async first() {
+					calls.push({ sql, binds });
+					return null;
+				},
+				async all() {
+					calls.push({ sql, binds });
+					return { results: [], success: true, meta: {} };
+				},
+			};
+			return stmt;
+		},
+		async batch(stmts: Array<{ run: () => Promise<unknown> }>) {
+			const out = [];
+			for (const s of stmts) out.push(await s.run());
+			return out;
+		},
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+function makeDeps(overrides: Partial<BrandAuditBatchStartDeps> = {}): BrandAuditBatchStartDeps {
+	const { db } = makeMockD1();
+	return {
+		db,
+		queue: { send: vi.fn().mockResolvedValue(undefined) },
+		enforceQuota: vi.fn().mockResolvedValue({ allowed: true, remaining: 49, limit: 50 }),
+		generateId: () => 'audit-test-id',
+		now: () => 1_750_000_000_000,
+		...overrides,
+	};
+}
+
+describe('brandAuditBatchStart', () => {
+	it('writes parent row, enqueues one message per target, returns audit metadata', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const { db, calls } = makeMockD1();
+		const queueSend = vi.fn().mockResolvedValue(undefined);
+		const enforceQuota = vi.fn().mockResolvedValue({ allowed: true, remaining: 47, limit: 50 });
+		const deps = makeDeps({ db, queue: { send: queueSend }, enforceQuota });
+
+		const result = await brandAuditBatchStart(
+			['apple.com', 'microsoft.com', 'nike.com'],
+			{},
+			'principal-key-hash-abc',
+			deps,
+		);
+
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.auditId).toBe('audit-test-id');
+		expect(summary?.metadata?.targetCount).toBe(3);
+		expect(summary?.metadata?.queuedAt).toBe(1_750_000_000_000);
+		expect(typeof summary?.metadata?.etaSeconds).toBe('number');
+
+		// Quota consumed once with count=3.
+		expect(enforceQuota).toHaveBeenCalledTimes(1);
+		expect(enforceQuota).toHaveBeenCalledWith(3);
+
+		// Parent + 3 child rows written to D1.
+		const inserts = calls.filter((c) => c.sql.includes('INSERT INTO brand_audit'));
+		expect(inserts.length).toBeGreaterThanOrEqual(4);
+
+		// 3 queue messages, one per target.
+		expect(queueSend).toHaveBeenCalledTimes(3);
+		const sentTargets = queueSend.mock.calls.map((c) => (c[0] as { target: string }).target).sort();
+		expect(sentTargets).toEqual(['apple.com', 'microsoft.com', 'nike.com']);
+	});
+
+	it('refuses when quota is exceeded — no D1 write, no queue send', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const { db, calls } = makeMockD1();
+		const queueSend = vi.fn();
+		const enforceQuota = vi.fn().mockResolvedValue({ allowed: false, remaining: 0, limit: 50, retryAfterMs: 86_400_000 });
+		const deps = makeDeps({ db, queue: { send: queueSend }, enforceQuota });
+
+		const result = await brandAuditBatchStart(['apple.com'], {}, 'pk', deps);
+
+		const errorFinding = result.findings.find((f) => f.metadata?.quotaExceeded === true);
+		expect(errorFinding).toBeDefined();
+		expect(errorFinding?.severity).toBe('high');
+		expect(calls.length).toBe(0);
+		expect(queueSend).not.toHaveBeenCalled();
+	});
+
+	it('caps batch size at 50 — rejects 51+ without consuming quota', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const enforceQuota = vi.fn();
+		const queueSend = vi.fn();
+		const deps = makeDeps({ enforceQuota, queue: { send: queueSend } });
+
+		const overSized = Array.from({ length: 51 }, (_, i) => `d${i}.example.com`);
+		const result = await brandAuditBatchStart(overSized, {}, 'pk', deps);
+
+		const errorFinding = result.findings.find((f) => f.metadata?.batchTooLarge === true);
+		expect(errorFinding).toBeDefined();
+		expect(enforceQuota).not.toHaveBeenCalled();
+		expect(queueSend).not.toHaveBeenCalled();
+	});
+
+	it('rejects empty domain list with a validation error', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const enforceQuota = vi.fn();
+		const deps = makeDeps({ enforceQuota });
+		const result = await brandAuditBatchStart([], {}, 'pk', deps);
+
+		const errorFinding = result.findings.find((f) => f.metadata?.invalidInput === true);
+		expect(errorFinding).toBeDefined();
+		expect(enforceQuota).not.toHaveBeenCalled();
+	});
+
+	it('deduplicates domains before quota check + enqueue', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const queueSend = vi.fn().mockResolvedValue(undefined);
+		const enforceQuota = vi.fn().mockResolvedValue({ allowed: true, remaining: 49, limit: 50 });
+		const deps = makeDeps({ queue: { send: queueSend }, enforceQuota });
+
+		await brandAuditBatchStart(['apple.com', 'Apple.com', 'apple.com', 'nike.com'], {}, 'pk', deps);
+
+		// Dedup + lowercase: 2 unique targets.
+		expect(enforceQuota).toHaveBeenCalledWith(2);
+		expect(queueSend).toHaveBeenCalledTimes(2);
+	});
+
+	it('stops short of any queue.send if the D1 parent insert fails', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const { db } = makeMockD1({ throwOnRun: true });
+		const queueSend = vi.fn();
+		const enforceQuota = vi.fn().mockResolvedValue({ allowed: true, remaining: 49, limit: 50 });
+		const deps = makeDeps({ db, queue: { send: queueSend }, enforceQuota });
+
+		const result = await brandAuditBatchStart(['apple.com'], {}, 'pk', deps);
+
+		const errorFinding = result.findings.find((f) => f.metadata?.persistenceFailure === true);
+		expect(errorFinding).toBeDefined();
+		expect(queueSend).not.toHaveBeenCalled();
+	});
+
+	it('on partial enqueue failure: flips audit to failed, returns partialEnqueue summary listing failed targets', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const { db, calls } = makeMockD1();
+		let callCount = 0;
+		const queueSend = vi.fn().mockImplementation(async () => {
+			callCount++;
+			if (callCount === 2) throw new Error('queue_send_throttled');
+		});
+		const deps = makeDeps({ db, queue: { send: queueSend } });
+
+		const result = await brandAuditBatchStart(
+			['apple.com', 'microsoft.com', 'nike.com'],
+			{},
+			'pk',
+			deps,
+		);
+
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.partialEnqueue).toBe(true);
+		expect(summary?.metadata?.requestedCount).toBe(3);
+		expect((summary?.metadata?.failedToEnqueue as unknown[])).toHaveLength(1);
+		expect(summary?.metadata?.targetCount).toBe(2);
+
+		const finalUpdate = calls.find(
+			(c) => c.sql.includes('UPDATE brand_audits') && c.sql.includes("status = 'failed'"),
+		);
+		expect(finalUpdate).toBeDefined();
+	});
+
+	it('threads format through to the parent row + queue message', async () => {
+		const { brandAuditBatchStart } = await import('../src/tools/brand-audit-batch-start');
+		const { db, calls } = makeMockD1();
+		const queueSend = vi.fn().mockResolvedValue(undefined);
+		const deps = makeDeps({ db, queue: { send: queueSend } });
+
+		await brandAuditBatchStart(['apple.com'], { format: 'markdown' }, 'pk', deps);
+
+		const parentInsert = calls.find((c) => c.sql.includes('INSERT INTO brand_audits'));
+		expect(parentInsert?.binds).toContain('markdown');
+		expect((queueSend.mock.calls[0][0] as { format: string }).format).toBe('markdown');
+	});
+});

--- a/test/brand-audit-get-report.integration.test.ts
+++ b/test/brand-audit-get-report.integration.test.ts
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the brand_audit_get_report MCP tool.
+ *
+ * Read-only D1 lookup returning either:
+ *   - Per-target result_json when `target` is provided + status='completed'
+ *   - Audit-level results_json aggregate when `target` is omitted + audit status='completed'
+ *   - notReady when the audit/target hasn't finished yet
+ *
+ * Owner-scoped (same ID-enumeration defense as brand_audit_status).
+ *
+ * R2 signed URL path (PDF mode) is Phase 3 — out of scope here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { BrandAuditGetReportDeps } from '../src/tools/brand-audit-get-report';
+
+interface RowMap {
+	audit?: Record<string, unknown> | null;
+	target?: Record<string, unknown> | null;
+}
+
+function makeMockD1(rows: RowMap) {
+	const calls: { sql: string; binds: unknown[] }[] = [];
+	const db = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					return stmt;
+				},
+				async first() {
+					calls.push({ sql, binds });
+					if (sql.includes('FROM brand_audits')) return rows.audit ?? null;
+					if (sql.includes('FROM brand_audit_targets')) return rows.target ?? null;
+					return null;
+				},
+				async all() {
+					calls.push({ sql, binds });
+					return { results: [], success: true, meta: {} };
+				},
+				async run() {
+					calls.push({ sql, binds });
+					return { success: true, meta: {} };
+				},
+			};
+			return stmt;
+		},
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+describe('brandAuditGetReport', () => {
+	it('returns per-target result_json when target is provided and status=completed', async () => {
+		const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+		const fakeResult = { category: 'brand_discovery', score: 100, findings: [{ category: 'brand_discovery', title: 'apple.net', severity: 'info', detail: '', metadata: { bucket: 'consolidated' } }] };
+		const { db } = makeMockD1({
+			audit: { id: 'aud-1', owner_id: 'owner-abc', status: 'completed', format: 'json' },
+			target: { audit_id: 'aud-1', target: 'apple.com', status: 'completed', result_json: JSON.stringify(fakeResult), error: null, completed_at: 1 },
+		});
+
+		const result = await brandAuditGetReport(
+			{ auditId: 'aud-1', target: 'apple.com' },
+			'owner-abc',
+			{ db },
+		);
+
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.auditId).toBe('aud-1');
+		expect(summary?.metadata?.target).toBe('apple.com');
+		expect(summary?.metadata?.result).toMatchObject({ category: 'brand_discovery' });
+	});
+
+	it('returns notReady when target is still queued/running', async () => {
+		const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+		const { db } = makeMockD1({
+			audit: { id: 'aud-1', owner_id: 'owner-abc', status: 'running' },
+			target: { audit_id: 'aud-1', target: 'apple.com', status: 'running', result_json: null, error: null, completed_at: null },
+		});
+
+		const result = await brandAuditGetReport(
+			{ auditId: 'aud-1', target: 'apple.com' },
+			'owner-abc',
+			{ db },
+		);
+
+		const notReady = result.findings.find((f) => f.metadata?.notReady === true);
+		expect(notReady).toBeDefined();
+	});
+
+	it('returns notFound when target row does not exist for the audit', async () => {
+		const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+		const { db } = makeMockD1({
+			audit: { id: 'aud-1', owner_id: 'owner-abc', status: 'completed' },
+			target: null,
+		});
+		const result = await brandAuditGetReport(
+			{ auditId: 'aud-1', target: 'never-seen.example.com' },
+			'owner-abc',
+			{ db },
+		);
+		expect(result.findings.find((f) => f.metadata?.notFound === true)).toBeDefined();
+	});
+
+	it('returns audit-level aggregate when target is omitted and audit status=completed', async () => {
+		const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+		const aggregate = { totalCandidates: 7, buckets: { consolidated: 3, shadowIt: 1, indeterminate: 2, impersonation: 1 } };
+		const { db } = makeMockD1({
+			audit: { id: 'aud-1', owner_id: 'owner-abc', status: 'completed', results_json: JSON.stringify(aggregate), format: 'json' },
+		});
+
+		const result = await brandAuditGetReport({ auditId: 'aud-1' }, 'owner-abc', { db });
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.aggregate).toMatchObject({ totalCandidates: 7 });
+	});
+
+	it('owner-scoping: someone else\'s auditId surfaces as notFound', async () => {
+		const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+		const { db } = makeMockD1({
+			audit: { id: 'aud-2', owner_id: 'owner-other', status: 'completed' },
+		});
+		const result = await brandAuditGetReport(
+			{ auditId: 'aud-2', target: 'apple.com' },
+			'owner-abc',
+			{ db },
+		);
+		expect(result.findings.find((f) => f.metadata?.notFound === true)).toBeDefined();
+		expect(result.findings.find((f) => f.metadata?.accessDenied === true)).toBeUndefined();
+	});
+});

--- a/test/brand-audit-get-report.integration.test.ts
+++ b/test/brand-audit-get-report.integration.test.ts
@@ -14,7 +14,6 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { BrandAuditGetReportDeps } from '../src/tools/brand-audit-get-report';
 
 interface RowMap {
 	audit?: Record<string, unknown> | null;

--- a/test/brand-audit-single.test.ts
+++ b/test/brand-audit-single.test.ts
@@ -241,4 +241,45 @@ describe('brandAuditSingle', () => {
 		expect(cand?.metadata?.bucket).toBe('consolidated');
 		expect(cand?.metadata?.note).toBe('Organizational Subdomain');
 	});
+
+	it('caps candidate fanout at 200 and marks summary.truncated when discovery returns more', async () => {
+		const { brandAuditSingle } = await import('../src/tools/brand-audit-single');
+		// 250 candidates — over the 200 cap.
+		const oversized = Array.from({ length: 250 }, (_, i) => ({
+			domain: `cand-${i}.example.com`,
+			signals: ['ns'],
+			conf: 0.95,
+		}));
+		const rdapSpy = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'rdap', 'Apple Inc.'));
+		const deps = makeDeps({
+			discoverBrandDomains: vi.fn().mockResolvedValue(discoveryResult('apple.com', oversized)),
+			checkRdapLookup: rdapSpy,
+		});
+		const result = await brandAuditSingle('apple.com', {}, deps);
+
+		const candFindings = result.findings.filter((f) => f.metadata?.candidate);
+		expect(candFindings).toHaveLength(200);
+
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.truncated).toBe(true);
+		expect(summary?.metadata?.truncatedAt).toBe(200);
+		expect(summary?.metadata?.discoveredTotal).toBe(250);
+
+		// Crucially: RDAP only fanned out to the capped candidate set, not all 250.
+		// (1 call for the target + 200 for capped candidates = 201.)
+		expect(rdapSpy.mock.calls.length).toBeLessThanOrEqual(201);
+	});
+
+	it('passes summary.truncated=false when discovery stays under the cap', async () => {
+		const { brandAuditSingle } = await import('../src/tools/brand-audit-single');
+		const candidates = [{ domain: 'apple.net', signals: ['ns'], conf: 0.95 }];
+		const deps = makeDeps({
+			discoverBrandDomains: vi.fn().mockResolvedValue(discoveryResult('apple.com', candidates)),
+		});
+		const result = await brandAuditSingle('apple.com', {}, deps);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.truncated).toBe(false);
+		expect(summary?.metadata?.truncatedAt).toBeUndefined();
+		expect(summary?.metadata?.discoveredTotal).toBe(1);
+	});
 });

--- a/test/brand-audit-status.integration.test.ts
+++ b/test/brand-audit-status.integration.test.ts
@@ -13,7 +13,7 @@
  * against ID enumeration.
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import type { BrandAuditStatusDeps } from '../src/tools/brand-audit-status';
 
 interface D1Call {

--- a/test/brand-audit-status.integration.test.ts
+++ b/test/brand-audit-status.integration.test.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the brand_audit_status MCP tool.
+ *
+ * Read-only D1 lookup for a previously-enqueued audit. Returns:
+ *   - audit-level status ('queued' | 'running' | 'completed' | 'failed')
+ *   - progress fraction ('N/M')
+ *   - per-target status array
+ *
+ * Owner-scoped: an audit row is only visible to its owner (owner_id === principalId).
+ * A request for someone else's auditId returns notFound, not access-denied — defending
+ * against ID enumeration.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import type { BrandAuditStatusDeps } from '../src/tools/brand-audit-status';
+
+interface D1Call {
+	sql: string;
+	binds: unknown[];
+}
+
+function makeMockD1(opts: { audit?: Record<string, unknown> | null; targets?: Record<string, unknown>[]; throwOnFirst?: boolean } = {}) {
+	const calls: D1Call[] = [];
+	const db = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					return stmt;
+				},
+				async first() {
+					calls.push({ sql, binds });
+					if (opts.throwOnFirst) throw new Error('d1_first_failed');
+					if (sql.includes('FROM brand_audits')) return opts.audit ?? null;
+					return null;
+				},
+				async all() {
+					calls.push({ sql, binds });
+					if (sql.includes('FROM brand_audit_targets')) {
+						return { results: opts.targets ?? [], success: true, meta: {} };
+					}
+					return { results: [], success: true, meta: {} };
+				},
+				async run() {
+					calls.push({ sql, binds });
+					return { success: true, meta: {} };
+				},
+			};
+			return stmt;
+		},
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+function makeDeps(overrides: Partial<BrandAuditStatusDeps> = {}): BrandAuditStatusDeps {
+	const { db } = makeMockD1();
+	return { db, ...overrides };
+}
+
+describe('brandAuditStatus', () => {
+	it('returns audit status + progress + per-target statuses', async () => {
+		const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+		const { db } = makeMockD1({
+			audit: {
+				id: 'aud-1',
+				owner_id: 'owner-abc',
+				status: 'running',
+				total_targets: 3,
+				completed_targets: 2,
+				format: 'both',
+				created_at: 1_750_000_000_000,
+				updated_at: 1_750_000_060_000,
+				completed_at: null,
+			},
+			targets: [
+				{ audit_id: 'aud-1', target: 'apple.com', status: 'completed', created_at: 1_750_000_000_000, completed_at: 1_750_000_030_000, error: null, pdf_r2_key: null },
+				{ audit_id: 'aud-1', target: 'microsoft.com', status: 'completed', created_at: 1_750_000_000_000, completed_at: 1_750_000_050_000, error: null, pdf_r2_key: null },
+				{ audit_id: 'aud-1', target: 'nike.com', status: 'running', created_at: 1_750_000_000_000, completed_at: null, error: null, pdf_r2_key: null },
+			],
+		});
+
+		const result = await brandAuditStatus('aud-1', 'owner-abc', { db });
+
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.auditId).toBe('aud-1');
+		expect(summary?.metadata?.status).toBe('running');
+		expect(summary?.metadata?.progress).toBe('2/3');
+		expect(summary?.metadata?.completed).toBe(2);
+		expect(summary?.metadata?.total).toBe(3);
+		expect((summary?.metadata?.targets as unknown[])).toHaveLength(3);
+	});
+
+	it('returns notFound when auditId is unknown', async () => {
+		const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+		const deps = makeDeps();
+		const result = await brandAuditStatus('aud-missing', 'owner-abc', deps);
+		const errorFinding = result.findings.find((f) => f.metadata?.notFound === true);
+		expect(errorFinding).toBeDefined();
+	});
+
+	it('returns notFound (not accessDenied) when audit belongs to a different owner', async () => {
+		const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+		const { db } = makeMockD1({
+			audit: {
+				id: 'aud-2',
+				owner_id: 'owner-other',
+				status: 'completed',
+				total_targets: 1,
+				completed_targets: 1,
+				format: 'json',
+				created_at: 1, updated_at: 2, completed_at: 3,
+			},
+		});
+		const result = await brandAuditStatus('aud-2', 'owner-abc', { db });
+		const notFound = result.findings.find((f) => f.metadata?.notFound === true);
+		const accessDenied = result.findings.find((f) => f.metadata?.accessDenied === true);
+		expect(notFound).toBeDefined();
+		expect(accessDenied).toBeUndefined();
+	});
+
+	it('reports D1 read failure as a structured error', async () => {
+		const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+		const { db } = makeMockD1({ throwOnFirst: true });
+		const result = await brandAuditStatus('aud-1', 'owner-abc', { db });
+		const errorFinding = result.findings.find((f) => f.metadata?.readFailure === true);
+		expect(errorFinding).toBeDefined();
+	});
+
+	it('rejects empty/invalid auditId', async () => {
+		const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+		const result = await brandAuditStatus('', 'owner-abc', makeDeps());
+		const invalid = result.findings.find((f) => f.metadata?.invalidInput === true);
+		expect(invalid).toBeDefined();
+	});
+});

--- a/test/chaos/brand-audit-consumer.chaos.test.ts
+++ b/test/chaos/brand-audit-consumer.chaos.test.ts
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Chaos invariant: duplicate queue delivery of a brand-audit message must not
+ * re-run `brandAuditSingle` or re-tick the audit counter.
+ *
+ * Hypothesis: GIVEN a brand-audit message whose target row is already in a
+ * terminal state ('completed' | 'failed'),
+ * WHEN the consumer receives that message (which Cloudflare Queues can deliver
+ * N times on retry — at-least-once semantics),
+ * THEN it ack()s the message without invoking `brandAuditSingle` and without
+ * any UPDATE on brand_audit_targets or brand_audits.
+ *
+ * Why this matters: the orchestrator costs ~3 min per target and consumes RDAP
+ * + outbound budget. A misconfigured retry policy or transient ack failure
+ * could deliver a "completed" message twice; without this guard, the second
+ * delivery silently double-bills CPU + outbound + (later) PDF rendering.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+interface D1Call {
+	sql: string;
+	binds: unknown[];
+}
+
+function makeMockD1(targetStatus: 'completed' | 'failed' | 'queued') {
+	const calls: D1Call[] = [];
+	const db = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					return stmt;
+				},
+				async first() {
+					calls.push({ sql, binds });
+					if (sql.includes('SELECT status, completed_at FROM brand_audit_targets')) {
+						return { status: targetStatus, completed_at: targetStatus === 'completed' ? 1 : null };
+					}
+					return null;
+				},
+				async run() {
+					calls.push({ sql, binds });
+					return { success: true, meta: {} };
+				},
+				async all() {
+					calls.push({ sql, binds });
+					return { results: [], success: true, meta: {} };
+				},
+			};
+			return stmt;
+		},
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+describe('chaos: brand-audit consumer idempotency under duplicate delivery', () => {
+	it('does not re-run brandAuditSingle when the target is already completed', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1('completed');
+		const brandAuditSingle = vi.fn();
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'apple.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(verdict).toBe('ack');
+		expect(brandAuditSingle).not.toHaveBeenCalled();
+
+		// No mutations — duplicate delivery is a pure no-op.
+		const writes = calls.filter((c) => c.sql.startsWith('UPDATE') || c.sql.startsWith('INSERT'));
+		expect(writes).toHaveLength(0);
+	});
+
+	it('does not re-run brandAuditSingle when the target is already failed', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1('failed');
+		const brandAuditSingle = vi.fn();
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'apple.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(verdict).toBe('ack');
+		expect(brandAuditSingle).not.toHaveBeenCalled();
+		const writes = calls.filter((c) => c.sql.startsWith('UPDATE') || c.sql.startsWith('INSERT'));
+		expect(writes).toHaveLength(0);
+	});
+
+	it('does run brandAuditSingle when the target is still queued (control)', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db } = makeMockD1('queued');
+		const brandAuditSingle = vi.fn().mockResolvedValue({ category: 'brand_discovery', score: 100, findings: [] });
+
+		await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'apple.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(brandAuditSingle).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/contracts/brand-audit-status.contract.test.ts
+++ b/test/contracts/brand-audit-status.contract.test.ts
@@ -1,0 +1,202 @@
+// SPDX-License-Identifier: BUSL-1.1
+/**
+ * Contract: brand_audit_status + brand_audit_batch_start + brand_audit_get_report
+ * response shapes.
+ *
+ * Downstream consumers (bv-web polling UI, future PDF renderer in Phase 3, MCP
+ * clients building status dashboards) parse these shapes. Locking them here
+ * prevents silent drift between producer and consumer.
+ *
+ * Per testing-methodology.md principle 3: Zod schemas ARE the inter-service contract.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { z } from 'zod';
+import type { BrandAuditStatusDeps } from '../../src/tools/brand-audit-status';
+import type { BrandAuditGetReportDeps } from '../../src/tools/brand-audit-get-report';
+import type { BrandAuditBatchStartDeps } from '../../src/tools/brand-audit-batch-start';
+
+const StatusEnum = z.enum(['queued', 'running', 'completed', 'failed']);
+const SeveritySchema = z.enum(['critical', 'high', 'medium', 'low', 'info']);
+const FormatEnum = z.enum(['json', 'markdown', 'both']);
+
+const BatchStartSummarySchema = z.object({
+	summary: z.literal(true),
+	auditId: z.string().min(1),
+	queuedAt: z.number().int().nonnegative(),
+	targetCount: z.number().int().positive(),
+	etaSeconds: z.number().int().nonnegative(),
+	format: FormatEnum,
+	targets: z.array(z.string().min(1)),
+});
+
+const StatusTargetSchema = z.object({
+	target: z.string().min(1),
+	status: StatusEnum,
+	createdAt: z.number().int().nonnegative(),
+	completedAt: z.number().int().nullable(),
+	error: z.string().nullable(),
+	hasPdf: z.boolean(),
+});
+
+const StatusSummarySchema = z.object({
+	summary: z.literal(true),
+	auditId: z.string().min(1),
+	status: StatusEnum,
+	progress: z.string().regex(/^\d+\/\d+$/),
+	completed: z.number().int().nonnegative(),
+	total: z.number().int().positive(),
+	format: z.string(),
+	createdAt: z.number().int().nonnegative(),
+	updatedAt: z.number().int().nonnegative(),
+	completedAt: z.number().int().nullable(),
+	targets: z.array(StatusTargetSchema),
+});
+
+const GetReportTargetSummarySchema = z.object({
+	summary: z.literal(true),
+	auditId: z.string().min(1),
+	target: z.string().min(1),
+	status: StatusEnum,
+	result: z.unknown(),
+	error: z.string().nullable(),
+});
+
+const GetReportAggregateSummarySchema = z.object({
+	summary: z.literal(true),
+	auditId: z.string().min(1),
+	status: StatusEnum,
+	format: z.string(),
+	aggregate: z.unknown(),
+});
+
+const FindingSchema = z.object({
+	category: z.string(),
+	title: z.string(),
+	severity: SeveritySchema,
+	detail: z.string(),
+	metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+function makeMockD1(rows: { audit?: unknown; target?: unknown; targets?: unknown[] }) {
+	const db = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					void binds;
+					return stmt;
+				},
+				async first() {
+					if (sql.includes('FROM brand_audits')) return rows.audit ?? null;
+					if (sql.includes('FROM brand_audit_targets')) return rows.target ?? null;
+					return null;
+				},
+				async all() {
+					if (sql.includes('FROM brand_audit_targets')) return { results: rows.targets ?? [], success: true, meta: {} };
+					return { results: [], success: true, meta: {} };
+				},
+				async run() {
+					return { success: true, meta: {} };
+				},
+			};
+			return stmt;
+		},
+	} as unknown as D1Database;
+	return db;
+}
+
+describe('brand_audit_batch_start response contract', () => {
+	it('summary metadata matches BatchStartSummarySchema on the happy path', async () => {
+		const { brandAuditBatchStart } = await import('../../src/tools/brand-audit-batch-start');
+		const db = makeMockD1({});
+		const deps: BrandAuditBatchStartDeps = {
+			db,
+			queue: { send: vi.fn().mockResolvedValue(undefined) },
+			enforceQuota: vi.fn().mockResolvedValue({ allowed: true, remaining: 49, limit: 50 }),
+			generateId: () => 'aud-contract-1',
+			now: () => 1_750_000_000_000,
+		};
+
+		const result = await brandAuditBatchStart(['apple.com', 'nike.com'], { format: 'both' }, 'owner-x', deps);
+
+		for (const f of result.findings) {
+			expect(FindingSchema.safeParse(f).success).toBe(true);
+		}
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary).toBeDefined();
+		const parsed = BatchStartSummarySchema.safeParse(summary?.metadata);
+		expect(parsed.success, JSON.stringify(parsed.success ? null : parsed.error.issues)).toBe(true);
+	});
+});
+
+describe('brand_audit_status response contract', () => {
+	it('summary metadata matches StatusSummarySchema on the happy path', async () => {
+		const { brandAuditStatus } = await import('../../src/tools/brand-audit-status');
+		const db = makeMockD1({
+			audit: {
+				id: 'aud-c',
+				owner_id: 'owner-x',
+				status: 'running',
+				total_targets: 2,
+				completed_targets: 1,
+				format: 'both',
+				created_at: 1, updated_at: 2, completed_at: null,
+			},
+			targets: [
+				{ audit_id: 'aud-c', target: 'apple.com', status: 'completed', created_at: 1, completed_at: 5, error: null, pdf_r2_key: null },
+				{ audit_id: 'aud-c', target: 'nike.com', status: 'running', created_at: 1, completed_at: null, error: null, pdf_r2_key: null },
+			],
+		});
+		const deps: BrandAuditStatusDeps = { db };
+		const result = await brandAuditStatus('aud-c', 'owner-x', deps);
+
+		for (const f of result.findings) {
+			expect(FindingSchema.safeParse(f).success).toBe(true);
+		}
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const parsed = StatusSummarySchema.safeParse(summary?.metadata);
+		expect(parsed.success, JSON.stringify(parsed.success ? null : parsed.error.issues)).toBe(true);
+	});
+});
+
+describe('brand_audit_get_report response contract', () => {
+	it('per-target summary matches GetReportTargetSummarySchema', async () => {
+		const { brandAuditGetReport } = await import('../../src/tools/brand-audit-get-report');
+		const db = makeMockD1({
+			audit: { id: 'aud-c', owner_id: 'owner-x', status: 'completed', format: 'json', results_json: null },
+			target: {
+				audit_id: 'aud-c',
+				target: 'apple.com',
+				status: 'completed',
+				result_json: JSON.stringify({ category: 'brand_discovery', score: 100, findings: [] }),
+				error: null,
+				completed_at: 5,
+			},
+		});
+		const deps: BrandAuditGetReportDeps = { db };
+		const result = await brandAuditGetReport({ auditId: 'aud-c', target: 'apple.com' }, 'owner-x', deps);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const parsed = GetReportTargetSummarySchema.safeParse(summary?.metadata);
+		expect(parsed.success, JSON.stringify(parsed.success ? null : parsed.error.issues)).toBe(true);
+	});
+
+	it('audit-level aggregate summary matches GetReportAggregateSummarySchema', async () => {
+		const { brandAuditGetReport } = await import('../../src/tools/brand-audit-get-report');
+		const db = makeMockD1({
+			audit: {
+				id: 'aud-c',
+				owner_id: 'owner-x',
+				status: 'completed',
+				format: 'json',
+				results_json: JSON.stringify({ totalCandidates: 5 }),
+			},
+		});
+		const deps: BrandAuditGetReportDeps = { db };
+		const result = await brandAuditGetReport({ auditId: 'aud-c' }, 'owner-x', deps);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const parsed = GetReportAggregateSummarySchema.safeParse(summary?.metadata);
+		expect(parsed.success, JSON.stringify(parsed.success ? null : parsed.error.issues)).toBe(true);
+	});
+});

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -462,11 +462,11 @@ describe('formatCheckResult - via handleToolsCall', () => {
 // -- handleToolsList --
 
 describe('handleToolsList', () => {
-	it('returns an object with a tools array of 53 entries', async () => {
+	it('returns an object with a tools array of 56 entries', async () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(53);
+		expect(result.tools).toHaveLength(56);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -353,7 +353,7 @@ describe('DNS Security MCP Server', () => {
 			const response = await worker.fetch(request, env, ctx);
 			await waitOnExecutionContext(ctx);
 			const body = (await response.json()) as { result: { tools: Array<{ name: string }> } };
-			expect(body.result.tools).toHaveLength(53);
+			expect(body.result.tools).toHaveLength(56);
 			const toolNames = body.result.tools.map((t) => t.name);
 			expect(toolNames).toContain('check_spf');
 			expect(toolNames).toContain('check_dmarc');

--- a/test/queue/brand-audit-consumer.integration.test.ts
+++ b/test/queue/brand-audit-consumer.integration.test.ts
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tests for the brand-audit queue consumer.
+ *
+ * Strategy: mock D1 with a recording fake, inject a mocked `brandAuditSingle`,
+ * exercise `processBrandAuditMessage` / `handleBrandAuditQueue` directly.
+ *
+ * Invariants asserted here:
+ *   - Happy path: target row flips queued → running → completed; counter ticks
+ *   - Idempotency: duplicate delivery of a `completed` row ack()s without re-running
+ *   - Validation: malformed message body → ack (drop, don't retry forever)
+ *   - Failure path: brandAuditSingle throws → target row flips → failed; counter ticks
+ *   - Final-target sentinel: when completed_targets === total_targets, audit
+ *     marked completed
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+interface D1Call {
+	sql: string;
+	binds: unknown[];
+}
+
+interface MakeMockOpts {
+	target?: { status: string; completed_at: number | null } | null;
+	auditAfter?: { completed_targets: number; total_targets: number } | null;
+	throwOnUpdate?: boolean;
+}
+
+function makeMockD1(opts: MakeMockOpts = {}) {
+	const calls: D1Call[] = [];
+	const db = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					return stmt;
+				},
+				async first() {
+					calls.push({ sql, binds });
+					if (sql.includes('SELECT status, completed_at FROM brand_audit_targets')) {
+						return opts.target ?? null;
+					}
+					if (sql.includes('SELECT completed_targets, total_targets FROM brand_audits')) {
+						return opts.auditAfter ?? null;
+					}
+					return null;
+				},
+				async run() {
+					calls.push({ sql, binds });
+					if (opts.throwOnUpdate && sql.includes('UPDATE')) throw new Error('d1_update_failed');
+					return { success: true, meta: { changes: 1, last_row_id: 0, duration: 0, rows_read: 0, rows_written: 1, size_after: 0 } };
+				},
+				async all() {
+					calls.push({ sql, binds });
+					return { results: [], success: true, meta: {} };
+				},
+			};
+			return stmt;
+		},
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+function fakeMessage(body: unknown, ack: () => void = vi.fn(), retry: () => void = vi.fn()) {
+	return { id: 'msg-1', timestamp: new Date(), body, attempts: 1, ack, retry };
+}
+
+describe('processBrandAuditMessage', () => {
+	it('runs brandAuditSingle, marks target completed, ticks audit counter', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 1, total_targets: 3 },
+		});
+		const fakeResult = { category: 'brand_discovery', score: 100, findings: [] };
+		const brandAuditSingle = vi.fn().mockResolvedValue(fakeResult);
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'apple.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(verdict).toBe('ack');
+		expect(brandAuditSingle).toHaveBeenCalledOnce();
+
+		const updates = calls.filter((c) => c.sql.includes('UPDATE brand_audit_targets'));
+		const completedUpdate = updates.find((c) => (c.binds[0] as string) === 'completed');
+		expect(completedUpdate).toBeDefined();
+
+		const auditTick = calls.find((c) => c.sql.includes('UPDATE brand_audits') && c.sql.includes('completed_targets'));
+		expect(auditTick).toBeDefined();
+	});
+
+	it('is idempotent: a duplicate delivery of a completed target ack()s without re-running brandAuditSingle', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1({
+			target: { status: 'completed', completed_at: 1_700_000_000_000 },
+		});
+		const brandAuditSingle = vi.fn();
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'apple.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(verdict).toBe('ack');
+		expect(brandAuditSingle).not.toHaveBeenCalled();
+		// Specifically: no UPDATE on brand_audit_targets after seeing completed.
+		const writeOps = calls.filter((c) => c.sql.includes('UPDATE'));
+		expect(writeOps).toHaveLength(0);
+	});
+
+	it('rejects malformed message body with ack (drop) — not retry forever', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1({});
+		const brandAuditSingle = vi.fn();
+
+		const verdict = await processBrandAuditMessage(
+			{ wrong: 'shape' } as unknown,
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(verdict).toBe('ack');
+		expect(brandAuditSingle).not.toHaveBeenCalled();
+		expect(calls).toHaveLength(0);
+	});
+
+	it('marks target failed and ticks counter when brandAuditSingle throws', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 1, total_targets: 3 },
+		});
+		const brandAuditSingle = vi.fn().mockRejectedValue(new Error('discovery_timeout'));
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'apple.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(verdict).toBe('ack');
+		const failedUpdate = calls.find(
+			(c) => c.sql.includes('UPDATE brand_audit_targets') && (c.binds[0] as string) === 'failed',
+		);
+		expect(failedUpdate).toBeDefined();
+	});
+
+	it('marks audit completed when this message was the final target', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 3, total_targets: 3 },
+		});
+		const fakeResult = { category: 'brand_discovery', score: 100, findings: [] };
+		const brandAuditSingle = vi.fn().mockResolvedValue(fakeResult);
+
+		await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'final.example.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		const auditFinalize = calls.find(
+			(c) => c.sql.includes('UPDATE brand_audits') && c.sql.includes("status = 'completed'"),
+		);
+		expect(auditFinalize).toBeDefined();
+	});
+
+	it('signals retry on a transient D1 update failure (no double-counting)', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db } = makeMockD1({
+			target: { status: 'queued', completed_at: null },
+			throwOnUpdate: true,
+		});
+		const fakeResult = { category: 'brand_discovery', score: 100, findings: [] };
+		const brandAuditSingle = vi.fn().mockResolvedValue(fakeResult);
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'apple.com', format: 'json' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000 },
+		);
+
+		expect(verdict).toBe('retry');
+	});
+});
+
+describe('handleBrandAuditQueue', () => {
+	it('ack/retry routes each message individually based on processBrandAuditMessage', async () => {
+		const { handleBrandAuditQueue } = await import('../../src/queue/brand-audit-consumer');
+		const { db } = makeMockD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 1, total_targets: 3 },
+		});
+
+		const fakeResult = { category: 'brand_discovery', score: 100, findings: [] };
+		const brandAuditSingle = vi.fn().mockResolvedValue(fakeResult);
+
+		const ack1 = vi.fn();
+		const retry1 = vi.fn();
+		const ack2 = vi.fn();
+		const retry2 = vi.fn();
+		const batch = {
+			queue: 'brand-audit-queue',
+			messages: [
+				fakeMessage({ auditId: 'aud-1', target: 'apple.com', format: 'json' }, ack1, retry1),
+				fakeMessage({ wrong: 'shape' }, ack2, retry2),
+			],
+		} as unknown as MessageBatch<unknown>;
+
+		await handleBrandAuditQueue(batch, { db, brandAuditSingle, now: () => 1_750_000_000_000 });
+
+		expect(ack1).toHaveBeenCalled();
+		expect(retry1).not.toHaveBeenCalled();
+		expect(ack2).toHaveBeenCalled();
+		expect(retry2).not.toHaveBeenCalled();
+	});
+});

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -154,8 +154,8 @@ describe('GetProviderInsightsArgs', () => {
 });
 
 describe('TOOL_SCHEMA_MAP', () => {
-	it('has 53 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(53);
+	it('has 56 tools', () => {
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(56);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
-	it('has 53 tools', () => {
-		expect(TOOLS).toHaveLength(53);
+	it('has 56 tools', () => {
+		expect(TOOLS).toHaveLength(56);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/tool-metadata.spec.ts
+++ b/test/tool-metadata.spec.ts
@@ -19,7 +19,7 @@ describe('tool metadata', () => {
 		}
 	});
 
-	it('has exactly 53 tools', () => {
-		expect(TOOLS).toHaveLength(53);
+	it('has exactly 56 tools', () => {
+		expect(TOOLS).toHaveLength(56);
 	});
 });

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -39,11 +39,14 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'check_fast_flux',
 	'discover_brand_domains',
 	'brand_audit_single',
+	'brand_audit_batch_start',
+	'brand_audit_status',
+	'brand_audit_get_report',
 ]);
 
 describe('tool-schemas metadata', () => {
-	it('exports exactly 53 tools', () => {
-		expect(TOOLS).toHaveLength(53);
+	it('exports exactly 56 tools', () => {
+		expect(TOOLS).toHaveLength(56);
 	});
 
 	it('all tool names are unique', () => {


### PR DESCRIPTION
## Summary

Phase 2 of the brand-audit MCP suite. Adds the async surface: `brand_audit_batch_start` (producer, ≤50 targets/call) → `brand-audit-queue` → consumer → D1 → `brand_audit_status` / `brand_audit_get_report` (read-only pollers).

- **`brand_audit_batch_start`** — validates + deduplicates the domain list, writes parent `brand_audits` row to D1, enqueues one message per target. Returns `{ auditId, queuedAt, targetCount, etaSeconds }` immediately. On mid-loop `queue.send` failure, flips the audit to `failed` and returns a `partialEnqueue` summary listing failed targets.
- **`brand_audit_status`** — owner-scoped read of `brand_audits` + `brand_audit_targets`. Returns `{ status, progress: 'N/M', targets: [...] }`. Cross-owner auditIds surface as `notFound` (never `accessDenied` — ID-enumeration defense).
- **`brand_audit_get_report`** — fetches per-target `result_json` OR audit-level aggregate. `notReady` on in-flight audits. Phase 3 adds R2 signed-URL PDF retrieval; this v2.19.0 returns inline JSON only.
- **Queue consumer** (`src/queue/brand-audit-consumer.ts`) — idempotency check first (terminal-state targets ack without re-running `brandAuditSingle`); Zod-validated wire format (defense in depth); per-message `Promise.race` against `BRAND_AUDIT_MESSAGE_TIMEOUT_MS = 300_000`; state machine queued → running → completed | failed; atomic counter tick; final-target sentinel finalizes the audit row.
- **D1 schema** (`src/lib/db/brand-audit-schema.ts`) — two tables in a new global `brand-audit-v1` database; composite PK on (audit_id, target); `(owner_id, created_at)` index. Migrations not committed (matches repo convention); inline SQL + ops in `docs/provisioning/brand-audit-bindings.md`.

## Phase 1 follow-up bundled

Applied the candidate-fanout cap flagged in the v2.18.0 security audit: `brand-audit-single.ts` slices discovery output to `MAX_CANDIDATES_PER_AUDIT = 200` with `summary.truncated / truncatedAt / discoveredTotal` metadata. Bounds outbound RDAP fanout regardless of how wide SAN/NS discovery grows.

## Security adjustments during advisor review

- **IDOR-via-cache fixed.** `brand_audit_status` and `brand_audit_get_report` are owner-scoped at execute time, but the cache framework keys on `cache:${domain}:check:${cacheKey}` with no principalId — Owner B polling Owner A's auditId would hit A's cached result before the owner check ran. Widened `TOOL_REGISTRY.cacheKey` signature to `(args, runtimeOptions) => string` and threaded principalId into both tools' cache keys.
- **CHANGELOG honesty fix.** Initial draft claimed atomic monthly quota enforcement; production wiring delivers daily caps via `TIER_TOOL_DAILY_LIMITS`. CHANGELOG now states "daily caps in v2.19.0; monthly enforcement deferred to Phase 4."
- **Per-message timeout actually enforced.** Initial draft defined `BRAND_AUDIT_MESSAGE_TIMEOUT_MS = 300_000` but no code read it. Wired into `Promise.race` against `brandAuditSingle`.
- **`partialEnqueue` path corrected.** Initial draft's comment claimed graceful degradation; code threw a stack trace. Now wraps `queue.send` in try/catch, flips the audit row to `failed`, surfaces a structured `partialEnqueue` finding listing failed targets.

## Wiring

- 3 Zod schemas + 3 `TOOL_DEFS` entries (group: `discovery`, scanIncluded: false) + 3 `TOOL_REGISTRY` entries
- `ToolRuntimeOptions` extended with `brandAuditDb`, `brandAuditQueue`, `rateLimitKv`, `principalId` (pure plumbing)
- `src/index.ts` `queue:` handler now dispatches by `batch.queue` between `bv-scanner-queue` and `brand-audit-queue`. Switched the existing `console.log` to structured `logEvent`.
- `FREE_TOOL_DAILY_LIMITS` + per-tier `TIER_TOOL_DAILY_LIMITS` for all 3 tools aligned with `BRAND_AUDIT_QUOTAS` (free/agent=0, developer=50/day batch + 5000/day polls, partner=200/10000, enterprise=500/25000)

## Tests

| Layer | File | Coverage |
|---|---|---|
| Integration (mock D1) | `test/brand-audit-batch-start.integration.test.ts` | 8 — happy, quota, cap, empty, dedup, persistence failure, partial enqueue, format threading |
| Integration | `test/brand-audit-status.integration.test.ts` | 5 — happy, notFound, cross-owner, read failure, invalid |
| Integration | `test/brand-audit-get-report.integration.test.ts` | 5 — target-ready, notReady, notFound, aggregate, owner-scoping |
| Integration | `test/queue/brand-audit-consumer.integration.test.ts` | 7 — happy, idempotency, malformed body, failure path, final-target sentinel, retry on transient D1, batch handler |
| Chaos | `test/chaos/brand-audit-consumer.chaos.test.ts` | 3 — completed/failed duplicate delivery is a no-op; queued is the control |
| Contract | `test/contracts/brand-audit-status.contract.test.ts` | 4 — Zod-validated response shapes (batch-start, status, get-report target + aggregate) |
| Unit (extension) | `test/brand-audit-single.test.ts` | 2 new — candidate cap at 200, summary.truncated=false under cap |

Tool-count assertion cascade: 53 → 56 across `test/{tool-metadata,tool-schemas,handlers-tools,index,schemas/tool-args,schemas/tool-definitions}.spec.ts`; `NON_SCAN_TOOL_NAMES` gets three new entries.

## Validation

- `npm run typecheck` clean
- **3307 of 3308 tests pass** (the 1 failure is the same pre-existing untracked `test/discovery-benchmark.spec.ts` calibration target — unrelated)
- All 8 new Phase 2 test files green; 23 chaos tests still pass; 78 audit tests still pass; full brand-discovery regression (115 tests) still green

## Operator action required (deploy)

Provision `brand-audit-v1` D1, `brand-audit-queue` queue, and `bv-brand-reports` R2 bucket per [`docs/provisioning/brand-audit-bindings.md`](docs/provisioning/brand-audit-bindings.md). Apply the schema (inline SQL in the doc). Add binding declarations to `.dev/wrangler.deploy.jsonc`. Then `npm run deploy:prod`. **Until these are provisioned, the three new tools return `{ unprovisioned: true }` error findings rather than 500-ing** — the surface is safe to ship before infrastructure is in place.

## Test plan

- [x] `npm run typecheck`
- [x] `npx vitest run test/brand-audit-batch-start.integration.test.ts test/brand-audit-status.integration.test.ts test/brand-audit-get-report.integration.test.ts` — 18 pass
- [x] `npx vitest run test/queue/brand-audit-consumer.integration.test.ts test/chaos/brand-audit-consumer.chaos.test.ts` — 10 pass
- [x] `npx vitest run test/contracts/brand-audit-status.contract.test.ts` — 4 pass
- [x] `npx vitest run test/brand-audit-single.test.ts` — 9 pass (2 new for cap)
- [x] `npx vitest run test/audits/` — 78 pass (no regression from tool-count cascade)
- [x] `npm test` — 3307 of 3308 pass
- [ ] Provision D1 + queue + R2 in prod
- [ ] `npm run deploy:prod`
- [ ] Live `brand_audit_batch_start` smoke test against deployed worker

## Follow-ups (not blocking)

- **Phase 3**: R2 PDF rendering via `BV_BROWSER_RENDERER` + a separate PDF queue consumer
- **Phase 4**: scheduled monitoring + monthly quota enforcement wiring (the `BRAND_AUDIT_QUOTAS` + `enforceBrandAuditQuota` building blocks shipped in v2.18.0)
- Stale `brand_audits` cleanup cron (audits stuck in `running` past their ETA)
- `result_json` size cap defense (D1 has 2MB row limit; pathological discovery output could exceed it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)