### PR TITLE
fix(brand-discovery): wire discovery_mode through brand_audit_batch_start

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -362,6 +362,7 @@ const TOOL_REGISTRY: Record<
 					planner_mode: args.planner_mode as 'off' | 'observe' | 'enforce' | undefined,
 					brand_aliases: args.brand_aliases as string[] | undefined,
 					candidate_domains: args.candidate_domains as string[] | undefined,
+					discovery_mode: args.discovery_mode as 'classic' | 'tiered' | undefined,
 				},
 				principalId,
 				{ db, queue, enforceQuota: buildMonthlyEnforceQuota(ro) },

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -63,6 +63,12 @@ export const BrandAuditQueueMessageSchema = z.object({
 	planner_mode: z.enum(['off', 'observe', 'enforce']).optional(),
 	brand_aliases: z.array(z.string().min(2).max(64)).max(20).optional(),
 	candidate_domains: z.array(z.string().min(1).max(253)).max(250).optional(),
+	/**
+	 * Per-target discovery mode forwarded by brand_audit_batch_start. Explicit
+	 * caller-supplied value wins over deps.discoveryModeDefault in the
+	 * pipeline's effective-mode resolution.
+	 */
+	discovery_mode: z.enum(['classic', 'tiered']).optional(),
 	/** Set when the message originated from the watch cron — drives post-completion diff/webhook. */
 	watchId: z.string().min(1).max(64).optional(),
 	/** Bound at enqueue time so the consumer doesn't need a D1 round-trip to look up the watch's owner. */
@@ -287,6 +293,10 @@ export async function processBrandAuditMessage(
 		planner_mode: message.planner_mode,
 		brand_aliases: message.brand_aliases,
 		candidate_domains: message.candidate_domains,
+		// Explicit per-target discovery mode from the batch_start payload
+		// (the caller's `discovery_mode` arg). Wins over discoveryModeDefault
+		// in the pipeline's effective-mode resolution.
+		discovery_mode: message.discovery_mode,
 		signal: controller.signal,
 		deadlineMs: messageStartedAt + BRAND_AUDIT_MESSAGE_TIMEOUT_MS,
 		// Phase 2b: retry messages re-run the pipeline from scratch instead

--- a/src/tools/brand-audit-batch-start.ts
+++ b/src/tools/brand-audit-batch-start.ts
@@ -47,6 +47,12 @@ export interface BrandAuditBatchStartOptions {
 	planner_mode?: 'off' | 'observe' | 'enforce';
 	brand_aliases?: string[];
 	candidate_domains?: string[];
+	/**
+	 * Threaded onto the queue message so the consumer can route discovery
+	 * through the tiered pipeline. Explicit caller value always wins over
+	 * env BRAND_AUDIT_DISCOVERY_MODE_DEFAULT on the consumer side.
+	 */
+	discovery_mode?: 'classic' | 'tiered';
 }
 
 export type EnforceBrandAuditQuota = (count: number) => Promise<{
@@ -65,6 +71,8 @@ export interface BrandAuditQueueMessage {
 	planner_mode?: 'off' | 'observe' | 'enforce';
 	brand_aliases?: string[];
 	candidate_domains?: string[];
+	/** Per-target discovery mode override. Consumer threads to runBrandAuditPipeline. */
+	discovery_mode?: 'classic' | 'tiered';
 }
 
 export interface BrandAuditQueueProducer {
@@ -195,6 +203,7 @@ export async function brandAuditBatchStart(
 					planner_mode: options.planner_mode,
 					brand_aliases: options.brand_aliases,
 					candidate_domains: options.candidate_domains,
+					discovery_mode: options.discovery_mode,
 				},
 				{ contentType: 'json' },
 			);


### PR DESCRIPTION
PR #154 wired discovery_mode through \`discover_brand_domains\` + \`brand_audit_single\`, but missed \`brand_audit_batch_start\` — the path scripts/generate-report.sh actually uses. Post-#154 smoke test confirmed the symptom: \`brand_audit_batch_start\` accepted the arg via \`.passthrough()\` but silently dropped it before enqueueing, so the consumer never saw it and the pipeline defaulted to classic regardless of caller intent.

3 files, 20 inserts:
- \`brand-audit-batch-start.ts\`: discovery_mode on options interface + queue message interface + queue.send payload
- \`handlers/tools.ts\`: pass args.discovery_mode to brandAuditBatchStart options
- \`brand-audit-consumer.ts\`: extend Zod schema + read message.discovery_mode → singleOptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)