### PR TITLE
fix(repo-safety): restore real client-domain list after history rewrite

### DIFF
--- a/scripts/repo-safety/policy.json
+++ b/scripts/repo-safety/policy.json
@@ -63,20 +63,20 @@
 		"placeholder"
 	],
 	"forbiddenClientDomains": [
-		"brand-eta.com",
-		"brand-zeta.com",
-		"brand-beta.com",
-		"brand-beta.com.au",
-		"brand-iota.com",
-		"brand-kappa.com",
-		"brand-theta.com",
-		"brand-gamma.com",
+		"bankofamerica.com",
+		"disney.com",
+		"ford.com",
+		"ford.com.au",
+		"lockheedmartin.com",
+		"marriott.com",
+		"mastercard.com",
+		"nike.com",
 		"paypal.com",
 		"stripe.com",
-		"brand-lambda.com",
-		"brand-mu.com",
-		"brand-mu.com.au",
-		"brand-alpha.com"
+		"uber.com",
+		"verizon.com",
+		"verizon.com.au",
+		"walmart.com"
 	],
 	"allowedPaths": [
 		".gitleaks.toml",

--- a/scripts/repo-safety/scan-commit-history.mjs
+++ b/scripts/repo-safety/scan-commit-history.mjs
@@ -11,15 +11,14 @@ const scriptDir = dirname(fileURLToPath(import.meta.url));
 const range = process.argv[2] ?? '--all';
 
 const basePolicy = JSON.parse(readFileSync(join(scriptDir, 'policy.json'), 'utf8'));
+// Survey-only: extend policy.forbiddenClientDomains with Tier-1 brands that
+// shouldn't gate commits (legitimate marketing/DNS-example usage) but ARE
+// worth surfacing during a history sweep. The gating rule reads policy.json
+// directly and stays narrow.
+const SURVEY_ONLY_DOMAINS = ['amazon.com', 'apple.com', 'github.com', 'google.com', 'microsoft.com'];
 const policy = normalizePolicy({
 	...basePolicy,
-	forbiddenClientDomains: [
-		'amazon.com', 'apple.com', 'brand-eta.com', 'brand-zeta.com',
-		'brand-beta.com', 'brand-beta.com.au', 'github.com', 'google.com',
-		'brand-iota.com', 'brand-kappa.com', 'brand-theta.com',
-		'microsoft.com', 'brand-gamma.com', 'paypal.com', 'stripe.com',
-		'brand-lambda.com', 'brand-mu.com', 'brand-mu.com.au', 'brand-alpha.com',
-	],
+	forbiddenClientDomains: [...(basePolicy.forbiddenClientDomains ?? []), ...SURVEY_ONLY_DOMAINS],
 });
 
 const SEP = '<<<<COMMIT-SEP>>>>';

--- a/src/lib/brand-audit-csc-enrichment.ts
+++ b/src/lib/brand-audit-csc-enrichment.ts
@@ -48,7 +48,7 @@ export interface EnrichOutputCandidate extends EnrichInputCandidate {
 
 export interface EnrichResult {
 	candidates: EnrichOutputCandidate[];
-	enrichmentStatus: 'ready' | 'partial' | 'sparse';
+	enrichmentStatus: 'ready' | 'partial';
 }
 
 export interface EnrichOptions {
@@ -165,7 +165,7 @@ export async function enrichCandidatesForDefensiveDetection(opts: EnrichOptions)
 					httpRedirectLocation,
 					defensive: evaluation.defensive,
 					// Map evaluateDefensiveRegistration's `reason` to our output field `defensiveReason`.
-					defensiveReason: evaluation.reason,
+					...(evaluation.reason ? { defensiveReason: evaluation.reason } : {}),
 				};
 			} catch {
 				anyFailed = true;

--- a/src/lib/brand-audit-csc-enrichment.ts
+++ b/src/lib/brand-audit-csc-enrichment.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Per-candidate MX + HTTP enrichment to feed the defensive-registration heuristic.
+ *
+ * For each top-N candidate (ranked by combinedConfidence, capped at MAX_ENRICH_CANDIDATES),
+ * fetches in parallel:
+ *   - MX records via Google DoH (safe — Google's DoH endpoint is public)
+ *   - HTTP HEAD via safeFetch (manual redirect; safe-fetch enforces SSRF guards
+ *     because the candidate's hostname is attacker-controllable through the
+ *     discovery pipeline).
+ *
+ * Stamps { defensive, defensiveReason } onto each candidate based on
+ * evaluateDefensiveRegistration's signal-based decision.
+ *
+ * Note on result mapping: evaluateDefensiveRegistration returns { defensive, reason? }
+ * but the enrichment output interface uses { defensive, defensiveReason? } for
+ * consistency with downstream consumers. The mapping is: reason → defensiveReason.
+ *
+ * Honest failure handling:
+ *   - Total budget exceeded → enrichmentStatus='partial'
+ *   - Any candidate's MX or HTTP fetch fails → that candidate is unenriched
+ *     (no stamp), reflected in overall status.
+ *
+ * Worker-runtime safe — uses only Web APIs (fetch, AbortController, Headers).
+ */
+
+import { safeFetch } from './safe-fetch';
+import { evaluateDefensiveRegistration, type DefensiveReason } from './brand-defensive-registration';
+
+const MAX_ENRICH_CANDIDATES = 50;
+const DEFAULT_BUDGET_MS = 8_000;
+const PER_CANDIDATE_TIMEOUT_MS = 3_000;
+const DOH_ENDPOINT = 'https://dns.google/resolve';
+
+export interface EnrichInputCandidate {
+	domain: string;
+	combinedConfidence: number | null;
+}
+
+export interface EnrichOutputCandidate extends EnrichInputCandidate {
+	defensive?: boolean;
+	/** Maps from evaluateDefensiveRegistration's `reason` field. */
+	defensiveReason?: DefensiveReason;
+	mxRecords?: string[];
+	httpRedirectLocation?: string | null;
+}
+
+export interface EnrichResult {
+	candidates: EnrichOutputCandidate[];
+	enrichmentStatus: 'ready' | 'partial' | 'sparse';
+}
+
+export interface EnrichOptions {
+	target: string;
+	candidates: ReadonlyArray<EnrichInputCandidate>;
+	budgetMs?: number;
+	/** Per-candidate NS hostnames, keyed by domain. Used by evaluateDefensiveRegistration's parked-ns signal. */
+	nsHosts?: Record<string, string[]>;
+}
+
+/**
+ * Fetch MX records for a domain via Google DoH.
+ *
+ * Returns the MX hostname list on success (may be empty), or `null` when
+ * the fetch fails or is aborted.
+ */
+async function fetchMx(domain: string, signal: AbortSignal): Promise<string[] | null> {
+	try {
+		const res = await fetch(`${DOH_ENDPOINT}?name=${encodeURIComponent(domain)}&type=MX`, {
+			signal,
+			headers: { Accept: 'application/dns-json' },
+		});
+		if (!res.ok) return null;
+		const body = (await res.json()) as { Answer?: Array<{ data: string }> };
+		if (!body.Answer) return [];
+		// MX data format: "<priority> <hostname>" — extract hostname only, strip trailing dot.
+		return body.Answer.map((a) => a.data.split(/\s+/).slice(-1)[0]!.replace(/\.$/, ''));
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Perform an HTTP HEAD of a candidate's root URL and return the `Location`
+ * header value if the response is a redirect (3xx), `null` if the response
+ * is non-redirect, or `undefined` if the fetch fails or is aborted.
+ *
+ * `undefined` is the "fetch failed — abstain" sentinel; `null` is "we looked,
+ * no redirect." This distinction matters downstream: evaluateDefensiveRegistration
+ * receives `httpRedirectLocation: undefined` → abstain, `null` → not a redirect.
+ *
+ * Uses safeFetch because the candidate hostname is attacker-controllable.
+ */
+async function fetchHttpRedirect(domain: string, signal: AbortSignal): Promise<string | null | undefined> {
+	try {
+		const res = await safeFetch(`https://${domain}/`, {
+			method: 'HEAD',
+			redirect: 'manual',
+			signal,
+		});
+		if (res.status >= 300 && res.status < 400) {
+			return res.headers.get('Location');
+		}
+		return null;
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Enrich up to MAX_ENRICH_CANDIDATES top candidates with MX records and HTTP
+ * redirect signals, then annotate each with { defensive, defensiveReason }
+ * based on evaluateDefensiveRegistration.
+ *
+ * Candidates are ranked descending by `combinedConfidence` before slicing so
+ * we always enrich the most-likely candidates within the budget.
+ */
+export async function enrichCandidatesForDefensiveDetection(opts: EnrichOptions): Promise<EnrichResult> {
+	const budget = opts.budgetMs ?? DEFAULT_BUDGET_MS;
+
+	const ranked = [...opts.candidates]
+		.sort((a, b) => (b.combinedConfidence ?? 0) - (a.combinedConfidence ?? 0))
+		.slice(0, MAX_ENRICH_CANDIDATES);
+
+	const globalController = new AbortController();
+	const budgetTimer = setTimeout(() => globalController.abort(), budget);
+
+	let anyFailed = false;
+
+	const enriched: EnrichOutputCandidate[] = await Promise.all(
+		ranked.map(async (candidate): Promise<EnrichOutputCandidate> => {
+			// Each candidate gets its own controller so per-candidate timeouts don't
+			// cancel the entire batch, and so the global budget abort propagates down.
+			const perCandidateController = new AbortController();
+			const onGlobalAbort = (): void => perCandidateController.abort();
+			globalController.signal.addEventListener('abort', onGlobalAbort);
+			const perTimer = setTimeout(() => perCandidateController.abort(), PER_CANDIDATE_TIMEOUT_MS);
+
+			try {
+				const [mxRecords, httpRedirectLocation] = await Promise.all([
+					fetchMx(candidate.domain, perCandidateController.signal),
+					fetchHttpRedirect(candidate.domain, perCandidateController.signal),
+				]);
+
+				// `null` from fetchMx means "fetch failed" — abstain rather than misfire.
+				// `undefined` from fetchHttpRedirect means "fetch failed" — abstain.
+				if (mxRecords === null || httpRedirectLocation === undefined) {
+					anyFailed = true;
+					return { ...candidate };
+				}
+
+				const evaluation = evaluateDefensiveRegistration({
+					candidateDomain: candidate.domain,
+					targetDomain: opts.target,
+					mxRecords,
+					// Narrow null → undefined so TS sees `string | undefined` matching the input type.
+					httpRedirectLocation: httpRedirectLocation ?? undefined,
+					nsHosts: opts.nsHosts?.[candidate.domain],
+				});
+
+				return {
+					...candidate,
+					mxRecords,
+					httpRedirectLocation,
+					defensive: evaluation.defensive,
+					// Map evaluateDefensiveRegistration's `reason` to our output field `defensiveReason`.
+					defensiveReason: evaluation.reason,
+				};
+			} catch {
+				anyFailed = true;
+				return { ...candidate };
+			} finally {
+				clearTimeout(perTimer);
+				globalController.signal.removeEventListener('abort', onGlobalAbort);
+			}
+		}),
+	);
+
+	clearTimeout(budgetTimer);
+
+	const status: EnrichResult['enrichmentStatus'] = anyFailed ? 'partial' : 'ready';
+	return { candidates: enriched, enrichmentStatus: status };
+}

--- a/test/brand-audit-csc-enrichment.spec.ts
+++ b/test/brand-audit-csc-enrichment.spec.ts
@@ -164,5 +164,17 @@ describe('enrichCandidatesForDefensiveDetection', () => {
 		expect(result.candidates[0].defensive).toBeUndefined();
 		expect(result.candidates[0].mxRecords).toBeUndefined();
 		expect(result.candidates[0].httpRedirectLocation).toBeUndefined();
+
+		// Pins the boundary the test claims to verify: safeFetch must reject the
+		// private-IP URL BEFORE any network call. Without this assertion, the test
+		// passes whether the rejection comes from safeFetch's SSRF gate or from
+		// the mock's catch-all "Unexpected fetch" rejection — i.e. it would still
+		// pass if safeFetch were silently replaced with bare fetch.
+		const fetchMock = globalThis.fetch as ReturnType<typeof vi.fn>;
+		const privateIpFetchCalls = fetchMock.mock.calls.filter(([input]) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : (input as Request).url;
+			return url.startsWith('https://192.168.1.1');
+		});
+		expect(privateIpFetchCalls).toHaveLength(0);
 	});
 });

--- a/test/brand-audit-csc-enrichment.spec.ts
+++ b/test/brand-audit-csc-enrichment.spec.ts
@@ -128,4 +128,41 @@ describe('enrichCandidatesForDefensiveDetection', () => {
 		});
 		expect(result.enrichmentStatus).toBe('partial');
 	});
+
+	it('isolates candidates blocked by safeFetch SSRF gate (unenriched, no crash)', async () => {
+		// Mock only the DoH endpoint (Google DNS is public, not SSRF-blocked).
+		// Let safeFetch's real SSRF gate reject the private-IP HTTP fetch.
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			// Mock only DoH for MX lookup (public endpoint, safe)
+			if (url.includes('dns.google') && url.includes('192.168.1.1') && url.includes('type=MX')) {
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					json: () => Promise.resolve({ Answer: [] }),
+					headers: new Headers(),
+				});
+			}
+			// For any other URL (including https://192.168.1.1/), return an error to simulate
+			// the real fetch happening — but safeFetch's validateOutboundUrl will throw
+			// before this mock is even invoked for private IPs.
+			return Promise.reject(new Error('Unexpected fetch'));
+		});
+
+		const { enrichCandidatesForDefensiveDetection } = await import('../src/lib/brand-audit-csc-enrichment');
+		const result = await enrichCandidatesForDefensiveDetection({
+			target: 'target.com',
+			candidates: [{ domain: '192.168.1.1', combinedConfidence: 0.9 }],
+			budgetMs: 3_000,
+		});
+
+		// safeFetch rejects the HTTP HEAD to 192.168.1.1 (SSRF gate), so fetchHttpRedirect returns undefined,
+		// triggering anyFailed = true and enrichmentStatus = 'partial'.
+		expect(result.enrichmentStatus).toBe('partial');
+		// The candidate is unenriched (no defensive field) because the HTTP fetch was rejected by SSRF gate.
+		// When httpRedirectLocation is undefined, the whole candidate enrichment is skipped (unenriched).
+		expect(result.candidates[0].defensive).toBeUndefined();
+		expect(result.candidates[0].mxRecords).toBeUndefined();
+		expect(result.candidates[0].httpRedirectLocation).toBeUndefined();
+	});
 });

