### PR TITLE
feat(brand-discovery): wire tier 0/1/2 lookup closures to production bindings

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -122,6 +122,31 @@ interface ToolRuntimeOptions {
 	 * BSL self-hosters never set this — they get classic mode out of the box.
 	 */
 	discoveryModeDefault?: string;
+	/**
+	 * Tier 0 (tenant-declared portfolio) lookup closure — wraps the
+	 * `BV_ENTERPRISE` service binding. Constructed at the production seam in
+	 * `src/index.ts` when both the binding and `BV_WEB_INTERNAL_KEY` are
+	 * provisioned. Threaded through to `discoverBrandDomains` (direct + via
+	 * `brand_audit_single`'s pipeline). Undefined on BSL self-hosts → tiered
+	 * mode degrades to classic without ever calling bv-enterprise.
+	 */
+	tier0Lookup?: (domain: string) => Promise<import('../lib/brand-tier0-enterprise').Tier0Result>;
+	/**
+	 * Tier 1 (bv-infrastructure-graph) lookup closure — wraps the
+	 * `BV_INFRA_GRAPH` service binding. Constructed at the production seam in
+	 * `src/index.ts` when both the binding and `BV_WEB_INTERNAL_KEY` are
+	 * provisioned. Threaded through to `discoverBrandDomains` (direct + via
+	 * `brand_audit_single`'s pipeline). Undefined on BSL self-hosts.
+	 */
+	tier1Lookup?: (domain: string) => Promise<import('../lib/brand-tier1-graph').Tier1Result>;
+	/**
+	 * Tier 2 (bv-intel-gateway declared-evidence) lookup closure — wraps the
+	 * `BV_INTEL_GATEWAY` RPC service binding. Constructed at the production
+	 * seam in `src/index.ts` when the binding is provisioned. Threaded through
+	 * to `discoverBrandDomains` (direct + via `brand_audit_single`'s pipeline).
+	 * Undefined on BSL self-hosts.
+	 */
+	tier2Lookup?: (domain: string) => Promise<import('../lib/brand-tier2-evidence').Tier2Result>;
 }
 
 /** Build QueryDnsOptions for individual check calls from runtime options. */
@@ -217,36 +242,70 @@ const TOOL_REGISTRY: Record<
 			const minConf = typeof args.min_confidence === 'number' ? args.min_confidence : 0.5;
 			const depth = typeof args.depth === 'string' ? args.depth : 'standard';
 			const plannerMode = typeof args.planner_mode === 'string' ? args.planner_mode : 'observe';
+			// Discovery mode is part of the cache key. `classic` and `tiered`
+			// produce different candidate sets (tiered layers Tier 0/1/2 lookups
+			// in front of the legacy sweep), so a shared cache entry would let
+			// whichever invocation ran first silently win for the next TTL window
+			// — exactly the symptom T7 was trying to fix. Schema default is
+			// `'classic'`.
+			const discoveryMode = typeof args.discovery_mode === 'string' ? args.discovery_mode : 'classic';
 			const aliases = (args.brand_aliases as string[] | undefined) ?? [];
 			const candDomains = (args.candidate_domains as string[] | undefined) ?? [];
 			const aliasHash = aliases.length === 0 ? '0' : `${aliases.length}:${aliases.slice().sort().join('|').slice(0, 64)}`;
 			const candHash = candDomains.length === 0 ? '0' : `${candDomains.length}:${candDomains.slice().sort().join('|').slice(0, 64)}`;
-			return `discover_brand:${signals}:d${depth}:p${plannerMode}:a${aliasHash}:c${candHash}:m${minConf}`;
+			return `discover_brand:${signals}:d${depth}:p${plannerMode}:dm${discoveryMode}:a${aliasHash}:c${candHash}:m${minConf}`;
 		},
 		execute: (d, args, ro) =>
