### PR TITLE
chore: bump version to 2.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [2.23.0] - 2026-05-21
+
+### Added
+- **CSC registrar family expansion** — `Corporation Service Company`, `CSC Corporate Domains`, `CSC Digital Brand Services`, `CSC Global`, and their regional subsidiaries (AU/CA/Malaysia) now collapse to a single `CSC` family in both `src/lib/registrar-identity.ts` (off-primary gate) and `src/lib/brand-classification.ts` (analyst reason string). Verified against ford.com.au, lockheedmartin.com.au, verizon.com.au — previously false-positively flagged as shadowIt.
+- **Defensive typosquat label** (`src/lib/brand-defensive-registration.ts`) — candidates within Damerau-Levenshtein 2 of the target with minimal operational infrastructure (no MX, parked-NS apex, or HTTP redirect to target) are annotated with `defensive: true` + `defensiveReason`. Surfaces in markdown and PDF rendering. Bucket assignment unchanged. Heuristic abstains in production until candidate MX + HTTP-redirect enrichment is wired through discovery (TODO marked).
+
+### Fixed
+- **Consumer-cap → reaper dead-zone** — audits whose worker hit the 5-min consumer cap previously sat in `running` until the 15-min cron reaper. Read-path piggyback on `brand_audit_status` and `brand_audit_get_report` now synthesises `failed` for running rows past a 7-min deadline (anchored on existing `created_at` column — no schema migration). Cron reaper threshold tightened from 15min → 10min as the safety net for non-polled audits.
+
+### Tests
+- `test/registrar-identity.test.ts` + `src/lib/brand-classification.test.ts` — CSC family normalisation and bucket-level integration assertions.
+- `test/brand-defensive-registration.test.ts` — 22 unit cases (distance, parking NS detection, signal precedence).
+- `test/brand-audit-{status,get-report}.integration.test.ts` — dead-zone closure (synthesised failed, persisted UPDATE, in-deadline negative, D1 write failure swallow).
+
 ## [2.22.0] - 2026-05-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.22.0",
+	"version": "2.23.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "2.22.0",
+			"version": "2.23.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.22.0",
+	"version": "2.23.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "2.22.0",
+	"version": "2.23.0",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "2.22.0",
+			"version": "2.23.0",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '2.22.0';
+export const SERVER_VERSION = '2.23.0';


### PR DESCRIPTION
## Summary

Version bump for the three brand-audit improvements merged in #164.

All five version sync sites updated:
- `package.json` + `package-lock.json` (via `npm version`)
- `src/lib/server-version.ts` (`SERVER_VERSION`)
- `server.json` — both top-level `version` AND `packages[0].version`
- `CHANGELOG.md` — new `[2.23.0] - 2026-05-21` heading

## Test plan

- [x] No code changes — pure metadata bump. CI should pass identically to #164.
- [ ] Post-merge: tag `v2.23.0` and push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)