### PR TITLE
fix(discovery-report): registrar extraction, classifier, and input guard

### DIFF
--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -10,6 +10,9 @@ fi
 export TARGET_DOMAIN=$1
 echo "Generating enterprise discovery report for $TARGET_DOMAIN..."
 
+# Remove any prior PDF so we never mistake a stale file for a fresh success.
+rm -f "reports/$TARGET_DOMAIN-discovery-report.pdf"
+
 # Inject the target domain into the test script
 # Use a temporary file for the run to avoid dirtying git state
 SPEC_FILE="test/generate-discovery-report.spec.ts"

--- a/scripts/generate-report.sh
+++ b/scripts/generate-report.sh
@@ -7,6 +7,13 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
+# Restrict the argument to DNS-label characters before we feed it into rm/sed.
+# Blocks path traversal, shell metacharacters, and sed-special bytes.
+if ! [[ "$1" =~ ^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$ ]]; then
+  echo "Error: '$1' is not a valid domain (expected lowercase labels separated by '.')." >&2
+  exit 1
+fi
+
 export TARGET_DOMAIN=$1
 echo "Generating enterprise discovery report for $TARGET_DOMAIN..."
 

--- a/test/generate-discovery-report.spec.ts
+++ b/test/generate-discovery-report.spec.ts
@@ -34,9 +34,12 @@ describe.skipIf(isPlaceholder)('Automated Report Generation', () => {
         let primaryRegistrar = 'Unknown';
         try {
             const rdap = await checkRdapLookup(target);
-            const rFind = rdap.findings.find(f => f.title.includes('Registrar'));
+            // Registrar is published in finding metadata; the title is
+            // "Registration details", not "...Registrar..." — relying on the
+            // title check silently produced "Unknown" for every brand.
+            const rFind = rdap.findings.find(f => typeof f.metadata?.registrar === 'string' && (f.metadata.registrar as string).length > 0);
             if (rFind) {
-                primaryRegistrar = rFind.detail.replace('Registrar: ', '').trim();
+                primaryRegistrar = String(rFind.metadata!.registrar).trim();
             }
         } catch (e) {
             console.warn(`Failed to lookup primary registrar: ${(e as Error).message}`);
@@ -73,18 +76,28 @@ describe.skipIf(isPlaceholder)('Automated Report Generation', () => {
         const primaryRegLower = primaryRegistrar.toLowerCase();
         const isPrimaryCore = primaryRegLower !== 'unknown' && primaryRegLower.length > 3;
 
-        for (const cand of uniqueCandidates) {
-            let candRegistrar = 'Unknown';
-            try {
-                const rdap = await checkRdapLookup(cand.domain);
-                const rFind = rdap.findings.find(f => f.title.includes('Registrar'));
-                if (rFind) {
-                    candRegistrar = rFind.detail.replace('Registrar: ', '').trim();
+        // Parallel RDAP lookups with bounded concurrency. Markov-only candidates
+        // are speculative variants — no shared infra to verify, so we skip RDAP
+        // for them entirely (saves significant wall time on brands like apple
+        // that produce dozens of trigram-generated lookalikes).
+        const RDAP_CONCURRENCY = 16;
+        const rdapTargets = uniqueCandidates.filter(c => !(c.signals.length === 1 && c.signals[0] === 'markov_gen'));
+        const candidateRegistrars = new Map<string, string>();
+        for (let i = 0; i < rdapTargets.length; i += RDAP_CONCURRENCY) {
+            const chunk = rdapTargets.slice(i, i + RDAP_CONCURRENCY);
+            const results = await Promise.allSettled(chunk.map(c => checkRdapLookup(c.domain)));
+            results.forEach((r, idx) => {
+                let reg = 'Unknown';
+                if (r.status === 'fulfilled') {
+                    const rFind = r.value.findings.find(f => typeof f.metadata?.registrar === 'string' && (f.metadata.registrar as string).length > 0);
+                    if (rFind) reg = String(rFind.metadata!.registrar).trim();
                 }
-            } catch {
-                // Ignore RDAP failures
-            }
+                candidateRegistrars.set(chunk[idx].domain, reg);
+            });
+        }
 
+        for (const cand of uniqueCandidates) {
+            const candRegistrar = candidateRegistrars.get(cand.domain) ?? 'Unknown';
             const candRegLower = candRegistrar.toLowerCase();
             
             let isMatch = false;
@@ -99,10 +112,25 @@ describe.skipIf(isPlaceholder)('Automated Report Generation', () => {
                 if (s === 'san') return 'Cert SAN Match';
                 if (s === 'dmarc_rua') return 'DMARC RUA Match';
                 if (s === 'dkim_key_reuse') return 'DKIM Key Match';
+                if (s === 'markov_gen') return 'Markov Variant';
                 return s.toUpperCase();
             }).join(', ');
 
-            if (isMatch || (candRegLower === primaryRegLower && primaryRegLower !== 'unknown')) {
+            const deterministicSignals = cand.signals.filter(s => s === 'ns' || s === 'dkim_key_reuse' || s === 'dmarc_rua');
+            const hasDeterministic = deterministicSignals.length > 0;
+            const onlyMarkov = cand.signals.length === 1 && cand.signals[0] === 'markov_gen';
+            const registrarsKnown = primaryRegLower !== 'unknown' && candRegLower !== 'unknown';
+
+            if (isMatch || (registrarsKnown && candRegLower === primaryRegLower)) {
+                consolidated.push({ domain: cand.domain, evidence: evidenceString, registrar: candRegistrar });
+            } else if (onlyMarkov) {
+                // Speculative trigram-generated variant — by definition no shared
+                // infrastructure, so it's a candidate impersonation regardless of registrar visibility.
+                impersonation.push({ domain: cand.domain, evidence: evidenceString, registrar: candRegistrar });
+            } else if (!registrarsKnown && hasDeterministic) {
+                // Without registrar visibility, fall back to deterministic infra
+                // signals (NS/DKIM/DMARC) — these prove operational linkage even
+                // when WHOIS/RDAP can't confirm registrar.
                 consolidated.push({ domain: cand.domain, evidence: evidenceString, registrar: candRegistrar });
             } else {
                 const isConsumer = CONSUMER_REGISTRARS.some(r => candRegLower.includes(r));
@@ -390,5 +418,5 @@ Based on the discovery of ${shadowIt.length} high-value Shadow IT domains, the f
         writeFileSync(filePath, pdfBuffer);
         
         console.log(`[4/4] PDF report generated: ${filePath}`);
-    }, 120000); // 120s timeout for large discoveries
+    }, 300000); // 5min timeout for large discoveries (brands like disney can have many candidates)
 });


### PR DESCRIPTION
## Summary

Two fixes to the local discovery-report generator (`npm run generate-report <domain>`).

- **5727419** — Registrar extraction read `f.title.includes('Registrar')`, but the RDAP finding title is `"Registration details"` — the check never matched, so every brand rendered "Unknown" and every ccTLD variant fell into a false-positive "Shadow IT / Vendor Sprawl" bucket. Now reads from `metadata.registrar`. Also: 16-way parallel RDAP, skip RDAP on Markov-only candidates, signal-based classifier fallback when registrar is Unknown, friendlier "Markov Variant" label, raise per-test timeout from 120s → 300s for brands like Disney/Stripe/Walmart.
- **fedb4a7** — `generate-report.sh` interpolated `\$1` into `rm -f` and `sed -i.bak` without validation. Added an RFC-1035 lowercase-label regex guard before any shell interpolation; blocks path traversal, shell meta, sed-special bytes.

Scope is local dev tooling — no production code, no auth/crypto/secret surface changes.

## Verification

- `npm run typecheck` clean
- All 11 Fortune-500 brands regenerated successfully end-to-end (was: 6 timing out, all "Unknown" registrar, false-positive Shadow IT)
- Guard smoke-tested against `../../etc/passwd`, `foo;rm -rf /`, `Example.COM`, `foo..bar` (all rejected); `blackveilsecurity.com`, `apple.co.uk` accepted

## Test plan

- [x] `npm run typecheck`
- [x] `npm run audit:oss-safety` (27/27)
- [x] `npm run audit:repo-safety` clean
- [x] Manual: regenerate report for at least one brand and confirm registrar populates

🤖 Generated with [Claude Code](https://claude.com/claude-code)