### PR TITLE
feat(brand-discovery): T7 orchestrator wiring + discovery_mode flag

### DIFF
--- a/src/lib/brand-audit-pipeline.ts
+++ b/src/lib/brand-audit-pipeline.ts
@@ -61,6 +61,13 @@ export interface BrandAuditPipelineOptions {
 	depth?: 'standard' | 'deep';
 	/** Planner mode for staged discovery fanout. */
 	planner_mode?: 'off' | 'observe' | 'enforce';
+	/**
+	 * Discovery mode threaded through to `discoverBrandDomains`. Default
+	 * `'classic'` preserves byte-identical legacy behavior; `'tiered'` enables
+	 * Tier 0/1/2 lookups in front of the legacy sweep (BSL boundary — public
+	 * default never flips).
+	 */
+	discovery_mode?: 'classic' | 'tiered';
 	/** Public brand aliases, product labels, or legal-entity labels to seed. */
 	brand_aliases?: string[];
 	/** Caller-supplied candidate domains to corroborate. */
@@ -455,6 +462,7 @@ export async function runBrandAuditPipeline(
 			min_confidence: options.min_confidence,
 			depth: options.depth,
 			planner_mode: options.planner_mode,
+			discovery_mode: options.discovery_mode,
 			brand_aliases: options.brand_aliases,
 			candidate_domains: options.candidate_domains,
 			certstream: deps.certstream,

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -236,6 +236,17 @@ export const DiscoverBrandDomainsArgs = z.object({
 		.max(1)
 		.optional()
 		.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
+	discovery_mode: z
+		.enum(['classic', 'tiered'])
+		.default('classic')
+		.describe(
+			'Discovery mode. "classic" (default, BSL-licensed) runs the public signal-sweep pipeline. ' +
+				'"tiered" layers Tier 0 (tenant-declared portfolio), Tier 1 (infrastructure-graph), and ' +
+				'Tier 2 (declared-evidence) lookups in front of the legacy sweep, falling back to Tier 3 ' +
+				'(the existing sweep) only on cache miss / very_stale fingerprint / uncovered caller ' +
+				'candidates. Tiered mode requires private BlackVeil service bindings — BSL self-hosts ' +
+				'should leave this on "classic".',
+		),
 	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 }).passthrough();
 

--- a/src/tools/discover-brand-domains.ts
+++ b/src/tools/discover-brand-domains.ts
@@ -68,6 +68,40 @@ import { checkLookalikes as defaultCheckLookalikes } from './check-lookalikes';
 import { clearsOwnershipGate, type BrandEvidenceObservation } from '../lib/brand-evidence';
 import { detectAppLinks } from '../tenants/discovery/app-links-detector';
 import { detectBountyScope, type BountyPlatform } from '../tenants/discovery/bounty-scope-detector';
+import type { Tier0Result } from '../lib/brand-tier0-enterprise';
+import type { Tier1Result } from '../lib/brand-tier1-graph';
+import type { Tier2Result } from '../lib/brand-tier2-evidence';
+import { applyOptoutFilter, type OptoutFetcher } from '../lib/brand-optout-enforcement';
+
+/**
+ * Discovery mode flag.
+ *
+ * - `classic` — default. Runs the legacy signal-sweep pipeline byte-identically.
+ *   The only mode supported under BSL — public clones never flip the default.
+ * - `tiered`  — runs Tier 0 (tenant portfolio), Tier 1 (infrastructure-graph),
+ *   Tier 2 (declared evidence) lookups in front of the legacy sweep. Falls
+ *   back to Tier 3 (= legacy sweep) only on a stale fingerprint / cache miss /
+ *   uncovered caller candidates. Requires private BlackVeil service bindings.
+ */
+export type DiscoveryMode = 'classic' | 'tiered';
+
+/** Closed enum of drop reasons emitted by the discovery aggregator. */
+export type DiscoveryDropReason =
+	| 'cap'
+	| 'seedOrSubdomain'
+	| 'infrastructureProvider'
+	| 'corroborationGate'
+	| 'belowConfidence'
+	| 'optOutRedacted';
+
+export const DISCOVERY_DROP_REASONS: readonly DiscoveryDropReason[] = [
+	'cap',
+	'seedOrSubdomain',
+	'infrastructureProvider',
+	'corroborationGate',
+	'belowConfidence',
+	'optOutRedacted',
+] as const;
 
 /**
  * Built-in bug-bounty program handles for the Phase-5 demo brands. Replace
@@ -196,6 +230,14 @@ export interface DiscoverBrandDomainsDeps {
 	checkLookalikes: typeof defaultCheckLookalikes;
 	domainLabelSimilarity: typeof defaultDomainLabelSimilarity;
 	createDnsContext?: typeof createDiscoveryDnsContext;
+	/** Tier 0 lookup (tenant-declared portfolio via bv-enterprise). Tiered mode only. */
+	tier0Lookup?: (domain: string) => Promise<Tier0Result>;
+	/** Tier 1 lookup (bv-infrastructure-graph). Tiered mode only. */
+	tier1Lookup?: (domain: string) => Promise<Tier1Result>;
+	/** Tier 2 lookup (bv-intel-gateway). Tiered mode only. */
+	tier2Lookup?: (domain: string) => Promise<Tier2Result>;
+	/** Opt-out fetcher used by the consumer-side filter. Tiered mode only. */
+	fetchOptouts?: OptoutFetcher;
 }
 
 /** Tool args shape — the Zod schema lives in `src/schemas/tool-args.ts`. */
@@ -208,6 +250,13 @@ export interface DiscoverBrandDomainsOptions {
 	depth?: BrandAuditDepth;
 	planner_mode?: 'off' | 'observe' | 'enforce';
 	planner_caps?: Partial<Record<DiscoverSignal, number>>;
+	/**
+	 * Discovery mode. `'classic'` (default) runs the legacy public pipeline
+	 * byte-identically. `'tiered'` layers Tier 0/1/2 lookups in front and
+	 * conditionally falls back to Tier 3 (= the legacy sweep). BSL boundary:
+	 * the default never flips.
+	 */
+	discovery_mode?: DiscoveryMode;
 	/** Internal clock override for deterministic telemetry tests. */
 	now?: () => number;
 	/** Epoch-ms deadline for returning partial discovery before the caller's queue/runtime budget expires. */
@@ -240,6 +289,20 @@ export interface BrandDiscoveryProgressEvent {
 	detail?: Record<string, unknown>;
 }
 
+interface BrandDiscoveryTiers {
+	tier0Count: number;
+	tier1Count: number;
+	tier2Count: number;
+	tier3Count: number;
+	tier4Count: number;
+	tier0Status: string;
+	tier1Status: string;
+	tier2Status: string;
+	tier3FallbackTriggered: number;
+	tier1Freshness: Record<string, unknown> | null;
+	optOutsFiltered: number;
+}
+
 interface BrandDiscoveryPerformance {
 	elapsedMs: number;
 	phases: BrandDiscoveryProgressEvent[];
@@ -256,6 +319,11 @@ interface BrandDiscoveryPerformance {
 		wouldProbeBySignal: Record<string, number>;
 		wouldDropBySignal: Record<string, number>;
 	};
+	/**
+	 * Per-tier metadata. Present iff `discovery_mode === 'tiered'`. Strict
+	 * invariance in classic mode: the key is omitted entirely (not `{}`).
+	 */
+	tiers?: BrandDiscoveryTiers;
 }
 
 /** Combine independent-event confidences: P(any signal correct). */
@@ -485,6 +553,25 @@ export async function discoverBrandDomains(
 	const candidateBackedSignalProbes: Record<string, number> = {};
 	let candidateBackedSignalBaselineProbes: Record<string, number> = {};
 	let signalPlan: BrandDiscoverySignalPlan = { candidatesBySignal: {}, droppedBySignal: {}, priorityByDomain: {}, guardedByDomain: {} };
+
+	// Tiered discovery state. Populated only when `discovery_mode === 'tiered'`.
+	// In classic mode the entire tiered block is skipped and `tieredState` stays
+	// null, so `discoveryPerformance.tiers` is omitted (strict BSL invariance).
+	const discoveryMode: DiscoveryMode = options.discovery_mode ?? 'classic';
+	interface TieredState {
+		tier0Count: number;
+		tier1Count: number;
+		tier2Count: number;
+		tier4Count: number;
+		tier3Count: number;
+		tier0Status: string;
+		tier1Status: string;
+		tier2Status: string;
+		tier3FallbackTriggered: 0 | 1;
+		tier1Freshness: Record<string, unknown> | null;
+		optOutsFiltered: number;
+	}
+	let tieredState: TieredState | null = null;
 	// Default flipped from 'observe' to 'enforce' after the planner cap-tuning
 	// was validated against production (walmart/bankofamerica/marriott: 44.8%
 	// probe reduction, zero surfaced/bucket regressions) and against a chaos
@@ -505,7 +592,7 @@ export async function discoverBrandDomains(
 		const baselineCandidateSignalProbes = Object.values(candidateBackedSignalBaselineProbes).reduce((sum, count) => sum + count, 0);
 		const surfaced = phaseTimings.find((phase) => phase.name === 'aggregation')?.detail?.surfaced;
 		const surfacedCandidates = typeof surfaced === 'number' ? surfaced : 0;
-		return {
+		const out: BrandDiscoveryPerformance = {
 			elapsedMs: Math.max(0, now() - discoveryStartedAtMs),
 			phases: phaseTimings.slice(),
 			efficiency: {
@@ -525,6 +612,24 @@ export async function discoverBrandDomains(
 				wouldDropBySignal: countDroppedCandidates(signalPlan.droppedBySignal),
 			},
 		};
+		// BSL invariance: attach `tiers` ONLY when tiered mode populated state.
+		// Classic mode leaves the key absent from the object entirely.
+		if (tieredState) {
+			out.tiers = {
+				tier0Count: tieredState.tier0Count,
+				tier1Count: tieredState.tier1Count,
+				tier2Count: tieredState.tier2Count,
+				tier3Count: tieredState.tier3Count,
+				tier4Count: tieredState.tier4Count,
+				tier0Status: tieredState.tier0Status,
+				tier1Status: tieredState.tier1Status,
+				tier2Status: tieredState.tier2Status,
+				tier3FallbackTriggered: tieredState.tier3FallbackTriggered,
+				tier1Freshness: tieredState.tier1Freshness,
+				optOutsFiltered: tieredState.optOutsFiltered,
+			};
+		}
+		return out;
 	};
 	const runTrackedSignal = async <R>(
 		name: DiscoverSignal,
@@ -619,6 +724,216 @@ export async function discoverBrandDomains(
 
 	for (const candidate of universe.candidates) {
 		addCandidateSeed(aggregator, candidate.domain, candidate.sources, candidate.reasons);
+	}
+
+	// ---------------------------------------------------------------------
+	// Tiered discovery (T7) — Tier 0/1/2 run BEFORE the legacy sweep (Tier 3).
+	// Tier 3 only fires conditionally: very_stale freshness, Tier 1 returned
+	// no candidates AND freshness != fresh, or caller_candidates not covered.
+	// Classic mode skips the entire block (strict BSL invariance — public
+	// default never flips).
+	// ---------------------------------------------------------------------
+	const seedNormForTiered = seedDomain.trim().toLowerCase().replace(/\.$/, '');
+	const tieredObservations: Array<{
+		candidate: string;
+		tier: 0 | 1 | 2 | 4;
+		source: string;
+		confidence: number;
+		metadata: Record<string, unknown>;
+	}> = [];
+	let runTier3 = true;
+	if (discoveryMode === 'tiered') {
+		tieredState = {
+			tier0Count: 0,
+			tier1Count: 0,
+			tier2Count: 0,
+			tier4Count: 0,
+			tier3Count: 0,
+			tier0Status: 'skipped',
+			tier1Status: 'skipped',
+			tier2Status: 'skipped',
+			tier3FallbackTriggered: 0,
+			tier1Freshness: null,
+			optOutsFiltered: 0,
+		};
+		const tieredStartedAtMs = await startPhase('tiered_lookup');
+		const tier0Started = now();
+		const tier1Started = now();
+		const tier2Started = now();
+		const [tier0Settled, tier1Settled, tier2Settled] = await Promise.allSettled([
+			d.tier0Lookup
+				? d.tier0Lookup(seedDomain)
+				: Promise.resolve<Tier0Result>({ observations: [], status: 'skipped', optedOut: false }),
+			d.tier1Lookup
+				? d.tier1Lookup(seedDomain)
+				: Promise.resolve<Tier1Result>({ observations: [], status: 'skipped', triggerTier3Fallback: false }),
+			d.tier2Lookup
+				? d.tier2Lookup(seedDomain)
+				: Promise.resolve<Tier2Result>({ observations: [], status: 'skipped' }),
+		]);
+
+		if (tier0Settled.status === 'fulfilled') {
+			const r = tier0Settled.value;
+			tieredState.tier0Status = r.status;
+			for (const obs of r.observations) {
+				tieredObservations.push({
+					candidate: obs.candidate,
+					tier: 0,
+					source: obs.source,
+					confidence: obs.confidence,
+					metadata: { tier: 0, source: obs.source, tenantId: obs.tenantId, registeredAt: obs.registeredAt },
+				});
+			}
+			await finishPhase('tier0_tenant', r.status, tier0Started, {
+				observations: r.observations.length,
+				optedOut: r.optedOut,
+			});
+		} else {
+			tieredState.tier0Status = 'degraded';
+			await finishPhase('tier0_tenant', 'failed', tier0Started, { error: String(tier0Settled.reason) });
+		}
+
+		if (tier1Settled.status === 'fulfilled') {
+			const r = tier1Settled.value;
+			tieredState.tier1Status = r.status;
+			tieredState.tier1Freshness = (r.freshness as unknown as Record<string, unknown>) ?? null;
+			for (const obs of r.observations) {
+				tieredObservations.push({
+					candidate: obs.candidate,
+					tier: 1,
+					source: obs.source,
+					confidence: obs.confidence,
+					metadata: {
+						tier: 1,
+						source: obs.source,
+						specificityScore: obs.specificityScore,
+						signalType: obs.signalType,
+						signalValue: obs.signalValue,
+						numSharedSignals: obs.numSharedSignals,
+						maxSpecificity: obs.maxSpecificity,
+						signalTypes: obs.signalTypes,
+					},
+				});
+			}
+			await finishPhase('tier1_graph', r.status, tier1Started, {
+				observations: r.observations.length,
+				triggerTier3Fallback: r.triggerTier3Fallback,
+			});
+		} else {
+			tieredState.tier1Status = 'degraded';
+			await finishPhase('tier1_graph', 'failed', tier1Started, { error: String(tier1Settled.reason) });
+		}
+
+		if (tier2Settled.status === 'fulfilled') {
+			const r = tier2Settled.value;
+			tieredState.tier2Status = r.status;
+			for (const obs of r.observations) {
+				if (obs.tier === 2) {
+					tieredObservations.push({
+						candidate: obs.candidate,
+						tier: 2,
+						source: obs.source,
+						confidence: obs.confidence,
+						metadata: { tier: 2, source: obs.source, threatLevel: obs.threatLevel, capturedAt: obs.capturedAt },
+					});
+				} else {
+					tieredObservations.push({
+						candidate: obs.candidate,
+						tier: 4,
+						source: obs.source,
+						confidence: obs.confidence,
+						metadata: { tier: 4, source: obs.source, alertType: obs.alertType, transition: obs.transition },
+					});
+				}
+			}
+			await finishPhase('tier2_evidence', r.status, tier2Started, { observations: r.observations.length });
+		} else {
+			tieredState.tier2Status = 'degraded';
+			await finishPhase('tier2_evidence', 'failed', tier2Started, { error: String(tier2Settled.reason) });
+		}
+
+		// Apply consumer-side opt-out filter to ALL surfaced tiered candidates.
+		// 3rd defensive layer: even if both producer-side filters miss an
+		// opted-out apex, bv-mcp redacts it here.
+		if (d.fetchOptouts && tieredObservations.length > 0) {
+			try {
+				const candidatesToCheck = Array.from(new Set(tieredObservations.map((o) => o.candidate)));
+				const optoutResult = await applyOptoutFilter(candidatesToCheck, d.fetchOptouts);
+				const survivors = new Set(optoutResult.filtered.map((c) => c.trim().toLowerCase().replace(/\.$/, '')));
+				const beforeLen = tieredObservations.length;
+				let writeIdx = 0;
+				for (let i = 0; i < tieredObservations.length; i++) {
+					const norm = tieredObservations[i].candidate.trim().toLowerCase().replace(/\.$/, '');
+					if (survivors.has(norm)) {
+						tieredObservations[writeIdx++] = tieredObservations[i];
+					}
+				}
+				tieredObservations.length = writeIdx;
+				tieredState.optOutsFiltered = Math.max(beforeLen - writeIdx, optoutResult.redactedCount);
+			} catch {
+				// Fail-soft: filter unavailable → no redaction, no abort.
+			}
+		}
+
+		// Land tiered observations in the aggregator BEFORE the Tier 3 decision,
+		// so the signal sweep (if it runs) corroborates rather than duplicates.
+		// Tiered candidates are treated as caller-asserted: they came from a
+		// declared/tenant/graph source and bypass the multi-signal corroboration
+		// gate (intended for unsolicited single-signal discoveries).
+		for (const obs of tieredObservations) {
+			callerAssertedDomains.add(obs.candidate.trim().toLowerCase().replace(/\.$/, ''));
+			// Tier observations live on the `markov_gen` signal key (zero
+			// contribution to combined-confidence — the caller-asserted bypass
+			// is what surfaces these). The metadata blob carries the real tier
+			// + source for the T8 classifier to read.
+			addObservation(aggregator, obs.candidate, 'markov_gen', obs.confidence, {
+				tier: obs.tier,
+				source: obs.source,
+				...obs.metadata,
+			});
+		}
+
+		// Tier counts (post-opt-out).
+		for (const obs of tieredObservations) {
+			if (obs.tier === 0) tieredState.tier0Count++;
+			else if (obs.tier === 1) tieredState.tier1Count++;
+			else if (obs.tier === 2) tieredState.tier2Count++;
+			else if (obs.tier === 4) tieredState.tier4Count++;
+		}
+
+		// ---- Tier 3 decision ----
+		// Per the source-of-truth plan §521-524 (and reconciled with the task
+		// description test at "fresh → no Tier 3 fallback"):
+		//   - tier1Freshness === 'very_stale', OR
+		//   - Tier 1 returned no candidates AND tier1Freshness !== 'fresh', OR
+		//   - caller_candidates present and not covered by Tier 0/1/2.
+		const tier1FreshnessStaleness =
+			tieredState.tier1Freshness && typeof tieredState.tier1Freshness.overallStaleness === 'string'
+				? (tieredState.tier1Freshness.overallStaleness as string)
+				: undefined;
+		const tier1Fresh = tier1FreshnessStaleness === 'fresh';
+		const tier1VeryStale = tier1FreshnessStaleness === 'very_stale';
+		const tier1HadCandidates = tieredState.tier1Count > 0;
+		const coveredByTiers = new Set(
+			tieredObservations.map((o) => o.candidate.trim().toLowerCase().replace(/\.$/, '')),
+		);
+		coveredByTiers.add(seedNormForTiered);
+		const callerNorm = candidateDomains
+			.map((dom) => dom.trim().toLowerCase().replace(/\.$/, ''))
+			.filter((dom) => dom.length > 0);
+		const uncoveredCaller = callerNorm.some((dom) => !coveredByTiers.has(dom));
+		const shouldRunTier3 = tier1VeryStale || (!tier1HadCandidates && !tier1Fresh) || uncoveredCaller;
+		runTier3 = shouldRunTier3;
+		tieredState.tier3FallbackTriggered = shouldRunTier3 ? 1 : 0;
+
+		await finishPhase('tiered_lookup', 'completed', tieredStartedAtMs, {
+			tier0Count: tieredState.tier0Count,
+			tier1Count: tieredState.tier1Count,
+			tier2Count: tieredState.tier2Count,
+			tier4Count: tieredState.tier4Count,
+			tier3FallbackTriggered: tieredState.tier3FallbackTriggered,
+			optOutsFiltered: tieredState.optOutsFiltered,
+		});
 	}
 
 	const signalStatus: Record<string, { status: string; error?: string }> = { ...preSignalStatus };
@@ -997,27 +1312,40 @@ export async function discoverBrandDomains(
 		});
 	}
 
-	const signalSweepStartedAtMs = await startPhase('signal_sweep', {
-		signals: jobs.map((job) => job.name),
-		probedCandidates: mergedCandidates.length,
-	});
-	await Promise.allSettled(jobs.map((j) => j.run()));
-	await finishPhase(
-		'signal_sweep',
-		options.signal?.aborted ? 'partial' : 'completed',
-		signalSweepStartedAtMs,
-		{
-			completedSignals: phaseTimings
-				.filter((phase) => jobs.some((job) => job.name === phase.name))
-				.map((phase) => phase.name),
-		},
-	);
+	if (!runTier3) {
+		// Tiered mode decided Tier 3 (= the legacy sweep) isn't needed. Mark
+		// every requested signal as `skipped_tiered` so the allFailed gate
+		// below sees a known-good non-failure outcome, then skip the sweep.
+		for (const s of signals) {
+			signalStatus[s] ??= { status: 'skipped_tiered' };
+		}
+		await recordInstantPhase('signal_sweep', 'skipped_tiered', { reason: 'tier1_fresh_no_uncovered_caller' });
+	} else {
+		const signalSweepStartedAtMs = await startPhase('signal_sweep', {
+			signals: jobs.map((job) => job.name),
+			probedCandidates: mergedCandidates.length,
+		});
+		await Promise.allSettled(jobs.map((j) => j.run()));
+		await finishPhase(
+			'signal_sweep',
+			options.signal?.aborted ? 'partial' : 'completed',
+			signalSweepStartedAtMs,
+			{
+				completedSignals: phaseTimings
+					.filter((phase) => jobs.some((job) => job.name === phase.name))
+					.map((phase) => phase.name),
+			},
+		);
+	}
 
 	// Budget gate: if the consumer's AbortController has fired while jobs were
 	// in flight, skip the recursive SAN expansion (the most expensive single
 	// step, ~30s) and head straight to the aggregator pass with whatever we
 	// already have. The consumer will flip the row to `failed` once we return.
-	if (options.signal?.aborted) {
+	if (!runTier3) {
+		// Tiered mode skipped the sweep entirely → nothing to do for san_recursive.
+		signalStatus.san_recursive ??= { status: 'skipped_tiered' };
+	} else if (options.signal?.aborted) {
 		signalStatus.san_recursive ??= { status: 'skipped_no_first_order' };
 		await recordInstantPhase('san_recursive', 'skipped_aborted');
 	} else if (signals.includes('san_recursive') && firstOrderSanCandidates.length > 0) {
@@ -1208,6 +1536,19 @@ export async function discoverBrandDomains(
 		surfaced: candidateFindings.length,
 		dropped: dropCounts,
 	});
+
+	// Tier 3 count: in tiered mode, count surviving candidates that were NOT
+	// surfaced by Tier 0/1/2. Identified by domain set membership.
+	if (tieredState) {
+		const tieredApex = new Set(
+			tieredObservations.map((o) => o.candidate.trim().toLowerCase().replace(/\.$/, '')),
+		);
+		let tier3Count = 0;
+		for (const cand of surviving) {
+			if (!tieredApex.has(cand.domain)) tier3Count++;
+		}
+		tieredState.tier3Count = tier3Count;
+	}
 
 	// Always emit a summary finding so the formatter has something to print.
 	const summary = createFinding(

--- a/test/audits/brand-discovery-drop-reasons.audit.test.ts
+++ b/test/audits/brand-discovery-drop-reasons.audit.test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Audit test (T7 / Task 7 Step 4): no silent drops.
+ *
+ * Every candidate that enters `discoverBrandDomains`' aggregator and does NOT
+ * surface as a finding MUST be accounted for under a structured drop reason
+ * from the closed `DiscoveryDropReason` enum. Adding a new drop site without
+ * extending the enum fails this audit.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { DISCOVERY_DROP_REASONS, type DiscoveryDropReason } from '../../src/tools/discover-brand-domains';
+
+const CANONICAL_DROP_REASONS = [
+	'cap',
+	'seedOrSubdomain',
+	'infrastructureProvider',
+	'corroborationGate',
+	'belowConfidence',
+	'optOutRedacted',
+] as const satisfies readonly DiscoveryDropReason[];
+
+describe('brand-discovery drop-reasons audit (closed enum)', () => {
+	it('exports the canonical drop-reasons enum', () => {
+		expect(DISCOVERY_DROP_REASONS.slice().sort()).toEqual(CANONICAL_DROP_REASONS.slice().sort());
+	});
+
+	it('source code records every drop site under a canonical reason', async () => {
+		const source = (
+			await import('../../src/tools/discover-brand-domains.ts?raw')
+		).default as string;
+		const referencedReasons = new Set<string>();
+		const regex = /dropCounts\.([A-Za-z_][A-Za-z0-9_]*)/g;
+		let match: RegExpExecArray | null;
+		while ((match = regex.exec(source)) !== null) {
+			referencedReasons.add(match[1]);
+		}
+		const offenders = Array.from(referencedReasons).filter(
+			(reason) => !CANONICAL_DROP_REASONS.includes(reason as DiscoveryDropReason),
+		);
+		expect(
+			offenders,
+			`Drop-counter property referenced in source that is not in the canonical DiscoveryDropReason enum: ${offenders.join(', ')}.`,
+		).toEqual([]);
+	});
+});

--- a/test/discover-brand-domains.spec.ts
+++ b/test/discover-brand-domains.spec.ts
@@ -889,3 +889,227 @@ describe('discoverBrandDomains', () => {
 		expect(/[🔵🟡🟠🔴]/.test(compact)).toBe(false);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// T7: tiered discovery_mode tests
+// ---------------------------------------------------------------------------
+
+describe('discoverBrandDomains — discovery_mode=tiered', () => {
+	const FRESH_FRESHNESS = {
+		overallStaleness: 'fresh' as const,
+		oldestSignalAgeMs: 1_000,
+		latestSweepAtMs: 1_800_000_000_000,
+	};
+	const VERY_STALE_FRESHNESS = {
+		overallStaleness: 'very_stale' as const,
+		oldestSignalAgeMs: 60 * 24 * 60 * 60 * 1000,
+		latestSweepAtMs: 1_800_000_000_000 - 60 * 24 * 60 * 60 * 1000,
+	};
+
+	function tier0Empty(): unknown {
+		return { observations: [], status: 'ok', optedOut: false };
+	}
+	function tier0Ok(candidate: string): unknown {
+		return {
+			observations: [{ candidate, source: 'tenant_domains', tier: 0, confidence: 1.0 }],
+			status: 'ok',
+			optedOut: false,
+		};
+	}
+	function tier1Empty(freshness = FRESH_FRESHNESS): unknown {
+		return { observations: [], status: 'ok', triggerTier3Fallback: false, freshness };
+	}
+	function tier1Ok(candidate: string, freshness = FRESH_FRESHNESS): unknown {
+		return {
+			observations: [
+				{
+					candidate,
+					source: 'infra_graph_signal',
+					tier: 1,
+					confidence: 0.8,
+					specificityScore: 0.9,
+					signalType: 'soa_admin',
+					signalValue: 'admin@example.com',
+					numSharedSignals: 1,
+					maxSpecificity: 0.9,
+					signalTypes: ['soa_admin'],
+				},
+			],
+			status: 'ok',
+			triggerTier3Fallback: false,
+			freshness,
+		};
+	}
+	function tier2Empty(): unknown {
+		return { observations: [], status: 'ok' };
+	}
+	void tier1Empty;
+
+	it('emits per-tier counts in discoveryPerformance.tiers when discovery_mode=tiered', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const tieredDeps = {
+			...makeDeps(),
+			tier0Lookup: vi.fn().mockResolvedValue(tier0Ok('tenant-portfolio.example.net')),
+			tier1Lookup: vi.fn().mockResolvedValue(tier1Ok('infra-graph.example.net', FRESH_FRESHNESS)),
+			tier2Lookup: vi.fn().mockResolvedValue({
+				observations: [
+					{ candidate: 'example.com', source: 'gsi_evidence', tier: 2, confidence: 0.9, threatLevel: 'low', capturedAt: 1 },
+					{ candidate: 'example.com', source: 'score_alert_critical_drop', tier: 4, confidence: 0.5, alertType: 'drop', transition: 'low->critical' },
+				],
+				status: 'ok',
+			}),
+		};
+		const result = await discoverBrandDomains(
+			'example.com',
+			{ discovery_mode: 'tiered', signals: ['ns'], candidate_domains: [] },
+			tieredDeps as unknown as DiscoverBrandDomainsDeps,
+		);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const tiers = (summary?.metadata?.discoveryPerformance as { tiers?: Record<string, unknown> } | undefined)?.tiers;
+		expect(tiers).toMatchObject({
+			tier0Count: 1,
+			tier1Count: 1,
+			tier2Count: 1,
+			tier4Count: 1,
+			tier3Count: expect.any(Number),
+			tier0Status: 'ok',
+			tier1Status: 'ok',
+			tier2Status: 'ok',
+			tier3FallbackTriggered: expect.any(Number),
+			tier1Freshness: expect.objectContaining({ overallStaleness: 'fresh' }),
+			optOutsFiltered: expect.any(Number),
+		});
+	});
+
+	it('does not trigger tier3 live sweep when tier1 freshness is fresh and returns candidates', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const correlateNs = vi.fn().mockResolvedValue(okNs([]));
+		const tieredDeps = {
+			...makeDeps({ correlateNs }),
+			tier0Lookup: vi.fn().mockResolvedValue(tier0Empty()),
+			tier1Lookup: vi.fn().mockResolvedValue(tier1Ok('related.example.net', FRESH_FRESHNESS)),
+			tier2Lookup: vi.fn().mockResolvedValue(tier2Empty()),
+		};
+		const result = await discoverBrandDomains(
+			'example.com',
+			{ discovery_mode: 'tiered', signals: ['ns'], candidate_domains: [] },
+			tieredDeps as unknown as DiscoverBrandDomainsDeps,
+		);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const tiers = (summary?.metadata?.discoveryPerformance as { tiers?: Record<string, unknown> } | undefined)?.tiers;
+		expect(tiers).toBeDefined();
+		expect(tiers?.tier3FallbackTriggered).toBe(0);
+		expect(correlateNs).not.toHaveBeenCalled();
+	});
+
+	it('triggers tier3 fallback when tier1 freshness is very_stale', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const correlateNs = vi.fn().mockResolvedValue(okNs([]));
+		const tieredDeps = {
+			...makeDeps({ correlateNs }),
+			tier0Lookup: vi.fn().mockResolvedValue(tier0Empty()),
+			tier1Lookup: vi.fn().mockResolvedValue({
+				observations: [],
+				status: 'ok',
+				triggerTier3Fallback: true,
+				freshness: VERY_STALE_FRESHNESS,
+			}),
+			tier2Lookup: vi.fn().mockResolvedValue(tier2Empty()),
+		};
+		const result = await discoverBrandDomains(
+			'example.com',
+			{ discovery_mode: 'tiered', signals: ['ns'], candidate_domains: [] },
+			tieredDeps as unknown as DiscoverBrandDomainsDeps,
+		);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const tiers = (summary?.metadata?.discoveryPerformance as { tiers?: Record<string, unknown> } | undefined)?.tiers;
+		expect(tiers?.tier3FallbackTriggered).toBe(1);
+		expect(correlateNs).toHaveBeenCalled();
+	});
+
+	it('triggers tier3 fallback when caller_candidates are not covered by tier 0/1/2', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const correlateNs = vi.fn().mockResolvedValue(okNs([]));
+		const tieredDeps = {
+			...makeDeps({ correlateNs }),
+			tier0Lookup: vi.fn().mockResolvedValue(tier0Empty()),
+			tier1Lookup: vi.fn().mockResolvedValue(tier1Ok('covered.example.net', FRESH_FRESHNESS)),
+			tier2Lookup: vi.fn().mockResolvedValue(tier2Empty()),
+		};
+		const result = await discoverBrandDomains(
+			'example.com',
+			{
+				discovery_mode: 'tiered',
+				signals: ['ns'],
+				candidate_domains: ['uncovered.example.net'],
+			},
+			tieredDeps as unknown as DiscoverBrandDomainsDeps,
+		);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const tiers = (summary?.metadata?.discoveryPerformance as { tiers?: Record<string, unknown> } | undefined)?.tiers;
+		expect(tiers?.tier3FallbackTriggered).toBe(1);
+		expect(correlateNs).toHaveBeenCalled();
+	});
+
+	it('classic mode does not emit tier counts and runs the legacy pipeline unchanged', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const tier0 = vi.fn();
+		const tier1 = vi.fn();
+		const tier2 = vi.fn();
+		const tieredDeps = {
+			...makeDeps(),
+			tier0Lookup: tier0,
+			tier1Lookup: tier1,
+			tier2Lookup: tier2,
+		};
+		const result = await discoverBrandDomains(
+			'example.com',
+			{ discovery_mode: 'classic', signals: ['ns'] },
+			tieredDeps as unknown as DiscoverBrandDomainsDeps,
+		);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const perf = summary?.metadata?.discoveryPerformance as Record<string, unknown> | undefined;
+		expect(perf).toBeDefined();
+		expect(perf && 'tiers' in perf).toBe(false);
+		expect(tier0).not.toHaveBeenCalled();
+		expect(tier1).not.toHaveBeenCalled();
+		expect(tier2).not.toHaveBeenCalled();
+	});
+
+	it('default discovery_mode is "classic" (BSL boundary — never flip the public default)', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const tier0 = vi.fn();
+		const tieredDeps = { ...makeDeps(), tier0Lookup: tier0, tier1Lookup: vi.fn(), tier2Lookup: vi.fn() };
+		await discoverBrandDomains(
+			'example.com',
+			{ signals: ['ns'] },
+			tieredDeps as unknown as DiscoverBrandDomainsDeps,
+		);
+		expect(tier0).not.toHaveBeenCalled();
+	});
+
+	it('applies opt-out filter to all surfaced tier 0/1/2 candidates', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const { __resetOptoutCacheForTests } = await import('../src/lib/brand-optout-enforcement');
+		__resetOptoutCacheForTests();
+		const tieredDeps = {
+			...makeDeps(),
+			tier0Lookup: vi.fn().mockResolvedValue(tier0Ok('opted-out.example.net')),
+			tier1Lookup: vi.fn().mockResolvedValue(tier1Ok('opted-out.example.net', FRESH_FRESHNESS)),
+			tier2Lookup: vi.fn().mockResolvedValue(tier2Empty()),
+			fetchOptouts: vi.fn().mockResolvedValue(new Set(['opted-out.example.net'])),
+		};
+		const result = await discoverBrandDomains(
+			'example.com',
+			{ discovery_mode: 'tiered', signals: ['ns'], candidate_domains: [] },
+			tieredDeps as unknown as DiscoverBrandDomainsDeps,
+		);
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		const tiers = (summary?.metadata?.discoveryPerformance as { tiers?: Record<string, number> } | undefined)?.tiers;
+		expect(tiers?.optOutsFiltered).toBeGreaterThanOrEqual(1);
+		const surfaced = result.findings
+			.filter((f) => f.metadata?.candidate)
+			.map((f) => f.metadata?.candidate as string);
+		expect(surfaced).not.toContain('opted-out.example.net');
+	});
+});


### PR DESCRIPTION
## Summary

Wires Tier 0/1/2 brand-discovery lookups into `discoverBrandDomains` behind a new `discovery_mode` flag. Default `'classic'` preserves byte-identical legacy behavior — the BSL boundary that keeps self-hosted clones runnable against the public source. `'tiered'` activates the Tier 0/1/2 phases that depend on private BlackVeil service bindings.

- **`discovery_mode: 'classic' | 'tiered'`**, default `'classic'`. Strict invariance: classic mode skips the entire tiered block, runs the legacy signal sweep byte-identically, and omits `discoveryPerformance.tiers` from the summary metadata.
- **Tier 0/1/2 phases** run in parallel via `Promise.allSettled` and never throw — every error path collapses to a `degraded` status entry.
- **Consumer-side opt-out filter** (`applyOptoutFilter`) applied to ALL surfaced Tier 0/1/2 candidates as the 3rd defensive layer.
- **Tier 3 (legacy sweep) is conditional**:
  - `tier1Freshness.overallStaleness === 'very_stale'`, OR
  - Tier 1 returned no candidates AND freshness is not `'fresh'`, OR
  - `caller_candidates` present and not covered by Tier 0/1/2.
- **`discoveryPerformance.tiers`** emits `tier0Count`, `tier1Count`, `tier2Count`, `tier3Count`, `tier4Count`, `tier0Status`, `tier1Status`, `tier2Status`, `tier3FallbackTriggered`, `tier1Freshness`, `optOutsFiltered`.
- **No-silent-drops audit test** verifies every drop site references a reason from the closed `DiscoveryDropReason` enum (`cap | seedOrSubdomain | infrastructureProvider | corroborationGate | belowConfidence | optOutRedacted`).
- **Pipeline threading**: `runBrandAuditPipeline` accepts `discovery_mode` and forwards to discovery; tier counts ride along on the existing discovery-step CheckResult payload (already persisted by stepStore).

## Files changed

- `src/schemas/tool-args.ts` — `discovery_mode` enum on `DiscoverBrandDomainsArgs`
- `src/tools/discover-brand-domains.ts` — Tier 0/1/2 orchestration + opt-out filter + Tier 3 gate + `DISCOVERY_DROP_REASONS` export
- `src/lib/brand-audit-pipeline.ts` — `discovery_mode` option threaded through
- `test/discover-brand-domains.spec.ts` — 7 tiered-mode integration tests
- `test/audits/brand-discovery-drop-reasons.audit.test.ts` — closed-enum drop-reasons audit (new)

## Wrapper integration (deps-injection seam)

`DiscoverBrandDomainsDeps` gains:

- `tier0Lookup?: (domain) => Promise<Tier0Result>`
- `tier1Lookup?: (domain) => Promise<Tier1Result>`
- `tier2Lookup?: (domain) => Promise<Tier2Result>`
- `fetchOptouts?: OptoutFetcher`

This matches the existing `correlateSans`-style seam — tests mock the function directly; production callers will close over the `Fetcher` bindings (`BV_ENTERPRISE`, `BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`) and call the existing wrappers in `src/lib/brand-tier{0,1,2}-*.ts`. No raw bindings on the deps interface keeps unit-testability cheap.

## BSL boundary

Public `wrangler.jsonc` remains binding-free — the audit in `test/audits/wrangler-public-no-private-bindings.audit.test.ts` still passes. No public-config changes in this PR.

## Test plan

- [x] 7 new tiered-mode tests pass (tier counts emitted; freshness-driven Tier 3 gating; caller-uncovered triggers Tier 3; classic mode omits `tiers`; default is `'classic'`; opt-out filter redacts)
- [x] All 35 tests in `test/discover-brand-domains.spec.ts` pass
- [x] Drop-reasons audit passes (2 tests)
- [x] `npm run lint` clean
- [x] `npm run typecheck` clean (only pre-existing wasm-pathing errors in `src/index.ts` unaffected by this PR)
- [x] 257 tests pass across schemas/handlers/tool-metadata/tool-schemas
- [x] Wrangler public-no-private-bindings audit still passes
- [ ] Verify `build-and-test`, `Secret & PII scan`, `Dependency audit`, `File hygiene check` (required CI gates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)