### PR TITLE
feat(scheduled): daily SPF canary with null-rate alert

### DIFF
--- a/src/lib/spf-canary.ts
+++ b/src/lib/spf-canary.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * SPF canary — daily synthetic probe against a curated list of domains that
+ * publish stable, well-formed SPF records. Run from the daily cron, this turns
+ * "elevated null SPF" from a dashboard impression into a tripwire:
+ *   - if more than `nullRateThreshold` of the canary set reports "No SPF record
+ *     found", an alert fires with the failing domains attached, so the next
+ *     responder has a concrete reproducer instead of an absence pattern.
+ *
+ * The list is intentionally narrow (well-known, high-stability publishers) so
+ * a single null is significant, not noise. Adding/removing entries is allowed
+ * — keep them domains that historically publish SPF and are unlikely to ever
+ * stop.
+ */
+
+import { checkSpf } from '../tools/check-spf';
+
+/**
+ * Curated SPF-publishing domains. Each is verified to publish a `v=spf1` TXT
+ * record at the apex; a null here means either our lookup path regressed or
+ * the publisher genuinely dropped SPF (rare, newsworthy).
+ */
+export const SPF_CANARY_DOMAINS: readonly string[] = [
+	'google.com',
+	'microsoft.com',
+	'paypal.com',
+	'stripe.com',
+	'anthropic.com',
+	'netflix.com',
+	'apple.com',
+	'facebook.com',
+	'salesforce.com',
+	'slack.com',
+	'adobe.com',
+	'nytimes.com',
+	'bbc.co.uk',
+	'spotify.com',
+	'mozilla.org',
+	'cloudflare.com',
+	'github.com',
+	'linkedin.com',
+	'amazon.com',
+	'dropbox.com',
+] as const;
+
+export interface SpfCanaryResult {
+	totalProbed: number;
+	nullCount: number;
+	errorCount: number;
+	nullRate: number;
+	nullDomains: string[];
+	errorDomains: string[];
+}
+
+/**
+ * Probe every canary domain and classify each result as null, error, or
+ * found. Runs in parallel; per-probe failures are isolated via allSettled so
+ * a single timeout does not poison the rest of the report.
+ */
+export async function runSpfCanary(domains: readonly string[] = SPF_CANARY_DOMAINS): Promise<SpfCanaryResult> {
+	const settled = await Promise.allSettled(
+		domains.map(async (domain) => {
+			const result = await checkSpf(domain);
+			const titles = result.findings.map((f) => f.title);
+			const isNull = titles.some((t) => t === 'No SPF record found');
+			const isError = titles.some((t) => /could not complete|timed out/i.test(t));
+			return { domain, isNull, isError };
+		}),
+	);
+
+	const nullDomains: string[] = [];
+	const errorDomains: string[] = [];
+
+	for (let i = 0; i < settled.length; i++) {
+		const r = settled[i];
+		if (r.status === 'fulfilled') {
+			if (r.value.isNull) nullDomains.push(r.value.domain);
+			if (r.value.isError) errorDomains.push(r.value.domain);
+		} else {
+			errorDomains.push(domains[i]);
+		}
+	}
+
+	return {
+		totalProbed: domains.length,
+		nullCount: nullDomains.length,
+		errorCount: errorDomains.length,
+		nullRate: nullDomains.length / Math.max(1, domains.length),
+		nullDomains,
+		errorDomains,
+	};
+}
+
+/**
+ * Decide whether the canary's null rate breaches the configured threshold.
+ * Kept pure for unit testing — the scheduled handler composes this with the
+ * webhook dispatch.
+ */
+export function shouldAlertOnCanary(result: SpfCanaryResult, nullRateThreshold: number): boolean {
+	return result.nullRate >= nullRateThreshold;
+}

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -20,6 +20,7 @@ import { readWindow } from './lib/fuzzing-counter';
 import { buildFuzzingAlertPayload } from './schemas/alerting';
 import { FUZZ_THRESHOLDS } from './lib/config';
 import { reapStuckBrandAudits } from './lib/brand-audit-reaper';
