### PR TITLE
fix(brand-audit): aggregate batch status when read-path synthesizes targets

### DIFF
--- a/src/tools/brand-audit-get-report.ts
+++ b/src/tools/brand-audit-get-report.ts
@@ -195,11 +195,54 @@ export async function brandAuditGetReport(
 		]);
 	}
 
-	if (auditRow.status !== 'completed' && auditRow.status !== 'failed') {
+	// Aggregate-mode dead-zone closure (2026-05-21 production fix). Mirror the
+	// per-target closure: when every target is terminal-via-synthesis but the
+	// orchestrator never wrote the batch row, the audit row's `status` stays
+	// 'running' forever and the customer is told to keep polling. Fetch
+	// targets, decide if the batch is in fact terminal, persist (best-effort)
+	// and treat the audit as terminal in this response. We don't synthesize
+	// `results_json` itself — the orchestrator's aggregate report data is
+	// genuinely lost when it dies mid-flight. The customer can fall back to
+	// per-target gets to recover the data we have.
+	let renderedAuditStatus: BrandAuditStatus = auditRow.status;
+	if (auditRow.status === 'queued' || auditRow.status === 'running') {
+		const now = (deps.now ?? Date.now)();
+		const targetRows = await deps.db
+			.prepare(
+				'SELECT audit_id, target, status, created_at, completed_at FROM brand_audit_targets WHERE audit_id = ?',
+			)
+			.bind(auditId)
+			.all<{ status: BrandAuditStatus; created_at: number; result_json?: string | null }>();
+		const rows = targetRows.results ?? [];
+		const counts = {
+			queued: rows.filter((r) => r.status === 'queued').length,
+			running: rows.filter((r) => r.status === 'running' && now - r.created_at <= BRAND_AUDIT_TARGET_DEADLINE_MS).length,
+			stuck: rows.filter((r) => r.status === 'running' && now - r.created_at > BRAND_AUDIT_TARGET_DEADLINE_MS).length,
+			completed: rows.filter((r) => r.status === 'completed').length,
+			failed: rows.filter((r) => r.status === 'failed').length,
+		};
+		const allTerminal = rows.length > 0 && counts.queued === 0 && counts.running === 0;
+		if (allTerminal) {
+			const completedCount = counts.completed;
+			renderedAuditStatus = completedCount > 0 ? 'completed' : 'failed';
+			try {
+				await deps.db
+					.prepare(
+						"UPDATE brand_audits SET status = ?, completed_targets = ?, completed_at = ?, updated_at = ? WHERE id = ? AND status IN ('queued', 'running')",
+					)
+					.bind(renderedAuditStatus, completedCount, now, now, auditId)
+					.run();
+			} catch {
+				// Best-effort — next reader retries the flip.
+			}
+		}
+	}
+
+	if (renderedAuditStatus !== 'completed' && renderedAuditStatus !== 'failed') {
 		return errorResult(
 			'notReady',
-			`Audit ${auditId} is currently ${auditRow.status}. Poll again with brand_audit_status.`,
-			{ auditId, currentStatus: auditRow.status },
+			`Audit ${auditId} is currently ${renderedAuditStatus}. Poll again with brand_audit_status.`,
+			{ auditId, currentStatus: renderedAuditStatus },
 		);
 	}
 
@@ -207,13 +250,13 @@ export async function brandAuditGetReport(
 	return buildCheckResult(CATEGORY, [
 		createFinding(
 			CATEGORY,
-			`Brand audit ${auditId} aggregate: ${auditRow.status}`,
+			`Brand audit ${auditId} aggregate: ${renderedAuditStatus}`,
 			'info',
-			`status=${auditRow.status} format=${auditRow.format}`,
+			`status=${renderedAuditStatus} format=${auditRow.format}`,
 			{
 				summary: true,
 				auditId,
-				status: auditRow.status,
+				status: renderedAuditStatus,
 				format: auditRow.format,
 				aggregate,
 			},

--- a/src/tools/brand-audit-status.ts
+++ b/src/tools/brand-audit-status.ts
@@ -94,7 +94,6 @@ export async function brandAuditStatus(
 	}
 
 	const now = (deps.now ?? Date.now)();
-	const progress = `${audit.completed_targets}/${audit.total_targets}`;
 
 	// Dead-zone closure (2026-05-21 disney.com hang). A `running` target whose
 	// row is older than BRAND_AUDIT_TARGET_DEADLINE_MS is past the point where
@@ -161,6 +160,39 @@ export async function brandAuditStatus(
 		completed: renderedTargets.filter((t) => t.status === 'completed').length,
 		failed: renderedTargets.filter((t) => t.status === 'failed').length,
 	};
+
+	// Batch-level aggregation (2026-05-21 production fix). When read-path
+	// synthesis has flipped every target out of queued/running, the
+	// `brand_audits` row's `status` and `completed_targets` are stale because
+	// the orchestrator that would have updated them was killed by the same
+	// consumer cap that stranded the targets. Recompute the rendered batch
+	// state and persist (best-effort) so subsequent reads, get_report's
+	// aggregate mode, and the cron reaper all see consistent state. Without
+	// this the customer polling `brand_audit_status` sees per-target failures
+	// inside `targetStatusCounts` but a top-level `status: 'running'` forever.
+	let renderedAuditStatus: BrandAuditStatus = audit.status;
+	let renderedCompletedTargets = audit.completed_targets;
+	let renderedAuditCompletedAt = audit.completed_at;
+	const allTerminal =
+		targets.length > 0 && targetStatusCounts.queued === 0 && targetStatusCounts.running === 0;
+	const batchStillProvisional = audit.status === 'queued' || audit.status === 'running';
+	if (allTerminal && batchStillProvisional) {
+		renderedCompletedTargets = targetStatusCounts.completed;
+		renderedAuditStatus = targetStatusCounts.completed > 0 ? 'completed' : 'failed';
+		renderedAuditCompletedAt = now;
+		try {
+			await deps.db
+				.prepare(
+					"UPDATE brand_audits SET status = ?, completed_targets = ?, completed_at = ?, updated_at = ? WHERE id = ? AND status IN ('queued', 'running')",
+				)
+				.bind(renderedAuditStatus, renderedCompletedTargets, renderedAuditCompletedAt, now, audit.id)
+				.run();
+		} catch {
+			// Best-effort — next reader retries the flip.
+		}
+	}
+
+	const progress = `${renderedCompletedTargets}/${audit.total_targets}`;
 	const ageMs = Math.max(0, now - audit.created_at);
 	const updatedAgeMs = Math.max(0, now - audit.updated_at);
 	const warnings: string[] = [];
@@ -169,20 +201,20 @@ export async function brandAuditStatus(
 	}
 	const summary = createFinding(
 		CATEGORY,
-		`Brand audit ${auditId}: ${audit.status} (${progress})`,
+		`Brand audit ${auditId}: ${renderedAuditStatus} (${progress})`,
 		'info',
-		`status=${audit.status} progress=${progress} format=${audit.format} created=${new Date(audit.created_at).toISOString()} updatedAgeMs=${updatedAgeMs}`,
+		`status=${renderedAuditStatus} progress=${progress} format=${audit.format} created=${new Date(audit.created_at).toISOString()} updatedAgeMs=${updatedAgeMs}`,
 		{
 			summary: true,
 			auditId: audit.id,
-			status: audit.status,
+			status: renderedAuditStatus,
 			progress,
-			completed: audit.completed_targets,
+			completed: renderedCompletedTargets,
 			total: audit.total_targets,
 			format: audit.format,
 			createdAt: audit.created_at,
 			updatedAt: audit.updated_at,
-			completedAt: audit.completed_at,
+			completedAt: renderedAuditCompletedAt,
 			ageMs,
 			updatedAgeMs,
 			targetStatusCounts,

--- a/test/brand-audit-get-report.integration.test.ts
+++ b/test/brand-audit-get-report.integration.test.ts
@@ -18,6 +18,7 @@ import { describe, it, expect } from 'vitest';
 interface RowMap {
 	audit?: Record<string, unknown> | null;
 	target?: Record<string, unknown> | null;
+	targets?: Record<string, unknown>[];
 }
 
 function makeMockD1(rows: RowMap) {
@@ -38,6 +39,9 @@ function makeMockD1(rows: RowMap) {
 				},
 				async all() {
 					calls.push({ sql, binds });
+					if (sql.includes('FROM brand_audit_targets')) {
+						return { results: rows.targets ?? [], success: true, meta: {} };
+					}
 					return { results: [], success: true, meta: {} };
 				},
 				async run() {
@@ -237,6 +241,51 @@ describe('brandAuditGetReport', () => {
 			);
 
 			// Legitimate in-flight audit still returns notReady, not synthesised-failed.
+			expect(result.findings.find((f) => f.metadata?.notReady === true)).toBeDefined();
+		});
+	});
+
+	describe('aggregate-mode dead-zone closure', () => {
+		it('renders status=failed and persists the batch flip when all targets synthesized failed', async () => {
+			const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 10_000;
+			const { db, calls } = makeMockD1({
+				audit: {
+					id: 'aud-deadzone',
+					owner_id: 'owner-abc',
+					status: 'running',
+					results_json: null,
+					format: 'json',
+				},
+				targets: [
+					{ status: 'running', created_at: createdAt },
+					{ status: 'running', created_at: createdAt },
+				],
+			});
+
+			const result = await brandAuditGetReport({ auditId: 'aud-deadzone' }, 'owner-abc', { db, now: () => now });
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+
+			expect(summary?.metadata?.status).toBe('failed');
+			expect(summary?.metadata?.aggregate).toBeNull();
+			const batchFlip = calls.find(
+				(c) =>
+					c.sql.includes('UPDATE brand_audits') &&
+					(c.binds as unknown[])[0] === 'failed',
+			);
+			expect(batchFlip).toBeDefined();
+		});
+
+		it('still returns notReady when no targets exist yet (audit just queued, consumer not started)', async () => {
+			const { brandAuditGetReport } = await import('../src/tools/brand-audit-get-report');
+			const { db } = makeMockD1({
+				audit: { id: 'aud-fresh', owner_id: 'owner-abc', status: 'queued', results_json: null, format: 'json' },
+				targets: [],
+			});
+
+			const result = await brandAuditGetReport({ auditId: 'aud-fresh' }, 'owner-abc', { db });
 			expect(result.findings.find((f) => f.metadata?.notReady === true)).toBeDefined();
 		});
 	});

--- a/test/brand-audit-status.integration.test.ts
+++ b/test/brand-audit-status.integration.test.ts
@@ -446,4 +446,179 @@ describe('brandAuditStatus', () => {
 			expect(summary?.metadata?.targetStatusCounts).toMatchObject({ running: 0, failed: 1 });
 		});
 	});
+
+	describe('batch-level aggregation when read-path synthesizes all targets terminal', () => {
+		// Regression: 2026-05-21 production observation that the per-target
+		// synthesis correctly flipped target rows to `failed` but the response's
+		// top-level `status` / `progress` / `completed` stayed pinned to the
+		// stale `brand_audits` row. Customer saw `status: 'running', progress:
+		// '0/3'` alongside `targetStatusCounts: {failed: 3}` and never exited a
+		// poll loop. These tests pin the aggregation behaviour.
+
+		it('renders top-level status=failed when all synthesized targets failed', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 10_000;
+			const { db } = makeMockD1({
+				audit: {
+					id: 'aud-deadzone',
+					owner_id: 'owner-abc',
+					status: 'running',
+					total_targets: 3,
+					completed_targets: 0,
+					format: 'both',
+					created_at: createdAt,
+					updated_at: createdAt,
+					completed_at: null,
+				},
+				targets: [
+					{ audit_id: 'aud-deadzone', target: 'ford.com', status: 'running', created_at: createdAt, completed_at: null, error: null, pdf_r2_key: null, result_json: null },
+					{ audit_id: 'aud-deadzone', target: 'lockheedmartin.com', status: 'running', created_at: createdAt, completed_at: null, error: null, pdf_r2_key: null, result_json: null },
+					{ audit_id: 'aud-deadzone', target: 'verizon.com', status: 'running', created_at: createdAt, completed_at: null, error: null, pdf_r2_key: null, result_json: null },
+				],
+			});
+
+			const result = await brandAuditStatus('aud-deadzone', 'owner-abc', { db, now: () => now });
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+
+			// The bug allowed `status: 'running', progress: '0/3'` to coexist
+			// with all-failed targetStatusCounts. Pin the corrected behaviour.
+			expect(summary?.metadata?.status).toBe('failed');
+			expect(summary?.metadata?.progress).toBe('0/3');
+			expect(summary?.metadata?.completed).toBe(0);
+			expect(summary?.metadata?.completedAt).toBe(now);
+			expect(summary?.metadata?.targetStatusCounts).toMatchObject({ running: 0, failed: 3 });
+		});
+
+		it('renders top-level status=completed when at least one target completed and the rest synthesized failed', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 10_000;
+			const { db } = makeMockD1({
+				audit: {
+					id: 'aud-mixed',
+					owner_id: 'owner-abc',
+					status: 'running',
+					total_targets: 3,
+					completed_targets: 0, // stale — the batch row never got updated
+					format: 'both',
+					created_at: createdAt,
+					updated_at: createdAt,
+					completed_at: null,
+				},
+				targets: [
+					{ audit_id: 'aud-mixed', target: 'ford.com', status: 'completed', created_at: createdAt, completed_at: createdAt + 60_000, error: null, pdf_r2_key: null, result_json: '{"ok":1}' },
+					{ audit_id: 'aud-mixed', target: 'lockheedmartin.com', status: 'running', created_at: createdAt, completed_at: null, error: null, pdf_r2_key: null, result_json: null },
+					{ audit_id: 'aud-mixed', target: 'verizon.com', status: 'running', created_at: createdAt, completed_at: null, error: null, pdf_r2_key: null, result_json: null },
+				],
+			});
+
+			const result = await brandAuditStatus('aud-mixed', 'owner-abc', { db, now: () => now });
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+
+			expect(summary?.metadata?.status).toBe('completed');
+			expect(summary?.metadata?.progress).toBe('1/3');
+			expect(summary?.metadata?.completed).toBe(1);
+			expect(summary?.metadata?.targetStatusCounts).toMatchObject({ completed: 1, failed: 2, running: 0 });
+		});
+
+		it('persists the batch row flip with the correct status + completed_targets', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 10_000;
+			const { db, calls } = makeMockD1({
+				audit: {
+					id: 'aud-persist',
+					owner_id: 'owner-abc',
+					status: 'running',
+					total_targets: 2,
+					completed_targets: 0,
+					format: 'json',
+					created_at: createdAt,
+					updated_at: createdAt,
+					completed_at: null,
+				},
+				targets: [
+					{ audit_id: 'aud-persist', target: 'a.com', status: 'completed', created_at: createdAt, completed_at: createdAt + 30_000, error: null, pdf_r2_key: null, result_json: '{"ok":1}' },
+					{ audit_id: 'aud-persist', target: 'b.com', status: 'running', created_at: createdAt, completed_at: null, error: null, pdf_r2_key: null, result_json: null },
+				],
+			});
+
+			await brandAuditStatus('aud-persist', 'owner-abc', { db, now: () => now });
+
+			const batchFlip = calls.find(
+				(c) =>
+					c.sql.includes('UPDATE brand_audits') &&
+					c.sql.includes("status IN ('queued', 'running')") &&
+					(c.binds as unknown[])[0] === 'completed' &&
+					(c.binds as unknown[])[1] === 1, // completed_targets
+			);
+			expect(batchFlip).toBeDefined();
+			// last bind is auditId
+			expect((batchFlip!.binds as unknown[])[(batchFlip!.binds as unknown[]).length - 1]).toBe('aud-persist');
+		});
+
+		it('does NOT persist a batch flip when targets are still in-flight', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			// All targets within deadline — normal in-flight audit.
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS - 60_000;
+			const { db, calls } = makeMockD1({
+				audit: {
+					id: 'aud-inflight',
+					owner_id: 'owner-abc',
+					status: 'running',
+					total_targets: 2,
+					completed_targets: 0,
+					format: 'json',
+					created_at: createdAt,
+					updated_at: createdAt + 30_000,
+					completed_at: null,
+				},
+				targets: [
+					{ audit_id: 'aud-inflight', target: 'a.com', status: 'running', created_at: createdAt, completed_at: null, error: null, pdf_r2_key: null, result_json: null },
+					{ audit_id: 'aud-inflight', target: 'b.com', status: 'completed', created_at: createdAt, completed_at: createdAt + 30_000, error: null, pdf_r2_key: null, result_json: '{"ok":1}' },
+				],
+			});
+
+			const result = await brandAuditStatus('aud-inflight', 'owner-abc', { db, now: () => now });
+
+			const summary = result.findings.find((f) => f.metadata?.summary === true);
+			expect(summary?.metadata?.status).toBe('running'); // unchanged
+			const batchFlip = calls.find((c) => c.sql.includes('UPDATE brand_audits'));
+			expect(batchFlip).toBeUndefined();
+		});
+
+		it('does not overwrite a batch row already in a terminal status', async () => {
+			const { brandAuditStatus } = await import('../src/tools/brand-audit-status');
+			const { BRAND_AUDIT_TARGET_DEADLINE_MS } = await import('../src/lib/brand-audit-reaper');
+			const createdAt = 1_750_000_000_000;
+			const now = createdAt + BRAND_AUDIT_TARGET_DEADLINE_MS + 60_000;
+			const { db, calls } = makeMockD1({
+				audit: {
+					id: 'aud-terminal',
+					owner_id: 'owner-abc',
+					status: 'completed', // already terminal
+					total_targets: 1,
+					completed_targets: 1,
+					format: 'json',
+					created_at: createdAt,
+					updated_at: createdAt + 60_000,
+					completed_at: createdAt + 60_000,
+				},
+				targets: [
+					{ audit_id: 'aud-terminal', target: 'a.com', status: 'completed', created_at: createdAt, completed_at: createdAt + 60_000, error: null, pdf_r2_key: null, result_json: '{"ok":1}' },
+				],
+			});
+
+			await brandAuditStatus('aud-terminal', 'owner-abc', { db, now: () => now });
+
+			const batchFlip = calls.find((c) => c.sql.includes('UPDATE brand_audits'));
+			expect(batchFlip).toBeUndefined();
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Fixes the aggregation bug observed on prod 2026-05-21 audit `c19b64cd-…`.

When the read-path piggyback flipped all target rows to `failed` past the 7-min deadline, the response carried correct per-target counts inside `targetStatusCounts` but the top-level `status` and `progress` stayed pinned to the stale `brand_audits` row values. Customers polling `brand_audit_status` would see `status: 'running', progress: '0/3'` alongside `targetStatusCounts: {failed: 3}` indefinitely.

Both read paths (`brand_audit_status` and `brand_audit_get_report` aggregate mode) now derive the terminal state from `targetStatusCounts` and persist a best-effort UPDATE to `brand_audits`. Subsequent reads, get_report aggregate mode, and the cron reaper all see consistent state.

### Behavior

| Scenario | Result |
| --- | --- |
| All targets terminal, batch row provisional, any completed | `status: 'completed'`, `completed: <count>` |
| All targets terminal, batch row provisional, none completed | `status: 'failed'`, `completed: 0` |
| Some targets still in-flight (within deadline) | No flip — existing behavior |
| Batch row already terminal | No flip — idempotent |
| D1 UPDATE fails | Swallowed; response is the durability contract |

## Test plan

- [x] `test/brand-audit-status.integration.test.ts`: 5 new tests for top-level aggregation + persistence
- [x] `test/brand-audit-get-report.integration.test.ts`: 2 new tests for aggregate-mode synthesis
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] Broader audit + brand-audit sweep: 437/437 pass

## Follow-up

Worker degradation observed during the same investigation (3-target batches hitting `KV put failed` and `quota coordinator tool quota error` cascades) is separate and tracked outside this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)