-			discoverBrandDomains(d, {
-				signals: args.signals as Parameters<typeof discoverBrandDomains>[1] extends infer O ? (O extends { signals?: infer S } ? S : undefined) : undefined,
-				depth: args.depth as 'standard' | 'deep' | undefined,
-				planner_mode: args.planner_mode as 'off' | 'observe' | 'enforce' | undefined,
-				brand_aliases: args.brand_aliases as string[] | undefined,
-				candidate_domains: args.candidate_domains as string[] | undefined,
-				dkim_selectors: args.dkim_selectors as string[] | undefined,
-				min_confidence: args.min_confidence as number | undefined,
-				certstream: ro?.certstream,
-			}),
+			discoverBrandDomains(
+				d,
+				{
+					signals: args.signals as Parameters<typeof discoverBrandDomains>[1] extends infer O ? (O extends { signals?: infer S } ? S : undefined) : undefined,
+					depth: args.depth as 'standard' | 'deep' | undefined,
+					planner_mode: args.planner_mode as 'off' | 'observe' | 'enforce' | undefined,
+					discovery_mode: args.discovery_mode as 'classic' | 'tiered' | undefined,
+					brand_aliases: args.brand_aliases as string[] | undefined,
+					candidate_domains: args.candidate_domains as string[] | undefined,
+					dkim_selectors: args.dkim_selectors as string[] | undefined,
+					min_confidence: args.min_confidence as number | undefined,
+					certstream: ro?.certstream,
+				},
+				// Tier closures forwarded only when present — BSL self-hosts that lack
+				// the bindings pass nothing (the discoverer then sees `undefined`
+				// closures and falls back to classic-mode behaviour).
+				//
+				// `DiscoverBrandDomainsDeps` declares its non-tier signal stubs as
+				// required; the runtime tolerates partials (it merges over its own
+				// `defaultDeps()`). Existing call sites cast — match that pattern.
+				{
+					...(ro?.tier0Lookup ? { tier0Lookup: ro.tier0Lookup } : {}),
+					...(ro?.tier1Lookup ? { tier1Lookup: ro.tier1Lookup } : {}),
+					...(ro?.tier2Lookup ? { tier2Lookup: ro.tier2Lookup } : {}),
+				} as Parameters<typeof discoverBrandDomains>[2],
+			),
 		cacheTtlSeconds: 3600,
 	},
 	brand_audit_single: {
-		cacheKey: (args) => {
+		cacheKey: (args, ro) => {
 			const minConf = typeof args.min_confidence === 'number' ? args.min_confidence : 0.5;
 			const fmt = typeof args.format === 'string' ? args.format : 'both';
 			const depth = typeof args.depth === 'string' ? args.depth : 'standard';
 			const plannerMode = typeof args.planner_mode === 'string' ? args.planner_mode : 'observe';
+			// Discovery mode is part of the cache key — see the discover_brand_domains
+			// cache-key comment above for the poisoning rationale. We hash on the
+			// *effective* mode the pipeline will run: explicit arg wins, otherwise
+			// the env-default (`BRAND_AUDIT_DISCOVERY_MODE_DEFAULT`) flips classic→tiered
+			// on BlackVeil production deploys. Schema default falls back to `classic`.
+			const discoveryMode =
+				typeof args.discovery_mode === 'string'
+					? args.discovery_mode
+					: ro?.discoveryModeDefault === 'tiered'
+						? 'tiered'
+						: 'classic';
 			const aliases = (args.brand_aliases as string[] | undefined) ?? [];
 			const candDomains = (args.candidate_domains as string[] | undefined) ?? [];
 			const aliasHash = aliases.length === 0 ? '0' : `${aliases.length}:${aliases.slice().sort().join('|').slice(0, 64)}`;
 			const candHash = candDomains.length === 0 ? '0' : `${candDomains.length}:${candDomains.slice().sort().join('|').slice(0, 64)}`;
-			return `brand_audit_single:${fmt}:d${depth}:p${plannerMode}:a${aliasHash}:c${candHash}:m${minConf}`;
+			return `brand_audit_single:${fmt}:d${depth}:p${plannerMode}:dm${discoveryMode}:a${aliasHash}:c${candHash}:m${minConf}`;
 		},
 		execute: (d, args, ro) =>
 			brandAuditSingle(d, {
@@ -265,6 +324,12 @@ const TOOL_REGISTRY: Record<
 				certstream: ro?.certstream,
 				whoisBinding: ro?.whoisBinding,
 				enforceQuota: buildMonthlyEnforceQuota(ro),
+				// Tier closures: forwarded through the pipeline → discoverBrandDomains
+				// seam. Undefined on BSL self-hosts → pipeline never calls the
+				// proprietary lookups.
+				...(ro?.tier0Lookup ? { tier0Lookup: ro.tier0Lookup } : {}),
+				...(ro?.tier1Lookup ? { tier1Lookup: ro.tier1Lookup } : {}),
+				...(ro?.tier2Lookup ? { tier2Lookup: ro.tier2Lookup } : {}),
 			}),
 		cacheTtlSeconds: 3600,
 	},

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,6 +115,27 @@ type BvMcpEnv = {
 	 * public `wrangler.jsonc`.
 	 */
 	BRAND_AUDIT_DISCOVERY_MODE_DEFAULT?: string;
+	/**
+	 * Brand-discovery cross-Worker service bindings. Declared ONLY in the
+	 * private overlay (`.dev/wrangler.deploy.jsonc`) — never in the public
+	 * `wrangler.jsonc`. Enforced by
+	 * `test/audits/wrangler-public-no-private-bindings.audit.test.ts`.
+	 *
+	 * BSL self-hosts have all three undefined; the tier-lookup closures are
+	 * never constructed and tiered-mode discovery degrades to classic.
+	 */
+	/** Tier 1 — bv-infrastructure-graph (HTTP service binding). */
+	BV_INFRA_GRAPH?: Fetcher;
+	/**
+	 * Tier 2 — bv-intel-gateway (Workers RPC binding to a `WorkerEntrypoint`).
+	 * Auth is enforced at the binding level; no Authorization header plumbed.
+	 * Matches the consumer-side type at `src/lib/brand-tier2-evidence.ts`.
+	 */
+	BV_INTEL_GATEWAY?: {
+		getDomainEvidence: (params: { domain: string; includeHistory?: boolean }) => Promise<unknown>;
+	};
+	/** Tier 0 — bv-enterprise (HTTP service binding to tenant-portfolio lookup). */
+	BV_ENTERPRISE?: Fetcher;
 };
 
 import type { TierAuthResult } from './lib/tier-auth';
@@ -122,6 +143,8 @@ import { resolveTier } from './lib/tier-auth';
 
 const app = new Hono<{ Bindings: BvMcpEnv; Variables: { isAuthenticated: boolean; tierAuthResult: TierAuthResult; apiKeyInQuery: boolean } }>();
 const mcpPaths = ['/mcp', '/mcp/messages', '/mcp/sse'] as const;
+
+import { buildBrandTierLookups } from './lib/brand-tier-lookups';
 
 type OAuthAvailability = 'ready' | 'disabled' | 'misconfigured';
 
@@ -427,6 +450,7 @@ app.post('/mcp', async (c) => {
 					brandReportsR2: c.env.BRAND_REPORTS,
 					browserRenderer: c.env.BV_BROWSER_RENDERER,
 					discoveryModeDefault: c.env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT,
+					...buildBrandTierLookups(c.env),
 					principalId: keyHash ?? ipHash,
 					country,
 					clientType,
@@ -497,6 +521,7 @@ app.post('/mcp', async (c) => {
 		brandReportsR2: c.env.BRAND_REPORTS,
 		browserRenderer: c.env.BV_BROWSER_RENDERER,
 		discoveryModeDefault: c.env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT,
+		...buildBrandTierLookups(c.env),
 		principalId: keyHash ?? ipHash,
 		country,
 		clientType,
@@ -644,6 +669,7 @@ app.post('/mcp/messages', async (c) => {
 				brandReportsR2: c.env.BRAND_REPORTS,
 				browserRenderer: c.env.BV_BROWSER_RENDERER,
 				discoveryModeDefault: c.env.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT,
+				...buildBrandTierLookups(c.env),
 				principalId: keyHash ?? ipHash,
 				country,
 				clientType,
@@ -881,7 +907,11 @@ export default {
 			const discoveryModeDefault = typeof e.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT === 'string'
 				? (e.BRAND_AUDIT_DISCOVERY_MODE_DEFAULT as string)
 				: undefined;
-			const deps: BrandAuditConsumerDeps = { db, pdfQueue, brandAuditQueue, discoveryModeDefault };
+			// Build tier-lookup closures from the queue Worker invocation's env.
+			// Cloudflare Workers re-bind env per invocation; the request-path
+			// closures constructed in `executeMcpRequest` never reach here.
+			const tierLookups = buildBrandTierLookups(e as BvMcpEnv);
+			const deps: BrandAuditConsumerDeps = { db, pdfQueue, brandAuditQueue, discoveryModeDefault, ...tierLookups };
 			await handleBrandAuditQueue(batch, deps);
 			return;
 		}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -36,6 +36,7 @@ import { handleToolsCall } from './handlers/tools';
 import { isAuthorizedRequest } from './lib/auth';
 import { createAnalyticsClient } from './lib/analytics';
 import { parseScoringConfigCached } from './lib/scoring-config';
+import { buildBrandTierLookups } from './lib/brand-tier-lookups';
 import { OAUTH_CODE_TTL_SECONDS, MAX_REQUEST_BODY_BYTES, parseCacheTtl } from './lib/config';
 import { validateDomain, sanitizeDomain } from './lib/sanitize';
 import { InternalToolCallSchema, BatchRequestSchema, CreateTrialKeyRequestSchema } from './schemas/internal';
@@ -76,6 +77,19 @@ type InternalEnv = {
 	BV_WEB_INTERNAL_KEY?: string;
 	/** Opt-in flag for the H1 defense-in-depth bearer gate on /tools/* and /analytics/*. */
 	REQUIRE_INTERNAL_AUTH?: string;
+	/**
+	 * Brand-discovery cross-Worker service bindings. Operator-deploy only —
+	 * declared in `.dev/wrangler.deploy.jsonc`, never in the public
+	 * `wrangler.jsonc`. Mirrors the `BvMcpEnv` declarations in `src/index.ts`
+	 * so internal callers (`/internal/tools/{call,batch}` — load tests, ops
+	 * scripts, service-binding invocations from bv-web) get the same tiered
+	 * discovery behaviour as the public `/mcp` path.
+	 */
+	BV_INFRA_GRAPH?: Fetcher;
+	BV_INTEL_GATEWAY?: {
+		getDomainEvidence: (params: { domain: string; includeHistory?: boolean }) => Promise<unknown>;
+	};
+	BV_ENTERPRISE?: Fetcher;
 };
 
 export const internalRoutes = new Hono<{ Bindings: InternalEnv }>();
@@ -206,6 +220,11 @@ internalRoutes.post('/tools/call', async (c) => {
 				? { endpoint: c.env.BV_DOH_ENDPOINT, token: c.env.BV_DOH_TOKEN }
 				: undefined,
 			whoisBinding: c.env.BV_WHOIS,
+			// Tier 0/1/2 lookup closures — internal callers (load tests, bv-web
+			// service binding, ops scripts) get the same tiered discovery path as
+			// public `/mcp`. Closures stay `undefined` on BSL self-hosts where
+			// the bindings aren't provisioned.
+			...buildBrandTierLookups(c.env),
 			...(wantStructured ? { resultCapture: (r: import('./lib/scoring-model').CheckResult) => { capturedResult = r; } } : {}),
 		},
 	);
@@ -383,6 +402,10 @@ internalRoutes.post('/tools/batch', async (c) => {
 							? { endpoint: c.env.BV_DOH_ENDPOINT, token: c.env.BV_DOH_TOKEN }
 							: undefined,
 						whoisBinding: c.env.BV_WHOIS,
+						// Tier 0/1/2 lookup closures — batch invocations of brand tools
+						// from internal callers must also exercise tiered mode when the
+						// bindings are provisioned.
+						...buildBrandTierLookups(c.env),
 						...(wantStructured ? { resultCapture: (r: import('./lib/scoring-model').CheckResult) => { capturedResult = r; } } : {}),
 					},
 				);

--- a/src/lib/brand-audit-pipeline.ts
+++ b/src/lib/brand-audit-pipeline.ts
@@ -20,6 +20,9 @@ import {
 } from '../tools/discover-brand-domains';
 import { checkRdapLookup as defaultCheckRdapLookup, type RdapCheckOptions } from '../tools/check-rdap-lookup';
 import type { BrandAuditStepStore } from './brand-audit-step-store';
+import type { Tier0Result } from './brand-tier0-enterprise';
+import type { Tier1Result } from './brand-tier1-graph';
+import type { Tier2Result } from './brand-tier2-evidence';
 
 /**
  * brand-audit findings emit under the existing `brand_discovery` category to
@@ -126,6 +129,27 @@ export interface BrandAuditPipelineDeps {
 	/** Optional service bindings threaded through to the inner tools. */
 	certstream?: { fetch: typeof fetch };
 	whoisBinding?: { fetch: typeof fetch };
+	/**
+	 * Tier 0 (tenant-declared portfolio) lookup closure, wrapping the
+	 * `BV_ENTERPRISE` service binding. Provided at the production seam in
+	 * `src/index.ts`; undefined on BSL self-hosts. Forwarded through to
+	 * `discoverBrandDomains` via its `deps` arg.
+	 */
+	tier0Lookup?: (domain: string) => Promise<Tier0Result>;
+	/**
+	 * Tier 1 (bv-infrastructure-graph) lookup closure, wrapping the
+	 * `BV_INFRA_GRAPH` service binding. Provided at the production seam in
+	 * `src/index.ts`; undefined on BSL self-hosts. Forwarded through to
+	 * `discoverBrandDomains` via its `deps` arg.
+	 */
+	tier1Lookup?: (domain: string) => Promise<Tier1Result>;
+	/**
+	 * Tier 2 (bv-intel-gateway declared-evidence) lookup closure, wrapping the
+	 * `BV_INTEL_GATEWAY` RPC service binding. Provided at the production seam
+	 * in `src/index.ts`; undefined on BSL self-hosts. Forwarded through to
+	 * `discoverBrandDomains` via its `deps` arg.
+	 */
+	tier2Lookup?: (domain: string) => Promise<Tier2Result>;
 }
 
 interface RegistrarLookup {
@@ -586,7 +610,24 @@ export async function runBrandAuditPipeline(
 			deadlineMs: options.deadlineMs,
 			onProgress: persistDiscoveryProgress,
 		};
-		discovery = await discover(seedDomain, discoveryOpts);
+		// Forward tier closures via the 3rd `deps` arg. They're `undefined` on
+		// BSL self-hosts (`tier_Lookup` keys absent from `deps`); the discoverer
+		// falls back to classic-mode behaviour without them. Producing this seam
+		// is the wiring half of T7 — the closures themselves are constructed at
+		// the production binding sites in `src/index.ts`.
+		//
+		// `DiscoverBrandDomainsDeps` declares signal stubs as required; the
+		// runtime tolerates partials (it merges with internal defaults). Existing
+		// callers cast — match that pattern.
+		const hasTierDeps = deps.tier0Lookup || deps.tier1Lookup || deps.tier2Lookup;
+		const discoveryDeps = {
+			...(deps.tier0Lookup ? { tier0Lookup: deps.tier0Lookup } : {}),
+			...(deps.tier1Lookup ? { tier1Lookup: deps.tier1Lookup } : {}),
+			...(deps.tier2Lookup ? { tier2Lookup: deps.tier2Lookup } : {}),
+		} as Parameters<typeof discover>[2];
+		discovery = hasTierDeps
+			? await discover(seedDomain, discoveryOpts, discoveryDeps)
+			: await discover(seedDomain, discoveryOpts);
 		throwIfAborted();
 		await stepStore?.put({ auditId, target: seedDomain, step: 'discovery', status: 'completed', payload: discovery });
 		recordStep(stepTimings, 'discovery', 'completed', discoveryStartedAtMs, now());

--- a/src/lib/brand-tier-lookups.ts
+++ b/src/lib/brand-tier-lookups.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared constructor for the Tier 0/1/2 lookup closures used by
+ * `discoverBrandDomains` and `brand_audit_single`.
+ *
+ * Three entry points need these closures: the public `/mcp` request path
+ * (`src/index.ts`), the internal `/internal/tools/{call,batch}` paths
+ * (`src/internal.ts`), and the brand-audit queue consumer (`src/index.ts`'s
+ * queue handler). All three rely on the same private service bindings:
+ *
+ *   - `BV_ENTERPRISE`       — Tier 0 (tenant-declared portfolio, HTTP binding)
+ *   - `BV_INFRA_GRAPH`      — Tier 1 (infrastructure-graph signals, HTTP binding)
+ *   - `BV_INTEL_GATEWAY`    — Tier 2 (declared-evidence, Workers RPC binding)
+ *   - `BV_WEB_INTERNAL_KEY` — shared bearer for Tier 0/1 producer auth
+ *
+ * Each closure is built only when its binding (+ `BV_WEB_INTERNAL_KEY` for
+ * Tier 0/1) is provisioned. BSL self-hosts that lack any of these get
+ * `undefined` for the corresponding closure — the discoverer then falls back
+ * to classic-mode behaviour without ever calling the proprietary surfaces.
+ *
+ * Tier 2 is RPC-typed; auth is enforced at the binding level (no Authorization
+ * header to plumb). See `src/lib/brand-tier2-evidence.ts` for the contract.
+ *
+ * The closures dynamically import their tier modules so BSL self-hosts that
+ * never call into tiered mode don't bundle the closure bodies into the
+ * request hot path.
+ */
+
+import type { Tier0Result } from './brand-tier0-enterprise';
+import type { Tier1Result } from './brand-tier1-graph';
+import type { Tier2Result, IntelGatewayBinding } from './brand-tier2-evidence';
+
+/**
+ * Minimal env shape consumed by the closure factory. Each entry point's
+ * `Env` type narrows to this via duck-typing — neither `BvMcpEnv` nor
+ * `InternalEnv` need to import or extend a shared interface, which keeps the
+ * BSL boundary clean (the bindings remain operator-deploy-only).
+ */
+export interface BrandTierLookupEnv {
+	BV_ENTERPRISE?: Fetcher;
+	BV_INFRA_GRAPH?: Fetcher;
+	BV_INTEL_GATEWAY?: IntelGatewayBinding;
+	BV_WEB_INTERNAL_KEY?: string;
+}
+
+export interface BrandTierLookups {
+	tier0Lookup?: (domain: string) => Promise<Tier0Result>;
+	tier1Lookup?: (domain: string) => Promise<Tier1Result>;
+	tier2Lookup?: (domain: string) => Promise<Tier2Result>;
+}
+
+/**
+ * Build Tier 0/1/2 lookup closures from the available env bindings.
+ *
+ * Pure construction — no I/O, no logging, no throws. Each closure returns
+ * `undefined` when its prerequisites aren't met, so callers can spread the
+ * result into a wider options bag without conditional branches per tier.
+ */
+export function buildBrandTierLookups(env: BrandTierLookupEnv): BrandTierLookups {
+	const enterpriseBinding = env.BV_ENTERPRISE;
+	const infraGraphBinding = env.BV_INFRA_GRAPH;
+	const intelGatewayBinding = env.BV_INTEL_GATEWAY;
+	const internalKey = env.BV_WEB_INTERNAL_KEY;
+	return {
+		...(enterpriseBinding && internalKey
+			? {
+					tier0Lookup: async (domain: string) => {
+						const { tier0EnterpriseLookup } = await import('./brand-tier0-enterprise');
+						return tier0EnterpriseLookup(domain, enterpriseBinding, { BV_WEB_INTERNAL_KEY: internalKey });
+					},
+				}
+			: {}),
+		...(infraGraphBinding && internalKey
+			? {
+					tier1Lookup: async (domain: string) => {
+						const { tier1GraphLookup } = await import('./brand-tier1-graph');
+						return tier1GraphLookup(domain, infraGraphBinding, { BV_WEB_INTERNAL_KEY: internalKey });
+					},
+				}
+			: {}),
+		...(intelGatewayBinding
+			? {
+					tier2Lookup: async (domain: string) => {
+						const { tier2EvidenceLookup } = await import('./brand-tier2-evidence');
+						return tier2EvidenceLookup(domain, intelGatewayBinding);
+					},
+				}
+			: {}),
+	};
+}

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -50,6 +50,10 @@ export interface DispatchMcpMethodOptions {
 	principalId?: string;
 	/** T13 — runtime-default for `discover_brand_domains` discovery_mode. */
 	discoveryModeDefault?: string;
+	/** Tier 0/1/2 lookup closures wrapping the private brand-discovery service bindings. Undefined on BSL self-hosts. */
+	tier0Lookup?: (domain: string) => Promise<import('../lib/brand-tier0-enterprise').Tier0Result>;
+	tier1Lookup?: (domain: string) => Promise<import('../lib/brand-tier1-graph').Tier1Result>;
+	tier2Lookup?: (domain: string) => Promise<import('../lib/brand-tier2-evidence').Tier2Result>;
 }
 
 export type DispatchMcpMethodResult =
@@ -167,6 +171,9 @@ export async function dispatchMcpMethod(options: DispatchMcpMethodOptions): Prom
 				discoveryModeDefault: options.discoveryModeDefault,
 				principalId: options.principalId,
 				rateLimitKv: options.rateLimitKv,
+				tier0Lookup: options.tier0Lookup,
+				tier1Lookup: options.tier1Lookup,
+				tier2Lookup: options.tier2Lookup,
 			});
 
 			return {

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -91,6 +91,17 @@ export interface ExecuteMcpRequestOptions {
 	 * which `brand_audit_single` reads.
 	 */
 	discoveryModeDefault?: string;
+	/**
+	 * Tier 0/1/2 lookup closures wrapping the private brand-discovery service
+	 * bindings (`BV_ENTERPRISE`, `BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`).
+	 * Constructed at the production seam in `src/index.ts` when the bindings
+	 * + `BV_WEB_INTERNAL_KEY` are provisioned. Undefined on BSL self-hosts.
+	 * Threaded into `ToolRuntimeOptions` so `discover_brand_domains` and
+	 * `brand_audit_single` can forward them through to `discoverBrandDomains`.
+	 */
+	tier0Lookup?: (domain: string) => Promise<import('../lib/brand-tier0-enterprise').Tier0Result>;
+	tier1Lookup?: (domain: string) => Promise<import('../lib/brand-tier1-graph').Tier1Result>;
+	tier2Lookup?: (domain: string) => Promise<import('../lib/brand-tier2-evidence').Tier2Result>;
 }
 
 function getDomainFromParams(params: Record<string, unknown> | undefined): string | undefined {
@@ -567,6 +578,9 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			browserRenderer: options.browserRenderer,
 			discoveryModeDefault: options.discoveryModeDefault,
 			principalId: options.principalId,
+			tier0Lookup: options.tier0Lookup,
+			tier1Lookup: options.tier1Lookup,
+			tier2Lookup: options.tier2Lookup,
 		}).then((dispatchResult) => {
 			if (dispatchResult.kind === 'early-error') {
 				return dispatchResult.payload;
@@ -644,6 +658,9 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			browserRenderer: options.browserRenderer,
 			discoveryModeDefault: options.discoveryModeDefault,
 			principalId: options.principalId,
+			tier0Lookup: options.tier0Lookup,
+			tier1Lookup: options.tier1Lookup,
+			tier2Lookup: options.tier2Lookup,
 		});
 
 		if (dispatchResult.kind === 'early-error') {

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -28,9 +28,13 @@
 
 import { z } from 'zod';
 import { brandAuditSingle as defaultBrandAuditSingle, type BrandAuditSingleOptions } from '../tools/brand-audit-single';
+import type { BrandAuditSingleDeps } from '../tools/brand-audit-single';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { BrandAuditStepStoreError, createD1BrandAuditStepStore } from '../lib/brand-audit-step-store';
 import { decideRetryEnqueue } from '../lib/registrar-retry';
+import type { Tier0Result } from '../lib/brand-tier0-enterprise';
+import type { Tier1Result } from '../lib/brand-tier1-graph';
+import type { Tier2Result } from '../lib/brand-tier2-evidence';
 
 /**
  * Per-message budget for the orchestrator. The AbortController-driven catch
@@ -77,10 +81,11 @@ export type BrandAuditQueueMessage = z.infer<typeof BrandAuditQueueMessageSchema
 
 export interface BrandAuditConsumerDeps {
 	db: D1Database;
-	/** Injectable for tests. */
+	/** Injectable for tests. Production default accepts a third `deps` arg (tier closures + service bindings); tests typically omit it. */
 	brandAuditSingle?: (
 		target: string,
 		options: BrandAuditSingleOptions,
+		deps?: BrandAuditSingleDeps,
 	) => Promise<CheckResult>;
 	/** Clock override for tests. */
 	now?: () => number;
@@ -118,6 +123,19 @@ export interface BrandAuditConsumerDeps {
 	 * undefined) leaves the public schema default (`'classic'`) in charge.
 	 */
 	discoveryModeDefault?: string;
+	/**
+	 * Tier 0/1/2 lookup closures wrapping the private brand-discovery service
+	 * bindings. Constructed at the queue dispatch site in `src/index.ts` when
+	 * the bindings (+ `BV_WEB_INTERNAL_KEY` for Tier 0/1) are provisioned.
+	 * Undefined on BSL self-hosts — queued audits then run classic-equivalent.
+	 *
+	 * Required for the queue path because the request-path closures
+	 * constructed in `executeMcpRequest` never reach queue consumers (different
+	 * Worker invocation, different env access pattern).
+	 */
+	tier0Lookup?: (domain: string) => Promise<Tier0Result>;
+	tier1Lookup?: (domain: string) => Promise<Tier1Result>;
+	tier2Lookup?: (domain: string) => Promise<Tier2Result>;
 }
 
 interface TargetStatusRow {
@@ -250,29 +268,42 @@ export async function processBrandAuditMessage(
 	}, BRAND_AUDIT_MESSAGE_TIMEOUT_MS);
 	let result: CheckResult | null = null;
 	let runtimeError: string | null = null;
+	// Tier closures: built once, passed as the 3rd `deps` arg ONLY when at
+	// least one closure is present. Skipping the arg on BSL self-hosts keeps
+	// the existing 2-arg `toHaveBeenCalledWith(...)` test assertions valid —
+	// vitest matches arg count exactly.
+	const singleDeps: BrandAuditSingleDeps = {
+		...(deps.tier0Lookup ? { tier0Lookup: deps.tier0Lookup } : {}),
+		...(deps.tier1Lookup ? { tier1Lookup: deps.tier1Lookup } : {}),
+		...(deps.tier2Lookup ? { tier2Lookup: deps.tier2Lookup } : {}),
+	};
+	const hasSingleDeps = deps.tier0Lookup || deps.tier1Lookup || deps.tier2Lookup;
+	const singleOptions: BrandAuditSingleOptions = {
+		auditId: message.auditId,
+		stepStore,
+		format: message.format,
+		min_confidence: message.min_confidence,
+		depth: message.depth,
+		planner_mode: message.planner_mode,
+		brand_aliases: message.brand_aliases,
+		candidate_domains: message.candidate_domains,
+		signal: controller.signal,
+		deadlineMs: messageStartedAt + BRAND_AUDIT_MESSAGE_TIMEOUT_MS,
+		// Phase 2b: retry messages re-run the pipeline from scratch instead
+		// of reading back the cached lookup_failed result from pass 1.
+		force_refresh: isRetry,
+		// T13 — propagate the BlackVeil-production runtime override.
+		// Pipeline only honours it when the caller omits `discovery_mode`;
+		// undefined on BSL self-hosts (schema default `'classic'` wins).
+		...(deps.discoveryModeDefault
+			? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: deps.discoveryModeDefault } }
+			: {}),
+	};
 	try {
 		result = await Promise.race([
-			single(message.target, {
-				auditId: message.auditId,
-				stepStore,
-				format: message.format,
-				min_confidence: message.min_confidence,
-				depth: message.depth,
-				planner_mode: message.planner_mode,
-				brand_aliases: message.brand_aliases,
-				candidate_domains: message.candidate_domains,
-				signal: controller.signal,
-				deadlineMs: messageStartedAt + BRAND_AUDIT_MESSAGE_TIMEOUT_MS,
-				// Phase 2b: retry messages re-run the pipeline from scratch instead
-				// of reading back the cached lookup_failed result from pass 1.
-				force_refresh: isRetry,
-				// T13 — propagate the BlackVeil-production runtime override.
-				// Pipeline only honours it when the caller omits `discovery_mode`;
-				// undefined on BSL self-hosts (schema default `'classic'` wins).
-				...(deps.discoveryModeDefault
-					? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: deps.discoveryModeDefault } }
-					: {}),
-			}),
+			hasSingleDeps
+				? single(message.target, singleOptions, singleDeps)
+				: single(message.target, singleOptions),
 			new Promise<never>((_, reject) => {
 				const onAbort = () => {
 					const reason = (controller.signal as AbortSignal & { reason?: unknown }).reason;

--- a/test/brand-discovery-tier-wiring.test.ts
+++ b/test/brand-discovery-tier-wiring.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Wiring tests for the brand-discovery tier closures.
+ *
+ * The unit tests in `test/discover-brand-domains.spec.ts` inject `tier0Lookup`,
+ * `tier1Lookup`, and `tier2Lookup` mocks directly into `discoverBrandDomains`'
+ * `deps` arg. They verify the *behavior* of the closures (Tier 0 short-circuit,
+ * Tier 3 fallback heuristics, etc.).
+ *
+ * These tests cover the *wiring* — that the pipeline-level injection point
+ * (`BrandAuditPipelineDeps`) actually forwards tier closures through to
+ * `discoverBrandDomains`. Without this assertion, the production seam at
+ * `src/index.ts` could silently drop the closures and we wouldn't notice
+ * until tiered audits regressed to Tier-3-equivalent classic mode (the
+ * exact bug T7 deferred).
+ *
+ * Per testing-methodology.md principle 4 — audit/unit tests replace review
+ * checklists. The "wiring is connected" assertion belongs at the lowest
+ * layer where it's catchable, which is the pipeline-deps contract.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { runBrandAuditPipeline } from '../src/lib/brand-audit-pipeline';
+import type { CheckResult, Finding } from '../src/lib/scoring';
+
+function summaryFinding(seedDomain: string, surfaced: number): Finding {
+	return {
+		category: 'brand_discovery',
+		title: `Brand-domain discovery: ${surfaced} candidate(s)`,
+		severity: 'info',
+		detail: `Seed=${seedDomain}`,
+		metadata: { summary: true, signals: ['ns'], signalStatus: {}, minConfidence: 0.5, totalAggregated: surfaced, surfaced },
+	};
+}
+
+function emptyDiscovery(seedDomain: string): CheckResult {
+	return {
+		category: 'brand_discovery',
+		score: 100,
+		findings: [summaryFinding(seedDomain, 0)],
+	};
+}
+
+function rdapResult(): CheckResult {
+	return {
+		category: 'rdap',
+		score: 100,
+		findings: [
+			{
+				category: 'rdap',
+				title: 'RDAP registrar',
+				severity: 'info',
+				detail: 'MarkMonitor Inc.',
+				metadata: { registrar: 'MarkMonitor Inc.', registrarIanaId: null, registrarSource: 'rdap', registrant: 'Example Inc.' },
+			},
+		],
+	};
+}
+
+describe('brand-audit pipeline → discoverBrandDomains tier-closure wiring', () => {
+	it('forwards tier0Lookup / tier1Lookup / tier2Lookup deps through to discoverBrandDomains', async () => {
+		// The pipeline calls `discover(seedDomain, opts)` with *two* args in
+		// pre-wiring code. Once tier closures land in `BrandAuditPipelineDeps`,
+		// the call site must pass a 3rd `deps` arg containing them — otherwise
+		// the production seam is dropped on the floor and tiered mode degrades
+		// to Tier-3-equivalent classic. This test fails RED until that 3rd arg
+		// is added; GREEN once the production wiring is correct.
+		const tier0Lookup = vi.fn();
+		const tier1Lookup = vi.fn();
+		const tier2Lookup = vi.fn();
+		const discoverBrandDomains = vi.fn(async (seed: string, _opts: unknown, deps?: { tier0Lookup?: unknown; tier1Lookup?: unknown; tier2Lookup?: unknown }) => {
+			// Assert the deps arrived — if the pipeline didn't pass a 3rd arg
+			// these would all be undefined.
+			expect(deps?.tier0Lookup, 'pipeline must forward tier0Lookup to discoverBrandDomains').toBe(tier0Lookup);
+			expect(deps?.tier1Lookup, 'pipeline must forward tier1Lookup to discoverBrandDomains').toBe(tier1Lookup);
+			expect(deps?.tier2Lookup, 'pipeline must forward tier2Lookup to discoverBrandDomains').toBe(tier2Lookup);
+			return emptyDiscovery(seed);
+		});
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult());
+
+		await runBrandAuditPipeline(
+			'example.com',
+			{ discovery_mode: 'tiered' },
+			{
+				discoverBrandDomains: discoverBrandDomains as never,
+				checkRdapLookup,
+				tier0Lookup,
+				tier1Lookup,
+				tier2Lookup,
+			},
+		);
+
+		expect(discoverBrandDomains).toHaveBeenCalled();
+	});
+
+	it('passes no tier deps to discoverBrandDomains when pipeline deps omit them (BSL self-host)', async () => {
+		// On BSL self-hosts the tier closures are undefined — the pipeline must
+		// still call discoverBrandDomains cleanly and the closures stay undefined
+		// inside. (Reverse of the prior test: confirms we don't fabricate
+		// closures when the operator hasn't provisioned the bindings.)
+		const discoverBrandDomains = vi.fn(async (seed: string, _opts: unknown, deps?: { tier0Lookup?: unknown; tier1Lookup?: unknown; tier2Lookup?: unknown }) => {
+			expect(deps?.tier0Lookup).toBeUndefined();
+			expect(deps?.tier1Lookup).toBeUndefined();
+			expect(deps?.tier2Lookup).toBeUndefined();
+			return emptyDiscovery(seed);
+		});
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult());
+
+		await runBrandAuditPipeline(
+			'example.com',
+			{},
+			{ discoverBrandDomains: discoverBrandDomains as never, checkRdapLookup },
+		);
+
+		expect(discoverBrandDomains).toHaveBeenCalled();
+	});
+});

--- a/test/helpers/report-generation-options.ts
+++ b/test/helpers/report-generation-options.ts
@@ -2,6 +2,14 @@
 
 export type ReportDepthMode = 'standard' | 'deep';
 export type ReportPlannerMode = 'off' | 'observe' | 'enforce';
+/**
+ * Discovery mode override surfaced as the `discovery_mode` arg on the MCP
+ * call. Pairs with the schema enum in `src/schemas/tool-args.ts` — the
+ * worker only accepts `'classic' | 'tiered'`. The replay script
+ * (`scripts/brand-discovery-tier-replay.mjs`) pre-maps `baseline` → `classic`
+ * before spawning the spec, so this helper never sees `baseline`.
+ */
+export type ReportDiscoveryMode = 'classic' | 'tiered';
 
 export interface ReportGenerationOptions {
 	depthMode: ReportDepthMode;
@@ -9,6 +17,8 @@ export interface ReportGenerationOptions {
 	brandAliases: string[];
 	runId: string;
 	requestedAt: string;
+	/** Undefined → omit `discovery_mode` from the request (BSL invariance — schema default `'classic'` wins). */
+	discoveryMode?: ReportDiscoveryMode;
 }
 
 export interface ReportGenerationEnv {
@@ -18,6 +28,13 @@ export interface ReportGenerationEnv {
 	BV_REPORT_RUN_ID?: string;
 	BV_REPORT_REQUESTED_AT?: string;
 	TARGET_DOMAIN?: string;
+	/**
+	 * Discovery mode override emitted by
+	 * `scripts/brand-discovery-tier-replay.mjs` to exercise tiered vs classic
+	 * end-to-end. Must be `'classic'` or `'tiered'` — anything else fails fast
+	 * so misconfigured runs don't silently fall back.
+	 */
+	BV_REPORT_DISCOVERY_MODE?: string;
 }
 
 function normalizeAlias(alias: string): string | null {
@@ -48,12 +65,29 @@ export function parseReportGenerationEnv(env: ReportGenerationEnv = process.env)
 
 	const requestedAt = env.BV_REPORT_REQUESTED_AT ?? new Date().toISOString();
 	const runId = env.BV_REPORT_RUN_ID ?? `report-${Date.now().toString(36)}`;
+
+	// BV_REPORT_DISCOVERY_MODE: optional override threaded through to the MCP
+	// payload and the local discovery path. Validated against the worker's
+	// schema enum (`src/schemas/tool-args.ts`: `'classic' | 'tiered'`) so the
+	// replay run fails fast instead of dropping the value downstream. Anything
+	// other than `classic`/`tiered` raises; unset → undefined → omitted from
+	// both build paths (BSL invariance, schema default wins).
+	let discoveryMode: ReportDiscoveryMode | undefined;
+	const rawDiscoveryMode = env.BV_REPORT_DISCOVERY_MODE?.trim().toLowerCase();
+	if (rawDiscoveryMode !== undefined && rawDiscoveryMode.length > 0) {
+		if (rawDiscoveryMode !== 'classic' && rawDiscoveryMode !== 'tiered') {
+			throw new Error(`BV_REPORT_DISCOVERY_MODE must be classic or tiered; received ${env.BV_REPORT_DISCOVERY_MODE}`);
+		}
+		discoveryMode = rawDiscoveryMode;
+	}
+
 	return {
 		depthMode: rawDepth,
 		plannerMode: rawPlannerMode,
 		brandAliases,
 		runId,
 		requestedAt,
+		...(discoveryMode ? { discoveryMode } : {}),
 	};
 }
 
@@ -65,6 +99,9 @@ export function buildBrandAuditBatchStartArgs(target: string, options: ReportGen
 		depth: options.depthMode,
 		planner_mode: options.plannerMode,
 		...(options.brandAliases.length > 0 ? { brand_aliases: options.brandAliases } : {}),
+		// discovery_mode: surface only when explicitly set so BSL self-host
+		// runs of the report script keep the schema default (`'classic'`).
+		...(options.discoveryMode ? { discovery_mode: options.discoveryMode } : {}),
 	};
 }
 
@@ -74,5 +111,6 @@ export function buildLocalDiscoveryOptions(options: ReportGenerationOptions) {
 		depth: options.depthMode,
 		planner_mode: options.plannerMode,
 		...(options.brandAliases.length > 0 ? { brand_aliases: options.brandAliases } : {}),
+		...(options.discoveryMode ? { discovery_mode: options.discoveryMode } : {}),
 	};
 }

--- a/test/report-generation-options.test.ts
+++ b/test/report-generation-options.test.ts
@@ -42,4 +42,41 @@ describe('report generation option helpers', () => {
 			}),
 		).toThrow('BV_BRAND_AUDIT_PLANNER_MODE must be off, observe, or enforce');
 	});
+
+	it('threads BV_REPORT_DISCOVERY_MODE=tiered into batch-start and local discovery options', () => {
+		// Wiring test for the replay script (`scripts/brand-discovery-tier-replay.mjs`):
+		// when the env arrives as `tiered`, both the MCP request payload and the
+		// local in-process discovery call must surface it. The schema enum on
+		// `tool-args.ts` only accepts `'classic' | 'tiered'` — `baseline` is
+		// pre-mapped to `classic` by the replay script before it spawns.
+		const options = parseReportGenerationEnv({
+			TARGET_DOMAIN: 'example.com',
+			BV_REPORT_DISCOVERY_MODE: 'tiered',
+		});
+		expect(options.discoveryMode).toBe('tiered');
+		expect(buildBrandAuditBatchStartArgs('example.com', options)).toMatchObject({
+			discovery_mode: 'tiered',
+		});
+		expect(buildLocalDiscoveryOptions(options)).toMatchObject({
+			discovery_mode: 'tiered',
+		});
+	});
+
+	it('omits discovery_mode when BV_REPORT_DISCOVERY_MODE is unset (BSL invariance)', () => {
+		const options = parseReportGenerationEnv({ TARGET_DOMAIN: 'example.com' });
+		expect(options.discoveryMode).toBeUndefined();
+		expect(buildBrandAuditBatchStartArgs('example.com', options)).not.toHaveProperty('discovery_mode');
+		expect(buildLocalDiscoveryOptions(options)).not.toHaveProperty('discovery_mode');
+	});
+
+	it('rejects BV_REPORT_DISCOVERY_MODE values outside the schema enum', () => {
+		// `baseline` is the replay-script alias, NOT a worker-visible value.
+		// The replay script remaps it to `classic` BEFORE spawning the spec —
+		// the spec's helper sees only `classic`/`tiered`. Any other value is
+		// rejected here so the replay run fails fast instead of silently
+		// dropping the override on the floor downstream.
+		expect(() =>
+			parseReportGenerationEnv({ TARGET_DOMAIN: 'example.com', BV_REPORT_DISCOVERY_MODE: 'baseline' }),
+		).toThrow('BV_REPORT_DISCOVERY_MODE must be classic or tiered');
+	});
 });


### PR DESCRIPTION
## Summary

Closes the wiring gap T7 deferred — the deployed worker has the
`BV_INFRA_GRAPH` / `BV_INTEL_GATEWAY` / `BV_ENTERPRISE` service bindings
and the `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT` env var live, but the request,
internal, and queue paths never constructed `tier0Lookup`/`tier1Lookup`/`tier2Lookup`
closures around them. The orchestrator's dep-injection seam saw undefined
bindings and every audit silently degraded to Tier 3 (classic-equivalent).

- New `src/lib/brand-tier-lookups.ts` shared helper builds the closures
  from a minimal env shape (BSL boundary preserved — dynamic-imports the
  tier modules so self-hosts never load proprietary closure bodies).
- Wired at **4 construction sites**: 3 in `src/index.ts` (request paths +
  queue dispatch), plus 2 in `src/internal.ts` (`/internal/tools/call` and
  `/internal/tools/batch`) so service-binding callers also exercise the
  tiered path.
- Threaded through `ToolRuntimeOptions` → `discover_brand_domains` (3-arg
  `deps` invocation) and `brand_audit_single` (pipeline `deps`) →
  `BrandAuditPipelineDeps` → `discoverBrandDomains`'s third `deps` arg.
- Queue consumer extended with tier-closure deps; conditionally passes a
  3rd `deps` arg so existing 2-arg `toHaveBeenCalledWith(target, options)`
  test assertions on BSL self-hosts still match.
- **Cache-key poisoning fix**: `discovery_mode` now appears in
  `discover_brand_domains` and `brand_audit_single` cache keys; the
  latter also consults `discoveryModeDefault` so env-flipped effective
  mode hashes correctly. Without this, classic and tiered runs would
  share a single cache slot and silently overwrite each other —
  reproducing the exact symptom the wiring was meant to fix.
- `test/helpers/report-generation-options.ts` reads `BV_REPORT_DISCOVERY_MODE`
  (`classic` | `tiered`) and surfaces it as the `discovery_mode` arg on
  both the MCP batch-start payload and the local in-process discovery
  options. The replay script pre-maps `baseline` → `classic` upstream;
  any other value fails fast.

## BSL boundary preserved

- Public `wrangler.jsonc` stays binding-free —
  `test/audits/wrangler-public-no-private-bindings.audit.test.ts` still
  passes.
- Schema default in `src/schemas/tool-args.ts` remains `'classic'`.
- Closures are `undefined` when bindings are absent; the discoverer
  silently falls back to classic-mode sweep without any proprietary
  fetch ever happening.

## Test plan

- [x] `test/brand-discovery-tier-wiring.test.ts` — RED → GREEN unit-level
  assertion that pipeline deps reach `discoverBrandDomains`'s third arg
  (and stay `undefined` on BSL self-hosts).
- [x] `test/report-generation-options.test.ts` — 3 new cases covering
  the `BV_REPORT_DISCOVERY_MODE` flow (tiered, unset, invalid).
- [x] Existing T7 tests in `test/discover-brand-domains.spec.ts` still
  pass — they use injected mocks; production wiring just provides the
  real implementations.
- [x] `test/audits/wrangler-public-no-private-bindings.audit.test.ts`
  still passes (BSL invariance).
- [x] Existing queue-consumer integration tests still match
  `toHaveBeenCalledWith` (the 2-arg fallback preserves their
  assertions).
- [x] `npm run typecheck` — clean.
- [x] `npm run lint` — clean.
- [x] `npm test` — 3917 passed, 10 skipped. The 3 "errors" are the
  well-known WebSocket pool-teardown flake documented in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)