+import { runSpfCanary, shouldAlertOnCanary } from './lib/spf-canary';
 
 interface AnomalyRow {
 	total_calls?: number;
@@ -40,6 +41,7 @@ export interface ScheduledEnv {
 	ALERT_P95_THRESHOLD?: string;
 	ALERT_RATE_LIMIT_THRESHOLD?: string;
 	ALERT_LOOKBACK_MINUTES?: string;
+	ALERT_SPF_NULL_RATE_THRESHOLD?: string;
 	RATE_LIMIT?: KVNamespace;
 	BRAND_AUDIT_DB?: D1Database;
 }
@@ -319,6 +321,10 @@ export async function handleFuzzingScan(env: ScheduledEnv): Promise<void> {
  * Called by a separate daily Cron Trigger (e.g., `0 8 * * *`).
  */
 export async function handleDailyDigest(env: ScheduledEnv): Promise<void> {
+	// SPF canary runs even when analytics are unconfigured — it does its own
+	// outbound DoH probes and depends only on ALERT_WEBHOOK_URL for delivery.
+	await handleSpfCanary(env);
+
 	if (!env.ALERT_WEBHOOK_URL) return;
 	if (!env.CF_ACCOUNT_ID || !env.CF_ANALYTICS_TOKEN) return;
 
@@ -339,6 +345,69 @@ export async function handleDailyDigest(env: ScheduledEnv): Promise<void> {
 			severity: 'error',
 			category: 'scheduled',
 			details: { message: 'Daily tier digest failed' },
+		});
+	}
+}
+
+/** Default null-rate threshold (15%): with 20 canaries, 3+ nulls trips it. */
+const DEFAULT_SPF_NULL_RATE_THRESHOLD = 0.15;
+
+/**
+ * SPF canary — daily synthetic probe of a curated stable-SPF domain set. When
+ * the null rate breaches `ALERT_SPF_NULL_RATE_THRESHOLD` (default 15%), emits a
+ * webhook alert listing the failing domains so the next responder has a
+ * concrete reproducer instead of a dashboard impression.
+ *
+ * Always logs the canary outcome — even at null=0 — so the absence of an alert
+ * is distinguishable from a silently-skipped run.
+ */
+export async function handleSpfCanary(env: ScheduledEnv): Promise<void> {
+	try {
+		const result = await runSpfCanary();
+		const rawThreshold = env.ALERT_SPF_NULL_RATE_THRESHOLD ? Number(env.ALERT_SPF_NULL_RATE_THRESHOLD) : NaN;
+		const threshold = Number.isFinite(rawThreshold) && rawThreshold > 0 && rawThreshold <= 1
+			? rawThreshold
+			: DEFAULT_SPF_NULL_RATE_THRESHOLD;
+
+		logEvent({
+			timestamp: new Date().toISOString(),
+			category: 'scheduled',
+			result: 'spf_canary',
+			severity: result.nullCount > 0 || result.errorCount > 0 ? 'warn' : 'info',
+			details: {
+				probed: result.totalProbed,
+				nullCount: result.nullCount,
+				errorCount: result.errorCount,
+				nullRatePct: Number((result.nullRate * 100).toFixed(2)),
+				thresholdPct: Number((threshold * 100).toFixed(2)),
+				nullDomains: result.nullDomains,
+				errorDomains: result.errorDomains,
+			},
+		});
+
+		if (!env.ALERT_WEBHOOK_URL) return;
+		if (!shouldAlertOnCanary(result, threshold)) return;
+
+		await sendAlert(
+			env.ALERT_WEBHOOK_URL,
+			buildAlertPayload({
+				title: `SPF canary null rate ${(result.nullRate * 100).toFixed(1)}% (${result.nullCount}/${result.totalProbed})`,
+				severity: result.nullRate >= threshold * 2 ? 'critical' : 'warning',
+				metrics: {
+					probed: result.totalProbed,
+					null_count: result.nullCount,
+					error_count: result.errorCount,
+					null_domains: result.nullDomains.join(', ') || '(none)',
+					error_domains: result.errorDomains.join(', ') || '(none)',
+				},
+				threshold: `spf_null_rate >= ${(threshold * 100).toFixed(0)}%`,
+			}),
+		);
+	} catch (err) {
+		logError(err instanceof Error ? err : String(err), {
+			severity: 'error',
+			category: 'scheduled',
+			details: { message: 'SPF canary failed' },
 		});
 	}
 }

