### PR TITLE
feat(brand-discovery): T13 promote tiered to default (BlackVeil prod, private overlay)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- **Brand discovery (BlackVeil production only)**: BlackVeil's hosted runtime at `dns-mcp.blackveilsecurity.com` now defaults `discover_brand_domains` / `brand_audit_*` to `discovery_mode: 'tiered'` when the caller omits the argument. The flip is gated entirely on the env var `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT="tiered"` set in BlackVeil's private deploy overlay (`.dev/wrangler.deploy.jsonc`); the public Zod schema default in `src/schemas/tool-args.ts` stays `'classic'` permanently. **BSL boundary**: anyone building this repo from `main` continues to get classic mode out of the box and does not need the proprietary cross-Worker bindings (`BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`, `BV_ENTERPRISE`) that tiered mode relies on. An explicit caller-supplied `discovery_mode` always wins over the env default.
+
+### Added
+- `BrandAuditPipelineOptions.env` — narrow runtime-env shim read by `runBrandAuditPipeline` so the BlackVeil-production env var can flip the default without breaking the schema contract for self-hosters.
+- `ToolRuntimeOptions.discoveryModeDefault` and `BrandAuditConsumerDeps.discoveryModeDefault` — runtime-only plumbing from the queue/HTTP dispatch sites in `src/index.ts` through `src/mcp/{execute,dispatch}.ts`, `src/handlers/tools.ts`, and `src/queue/brand-audit-consumer.ts` into the pipeline.
+- README section "Brand-discovery modes" describing the `classic` (BSL self-host default) vs `tiered` (operator-deploy only) split and the deployment story.
+- CLAUDE.md operator-deploy-only binding rows for `BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`, `BV_ENTERPRISE`, and the `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT` env var.
+
+### Tests
+- 5 new vitest cases in `test/brand-audit-pipeline.test.ts` pinning the env-override semantics: (1) tiered when env says tiered + caller omits; (2) caller wins over env; (3) unset env → undefined (BSL default path); (4) any env value other than the literal `"tiered"` is ignored; (5) env-defaulted tiered runs stamp `discoveryMode: 'tiered'` on the summary finding identically to explicit-tiered runs.
+
 ## [2.21.4] - 2026-05-17
 
 ### Security

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -299,6 +299,10 @@ ignored env only; never commit it or paste it into workflow logs.
 | `BV_DOH_ENDPOINT` / `BV_DOH_TOKEN` | var / Secret | Custom secondary DoH (`X-BV-Token`) |
 | `BV_CERTSTREAM` | Service | CT logs: `/enumerate` (discover_subdomains, scan) + `/sans` (brand SAN siblings). Direct-crt.sh fallback w/ jittered backoff |
 | `BV_WHOIS` | Service | WHOIS/43 shim; optional, RDAP-only fallback. KV-cached IANA referrals |
+| `BV_INFRA_GRAPH` | Service | **Operator-deploy only.** Tier-1 infrastructure-graph lookup for `discovery_mode='tiered'`. Not packaged with the public distribution — wired via `.dev/wrangler.deploy.jsonc`. Absent → tiered pipeline falls back to classic sweep |
+| `BV_INTEL_GATEWAY` | Service | **Operator-deploy only.** Tier-2 declared-evidence lookups for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc` |
+| `BV_ENTERPRISE` | Service | **Operator-deploy only.** Tier-0 portfolio + enterprise tenant data for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc` |
+| `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT` | var | **Operator-deploy only.** When set to `"tiered"` (the BlackVeil-production default), flips the runtime default for callers that omit `discovery_mode`. Unset on BSL self-hosts → public schema default `'classic'` wins. Set only in `.dev/wrangler.deploy.jsonc` |
 | `SCORING_CONFIG` | var | JSON scoring overrides |
 | `CF_ACCOUNT_ID` / `CF_ANALYTICS_TOKEN` | var / Secret | Alerting query auth |
 | `ALERT_WEBHOOK_URL` / `ALERT_*_THRESHOLD` / `ALERT_LOOKBACK_MINUTES` | var | Cron alerts |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,15 @@ Run the chaos tests locally: `python3 scripts/chaos/chaos-test-clients.py`
 - **Adaptive Scoring**: Durable Object telemetry adjusts weights based on real-world distributions
 - **Client Awareness**: Automatic response formatting (`compact` vs `full`) based on client `User-Agent`
 
