### PR TITLE
feat(brand-discovery): T1.4 + T6 — tier field + ownership gate bypass

### DIFF
--- a/src/lib/brand-evidence.ts
+++ b/src/lib/brand-evidence.ts
@@ -26,6 +26,23 @@ export interface BrandEvidenceObservation {
 	signal: BrandEvidenceSignal;
 	confidence?: number;
 	metadata?: Record<string, unknown>;
+	/**
+	 * First-principles discovery tier (T1.4):
+	 *   0 = tenant-declared (bv-enterprise)
+	 *   1 = infrastructure graph (bv-infrastructure-graph)
+	 *   2 = declared / witnessed evidence (bv-intel-gateway)
+	 *   3 = fingerprint sweep fallback (this worker)
+	 *   4 = becoming-critical candidate
+	 * Absent on legacy fingerprint observations; T6 keys ownership-gate bypass off it.
+	 */
+	tier?: 0 | 1 | 2 | 3 | 4;
+	/**
+	 * Per-signal specificity (Tier 1, infrastructure-graph). Higher → rarer signal
+	 * across the corpus, so a co-occurrence is more meaningful (e.g. unique cert
+	 * fingerprint ~ 0.9; shared `mx.gmail.com` ~ 0.05). Used by T6 to decide
+	 * whether a single Tier-1 observation is strong enough to clear ownership alone.
+	 */
+	specificityScore?: number;
 }
 
 export interface OwnershipGateOptions {
@@ -97,6 +114,21 @@ export function clearsOwnershipGate(
 	}
 	const distinct = Array.from(unique.values());
 	if (distinct.length === 0) return false;
+
+	// T6: tier-based bypass of the legacy N-of-M corroboration gate.
+	// Tier 0 (tenant-declared) and Tier 2 (declared/witnessed evidence) are gold-
+	// standard and auto-clear. Tier 1 (infrastructure-graph) auto-clears only when
+	// the underlying signal is specific enough (>= 0.5) — broad signals like a
+	// shared `mx.gmail.com` carry tier=1 but specificityScore ~ 0.05 and must
+	// still corroborate. Tier 3/4 and untiered observations fall through to the
+	// existing strong-or-N-of-M-medium logic.
+	for (const observation of distinct) {
+		if (observation.tier === 0) return true;
+		if (observation.tier === 2) return true;
+		if (observation.tier === 1 && typeof observation.specificityScore === 'number' && observation.specificityScore >= 0.5) {
+			return true;
+		}
+	}
 
 	if (options.callerAsserted === true) {
 		return distinct.some((observation) => !isSeedObservation(observation));

--- a/test/brand-evidence.test.ts
+++ b/test/brand-evidence.test.ts
@@ -95,4 +95,57 @@ describe('brand evidence tier policy', () => {
 		expect(clearsOwnershipGate([{ signal: 'active_lookalike' }], { callerAsserted: false })).toBe(false);
 		expect(clearsOwnershipGate([{ signal: 'markov_gen' }], { callerAsserted: false })).toBe(false);
 	});
+
+	// T6: tier metadata short-circuits the legacy N-of-M corroboration gate.
+	describe('tier-based ownership-gate bypass (T6)', () => {
+		it('clears ownership for a single tier-0 observation (tenant-declared)', () => {
+			// `ns` alone is medium and would otherwise fail the legacy gate —
+			// so a `true` result here can only come from the tier-0 bypass.
+			expect(
+				clearsOwnershipGate([{ signal: 'ns', confidence: 1.0, tier: 0 }], { callerAsserted: false }),
+			).toBe(true);
+		});
+
+		it('clears ownership for a tier-1 observation with specificityScore >= 0.5', () => {
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'ns', confidence: 0.7, tier: 1, specificityScore: 0.7 }],
+					{ callerAsserted: false },
+				),
+			).toBe(true);
+		});
+
+		it('does NOT auto-clear for a tier-1 observation with specificityScore < 0.5', () => {
+			// Use a weak (seed) signal so legacy fall-through cannot accidentally
+			// clear it — proving the tier-1 bypass is gated on specificityScore.
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'active_lookalike', confidence: 0.1, tier: 1, specificityScore: 0.1 }],
+					{ callerAsserted: false },
+				),
+			).toBe(false);
+		});
+
+		it('clears ownership for a single tier-2 observation (declared/witnessed evidence)', () => {
+			// Solo `ns` would fail legacy; clearing must come from the tier-2 bypass.
+			expect(
+				clearsOwnershipGate([{ signal: 'ns', confidence: 0.95, tier: 2 }], { callerAsserted: false }),
+			).toBe(true);
+		});
+
+		it('falls through to legacy N-of-M gate when no observations carry a tier (Tier 3 fallback)', () => {
+			// Two non-seed medium signals → legacy gate clears (unchanged behavior).
+			expect(
+				clearsOwnershipGate(
+					[
+						{ signal: 'ns' },
+						{ signal: 'mx_overlap' },
+					],
+					{ callerAsserted: false },
+				),
+			).toBe(true);
+			// Single medium without tier → legacy gate rejects (unchanged behavior).
+			expect(clearsOwnershipGate([{ signal: 'ns' }], { callerAsserted: false })).toBe(false);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Bundled implementation of **Task 1 Step 4** + **Task 6** from the brand-discovery first-principles TDD plan (`docs/superpowers/plans/2026-05-20-brand-discovery-first-principles-tdd.md`). Both tasks modify `src/lib/brand-evidence.ts`, so bundling avoids a known merge conflict.

### T1.4 — Observation tier metadata (pure plumbing)
Extend `BrandEvidenceObservation` with:
- `tier?: 0 | 1 | 2 | 3 | 4` — first-principles discovery tier
- `specificityScore?: number` — per-signal specificity (used by T6 for Tier-1 routing)

Both fields are optional. No behavior change for existing callers; the legacy fingerprint sweep continues to emit untiered observations and falls through to the existing N-of-M gate.

### T6 — `clearsOwnershipGate` honors tier
Early-return `true` when **any** observation has:
- `tier === 0` (tenant-declared, gold-standard), OR
- `tier === 1` AND `specificityScore >= 0.5` (narrow infra-graph signal), OR
- `tier === 2` (declared / witnessed evidence)

Otherwise fall through to the existing `callerAsserted` + strong-or-N-of-M-medium logic. **Tier 3 fallback path is unchanged.**

The Tier-1 specificity gate guarantees broad signals (e.g. shared `mx.gmail.com` with specificityScore ~ 0.05) still need corroboration — a single Tier-1 observation is not enough by itself.

## Stacked PR

> [!IMPORTANT]
> **Base branch: `brand-audit-data-depth`** (not `main`). `src/lib/brand-evidence.ts` lives on that branch; this PR cannot be reviewed against `main` until the parent merges.

## Test plan

- [x] RED: 3 new tier-bypass tests fail against pre-T6 implementation (legacy logic returns `false` for solo `ns` + tier metadata)
- [x] GREEN: all 14 tests pass after the tier-bypass + type extension
- [x] **Legacy regression suite passes unchanged** (T6 Step 5 hard requirement) — original 9 tests are byte-identical and still green
- [x] `npm run typecheck` clean
- [x] `npm test` — 3757 tests passed, 0 test failures (3 pool-teardown WebSocket errors at shutdown are the documented "known flake" per `CLAUDE.md` §Testing)
- [x] Scope kept to T1.4 + T6: only `src/lib/brand-evidence.ts` + `test/brand-evidence.test.ts` modified

## Notes for reviewers

- **No widening of `BrandEvidenceSignal`.** Tests use existing signal names (`ns`, `active_lookalike`) deliberately, to prove the *tier* is what clears the gate — not the underlying signal classification. New tier-source signal names (`tenant_domains`, `infra_graph_signal`, `rdap_registrant_match`) belong in the T2-T4 wrapper types, which already use their own `TierClassifiableObservation` shape per the plan.
- **No signature change to `clearsOwnershipGate`.** The TDD plan's test snippets show a hypothetical `{ observations, callerAsserted }` single-arg form, but live callers use the existing `(observations, options)` two-arg form. The user's brief said "Modify `clearsOwnershipGate()` to early-return" and "use TDD plan T6 Step 1 as starting point" — the tests are adapted accordingly to stay within scope ("do NOT touch other files").

🤖 Generated with [Claude Code](https://claude.com/claude-code)