### PR TITLE
chore: bump version to 2.21.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.21.3] - 2026-05-17
+
+### Fixed
+- Restored production customer OAuth consent routing by deploying `BV_WEB_OAUTH_CONSENT_URL` for `/oauth/authorize` while keeping legacy owner-key browser consent disabled.
+- Added production redirect probing so `/oauth/authorize` must redirect to the bv-web customer consent URL with OAuth parameters preserved instead of returning `503 OAuth customer login is not configured`.
+
+### Changed
+- Deploy and release workflows now verify OAuth smoke health and customer-consent redirect behavior after Worker deployment.
+- Production OAuth runbook now documents the customer redirect probe and required secrets.
+
+### Tests
+- Added an audit test for production OAuth Worker vars, bv-web service binding, secret hygiene, and deploy/release verification coverage.
+- Added Python unit tests for `scripts/oauth/prod-probe.py --mode=redirect`.
+
 ## [2.21.2] - 2026-05-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.21.2",
+	"version": "2.21.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "2.21.2",
+			"version": "2.21.3",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.21.2",
+	"version": "2.21.3",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "2.21.2",
+	"version": "2.21.3",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "2.21.2",
+			"version": "2.21.3",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '2.21.2';
+export const SERVER_VERSION = '2.21.3';


### PR DESCRIPTION
## Summary
- Bump root package/server metadata to v2.21.3.
- Add the v2.21.3 changelog entry for production OAuth redirect verification.

## Test Plan
- npm -w packages/dns-checks run build
- npm run build:wasm
- npm run validate:internal-deps
- npm run typecheck
- npm run lint
- npm test -- test/audits/oauth-production-config.audit.test.ts test/oauth/authorize-get.spec.ts test/oauth/internal-grant.spec.ts test/oauth/token.spec.ts test/oauth/e2e.spec.ts
- python3 scripts/oauth/test_prod_probe.py
- npm audit --audit-level=high

Note: local full npm test exited 0 with 3397 tests passed, but the Workers pool reported 2 unhandled worker-exit errors after a local segfault; relying on PR CI for the final full-suite gate.