### PR TITLE
Brand-audit: corporate-registrar family + defensive typosquat label + reaper dead-zone

### DIFF
--- a/src/lib/brand-audit-html-template.ts
+++ b/src/lib/brand-audit-html-template.ts
@@ -36,6 +36,10 @@ export interface BrandCandidateRow {
 	reasons: string[];
 	signals: string[];
 	combinedConfidence: number;
+	/** True when the heuristic in `brand-defensive-registration.ts` flagged this candidate. */
+	defensive?: boolean;
+	/** Discriminated reason token from the same heuristic. */
+	defensiveReason?: 'redirect-to-target' | 'no-mx' | 'parked-ns';
 }
 
 function relationshipTypeFor(bucket: BrandAuditBucket, raw: unknown): BrandRelationshipType {
@@ -95,6 +99,10 @@ export function candidatesFromCheckResult(result: CheckResult): BrandCandidateRo
 		const m = f.metadata;
 		if (!m || typeof m.candidate !== 'string' || typeof m.bucket !== 'string') continue;
 		const bucket = m.bucket as BrandAuditBucket;
+		const defensiveReason =
+			m.defensiveReason === 'redirect-to-target' || m.defensiveReason === 'no-mx' || m.defensiveReason === 'parked-ns'
+				? m.defensiveReason
+				: undefined;
 		rows.push({
 			domain: m.candidate as string,
 			bucket,
@@ -104,6 +112,8 @@ export function candidatesFromCheckResult(result: CheckResult): BrandCandidateRo
 			reasons: Array.isArray(m.reasons) ? (m.reasons as string[]) : [],
 			signals: Array.isArray(m.signals) ? (m.signals as string[]) : [],
 			combinedConfidence: typeof m.combinedConfidence === 'number' ? (m.combinedConfidence as number) : 0,
+			...(m.defensive === true ? { defensive: true } : {}),
+			...(defensiveReason ? { defensiveReason } : {}),
 		});
 	}
 	return rows;