+### Brand-discovery modes (`discover_brand_domains` / `brand_audit_*`)
+
+The `discovery_mode` argument accepts two values:
+
+- **`classic`** (the default everywhere this repo runs out-of-the-box) — the public, BSL-licensed signal-sweep pipeline. Uses only public-internet data sources (DNS, RDAP, CT logs, MX/TXT inspection). This is the only mode supported for self-hosted deployments and the only mode the open test suite covers end-to-end.
+- **`tiered`** — layers a portfolio-aware Tier 0 / infrastructure-graph Tier 1 / declared-evidence Tier 2 pipeline in front of the classic sweep. Tiered mode requires private BlackVeil-internal cross-Worker bindings (`BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`, `BV_ENTERPRISE`) that are **not packaged with the open distribution** — they live in BlackVeil's production deploy overlay (`.dev/wrangler.deploy.jsonc`) and call into proprietary Workers. Self-hosters cannot enable tiered mode without those bindings.
+
+BlackVeil's hosted production at `dns-mcp.blackveilsecurity.com` flips its runtime default to `tiered` via the env var `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT="tiered"` in the private overlay; the public schema default in `src/schemas/tool-args.ts` stays `'classic'` permanently so anyone building from `main` gets the BSL-licensed behaviour unchanged. An explicit caller-supplied `discovery_mode` always wins over the env default.
+
 ---
 
 ## Client setup

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -113,6 +113,15 @@ interface ToolRuntimeOptions {
 	brandReportsR2?: R2Bucket;
 	/** Service binding to bv-browser-renderer Worker. v2.20.0+; used by brand_audit_pdf_consumer at queue time, not by request-path tools. */
 	browserRenderer?: { fetch: typeof fetch };
+	/**
+	 * T13 — runtime-default for `discover_brand_domains` discovery_mode.
+	 * Sourced from `env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT` at the index.ts
+	 * construction sites. Threaded into `brandAuditSingle`'s pipeline
+	 * `options.env`. `'tiered'` flips the default; any other value (including
+	 * undefined) leaves the public schema default (`'classic'`) in charge.
+	 * BSL self-hosters never set this — they get classic mode out of the box.
+	 */
+	discoveryModeDefault?: string;
 }
 
 /** Build QueryDnsOptions for individual check calls from runtime options. */
@@ -245,8 +254,13 @@ const TOOL_REGISTRY: Record<
 				min_confidence: args.min_confidence as number | undefined,
 				depth: args.depth as 'standard' | 'deep' | undefined,
 				planner_mode: args.planner_mode as 'off' | 'observe' | 'enforce' | undefined,
+				discovery_mode: args.discovery_mode as 'classic' | 'tiered' | undefined,
 				brand_aliases: args.brand_aliases as string[] | undefined,
 				candidate_domains: args.candidate_domains as string[] | undefined,
