### PR TITLE
feat(brand-discovery): T6 tier-bypass on clearsOwnershipGate

### DIFF
--- a/src/lib/brand-evidence.ts
+++ b/src/lib/brand-evidence.ts
@@ -101,6 +101,13 @@ function isSeedObservation(observation: BrandEvidenceObservation): boolean {
 	return observation.signal === 'markov_gen' || observation.signal === 'active_lookalike';
 }
 
+/**
+ * Tier-1 observations only bypass the N-of-M gate when their signal-graph
+ * specificity meets this threshold. Below it (e.g. shared gmail MX), the
+ * observation falls through to the legacy corroboration logic.
+ */
+const TIER_1_SPECIFICITY_THRESHOLD = 0.5;
+
 export function clearsOwnershipGate(
 	observations: BrandEvidenceObservation[],
 	options: OwnershipGateOptions = {},
@@ -111,6 +118,18 @@ export function clearsOwnershipGate(
 	}
 	const distinct = Array.from(unique.values());
 	if (distinct.length === 0) return false;
+
+	// Tier-aware bypass (T6): Tier 0/1/2 observations carry enough source-side
+	// confidence to short-circuit the N-of-M corroboration gate. Tier 3 (the
+	// legacy live-signal sweep) falls through to the historic logic below.
+	for (const observation of distinct) {
+		const { tier, specificityScore } = observation;
+		if (tier === 0) return true;
+		if (tier === 2) return true;
+		if (tier === 1 && typeof specificityScore === 'number' && specificityScore >= TIER_1_SPECIFICITY_THRESHOLD) {
+			return true;
+		}
+	}
 
 	if (options.callerAsserted === true) {
 		return distinct.some((observation) => !isSeedObservation(observation));

--- a/test/brand-evidence.test.ts
+++ b/test/brand-evidence.test.ts
@@ -95,4 +95,84 @@ describe('brand evidence tier policy', () => {
 		expect(clearsOwnershipGate([{ signal: 'active_lookalike' }], { callerAsserted: false })).toBe(false);
 		expect(clearsOwnershipGate([{ signal: 'markov_gen' }], { callerAsserted: false })).toBe(false);
 	});
+
+	// T6: tier-aware bypass of N-of-M corroboration. Tier 0/1/2 carry enough
+	// source-side confidence to short-circuit the gate; Tier 3 stays on the
+	// legacy live-signal sweep path.
+	describe('tier-aware ownership gate (T6)', () => {
+		it('returns true for a single tier-0 observation', () => {
+			// Tier 0 = tenant-declared (gold standard). A weak signal name should
+			// not matter — provenance dominates.
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'mx_platform', confidence: 1.0, tier: 0, metadata: { sharedMxPlatform: 'm365' } }],
+					{ callerAsserted: false },
+				),
+			).toBe(true);
+		});
+
+		it('returns true for a tier-1 observation with specificityScore >= 0.5', () => {
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'mx_overlap', confidence: 0.7, tier: 1, specificityScore: 0.7 }],
+					{ callerAsserted: false },
+				),
+			).toBe(true);
+		});
+
+		it('does NOT auto-clear for tier-1 with specificityScore < 0.5', () => {
+			// e.g. shared gmail MX, low signal-graph specificity.
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'mx_platform', confidence: 0.1, tier: 1, specificityScore: 0.1, metadata: { sharedMxPlatform: 'gmail' } }],
+					{ callerAsserted: false },
+				),
+			).toBe(false);
+		});
+
+		it('does NOT auto-clear for tier-1 with missing specificityScore', () => {
+			// Tier 1 requires the specificity threshold to be met explicitly.
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'mx_platform', confidence: 0.4, tier: 1, metadata: { sharedMxPlatform: 'gmail' } }],
+					{ callerAsserted: false },
+				),
+			).toBe(false);
+		});
+
+		it('returns true for a single tier-2 observation', () => {
+			// Tier 2 = declared/witnessed (e.g. RDAP registrant match). Specificity
+			// is not required.
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'ns', confidence: 0.95, tier: 2 }],
+					{ callerAsserted: false },
+				),
+			).toBe(true);
+		});
+
+		it('legacy N-of-M gate still applies when observations carry no tier (Tier 3 fallback)', () => {
+			// Two medium non-seed signals without tier metadata should still clear
+			// via the existing rule.
+			expect(
+				clearsOwnershipGate(
+					[
+						{ signal: 'ns' },
+						{ signal: 'mx_overlap' },
+					],
+					{ callerAsserted: false },
+				),
+			).toBe(true);
+		});
+
+		it('legacy N-of-M gate still rejects under-corroborated tierless observations', () => {
+			// A single medium tierless signal should still fail the gate.
+			expect(
+				clearsOwnershipGate(
+					[{ signal: 'ns' }],
+					{ callerAsserted: false },
+				),
+			).toBe(false);
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Implements **Task 6** of the brand-discovery first-principles plan
(`docs/superpowers/plans/2026-05-20-brand-discovery-first-principles-tdd.md`,
lines 414-460).

`clearsOwnershipGate()` now honors observation tier metadata before falling
back to the legacy N-of-M corroboration logic:

- `tier === 0` -> auto-clears (tenant-declared, gold-standard provenance)
- `tier === 1` + `specificityScore >= 0.5` -> auto-clears
- `tier === 2` -> auto-clears (declared/witnessed evidence, e.g. RDAP match)
- otherwise -> falls through to the existing logic (Tier 3 fallback path unchanged)

Builds on #145 (T8), which added `tier` and `specificityScore` fields to
`BrandEvidenceObservation`.

## Files

- `src/lib/brand-evidence.ts` — tier-bypass loop added at top of `clearsOwnershipGate`; new `TIER_1_SPECIFICITY_THRESHOLD = 0.5` constant
- `test/brand-evidence.test.ts` — new `tier-aware ownership gate (T6)` describe block (7 tests)

## Test plan

- [x] Failing tests authored first (RED — 3 failures: tier-0, tier-1 >= 0.5, tier-2)
- [x] `npx vitest run test/brand-evidence.test.ts` — 16/16 pass
- [x] No regressions in dependent suites: `discover-brand-domains.spec.ts`, `discover-brand-domains-corroboration.test.ts`, `audits/brand-discovery-tier-mutual-exclusion.audit.test.ts`, `src/lib/brand-classification.test.ts` (61 + 60 pass)
- [x] `npx tsc --noEmit` clean
- [x] Tier 3 fallback path verified unchanged (tierless observations still go through legacy N-of-M)