@@ -169,8 +179,14 @@ function renderTableSection(
 			const sourceBadge = r.registrarSource === 'redacted' || r.registrarSource === 'notfound'
 				? ` <span class="badge badge-gray">${esc(r.registrarSource)}</span>`
 				: '';
+			// Defensive-registration label — see `brand-defensive-registration.ts`. The
+			// candidate stays in its classifier-assigned bucket; the badge tells the
+			// reader this is a deliberately-parked typo defence, not operational infra.
+			const defensiveBadge = r.defensive
+				? ` <span class="badge badge-gray" title="${esc(`defensive registration${r.defensiveReason ? ` — ${r.defensiveReason}` : ''}`)}">defensive</span>`
+				: '';
 			return `<tr>
-				<td>${esc(r.domain)}</td>
+				<td>${esc(r.domain)}${defensiveBadge}</td>
 				<td>${esc(r.registrar)}${sourceBadge}</td>
 				<td><span class="badge ${badgeClass}">${esc(columnValue(r))}</span></td>
 				<td class="sources">${citationLinks(r)}</td>

--- a/src/lib/brand-audit-markdown.ts
+++ b/src/lib/brand-audit-markdown.ts
@@ -66,6 +66,21 @@ function isVendorDependency(f: Finding): boolean {
 	return relationshipType(f) === 'authorized_vendor_dependency';
 }
 
+/**
+ * Render a `(defensive registration)` suffix for a candidate finding when
+ * the pipeline stamped `metadata.defensive === true`. Defensive candidates
+ * are typosquat-shaped domains the brand owns on purpose (e.g.
+ * `masterard.com` next to `mastercard.com`) — without a label customers
+ * can't visually distinguish them from operational properties. We label,
+ * we never re-bucket.
+ */
+function defensiveSuffix(f: Finding): string {
+	if (f.metadata?.defensive !== true) return '';
+	const reason = typeof f.metadata?.defensiveReason === 'string' ? f.metadata.defensiveReason : undefined;
+	const reasonText = reason ? ` — ${sanitizeOutputText(reason, 40)}` : '';
+	return ` _(defensive registration${reasonText})_`;
+}
+
 /** Render `result` from `brandAuditSingle()` as a compact Markdown document. */
 export function formatBrandAuditMarkdown(result: CheckResult): string {
 	const summary = result.findings.find((f) => f.metadata?.summary === true);
@@ -144,7 +159,8 @@ export function formatBrandAuditMarkdown(result: CheckResult): string {
 			const signalArr = Array.isArray(f.metadata?.signals) ? (f.metadata!.signals as string[]) : [];
 			const signals = signalArr.length > 0 ? sanitizeOutputText(signalArr.join(', '), 200) : '—';
 			const note = f.metadata?.note ? ` _(${sanitizeOutputText(String(f.metadata.note), 100)})_` : '';
-			lines.push(`- **${domain}**${note} — registrar: ${registrar} (${source}) · confidence ${conf} · signals: ${signals}`);
+			const defensive = defensiveSuffix(f);
+			lines.push(`- **${domain}**${note}${defensive} — registrar: ${registrar} (${source}) · confidence ${conf} · signals: ${signals}`);
 		}
 		lines.push('');
 	}
@@ -208,7 +224,8 @@ function appendVendorDependencies(lines: string[], items: Finding[]): void {
 		const conf = typeof f.metadata?.combinedConfidence === 'number' ? (f.metadata.combinedConfidence as number).toFixed(2) : '—';
 		const signalArr = Array.isArray(f.metadata?.signals) ? (f.metadata!.signals as string[]) : [];
 		const signals = signalArr.length > 0 ? sanitizeOutputText(signalArr.join(', '), 200) : '—';
-		lines.push(`- **${domain}** — registrar: ${registrar} (${source}) · confidence ${conf} · signals: ${signals}`);
+		const defensive = defensiveSuffix(f);
+		lines.push(`- **${domain}**${defensive} — registrar: ${registrar} (${source}) · confidence ${conf} · signals: ${signals}`);
 	}
 	lines.push('');
 }
@@ -226,7 +243,8 @@ function appendPortfolioSubsection(lines: string[], title: string, items: Findin
 		const registrar = sanitizeOutputText(String(f.metadata?.registrar ?? 'Unknown'), 100);
 		const source = sanitizeOutputText(String(f.metadata?.registrarSource ?? 'unknown'), 20);
 		const conf = typeof f.metadata?.combinedConfidence === 'number' ? (f.metadata.combinedConfidence as number).toFixed(2) : '—';
-		lines.push(`- **${domain}** — registrar: ${registrar} (${source}) · confidence ${conf}`);
+		const defensive = defensiveSuffix(f);
+		lines.push(`- **${domain}**${defensive} — registrar: ${registrar} (${source}) · confidence ${conf}`);
 	}
 	lines.push('');
 }

--- a/src/lib/brand-audit-pipeline.ts
+++ b/src/lib/brand-audit-pipeline.ts
@@ -14,6 +14,7 @@ import {
 	type TargetContext,
 } from './brand-classification';
 import { validateSprawlItem } from './sprawl-invariants';
+import { evaluateDefensiveRegistration } from './brand-defensive-registration';
 import type { BrandEvidenceObservation } from './brand-evidence';
 import {
 	discoverBrandDomains as defaultDiscoverBrandDomains,
@@ -378,6 +379,38 @@ function scoreAlertContextFromObservations(
 		}
 	}
 	return undefined;
+}
+
+/**
+ * Pluck candidate NS hostnames out of evidence observations. The `ns`
+ * signal stores its co-ownership match as `sharedNs: string[]` in
+ * observation metadata (see `discoverBrandDomains` → ns-correlator). When
+ * present we surface it to the defensive-registration heuristic so a
+ * candidate parked on `ns1.sedoparking.com` can be labelled even without
+ * an additional DNS pass.
+ *
+ * Returns undefined when no `ns` observation carries `sharedNs` — the
+ * heuristic then abstains on this signal.
+ *
+ * TODO(defensive): wire a candidate MX + HTTP HEAD enrichment pass for
+ * label-distance≤2 candidates so the `no-mx` / `redirect-to-target`
+ * branches can fire on the customer-visible PDF path. Today only the NS
+ * route lights up automatically.
+ */
+function nsHostsFromObservations(observations: BrandEvidenceObservation[] | undefined): string[] | undefined {
+	if (!observations) return undefined;
+	const hosts: string[] = [];
+	for (const obs of observations) {
+		if (obs.signal !== 'ns') continue;
+		const md = obs.metadata;
+		if (!isRecord(md)) continue;
+		const shared = md.sharedNs;
+		if (!Array.isArray(shared)) continue;
+		for (const ns of shared) {
+			if (typeof ns === 'string' && ns.length > 0) hosts.push(ns);
+		}
+	}
+	return hosts.length > 0 ? hosts : undefined;
 }
 
 function graphEvidenceFromObservations(
@@ -910,6 +943,17 @@ export async function runBrandAuditPipeline(
 		const scoreAlertCtx =
 			classification.bucket === 'impersonationSurface' ? scoreAlertContextFromObservations(evidenceObservations) : undefined;
 		const graphEvidence = graphEvidenceFromObservations(evidenceObservations);
+		// Defensive-registration label. We do NOT change `classification.bucket`;
+		// this is a metadata annotation the renderers consume to mark close-typo
+		// candidates with minimal infrastructure (e.g. `masterard.com` parked at
+		// sedoparking next to `mastercard.com`). Pure data-only call — the
+		// heuristic abstains when minimal-infra inputs are absent.
+		const candidateNsHosts = nsHostsFromObservations(evidenceObservations);
+		const defensiveResult = evaluateDefensiveRegistration({
+			candidateDomain: domain,
+			targetDomain: seedDomain,
+			...(candidateNsHosts ? { nsHosts: candidateNsHosts } : {}),
+		});
 		return createFinding(CATEGORY, `Brand candidate: ${domain}`, severity, detailParts.join(' — '), {
 			candidate: domain,
 			bucket: classification.bucket,
@@ -931,6 +975,9 @@ export async function runBrandAuditPipeline(
 			...(lookalikeScore > 0 ? { lookalikeScore } : {}),
 			...(scoreAlertCtx ? { scoreAlertContext: scoreAlertCtx } : {}),
 			...(graphEvidence ? { graphEvidence } : {}),
+			...(defensiveResult.defensive
+				? { defensive: true, ...(defensiveResult.reason ? { defensiveReason: defensiveResult.reason } : {}) }
+				: {}),
 		});
 	});
 	recordStep(stepTimings, 'classification', 'completed', classificationStartedAtMs, now());

--- a/src/lib/brand-audit-reaper.ts
+++ b/src/lib/brand-audit-reaper.ts
@@ -31,8 +31,37 @@
  * cron interval.
  */
 
-/** Targets in `running` longer than this are definitely stuck. */
-export const STUCK_TARGET_THRESHOLD_MS = 15 * 60 * 1000;
+/**
+ * Targets in `running` longer than this are definitely stuck — cron-tick reaper
+ * cutoff. Tightened from 15min → 10min on 2026-05-21 after the disney.com
+ * dead-zone investigation: the 300s consumer cap, plus generous grace for the
+ * cap-fire macrotask + final D1 flip, plus a couple of cron-tick safety
+ * margins, fits comfortably under 10 minutes. The read-path piggyback in
+ * `brand_audit_status` (see {@link BRAND_AUDIT_TARGET_DEADLINE_MS}) handles
+ * the polling-customer case near-instantly; this constant is the backstop for
+ * audits nobody is polling (cron watches, fire-and-forget enqueues).
+ */
+export const STUCK_TARGET_THRESHOLD_MS = 10 * 60 * 1000;
+
+/**
+ * Per-target running-budget deadline used by the read path
+ * (`brand_audit_status`, `brand_audit_get_report`) to synthesise `failed` for
+ * targets whose consumer could no longer self-flip. Set to the consumer cap
+ * (300s) plus 120s of grace — accounts for:
+ *   1. Cloudflare Queue delivery lag between INSERT (`created_at`) and the
+ *      consumer's running-flip. Typically sub-second in prod, but bursts can
+ *      push 30–60s during redeliveries.
+ *   2. Cap-fire macrotask + D1 catch-handler UPDATE when microtasks are
+ *      partially starved.
+ *
+ * 7 minutes leaves a buffer wide enough that a legitimate 5-minute audit
+ * isn't truncated by a polling read at the cliff. Anything older is the
+ * disney/walmart-class hang where the worker was killed before the catch ran.
+ *
+ * Must remain strictly less than {@link STUCK_TARGET_THRESHOLD_MS} so the read
+ * path closes the dead zone before the cron reaper would.
+ */
+export const BRAND_AUDIT_TARGET_DEADLINE_MS = 7 * 60 * 1000;
 
 /** Hard cap on reaps per cron tick — prevents runaway D1 spend on infra incidents. */
 export const MAX_REAP_PER_TICK = 50;

--- a/src/lib/brand-classification.test.ts
+++ b/src/lib/brand-classification.test.ts
@@ -69,6 +69,20 @@ describe('normalizeRegistrar', () => {
 		expect(normalizeRegistrar('CSC Corporate Domains (Canada) Company')).toBe('CSC');
 	});
 
+	it('collapses CSC global subsidiaries (regression: 2026-05 ford.com.au shadowIt FP)', () => {
+		// Real WHOIS strings observed in production brand-audit PDFs for
+		// ford.com.au, lockheedmartin.com.au, verizon.com.au — all flagged as
+		// shadowIt because the family detector did not recognise CSC's regional
+		// arms. Collapse them all to the canonical "CSC" family so analyst
+		// reasons consistently attribute defensive registration to CSC.
+		expect(normalizeRegistrar('Corporation Service Company (Aust) Pty Ltd')).toBe('CSC');
+		expect(normalizeRegistrar('Corporation Service Company, LLC')).toBe('CSC');
+		expect(normalizeRegistrar('CSC Digital Brand Services Malaysia Sdn Bhd')).toBe('CSC');
+		expect(normalizeRegistrar('CSC Digital Brand Services, Inc.')).toBe('CSC');
+		expect(normalizeRegistrar('CSC Global')).toBe('CSC');
+		expect(normalizeRegistrar('cscglobal.com')).toBe('CSC');
+	});
+
 	it('returns Unknown for empty / Unknown', () => {
 		expect(normalizeRegistrar('')).toBe('Unknown');
 		expect(normalizeRegistrar('Unknown')).toBe('Unknown');
@@ -260,6 +274,50 @@ describe('classifyCandidate', () => {
 				registrarSource: 'redacted',
 			});
 			expect(classifyCandidate(c, target()).bucket).toBe('consolidated');
+		});
+
+		// Regression: 2026-05 CSC Global sales-meeting verification.
+		// ford.com.au (CSC Australia: "Corporation Service Company (Aust) Pty Ltd")
+		// was flagged as shadowIt against ford.com (CSC US). Both are CSC. The
+		// off-primary-registrar inference must NOT fire on cross-subsidiary CSC
+		// registrations — that's defensive registration, not shadow IT.
+		it('CSC regional subsidiaries (ford.com.au CSC AU ↔ ford.com CSC US) are NOT shadowIt', () => {
+			const c = candidate({
+				domain: 'ford.com.au',
+				signals: ['markov_gen', 'ns', 'spf_include'],
+				confidence: 1,
+				registrar: 'Corporation Service Company (Aust) Pty Ltd',
+				registrarSource: 'rdap',
+			});
+			const result = classifyCandidate(
+				c,
+				target({
+					domain: 'ford.com',
+					registrar: 'CSC Corporate Domains, Inc.',
+					registrarFamily: 'CSC',
+				}),
+			);
+			expect(result.bucket).not.toBe('shadowIt');
+			expect((result as { relationshipType?: string }).relationshipType).not.toBe('owned_off_primary_registrar');
+		});
+
+		it('two CSC global subsidiaries (CSC Malaysia ↔ CSC US) classify as consolidated, not shadowIt', () => {
+			const c = candidate({
+				domain: 'verizon.com.my',
+				signals: ['markov_gen', 'ns', 'spf_include'],
+				confidence: 1,
+				registrar: 'CSC Digital Brand Services Malaysia Sdn Bhd',
+				registrarSource: 'rdap',
+			});
+			const result = classifyCandidate(
+				c,
+				target({
+					domain: 'verizon.com',
+					registrar: 'CSC Corporate Domains, Inc.',
+					registrarFamily: 'CSC',
+				}),
+			);
+			expect(result.bucket).not.toBe('shadowIt');
 		});
 	});
 

--- a/src/lib/brand-classification.ts
+++ b/src/lib/brand-classification.ts
@@ -168,10 +168,19 @@ export function normalizeRegistrar(raw: string): string {
 	if (/com\s*laude|nom[ -]?iq/.test(lower)) return 'Com Laude';
 	if (/safenames/.test(lower)) return 'SafeNames';
 	// CSC Corporate Domains operates dozens of regional entities (CSC US, CSC
-	// Canada, CSC UK, etc.) all sharing infra. Match the family, not each
-	// regional variant. Legacy regex used 'BrandAudit' as a placeholder name —
-	// see test for the production incident that surfaced this.
+	// Canada, CSC UK, CSC Digital Brand Services Malaysia, Corporation Service
+	// Company (Aust) Pty Ltd, etc.) all sharing infra. Match the family, not
+	// each regional variant. Legacy regex used 'BrandAudit' as a placeholder
+	// name — see test for the production incident that surfaced this.
+	// Regression: 2026-05 CSC Global verification of ford.com.au /
+	// lockheedmartin.com.au / verizon.com.au showed the AU subsidiary string
+	// ("Corporation Service Company (Aust) Pty Ltd") slipping through and
+	// driving false-positive shadowIt findings.
 	if (/corporate\s*domains/.test(lower)) return 'CSC';
+	if (/corporation\s+service\s+company/.test(lower)) return 'CSC';
+	if (/csc\s+digital\s+brand\s+services?/.test(lower)) return 'CSC';
+	if (/(?:^|\b)csc\s+global(?:\b|$)/.test(lower)) return 'CSC';
+	if (/(?:^|\b)cscglobal\.com(?:\b|$)/.test(lower)) return 'CSC';
 	if (/cloudflare/.test(lower)) return 'Cloudflare';
 	if (/tucows/.test(lower)) return 'Tucows';
 	if (/godaddy/.test(lower)) return 'GoDaddy';

--- a/src/lib/brand-defensive-registration.ts
+++ b/src/lib/brand-defensive-registration.ts
@@ -1,0 +1,227 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Defensive-registration heuristic.
+ *
+ * A "defensive registration" is a typosquat-shaped domain the brand owns on
+ * purpose — registered to prevent attackers from grabbing it, then parked
+ * (no real mail flow, NS at a parking provider, or a simple 301 redirect
+ * back to the canonical brand domain). Customers reading a brand-audit PDF
+ * cannot visually distinguish these from operational infrastructure even
+ * though the operational implications are very different.
+ *
+ * This module ships a pure annotation function. It is intentionally
+ * label-only and `bucket`-agnostic — the existing classifier still decides
+ * the bucket, and this heuristic only stamps `defensive: true` plus a
+ * `defensiveReason` token on the candidate metadata. The markdown / HTML
+ * renderers consume the annotation to surface a `(defensive registration)`
+ * suffix next to the candidate's line.
+ *
+ * Wiring note: today the candidate enrichment pipeline does not surface
+ * per-candidate MX records or HTTP redirect targets, so the heuristic only
+ * fires when the discovery pipeline already attached `sharedNs` metadata
+ * (the NS-correlator path). Adding a small enrichment pass for typo-close
+ * candidates is the production follow-up that turns the mastercard.com PDF
+ * fix on for the customer-visible case.
+ *
+ * Worker-runtime safe — pure string + Set operations, no Node APIs.
+ */
+
+import { extractBrandName } from './public-suffix';
+
+/** Maximum Damerau-Levenshtein distance between candidate label and target label. */
+const MAX_LABEL_DISTANCE = 2;
+
+/**
+ * Apex domains of NS providers we treat as "parked" — i.e. seeing a
+ * candidate's NS land on one of these is a strong signal the domain is not
+ * operationally hosting anything. Distinct from `SHARED_NS_APEXES` in
+ * `src/tenants/discovery/shared-ns-hosts.ts`: that set is consumed by the
+ * NS-correlator to suppress shared-tenant inflation of co-ownership
+ * confidence; this set is consumed by the defensive-registration label and
+ * uses a tighter "parking-only" definition (no registrar defaults like
+ * `domaincontrol.com` / `secureserver.net`, which can legitimately host
+ * production mail/web).
+ */
+const PARKING_NS_APEXES: ReadonlySet<string> = new Set([
+	'sedoparking.com',
+	'dan.com',
+	'parkingcrew.com',
+	'parkingcrew.net',
+	'bodis.com',
+	'uniregistry.com',
+	'afternic.com',
+	'namebright-dns.com',
+	'dotster.com',
+]);
+
+/** Discriminated token explaining why the heuristic decided a candidate is defensive. */
+export type DefensiveReason = 'redirect-to-target' | 'no-mx' | 'parked-ns';
+
+export interface DefensiveRegistrationInput {
+	/** Candidate domain (e.g. `masterard.com`). */
+	candidateDomain: string;
+	/** Target domain the audit is anchored to (e.g. `mastercard.com`). */
+	targetDomain: string;
+	/**
+	 * Candidate's MX records (hostnames only). `undefined` means "unknown
+	 * — heuristic abstains on this signal"; an empty array means "we looked
+	 * and there are no MX records" (drives the `no-mx` reason).
+	 */
+	mxRecords?: readonly string[];
+	/**
+	 * Candidate's NS hostnames. `undefined` → heuristic abstains. Used to
+	 * detect parking providers.
+	 */
+	nsHosts?: readonly string[];
+	/**
+	 * `Location:` header value the candidate's HTTP root served on a 301/302
+	 * response, if any. Used to detect "redirects back to the target".
+	 * Caller is responsible for limiting follow depth (we just inspect the
+	 * first hop). `undefined` → heuristic abstains.
+	 */
+	httpRedirectLocation?: string;
+}
+
+export interface DefensiveRegistrationResult {
+	defensive: boolean;
+	reason?: DefensiveReason;
+}
+
+/**
+ * Damerau-Levenshtein distance with adjacent-transposition. Worker-safe,
+ * O(|a|·|b|) time and space — strings are short (domain labels, ≤63 chars
+ * by RFC 1035), so this is trivially cheap.
+ *
+ * Distinct from plain Levenshtein: a single adjacent character swap (e.g.
+ * `appel` vs `apple`) costs 1 here, not 2. That branch is the reason this
+ * heuristic catches transposition typos, which are a common defensive
+ * registration shape.
+ */
+export function damerauLevenshtein(a: string, b: string): number {
+	const lenA = a.length;
+	const lenB = b.length;
+	if (lenA === 0) return lenB;
+	if (lenB === 0) return lenA;
+
+	// `d[i][j]` = distance between a[..i] and b[..j].
+	const d: number[][] = Array.from({ length: lenA + 1 }, () => new Array(lenB + 1).fill(0));
+	for (let i = 0; i <= lenA; i++) d[i]![0] = i;
+	for (let j = 0; j <= lenB; j++) d[0]![j] = j;
+
+	for (let i = 1; i <= lenA; i++) {
+		for (let j = 1; j <= lenB; j++) {
+			const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+			let best = Math.min(
+				d[i - 1]![j]! + 1, // deletion
+				d[i]![j - 1]! + 1, // insertion
+				d[i - 1]![j - 1]! + cost, // substitution
+			);
+			// Damerau adjacent-transposition branch.
+			if (i > 1 && j > 1 && a[i - 1] === b[j - 2] && a[i - 2] === b[j - 1]) {
+				best = Math.min(best, d[i - 2]![j - 2]! + 1);
+			}
+			d[i]![j] = best;
+		}
+	}
+
+	return d[lenA]![lenB]!;
+}
+
+/**
+ * Return the registered apex of an NS hostname. Pure string operation —
+ * takes the last two labels. For `ns1.sedoparking.com` → `sedoparking.com`.
+ * For hosts with longer eTLDs (`ns1.example.co.uk`) this is best-effort and
+ * may match too coarsely; we mitigate by gating callers on a small,
+ * curated allowlist of `PARKING_NS_APEXES`.
+ */
+function registeredApex(host: string): string {
+	const trimmed = host.trim().toLowerCase().replace(/\.$/, '');
+	if (!trimmed) return '';
+	const parts = trimmed.split('.');
+	if (parts.length <= 2) return trimmed;
+	return parts.slice(-2).join('.');
+}
+
+/** True if `nsHost` is a nameserver hostname operated by a known parking provider. */
+export function isParkingNsHost(nsHost: string): boolean {
+	if (!nsHost) return false;
+	return PARKING_NS_APEXES.has(registeredApex(nsHost));
+}
+
+/**
+ * Extract the second-level label from a domain, stripping the eTLD. Wraps
+ * `extractBrandName()` from `public-suffix.ts` so the comparison is
+ * label-only (`masterard` vs `mastercard`), never against the full TLD.
+ */
+function brandLabel(domain: string): string | null {
+	const label = extractBrandName(domain);
+	return label ? label.toLowerCase() : null;
+}
+
+/**
+ * True if `redirectLocation` is a URL whose host equals the target or
+ * `www.<target>`. Conservative: anything else (path-relative redirects,
+ * other domains, malformed URLs) returns false.
+ */
+function redirectsBackToTarget(redirectLocation: string, targetDomain: string): boolean {
+	const target = targetDomain.trim().toLowerCase();
+	if (!target) return false;
+	let url: URL;
+	try {
+		url = new URL(redirectLocation);
+	} catch {
+		return false;
+	}
+	const host = url.hostname.toLowerCase().replace(/\.$/, '');
+	return host === target || host === `www.${target}`;
+}
+
+/**
+ * Decide whether a candidate looks like a defensive registration.
+ *
+ * Returns `{ defensive: true, reason }` when ALL of:
+ *   - candidate's second-level label is within Damerau-Levenshtein distance
+ *     ≤ 2 of the target's second-level label, AND
+ *   - any ONE of the "minimal infrastructure" signals fires:
+ *       - HTTP 301/302 to a Location whose host is the target or `www.<target>`
+ *         → `'redirect-to-target'`
+ *       - MX record set is empty (caller looked and found none)
+ *         → `'no-mx'`
+ *       - any NS hostname matches a known parking-provider apex
+ *         → `'parked-ns'`
+ *
+ * Reason precedence (most-specific first): `redirect-to-target` >
+ * `parked-ns` > `no-mx`. The redirect signal is the strongest evidence
+ * (someone configured a redirect intentionally); parked-ns is more specific
+ * than absence-of-MX (parking is an active choice; missing MX could just
+ * mean a web-only domain).
+ *
+ * Pure function: callers (e.g. the brand-audit pipeline) feed the inputs;
+ * this returns the decision without DNS or fetch I/O.
+ */
+export function evaluateDefensiveRegistration(input: DefensiveRegistrationInput): DefensiveRegistrationResult {
+	const candidateLabel = brandLabel(input.candidateDomain);
+	const targetLabel = brandLabel(input.targetDomain);
+	if (!candidateLabel || !targetLabel) return { defensive: false };
+
+	const distance = damerauLevenshtein(candidateLabel, targetLabel);
+	if (distance > MAX_LABEL_DISTANCE) return { defensive: false };
+
+	// Reason precedence — redirect is the strongest declaration of intent.
+	if (input.httpRedirectLocation && redirectsBackToTarget(input.httpRedirectLocation, input.targetDomain)) {
+		return { defensive: true, reason: 'redirect-to-target' };
+	}
+
+	if (input.nsHosts && input.nsHosts.some((ns) => isParkingNsHost(ns))) {
+		return { defensive: true, reason: 'parked-ns' };
+	}
+
+	// `mxRecords === undefined` means "we didn't look" — abstain.
+	// `mxRecords.length === 0` means "we looked, nothing there" — fire.
+	if (input.mxRecords !== undefined && input.mxRecords.length === 0) {
+		return { defensive: true, reason: 'no-mx' };
+	}
+
+	return { defensive: false };
+}

--- a/src/lib/registrar-identity.ts
+++ b/src/lib/registrar-identity.ts
@@ -18,18 +18,43 @@ const UNKNOWN_REGISTRAR_NAMES = new Set([
 	'registrar not found in registry',
 ]);
 
-const KNOWN_REGISTRAR_FAMILIES: Array<{ family: string; patterns: RegExp[] }> = [
+/**
+ * Registrar-family detector entries.
+ *
+ * - `patterns` run against the normalized identifier (lowercased, punctuation
+ *   stripped, corporate suffixes removed) produced by `normalizeRegistrarIdentity`.
+ *   Use anchored regexes to avoid substring false-positives.
+ * - `rawPatterns` run against the raw lowercased input (no normalization).
+ *   Use sparingly — only for cases where normalization deletes the signal,
+ *   e.g. `cscglobal.com` whose URL strip removes the host.
+ */
+const KNOWN_REGISTRAR_FAMILIES: Array<{ family: string; patterns: RegExp[]; rawPatterns?: RegExp[] }> = [
 	{ family: 'markmonitor', patterns: [/^markmonitor(?:\b|$)/] },
 	{ family: 'com laude', patterns: [/(?:^|\b)com\s+laude(?:\b|$)/, /^nom\s*iq(?:\b|$)/] },
 	{ family: 'safenames', patterns: [/^safenames(?:\b|$)/] },
 	{
+		// CSC operates many regional subsidiaries (CSC US, CSC Canada, CSC UK,
+		// CSC Digital Brand Services Malaysia, Corporation Service Company (Aust)
+		// Pty Ltd, etc.) all sharing infrastructure. Collapse every regional
+		// brand string into a single family so the off-primary-registrar
+		// inference does not flag CSC-managed ccTLD registrations as shadowIt.
+		// Regression source: 2026-05 CSC Global sales-meeting verification of
+		// ford.com.au / lockheedmartin.com.au / verizon.com.au.
 		family: 'csc corporate domains',
 		patterns: [
 			/^csc\s+corporate\s+domains(?:\b|$)/,
 			/^csc\s+corp\s+domains(?:\b|$)/,
 			/^csc\s+digital\s+brand\s+services?(?:\b|$)/,
-			/^corporation\s+service(?:\s+company)?$/,
+			/^csc\s+global(?:\b|$)/,
+			// "Corporation Service Company" with any trailing regional qualifier
+			// (e.g. "Aust Pty"); corporate suffixes like Ltd/LLC are already
+			// stripped by normalizeRegistrarIdentity before this regex runs.
+			/^corporation\s+service\s+company(?:\b|$)/,
+			/^corporation\s+service$/,
 		],
+		// cscglobal.com appears verbatim in some WHOIS responses; the URL strip
+		// in normalizeRegistrarIdentity would delete it, so match against raw.
+		rawPatterns: [/(?:^|\b)cscglobal\.com(?:\b|$)/],
 	},
 	{ family: 'cloudflare', patterns: [/^cloudflare(?:\b|$)/] },
 	{ family: 'tucows', patterns: [/^tucows(?:\b|$)/] },
@@ -65,12 +90,19 @@ function normalizeIanaId(value: string | null | undefined): string | null {
 	return normalized.length > 0 ? normalized : null;
 }
 
-function knownFamily(normalizedName: string | null): string | null {
-	if (!normalizedName) return null;
-	for (const { family, patterns } of KNOWN_REGISTRAR_FAMILIES) {
-		if (patterns.some((pattern) => pattern.test(normalizedName))) return family;
+function knownFamily(normalizedName: string | null, rawLowerName: string | null): string | null {
+	if (!normalizedName && !rawLowerName) return null;
+	for (const { family, patterns, rawPatterns } of KNOWN_REGISTRAR_FAMILIES) {
+		if (normalizedName && patterns.some((pattern) => pattern.test(normalizedName))) return family;
+		if (rawLowerName && rawPatterns?.some((pattern) => pattern.test(rawLowerName))) return family;
 	}
 	return null;
+}
+
+function rawLower(raw: string | null | undefined): string | null {
+	if (!raw) return null;
+	const trimmed = raw.toLowerCase().trim();
+	return trimmed.length > 0 ? trimmed : null;
 }
 
 export function sameRegistrarFamily(left: RegistrarIdentity, right: RegistrarIdentity): boolean {
@@ -80,10 +112,15 @@ export function sameRegistrarFamily(left: RegistrarIdentity, right: RegistrarIde
 
 	const leftName = normalizeRegistrarIdentity(left.name);
 	const rightName = normalizeRegistrarIdentity(right.name);
+	const leftRaw = rawLower(left.name);
+	const rightRaw = rawLower(right.name);
+
+	const leftFamily = knownFamily(leftName, leftRaw);
+	const rightFamily = knownFamily(rightName, rightRaw);
+	if (leftFamily && leftFamily === rightFamily) return true;
+
 	if (!leftName || !rightName) return false;
 	if (leftName === rightName) return true;
 
-	const leftFamily = knownFamily(leftName);
-	const rightFamily = knownFamily(rightName);
-	return !!leftFamily && leftFamily === rightFamily;
+	return false;
 }

--- a/src/tools/brand-audit-get-report.ts
+++ b/src/tools/brand-audit-get-report.ts
@@ -20,6 +20,7 @@
 
 import { buildCheckResult, createFinding, type CheckResult } from '../lib/scoring';
 import type { BrandAuditStatus } from '../lib/db/brand-audit-schema';
+import { BRAND_AUDIT_TARGET_DEADLINE_MS } from '../lib/brand-audit-reaper';
 
 const CATEGORY = 'brand_discovery';
 
@@ -34,6 +35,8 @@ export interface BrandAuditGetReportDeps {
 	bucket?: { createSignedUrl?: (input: { key: string; expiresInSeconds: number }) => Promise<string> };
 	/** TTL for the signed URL — defaults to 7 days, override for tests. */
 	signedUrlTtlSeconds?: number;
+	/** Clock override for tests + dead-zone closure. */
+	now?: () => number;
 }
 
 interface AuditRowSlim {
@@ -52,6 +55,7 @@ interface TargetRowSlim {
 	pdf_r2_key: string | null;
 	error: string | null;
 	completed_at: number | null;
+	created_at: number;
 }
 
 function errorResult(flag: string, message: string, extra: Record<string, unknown> = {}): CheckResult {
@@ -93,7 +97,7 @@ export async function brandAuditGetReport(
 	if (target) {
 		const targetRow = (await deps.db
 			.prepare(
-				'SELECT audit_id, target, status, result_json, pdf_r2_key, error, completed_at FROM brand_audit_targets WHERE audit_id = ? AND target = ? LIMIT 1',
+				'SELECT audit_id, target, status, result_json, pdf_r2_key, error, completed_at, created_at FROM brand_audit_targets WHERE audit_id = ? AND target = ? LIMIT 1',
 			)
 			.bind(auditId, target.trim().toLowerCase())
 			.first()) as TargetRowSlim | null;
@@ -102,9 +106,35 @@ export async function brandAuditGetReport(
 			return errorResult('notFound', `Target ${target} not in audit ${auditId}.`, { auditId, target });
 		}
 
+		// Dead-zone closure (2026-05-21 disney.com hang). A `running` target past
+		// its budget deadline is one the consumer couldn't self-flip — surface
+		// it as terminal-failed here so the customer doesn't get told "poll
+		// again" for the next 15 minutes. Mirrors the closure in
+		// `brand_audit_status`. Best-effort UPDATE persists the flip; failure is
+		// swallowed because the response is the durability contract.
+		const now = (deps.now ?? Date.now)();
+		const isStuck = targetRow.status === 'running' && now - targetRow.created_at > BRAND_AUDIT_TARGET_DEADLINE_MS;
+		if (isStuck) {
+			try {
+				await deps.db
+					.prepare(
+						"UPDATE brand_audit_targets SET status = 'failed', error = ?, completed_at = ? WHERE audit_id = ? AND target = ? AND status = 'running'",
+					)
+					.bind(
+						`read-path: target stuck >${Math.floor(BRAND_AUDIT_TARGET_DEADLINE_MS / 60_000)}min; consumer cap did not flip status`,
+						now,
+						auditId,
+						targetRow.target,
+					)
+					.run();
+			} catch {
+				// Best-effort — next read or reaper tick retries the persistence.
+			}
+		}
+
 		const parsed = safeParse(targetRow.result_json);
 		const renderedStatus: BrandAuditStatus =
-			targetRow.status === 'failed'
+			targetRow.status === 'failed' || isStuck
 				? 'failed'
 				: auditRow.status === 'completed' && parsed !== null
 					? 'completed'
@@ -155,7 +185,9 @@ export async function brandAuditGetReport(
 					target: targetRow.target,
 					status: renderedStatus,
 					result: parsed,
-					error: targetRow.error,
+					error: isStuck
+						? `read-path: target stuck >${Math.floor(BRAND_AUDIT_TARGET_DEADLINE_MS / 60_000)}min; consumer cap did not flip status`
+						: targetRow.error,
 					pdfUrl,
 					pdfPending,
 				},

--- a/src/tools/brand-audit-status.ts
+++ b/src/tools/brand-audit-status.ts
@@ -15,6 +15,7 @@
 
 import { buildCheckResult, createFinding, type CheckResult } from '../lib/scoring';
 import type { BrandAuditStatus } from '../lib/db/brand-audit-schema';
+import { BRAND_AUDIT_TARGET_DEADLINE_MS } from '../lib/brand-audit-reaper';
 
 const CATEGORY = 'brand_discovery';
 
@@ -94,15 +95,66 @@ export async function brandAuditStatus(
 
 	const now = (deps.now ?? Date.now)();
 	const progress = `${audit.completed_targets}/${audit.total_targets}`;
+
+	// Dead-zone closure (2026-05-21 disney.com hang). A `running` target whose
+	// row is older than BRAND_AUDIT_TARGET_DEADLINE_MS is past the point where
+	// the consumer could have flipped it itself — its worker was killed before
+	// the catch handler ran (CPU-saturated tier-1 brands starve the abort-fire
+	// macrotask). The cron reaper would catch it eventually, but the customer
+	// polling this endpoint shouldn't have to wait an extra cron tick. We:
+	//   1. Surface it as `failed` in the response so the customer sees terminal
+	//      progress immediately.
+	//   2. Fire a best-effort UPDATE so the next reader (and the reaper) see
+	//      consistent state. Failure is swallowed — the next reaper tick or
+	//      polling read will retry the same flip.
+	const deadZoneTargets: BrandAuditTargetRow[] = [];
 	const renderedTargets = targets.map((t) => {
 		const hasResultJson = typeof t.result_json === 'string' && t.result_json.length > 0;
-		const renderedStatus: BrandAuditStatus = audit.status === 'completed' && t.status !== 'failed' && hasResultJson ? 'completed' : t.status;
+		const isStuck = t.status === 'running' && now - t.created_at > BRAND_AUDIT_TARGET_DEADLINE_MS;
+		if (isStuck) {
+			deadZoneTargets.push(t);
+		}
+		let renderedStatus: BrandAuditStatus = t.status;
+		if (isStuck) {
+			renderedStatus = 'failed';
+		} else if (audit.status === 'completed' && t.status !== 'failed' && hasResultJson) {
+			renderedStatus = 'completed';
+		}
 		return {
 			row: t,
 			status: renderedStatus,
 			completedAt: renderedStatus === 'completed' ? t.completed_at ?? audit.completed_at : t.completed_at,
+			synthesisedError: isStuck
+				? `target stuck >${Math.floor(BRAND_AUDIT_TARGET_DEADLINE_MS / 60_000)}min in running; consumer cap did not flip status (read-path closure)`
+				: null,
 		};
 	});
+
+	// Fire-and-forget persistence of synthesised failures. We await each UPDATE
+	// (single-row D1 writes are sub-50ms typically) so the next read by anyone
+	// — customer, reaper, brand_audit_get_report — observes the corrected
+	// state. We swallow throws because the response payload is the durability
+	// contract for the polling customer; persistence catches up on subsequent
+	// reads / the next reaper tick.
+	if (deadZoneTargets.length > 0) {
+		for (const t of deadZoneTargets) {
+			try {
+				await deps.db
+					.prepare(
+						"UPDATE brand_audit_targets SET status = 'failed', error = ?, completed_at = ? WHERE audit_id = ? AND target = ? AND status = 'running'",
+					)
+					.bind(
+						`read-path: target stuck >${Math.floor(BRAND_AUDIT_TARGET_DEADLINE_MS / 60_000)}min; consumer cap did not flip status`,
+						now,
+						t.audit_id,
+						t.target,
+					)
+					.run();
+			} catch {
+				// Best-effort — see comment above.
+			}
+		}
+	}
 	const targetStatusCounts = {
 		queued: renderedTargets.filter((t) => t.status === 'queued').length,
 		running: renderedTargets.filter((t) => t.status === 'running').length,
@@ -135,12 +187,12 @@ export async function brandAuditStatus(
 			updatedAgeMs,
 			targetStatusCounts,
 			warnings,
-			targets: renderedTargets.map(({ row, status, completedAt }) => ({
+			targets: renderedTargets.map(({ row, status, completedAt, synthesisedError }) => ({
 				target: row.target,
 				status,
 				createdAt: row.created_at,
 				completedAt,
-				error: row.error,
+				error: synthesisedError ?? row.error,
 				hasPdf: row.pdf_r2_key !== null,
 			})),
 		},

--- a/test/brand-audit-get-report.integration.test.ts
+++ b/test/brand-audit-get-report.integration.test.ts
@@ -144,6 +144,103 @@ describe('brandAuditGetReport', () => {
 		expect(summary?.metadata?.aggregate).toMatchObject({ totalCandidates: 7 });
 	});
 
+	// Dead-zone closure (2026-05-21 disney.com hang). See
+	// brand-audit-status.integration.test.ts for the full rationale.
+	describe('dead-zone closure for stuck running targets', () => {
+		it('synthesises status=failed for a running target whose deadline has passed', async () => {
+			const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 5_000;
+			const { db } = makeMockD1({
+				audit: { id: 'aud-disney', owner_id: 'owner-abc', status: 'running', format: 'json' },
+				target: {
+					audit_id: 'aud-disney',
+					target: 'disney.com',
+					status: 'running',
+					result_json: null,
+					error: null,
+					completed_at: null,
+					created_at: createdAt,
+				},
+			});
+
+			const result = await brandAuditGetReport(
+				{ auditId: 'aud-disney', target: 'disney.com' },
+				'owner-abc',
+				{ db, now: () => now },
+			);
+
+			// No more "notReady" for the duration of the dead zone.
+			expect(result.findings.find((f) => f.metadata?.notReady === true)).toBeUndefined();
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+			expect(summary?.metadata?.status).toBe('failed');
+			expect(summary?.metadata?.error).toMatch(/stuck/i);
+		});
+
+		it('issues a best-effort UPDATE to persist the synthesised failed status', async () => {
+			const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 5_000;
+			const { db, calls } = makeMockD1({
+				audit: { id: 'aud-disney', owner_id: 'owner-abc', status: 'running', format: 'json' },
+				target: {
+					audit_id: 'aud-disney',
+					target: 'disney.com',
+					status: 'running',
+					result_json: null,
+					error: null,
+					completed_at: null,
+					created_at: createdAt,
+				},
+			});
+
+			await brandAuditGetReport(
+				{ auditId: 'aud-disney', target: 'disney.com' },
+				'owner-abc',
+				{ db, now: () => now },
+			);
+
+			const persistFlip = calls.find(
+				(c) =>
+					c.sql.includes('UPDATE brand_audit_targets') &&
+					c.sql.includes("status = 'failed'") &&
+					c.sql.includes("status = 'running'") &&
+					(c.binds as unknown[]).includes('disney.com'),
+			);
+			expect(persistFlip).toBeDefined();
+		});
+
+		it('does NOT synthesise failed for a running target still within deadline', async () => {
+			const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS - 60_000;
+			const { db } = makeMockD1({
+				audit: { id: 'aud-inflight', owner_id: 'owner-abc', status: 'running', format: 'json' },
+				target: {
+					audit_id: 'aud-inflight',
+					target: 'example.com',
+					status: 'running',
+					result_json: null,
+					error: null,
+					completed_at: null,
+					created_at: createdAt,
+				},
+			});
+
+			const result = await brandAuditGetReport(
+				{ auditId: 'aud-inflight', target: 'example.com' },
+				'owner-abc',
+				{ db, now: () => now },
+			);
+
+			// Legitimate in-flight audit still returns notReady, not synthesised-failed.
+			expect(result.findings.find((f) => f.metadata?.notReady === true)).toBeDefined();
+		});
+	});
+
 	it('owner-scoping: someone else\'s auditId surfaces as notFound', async () => {
 		const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
 		const { db } = makeMockD1({

--- a/test/brand-audit-markdown.test.ts
+++ b/test/brand-audit-markdown.test.ts
@@ -68,6 +68,59 @@ describe('formatBrandAuditMarkdown', () => {
 		expect(markdown.indexOf('pphosted.example')).toBeGreaterThan(markdown.indexOf('## Authorized Vendor Dependencies'));
 	});
 
+	it('annotates defensive registrations with a "(defensive registration)" suffix', () => {
+		const result: CheckResult = {
+			category: 'brand_discovery',
+			score: 100,
+			findings: [
+				{
+					category: 'brand_discovery',
+					title: 'summary',
+					severity: 'info',
+					detail: '',
+					metadata: {
+						summary: true,
+						target: 'mastercard.com',
+						consolidated: 1,
+						shadowIt: 0,
+						indeterminate: 0,
+						impersonation: 0,
+					},
+				},
+				{
+					category: 'brand_discovery',
+					title: 'Brand candidate: masterard.com',
+					severity: 'info',
+					detail: '',
+					metadata: {
+						candidate: 'masterard.com',
+						bucket: 'consolidated',
+						relationshipType: 'owned_primary',
+						registrar: 'CSC Corporate Domains',
+						registrarSource: 'rdap',
+						reasons: ['shared registrar family (CSC) + 2 corroborating signals'],
+						signals: ['ns', 'san'],
+						combinedConfidence: 0.9,
+						defensive: true,
+						defensiveReason: 'parked-ns',
+					},
+				},
+			],
+		};
+
+		const markdown = formatBrandAuditMarkdown(result);
+
+		// Candidate still belongs in the Consolidated section — we label, not re-bucket.
+		expect(markdown).toContain('## Consolidated (owned/operated by the brand)');
+		expect(markdown).toContain('masterard.com');
+		// And carries the defensive-registration tag inline. The label is wrapped
+		// in markdown italics and includes the reason discriminant; assert the
+		// canonical prefix rather than the exact closing-paren form so the test
+		// is robust to reason-token additions.
+		expect(markdown).toContain('defensive registration');
+		expect(markdown).toContain('parked-ns');
+	});
+
 	it('surfaces discovery depth warnings from the summary metadata', () => {
 		const result: CheckResult = {
 			category: 'brand_discovery',

--- a/test/brand-audit-pipeline.test.ts
+++ b/test/brand-audit-pipeline.test.ts
@@ -557,6 +557,60 @@ describe('runBrandAuditPipeline — T13 BRAND_AUDIT_DISCOVERY_MODE_DEFAULT env o
 		expect(summary?.metadata?.discoveryMode).toBe('tiered');
 	});
 
+	it('stamps defensive=true on a classified candidate whose discovery observation carries parking NS', async () => {
+		// `masterard.com` vs `mastercard.com` — label distance 1, NS at sedoparking.
+		// The pipeline must surface `defensive: true` and the precise reason on
+		// the classified finding's metadata.
+		const discovery = discoveryResult('mastercard.com', ['masterard.com']);
+		const candidate = discovery.findings.find((f) => f.metadata?.candidate === 'masterard.com');
+		candidate!.metadata = {
+			...candidate!.metadata,
+			signals: ['ns'],
+			combinedConfidence: 0.5,
+			evidenceObservations: [
+				{ signal: 'ns', metadata: { sharedNs: ['ns1.sedoparking.com', 'ns2.sedoparking.com'] } },
+			],
+		};
+		const checkRdapLookup = vi.fn(async (domain: string) => {
+			if (domain === 'mastercard.com') return rdapResult('CSC Corporate Domains, Inc.', 'Mastercard Inc.', '299');
+			return rdapResult('CSC Corporate Domains, Inc.', 'Mastercard Inc.', '299');
+		});
+
+		const result = await runBrandAuditPipeline(
+			'mastercard.com',
+			{ auditId: 'aud-defensive' },
+			{ discoverBrandDomains: vi.fn().mockResolvedValue(discovery), checkRdapLookup },
+		);
+		const finding = result.findings.find((f) => f.metadata?.candidate === 'masterard.com');
+
+		expect(finding?.metadata?.defensive).toBe(true);
+		expect(finding?.metadata?.defensiveReason).toBe('parked-ns');
+	});
+
+	it('does NOT stamp defensive on a candidate that is not label-close to the target', async () => {
+		// `bigbank.com` vs `mastercard.com` — distance far above the threshold,
+		// even though the candidate's NS happens to overlap a parking provider.
+		const discovery = discoveryResult('mastercard.com', ['bigbank.com']);
+		const candidate = discovery.findings.find((f) => f.metadata?.candidate === 'bigbank.com');
+		candidate!.metadata = {
+			...candidate!.metadata,
+			signals: ['ns'],
+			combinedConfidence: 0.5,
+			evidenceObservations: [{ signal: 'ns', metadata: { sharedNs: ['ns1.sedoparking.com'] } }],
+		};
+		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'Mastercard Inc.'));
+
+		const result = await runBrandAuditPipeline(
+			'mastercard.com',
+			{ auditId: 'aud-notdefensive' },
+			{ discoverBrandDomains: vi.fn().mockResolvedValue(discovery), checkRdapLookup },
+		);
+		const finding = result.findings.find((f) => f.metadata?.candidate === 'bigbank.com');
+
+		expect(finding?.metadata?.defensive).toBeUndefined();
+		expect(finding?.metadata?.defensiveReason).toBeUndefined();
+	});
+
 	it('stamps discoveryMode and tiers when env-defaulted tiered run surfaces zero candidates', async () => {
 		const discoverBrandDomains = vi.fn().mockResolvedValue(tieredEmptyDiscoveryResult('example.com'));
 		const checkRdapLookup = vi.fn().mockResolvedValue(rdapResult('MarkMonitor Inc.', 'Example Inc.'));

--- a/test/brand-audit-reaper.test.ts
+++ b/test/brand-audit-reaper.test.ts
@@ -10,6 +10,7 @@ import {
 	reapStuckBrandAudits,
 	STUCK_TARGET_THRESHOLD_MS,
 	MAX_REAP_PER_TICK,
+	BRAND_AUDIT_TARGET_DEADLINE_MS,
 } from '../src/lib/brand-audit-reaper';
 
 interface MockOpts {
@@ -162,6 +163,24 @@ describe('reapStuckBrandAudits', () => {
 		expect(result.reapedTargets).toBe(0);
 		const counterTick = calls.find((c) => c.sql.includes('UPDATE brand_audits SET completed_targets'));
 		expect(counterTick).toBeUndefined();
+	});
+
+	it('uses a 10-minute STUCK_TARGET_THRESHOLD_MS (tightened from 15min after the 2026-05-21 disney dead-zone investigation)', () => {
+		// The consumer cap is 5 min. We previously waited 15min to reap, leaving
+		// a 5–15min dead zone. The read-path piggyback in `brand_audit_status`
+		// now handles polling customers near-instantly; the cron reaper still
+		// catches non-polled audits, but at 10min instead of 15min.
+		expect(STUCK_TARGET_THRESHOLD_MS).toBe(10 * 60 * 1000);
+	});
+
+	it('exposes BRAND_AUDIT_TARGET_DEADLINE_MS for the read-path piggyback (~7min)', () => {
+		// Consumer cap (300s) + 120s grace for queue delivery lag + cap-fire
+		// macrotask + D1 flip. Used by `brand_audit_status` /
+		// `brand_audit_get_report` to synthesise `failed` for targets the
+		// consumer can no longer save. MUST be < STUCK_TARGET_THRESHOLD_MS so
+		// the read path acts before the reaper.
+		expect(BRAND_AUDIT_TARGET_DEADLINE_MS).toBe(7 * 60 * 1000);
+		expect(BRAND_AUDIT_TARGET_DEADLINE_MS).toBeLessThan(STUCK_TARGET_THRESHOLD_MS);
 	});
 
 	it('continues reaping other rows when one flip throws', async () => {

--- a/test/brand-audit-status.integration.test.ts
+++ b/test/brand-audit-status.integration.test.ts
@@ -82,7 +82,10 @@ describe('brandAuditStatus', () => {
 			],
 		});
 
-		const result = await brandAuditStatus('aud-1', 'owner-abc', { db });
+		// Pin `now` close to created_at so the dead-zone closure (which would
+		// otherwise mark a `running` target older than ~6min as failed) leaves
+		// the row alone — this test asserts the standard rendering path.
+		const result = await brandAuditStatus('aud-1', 'owner-abc', { db, now: () => 1_750_000_060_000 });
 
 		const summary = result.findings.find((f) => f.metadata?.summary === true);
 		expect(summary?.metadata?.auditId).toBe('aud-1');
@@ -129,7 +132,10 @@ describe('brandAuditStatus', () => {
 			],
 		});
 
-		const result = await brandAuditStatus('aud-race', 'owner-abc', { db });
+		// Pin `now` so the legacy `running` target with an older created_at
+		// isn't swept by the dead-zone closure; this case asserts the
+		// completed-parent + result_json coalesce path.
+		const result = await brandAuditStatus('aud-race', 'owner-abc', { db, now: () => 1_750_000_120_000 });
 
 		const summary = result.findings.find((f) => f.metadata?.summary === true);
 		expect(summary?.metadata?.targetStatusCounts).toEqual({
@@ -221,5 +227,223 @@ describe('brandAuditStatus', () => {
 		const result = await brandAuditStatus('', 'owner-abc', makeDeps());
 		const invalid = result.findings.find((f) => f.metadata?.invalidInput === true);
 		expect(invalid).toBeDefined();
+	});
+
+	// Dead-zone closure tests (2026-05-21 disney.com hang).
+	//
+	// When the consumer's 300s `Promise.race` cap fires but the worker is
+	// killed before the catch UPDATE commits (CPU-saturated tier-1 brands —
+	// disney.com / walmart.com), the target row stays `status='running'`
+	// indefinitely until the next 15-min cron reaper tick. Customer polling
+	// `brand_audit_status` during the 5–15 min dead zone sees progress 0/1
+	// forever.
+	//
+	// Closure: `brand_audit_status` synthesises `failed` for any `running`
+	// target older than {@link BRAND_AUDIT_TARGET_DEADLINE_MS} (~6 min — the
+	// 300s consumer cap + 60s grace for cap-fire macrotask + D1 flip), AND
+	// issues a best-effort UPDATE so the persisted row catches up. This
+	// closes the customer-perceived dead zone to ~0s because the customer is
+	// the polling agent.
+	describe('dead-zone closure for stuck running targets', () => {
+		it('synthesises status=failed for a running target whose deadline has passed', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 5_000; // 5s past deadline
+			const { db } = makeMockD1({
+				audit: {
+					id: 'aud-disney',
+					owner_id: 'owner-abc',
+					status: 'running',
+					total_targets: 1,
+					completed_targets: 0,
+					format: 'json',
+					created_at: createdAt,
+					updated_at: createdAt,
+					completed_at: null,
+				},
+				targets: [
+					{
+						audit_id: 'aud-disney',
+						target: 'disney.com',
+						status: 'running',
+						created_at: createdAt,
+						completed_at: null,
+						error: null,
+						pdf_r2_key: null,
+						result_json: null,
+					},
+				],
+			});
+
+			const result = await brandAuditStatus('aud-disney', 'owner-abc', { db, now: () => now });
+
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+			// Customer sees a terminal status now — not "running" forever.
+			expect(summary?.metadata?.targetStatusCounts).toMatchObject({ running: 0, failed: 1 });
+			const targets = summary?.metadata?.targets as Array<{ target: string; status: string; error: string | null }>;
+			expect(targets[0]).toMatchObject({ target: 'disney.com', status: 'failed' });
+			expect(targets[0].error).toMatch(/deadline|stuck/i);
+		});
+
+		it('issues a best-effort UPDATE to persist the synthesised failed status', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 5_000;
+			const { db, calls } = makeMockD1({
+				audit: {
+					id: 'aud-disney',
+					owner_id: 'owner-abc',
+					status: 'running',
+					total_targets: 1,
+					completed_targets: 0,
+					format: 'json',
+					created_at: createdAt,
+					updated_at: createdAt,
+					completed_at: null,
+				},
+				targets: [
+					{
+						audit_id: 'aud-disney',
+						target: 'disney.com',
+						status: 'running',
+						created_at: createdAt,
+						completed_at: null,
+						error: null,
+						pdf_r2_key: null,
+						result_json: null,
+					},
+				],
+			});
+
+			await brandAuditStatus('aud-disney', 'owner-abc', { db, now: () => now });
+
+			const persistFlip = calls.find(
+				(c) =>
+					c.sql.includes('UPDATE brand_audit_targets') &&
+					c.sql.includes("status = 'failed'") &&
+					c.sql.includes("status = 'running'") &&
+					(c.binds as unknown[]).includes('disney.com'),
+			);
+			expect(persistFlip).toBeDefined();
+		});
+
+		it('does NOT synthesise failed for a running target still within deadline', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			// 60s inside the deadline — a normal in-flight deep audit at the
+			// 2-minute mark.
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS - 60_000;
+			const { db, calls } = makeMockD1({
+				audit: {
+					id: 'aud-inflight',
+					owner_id: 'owner-abc',
+					status: 'running',
+					total_targets: 1,
+					completed_targets: 0,
+					format: 'json',
+					created_at: createdAt,
+					updated_at: createdAt + 30_000,
+					completed_at: null,
+				},
+				targets: [
+					{
+						audit_id: 'aud-inflight',
+						target: 'example.com',
+						status: 'running',
+						created_at: createdAt,
+						completed_at: null,
+						error: null,
+						pdf_r2_key: null,
+						result_json: null,
+					},
+				],
+			});
+
+			const result = await brandAuditStatus('aud-inflight', 'owner-abc', { db, now: () => now });
+
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+			expect(summary?.metadata?.targetStatusCounts).toMatchObject({ running: 1, failed: 0 });
+			// No persist flip happens during a normal in-flight audit.
+			const persistFlip = calls.find(
+				(c) =>
+					c.sql.includes('UPDATE brand_audit_targets') &&
+					c.sql.includes("status = 'failed'"),
+			);
+			expect(persistFlip).toBeUndefined();
+		});
+
+		it('swallows D1 write failure on the synthetic flip (read path stays responsive)', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 5_000;
+			// Build a custom D1 mock that throws on UPDATE — the read path must
+			// still return a synthesised failed status to the caller.
+			const calls: D1Call[] = [];
+			const db = {
+				prepare(sql: string) {
+					let binds: unknown[] = [];
+					const stmt = {
+						bind(...args: unknown[]) {
+							binds = args;
+							return stmt;
+						},
+						async first() {
+							calls.push({ sql, binds });
+							if (sql.includes('FROM brand_audits')) {
+								return {
+									id: 'aud-disney',
+									owner_id: 'owner-abc',
+									status: 'running',
+									total_targets: 1,
+									completed_targets: 0,
+									format: 'json',
+									created_at: createdAt,
+									updated_at: createdAt,
+									completed_at: null,
+								};
+							}
+							return null;
+						},
+						async all() {
+							calls.push({ sql, binds });
+							if (sql.includes('FROM brand_audit_targets')) {
+								return {
+									results: [
+										{
+											audit_id: 'aud-disney',
+											target: 'disney.com',
+											status: 'running',
+											created_at: createdAt,
+											completed_at: null,
+											error: null,
+											pdf_r2_key: null,
+											result_json: null,
+										},
+									],
+									success: true,
+									meta: {},
+								};
+							}
+							return { results: [], success: true, meta: {} };
+						},
+						async run() {
+							calls.push({ sql, binds });
+							throw new Error('d1_update_failed');
+						},
+					};
+					return stmt;
+				},
+			} as unknown as D1Database;
+
+			const result = await brandAuditStatus('aud-disney', 'owner-abc', { db, now: () => now });
+
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+			// Even though persist failed, customer still sees terminal status.
+			expect(summary?.metadata?.targetStatusCounts).toMatchObject({ running: 0, failed: 1 });
+		});
 	});
 });

--- a/test/brand-defensive-registration.test.ts
+++ b/test/brand-defensive-registration.test.ts
@@ -1,0 +1,201 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Unit tests for the defensive-registration heuristic.
+ *
+ * Real-world motivation: brand-audit PDF for mastercard.com shipped
+ * `masterard.com` (a defensive typosquat Mastercard owns on purpose) inside
+ * the `consolidated` bucket alongside operational properties, with no
+ * visual distinction between the two. The heuristic flags candidates that
+ * are (a) close in label-distance to the target AND (b) show only minimal
+ * infrastructure, so the renderer can label them `(defensive registration)`.
+ *
+ * Pure function tests — no DNS, no network. The pipeline owns the wiring.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	damerauLevenshtein,
+	evaluateDefensiveRegistration,
+	isParkingNsHost,
+} from '../src/lib/brand-defensive-registration';
+
+describe('damerauLevenshtein', () => {
+	it('returns 0 for identical strings', () => {
+		expect(damerauLevenshtein('mastercard', 'mastercard')).toBe(0);
+	});
+
+	it('returns 1 for a single deletion (masterard vs mastercard)', () => {
+		expect(damerauLevenshtein('masterard', 'mastercard')).toBe(1);
+	});
+
+	it('returns 1 for a single insertion (gooogle vs google)', () => {
+		expect(damerauLevenshtein('gooogle', 'google')).toBe(1);
+	});
+
+	it('returns 1 for an adjacent transposition (appel vs apple)', () => {
+		// Plain Levenshtein scores this 2 (delete + insert); the Damerau
+		// adjacent-transposition branch must drop it to 1.
+		expect(damerauLevenshtein('appel', 'apple')).toBe(1);
+	});
+
+	it('returns 2 for two edits (mstrcrd vs mastercard)', () => {
+		// 3 deletions actually; check that distance grows
+		expect(damerauLevenshtein('mstrcrd', 'mastercard')).toBeGreaterThanOrEqual(3);
+	});
+
+	it('handles empty strings', () => {
+		expect(damerauLevenshtein('', 'apple')).toBe(5);
+		expect(damerauLevenshtein('apple', '')).toBe(5);
+		expect(damerauLevenshtein('', '')).toBe(0);
+	});
+
+	it('large distance for unrelated words', () => {
+		expect(damerauLevenshtein('bigbank', 'mastercard')).toBeGreaterThan(2);
+	});
+});
+
+describe('isParkingNsHost', () => {
+	it('matches sedoparking subdomains', () => {
+		expect(isParkingNsHost('ns1.sedoparking.com')).toBe(true);
+		expect(isParkingNsHost('ns2.sedoparking.com')).toBe(true);
+	});
+
+	it('matches all task-listed parking apexes', () => {
+		expect(isParkingNsHost('ns1.dan.com')).toBe(true);
+		expect(isParkingNsHost('ns2.parkingcrew.net')).toBe(true);
+		expect(isParkingNsHost('ns1.bodis.com')).toBe(true);
+		expect(isParkingNsHost('ns1.uniregistry.com')).toBe(true);
+		expect(isParkingNsHost('ns2.afternic.com')).toBe(true);
+		expect(isParkingNsHost('ns1.namebright-dns.com')).toBe(true);
+		expect(isParkingNsHost('ns1.dotster.com')).toBe(true);
+	});
+
+	it('does not match hyperscaler NS', () => {
+		expect(isParkingNsHost('alex.ns.cloudflare.com')).toBe(false);
+		expect(isParkingNsHost('ns-123.awsdns-45.com')).toBe(false);
+		expect(isParkingNsHost('ns1.google.com')).toBe(false);
+	});
+
+	it('returns false for empty or malformed input', () => {
+		expect(isParkingNsHost('')).toBe(false);
+	});
+});
+
+describe('evaluateDefensiveRegistration', () => {
+	it('flags masterard.com vs mastercard.com when NS is parked (parked-ns)', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'masterard.com',
+			targetDomain: 'mastercard.com',
+			nsHosts: ['ns1.sedoparking.com', 'ns2.sedoparking.com'],
+		});
+		expect(result.defensive).toBe(true);
+		// `parked-ns` is a sufficient reason on its own; report it precisely.
+		expect(result.reason).toBe('parked-ns');
+	});
+
+	it('flags masterard.com vs mastercard.com when MX is absent (no-mx)', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'masterard.com',
+			targetDomain: 'mastercard.com',
+			mxRecords: [],
+			nsHosts: ['some.unknown.ns.example'],
+		});
+		expect(result.defensive).toBe(true);
+		expect(result.reason).toBe('no-mx');
+	});
+
+	it('flags gooogle.com vs google.com on redirect-to-target', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'gooogle.com',
+			targetDomain: 'google.com',
+			httpRedirectLocation: 'https://google.com/',
+		});
+		expect(result.defensive).toBe(true);
+		expect(result.reason).toBe('redirect-to-target');
+	});
+
+	it('flags redirect to www subdomain of target as defensive', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'gooogle.com',
+			targetDomain: 'google.com',
+			httpRedirectLocation: 'https://www.google.com/path',
+		});
+		expect(result.defensive).toBe(true);
+		expect(result.reason).toBe('redirect-to-target');
+	});
+
+	it('does NOT flag appel.com when it has real MX + non-parked NS + no redirect', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'appel.com',
+			targetDomain: 'apple.com',
+			mxRecords: ['mx1.someprovider.com', 'mx2.someprovider.com'],
+			nsHosts: ['alex.ns.cloudflare.com', 'kate.ns.cloudflare.com'],
+		});
+		expect(result.defensive).toBe(false);
+		expect(result.reason).toBeUndefined();
+	});
+
+	it('does NOT flag bigbank.com vs mastercard.com (label distance too high)', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'bigbank.com',
+			targetDomain: 'mastercard.com',
+			mxRecords: [],
+			nsHosts: ['ns1.sedoparking.com'],
+		});
+		// Distance fails even though infra signals would otherwise match.
+		expect(result.defensive).toBe(false);
+	});
+
+	it('compares second-level label only, not full TLD', () => {
+		// `mastercard.co.uk` should compare `mastercard` against `mastercard`,
+		// not `mastercard.co.uk` vs `mastercard.com`.
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'mastercard.co.uk',
+			targetDomain: 'mastercard.com',
+			nsHosts: ['ns1.sedoparking.com'],
+		});
+		// Labels are identical → distance 0 ≤ 2 → defensive when minimal infra.
+		expect(result.defensive).toBe(true);
+	});
+
+	it('does NOT flag when no minimal-infra signal supplied (heuristic abstains)', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'masterard.com',
+			targetDomain: 'mastercard.com',
+			// No mxRecords / nsHosts / httpRedirectLocation supplied.
+		});
+		expect(result.defensive).toBe(false);
+		expect(result.reason).toBeUndefined();
+	});
+
+	it('does NOT flag a redirect pointing to an unrelated domain', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'gooogle.com',
+			targetDomain: 'google.com',
+			httpRedirectLocation: 'https://malicious.example/landing',
+		});
+		expect(result.defensive).toBe(false);
+	});
+
+	it('handles invalid candidate / target labels gracefully', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: '',
+			targetDomain: 'mastercard.com',
+			nsHosts: ['ns1.sedoparking.com'],
+		});
+		expect(result.defensive).toBe(false);
+	});
+
+	it('still flags when distance is exactly 2', () => {
+		// `mstercard` vs `mastercard` — single deletion, distance 1. Pick a
+		// distance-2 case: drop two chars.
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'mstrcard.com',
+			targetDomain: 'mastercard.com',
+			nsHosts: ['ns1.sedoparking.com'],
+		});
+		// 'mstrcard' vs 'mastercard' — distance 2 (two insertions).
+		expect(result.defensive).toBe(true);
+	});
+});

--- a/test/registrar-identity.test.ts
+++ b/test/registrar-identity.test.ts
@@ -58,6 +58,39 @@ describe('registrar identity matching', () => {
 		expect(sameRegistrarFamily({ name: 'REG-IPMIRROR' }, target)).toBe(false);
 	});
 
+	// Regression: 2026-05 CSC Global sales-meeting verification surfaced false-positive
+	// shadowIt findings on ford.com.au, lockheedmartin.com.au, verizon.com.au because
+	// the registrar display string contained "Corporation Service Company (Aust) Pty Ltd"
+	// — CSC's Australian arm — and the family detector did not collapse it to CSC.
+	it('matches CSC global regional subsidiary registrar strings (Aust Pty Ltd, Digital Brand Services, CSC Global)', () => {
+		const target: RegistrarIdentity = { name: 'CSC Corporate Domains, Inc.' };
+		for (const variant of [
+			'Corporation Service Company (Aust) Pty Ltd',
+			'Corporation Service Company, LLC',
+			'CSC Digital Brand Services Malaysia Sdn Bhd',
+			'CSC Digital Brand Services, Inc.',
+			'CSC Global',
+			'cscglobal.com',
+			'https://cscglobal.com',
+		]) {
+			expect(sameRegistrarFamily({ name: variant }, target), variant).toBe(true);
+		}
+	});
+
+	it('groups two CSC-subsidiary candidates into the same registrar family (consolidated, not shadowIt)', () => {
+		// Two regional CSC subsidiaries observed verbatim in production WHOIS
+		// for ford.com.au, lockheedmartin.com.au, verizon.com.au, etc.
+		const fordAu: RegistrarIdentity = { name: 'Corporation Service Company (Aust) Pty Ltd' };
+		const cscMalaysia: RegistrarIdentity = { name: 'CSC Digital Brand Services Malaysia Sdn Bhd' };
+		const cscUs: RegistrarIdentity = { name: 'CSC Corporate Domains, Inc.' };
+		// All pairwise comparisons must be same-family — this is the
+		// user-visible bug: any pair returning false drives an off-primary-registrar
+		// inference and a shadowIt finding in the brand-audit report.
+		expect(sameRegistrarFamily(fordAu, cscMalaysia)).toBe(true);
+		expect(sameRegistrarFamily(fordAu, cscUs)).toBe(true);
+		expect(sameRegistrarFamily(cscMalaysia, cscUs)).toBe(true);
+	});
+
 	it('falls back to registrar-family names when registry-specific registrar IDs differ', () => {
 		expect(
 			sameRegistrarFamily(


### PR DESCRIPTION
## Summary

Three high-impact, low-effort improvements to the brand-audit pipeline, motivated by yesterday's corporate-registrar pitch verification work:

- **Corporate-registrar family expansion** — recognise a corporate brand-protection registrar's regional and product-line operating names as one family (fixes false-positive shadowIt on ford.com.au, lockheedmartin.com.au, verizon.com.au, etc.)
- **Defensive typosquat label** — annotate candidates within Damerau-Levenshtein 2 of the target that have minimal operational infrastructure (no MX, parked NS, HTTP redirect to target) so brand-protection registrations are visually distinguishable from operational properties (e.g. masterard.com vs mastercard.com)
- **Consumer-cap → reaper dead-zone fix** — close the 10-minute window where audits hitting the 5min consumer cap sat as 'running' until the 15min reaper tick. Read-path now synthesises failed status past a 7min deadline; cron reaper tightened to 10min as safety net. No schema migration.

Each commit corresponds to one change, TDD-authored, all tests passing.

## Test plan

- [x] `npx vitest run` across all 8 affected spec files — **152/152 pass**
- [x] Broader sweep across `test/audits/`, `test/contracts/`, brand-audit specs — **359/359 pass**
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (warnings inside a worktree's wasm artifacts only, not source)
- [ ] Manual verification: re-run ford.com / lockheedmartin.com brand audit and confirm `.com.au` no longer flagged shadowIt
- [ ] Manual verification: re-run mastercard.com brand audit and confirm `masterard.com` carries the defensive annotation (requires the candidate-MX/HTTP enrichment follow-up — TODO marked in pipeline)
- [ ] Manual verification: deep-depth brand audit on a previously-hung target and confirm the new 7min deadline fires the synthesised failed state

## Caveats called out

- **Defensive annotation abstains in production today** until candidate MX + HTTP-redirect enrichment is wired through discovery. The annotation logic and render path are complete; only the input data is missing. `TODO(defensive):` marks the call site in `brand-audit-pipeline.ts`. Worth filing as a follow-up.
- **Consumer-cap self-mark from within the worker (Option C in the original brief) was ruled out** by the reaper agent + advisor: a saturated microtask queue is the precondition for the cap to fire, so the macrotask write never runs. The chosen design pushes responsibility OUT of the failing worker entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)