### PR TITLE
feat(brand-discovery): T8 classification routing with tier metadata

### DIFF
--- a/src/lib/brand-audit-pipeline.ts
+++ b/src/lib/brand-audit-pipeline.ts
@@ -48,6 +48,12 @@ const BUCKET_SEVERITY: Record<Bucket, Severity> = {
 	indeterminate: 'low',
 	shadowIt: 'medium',
 	impersonation: 'high',
+	// Task 8 — impersonationSurface is emitted only in tier-aware (tiered) mode.
+	// The classic pipeline below does not currently feed tier-tagged observations
+	// to the classifier, so this branch is unreachable today; the entry exists to
+	// keep the exhaustive `Record<Bucket, Severity>` typecheck green now that
+	// `Bucket` includes the impersonation-surface variant.
+	impersonationSurface: 'high',
 };
 
 const STRONG_REGISTRAR_INDEPENDENT_SIGNALS = new Set(['san', 'ns', 'dkim_key_reuse']);
@@ -571,7 +577,15 @@ export async function runBrandAuditPipeline(
 		return result;
 	}
 
-	const bucketCounts: Record<Bucket, number> = { consolidated: 0, shadowIt: 0, indeterminate: 0, impersonation: 0 };
+	const bucketCounts: Record<Bucket, number> = {
+		consolidated: 0,
+		shadowIt: 0,
+		indeterminate: 0,
+		impersonation: 0,
+		// Task 8 — unreachable in classic-mode pipeline (no tier-tagged obs are
+		// produced here); included to satisfy the exhaustive Record typecheck.
+		impersonationSurface: 0,
+	};
 	const classificationStartedAtMs = now();
 	const classifiedFindings: Finding[] = candidateFindings.map((f) => {
 		const domain = f.metadata!.candidate as string;

--- a/src/lib/brand-classification.test.ts
+++ b/src/lib/brand-classification.test.ts
@@ -620,4 +620,125 @@ describe('classifyCandidate', () => {
 			expect(classifyCandidate(c, target()).bucket).toBe('impersonation');
 		});
 	});
