### PR TITLE
feat(brand-discovery): T3 BV_INFRA_GRAPH service-binding wrapper

### DIFF
--- a/src/lib/brand-fingerprint-freshness.ts
+++ b/src/lib/brand-fingerprint-freshness.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure freshness-fallback decision logic for cross-worker brand-discovery
+ * service-binding responses.
+ *
+ * Both bv-infrastructure-graph (Tier 1) and bv-intel-gateway (Tier 2) surface
+ * the same `freshness` shape on their responses; this module is the shared
+ * pure function the wrappers consult before deciding whether to escalate to
+ * a live-fetch fallback.
+ *
+ * Contract: docs/superpowers/plans/2026-05-20-brand-discovery-cross-worker-contract.md
+ *   → "Fingerprint freshness contract"
+ *
+ * Decision:
+ *   - fresh / partial / stale → trust the producer's response; no fallback.
+ *   - very_stale              → trigger Tier 3 / live-sweep fallback for this seed.
+ *
+ * No I/O, no bindings, no network — pure on the input.
+ */
+
+import type { Freshness } from '../schemas/cross-worker-domain-related';
+
+/** Type-only re-export so consumers don't have to know about the schema module. */
+export type FreshnessResponse = Freshness;
+
+/**
+ * Returns true when the producer's data is so stale (>30d on any signal) that
+ * the consumer should fall back to a live infrastructure sweep instead of
+ * relying on the graph response.
+ *
+ * Stale (7d–30d) is intentionally NOT a fallback trigger — the producer's
+ * recommended strategy there is "re-fetch all signals," handled by the
+ * producer-side sweep cron, not by us synchronously.
+ */
+export function shouldTriggerLiveFallback(freshness: FreshnessResponse): boolean {
+	return freshness.overallStaleness === 'very_stale';
+}

--- a/src/lib/brand-tier1-graph.ts
+++ b/src/lib/brand-tier1-graph.ts
@@ -4,8 +4,11 @@
  * Tier 1 service-binding wrapper for `bv-infrastructure-graph`.
  *
  * Calls `GET /domain/:domain/related` via the `BV_INFRA_GRAPH` Fetcher binding
- * and converts each shared-signal co-occurrence into a Tier 1 observation
- * weighted by `specificityScore`.
+ * and converts the producer's shared-signal payload into one Tier 1
+ * observation **per candidate domain**, with confidence computed via the
+ * three-term formula documented in
+ *   docs/superpowers/plans/2026-05-20-brand-discovery-first-principles.md
+ * (search "Tier 1 confidence formula").
  *
  * Cross-worker contract: bv-mcp consumer side, producer schema lives in
  * bv-web. See:
@@ -21,8 +24,11 @@
  *   3. Clamp `specificityScore` to [0, 1] on the consumer side as defense vs
  *      producer drift — the schema requires it but we don't depend on validation.
  *   4. No PII logging. The wrapper does not log domain values or auth tokens.
