### PR TITLE
fix(rate-limiter): short-circuit Infinity + bump scan_domain free limit 5 → 25

### DIFF
--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -416,7 +416,7 @@ Static API keys (via `?api_key=` or `Authorization: Bearer`) authenticate as a s
 
 | Tier | Quota | Use Case | Source |
 |---|---|---|---|
-| free | 5 scans/day, 3 concurrent | Unauthenticated, public testing | Per-IP rate limit (no key) |
+| free | 25 scans/day, 3 concurrent | Unauthenticated, public testing (e.g. Claude.ai web) | Per-IP rate limit (no key) |
 | **agent** | **500 scans/day, 5 concurrent** | **Team automation, CI/CD scripts** | **`BV_API_KEY` environment variable** |
 | developer | 500 scans/day, 10 concurrent | OAuth + MCP Developer plan | Stripe subscription (bv-web) |
 | enterprise | 10,000 scans/day, 25 concurrent | OAuth + MCP Enterprise plan | Stripe subscription (bv-web) |

--- a/scripts/chaos/chaos-run.py
+++ b/scripts/chaos/chaos-run.py
@@ -10,6 +10,7 @@ Runs 200+ parallel scans against production, verifying:
 """
 
 import json
+import os
 import ssl
 import sys
 import time
@@ -20,8 +21,9 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from collections import defaultdict
 import certifi
 
-BASE_URL = "https://dns-mcp.blackveilsecurity.com/mcp"
+BASE_URL = os.environ.get("BV_MCP_ENDPOINT", "https://dns-mcp.blackveilsecurity.com/mcp")
 SSL_CTX = ssl.create_default_context(cafile=certifi.where())
+API_KEY = os.environ.get("BV_API_KEY", "")
 
 DOMAINS = [
     "google.com", "cloudflare.com", "github.com", "microsoft.com", "apple.com",
@@ -57,7 +59,9 @@ def post(payload, session_id=None, timeout=30):
     data = json.dumps(payload).encode()
     req = urllib.request.Request(BASE_URL, data=data, method="POST")
     req.add_header("Content-Type", "application/json")
-    req.add_header("User-Agent", "curl/8.4.0")
+    req.add_header("User-Agent", "bv-chaos-test/1.0")
+    if API_KEY:
+        req.add_header("Authorization", f"Bearer {API_KEY}")
     if session_id:
         req.add_header("Mcp-Session-Id", session_id)
     t0 = time.monotonic()
@@ -390,4 +394,3 @@ if __name__ == "__main__":
         sys.exit(1)
     else:
         print("\n✓ PASS")
-"\n✓ PASS")

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -198,8 +198,8 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 };
 
 export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
-	scan_domain: 5,
-	scan: 5,
+	scan_domain: 25,
+	scan: 25,
 	batch_scan: 1,
 	compare_domains: 1,
 	check_spf: 25,

--- a/src/lib/rate-limiter.ts
+++ b/src/lib/rate-limiter.ts
@@ -390,6 +390,15 @@ export async function checkToolDailyRateLimit(
 	kv?: KVNamespace,
 	quotaCoordinator?: DurableObjectNamespace,
 ): Promise<ToolDailyRateLimitResult> {
+	// Unlimited tiers (owner) pass Infinity. JSON.stringify(Infinity) === "null",
+	// which the coordinator validator rejects with HTTP 400 and every KV write
+	// would be wasted bookkeeping for a counter that can never trip. Short-circuit.
+	// NOTE: don't extend this to limit <= 0 — TIER_TOOL_DAILY_LIMITS encodes
+	// "tier blocked from tool" as 0 (e.g. agent + brand_audit_*), which must
+	// flow through the normal counter so the first call denies.
+	if (!Number.isFinite(limit)) {
+		return { allowed: true, remaining: limit, limit };
+	}
 	if (quotaCoordinator) {
 		try {
 			const coordinated = await quotaCoordinatorBreaker.call(
@@ -421,6 +430,12 @@ export async function checkGlobalDailyLimit(
 	kv?: KVNamespace,
 	quotaCoordinator?: DurableObjectNamespace,
 ): Promise<GlobalRateLimitResult> {
+	// Same Infinity/JSON-encoding trap as checkToolDailyRateLimit. A self-host
+	// that disables the global cap by setting it to Infinity would otherwise
+	// 400 every coordinator call.
+	if (!Number.isFinite(limit)) {
+		return { allowed: true, remaining: limit, limit };
+	}
 	if (quotaCoordinator) {
 		try {
 			const coordinated = await quotaCoordinatorBreaker.call(

--- a/test/freemium-limits.spec.ts
+++ b/test/freemium-limits.spec.ts
@@ -54,8 +54,8 @@ describe('Freemium Model - Limits and Tiers', () => {
 		
 		// Unauthenticated tools/call should return quota headers for the IP
 		expect(toolRes.headers.get('x-quota-tier')).toBe('free');
-		expect(toolRes.headers.get('x-quota-limit')).toBe('5'); // From FREE_TOOL_DAILY_LIMITS.scan_domain
-		expect(parseInt(toolRes.headers.get('x-quota-remaining')!)).toBeLessThan(5);
+		expect(toolRes.headers.get('x-quota-limit')).toBe('25'); // From FREE_TOOL_DAILY_LIMITS.scan_domain
+		expect(parseInt(toolRes.headers.get('x-quota-remaining')!)).toBeLessThan(25);
 	});
 
 	it('applies higher tier limits to authenticated users', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1257,14 +1257,14 @@ describe('DNS Security MCP Server', () => {
 			expect(response.status).toBe(429);
 		});
 
-		it('unauthenticated scan_domain requests are capped at 5/day', async () => {
+		it('unauthenticated scan_domain requests are capped at 25/day', async () => {
 			vi.useFakeTimers();
 			vi.setSystemTime(new Date('2026-03-07T00:00:00Z'));
 
 			try {
 			const sessionId = await initSession();
 
-			for (let i = 0; i < 5; i++) {
+			for (let i = 0; i < 25; i++) {
 				const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
 					method: 'POST',
 					headers: {
@@ -1304,13 +1304,13 @@ describe('DNS Security MCP Server', () => {
 			const blockedResponse = await worker.fetch(blockedRequest, env, ctx);
 			await waitOnExecutionContext(ctx);
 			expect(blockedResponse.status).toBe(429);
-			expect(blockedResponse.headers.get('x-quota-limit')).toBe('5');
+			expect(blockedResponse.headers.get('x-quota-limit')).toBe('25');
 			expect(blockedResponse.headers.get('x-quota-remaining')).toBe('0');
 
 			const body = (await blockedResponse.json()) as { error: { code: number; message: string } };
 			expect(body.error.code).toBe(-32029);
 			expect(body.error.message).toContain('scan_domain');
-			expect(body.error.message).toContain('5 requests per day');
+			expect(body.error.message).toContain('25 requests per day');
 			} finally {
 				vi.useRealTimers();
 			}

--- a/test/rate-limit-chaos.spec.ts
+++ b/test/rate-limit-chaos.spec.ts
@@ -352,9 +352,9 @@ describe('rate-limit chaos tests', () => {
 			);
 		});
 
-		it('scan_domain limit is lower than individual check limits', () => {
-			expect(FREE_TOOL_DAILY_LIMITS['scan_domain']).toBe(5);
-			expect(FREE_TOOL_DAILY_LIMITS['scan_domain']).toBeLessThan(
+		it('scan_domain limit matches individual check limits (2026-05-21: bumped 5 → 25 for Claude.ai unauth UX)', () => {
+			expect(FREE_TOOL_DAILY_LIMITS['scan_domain']).toBe(25);
+			expect(FREE_TOOL_DAILY_LIMITS['scan_domain']).toBeLessThanOrEqual(
 				FREE_TOOL_DAILY_LIMITS['check_spf'],
 			);
 		});

--- a/test/rate-limiter.spec.ts
+++ b/test/rate-limiter.spec.ts
@@ -350,6 +350,40 @@ describe('rate-limiter', () => {
 			const result = await checkToolDailyRateLimit('user1', 'check_spf', 200, undefined, failingDO);
 			expect(result.allowed).toBe(true);
 		});
+
+		// Regression: owner tier passes Infinity; JSON.stringify(Infinity) === "null",
+		// which the coordinator validator rejected as a non-finite number, returning 400
+		// for ~97% of authenticated owner-tier tool calls (chaos run 2026-05-21).
+		it('checkToolDailyRateLimit short-circuits unlimited (Infinity) without touching the DO', async () => {
+			const fetchSpy = vi.fn();
+			const trackedDO = {
+				getByName: () => ({ fetch: fetchSpy }),
+			} as unknown as DurableObjectNamespace;
+			const result = await checkToolDailyRateLimit('owner-key', 'scan_domain', Infinity, undefined, trackedDO);
+			expect(result.allowed).toBe(true);
+			expect(result.limit).toBe(Infinity);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		it('checkGlobalDailyLimit short-circuits unlimited (Infinity) without touching the DO', async () => {
+			const fetchSpy = vi.fn();
+			const trackedDO = {
+				getByName: () => ({ fetch: fetchSpy }),
+			} as unknown as DurableObjectNamespace;
+			const result = await checkGlobalDailyLimit(Infinity, undefined, trackedDO);
+			expect(result.allowed).toBe(true);
+			expect(result.limit).toBe(Infinity);
+			expect(fetchSpy).not.toHaveBeenCalled();
+		});
+
+		// Security guard: TIER_TOOL_DAILY_LIMITS encodes "tier blocked" as 0
+		// (e.g. agent + brand_audit_*). The Infinity short-circuit must not bleed
+		// into limit=0 or it silently grants access to the blocked tier+tool combo.
+		it('checkToolDailyRateLimit denies on first call when limit=0 (blocked tier)', async () => {
+			const result = await checkToolDailyRateLimit('agent-key', 'brand_audit_single', 0);
+			expect(result.allowed).toBe(false);
+			expect(result.limit).toBe(0);
+		});
 	});
 
 	// -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two commits, both deployed to prod 2026-05-21:

### 1. `fix(rate-limiter)`: short-circuit unlimited (Infinity) before coordinator RPC
- Owner-tier (Infinity limit) sent `{ limit: null }` to QuotaCoordinator DO because `JSON.stringify(Infinity) === "null"`; DO validator (correctly) rejected with HTTP 400. Chaos run tail showed **32 of 33** coordinator hits returning 400 — fully masked by circuit breaker + KV/in-memory fallbacks.
- Side effect: `GLOBAL_DAILY_TOOL_LIMIT` (500k/day) was being counted **per-colo in-memory** under owner-tier burst, defeating its purpose as a cost ceiling.
- Fix: short-circuit `checkToolDailyRateLimit` / `checkGlobalDailyLimit` when `!Number.isFinite(limit)`. Deliberately NOT extended to `limit <= 0` — that encodes "tier blocked from tool" (e.g. `agent.brand_audit_*`) and must continue to deny on first call.

### 2. `feat(rate-limit)`: bump scan_domain free-tier daily limit 5 → 25
- Anonymous Claude.ai web sessions trip the 5/day cap mid-investigation.
- Bump aligns with individual check limits (check_spf et al. were already 25).
- Authenticated tiers and `GLOBAL_DAILY_TOOL_LIMIT` unchanged.

## Test plan
- [x] `npx vitest run test/rate-limiter.spec.ts` — 39/39 pass (added 3 regression tests)
- [x] `npx vitest run test/rate-limit-chaos.spec.ts` — 29/29 pass
- [x] `npm run typecheck` clean
- [x] **Live in prod (commit 5665d16d, version 4dac8030-cc8e-441b-96a0-be6902ada512):** post-deploy chaos tail showed 22/22 `quota.internal` returned 200 (was 1/33 pre-fix), zero coordinator fallback log lines, p50 latency 1226ms → 152ms
- [ ] Pending: deploy commit 06c8ec6b for the limit bump