### PR TITLE
feat(brand-discovery): T11 n=14 benchmark replay script

### DIFF
--- a/scripts/brand-discovery-tier-replay.mjs
+++ b/scripts/brand-discovery-tier-replay.mjs
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * T11 — n=14 brand-discovery tier replay validator.
+ *
+ * For every domain (CLI args, or the documented 14-brand default cohort) we
+ * invoke the generate-report pipeline twice — once in `tiered` discovery_mode
+ * and once in `baseline` (classic) discovery_mode — and copy the resulting
+ * report JSON into `.reports/brand-discovery-tier-replay/`.
+ *
+ * Filenames are deterministic per (brand, mode), so re-running overwrites
+ * cleanly:
+ *
+ *     .reports/brand-discovery-tier-replay/<brand>-tiered.json
+ *     .reports/brand-discovery-tier-replay/<brand>-baseline.json
+ *
+ * Manual validation against the predicted lifts (Google/Nike/PayPal/Apple
+ * improve; Microsoft ≥ 40 surfaces; no regressions on ownedPortfolioTotal)
+ * happens in T13 — this script is the operator-run replay producer.
+ *
+ * Mirrors scripts/brand-audit-planner-benchmark.mjs in convention.
+ */
+
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+/**
+ * The n=14 production-brand cohort from the design doc. Order matches the doc
+ * so audit-test failures point clearly at any drift.
+ */
+const DEFAULT_BRANDS = Object.freeze([
+	'google.com',
+	'microsoft.com',
+	'apple.com',
+	'amazon.com',
+	'github.com',
+	'paypal.com',
+	'nike.com',
+	'disney.com',
+	'mastercard.com',
+	'marriott.com',
+	'walmart.com',
+	'blackveilsecurity.com',
+	'bankofamerica.com',
+	'stripe.com',
+]);
+
+/** discovery_mode values, paired per brand. `baseline` → classic downstream. */
+const modes = ['tiered', 'baseline'];
+
+const argvDomains = process.argv.slice(2).map((d) => d.trim().toLowerCase()).filter(Boolean);
+const domains = argvDomains.length > 0 ? argvDomains : [...DEFAULT_BRANDS];
+
+const outDir = '.reports/brand-discovery-tier-replay';
+mkdirSync(outDir, { recursive: true });
+
+const generatedAt = new Date().toISOString();
+const indexPath = `${outDir}/index.json`;
+const rows = [];
+
+function safeFileStem(value) {
+	return value.toLowerCase().replace(/[^a-z0-9.-]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+function readJson(path) {
+	return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function extractSidecarMetrics(sidecar) {
+	if (!sidecar || typeof sidecar !== 'object') return null;
+	const depth = sidecar.depth ?? null;
+	return {
+		target: typeof sidecar.target === 'string' ? sidecar.target : null,
+		generatedAt: typeof sidecar.generatedAt === 'string' ? sidecar.generatedAt : null,
+		counts: sidecar.counts ?? null,
+		ownedPortfolioTotal: sidecar.counts?.ownedPortfolioTotal ?? null,
+		consolidated: sidecar.counts?.consolidated ?? null,
+		shadowIt: sidecar.counts?.shadowIt ?? null,
+		impersonation: sidecar.counts?.impersonation ?? null,
+		tierMetadata: sidecar.tierMetadata ?? null,
+		discoveryMode: sidecar.discoveryMode ?? null,
+		warnings: Array.isArray(depth?.warnings) ? depth.warnings : [],
+	};
+}
+
+function writeIndexSnapshot() {
+	writeFileSync(
+		indexPath,
+		JSON.stringify(
+			{
+				generatedAt,
+				updatedAt: new Date().toISOString(),
+				domains,
+				modes,
+				rows,
+			},
+			null,
+			2,
+		),
+	);
+}
+
+writeIndexSnapshot();
+
+for (const domain of domains) {
+	for (const mode of modes) {
+		const stem = safeFileStem(domain);
+		const rowRunId = `tier-replay-${stem}-${mode}`;
+		const startedAt = Date.now();
+		console.log(`[tier-replay] start domain=${domain} mode=${mode}`);
+
+		// `baseline` collapses to classic downstream — the pipeline accepts
+		// 'classic' | 'tiered' (src/schemas/tool-args.ts). Aliased here so the
+		// CLI argv / output filenames read in benchmark terms.
+		const discoveryMode = mode === 'baseline' ? 'classic' : 'tiered';
+
+		const child = spawnSync('npm', ['run', 'generate-report', '--', domain], {
+			env: {
+				...process.env,
+				BV_REPORT_DISCOVERY_MODE: discoveryMode,
+				BV_REPORT_RUN_ID: rowRunId,
+			},
+			encoding: 'utf8',
+			maxBuffer: 10 * 1024 * 1024,
+		});
+
+		const finalJsonPath = `reports/${domain}-discovery-report.json`;
+		const finalPdfPath = `reports/${domain}-discovery-report.pdf`;
+		// Deterministic per-(brand, mode) artifact names — idempotent.
+		const artifactJsonPath = `${outDir}/${stem}-${mode}.json`;
+		const artifactPdfPath = `${outDir}/${stem}-${mode}.pdf`;
+
+		let metrics = null;
+		if (child.status === 0 && existsSync(finalJsonPath)) {
+			copyFileSync(finalJsonPath, artifactJsonPath);
+			try {
+				metrics = extractSidecarMetrics(readJson(artifactJsonPath));
+			} catch (error) {
+				metrics = { error: error instanceof Error ? error.message : String(error) };
+			}
+		}
+		if (child.status === 0 && existsSync(finalPdfPath)) {
+			copyFileSync(finalPdfPath, artifactPdfPath);
+		}
+
+		const row = {
+			domain,
+			mode,
+			discoveryMode,
+			exitCode: child.status,
+			elapsedMs: Date.now() - startedAt,
+			artifactJsonPath: existsSync(artifactJsonPath) ? artifactJsonPath : null,
+			artifactPdfPath: existsSync(artifactPdfPath) ? artifactPdfPath : null,
+			metrics,
+			stdoutTail: (child.stdout ?? '').slice(-2000),
+			stderrTail: (child.stderr ?? '').slice(-2000),
+		};
+		rows.push(row);
+		writeIndexSnapshot();
+		console.log(
+			`[tier-replay] done domain=${domain} mode=${mode} exit=${row.exitCode} elapsedMs=${row.elapsedMs} artifact=${artifactJsonPath}`,
+		);
+	}
+}
+
+console.log('');
+console.log(`Wrote ${rows.length} row(s) across ${domains.length} domain(s) to ${indexPath}`);

--- a/test/audits/brand-discovery-tier-replay-script.audit.test.ts
+++ b/test/audits/brand-discovery-tier-replay-script.audit.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import source from '../../scripts/brand-discovery-tier-replay.mjs?raw';
+
+/**
+ * T11 — n=14 benchmark replay script safety audit.
+ *
+ * Pins:
+ *   - Output dir is .reports/brand-discovery-tier-replay/ (gitignored).
+ *   - Domain list parsed from argv with a default of the 14 documented brands.
+ *   - Both `tiered` and `baseline` modes are explicitly invoked per brand.
+ *   - Output filenames are deterministic (no timestamp in filename) → idempotent
+ *     re-runs overwrite cleanly.
+ */
+describe('brand-discovery tier replay script safety', () => {
+	it('writes replay output only under .reports/brand-discovery-tier-replay/', () => {
+		expect(source).toContain('.reports/brand-discovery-tier-replay');
+		// No other top-level write paths.
+		expect(source).not.toMatch(/writeFileSync\(\s*['"](?!\.reports\/)/);
+	});
+
+	it('reads the domain list from argv', () => {
+		expect(source).toContain('process.argv.slice(2)');
+	});
+
+	it('defaults to the 14 documented production brands when argv is empty', () => {
+		// The 14-brand cohort documented in the design doc (Task 11 / line 723).
+		const expectedDefaults = [
+			'google.com',
+			'microsoft.com',
+			'apple.com',
+			'amazon.com',
+			'github.com',
+			'paypal.com',
+			'nike.com',
+			'disney.com',
+			'mastercard.com',
+			'marriott.com',
+			'walmart.com',
+			'blackveilsecurity.com',
+			'bankofamerica.com',
+			'stripe.com',
+		];
+		for (const brand of expectedDefaults) {
+			expect(source).toContain(brand);
+		}
+	});
+
+	it('explicitly invokes both tiered and baseline modes per brand', () => {
+		expect(source).toContain("'tiered'");
+		expect(source).toContain("'baseline'");
+		// Threaded as the discovery_mode env var (classic = baseline downstream).
+		expect(source).toContain('BV_REPORT_DISCOVERY_MODE');
+	});
+
+	it('uses deterministic per-brand filenames so re-runs overwrite cleanly', () => {
+		// No Date.now()-based filenames (would defeat idempotency).
+		expect(source).not.toMatch(/\$\{[^}]*Date\.now\(\)[^}]*\}\.json/);
+		// File stem references the brand domain.
+		expect(source).toMatch(/\$\{[^}]*(domain|brand|stem)[^}]*\}[^`'"]*\.json/i);
+	});
+
+	it('safely renames brand domains before using them in file paths', () => {
+		// Path-traversal / shell-metachar guard — same hygiene as the planner benchmark.
+		expect(source).toMatch(/replace\(\s*\/\[\^a-z0-9\.-\]/i);
+	});
+});


### PR DESCRIPTION
## Summary

Adds the operator-run replay script for the n=14 brand-discovery benchmark per Task 11 of the brand-discovery TDD plan. The script invokes the existing `generate-report` pipeline twice per brand (once in `tiered` discovery_mode and once in `baseline`/classic) and writes paired JSON artifacts to ignored `.reports/brand-discovery-tier-replay/`.

- New script: `scripts/brand-discovery-tier-replay.mjs` — mirrors `scripts/brand-audit-planner-benchmark.mjs` convention. Domain list parsed from argv with a default of the 14 documented production brands (google, microsoft, apple, amazon, github, paypal, nike, disney, mastercard, marriott, walmart, blackveilsecurity, bankofamerica, stripe).
- New audit test: `test/audits/brand-discovery-tier-replay-script.audit.test.ts` — pins the output directory, argv parsing, mode list (`tiered` + `baseline`), the 14-brand default cohort, deterministic per-(brand, mode) filenames, and path-stem hygiene.

Output filenames are deterministic (`<brand>-tiered.json`, `<brand>-baseline.json`) — no `Date.now()` in the path — so re-runs overwrite cleanly.

`.reports/` is already gitignored (`.gitignore:104`), so the script never produces committable artifacts.

The replay execution + lift validation gate (`ownedPortfolioTotal` >= observe-mode `consolidated + shadowIt`; Google/Nike/PayPal/Apple strict improvement; Microsoft >= 40 surfaces lift) runs in T13's manual production-smoke step — this PR only ships the script and its safety audit.

## Test plan

- [x] `npx vitest run test/audits/brand-discovery-tier-replay-script.audit.test.ts` — 6/6 passing
- [x] `npx vitest run test/audits/brand-audit-planner-benchmark-script.audit.test.ts test/audits/brand-discovery-drop-reasons.audit.test.ts test/audits/brand-discovery-tier-mutual-exclusion.audit.test.ts` — sibling audits still green
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] `git check-ignore .reports/brand-discovery-tier-replay/test.json` — confirms `.reports/` is gitignored
- [ ] Operator: run `node scripts/brand-discovery-tier-replay.mjs` against the 14 production brands (deferred to T13 manual validation per the plan)

Plan reference: `docs/superpowers/plans/2026-05-20-brand-discovery-first-principles-tdd.md` Task 11 (lines 721-737).

Generated with [Claude Code](https://claude.com/claude-code)