- *   5. Emit ALL co-occurring domains, weighted by specificity. Do not pre-filter
- *      low-specificity entries — downstream gating (T6) decides.
+ *   5. Emit ALL co-occurring domains, weighted by the formula. Do not pre-filter
+ *      low-specificity entries — downstream gating (T6/T8) decides.
+ *   6. Aggregate per candidate: one observation per candidate even when multiple
+ *      shared signals contribute. This matches the design doc and prevents the
+ *      downstream classifier from double-counting evidence.
  */
 
 import {
@@ -35,15 +41,24 @@ import {
 	type FreshnessResponse,
 } from './brand-fingerprint-freshness';
 
-/** Single observation emitted per co-occurring domain. */
+/** Single aggregated observation per co-occurring candidate domain. */
 export interface Tier1Observation {
 	candidate: string;
 	source: 'infra_graph_signal';
 	tier: 1;
 	confidence: number;
+	/** Specificity of the strongest contributing signal (== `maxSpecificity`). */
 	specificityScore: number;
+	/** Signal type of the strongest contributing signal (max specificity). */
 	signalType: string;
+	/** Signal value of the strongest contributing signal (max specificity). */
 	signalValue: string;
+	/** Count of distinct shared signals contributing to this candidate. */
+	numSharedSignals: number;
+	/** Maximum specificity across all contributing signals. */
+	maxSpecificity: number;
+	/** All signal types contributing to this candidate (deduped, input order). */
+	signalTypes: string[];
 }
 
 export type Tier1Status = 'ok' | 'degraded' | 'partial' | 'timeout' | 'skipped';
@@ -76,22 +91,110 @@ function clamp01(n: number): number {
 	return n;
 }
 
-/** Map a parsed producer response into Tier 1 observations. */
+/**
+ * Tier 1 confidence formula — pure helper, exported for unit tests.
+ *
+ * confidence = clamp(0, 1,
+ *   0.15 * num_shared_signals
+ * + 0.50 * max_specificity
+ * + 0.10 * signal_type_weight_bonus)
+ *
+ * `signal_type_weight_bonus` is currently always 0 — see the activation TODO
+ * at the call site in `flattenSharedSignals`.
+ *
+ * Source: docs/superpowers/plans/2026-05-20-brand-discovery-first-principles.md
+ */
+export function computeTier1Confidence(args: {
+	numSharedSignals: number;
+	maxSpecificity: number;
+	// TODO(brand-discovery): activate signal_type_weight_bonus once bv-web amends
+	// cross-Worker contract to include domainCount on SharedSignal. Bonus weights
+	// are documented in 2026-05-20-brand-discovery-first-principles.md (search
+	// "signal_type_weight_bonus"). Until then, conglomerate brands (PepsiCo-style
+	// multi-brand portfolios) will underweight on low-specificity soa_admin
+	// signals.
+	signalTypeWeightBonus: number;
+}): number {
+	const raw =
+		0.15 * args.numSharedSignals +
+		0.5 * args.maxSpecificity +
+		0.1 * args.signalTypeWeightBonus;
+	if (Number.isNaN(raw)) return 0;
+	if (raw < 0) return 0;
+	if (raw > 1) return 1;
+	return raw;
+}
+
+/**
+ * Map a parsed producer response into Tier 1 observations.
+ *
+ * Aggregates per candidate: each candidate appears once even if multiple
+ * shared signals contribute. The strongest-specificity contributor wins for
+ * the singular `signalType`/`signalValue`/`specificityScore` fields, with
+ * input order as a deterministic tie-break.
+ */
 function flattenSharedSignals(signals: readonly SharedSignal[]): Tier1Observation[] {
-	const observations: Tier1Observation[] = [];
+	interface Accumulator {
+		topSignal: SharedSignal;
+		topSpecificity: number;
+		signalTypes: string[]; // dedup, input order
+		seenTypes: Set<string>;
+		count: number;
+	}
+
+	const byCandidate = new Map<string, Accumulator>();
+
 	for (const signal of signals) {
-		const confidence = clamp01(signal.specificityScore);
+		const specificity = clamp01(signal.specificityScore);
 		for (const candidate of signal.coOccurringDomains) {
-			observations.push({
-				candidate,
-				source: 'infra_graph_signal',
-				tier: 1,
-				confidence,
-				specificityScore: confidence,
-				signalType: signal.signalType,
-				signalValue: signal.signalValue,
-			});
+			const existing = byCandidate.get(candidate);
+			if (!existing) {
+				byCandidate.set(candidate, {
+					topSignal: signal,
+					topSpecificity: specificity,
+					signalTypes: [signal.signalType],
+					seenTypes: new Set([signal.signalType]),
+					count: 1,
+				});
+				continue;
+			}
+			existing.count += 1;
+			if (!existing.seenTypes.has(signal.signalType)) {
+				existing.seenTypes.add(signal.signalType);
+				existing.signalTypes.push(signal.signalType);
+			}
+			// Strict `>` keeps input-order tie-break — first encountered wins on ties.
+			if (specificity > existing.topSpecificity) {
+				existing.topSignal = signal;
+				existing.topSpecificity = specificity;
+			}
 		}
+	}
+
+	const observations: Tier1Observation[] = [];
+	for (const [candidate, acc] of byCandidate) {
+		// TODO(brand-discovery): once SharedSignal.domainCount lands in the
+		// producer contract, compute the bonus here from the strongest
+		// contributing signal's (signalType, domainCount). Until then we
+		// pass 0 — see computeTier1Confidence for the bonus rubric.
+		const signalTypeWeightBonus = 0;
+		const confidence = computeTier1Confidence({
+			numSharedSignals: acc.count,
+			maxSpecificity: acc.topSpecificity,
+			signalTypeWeightBonus,
+		});
+		observations.push({
+			candidate,
+			source: 'infra_graph_signal',
+			tier: 1,
+			confidence,
+			specificityScore: acc.topSpecificity,
+			signalType: acc.topSignal.signalType,
+			signalValue: acc.topSignal.signalValue,
+			numSharedSignals: acc.count,
+			maxSpecificity: acc.topSpecificity,
+			signalTypes: acc.signalTypes,
+		});
 	}
 	return observations;
 }

--- a/src/lib/brand-tier1-graph.ts
+++ b/src/lib/brand-tier1-graph.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tier 1 service-binding wrapper for `bv-infrastructure-graph`.
+ *
+ * Calls `GET /domain/:domain/related` via the `BV_INFRA_GRAPH` Fetcher binding
+ * and converts each shared-signal co-occurrence into a Tier 1 observation
+ * weighted by `specificityScore`.
+ *
+ * Cross-worker contract: bv-mcp consumer side, producer schema lives in
+ * bv-web. See:
+ *   docs/superpowers/plans/2026-05-20-brand-discovery-cross-worker-contract.md § 1.1
+ *   docs/superpowers/plans/2026-05-20-brand-discovery-first-principles-tdd.md   Task 3
+ *
+ * Invariants enforced here:
+ *   1. Never construct an `Authorization` header without `BV_WEB_INTERNAL_KEY`.
+ *      Missing key → short-circuit with degraded status; the binding is never called.
+ *   2. Never throw. Every failure mode (binding error, non-2xx, malformed JSON,
+ *      schema mismatch) collapses into `{ observations: [], status: 'degraded',
+ *      triggerTier3Fallback: true }`.
+ *   3. Clamp `specificityScore` to [0, 1] on the consumer side as defense vs
+ *      producer drift — the schema requires it but we don't depend on validation.
+ *   4. No PII logging. The wrapper does not log domain values or auth tokens.
+ *   5. Emit ALL co-occurring domains, weighted by specificity. Do not pre-filter
+ *      low-specificity entries — downstream gating (T6) decides.
+ */
+
+import {
+	DomainRelatedResponseSchema,
+	type DomainRelatedResponse,
+	type SharedSignal,
+} from '../schemas/cross-worker-domain-related';
+import {
+	shouldTriggerLiveFallback,
+	type FreshnessResponse,
+} from './brand-fingerprint-freshness';
+
+/** Single observation emitted per co-occurring domain. */
+export interface Tier1Observation {
+	candidate: string;
+	source: 'infra_graph_signal';
+	tier: 1;
+	confidence: number;
+	specificityScore: number;
+	signalType: string;
+	signalValue: string;
+}
+
+export type Tier1Status = 'ok' | 'degraded' | 'partial' | 'timeout' | 'skipped';
+
+export interface Tier1Result {
+	observations: Tier1Observation[];
+	status: Tier1Status;
+	triggerTier3Fallback: boolean;
+	freshness?: FreshnessResponse;
+}
+
+/** Env shape minimally required by this wrapper. */
+export interface Tier1Env {
+	BV_WEB_INTERNAL_KEY?: string;
+}
+
+/** Cross-worker contract version pinned in the request header. */
+const CONTRACT_VERSION = '1';
+
+/** Build the absolute URL passed to the service-binding fetch. */
+function buildUrl(domain: string): string {
+	return `https://bv-infrastructure-graph/domain/${encodeURIComponent(domain)}/related`;
+}
+
+/** Clamp a numeric specificity to the contract range [0, 1]. */
+function clamp01(n: number): number {
+	if (Number.isNaN(n)) return 0;
+	if (n < 0) return 0;
+	if (n > 1) return 1;
+	return n;
+}
+
+/** Map a parsed producer response into Tier 1 observations. */
+function flattenSharedSignals(signals: readonly SharedSignal[]): Tier1Observation[] {
+	const observations: Tier1Observation[] = [];
+	for (const signal of signals) {
+		const confidence = clamp01(signal.specificityScore);
+		for (const candidate of signal.coOccurringDomains) {
+			observations.push({
+				candidate,
+				source: 'infra_graph_signal',
+				tier: 1,
+				confidence,
+				specificityScore: confidence,
+				signalType: signal.signalType,
+				signalValue: signal.signalValue,
+			});
+		}
+	}
+	return observations;
+}
+
+/** The single failure mode for every error path — keeps semantics uniform. */
+function degraded(): Tier1Result {
+	return { observations: [], status: 'degraded', triggerTier3Fallback: true };
+}
+
+/**
+ * Tier 1 candidate lookup against `bv-infrastructure-graph`.
+ *
+ * Returns observations + status; never throws.
+ */
+export async function tier1GraphLookup(
+	domain: string,
+	binding: Fetcher,
+	env: Tier1Env,
+): Promise<Tier1Result> {
+	// Invariant 1: no auth key → never construct an Authorization header.
+	if (!env.BV_WEB_INTERNAL_KEY) {
+		return degraded();
+	}
+
+	let response: Response;
+	try {
+		const req = new Request(buildUrl(domain), {
+			method: 'GET',
+			headers: {
+				Authorization: `Bearer ${env.BV_WEB_INTERNAL_KEY}`,
+				'X-Contract-Version': CONTRACT_VERSION,
+				Accept: 'application/json',
+			},
+		});
+		response = await binding.fetch(req);
+	} catch {
+		return degraded();
+	}
+
+	if (!response.ok) {
+		return degraded();
+	}
+
+	let rawBody: unknown;
+	try {
+		rawBody = await response.json();
+	} catch {
+		return degraded();
+	}
+
+	const parsed = DomainRelatedResponseSchema.safeParse(rawBody);
+	if (!parsed.success) {
+		return degraded();
+	}
+
+	const data: DomainRelatedResponse = parsed.data;
+	const observations = flattenSharedSignals(data.sharedSignals);
+	const triggerTier3Fallback = shouldTriggerLiveFallback(data.freshness);
+
+	return {
+		observations,
+		status: 'ok',
+		triggerTier3Fallback,
+		freshness: data.freshness,
+	};
+}

--- a/src/schemas/cross-worker-domain-related.ts
+++ b/src/schemas/cross-worker-domain-related.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+import { z } from 'zod';
+
+/**
+ * Consumer-side Zod schema for the cross-worker contract surface
+ *   `bv-infrastructure-graph` → `GET /domain/:domain/related`
+ *
+ * Producer-side schema lives in bv-web under proprietary license at
+ *   cloudflare/infrastructure-graph/src/schemas/domain-related.ts
+ * Both copies must accept the same payloads. Schema drift is caught by
+ * `test/contracts/bv-infra-graph-domain-related.contract.test.ts` running
+ * against a captured-from-live fixture.
+ *
+ * No source imports cross the license boundary — this file is duplicated
+ * intentionally under BSL-1.1.
+ *
+ * See: docs/superpowers/plans/2026-05-20-brand-discovery-cross-worker-contract.md § 1.1
+ */
+
+/** A single shared signal correlating the seed to one or more co-occurring domains. */
+export const SharedSignalSchema = z
+	.object({
+		// signalType remains an open string — the contract enumerates
+		// "ns" | "mx" | "spf_include" | "cert_issuer" | "cert_fingerprint" | "soa_admin" | "txt" | ...
+		// with a trailing "..." reserving room for producer additions. Tightening to an enum
+		// would break the consumer on the next added signal type.
+		signalType: z.string(),
+		signalValue: z.string(),
+		specificityScore: z.number().min(0).max(1),
+		coOccurringDomains: z.array(z.string()),
+	})
+	.passthrough();
+
+/** Per-signal-type freshness — captured timestamp + computed age in hours. */
+export const PerSignalFreshnessSchema = z.object({
+	capturedAt: z.number(),
+	ageHours: z.number(),
+});
+
+/**
+ * Freshness contract:
+ *   fresh       — every signal type has a capture < 24h old
+ *   partial     — some signals fresh, some 24h–7d
+ *   stale       — all signals 7d–30d old
+ *   very_stale  — any signal > 30d old (triggers fallback to live sweep)
+ */
+export const FreshnessSchema = z.object({
+	perSignalType: z.record(z.string(), PerSignalFreshnessSchema),
+	overallStaleness: z.enum(['fresh', 'partial', 'stale', 'very_stale']),
+});
+
+export const DomainRelatedClusterSchema = z
+	.object({
+		id: z.string(),
+		name: z.string().nullable(),
+		type: z.string(),
+		riskLevel: z.string(),
+		domainCount: z.number(),
+		matchScore: z.number(),
+	})
+	.passthrough();
+
+export const DomainRelatedResponseSchema = z
+	.object({
+		domain: z.string(),
+		totalRelated: z.number(),
+		clusters: z.array(DomainRelatedClusterSchema),
+		sharedSignals: z.array(SharedSignalSchema),
+		freshness: FreshnessSchema,
+	})
+	.passthrough();
+
+export type SharedSignal = z.infer<typeof SharedSignalSchema>;
+export type PerSignalFreshness = z.infer<typeof PerSignalFreshnessSchema>;
+export type Freshness = z.infer<typeof FreshnessSchema>;
+export type DomainRelatedCluster = z.infer<typeof DomainRelatedClusterSchema>;
+export type DomainRelatedResponse = z.infer<typeof DomainRelatedResponseSchema>;

--- a/src/schemas/cross-worker-domain-related.ts
+++ b/src/schemas/cross-worker-domain-related.ts
@@ -28,6 +28,11 @@ export const SharedSignalSchema = z
 		signalValue: z.string(),
 		specificityScore: z.number().min(0).max(1),
 		coOccurringDomains: z.array(z.string()),
+		// Forward-compat: producer may emit the size of the cohort sharing
+		// this signal. Used by the Tier 1 confidence formula's
+		// `signal_type_weight_bonus` term (deferred until the producer ships
+		// this field — see brand-tier1-graph.ts).
+		domainCount: z.number().int().min(0).optional(),
 	})
 	.passthrough();
 

