### PR TITLE
chore: bump version to 2.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [2.24.0] - 2026-05-21
+
+### Added
+- **Daily SPF canary** (`src/lib/spf-canary.ts`, `src/scheduled.ts`) — probes a curated stable-SPF domain set during the daily cron and emits a webhook alert (with failing domains attached) when the null-rate breaches `ALERT_SPF_NULL_RATE_THRESHOLD` (default 15%). Outcome is always logged so silent runs are distinguishable from clean runs. A 189-domain pre-flight on the SPF lookup path found zero false-null SPFs — the canary exists as a tripwire for the next "elevated null SPF" dashboard observation.
+
+### Changed
+- **`scan_domain` free-tier daily limit raised 5 → 25** (`src/lib/config.ts`) — unauthenticated callers now get 25 scans per IP per day instead of 5. Quota headers (`x-quota-limit`) and `-32029` error messages updated accordingly.
+
+### Fixed
+- **Rate-limiter short-circuit on `Infinity` limits** (`src/lib/rate-limiter.ts`) — `checkToolDailyRateLimit` and `checkGlobalDailyLimit` now return early when `limit` is non-finite, before the `QuotaCoordinator` DO call. `JSON.stringify(Infinity)` yielded `"null"`, which hit the `validateQuotaPayload` finite-number guard and returned HTTP 400 on legitimate owner-tier requests. The `limit <= 0` carve-out (e.g. agent-tier brand-audit deny) is preserved.
+
+### Tests
+- `test/lib/spf-canary.spec.ts` — threshold breach, clean run, and DNS-error paths.
+- `test/rate-limiter.spec.ts` — Infinity short-circuit, global-cap Infinity, `limit=0` security guard.
+- `test/index.spec.ts`, `test/freemium-limits.spec.ts` — assertions realigned with the new `scan_domain` cap.
+
+### Dependencies
+- Patch bumps: `hono` 4.12.18 → 4.12.21, `marked` 18.0.3 → 18.0.4, `typescript-eslint` 8.59.3 → 8.59.4, Cloudflare devtools group (3 updates).
+
 ## [2.23.0] - 2026-05-21
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.23.0",
+	"version": "2.24.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "2.23.0",
+			"version": "2.24.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "2.23.0",
+	"version": "2.24.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "2.23.0",
+	"version": "2.24.0",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "2.23.0",
+			"version": "2.24.0",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '2.23.0';
+export const SERVER_VERSION = '2.24.0';


### PR DESCRIPTION
## Summary
- Bumps `SERVER_VERSION`, `package.json`, `package-lock.json`, and both `server.json` version fields to `2.24.0`
- CHANGELOG entry rolls up the post-2.23.0 work:
  - feat(scheduled): daily SPF canary with null-rate alert (#168)
  - fix(rate-limiter): Infinity short-circuit + scan_domain free limit 5 → 25 (#167)
  - chore(deps): hono, marked, typescript-eslint, cloudflare group patch bumps

## Test plan
- [x] typecheck + lint clean locally
- [x] rate-limit + spf-canary + freemium spec suites pass (80 tests)
- [ ] CI required checks
- [ ] After merge: tag `v2.24.0` and trigger publish.yml

🤖 Generated with [Claude Code](https://claude.com/claude-code)