+				// T13 — propagate the BlackVeil-production runtime override.
+				// Pipeline only honours it when the caller omits `discovery_mode`;
+				// undefined on BSL self-hosts (schema default `'classic'` wins).
+				...(ro?.discoveryModeDefault ? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: ro.discoveryModeDefault } } : {}),
 			}, {
 				certstream: ro?.certstream,
 				whoisBinding: ro?.whoisBinding,

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,6 +104,17 @@ type BvMcpEnv = {
 	BV_BROWSER_RENDERER?: Fetcher;
 	/** ADMIN_API_KEY for bv-browser-renderer's /pdf/html endpoint. Bearer-authed. */
 	BV_BROWSER_RENDERER_KEY?: string;
+	/**
+	 * T13 — BlackVeil-production runtime override. When set to "tiered",
+	 * `discover_brand_domains` defaults to tiered mode for callers that omit
+	 * `discovery_mode`. Unset on BSL self-hosts; the public schema default
+	 * (`'classic'`) wins. Wired through `ToolRuntimeOptions.discoveryModeDefault`
+	 * (HTTP `/mcp` request path) and `BrandAuditConsumerDeps.discoveryModeDefault`
+	 * (Cloudflare Queue consumer path) into `runBrandAuditPipeline`'s
+	 * `options.env`. Set only in `.dev/wrangler.deploy.jsonc`; never in the
+	 * public `wrangler.jsonc`.
+	 */
+	BRAND_AUDIT_DISCOVERY_MODE_DEFAULT?: string;
 };
 
 import type { TierAuthResult } from './lib/tier-auth';
@@ -415,6 +426,7 @@ app.post('/mcp', async (c) => {
 					brandAuditQueue: c.env.BRAND_AUDIT_QUEUE,
 					brandReportsR2: c.env.BRAND_REPORTS,
 					browserRenderer: c.env.BV_BROWSER_RENDERER,
+					discoveryModeDefault: c.env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT,
 					principalId: keyHash ?? ipHash,
 					country,
 					clientType,
@@ -484,6 +496,7 @@ app.post('/mcp', async (c) => {
 		brandAuditQueue: c.env.BRAND_AUDIT_QUEUE,
 		brandReportsR2: c.env.BRAND_REPORTS,
 		browserRenderer: c.env.BV_BROWSER_RENDERER,
+		discoveryModeDefault: c.env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT,
 		principalId: keyHash ?? ipHash,
 		country,
 		clientType,
@@ -630,6 +643,7 @@ app.post('/mcp/messages', async (c) => {
 				brandAuditQueue: c.env.BRAND_AUDIT_QUEUE,
 				brandReportsR2: c.env.BRAND_REPORTS,
 				browserRenderer: c.env.BV_BROWSER_RENDERER,
+				discoveryModeDefault: c.env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT,
 				principalId: keyHash ?? ipHash,
 				country,
 				clientType,
@@ -860,7 +874,14 @@ export default {
 			// the consumer enqueues a `retry_attempt: 1` message back onto itself
 			// when a completed audit has registrar lookup_failed candidates.
 			const brandAuditQueue = e.BRAND_AUDIT_QUEUE as BrandAuditConsumerDeps['brandAuditQueue'] | undefined;
-			const deps: BrandAuditConsumerDeps = { db, pdfQueue, brandAuditQueue };
+			// T13 — thread the BlackVeil-production discovery_mode override
+			// into the consumer so queued audits run in tiered mode by default
+			// when the operator sets `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT=tiered`
+			// in the private overlay. Undefined on BSL self-hosts.
+			const discoveryModeDefault = typeof e.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT === 'string'
+				? (e.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT as string)
+				: undefined;
+			const deps: BrandAuditConsumerDeps = { db, pdfQueue, brandAuditQueue, discoveryModeDefault };
 			await handleBrandAuditQueue(batch, deps);
 			return;
 		}

--- a/src/lib/brand-audit-pipeline.ts
+++ b/src/lib/brand-audit-pipeline.ts
@@ -74,6 +74,21 @@ export interface BrandAuditPipelineOptions {
 	 * default never flips).
 	 */
 	discovery_mode?: 'classic' | 'tiered';
+	/**
+	 * T13 — BlackVeil-production runtime environment overrides.
+	 *
+	 * `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT === 'tiered'` flips the *runtime
+	 * default* discovery mode to `'tiered'` when the caller omits
+	 * `discovery_mode`. Unset, missing, or any other value → the public schema
+	 * default (`'classic'`) wins, preserving the BSL boundary for self-hosted
+	 * deployments. The env var is only set in the private wrangler overlay
+	 * (`.dev/wrangler.deploy.jsonc`); the public `wrangler.jsonc` never carries
+	 * it. An explicit caller-supplied `discovery_mode` always wins regardless
+	 * of env.
+	 */
+	env?: {
+		BRAND_AUDIT_DISCOVERY_MODE_DEFAULT?: string;
+	};
 	/** Public brand aliases, product labels, or legal-entity labels to seed. */
 	brand_aliases?: string[];
 	/** Caller-supplied candidate domains to corroborate. */
@@ -501,6 +516,15 @@ export async function runBrandAuditPipeline(
 	// Phase 2b: retry messages set force_refresh so a transient lookup_failed
 	// from the first pass doesn't get served back from the cache.
 	const readCachedStep = options.force_refresh ? null : stepStore;
+	// T13 — resolve the effective discovery mode.
+	// Caller-supplied `discovery_mode` always wins. If the caller omits it,
+	// the BlackVeil-production runtime env (`BRAND_AUDIT_DISCOVERY_MODE_DEFAULT`)
+	// can flip the default to `'tiered'`. Any other env value (including
+	// `undefined`, `'classic'`, or junk) leaves it unset — `discoverBrandDomains`
+	// then falls back to the schema default `'classic'`. BSL self-hosters never
+	// set this var, so they get classic mode regardless.
+	const effectiveDiscoveryMode: 'classic' | 'tiered' | undefined =
+		options.discovery_mode ?? (options.env?.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT === 'tiered' ? 'tiered' : undefined);
 	const throwIfAborted = (): void => {
 		if (signal?.aborted) {
 			const reason = (signal as AbortSignal & { reason?: unknown }).reason;
@@ -554,7 +578,7 @@ export async function runBrandAuditPipeline(
 			min_confidence: options.min_confidence,
 			depth: options.depth,
 			planner_mode: options.planner_mode,
-			discovery_mode: options.discovery_mode,
+			discovery_mode: effectiveDiscoveryMode,
 			brand_aliases: options.brand_aliases,
 			candidate_domains: options.candidate_domains,
 			certstream: deps.certstream,
@@ -806,8 +830,12 @@ export async function runBrandAuditPipeline(
 			}),
 			// T9 — forward per-tier stats only when discovery_mode === 'tiered'
 			// (tierStats === undefined in classic mode — BSL invariance).
+			// T13 — env-defaulted tiered runs must stamp `discoveryMode: 'tiered'`
+			// identically to explicit-tiered runs so `brand-audit-markdown.ts`
+			// (and any other downstream reader keying on this field) treats the
+			// report the same way regardless of how the mode was selected.
 			...(tierStats ? { tiers: tierStats } : {}),
-			...(options.discovery_mode === 'tiered' ? { discoveryMode: 'tiered' as const } : {}),
+			...(effectiveDiscoveryMode === 'tiered' ? { discoveryMode: 'tiered' as const } : {}),
 		},
 	);
 

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -48,6 +48,8 @@ export interface DispatchMcpMethodOptions {
 	brandReportsR2?: R2Bucket;
 	browserRenderer?: { fetch: typeof fetch };
 	principalId?: string;
+	/** T13 — runtime-default for `discover_brand_domains` discovery_mode. */
+	discoveryModeDefault?: string;
 }
 
 export type DispatchMcpMethodResult =
@@ -162,6 +164,7 @@ export async function dispatchMcpMethod(options: DispatchMcpMethodOptions): Prom
 				brandAuditQueue: options.brandAuditQueue,
 				brandReportsR2: options.brandReportsR2,
 				browserRenderer: options.browserRenderer,
+				discoveryModeDefault: options.discoveryModeDefault,
 				principalId: options.principalId,
 				rateLimitKv: options.rateLimitKv,
 			});

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -83,6 +83,14 @@ export interface ExecuteMcpRequestOptions {
 	browserRenderer?: { fetch: typeof fetch };
 	/** principalId for the calling user — required by enforceBrandAuditQuota and IDOR-cache fix. v2.21.2+. */
 	principalId?: string;
+	/**
+	 * T13 — runtime-default for `discover_brand_domains` discovery_mode.
+	 * Sourced from `env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT`. `'tiered'` flips
+	 * the default; undefined leaves the public schema default (`'classic'`)
+	 * in charge. Threaded into `ToolRuntimeOptions.discoveryModeDefault`
+	 * which `brand_audit_single` reads.
+	 */
+	discoveryModeDefault?: string;
 }
 
 function getDomainFromParams(params: Record<string, unknown> | undefined): string | undefined {
@@ -557,6 +565,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			brandAuditQueue: options.brandAuditQueue,
 			brandReportsR2: options.brandReportsR2,
 			browserRenderer: options.browserRenderer,
+			discoveryModeDefault: options.discoveryModeDefault,
 			principalId: options.principalId,
 		}).then((dispatchResult) => {
 			if (dispatchResult.kind === 'early-error') {
@@ -633,6 +642,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			brandAuditQueue: options.brandAuditQueue,
 			brandReportsR2: options.brandReportsR2,
 			browserRenderer: options.browserRenderer,
+			discoveryModeDefault: options.discoveryModeDefault,
 			principalId: options.principalId,
 		});
 

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -108,6 +108,16 @@ export interface BrandAuditConsumerDeps {
 	 * Defaults to a `safeFetch`-wrapped POST in production.
 	 */
 	deliverWebhook?: (url: string, payload: unknown) => Promise<boolean>;
+	/**
+	 * T13 — runtime-default for `discover_brand_domains` discovery_mode.
+	 * Sourced from `env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT` at the queue
+	 * dispatch site in `src/index.ts`. Threaded into the pipeline's
+	 * `options.env`. `'tiered'` flips the default for queue-message audits
+	 * that omit `discovery_mode` (which is all of them, since the queue
+	 * message schema doesn't carry it); any other value (including
+	 * undefined) leaves the public schema default (`'classic'`) in charge.
+	 */
+	discoveryModeDefault?: string;
 }
 
 interface TargetStatusRow {
@@ -256,6 +266,12 @@ export async function processBrandAuditMessage(
 				// Phase 2b: retry messages re-run the pipeline from scratch instead
 				// of reading back the cached lookup_failed result from pass 1.
 				force_refresh: isRetry,
+				// T13 — propagate the BlackVeil-production runtime override.
+				// Pipeline only honours it when the caller omits `discovery_mode`;
+				// undefined on BSL self-hosts (schema default `'classic'` wins).
+				...(deps.discoveryModeDefault
+					? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: deps.discoveryModeDefault } }
+					: {}),
 			}),
 			new Promise<never>((_, reject) => {
 				const onAbort = () => {

--- a/test/brand-audit-pipeline.test.ts
+++ b/test/brand-audit-pipeline.test.ts
@@ -385,3 +385,95 @@ describe('runBrandAuditPipeline', () => {
 		expect(result).toBe(sentinel);
 	});
 });
+
+// ----------------------------------------------------------------------------
+// T13 — BlackVeil-production env-var override for discovery_mode default.
+//
+// The public schema default in `src/schemas/tool-args.ts` stays `'classic'`
+// permanently — BSL self-hosters get classic mode out of the box. BlackVeil's
+// production runtime flips its own default to `'tiered'` via the private
+// wrangler overlay (`.dev/wrangler.deploy.jsonc`) by setting
+// `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: "tiered"`. The pipeline reads that env
+// var via `options.env` and uses `'tiered'` as the *runtime default* — but
+// ONLY when the caller hasn't passed an explicit `discovery_mode`. An
+// explicit caller value always wins.
+//
+// This test pins the BSL boundary: the env-var override is opt-in,
+// caller-overridable, and a no-op unless the env var is exactly `'tiered'`.
+// ----------------------------------------------------------------------------
+describe('runBrandAuditPipeline — T13 BRAND_AUDIT_DISCOVERY_MODE_DEFAULT env override', () => {
+	it('uses tiered mode by default when env says tiered and caller omits discovery_mode', async () => {
+		const discoverBrandDomains = vi.fn().mockResolvedValue(discoveryResult('example.com', ['example.net']));
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'Example Inc.'));
+
+		await runBrandAuditPipeline(
+			'example.com',
+			{ env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: 'tiered' } },
+			{ discoverBrandDomains: discoverBrandDomains as never, checkRdapLookup },
+		);
+
+		expect(discoverBrandDomains).toHaveBeenCalledOnce();
+		const [, discoveryOpts] = discoverBrandDomains.mock.calls[0]!;
+		expect((discoveryOpts as { discovery_mode?: string }).discovery_mode).toBe('tiered');
+	});
+
+	it('explicit caller discovery_mode wins over env override', async () => {
+		const discoverBrandDomains = vi.fn().mockResolvedValue(discoveryResult('example.com', ['example.net']));
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'Example Inc.'));
+
+		await runBrandAuditPipeline(
+			'example.com',
+			{ discovery_mode: 'classic', env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: 'tiered' } },
+			{ discoverBrandDomains: discoverBrandDomains as never, checkRdapLookup },
+		);
+
+		const [, discoveryOpts] = discoverBrandDomains.mock.calls[0]!;
+		expect((discoveryOpts as { discovery_mode?: string }).discovery_mode).toBe('classic');
+	});
+
+	it('leaves discovery_mode undefined when env unset (BSL default path)', async () => {
+		const discoverBrandDomains = vi.fn().mockResolvedValue(discoveryResult('example.com', ['example.net']));
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'Example Inc.'));
+
+		await runBrandAuditPipeline(
+			'example.com',
+			{},
+			{ discoverBrandDomains: discoverBrandDomains as never, checkRdapLookup },
+		);
+
+		const [, discoveryOpts] = discoverBrandDomains.mock.calls[0]!;
+		expect((discoveryOpts as { discovery_mode?: string }).discovery_mode).toBeUndefined();
+	});
+
+	it('ignores env values other than the literal string "tiered"', async () => {
+		const discoverBrandDomains = vi.fn().mockResolvedValue(discoveryResult('example.com', ['example.net']));
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'Example Inc.'));
+
+		await runBrandAuditPipeline(
+			'example.com',
+			{ env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: 'classic' } },
+			{ discoverBrandDomains: discoverBrandDomains as never, checkRdapLookup },
+		);
+
+		const [, discoveryOpts] = discoverBrandDomains.mock.calls[0]!;
+		expect((discoveryOpts as { discovery_mode?: string }).discovery_mode).toBeUndefined();
+	});
+
+	it('stamps discoveryMode metadata when env-defaulted tiered run surfaces candidates', async () => {
+		// When env-default flips tiered, the summary finding must still carry
+		// `discoveryMode: 'tiered'` — `brand-audit-markdown.ts` reads this field
+		// to drive the v3 sections, and an env-defaulted run must not look any
+		// different from an explicitly-tiered run at the report layer.
+		const discoverBrandDomains = vi.fn().mockResolvedValue(discoveryResult('example.com', ['example.net']));
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'Example Inc.'));
+
+		const result = await runBrandAuditPipeline(
+			'example.com',
+			{ env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: 'tiered' } },
+			{ discoverBrandDomains: discoverBrandDomains as never, checkRdapLookup },
+		);
+
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.discoveryMode).toBe('tiered');
+	});
+});


