### PR TITLE
Release v2.21.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [2.21.4] - 2026-05-17
+
+### Security
+- Removed tracked internal tenant and commercial planning documents from the public repository.
+- Scrubbed customer-placeholder references from docs, comments, and chaos output.
+- Tightened gitleaks coverage for customer-name placeholders while allowing timestamp-shaped SQL seed values.
+
+### Changed
+- Restricted the root npm package publish surface to `dist`, `LICENSE`, and `README.md` so npm releases do not include repo internals, tests, scripts, workflows, docs, or build caches.
+
+### Tests
+- Added an npm publish-surface audit that fails if the root package allowlist exposes internal repo paths.
+
 ## [2.21.3] - 2026-05-17
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.21.3",
+	"version": "2.21.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "2.21.3",
+			"version": "2.21.4",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.21.3",
+	"version": "2.21.4",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "2.21.3",
+	"version": "2.21.4",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "2.21.3",
+			"version": "2.21.4",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '2.21.3';
+export const SERVER_VERSION = '2.21.4';


### PR DESCRIPTION
## Summary
- bump root package, package-lock, server.json, and SERVER_VERSION to 2.21.4
- document the leakage-hardening release notes

## Verification
- npm -w packages/dns-checks run build
- npm run build
- npm run typecheck
- npm run lint
- npm audit --audit-level=high
- npm test -- test/audits/no-tracked-secrets.audit.test.ts test/audits/workflow-secret-check.audit.test.ts test/audits/npm-publish-surface.audit.test.ts
- gitleaks detect --config=.gitleaks.toml --source=. --redact --verbose --exit-code 1 --no-banner --no-git
- npm run validate:internal-deps
- npm run build:wasm
- npm pack --dry-run
- npm -w packages/dns-checks pack --dry-run
- git diff --check