+
+	// Task 8 — brand-discovery tier routing.
+	// When `evidenceObservations` carry a `tier` field (0/1/2/4), the classifier
+	// short-circuits BEFORE the legacy rules and routes by tier provenance.
+	// Tier-less observations preserve the existing Tier 3 behaviour byte-identically.
+	describe('brand-discovery tier routing (Task 8)', () => {
+		it('routes tier 0 observation to consolidated with tier=0', () => {
+			const c = candidate({
+				domain: 'apple-sub.example',
+				confidence: 0.4,
+				signals: [],
+				evidenceObservations: [{ signal: 'http_redirect', confidence: 1.0, tier: 0 }],
+			});
+			const result = classifyCandidate(c, target());
+			expect(result.bucket).toBe('consolidated');
+			expect(result.tier).toBe(0);
+		});
+
+		it('routes tier 1 + specificityScore >= 0.5 to consolidated with tier=1', () => {
+			const c = candidate({
+				domain: 'apple-graph.example',
+				confidence: 0.3,
+				signals: [],
+				evidenceObservations: [{ signal: 'ns', confidence: 0.8, tier: 1, specificityScore: 0.9 }],
+			});
+			const result = classifyCandidate(c, target());
+			expect(result.bucket).toBe('consolidated');
+			expect(result.tier).toBe(1);
+		});
+
+		it('falls through to legacy rules when tier 1 obs has specificityScore < 0.5', () => {
+			// Low specificity → not enough confidence to claim graph ownership;
+			// the legacy classifier path takes over and routes by other rules.
+			const c = candidate({
+				domain: 'apple-weakgraph.example',
+				confidence: 0.3,
+				signals: [],
+				registrar: 'Unknown',
+				registrarSource: 'unknown',
+				evidenceObservations: [{ signal: 'ns', confidence: 0.5, tier: 1, specificityScore: 0.2 }],
+			});
+			const result = classifyCandidate(c, target());
+			// With no strong signals and low confidence + unknown registrar, the legacy
+			// Rule 8 path lands on impersonation. The key invariant: tier is NOT set.
+			expect(result.tier).toBeUndefined();
+		});
+
+		it('routes tier 2 observation to consolidated with tier=2', () => {
+			const c = candidate({
+				domain: 'apple-rdap.example',
+				confidence: 0.6,
+				signals: [],
+				evidenceObservations: [{ signal: 'dmarc_rua', confidence: 0.9, tier: 2 }],
+			});
+			const result = classifyCandidate(c, target());
+			expect(result.bucket).toBe('consolidated');
+			expect(result.tier).toBe(2);
+		});
+
+		it('routes only-tier-4 observations to impersonationSurface with tier=4', () => {
+			const c = candidate({
+				domain: 'appel.example',
+				confidence: 0.3,
+				signals: [],
+				registrar: 'Different Reg',
+				lookalikeScore: 0.9,
+				evidenceObservations: [{ signal: 'active_lookalike', confidence: 0.3, tier: 4 }],
+			});
+			const result = classifyCandidate(c, target());
+			expect(result.bucket).toBe('impersonationSurface');
+			expect(result.tier).toBe(4);
+		});
+
+		it('mutual exclusion: tier 2 + tier 4 together → consolidated (owned wins over impersonation)', () => {
+			const c = candidate({
+				domain: 'apple-mixed.example',
+				confidence: 0.5,
+				signals: [],
+				evidenceObservations: [
+					{ signal: 'dmarc_rua', confidence: 0.9, tier: 2 },
+					{ signal: 'active_lookalike', confidence: 0.3, tier: 4 },
+				],
+			});
+			const result = classifyCandidate(c, target());
+			expect(result.bucket).toBe('consolidated');
+			expect(result.tier).toBe(2);
+		});
+
+		it('mutual exclusion: tier 0 + tier 4 together → consolidated tier=0 (highest provenance wins)', () => {
+			const c = candidate({
+				domain: 'apple-mixed0.example',
+				confidence: 0.5,
+				signals: [],
+				evidenceObservations: [
+					{ signal: 'active_lookalike', confidence: 0.3, tier: 4 },
+					{ signal: 'http_redirect', confidence: 1.0, tier: 0 },
+				],
+			});
+			const result = classifyCandidate(c, target());
+			expect(result.bucket).toBe('consolidated');
+			expect(result.tier).toBe(0);
+		});
+
+		it('preserves legacy classifier output for observations with no tier field (Tier 3 fallback)', () => {
+			// Without any tier-tagged observation, the new routing block is bypassed
+			// entirely and the existing rules apply unchanged. This is the byte-identical
+			// regression guard against the "do not change legacy paths" hard rule.
+			const c = candidate({
+				domain: 'apple.net',
+				confidence: 0.9,
+				signals: ['dkim_key_reuse'],
+				registrar: 'MarkMonitor Inc.',
+				registrarSource: 'rdap',
+				// No evidenceObservations / no tier on them.
+			});
+			const result = classifyCandidate(c, target());
+			expect(result.bucket).toBe('consolidated');
+			expect(result.tier).toBeUndefined();
+			expect(result.reasons).toContain('shared DKIM key');
+		});
+	});
 });

--- a/src/lib/brand-classification.ts
+++ b/src/lib/brand-classification.ts
@@ -18,8 +18,20 @@
 
 import { sameRegistrarFamily } from './registrar-identity';
 import { clearsOwnershipGate, type BrandEvidenceObservation } from './brand-evidence';
+import type { BrandDiscoveryTier } from './brand-discovery-tiers';
 
-export type Bucket = 'consolidated' | 'shadowIt' | 'indeterminate' | 'impersonation';
+/**
+ * Buckets emitted by the classifier.
+ *
+ * - `consolidated`, `shadowIt`, `indeterminate`, `impersonation` — legacy
+ *   Tier-3 classifier outputs, unchanged.
+ * - `impersonationSurface` — Task 8 (brand-discovery first-principles). Emitted
+ *   ONLY when all observations on a candidate carry `tier === 4` (and no
+ *   higher-provenance tier). Mutually exclusive with the Owned buckets:
+ *   a domain with any tier 0/1/2 obs routes to `consolidated`, never to
+ *   `impersonationSurface`. The invariant is pinned by an audit test.
+ */
+export type Bucket = 'consolidated' | 'shadowIt' | 'indeterminate' | 'impersonation' | 'impersonationSurface';
 export type ConfidenceTier = 'high' | 'medium' | 'low';
 export type RegistrarSource = 'rdap' | 'whois' | 'redacted' | 'notfound' | 'lookup_failed' | 'unknown';
 