### PR DESCRIPTION
## Summary

Final task in the brand-discovery tiered-pipeline series. Flips BlackVeil's production runtime default to \`'tiered'\` via the private wrangler overlay. **The public default in \`src/schemas/tool-args.ts\` STAYS \`'classic'\` permanently** — BSL self-hosters of bv-mcp from main get classic mode out of the box and don't need any cross-Worker bindings to run.

## Mechanism

- \`env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT='tiered'\` set via \`.dev/wrangler.deploy.jsonc\` private overlay (never the public \`wrangler.jsonc\`).
- \`brand-audit-pipeline\` reads this env var as the default when the caller omits \`discovery_mode\`. Unset → schema default \`'classic'\` wins.
- Env threaded through \`handlers/tools\`, \`mcp/dispatch\`, \`mcp/execute\`, \`queue/brand-audit-consumer\` so the override reaches both interactive tool calls and queued audit jobs.

## Docs

- README: tiered-mode prerequisite (BlackVeil-internal cross-Worker bindings).
- CLAUDE.md: \`BV_INFRA_GRAPH\` / \`BV_INTEL_GATEWAY\` / \`BV_ENTERPRISE\` in operator-only bindings section (same pattern as \`BV_CERTSTREAM\` / \`BV_WHOIS\`).
- CHANGELOG: BSL boundary + deployment story.

## Test plan

- [x] env override applies when set to \`'tiered'\` and caller omits \`discovery_mode\`
- [x] schema default \`'classic'\` wins when env unset
- [x] T1 audit test (\`wrangler-public-no-private-bindings\`) still passes — public file binding-free
- [x] Required CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)