### PR TITLE
ci(publish): gate npm + MCP Registry jobs pending NPM_TOKEN rotation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -135,6 +135,13 @@ jobs:
     needs: version-bump
     runs-on: ubuntu-latest
     environment: production
+    # Gated off while the production `NPM_TOKEN` is being rotated. The hosted
+    # token returned 404 on `npm publish` for v2.24.0 (npm reports 404 for
+    # auth-shaped misses). Re-enable by deleting this `if:` line once a fresh
+    # token with publish rights to both `blackveil-dns` and
+    # `@blackveil/dns-checks` is in the production env. Releases are running
+    # via the manual fallback in the meantime.
+    if: false
     steps:
       - name: Check npm token
         env:
@@ -245,6 +252,11 @@ jobs:
     needs: [validate, version-bump]
     runs-on: ubuntu-latest
     environment: production
+    # Gated off in lockstep with publish-npm. The MCP Registry validates that
+    # the npm package version exists before publishing, so this job cascades to
+    # `NPM package 'blackveil-dns' not found (status: 404)` whenever npm is
+    # stale. Re-enable together with publish-npm once `NPM_TOKEN` is rotated.
+    if: false
     steps:
       - name: Check publisher key
         env:


### PR DESCRIPTION
## Summary
- Adds `if: false` gates on `publish-npm` and `publish-registry` jobs in `publish.yml`
- Token returned 404 on `npm publish` during the v2.24.0 release; releases now go through the manual fallback in the meantime
- Cloudflare-deploy job left as-is (token intentionally absent — manual deploys via `npm run deploy:prod`)

Re-enable by deleting the `if:` lines once a fresh `NPM_TOKEN` with publish rights to both `blackveil-dns` and `@blackveil/dns-checks` is added to the production env.

## Test plan
- [x] `workflow-secret-check.audit.test.ts` passes (the audit forbids the `skip=true → if: env.skip != 'true'` warn-and-skip pattern; job-level `if: false` is a different mechanism and not flagged)
- [ ] CI required checks
- [ ] Future tag push: workflow run no longer shows red for npm/MCP-Registry; Cloudflare-deploy still red (by design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)