--- a/test/lib/spf-canary.spec.ts
+++ b/test/lib/spf-canary.spec.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from '../helpers/dns-mock';
+import { runSpfCanary, shouldAlertOnCanary, SPF_CANARY_DOMAINS } from '../../src/lib/spf-canary';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/** Per-domain TXT mock: returns whatever SPF (or no SPF) the test wants for each name. */
+function mockPerDomainSpf(domainSpf: Record<string, string | null>) {
+	globalThis.fetch = vi.fn().mockImplementation((url: string | URL) => {
+		const u = new URL(typeof url === 'string' ? url : url.toString());
+		const name = u.searchParams.get('name') ?? '';
+		const type = u.searchParams.get('type') ?? '';
+		// only care about TXT here; non-TXT (e.g. DMARC at _dmarc.<name>) returns empty
+		if (type !== 'TXT') return Promise.resolve(createDohResponse([{ name, type: Number(type) }], []));
+		// _dmarc lookups: return empty so the SPF check skips DMARC-side branches deterministically
+		if (name.startsWith('_dmarc.')) return Promise.resolve(createDohResponse([{ name, type: 16 }], []));
+		const spf = domainSpf[name];
+		if (spf == null) return Promise.resolve(createDohResponse([{ name, type: 16 }], []));
+		return Promise.resolve(
+			createDohResponse(
+				[{ name, type: 16 }],
+				[{ name, type: 16, TTL: 300, data: `"${spf}"` }],
+			),
+		);
+	});
+}
+
+describe('runSpfCanary', () => {
+	it('reports zero nulls when every domain has SPF', async () => {
+		const spf: Record<string, string | null> = {};
+		for (const d of SPF_CANARY_DOMAINS) spf[d] = 'v=spf1 -all';
+		mockPerDomainSpf(spf);
+
+		const r = await runSpfCanary();
+		expect(r.totalProbed).toBe(SPF_CANARY_DOMAINS.length);
+		expect(r.nullCount).toBe(0);
+		expect(r.nullRate).toBe(0);
+		expect(r.nullDomains).toEqual([]);
+	});
+
+	it('reports a null when a canary domain has no SPF', async () => {
+		const spf: Record<string, string | null> = {};
+		for (const d of SPF_CANARY_DOMAINS) spf[d] = 'v=spf1 -all';
+		spf['google.com'] = null; // genuine absence
+
+		mockPerDomainSpf(spf);
+
+		const r = await runSpfCanary();
+		expect(r.nullCount).toBe(1);
+		expect(r.nullDomains).toContain('google.com');
+		expect(r.nullRate).toBeCloseTo(1 / SPF_CANARY_DOMAINS.length, 6);
+	});
+
+	it('counts every canary domain as null when none publish SPF', async () => {
+		const spf: Record<string, string | null> = {};
+		for (const d of SPF_CANARY_DOMAINS) spf[d] = null;
+		mockPerDomainSpf(spf);
+
+		const r = await runSpfCanary();
+		expect(r.nullCount).toBe(SPF_CANARY_DOMAINS.length);
+		expect(r.nullRate).toBe(1);
+	});
+
+	it('classifies transport failure as error, not null', async () => {
+		const subset = ['only.example'];
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down'));
+
+		const r = await runSpfCanary(subset);
+		// checkSpf wraps DNS errors into a finding (errorKind=dns_error, NOT "No SPF record found"),
+		// so the canary should classify this as error, not null.
+		expect(r.nullCount).toBe(0);
+		expect(r.errorCount).toBe(1);
+		expect(r.errorDomains).toContain('only.example');
+	});
+});
+
+describe('shouldAlertOnCanary', () => {
+	const base = { totalProbed: 20, errorCount: 0, errorDomains: [] as string[], nullDomains: [] as string[] };
+
+	it('does not alert below threshold', () => {
+		expect(shouldAlertOnCanary({ ...base, nullCount: 2, nullRate: 0.1 }, 0.15)).toBe(false);
+	});
+
+	it('alerts at threshold', () => {
+		expect(shouldAlertOnCanary({ ...base, nullCount: 3, nullRate: 0.15 }, 0.15)).toBe(true);
+	});
+
+	it('alerts above threshold', () => {
+		expect(shouldAlertOnCanary({ ...base, nullCount: 10, nullRate: 0.5 }, 0.15)).toBe(true);
+	});
+});
+
+describe('SPF_CANARY_DOMAINS sanity', () => {
+	it('has a minimum representative sample size', () => {
+		// Below ~15 domains, a single false negative is >6%, making thresholds noisy.
+		expect(SPF_CANARY_DOMAINS.length).toBeGreaterThanOrEqual(15);
+	});
+
+	it('contains only lowercase ascii domains (no IPs, no spaces, no uppercase)', () => {
+		for (const d of SPF_CANARY_DOMAINS) {
+			expect(d).toMatch(/^[a-z0-9.-]+\.[a-z]{2,}$/);
+		}
+	});
+
+	it('contains no duplicates', () => {
+		expect(new Set(SPF_CANARY_DOMAINS).size).toBe(SPF_CANARY_DOMAINS.length);
+	});
+});


### PR DESCRIPTION
## Summary
- Adds a daily SPF canary that probes a curated stable-SPF domain set during the cron handler
- Emits a webhook alert (with failing domains attached) when null rate breaches `ALERT_SPF_NULL_RATE_THRESHOLD` (default 15%)
- Always logs the outcome so a silent run is distinguishable from a clean run

A 189-domain probe before this change found zero false-null SPFs on the sample — the canary exists so the next time nulls appear in production, the responder gets a concrete reproducer instead of a pattern.

## Test plan
- [x] `test/lib/spf-canary.spec.ts` covers threshold breach, clean run, and DNS-error paths
- [ ] CI: build-and-test, contract, security, repo-hygiene
- [ ] After merge: watch first scheduled run for the new log line

🤖 Generated with [Claude Code](https://claude.com/claude-code)