--- a/test/brand-fingerprint-freshness.test.ts
+++ b/test/brand-fingerprint-freshness.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the pure freshness-fallback decision module.
+ *
+ * Pyramid layer: Unit. No I/O, no bindings, no network.
+ * The function is shared by the Tier 1 and Tier 2 service-binding wrappers,
+ * so it lives in `src/lib/` independent of either consumer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { shouldTriggerLiveFallback } from '../src/lib/brand-fingerprint-freshness';
+
+describe('shouldTriggerLiveFallback', () => {
+	it('returns false when overallStaleness === "fresh"', () => {
+		expect(
+			shouldTriggerLiveFallback({ perSignalType: {}, overallStaleness: 'fresh' }),
+		).toBe(false);
+	});
+
+	it('returns false when overallStaleness === "partial"', () => {
+		expect(
+			shouldTriggerLiveFallback({ perSignalType: {}, overallStaleness: 'partial' }),
+		).toBe(false);
+	});
+
+	it('returns false when overallStaleness === "stale"', () => {
+		// stale (7d-30d) is recoverable by re-fetching all signals — not a
+		// live-sweep trigger. Only very_stale (>30d, signals dead) triggers it.
+		expect(
+			shouldTriggerLiveFallback({ perSignalType: {}, overallStaleness: 'stale' }),
+		).toBe(false);
+	});
+
+	it('returns true when overallStaleness === "very_stale"', () => {
+		expect(
+			shouldTriggerLiveFallback({ perSignalType: {}, overallStaleness: 'very_stale' }),
+		).toBe(true);
+	});
+
+	it('ignores perSignalType contents — decision is purely on overallStaleness', () => {
+		// Per-signal data may be empty even with very_stale overall; or rich
+		// even with fresh overall. The consumer doesn't compute its own
+		// rollup — it trusts the producer's overallStaleness verdict.
+		expect(
+			shouldTriggerLiveFallback({
+				perSignalType: { mx: { capturedAt: 1, ageHours: 99_999 } },
+				overallStaleness: 'fresh',
+			}),
+		).toBe(false);
+		expect(
+			shouldTriggerLiveFallback({
+				perSignalType: {},
+				overallStaleness: 'very_stale',
+			}),
+		).toBe(true);
+	});
+});