--- a/test/brand-audit-csc-enrichment.spec.ts
+++ b/test/brand-audit-csc-enrichment.spec.ts
@@ -1,0 +1,131 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { setupFetchMock } from './helpers/dns-mock';
+
+describe('enrichCandidatesForDefensiveDetection', () => {
+	let fetchMock: ReturnType<typeof setupFetchMock>;
+
+	beforeEach(() => {
+		fetchMock = setupFetchMock();
+	});
+
+	afterEach(() => {
+		fetchMock.restore();
+	});
+
+	it('stamps defensive=true with reason=redirect-to-target on a candidate that 301s to target', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('dns.google') && url.includes('forrd.com') && url.includes('type=MX')) {
+				return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ Answer: [] }) });
+			}
+			if (url === 'https://forrd.com/') {
+				return Promise.resolve({
+					ok: false,
+					status: 301,
+					headers: new Headers({ Location: 'https://ford.com/' }),
+				});
+			}
+			return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({}) });
+		});
+
+		const { enrichCandidatesForDefensiveDetection } = await import('../src/lib/brand-audit-csc-enrichment');
+		const result = await enrichCandidatesForDefensiveDetection({
+			target: 'ford.com',
+			candidates: [{ domain: 'forrd.com', combinedConfidence: 0.9 }],
+			budgetMs: 5_000,
+		});
+
+		expect(result.enrichmentStatus).toBe('ready');
+		const forrd = result.candidates[0];
+		expect(forrd.defensive).toBe(true);
+		expect(forrd.defensiveReason).toBe('redirect-to-target');
+	});
+
+	it('returns enrichmentStatus=partial when some fetches fail', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('dns.google') && url.includes('forrd.com') && url.includes('type=MX')) {
+				return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ Answer: [] }) });
+			}
+			if (url === 'https://forrd.com/') {
+				return Promise.resolve({
+					ok: false,
+					status: 301,
+					headers: new Headers({ Location: 'https://ford.com/' }),
+				});
+			}
+			// timeout.com fetches all throw
+			return Promise.reject(new Error('timeout'));
+		});
+
+		const { enrichCandidatesForDefensiveDetection } = await import('../src/lib/brand-audit-csc-enrichment');
+		const result = await enrichCandidatesForDefensiveDetection({
+			target: 'ford.com',
+			candidates: [
+				{ domain: 'forrd.com', combinedConfidence: 0.9 },
+				{ domain: 'timeout.com', combinedConfidence: 0.7 },
+			],
+			budgetMs: 5_000,
+		});
+
+		expect(result.enrichmentStatus).toBe('partial');
+	});
+
+	it('caps candidates at 50 by combinedConfidence', async () => {
+		// Return fast empty responses for all fetches so the test is deterministic
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status: 200,
+			json: () => Promise.resolve({ Answer: [] }),
+			headers: new Headers(),
+		});
+
+		const candidates = Array.from({ length: 100 }, (_, i) => ({
+			domain: `c${i}.com`,
+			combinedConfidence: i / 100,
+		}));
+		const { enrichCandidatesForDefensiveDetection } = await import('../src/lib/brand-audit-csc-enrichment');
+		const result = await enrichCandidatesForDefensiveDetection({
+			target: 'ford.com',
+			candidates,
+			budgetMs: 5_000,
+		});
+		expect(result.candidates.length).toBe(50);
+		// Sorted descending by combinedConfidence — c99 (99/100) is first
+		expect(result.candidates[0].domain).toBe('c99.com');
+	});
+
+	it('respects budgetMs and returns partial enrichment if budget exceeded', async () => {
+		// Simulate slow fetches — delay longer than the 1ms budget
+		globalThis.fetch = vi.fn().mockImplementation(
+			(_input: string | URL | Request, init?: RequestInit) =>
+				new Promise<Response>((resolve, reject) => {
+					const timer = setTimeout(() => {
+						resolve({
+							ok: true,
+							status: 200,
+							json: () => Promise.resolve({ Answer: [] }),
+							headers: new Headers(),
+						} as unknown as Response);
+					}, 100);
+					// Respect abort signal
+					init?.signal?.addEventListener('abort', () => {
+						clearTimeout(timer);
+						reject(new DOMException('Aborted', 'AbortError'));
+					});
+				}),
+		);
+
+		const candidates = Array.from({ length: 50 }, (_, i) => ({
+			domain: `c${i}.com`,
+			combinedConfidence: 0.9,
+		}));
+		const { enrichCandidatesForDefensiveDetection } = await import('../src/lib/brand-audit-csc-enrichment');
+		const result = await enrichCandidatesForDefensiveDetection({
+			target: 'ford.com',
+			candidates,
+			budgetMs: 1,
+		});
+		expect(result.enrichmentStatus).toBe('partial');
+	});
+});


### PR DESCRIPTION
The 2026-05-22 `filter-repo --replace-text` pass rewrote ALL file blobs including `policy.json` itself, turning the live `forbiddenClientDomains` list into placeholders (`brand-eta.com`, etc.). The actual gating rule then matched placeholders instead of real client names — defeating the forward-leak protection.

## Changes
- `policy.forbiddenClientDomains` restored to the 12 real client domains: `bankofamerica.com`, `disney.com`, `ford.com[.au]`, `lockheedmartin.com`, `marriott.com`, `mastercard.com`, `nike.com`, `paypal.com`, `stripe.com`, `uber.com`, `verizon.com[.au]`, `walmart.com`. `policy.json` is in `allowedPaths` so the rule doesn't flag itself.
- `scan-commit-history.mjs` now reads from `policy.forbiddenClientDomains` directly. A small `SURVEY_ONLY_DOMAINS` array (`amazon`/`apple`/`github`/`google`/`microsoft`) is added for Tier-1 brands worth surfacing in history sweeps without gating commits.

## Test plan
- [x] `npm run audit:repo-safety` clean
- [x] history survey: 56 commits flagged (down from 59) — residual hits are Tier-1 brand mentions in legitimate marketing context only
- [ ] CI required checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)