@@ -73,7 +85,17 @@ export interface Classification {
 	confidenceTier: ConfidenceTier;
 	note?: string;
 	reasons: string[];
+	/**
+	 * Brand-discovery tier (Task 8). Set only when the candidate routed via the
+	 * tier-aware short-circuit (i.e. at least one observation carried a `tier`
+	 * field). Unset for legacy Tier-3 / classic-mode classification — the
+	 * field's absence is the byte-identical signal that the legacy path ran.
+	 */
+	tier?: BrandDiscoveryTier;
 }
+
+/** Minimum specificityScore for a tier-1 observation to qualify as consolidated evidence. */
+const TIER1_SPECIFICITY_THRESHOLD = 0.5;
 
 /** Strong ownership signals — sharing any of these is near-deterministic operational control evidence. */
 const STRONG_INFRA_SIGNALS = new Set([
@@ -266,6 +288,48 @@ function signalLabel(s: string): string {
 export function classifyCandidate(c: CandidateInput, t: TargetContext): Classification {
 	const tier = confidenceTier(c.confidence);
 	const reasons: string[] = [];
+
+	// Task 8 — brand-discovery tier routing.
+	//
+	// When ANY observation carries a `tier` field, route by tier provenance
+	// BEFORE the legacy classifier rules. Mutual-exclusion rule: Owned tiers
+	// (0/1/2) beat the impersonation surface (4), so a candidate with both a
+	// tier-2 dmarc_rua AND a tier-4 active_lookalike obs routes to
+	// `consolidated`, never to `impersonationSurface`.
+	//
+	// If no observation carries a tier, this block is bypassed entirely and the
+	// legacy Tier-3 rules below execute byte-identically — that's the invariant
+	// the "no tier field" regression test pins.
+	const observations = c.evidenceObservations ?? [];
+	const anyTierTagged = observations.some((o) => o.tier !== undefined);
+	if (anyTierTagged) {
+		const tier0 = observations.find((o) => o.tier === 0);
+		if (tier0) {
+			reasons.push(`tier 0 (tenant-declared) via ${tier0.signal}`);
+			return { bucket: 'consolidated', confidenceTier: tier, reasons, tier: 0 };
+		}
+		const tier1 = observations.find(
+			(o) => o.tier === 1 && (o.specificityScore ?? 0) >= TIER1_SPECIFICITY_THRESHOLD,
+		);
+		if (tier1) {
+			reasons.push(
+				`tier 1 (graph-surfaced) via ${tier1.signal}, specificity=${(tier1.specificityScore ?? 0).toFixed(2)}`,
+			);
+			return { bucket: 'consolidated', confidenceTier: tier, reasons, tier: 1 };
+		}
+		const tier2 = observations.find((o) => o.tier === 2);
+		if (tier2) {
+			reasons.push(`tier 2 (declared/witnessed) via ${tier2.signal}`);
+			return { bucket: 'consolidated', confidenceTier: tier, reasons, tier: 2 };
+		}
+		const onlyTier4 = observations.every((o) => o.tier === 4);
+		if (onlyTier4) {
+			const sample = observations[0];
+			reasons.push(`tier 4 (impersonation surface) via ${sample?.signal ?? 'unknown'}`);
+			return { bucket: 'impersonationSurface', confidenceTier: tier, reasons, tier: 4 };
+		}
+		// Mixed tier 3-only or tier-3-with-tier-4: fall through to legacy rules.
+	}
 
 	// Rule 1: Subdomain of target — DNS managed by parent zone, always organizational.
 	if (isSubdomainOf(c.domain, t.domain)) {

--- a/src/lib/brand-evidence.ts
+++ b/src/lib/brand-evidence.ts
@@ -26,6 +26,20 @@ export interface BrandEvidenceObservation {
 	signal: BrandEvidenceSignal;
 	confidence?: number;
 	metadata?: Record<string, unknown>;
+	/**
+	 * Brand-discovery tier (0..4). Optional — populated by the tier-aware
+	 * discovery pipeline (Task 8+). Tier 0/1/2 = owned-portfolio provenance,
+	 * Tier 3 = legacy live signal sweep, Tier 4 = impersonation surface.
+	 * See `src/lib/brand-discovery-tiers.ts` for the canonical assignment.
+	 */
+	tier?: 0 | 1 | 2 | 3 | 4;
+	/**
+	 * Specificity weight in [0, 1] from the signal-graph (`bv-infrastructure-graph`).
+	 * Required for tier-1 observations to qualify as consolidated evidence
+	 * (threshold ≥0.5). Undefined when the observation does not come from the
+	 * signal-graph pipeline.
+	 */
+	specificityScore?: number;
 }
 
 export interface OwnershipGateOptions {

--- a/test/audits/brand-discovery-tier-mutual-exclusion.audit.test.ts
+++ b/test/audits/brand-discovery-tier-mutual-exclusion.audit.test.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Audit: brand-discovery tier mutual-exclusion invariant.
+ *
+ * A domain may NOT appear in both an Owned bucket (Tier 0/1/2/3 →
+ * `consolidated` / `shadowIt` / `indeterminate` / `impersonation`) AND the
+ * Impersonation Surface bucket (`impersonationSurface`, Tier 4). The
+ * classifier in `src/lib/brand-classification.ts` enforces this at the
+ * single-domain level by routing tier 0/1/2 evidence to `consolidated`
+ * BEFORE the only-tier-4 short-circuit. This audit pins the invariant
+ * across a fixture spanning every tier combination.
+ *
+ * Layer: Audit (cross-output invariant on a fixture, beyond what a single
+ * unit test in `brand-classification.test.ts` can express).
+ *
+ * Plan: docs/superpowers/plans/2026-05-20-brand-discovery-first-principles-tdd.md
+ * (Task 8 Step 5).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { classifyCandidate, type CandidateInput, type TargetContext } from '../../src/lib/brand-classification';
+import type { BrandEvidenceObservation } from '../../src/lib/brand-evidence';
+
+const OWNED_BUCKETS = new Set(['consolidated', 'shadowIt', 'indeterminate', 'impersonation']);
+
+function makeTarget(overrides: Partial<TargetContext> = {}): TargetContext {
+	return {
+		domain: 'example.com',
+		registrar: 'MarkMonitor Inc.',
+		registrarFamily: 'MarkMonitor',
+		...overrides,
+	};
+}
+
+function makeCandidate(domain: string, observations: BrandEvidenceObservation[]): CandidateInput {
+	return {
+		domain,
+		confidence: 0.5,
+		signals: [],
+		registrar: 'Unknown',
+		registrarSource: 'unknown',
+		evidenceObservations: observations,
+	};
+}
+
+/**
+ * Fixture: synthetic candidates exercising every tier combination that could
+ * threaten the mutual-exclusion invariant. Each row is intentionally
+ * minimal — the audit asserts a structural property of the classifier,
+ * not the rich signal-routing covered in the unit tests.
+ */
+interface FixtureRow {
+	readonly name: string;
+	readonly observations: BrandEvidenceObservation[];
+	readonly expectedSurface: 'owned' | 'impersonationSurface';
+}
+
+const FIXTURE: readonly FixtureRow[] = [
+	{
+		name: 'tier 0 alone',
+		observations: [{ signal: 'http_redirect', tier: 0 }],
+		expectedSurface: 'owned',
+	},
+	{
+		name: 'tier 1 specific',
+		observations: [{ signal: 'ns', tier: 1, specificityScore: 0.9 }],
+		expectedSurface: 'owned',
+	},
+	{
+		name: 'tier 2 alone',
+		observations: [{ signal: 'dmarc_rua', tier: 2 }],
+		expectedSurface: 'owned',
+	},
+	{
+		name: 'tier 4 alone',
+		observations: [{ signal: 'active_lookalike', tier: 4 }],
+		expectedSurface: 'impersonationSurface',
+	},
+	{
+		name: 'tier 0 + tier 4 — owned wins',
+		observations: [
+			{ signal: 'active_lookalike', tier: 4 },
+			{ signal: 'http_redirect', tier: 0 },
+		],
+		expectedSurface: 'owned',
+	},
+	{
+		name: 'tier 1 specific + tier 4 — owned wins',
+		observations: [
+			{ signal: 'active_lookalike', tier: 4 },
+			{ signal: 'ns', tier: 1, specificityScore: 0.7 },
+		],
+		expectedSurface: 'owned',
+	},
+	{
+		name: 'tier 2 + tier 4 — owned wins',
+		observations: [
+			{ signal: 'active_lookalike', tier: 4 },
+			{ signal: 'dmarc_rua', tier: 2 },
+		],
+		expectedSurface: 'owned',
+	},
+	{
+		name: 'tier 1 low specificity + tier 4 — falls through to legacy (no impersonationSurface)',
+		// Tier 1 fails the specificity gate. Tier 4 is not alone, so the only-tier-4
+		// short-circuit does not fire either. Legacy rules take over — the result MUST
+		// be an Owned bucket (one of indeterminate/impersonation), never impersonationSurface.
+		observations: [
+			{ signal: 'ns', tier: 1, specificityScore: 0.2 },
+			{ signal: 'active_lookalike', tier: 4 },
+		],
+		expectedSurface: 'owned',
+	},
+];
+
+describe('brand-discovery tier mutual-exclusion invariant (Task 8)', () => {
+	it.each(FIXTURE)('$name → expected surface is $expectedSurface', ({ observations, expectedSurface }) => {
+		const candidate = makeCandidate('candidate.example', observations);
+		const result = classifyCandidate(candidate, makeTarget());
+
+		if (expectedSurface === 'impersonationSurface') {
+			expect(result.bucket).toBe('impersonationSurface');
+			expect(OWNED_BUCKETS.has(result.bucket)).toBe(false);
+		} else {
+			expect(OWNED_BUCKETS.has(result.bucket)).toBe(true);
+			expect(result.bucket).not.toBe('impersonationSurface');
+		}
+	});
+
+	it('NO single classification ever returns both an Owned bucket AND impersonationSurface', () => {
+		// The classifier returns exactly one bucket — so the per-domain invariant is
+		// trivially that bucket ∈ Owned XOR bucket === 'impersonationSurface'. This
+		// assertion pins the structural exclusivity across the entire fixture so a
+		// future refactor that (e.g.) returns an array of buckets cannot silently
+		// violate the invariant without breaking this audit.
+		for (const row of FIXTURE) {
+			const candidate = makeCandidate('candidate.example', row.observations);
+			const { bucket } = classifyCandidate(candidate, makeTarget());
+			const inOwned = OWNED_BUCKETS.has(bucket);
+			const inImpersonationSurface = bucket === 'impersonationSurface';
+			// XOR — exactly one of the two must be true.
+			expect(inOwned !== inImpersonationSurface).toBe(true);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- Brand-classification now honors brand-discovery tier metadata on observations: tier 0 / tier 1 (specificityScore ≥ 0.5) / tier 2 → `consolidated`; only-tier-4 → new `impersonationSurface` bucket. Mutual exclusion: a domain with any Owned-tier evidence (0/1/2) never routes to the Impersonation Surface.
- Legacy Tier-3 paths preserved byte-identically — the new routing block fires only when at least one observation carries a `tier` field. Regression-guarded by a unit test.
- Added evidence-type fields (`tier`, `specificityScore`) deferred from T1 Step 4 (gated on data-depth landing, now done).

## Test plan

- [x] RED — 6 new unit tests added first, fail against unmodified classifier (verified locally).
- [x] GREEN — `src/lib/brand-classification.test.ts` 60/60 pass after implementation; full test sweep `test/brand-evidence.test.ts`, `test/brand-audit-pipeline.test.ts`, `test/brand-audit-batch-start.integration.test.ts`, `test/brand-audit-markdown.test.ts`, `test/brand-audit-pdf-render-lib.test.ts`, `test/brand-audit-status.integration.test.ts`, `test/brand-audit-get-report.integration.test.ts`, `test/brand-audit-reaper.test.ts`, `test/chaos/brand-audit-consumer.chaos.test.ts` all pass.
- [x] Audit — `test/audits/brand-discovery-tier-mutual-exclusion.audit.test.ts` pins the cross-output invariant across an 8-row fixture covering every tier combination.
- [x] `npm run typecheck` clean.
- [x] `npm run lint` clean.

## Notes

`Bucket` was widened to include `'impersonationSurface'`. Forced minimal touches to `brand-audit-pipeline.ts` (BUCKET_SEVERITY + bucketCounts) and `brand-evidence.ts` (optional fields) keep the exhaustive `Record<Bucket, ...>` typecheck green. The pipeline branch is unreachable in classic mode (no tier-tagged obs are produced there yet); it will be exercised once tiered mode lights up in T9+.

Plan: `docs/superpowers/plans/2026-05-20-brand-discovery-first-principles-tdd.md` (Task 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)