--- a/test/brand-tier1-graph.integration.test.ts
+++ b/test/brand-tier1-graph.integration.test.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Integration tests for the Tier 1 `bv-infrastructure-graph` service-binding
+ * wrapper against a stubbed binding wired through the Workers runtime.
+ *
+ * These tests stay `.skip`'d until the cross-worker contract is live in the
+ * BlackVeil production environment (see
+ *   docs/superpowers/plans/2026-05-20-brand-discovery-cross-worker-contract.md
+ *   § "Implementation order")
+ * and a captured fixture (PII-scrubbed) is available at
+ * `test/fixtures/cross-worker/domain-related.example.json`.
+ *
+ * Pyramid layer: Integration. One external dependency (the bv-infra-graph
+ * binding stubbed via the Workers runtime). Unit-level coverage of the same
+ * function lives in `test/brand-tier1-graph.test.ts`.
+ */
+
+import { describe, it } from 'vitest';
+
+describe.skip('tier1GraphLookup integration (bv-infrastructure-graph binding)', () => {
+	it.skip('happy-path call returns observations from a stubbed binding', async () => {
+		// TODO(T3 follow-up): once the binding is mocked via SELF / env in the
+		// Workers test pool, drive the wrapper end-to-end against the stub and
+		// assert observation count + freshness propagation.
+	});
+
+	it.skip('propagates the X-Contract-Version header through the binding', async () => {
+		// TODO(T3 follow-up): assert producer-side header reception when the
+		// binding mock surfaces request headers.
+	});
+
+	it.skip('handles a real producer-shaped fixture without degrading', async () => {
+		// TODO(T3 follow-up): load test/fixtures/cross-worker/domain-related.example.json
+		// (captured from prod, PII-scrubbed) and assert status === 'ok'.
+	});
+
+	it.skip('degrades cleanly when the binding rejects with 401 (internal-key mismatch)', async () => {
+		// TODO(T3 follow-up): drive the wrapper against a binding that returns
+		// the contract-defined error code `internal_key_invalid` and assert
+		// status === 'degraded' + triggerTier3Fallback === true.
+	});
+});

--- a/test/brand-tier1-graph.test.ts
+++ b/test/brand-tier1-graph.test.ts
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, vi } from 'vitest';
-import { tier1GraphLookup } from '../src/lib/brand-tier1-graph';
+import { computeTier1Confidence, tier1GraphLookup } from '../src/lib/brand-tier1-graph';
 
 interface MockEnv {
 	BV_WEB_INTERNAL_KEY?: string;
@@ -48,9 +48,37 @@ const baseResponse = {
 	freshness: { perSignalType: {}, overallStaleness: 'fresh' as const },
 };
 
+describe('computeTier1Confidence', () => {
+	it('applies the three-term formula', () => {
+		// 0.15*1 + 0.50*0.9 + 0.10*0 = 0.15 + 0.45 + 0 = 0.60
+		expect(
+			computeTier1Confidence({ numSharedSignals: 1, maxSpecificity: 0.9, signalTypeWeightBonus: 0 }),
+		).toBeCloseTo(0.6, 2);
+		// 0.15*3 + 0.50*0.7 + 0.10*0.3 = 0.45 + 0.35 + 0.03 = 0.83
+		expect(
+			computeTier1Confidence({ numSharedSignals: 3, maxSpecificity: 0.7, signalTypeWeightBonus: 0.3 }),
+		).toBeCloseTo(0.83, 2);
+	});
+
+	it('clamps to [0, 1]', () => {
+		expect(
+			computeTier1Confidence({ numSharedSignals: 100, maxSpecificity: 1, signalTypeWeightBonus: 0 }),
+		).toBe(1);
+		expect(
+			computeTier1Confidence({ numSharedSignals: 0, maxSpecificity: 0, signalTypeWeightBonus: -0.5 }),
+		).toBe(0);
+	});
+
+	it('returns 0 when no signals contribute (defensive)', () => {
+		expect(
+			computeTier1Confidence({ numSharedSignals: 0, maxSpecificity: 0, signalTypeWeightBonus: 0 }),
+		).toBe(0);
+	});
+});
+
 describe('tier1GraphLookup', () => {
 	describe('happy path', () => {
-		it('emits one Tier 1 observation per coOccurringDomain, weighted by specificityScore', async () => {
+		it('emits one Tier 1 observation per candidate with three-term confidence formula', async () => {
 			const mockResponse = {
 				domain: 'example.com',
 				totalRelated: 3,
@@ -80,24 +108,74 @@ describe('tier1GraphLookup', () => {
 
 			expect(result.status).toBe('ok');
 			expect(result.triggerTier3Fallback).toBe(false);
+			// 3 distinct candidates → 3 observations (one per candidate).
 			expect(result.observations).toHaveLength(3);
 
 			const shop = result.observations.find((o) => o.candidate === 'shop.example.net');
+			// 1 signal (cert_fingerprint), max specificity 0.9, bonus 0 (deferred):
+			// 0.15*1 + 0.50*0.9 + 0.10*0 = 0.60
 			expect(shop).toMatchObject({
 				tier: 1,
 				source: 'infra_graph_signal',
-				confidence: 0.9,
 				specificityScore: 0.9,
 				signalType: 'cert_fingerprint',
 				signalValue: 'sha256:abc',
+				numSharedSignals: 1,
+				maxSpecificity: 0.9,
 			});
+			expect(shop?.confidence).toBeCloseTo(0.6, 2);
+			expect(shop?.signalTypes).toEqual(['cert_fingerprint']);
 
 			const login = result.observations.find((o) => o.candidate === 'login.example.net');
-			expect(login?.confidence).toBeLessThan(0.1);
+			// 1 signal (mx), max specificity 0.05, bonus 0:
+			// 0.15*1 + 0.50*0.05 + 0 = 0.175
+			expect(login?.confidence).toBeCloseTo(0.175, 3);
 			expect(login?.signalType).toBe('mx');
 		});
 
-		it('emits ALL co-occurring domains, including low-specificity (no consumer-side filter)', async () => {
+		it('aggregates multiple shared signals per candidate into one observation', async () => {
+			const mockResponse = {
+				...baseResponse,
+				totalRelated: 1,
+				sharedSignals: [
+					{
+						signalType: 'cert_fingerprint',
+						signalValue: 'sha256:abc',
+						specificityScore: 0.9,
+						coOccurringDomains: ['shop.example.net'],
+					},
+					{
+						signalType: 'soa_admin',
+						signalValue: 'admin@example.com',
+						specificityScore: 0.7,
+						coOccurringDomains: ['shop.example.net'],
+					},
+				],
+			};
+
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning(mockResponse),
+				baseEnv,
+			);
+
+			const shop = result.observations.filter((o) => o.candidate === 'shop.example.net');
+			// ONE aggregated observation, not two.
+			expect(shop).toHaveLength(1);
+			// 2 signals, max specificity 0.9, bonus 0:
+			// 0.15*2 + 0.50*0.9 + 0 = 0.75
+			expect(shop[0].confidence).toBeCloseTo(0.75, 2);
+			expect(shop[0].numSharedSignals).toBe(2);
+			expect(shop[0].maxSpecificity).toBe(0.9);
+			// Highest-specificity signal wins for the singular fields.
+			expect(shop[0].signalType).toBe('cert_fingerprint');
+			expect(shop[0].signalValue).toBe('sha256:abc');
+			// Both contributing signal types listed.
+			expect(shop[0].signalTypes).toEqual(expect.arrayContaining(['cert_fingerprint', 'soa_admin']));
+			expect(shop[0].signalTypes).toHaveLength(2);
+		});
+
+		it('emits ALL co-occurring candidates, including low-specificity (no consumer-side filter)', async () => {
 			// Producer-side bug compensation is explicitly NOT this wrapper's job.
 			// Even tiny specificityScore entries (e.g. gmail-shared MX) must surface
 			// so downstream gating (T6) sees the full data.
@@ -169,8 +247,8 @@ describe('tier1GraphLookup', () => {
 		});
 	});
 
-	describe('specificity boundary handling', () => {
-		it('emits confidence === specificityScore when in-range', async () => {
+	describe('specificity input boundary handling', () => {
+		it('applies three-term formula to a single-signal candidate', async () => {
 			const inRange = {
 				...baseResponse,
 				sharedSignals: [
@@ -187,11 +265,14 @@ describe('tier1GraphLookup', () => {
 				mockBindingReturning(inRange),
 				baseEnv,
 			);
-			expect(result.observations[0].confidence).toBe(0.42);
+			// 1 signal, max specificity 0.42, bonus 0:
+			// 0.15*1 + 0.50*0.42 + 0 = 0.36
+			expect(result.observations[0].confidence).toBeCloseTo(0.36, 2);
 			expect(result.observations[0].specificityScore).toBe(0.42);
+			expect(result.observations[0].maxSpecificity).toBe(0.42);
 		});
 
-		it('accepts 0 and 1 as inclusive boundaries', async () => {
+		it('propagates 0 and 1 specificity inputs correctly through the formula', async () => {
 			const inRange = {
 				...baseResponse,
 				sharedSignals: [
@@ -215,15 +296,18 @@ describe('tier1GraphLookup', () => {
 				baseEnv,
 			);
 			expect(result.status).toBe('ok');
-			expect(result.observations.map((o) => o.confidence)).toEqual([0, 1]);
+			// a: 1 signal, max 0 → 0.15*1 + 0.50*0 = 0.15
+			// b: 1 signal, max 1 → 0.15*1 + 0.50*1 = 0.65
+			const a = result.observations.find((o) => o.candidate === 'a.example.net');
+			const b = result.observations.find((o) => o.candidate === 'b.example.net');
+			expect(a?.confidence).toBeCloseTo(0.15, 2);
+			expect(b?.confidence).toBeCloseTo(0.65, 2);
 		});
 
 		it('degrades when producer emits specificityScore > 1 (schema-level guard)', async () => {
 			// Contract is min(0).max(1); a drifted producer emitting 1.7 means
 			// schema validation fails and the wrapper falls back to degraded
-			// rather than silently surfacing out-of-contract data. The
-			// consumer-side clamp is belt-and-braces for any in-range float
-			// drift that slips through.
+			// rather than silently surfacing out-of-contract data.
 			const drifted = {
 				...baseResponse,
 				sharedSignals: [

--- a/test/brand-tier1-graph.test.ts
+++ b/test/brand-tier1-graph.test.ts
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the Tier 1 `bv-infrastructure-graph` service-binding wrapper.
+ *
+ * Pyramid layer: Unit. We pass a stub Fetcher object; no real Workers binding
+ * involved. Integration coverage of the live binding lives in
+ * `test/brand-tier1-graph.integration.test.ts` (skipped placeholders until
+ * the cross-worker contract is deployed).
+ *
+ * Privacy invariant: tests never assert on raw domain values inside log
+ * output — they only assert on returned observation shapes.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { tier1GraphLookup } from '../src/lib/brand-tier1-graph';
+
+interface MockEnv {
+	BV_WEB_INTERNAL_KEY?: string;
+}
+
+function mockBindingReturning(payload: unknown, status = 200): Fetcher {
+	return {
+		fetch: vi.fn(async () =>
+			new Response(JSON.stringify(payload), {
+				status,
+				headers: { 'Content-Type': 'application/json' },
+			}),
+		),
+	} as unknown as Fetcher;
+}
+
+function mockBindingThrowing(err: Error): Fetcher {
+	return {
+		fetch: vi.fn(async () => {
+			throw err;
+		}),
+	} as unknown as Fetcher;
+}
+
+const baseEnv: MockEnv = { BV_WEB_INTERNAL_KEY: 'test-internal-key' };
+
+const baseResponse = {
+	domain: 'example.com',
+	totalRelated: 0,
+	clusters: [],
+	sharedSignals: [],
+	freshness: { perSignalType: {}, overallStaleness: 'fresh' as const },
+};
+
+describe('tier1GraphLookup', () => {
+	describe('happy path', () => {
+		it('emits one Tier 1 observation per coOccurringDomain, weighted by specificityScore', async () => {
+			const mockResponse = {
+				domain: 'example.com',
+				totalRelated: 3,
+				clusters: [],
+				sharedSignals: [
+					{
+						signalType: 'cert_fingerprint',
+						signalValue: 'sha256:abc',
+						specificityScore: 0.9,
+						coOccurringDomains: ['shop.example.net', 'pay.example.net'],
+					},
+					{
+						signalType: 'mx',
+						signalValue: 'mx.gmail.com',
+						specificityScore: 0.05,
+						coOccurringDomains: ['login.example.net'],
+					},
+				],
+				freshness: { perSignalType: {}, overallStaleness: 'fresh' as const },
+			};
+
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning(mockResponse),
+				baseEnv,
+			);
+
+			expect(result.status).toBe('ok');
+			expect(result.triggerTier3Fallback).toBe(false);
+			expect(result.observations).toHaveLength(3);
+
+			const shop = result.observations.find((o) => o.candidate === 'shop.example.net');
+			expect(shop).toMatchObject({
+				tier: 1,
+				source: 'infra_graph_signal',
+				confidence: 0.9,
+				specificityScore: 0.9,
+				signalType: 'cert_fingerprint',
+				signalValue: 'sha256:abc',
+			});
+
+			const login = result.observations.find((o) => o.candidate === 'login.example.net');
+			expect(login?.confidence).toBeLessThan(0.1);
+			expect(login?.signalType).toBe('mx');
+		});
+
+		it('emits ALL co-occurring domains, including low-specificity (no consumer-side filter)', async () => {
+			// Producer-side bug compensation is explicitly NOT this wrapper's job.
+			// Even tiny specificityScore entries (e.g. gmail-shared MX) must surface
+			// so downstream gating (T6) sees the full data.
+			const mockResponse = {
+				...baseResponse,
+				sharedSignals: [
+					{
+						signalType: 'mx',
+						signalValue: 'mx.gmail.com',
+						specificityScore: 0.001,
+						coOccurringDomains: ['random.example.net'],
+					},
+				],
+			};
+
+			const result = await tier1GraphLookup('seed.example', mockBindingReturning(mockResponse), baseEnv);
+			expect(result.observations).toHaveLength(1);
+			expect(result.observations[0].candidate).toBe('random.example.net');
+		});
+
+		it('returns an empty observation set on empty sharedSignals', async () => {
+			const result = await tier1GraphLookup(
+				'isolated.example',
+				mockBindingReturning(baseResponse),
+				baseEnv,
+			);
+			expect(result.status).toBe('ok');
+			expect(result.observations).toEqual([]);
+		});
+
+		it('carries the freshness field through to the caller', async () => {
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning(baseResponse),
+				baseEnv,
+			);
+			expect(result.freshness?.overallStaleness).toBe('fresh');
+		});
+
+		it('forwards Authorization bearer + X-Contract-Version header to the binding', async () => {
+			const fetchSpy = vi.fn(async () =>
+				new Response(JSON.stringify(baseResponse), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}),
+			);
+			const binding: Fetcher = { fetch: fetchSpy } as unknown as Fetcher;
+
+			await tier1GraphLookup('example.com', binding, baseEnv);
+
+			expect(fetchSpy).toHaveBeenCalledTimes(1);
+			const callArg = fetchSpy.mock.calls[0]?.[0] as Request;
+			expect(callArg.headers.get('Authorization')).toBe('Bearer test-internal-key');
+			expect(callArg.headers.get('X-Contract-Version')).toBe('1');
+			// URL-encodes the domain segment
+			expect(callArg.url).toContain('/domain/example.com/related');
+		});
+
+		it('URL-encodes the domain path segment to avoid binding-side path injection', async () => {
+			const fetchSpy = vi.fn(async () =>
+				new Response(JSON.stringify(baseResponse), { status: 200 }),
+			);
+			const binding: Fetcher = { fetch: fetchSpy } as unknown as Fetcher;
+
+			await tier1GraphLookup('foo bar.example/x', binding, baseEnv);
+
+			const callArg = fetchSpy.mock.calls[0]?.[0] as Request;
+			expect(callArg.url).toContain('/domain/foo%20bar.example%2Fx/related');
+		});
+	});
+
+	describe('specificity boundary handling', () => {
+		it('emits confidence === specificityScore when in-range', async () => {
+			const inRange = {
+				...baseResponse,
+				sharedSignals: [
+					{
+						signalType: 'ns',
+						signalValue: 'ns1.example',
+						specificityScore: 0.42,
+						coOccurringDomains: ['sib.example.net'],
+					},
+				],
+			};
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning(inRange),
+				baseEnv,
+			);
+			expect(result.observations[0].confidence).toBe(0.42);
+			expect(result.observations[0].specificityScore).toBe(0.42);
+		});
+
+		it('accepts 0 and 1 as inclusive boundaries', async () => {
+			const inRange = {
+				...baseResponse,
+				sharedSignals: [
+					{
+						signalType: 'ns',
+						signalValue: 'ns1.example',
+						specificityScore: 0,
+						coOccurringDomains: ['a.example.net'],
+					},
+					{
+						signalType: 'ns',
+						signalValue: 'ns2.example',
+						specificityScore: 1,
+						coOccurringDomains: ['b.example.net'],
+					},
+				],
+			};
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning(inRange),
+				baseEnv,
+			);
+			expect(result.status).toBe('ok');
+			expect(result.observations.map((o) => o.confidence)).toEqual([0, 1]);
+		});
+
+		it('degrades when producer emits specificityScore > 1 (schema-level guard)', async () => {
+			// Contract is min(0).max(1); a drifted producer emitting 1.7 means
+			// schema validation fails and the wrapper falls back to degraded
+			// rather than silently surfacing out-of-contract data. The
+			// consumer-side clamp is belt-and-braces for any in-range float
+			// drift that slips through.
+			const drifted = {
+				...baseResponse,
+				sharedSignals: [
+					{
+						signalType: 'ns',
+						signalValue: 'ns1.example',
+						specificityScore: 1.7,
+						coOccurringDomains: ['sib.example.net'],
+					},
+				],
+			};
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning(drifted),
+				baseEnv,
+			);
+			expect(result.status).toBe('degraded');
+		});
+
+		it('degrades when producer emits specificityScore < 0', async () => {
+			const drifted = {
+				...baseResponse,
+				sharedSignals: [
+					{
+						signalType: 'ns',
+						signalValue: 'ns1.example',
+						specificityScore: -0.5,
+						coOccurringDomains: ['sib.example.net'],
+					},
+				],
+			};
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning(drifted),
+				baseEnv,
+			);
+			expect(result.status).toBe('degraded');
+		});
+	});
+
+	describe('freshness fallback', () => {
+		it('returns triggerTier3Fallback=true when freshness=very_stale', async () => {
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning({
+					...baseResponse,
+					freshness: { perSignalType: {}, overallStaleness: 'very_stale' as const },
+				}),
+				baseEnv,
+			);
+			expect(result.triggerTier3Fallback).toBe(true);
+		});
+
+		it('does NOT trigger fallback for stale (7d-30d)', async () => {
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning({
+					...baseResponse,
+					freshness: { perSignalType: {}, overallStaleness: 'stale' as const },
+				}),
+				baseEnv,
+			);
+			expect(result.triggerTier3Fallback).toBe(false);
+		});
+	});
+
+	describe('error handling', () => {
+		it('returns degraded status (with fallback trigger) when binding throws', async () => {
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingThrowing(new Error('binding unreachable')),
+				baseEnv,
+			);
+			expect(result.status).toBe('degraded');
+			expect(result.observations).toEqual([]);
+			expect(result.triggerTier3Fallback).toBe(true);
+		});
+
+		it('returns degraded on non-2xx HTTP status', async () => {
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning({ error: 'internal_key_invalid' }, 401),
+				baseEnv,
+			);
+			expect(result.status).toBe('degraded');
+			expect(result.observations).toEqual([]);
+			expect(result.triggerTier3Fallback).toBe(true);
+		});
+
+		it('returns degraded on malformed JSON', async () => {
+			const malformed: Fetcher = {
+				fetch: vi.fn(async () =>
+					new Response('not-json-at-all', { status: 200 }),
+				),
+			} as unknown as Fetcher;
+
+			const result = await tier1GraphLookup('example.com', malformed, baseEnv);
+			expect(result.status).toBe('degraded');
+			expect(result.triggerTier3Fallback).toBe(true);
+		});
+
+		it('returns degraded on schema-mismatched payload', async () => {
+			const result = await tier1GraphLookup(
+				'example.com',
+				mockBindingReturning({ unexpected: 'shape' }),
+				baseEnv,
+			);
+			expect(result.status).toBe('degraded');
+			expect(result.observations).toEqual([]);
+			expect(result.triggerTier3Fallback).toBe(true);
+		});
+
+		it('returns degraded with empty observations when BV_WEB_INTERNAL_KEY is missing', async () => {
+			// Hard requirement: never construct an Authorization header without
+			// the env var. The wrapper must short-circuit before touching the
+			// binding (preventing any unauth'd call from reaching the producer).
+			const noopBinding: Fetcher = {
+				fetch: vi.fn(async () => new Response('{}', { status: 200 })),
+			} as unknown as Fetcher;
+
+			const result = await tier1GraphLookup('example.com', noopBinding, {});
+
+			expect(result.status).toBe('degraded');
+			expect(result.observations).toEqual([]);
+			expect(result.triggerTier3Fallback).toBe(true);
+			expect((noopBinding.fetch as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0);
+		});
+
+		it('does not throw on any error path', async () => {
+			// Defensive: belt-and-braces. Any throw here is a regression.
+			await expect(
+				tier1GraphLookup(
+					'example.com',
+					mockBindingThrowing(new Error('boom')),
+					baseEnv,
+				),
+			).resolves.toBeDefined();
+		});
+	});
+});

--- a/test/contracts/bv-infra-graph-domain-related.contract.test.ts
+++ b/test/contracts/bv-infra-graph-domain-related.contract.test.ts
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Contract: bv-infrastructure-graph `GET /domain/:domain/related` payload
+ * conforms to {@link DomainRelatedResponseSchema}.
+ *
+ * Producer-side schema lives in bv-web under proprietary license. This file
+ * holds the bv-mcp consumer copy under BSL-1.1 and is the drift-detector
+ * for the cross-worker contract surface defined in
+ * docs/superpowers/plans/2026-05-20-brand-discovery-cross-worker-contract.md § 1.1.
+ *
+ * The fixture below is hand-written (PII-free) — when a real
+ * test/fixtures/cross-worker/* capture exists it can be substituted directly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	DomainRelatedResponseSchema,
+	FreshnessSchema,
+	SharedSignalSchema,
+} from '../../src/schemas/cross-worker-domain-related';
+
+function representativeProducerPayload() {
+	return {
+		domain: 'example.com',
+		totalRelated: 3,
+		clusters: [
+			{
+				id: 'cluster-1',
+				name: 'example-corp',
+				type: 'organization',
+				riskLevel: 'low',
+				domainCount: 12,
+				matchScore: 0.82,
+			},
+		],
+		sharedSignals: [
+			{
+				signalType: 'cert_fingerprint',
+				signalValue: 'sha256:abc...',
+				specificityScore: 0.92,
+				coOccurringDomains: ['shop.example.net', 'pay.example.net'],
+			},
+			{
+				signalType: 'mx',
+				signalValue: 'mx.gmail.com',
+				specificityScore: 0.05,
+				coOccurringDomains: ['login.example.net'],
+			},
+		],
+		freshness: {
+			perSignalType: {
+				cert_fingerprint: { capturedAt: 1_700_000_000_000, ageHours: 4 },
+				mx: { capturedAt: 1_699_000_000_000, ageHours: 100 },
+			},
+			overallStaleness: 'partial' as const,
+		},
+	};
+}
+
+describe('bv-infra-graph /domain/:domain/related contract', () => {
+	describe('representative producer payloads', () => {
+		it('accepts a fully-populated response', () => {
+			const result = DomainRelatedResponseSchema.safeParse(representativeProducerPayload());
+			if (!result.success) {
+				throw new Error(`producer payload failed schema: ${JSON.stringify(result.error.issues)}`);
+			}
+			expect(result.success).toBe(true);
+		});
+
+		it('accepts an empty sharedSignals + empty clusters response (no co-occurrences)', () => {
+			const empty = {
+				domain: 'isolated.example',
+				totalRelated: 0,
+				clusters: [],
+				sharedSignals: [],
+				freshness: { perSignalType: {}, overallStaleness: 'fresh' as const },
+			};
+			expect(DomainRelatedResponseSchema.safeParse(empty).success).toBe(true);
+		});
+
+		it('preserves unknown producer-added fields via passthrough', () => {
+			const payload = representativeProducerPayload() as Record<string, unknown>;
+			payload.redactedOptOuts = 2;
+			const result = DomainRelatedResponseSchema.safeParse(payload);
+			expect(result.success).toBe(true);
+			if (result.success) {
+				expect((result.data as Record<string, unknown>).redactedOptOuts).toBe(2);
+			}
+		});
+
+		it('accepts a producer-added novel signalType (open string contract)', () => {
+			const payload = representativeProducerPayload();
+			payload.sharedSignals.push({
+				signalType: 'webhook_target_host', // hypothetical future signal
+				signalValue: 'hooks.example.com',
+				specificityScore: 0.5,
+				coOccurringDomains: ['hooks.example.net'],
+			});
+			expect(DomainRelatedResponseSchema.safeParse(payload).success).toBe(true);
+		});
+	});
+
+	describe('consumer rejects invalid shapes', () => {
+		it('rejects missing freshness', () => {
+			const bad = representativeProducerPayload() as Record<string, unknown>;
+			delete bad.freshness;
+			expect(DomainRelatedResponseSchema.safeParse(bad).success).toBe(false);
+		});
+
+		it('rejects missing sharedSignals', () => {
+			const bad = representativeProducerPayload() as Record<string, unknown>;
+			delete bad.sharedSignals;
+			expect(DomainRelatedResponseSchema.safeParse(bad).success).toBe(false);
+		});
+
+		it('rejects specificityScore outside 0..1', () => {
+			const bad = {
+				signalType: 'mx',
+				signalValue: 'x',
+				specificityScore: 1.5,
+				coOccurringDomains: [],
+			};
+			expect(SharedSignalSchema.safeParse(bad).success).toBe(false);
+
+			const bad2 = { ...bad, specificityScore: -0.1 };
+			expect(SharedSignalSchema.safeParse(bad2).success).toBe(false);
+		});
+
+		it('rejects coOccurringDomains containing non-strings', () => {
+			const bad = {
+				signalType: 'mx',
+				signalValue: 'x',
+				specificityScore: 0.5,
+				coOccurringDomains: ['ok.com', 42],
+			};
+			expect(SharedSignalSchema.safeParse(bad).success).toBe(false);
+		});
+
+		it('rejects unknown overallStaleness values', () => {
+			const bad = { perSignalType: {}, overallStaleness: 'unknown' };
+			expect(FreshnessSchema.safeParse(bad).success).toBe(false);
+		});
+
+		it('rejects a perSignalType entry missing capturedAt', () => {
+			const bad = {
+				perSignalType: { mx: { ageHours: 5 } },
+				overallStaleness: 'fresh',
+			};
+			expect(FreshnessSchema.safeParse(bad).success).toBe(false);
+		});
+	});
+
+	describe('freshness staleness enum', () => {
+		it('accepts every defined value', () => {
+			for (const v of ['fresh', 'partial', 'stale', 'very_stale'] as const) {
+				const result = FreshnessSchema.safeParse({ perSignalType: {}, overallStaleness: v });
+				expect(result.success).toBe(true);
+			}
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Tier 1 service-binding wrapper for \`bv-infrastructure-graph\` \`/domain/:domain/related\`.
- Maps each co-occurring domain to a Tier 1 observation weighted by \`specificityScore\`.
- Honors \`freshness.overallStaleness\` — \`very_stale\` triggers Tier 3 live-fallback flag.
- Auth: shared \`BV_WEB_INTERNAL_KEY\` bearer.

## Files

- \`src/schemas/cross-worker-domain-related.ts\` — local BSL Zod copy.
- \`src/lib/brand-fingerprint-freshness.ts\` — reusable freshness predicate (T2/T3 both consume).
- \`src/lib/brand-tier1-graph.ts\` — pure wrapper, never throws.
- \`test/brand-tier1-graph.test.ts\` — unit tests including specificity weighting + fallback trigger.
- \`test/brand-fingerprint-freshness.test.ts\` — covers all four staleness levels.
- \`test/brand-tier1-graph.integration.test.ts\` — \`.skip\` placeholders.
- \`test/contracts/bv-infra-graph-domain-related.contract.test.ts\` — pin schema.

## Prerequisites

bv-web has NOT yet shipped the \`freshness\` field or the shared-key auth gate on \`/domain/:domain/related\`. Producer-side P0 (\`sortBy=specificity\` not respected before \`slice(0,20)\` at \`cloudflare/infrastructure-graph/src/routes/domain.ts:65-69\`, ~30 min fix) is also outstanding. Consumer-side wrapper does NOT compensate for the P0 — it consumes whatever the producer emits.

## Plan refs

- TDD plan: Task 3 (lines 238-321)
- Cross-Worker contract: § 1.1 BV_INFRA_GRAPH

## Test plan

- [x] 34 new tests pass, 4 \`.skip\` placeholders
- [x] Full suite: 3786/3786, zero regressions
- [x] Lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)