### PR TITLE
chore(repo-safety): Phase 1 — redact client names from source code + hashed scanner gate

### DIFF
--- a/scripts/generate-consolidated-report.mjs
+++ b/scripts/generate-consolidated-report.mjs
@@ -145,7 +145,7 @@ lines.push('');
 lines.push('- **ccTLDs without RDAP** (`.me/.co/.us/.sh/.io/.uk/.fr/.ca/...`) resolved via the bv-whois shim Worker (WHOIS-over-TCP/43 with IANA referral cache).');
 lines.push('- **`.de` (DENIC) is short-circuited as redacted** — German law (BDSG) requires the registry to withhold the registrar field, and DENIC blocks Cloudflare Workers\' egress IPs at port 43. The shim returns `source: redacted` instantly without contacting the network.');
 lines.push('- **MarkMonitor / Com Laude / SafeNames** each appear under multiple string variants (case, regional subsidiary, dba); normalized to one family per provider.');
-lines.push('- **Confidence threshold for shadow IT = 0.7** matches the original spec. Defensive registrations at conf=0.5 (e.g., `walmart.app/io/org`) fall into the impersonation bucket despite being likely Walmart-owned. Threshold tuning is a follow-up.');
+lines.push('- **Confidence threshold for shadow IT = 0.7** matches the original spec. Defensive registrations at conf=0.5 (e.g., `brand-name.app/io/org`) fall into the impersonation bucket despite being likely brand-owned. Threshold tuning is a follow-up.');
 lines.push('- **Candidate set is `<base>.<TLD>` for 15 hardcoded TLDs.** Subdomains under target (e.g., `mail.apple.com`) come from discovery signals separately.');
 
 writeFileSync('reports/CONSOLIDATED_BRAND_AUDIT.md', lines.join('\n'));

--- a/scripts/repo-safety/policy.json
+++ b/scripts/repo-safety/policy.json
@@ -38,13 +38,7 @@
 		".yaml",
 		".yml"
 	],
-	"allowedEmailDomains": [
-		"example.com",
-		"example.test",
-		"example.invalid",
-		"blackveilsecurity.com",
-		"anthropic.com"
-	],
+	"allowedEmailDomains": ["example.com", "example.test", "example.invalid", "blackveilsecurity.com", "anthropic.com"],
 	"allowedDomainSuffixes": [
 		"example.com",
 		"example.net",
@@ -62,21 +56,21 @@
 		"bv-enterprise.internal",
 		"placeholder"
 	],
-	"forbiddenClientDomains": [
-		"bankofamerica.com",
-		"disney.com",
-		"ford.com",
-		"ford.com.au",
-		"lockheedmartin.com",
-		"marriott.com",
-		"mastercard.com",
-		"nike.com",
-		"paypal.com",
-		"stripe.com",
-		"uber.com",
-		"verizon.com",
-		"verizon.com.au",
-		"walmart.com"
+	"forbiddenClientDomainsSha256": [
+		"4db297a4c73fa253f97f31b562be9dd9349ad26f93c44ebcd0c2a742426d56ba",
+		"0c9f99ea4d1e717635f3e35a7bdd7bb09672f2e94fe36a73c7677448f9faffe4",
+		"f990f7e144194cd2d403c219b41a07c394dab4b9fc7964b7f2c2b29afcf16990",
+		"6618496ed36097566de119c950f3590fcb9c983419fd917d67108de7d583be30",
+		"b5d41f3f34570aca8c8e0bc2b3239c9ed3532032ab514468c5378ee0903f3748",
+		"458f9c53ba8f671d8c73b49a4617abc2eb93c7fefdee11eadd4a4de23d033f91",
+		"d2df6e8a4ab3e118a8777b97ade0ba94e003bcb8ab8553b984541a0667dae6a9",
+		"67037bf0aa492bd826e82f670f46e6ba1dcba18e6a69209d17725c0f442a1301",
+		"d9bc33bd9d8199dcdc7be674668f18d908adfd3c435c4db09f35221db800ad7a",
+		"1ffda32ad70e3cac6d6a04e2fbb00c062cc12d3a02796149e639c6d9a3e2774b",
+		"29bbd23dd5a92cba0fa162bf42a85331460327414ea31d4f6e1cce6194f760d5",
+		"9f0f1d59232eb5cc8912891f20ac79c3382cb6a6ddaa3219fa6ea580246c1516",
+		"535ec9f5db721c7b882abb6b45b601b5549a33145de2ab97b817c4790e7570f3",
+		"b440031c0ea27cb8f0efb1df3db2857bd54331b529cde6ba7d7641ee94754436"
 	],
 	"allowedPaths": [
 		".gitleaks.toml",
@@ -98,8 +92,6 @@
 		"scripts/repo-safety/scanner-core.mjs",
 		"scripts/repo-safety/scan-branch.mjs",
 		"scripts/repo-safety/scan-commit-history.mjs",
-		"src/lib/spf-canary.ts",
-		"src/lib/brand-audit-provider-sprawl.ts",
 		"test/brand-audit-provider-sprawl.test.ts",
 		"scripts/pressure-chaos-test.mjs",
 		"test/audits/repo-safety-scanner.audit.test.ts",
@@ -107,9 +99,5 @@
 		"scripts/repo-safety/policy.json",
 		"src/lib/authoritative-dns-infra/root-hints.ts"
 	],
-	"allowedPathPrefixes": [
-		".github/",
-		"test/",
-		"packages/dns-checks/src/__tests__/"
-	]
+	"allowedPathPrefixes": [".github/", "test/", "packages/dns-checks/src/__tests__/"]
 }

--- a/scripts/repo-safety/scan-branch.mjs
+++ b/scripts/repo-safety/scan-branch.mjs
@@ -16,17 +16,13 @@ if (!ref) {
 const enableClientDomains = process.argv.includes('--with-client-domains');
 
 const basePolicy = JSON.parse(readFileSync(join(scriptDir, 'policy.json'), 'utf8'));
+// Survey-only extension: Tier-1 brands worth surfacing in a sweep but not
+// worth gating (legitimate DNS-example / marketing usage). The base policy's
+// hashed forbidden list still applies — this just widens the survey.
+const SURVEY_ONLY_DOMAINS = ['amazon.com', 'apple.com', 'github.com', 'google.com', 'microsoft.com'];
 const policy = normalizePolicy({
 	...basePolicy,
-	forbiddenClientDomains: enableClientDomains
-		? [
-				'amazon.com', 'apple.com', 'brand-eta.com', 'brand-zeta.com',
-				'brand-beta.com', 'brand-beta.com.au', 'github.com', 'google.com',
-				'brand-iota.com', 'brand-kappa.com', 'brand-theta.com',
-				'microsoft.com', 'brand-gamma.com', 'paypal.com', 'stripe.com',
-				'brand-lambda.com', 'brand-mu.com', 'brand-mu.com.au', 'brand-alpha.com',
-			]
-		: basePolicy.forbiddenClientDomains ?? [],
+	forbiddenClientDomains: enableClientDomains ? SURVEY_ONLY_DOMAINS : (basePolicy.forbiddenClientDomains ?? []),
 });
 
 const files = execFileSync('git', ['ls-tree', '-r', '--name-only', '-z', ref], { encoding: 'utf8' })

--- a/scripts/repo-safety/scanner-core.mjs
+++ b/scripts/repo-safety/scanner-core.mjs
@@ -1,3 +1,5 @@
+import { createHash } from 'node:crypto';
+
 const DEFAULT_POLICY = {
 	forbiddenPaths: [],
 	sourceExtensions: ['.cjs', '.js', '.json', '.jsonc', '.md', '.mjs', '.py', '.sh', '.sql', '.toml', '.ts', '.tsx', '.yaml', '.yml'],
@@ -5,6 +7,7 @@ const DEFAULT_POLICY = {
 	allowedDomainSuffixes: ['example.com', 'example.net', 'example.org', 'example.test', 'example.invalid', 'localhost', 'blackveilsecurity.com'],
 	allowedInternalHostnames: [],
 	forbiddenClientDomains: [],
+	forbiddenClientDomainsSha256: [],
 	allowedPaths: [],
 	allowedPathPrefixes: [],
 };
@@ -43,6 +46,7 @@ export function normalizePolicy(policy = {}) {
 		allowedDomainSuffixes: policy.allowedDomainSuffixes ?? DEFAULT_POLICY.allowedDomainSuffixes,
 		allowedInternalHostnames: policy.allowedInternalHostnames ?? DEFAULT_POLICY.allowedInternalHostnames,
 		forbiddenClientDomains: policy.forbiddenClientDomains ?? DEFAULT_POLICY.forbiddenClientDomains,
+		forbiddenClientDomainsSha256: policy.forbiddenClientDomainsSha256 ?? DEFAULT_POLICY.forbiddenClientDomainsSha256,
 		allowedPaths: policy.allowedPaths ?? DEFAULT_POLICY.allowedPaths,
 		allowedPathPrefixes: policy.allowedPathPrefixes ?? DEFAULT_POLICY.allowedPathPrefixes,
 	};
@@ -112,6 +116,22 @@ function clientDomainPattern(domain) {
 	return new RegExp(`\\b${escaped}\\b`, 'gi');
 }
 
+// Multi-label hostname candidate, e.g. `foo.bar.example.com`. Used to extract
+// domain-like tokens from text so each can be checked against the hashed
+// forbidden list without storing plaintext names in policy.json.
+const DOMAIN_CANDIDATE_PATTERN = /\b[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?){1,}\b/gi;
+
+function sha256Hex(value) {
+	return createHash('sha256').update(value.toLowerCase()).digest('hex');
+}
+
+function* tailSuffixes(domain) {
+	const labels = domain.toLowerCase().split('.');
+	for (let i = 0; i < labels.length - 1; i++) {
+		yield labels.slice(i).join('.');
+	}
+}
+
 function finding(file, text, lineIndex, match, ruleId) {
 	return {
 		file,
@@ -140,6 +160,18 @@ export function scanTextForSensitiveSurface(file, text, policy = DEFAULT_POLICY)
 		for (const domain of normalized.forbiddenClientDomains) {
 			for (const match of line.matchAll(clientDomainPattern(domain))) {
 				findings.push(finding(file, line, lineIndex, match, 'client-domain'));
+			}
+		}
+
+		if (normalized.forbiddenClientDomainsSha256.length > 0) {
+			const hashes = new Set(normalized.forbiddenClientDomainsSha256);
+			for (const match of line.matchAll(DOMAIN_CANDIDATE_PATTERN)) {
+				for (const suffix of tailSuffixes(match[0])) {
+					if (hashes.has(sha256Hex(suffix))) {
+						findings.push(finding(file, line, lineIndex, match, 'client-domain'));
+						break;
+					}
+				}
 			}
 		}
 

--- a/src/lib/brand-audit-pdf-render.ts
+++ b/src/lib/brand-audit-pdf-render.ts
@@ -71,24 +71,26 @@ function badgeColor(bucket: BrandAuditBucket) {
  * defensive fallback (last `.replace`).
  */
 function winAnsiSafe(s: string): string {
-	return s
-		.replace(/≥/g, '>=')
-		.replace(/≤/g, '<=')
-		.replace(/≠/g, '!=')
-		.replace(/≈/g, '~')
-		.replace(/×/g, 'x')
-		.replace(/±/g, '+/-')
-		.replace(/—/g, '--')
-		.replace(/–/g, '-')
-		.replace(/…/g, '...')
-		.replace(/[“”]/g, '"')
-		.replace(/[‘’]/g, "'")
-		.replace(/→/g, '->')
-		.replace(/←/g, '<-')
-		.replace(/✓/g, 'v')
-		.replace(/✗/g, 'x')
-		// Strip any remaining > U+00FF that WinAnsi can't encode.
-		.replace(/[^\x00-\xff]/g, '?');
+	return (
+		s
+			.replace(/≥/g, '>=')
+			.replace(/≤/g, '<=')
+			.replace(/≠/g, '!=')
+			.replace(/≈/g, '~')
+			.replace(/×/g, 'x')
+			.replace(/±/g, '+/-')
+			.replace(/—/g, '--')
+			.replace(/–/g, '-')
+			.replace(/…/g, '...')
+			.replace(/[“”]/g, '"')
+			.replace(/[‘’]/g, "'")
+			.replace(/→/g, '->')
+			.replace(/←/g, '<-')
+			.replace(/✓/g, 'v')
+			.replace(/✗/g, 'x')
+			// Strip any remaining > U+00FF that WinAnsi can't encode.
+			.replace(/[^\x00-\xff]/g, '?')
+	);
 }
 
 /**
@@ -155,7 +157,7 @@ function drawCandidateRow(ctx: DrawContext, row: BrandCandidateRow): void {
 	// Row has 2 text lines (domain, metadata) + optional 3rd (reasons). Background
 	// rect height must cover ALL of them — the prior 2-line-only height let the
 	// next row's bg overdraw the reasons text (surfaced 2026-05-19 in production
-	// marriott/brandepsilon PDFs).
+	// tier-1/brandepsilon PDFs).
 	const textLines = hasReasons ? 3 : 2;
 	const rowBgHeight = ROW_HEIGHT * textLines + 4;
 	const rowSpacing = 4; // gap between rows
@@ -245,14 +247,13 @@ function tieredRowsFromCheckResult(result: CheckResult): TieredRow[] {
 		// Bucket override if the original finding said impersonationSurface but
 		// the legacy extractor coerced/dropped it.
 		const bucket = typeof m.bucket === 'string' ? (m.bucket as BrandAuditBucket | 'impersonationSurface') : baseRow.bucket;
-		const tier =
-			m.tier === 0 || m.tier === 1 || m.tier === 2 || m.tier === 3 || m.tier === 4
-				? (m.tier as 0 | 1 | 2 | 3 | 4)
-				: undefined;
+		const tier = m.tier === 0 || m.tier === 1 || m.tier === 2 || m.tier === 3 || m.tier === 4 ? (m.tier as 0 | 1 | 2 | 3 | 4) : undefined;
 		const lookalikeScore = typeof m.lookalikeScore === 'number' ? (m.lookalikeScore as number) : undefined;
 		const scoreAlertCtxRaw = m.scoreAlertContext;
 		const scoreAlertContext =
-			scoreAlertCtxRaw && typeof scoreAlertCtxRaw === 'object' && !Array.isArray(scoreAlertCtxRaw) &&
+			scoreAlertCtxRaw &&
+			typeof scoreAlertCtxRaw === 'object' &&
+			!Array.isArray(scoreAlertCtxRaw) &&
 			typeof (scoreAlertCtxRaw as { alertType?: unknown }).alertType === 'string' &&
 			typeof (scoreAlertCtxRaw as { transition?: unknown }).transition === 'string'
 				? {
@@ -300,7 +301,9 @@ function drawOwnedPortfolio(ctx: DrawContext, candidates: TieredRow[]): void {
 	const declaredEvidence = consolidated.filter((c) => c.tier === 2);
 	const inferredConsolidated = consolidated.filter((c) => c.tier === undefined || c.tier === 3);
 	const inferredShadowIt = candidates.filter((c) => c.bucket === 'shadowIt' && c.relationshipType === 'owned_off_primary_registrar');
-	const inferredIndeterminate = candidates.filter((c) => c.bucket === 'indeterminate' && c.relationshipType !== 'authorized_vendor_dependency');
+	const inferredIndeterminate = candidates.filter(
+		(c) => c.bucket === 'indeterminate' && c.relationshipType !== 'authorized_vendor_dependency',
+	);
 	const total =
 		tenantDeclared.length +
 		graphSurfaced.length +
@@ -316,11 +319,7 @@ function drawOwnedPortfolio(ctx: DrawContext, candidates: TieredRow[]): void {
 	drawSubsectionRows(ctx, graphSurfaced);
 	drawSubsectionHeader(ctx, 'Declared evidence (tier 2)', declaredEvidence.length);
 	drawSubsectionRows(ctx, declaredEvidence);
-	drawSubsectionHeader(
-		ctx,
-		'Inferred (tier 3)',
-		inferredConsolidated.length + inferredShadowIt.length + inferredIndeterminate.length,
-	);
+	drawSubsectionHeader(ctx, 'Inferred (tier 3)', inferredConsolidated.length + inferredShadowIt.length + inferredIndeterminate.length);
 	drawSubsectionRows(ctx, [...inferredConsolidated, ...inferredShadowIt, ...inferredIndeterminate]);
 }
 
@@ -358,7 +357,11 @@ function drawDepthWarnings(ctx: DrawContext, warnings: string[]): void {
 		ctx.cursorY -= 11;
 	}
 	if (extraCount > 0) {
-		drawText(ctx, `- ${extraCount} additional warning${extraCount === 1 ? '' : 's'} in JSON metadata`, { x: MARGIN + 8, size: 8, color: COLOR_DIM });
+		drawText(ctx, `- ${extraCount} additional warning${extraCount === 1 ? '' : 's'} in JSON metadata`, {
+			x: MARGIN + 8,
+			size: 8,
+			color: COLOR_DIM,
+		});
 		ctx.cursorY -= 11;
 	}
 	ctx.cursorY -= 6;
@@ -384,7 +387,13 @@ function drawFooter(ctx: DrawContext, target: string, serverVersion: string, dat
 	const pages = ctx.doc.getPages();
 	for (const p of pages) {
 		p.drawRectangle({ x: MARGIN, y: MARGIN + 24, width: CONTENT_WIDTH, height: 0.5, color: COLOR_DIM });
-		p.drawText(winAnsiSafe(`bv-mcp brand-audit · ${target} · ${dateLabel}`), { x: MARGIN, y: MARGIN + 8, size: 7, font: ctx.mono, color: COLOR_DIM });
+		p.drawText(winAnsiSafe(`bv-mcp brand-audit · ${target} · ${dateLabel}`), {
+			x: MARGIN,
+			y: MARGIN + 8,
+			size: 7,
+			font: ctx.mono,
+			color: COLOR_DIM,
+		});
 		p.drawText(winAnsiSafe(`v${serverVersion}`), { x: PAGE_WIDTH - MARGIN - 40, y: MARGIN + 8, size: 7, font: ctx.mono, color: COLOR_DIM });
 	}
 }

--- a/src/lib/brand-audit-provider-sprawl.ts
+++ b/src/lib/brand-audit-provider-sprawl.ts
@@ -27,7 +27,6 @@ const PROVIDER_RULES: readonly ProviderRule[] = [
 	{ test: /\bmarkmonitor\.com$/i, name: 'MarkMonitor' },
 	{ test: /\bgoogle\.com$/i, name: 'Google (in-house)' },
 	{ test: /\bapple\.com$/i, name: 'Apple (in-house)' },
-	{ test: /\bpaypal\.com$/i, name: 'PayPal (in-house)' },
 ];
 
 /**

--- a/src/lib/brand-audit-reaper.ts
+++ b/src/lib/brand-audit-reaper.ts
@@ -56,7 +56,7 @@ export const STUCK_TARGET_THRESHOLD_MS = 10 * 60 * 1000;
  *
  * 7 minutes leaves a buffer wide enough that a legitimate 5-minute audit
  * isn't truncated by a polling read at the cliff. Anything older is the
- * disney/walmart-class hang where the worker was killed before the catch ran.
+ * tier-1-class hang where the worker was killed before the catch ran.
  *
  * Must remain strictly less than {@link STUCK_TARGET_THRESHOLD_MS} so the read
  * path closes the dead zone before the cron reaper would.
@@ -106,9 +106,7 @@ export async function reapStuckBrandAudits(deps: ReaperDeps): Promise<ReaperResu
 	let stuck: StuckTargetRow[];
 	try {
 		const rows = await deps.db
-			.prepare(
-				'SELECT audit_id, target FROM brand_audit_targets WHERE status = ? AND created_at < ? LIMIT ?',
-			)
+			.prepare('SELECT audit_id, target FROM brand_audit_targets WHERE status = ? AND created_at < ? LIMIT ?')
 			.bind('running', threshold, MAX_REAP_PER_TICK + 1)
 			.all<StuckTargetRow>();
 		stuck = rows.results ?? [];
@@ -163,9 +161,7 @@ async function flipTargetFailed(db: D1Database, row: StuckTargetRow, now: number
 async function bumpAuditCounter(db: D1Database, auditId: string, now: number): Promise<AuditCounterRow | null> {
 	try {
 		await db
-			.prepare(
-				'UPDATE brand_audits SET completed_targets = completed_targets + 1, updated_at = ? WHERE id = ?',
-			)
+			.prepare('UPDATE brand_audits SET completed_targets = completed_targets + 1, updated_at = ? WHERE id = ?')
 			.bind(now, auditId)
 			.run();
 		const counter = (await db
@@ -181,9 +177,7 @@ async function bumpAuditCounter(db: D1Database, auditId: string, now: number): P
 async function finalizeAudit(db: D1Database, auditId: string, now: number): Promise<boolean> {
 	try {
 		const res = await db
-			.prepare(
-				"UPDATE brand_audits SET status = 'completed', completed_at = ?, updated_at = ? WHERE id = ? AND status != 'completed'",
-			)
+			.prepare("UPDATE brand_audits SET status = 'completed', completed_at = ?, updated_at = ? WHERE id = ? AND status != 'completed'")
 			.bind(now, now, auditId)
 			.run();
 		return (res.meta?.changes ?? 0) > 0;

--- a/src/lib/brand-candidate-universe.ts
+++ b/src/lib/brand-candidate-universe.ts
@@ -1,13 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 export type BrandAuditDepth = 'standard' | 'deep';
-export type CandidateSeedSource =
-	| 'caller_candidate'
-	| 'tld_sweep'
-	| 'alias_tld_sweep'
-	| 'enterprise_affix'
-	| 'markov'
-	| 'active_lookalike';
+export type CandidateSeedSource = 'caller_candidate' | 'tld_sweep' | 'alias_tld_sweep' | 'enterprise_affix' | 'markov' | 'active_lookalike';
 
 export interface CandidateSeed {
 	domain: string;
@@ -123,27 +117,14 @@ const DEEP_ONLY_TLDS = [
 	'eg',
 ];
 
-const ENTERPRISE_AFFIXES = [
-	'secure',
-	'security',
-	'id',
-	'cloud',
-	'pay',
-	'shop',
-	'support',
-	'login',
-	'portal',
-	'auth',
-	'corp',
-	'global',
-];
+const ENTERPRISE_AFFIXES = ['secure', 'security', 'id', 'cloud', 'pay', 'shop', 'support', 'login', 'portal', 'auth', 'corp', 'global'];
 
 const ENTERPRISE_AFFIX_TLDS = ['com', 'net', 'org', 'co', 'io', 'app', 'cloud', 'dev', 'support', 'shop'];
 // Hard caps reduced from 120/250 (2026-05-19) after synthetic brand audits wedged at
 // the Cloudflare Worker CPU budget. Each candidate is probed by ~12 signal
 // detectors at concurrency 6 through a shared DoH semaphore — 100 candidates
 // × 12 signals = up to 1200 DoH queries plus per-candidate RDAP fan-out.
-// Tier-1 brands (walmart, disney) routinely exceed CPU budget at the prior
+// Tier-1 brands (mega-portfolio) routinely exceed CPU budget at the prior
 // caps. Universe candidates beyond the cap are dropped with stats.dropped.cap
 // so downstream telemetry surfaces the truncation.
 const STANDARD_CANDIDATE_CAP = 50;
@@ -173,7 +154,10 @@ function seedLabel(seedDomain: string): string | null {
 }
 
 function normalizeAlias(alias: string): string | null {
-	const lower = alias.trim().toLowerCase().replace(/[^a-z0-9-]/g, '');
+	const lower = alias
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9-]/g, '');
 	return lower.length >= 2 ? lower : null;
 }
 

--- a/src/lib/brand-discovery-planner.ts
+++ b/src/lib/brand-discovery-planner.ts
@@ -26,7 +26,7 @@ export interface BrandDiscoverySignalPlan {
 }
 
 // Per-signal cost tiers. Caps are calibrated against production benchmarks
-// (walmart/bankofamerica/marriott, 150-candidate deep audits):
+// (large-portfolio brands, 150-candidate deep audits):
 //   - High-yield signals (ns/mx_platform/spf_include) accounted for every
 //     surfaced candidate in observed runs; keep them effectively uncapped so
 //     recall is not the lever we trade away.
@@ -94,8 +94,8 @@ export function planBrandDiscoverySignals(options: BrandDiscoveryPlannerOptions)
 		if (!CANDIDATE_BACKED_SIGNALS.has(signal)) continue;
 		const defaultCap =
 			options.depth === 'deep'
-				? DEFAULT_SIGNAL_CAPS[signal] ?? ranked.length
-				: STANDARD_SIGNAL_CAPS[signal] ?? Math.min(40, ranked.length);
+				? (DEFAULT_SIGNAL_CAPS[signal] ?? ranked.length)
+				: (STANDARD_SIGNAL_CAPS[signal] ?? Math.min(40, ranked.length));
 		const cap = Math.max(1, Math.trunc(options.caps?.[signal] ?? defaultCap));
 		// Guarded candidates (caller_candidate / app_links / bounty_scope) always
 		// pass; only the unguarded remainder competes for the residual budget.
@@ -112,13 +112,14 @@ export function planBrandDiscoverySignals(options: BrandDiscoveryPlannerOptions)
 }
 
 function isStandardEligible(candidate: PlannerCandidate): boolean {
-	return candidate.sources.some((source) =>
-		source === 'caller_candidate' ||
-		source === 'app_links' ||
-		source === 'bounty_scope' ||
-		source === 'tld_sweep' ||
-		source === 'alias_tld_sweep' ||
-		source === 'active_lookalike',
+	return candidate.sources.some(
+		(source) =>
+			source === 'caller_candidate' ||
+			source === 'app_links' ||
+			source === 'bounty_scope' ||
+			source === 'tld_sweep' ||
+			source === 'alias_tld_sweep' ||
+			source === 'active_lookalike',
 	);
 }
 

--- a/src/lib/spf-canary.ts
+++ b/src/lib/spf-canary.ts
@@ -24,8 +24,8 @@ import { checkSpf } from '../tools/check-spf';
 export const SPF_CANARY_DOMAINS: readonly string[] = [
 	'google.com',
 	'microsoft.com',
-	'paypal.com',
-	'stripe.com',
+	'wikipedia.org',
+	'reddit.com',
 	'anthropic.com',
 	'netflix.com',
 	'apple.com',

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -40,11 +40,11 @@ import type { Tier2Result } from '../lib/brand-tier2-evidence';
  * Per-message budget for the orchestrator. The AbortController-driven catch
  * path commits a `failed` row only when the inner orchestrator is well-behaved
  * — the abort `setTimeout` macrotask competes with whatever microtasks the
- * orchestrator generates, and for fan-out-heavy brands (tier-1: walmart,
- * disney) the microtask queue stays saturated long enough that the worker is
+ * orchestrator generates, and for fan-out-heavy brands (tier-1 portfolios)
+ * the microtask queue stays saturated long enough that the worker is
  * killed before any catch UPDATE can flush. Those rows are recovered by the
  * cron reaper (`reapStuckBrandAudits`) ~15 min later — see the 2026-05-19
- * walmart investigation for the trace evidence. Until AbortSignal is plumbed
+ * tier-1 investigation for the trace evidence. Until AbortSignal is plumbed
  * through `dns-transport`/`safe-fetch` (so in-flight fetches actually cancel),
  * the reaper is the durability boundary for oversized audits.
  *
@@ -94,11 +94,7 @@ export type BrandAuditQueueMessage = z.infer<typeof BrandAuditQueueMessageSchema
 export interface BrandAuditConsumerDeps {
 	db: D1Database;
 	/** Injectable for tests. Production default accepts a third `deps` arg (tier closures + service bindings); tests typically omit it. */
-	brandAuditSingle?: (
-		target: string,
-		options: BrandAuditSingleOptions,
-		deps?: BrandAuditSingleDeps,
-	) => Promise<CheckResult>;
+	brandAuditSingle?: (target: string, options: BrandAuditSingleOptions, deps?: BrandAuditSingleDeps) => Promise<CheckResult>;
 	/** Clock override for tests. */
 	now?: () => number;
 	/**
@@ -108,7 +104,12 @@ export interface BrandAuditConsumerDeps {
 	 * Absent in dev / unprovisioned environments — primary completion still
 	 * succeeds; PDF rendering just doesn't happen.
 	 */
-	pdfQueue?: { send(message: { auditId: string; target: string; format: 'json' | 'markdown' | 'both' }, options?: { contentType?: 'json' }): Promise<void> };
+	pdfQueue?: {
+		send(
+			message: { auditId: string; target: string; format: 'json' | 'markdown' | 'both' },
+			options?: { contentType?: 'json' },
+		): Promise<void>;
+	};
 	/**
 	 * Optional binding for the brand-audit queue itself, used by Phase 2b to
 	 * enqueue a single retry pass when a completed audit has transient
@@ -175,10 +176,7 @@ interface AuditCounterRow {
  *   - `'ack'` — message handled (success, idempotent skip, or unrecoverable error)
  *   - `'retry'` — transient infrastructure failure; Cloudflare should redeliver
  */
-export async function processBrandAuditMessage(
-	rawBody: unknown,
-	deps: BrandAuditConsumerDeps,
-): Promise<'ack' | 'retry'> {
+export async function processBrandAuditMessage(rawBody: unknown, deps: BrandAuditConsumerDeps): Promise<'ack' | 'retry'> {
 	const parsed = BrandAuditQueueMessageSchema.safeParse(rawBody);
 	if (!parsed.success) {
 		// Malformed payload — never recoverable by retry. Drop.
@@ -201,9 +199,7 @@ export async function processBrandAuditMessage(
 	let existing: TargetStatusRow | null;
 	try {
 		existing = (await deps.db
-			.prepare(
-				'SELECT status, completed_at FROM brand_audit_targets WHERE audit_id = ? AND target = ? LIMIT 1',
-			)
+			.prepare('SELECT status, completed_at FROM brand_audit_targets WHERE audit_id = ? AND target = ? LIMIT 1')
 			.bind(message.auditId, message.target)
 			.first()) as TargetStatusRow | null;
 	} catch {
@@ -242,17 +238,13 @@ export async function processBrandAuditMessage(
 		// the rest of the file's binding pattern.
 		const fromStatus = isRetry ? 'completed' : 'queued';
 		const claim = await deps.db
-			.prepare(
-				"UPDATE brand_audit_targets SET status = 'running' WHERE audit_id = ? AND target = ? AND status = ?",
-			)
+			.prepare("UPDATE brand_audit_targets SET status = 'running' WHERE audit_id = ? AND target = ? AND status = ?")
 			.bind(message.auditId, message.target, fromStatus)
 			.run();
 		claimed = (claim.meta?.changes ?? 0) > 0;
 		// Parent audit flip is best-effort; safe to no-op when already running.
 		await deps.db
-			.prepare(
-				"UPDATE brand_audits SET status = 'running', updated_at = ? WHERE id = ? AND status = 'queued'",
-			)
+			.prepare("UPDATE brand_audits SET status = 'running', updated_at = ? WHERE id = ? AND status = 'queued'")
 			.bind(messageStartedAt, message.auditId)
 			.run();
 	} catch {
@@ -325,15 +317,11 @@ export async function processBrandAuditMessage(
 		// T13 — propagate the BlackVeil-production runtime override.
 		// Pipeline only honours it when the caller omits `discovery_mode`;
 		// undefined on BSL self-hosts (schema default `'classic'` wins).
-		...(deps.discoveryModeDefault
-			? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: deps.discoveryModeDefault } }
-			: {}),
+		...(deps.discoveryModeDefault ? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: deps.discoveryModeDefault } } : {}),
 	};
 	try {
 		result = await Promise.race([
-			hasSingleDeps
-				? single(message.target, singleOptions, singleDeps)
-				: single(message.target, singleOptions),
+			hasSingleDeps ? single(message.target, singleOptions, singleDeps) : single(message.target, singleOptions),
 			new Promise<never>((_, reject) => {
 				const onAbort = () => {
 					const reason = (controller.signal as AbortSignal & { reason?: unknown }).reason;
@@ -382,9 +370,7 @@ export async function processBrandAuditMessage(
 			// 'running' until the cron reaper sweeps at 15min). Surfaced by audit
 			// synthetic-audit-brandepsilon.com on 2026-05-19.
 			await deps.db
-				.prepare(
-					"UPDATE brand_audit_targets SET status = 'completed', error = ?, completed_at = ? WHERE audit_id = ? AND target = ?",
-				)
+				.prepare("UPDATE brand_audit_targets SET status = 'completed', error = ?, completed_at = ? WHERE audit_id = ? AND target = ?")
 				.bind(errorString, clock(), message.auditId, message.target)
 				.run();
 		} else {
@@ -438,10 +424,7 @@ export async function processBrandAuditMessage(
 	// Same policy as the watch-webhook gate in 4c.
 	if (finalStatus === 'completed' && !retryEnqueued && deps.pdfQueue && (message.format === 'markdown' || message.format === 'both')) {
 		try {
-			await deps.pdfQueue.send(
-				{ auditId: message.auditId, target: message.target, format: message.format },
-				{ contentType: 'json' },
-			);
+			await deps.pdfQueue.send({ auditId: message.auditId, target: message.target, format: message.format }, { contentType: 'json' });
 		} catch {
 			// swallow — PDF rendering is enrichment, not part of the
 			// audit's durability contract
@@ -484,25 +467,19 @@ export async function processBrandAuditMessage(
 	try {
 		const tickAt = clock();
 		await deps.db
-			.prepare(
-				'UPDATE brand_audits SET completed_targets = completed_targets + 1, updated_at = ? WHERE id = ?',
-			)
+			.prepare('UPDATE brand_audits SET completed_targets = completed_targets + 1, updated_at = ? WHERE id = ?')
 			.bind(tickAt, message.auditId)
 			.run();
 
 		const counter = (await deps.db
-			.prepare(
-				'SELECT completed_targets, total_targets FROM brand_audits WHERE id = ? LIMIT 1',
-			)
+			.prepare('SELECT completed_targets, total_targets FROM brand_audits WHERE id = ? LIMIT 1')
 			.bind(message.auditId)
 			.first()) as AuditCounterRow | null;
 
 		if (counter && counter.completed_targets >= counter.total_targets) {
 			const finalizedAt = clock();
 			await deps.db
-				.prepare(
-					"UPDATE brand_audits SET status = 'completed', completed_at = ?, updated_at = ? WHERE id = ?",
-				)
+				.prepare("UPDATE brand_audits SET status = 'completed', completed_at = ?, updated_at = ? WHERE id = ?")
 				.bind(finalizedAt, finalizedAt, message.auditId)
 				.run();
 		}
@@ -522,10 +499,7 @@ function sanitizeErrorString(raw: string): string {
 }
 
 /** Cloudflare Queue consumer entrypoint — fans out to `processBrandAuditMessage` per message. */
-export async function handleBrandAuditQueue(
-	batch: MessageBatch<unknown>,
-	deps: BrandAuditConsumerDeps,
-): Promise<void> {
+export async function handleBrandAuditQueue(batch: MessageBatch<unknown>, deps: BrandAuditConsumerDeps): Promise<void> {
 	for (const message of batch.messages) {
 		// Phase detection before Zod parse: deep_scan messages don't carry `format`
 		// and would be silently acked as "malformed" by BrandAuditQueueMessageSchema.
@@ -594,9 +568,7 @@ interface WatchSlim {
  */
 async function deliverWatchWebhookIfShifted(args: DeliverWatchWebhookArgs): Promise<void> {
 	const watch = (await args.db
-		.prepare(
-			'SELECT id, owner_id, domain, interval, webhook_url, last_classification_hash FROM brand_audit_watches WHERE id = ? LIMIT 1',
-		)
+		.prepare('SELECT id, owner_id, domain, interval, webhook_url, last_classification_hash FROM brand_audit_watches WHERE id = ? LIMIT 1')
 		.bind(args.watchId)
 		.first()) as WatchSlim | null;
 	if (!watch) return;
@@ -615,10 +587,7 @@ async function deliverWatchWebhookIfShifted(args: DeliverWatchWebhookArgs): Prom
 
 	// Stamp the new hash immediately — even if the webhook fails downstream,
 	// we don't want to re-fire on every redelivery of the same completed message.
-	await args.db
-		.prepare('UPDATE brand_audit_watches SET last_classification_hash = ? WHERE id = ?')
-		.bind(currentHash, args.watchId)
-		.run();
+	await args.db.prepare('UPDATE brand_audit_watches SET last_classification_hash = ? WHERE id = ?').bind(currentHash, args.watchId).run();
 
 	if (!watch.webhook_url) {
 		// Logging-only watch — drift detected but no delivery target.

--- a/src/tenants/discovery/san-correlator.ts
+++ b/src/tenants/discovery/san-correlator.ts
@@ -74,7 +74,7 @@ export interface SanCorrelationOptions {
 	certstream?: { fetch: typeof fetch };
 	/**
 	 * Caller-supplied abort signal. Cancels in-flight crt.sh fetches when the
-	 * audit budget fires — the JSON parse for tier-1 brands (walmart-scale)
+	 * audit budget fires — the JSON parse for tier-1 brands (mega-portfolio-scale)
 	 * is the single largest CPU sink in the orchestrator, so cancelling it
 	 * mid-stream is what lets the consumer's catch handler win the race
 	 * against CF's CPU kill.
@@ -174,10 +174,7 @@ async function attemptCertstreamSans(
 
 	let response: Response;
 	try {
-		response = await certstream.fetch(
-			`https://certstream/sans?domain=${encodeURIComponent(seedLower)}`,
-			{ signal: controller.signal },
-		);
+		response = await certstream.fetch(`https://certstream/sans?domain=${encodeURIComponent(seedLower)}`, { signal: controller.signal });
 	} catch {
 		clearTimeout(timeoutId);
 		return null;
@@ -471,10 +468,7 @@ export async function correlateSansRecursive(
 	};
 }
 
-export async function correlateSans(
-	seedDomain: string,
-	options: SanCorrelationOptions = {},
-): Promise<SanCorrelationResult> {
+export async function correlateSans(seedDomain: string, options: SanCorrelationOptions = {}): Promise<SanCorrelationResult> {
 	const validation = validateDomain(seedDomain);
 	if (!validation.valid) {
 		throw new Error(`Domain validation failed: ${validation.error ?? 'invalid domain'}`);

--- a/src/tools/discover-brand-domains.ts
+++ b/src/tools/discover-brand-domains.ts
@@ -109,15 +109,15 @@ export const DISCOVERY_DROP_REASONS: readonly DiscoveryDropReason[] = [
  * map simply skip the bounty-scope detector; no harm done.
  */
 const PHASE5_BOUNTY_HANDLES: Record<string, Partial<Record<BountyPlatform, string>>> = {
-	'brand-alpha.example.com': { hackerone: 'walmart' },
-	'brand-beta.example.com': { hackerone: 'disney' },
-	'brand-gamma.example.com': { hackerone: 'marriott' },
-	'brand-delta.example.com': { hackerone: 'bankofamerica' },
-	'brand-epsilon.example.com': { hackerone: 'brandepsilon' },
-	'brand-eta.example.com': { hackerone: 'paypal' },
+	'brand-alpha.example.com': { hackerone: 'brand-alpha' },
+	'brand-beta.example.com': { hackerone: 'brand-beta' },
+	'brand-gamma.example.com': { hackerone: 'brand-gamma' },
+	'brand-delta.example.com': { hackerone: 'brand-delta' },
+	'brand-epsilon.example.com': { hackerone: 'brand-epsilon' },
+	'brand-eta.example.com': { hackerone: 'brand-eta' },
 	'github.com': { hackerone: 'github' },
 	'shopify.com': { hackerone: 'shopify' },
-	'brand-iota.example.com': { hackerone: 'uber' },
+	'brand-iota.example.com': { hackerone: 'brand-iota' },
 };
 
 /** All supported signal kinds. */
@@ -417,12 +417,7 @@ function ensureCandidate(agg: Map<string, CandidateAggregator>, domain: string):
 	return entry;
 }
 
-function addCandidateSeed(
-	agg: Map<string, CandidateAggregator>,
-	domain: string,
-	sources: CandidateSeedSource[],
-	reasons: string[],
-): void {
+function addCandidateSeed(agg: Map<string, CandidateAggregator>, domain: string, sources: CandidateSeedSource[], reasons: string[]): void {
 	const entry = ensureCandidate(agg, domain);
 	if (!entry) return;
 	for (const source of sources) {
@@ -523,9 +518,8 @@ function graphSignalForTieredObservation(obs: { tier: 0 | 1 | 2 | 4; metadata: R
 function buildEvidenceObservations(entry: CandidateAggregator): BrandEvidenceObservation[] {
 	return Array.from(entry.perSignalConfidence.entries()).map(([signal, confidence]) => {
 		const source = entry.sources[signal];
-		const metadata = typeof source === 'object' && source !== null && !Array.isArray(source)
-			? (source as Record<string, unknown>)
-			: undefined;
+		const metadata =
+			typeof source === 'object' && source !== null && !Array.isArray(source) ? (source as Record<string, unknown>) : undefined;
 		const tier = tierFromSource(source);
 		const specificityScore = specificityFromSource(source);
 		return {
@@ -542,11 +536,7 @@ function buildEvidenceObservations(entry: CandidateAggregator): BrandEvidenceObs
 // the dmarc-rua miner can consume the same source of truth. Re-exported here
 // so existing test imports (test/audits/infrastructure-providers.audit.test.ts)
 // keep working.
-export {
-	INFRASTRUCTURE_PROVIDERS,
-	registeredApex,
-	isInfrastructureProvider,
-} from '../tenants/discovery/infrastructure-providers';
+export { INFRASTRUCTURE_PROVIDERS, registeredApex, isInfrastructureProvider } from '../tenants/discovery/infrastructure-providers';
 import { isInfrastructureProvider } from '../tenants/discovery/infrastructure-providers';
 
 function extractActiveLookalikeDomains(result: CheckResult): string[] {
@@ -616,11 +606,7 @@ export async function discoverBrandDomains(
 		await emitProgress(event);
 		return event;
 	};
-	const recordInstantPhase = async (
-		name: string,
-		status: string,
-		detail?: Record<string, unknown>,
-	): Promise<void> => {
+	const recordInstantPhase = async (name: string, status: string, detail?: Record<string, unknown>): Promise<void> => {
 		const atMs = now();
 		await finishPhase(name, status, atMs, detail);
 	};
@@ -670,10 +656,7 @@ export async function discoverBrandDomains(
 				baselineCandidateSignalProbes,
 				surfacedCandidates,
 				probesPerSurfacedCandidate: candidateSignalProbes / Math.max(1, surfacedCandidates),
-				probeReductionRatio:
-					baselineCandidateSignalProbes > 0
-						? 1 - candidateSignalProbes / baselineCandidateSignalProbes
-						: 0,
+				probeReductionRatio: baselineCandidateSignalProbes > 0 ? 1 - candidateSignalProbes / baselineCandidateSignalProbes : 0,
 				plannerMode,
 			},
 			planner: {
@@ -735,13 +718,10 @@ export async function discoverBrandDomains(
 	// One signal hit is enough when the caller has already named the domain
 	// — see the gate below. Unsolicited single-signal discoveries still get
 	// dropped per LR-1/LR-2.
-	const callerAssertedDomains = new Set(
-		candidateDomains.map((dom) => dom.trim().toLowerCase().replace(/\.$/, '')),
-	);
+	const callerAssertedDomains = new Set(candidateDomains.map((dom) => dom.trim().toLowerCase().replace(/\.$/, '')));
 	const dkimSelectors = options.dkim_selectors;
-	const minConfidence = typeof options.min_confidence === 'number'
-		? Math.max(0, Math.min(1, options.min_confidence))
-		: DEFAULT_MIN_CONFIDENCE;
+	const minConfidence =
+		typeof options.min_confidence === 'number' ? Math.max(0, Math.min(1, options.min_confidence)) : DEFAULT_MIN_CONFIDENCE;
 
 	const depth = options.depth ?? 'standard';
 	const candidateUniverseStartedAtMs = await startPhase('candidate_universe', { depth });
@@ -831,15 +811,11 @@ export async function discoverBrandDomains(
 		const tier1Started = now();
 		const tier2Started = now();
 		const [tier0Settled, tier1Settled, tier2Settled] = await Promise.allSettled([
-			d.tier0Lookup
-				? d.tier0Lookup(seedDomain)
-				: Promise.resolve<Tier0Result>({ observations: [], status: 'skipped', optedOut: false }),
+			d.tier0Lookup ? d.tier0Lookup(seedDomain) : Promise.resolve<Tier0Result>({ observations: [], status: 'skipped', optedOut: false }),
 			d.tier1Lookup
 				? d.tier1Lookup(seedDomain)
 				: Promise.resolve<Tier1Result>({ observations: [], status: 'skipped', triggerTier3Fallback: false }),
-			d.tier2Lookup
-				? d.tier2Lookup(seedDomain)
-				: Promise.resolve<Tier2Result>({ observations: [], status: 'skipped' }),
+			d.tier2Lookup ? d.tier2Lookup(seedDomain) : Promise.resolve<Tier2Result>({ observations: [], status: 'skipped' }),
 		]);
 
 		if (tier0Settled.status === 'fulfilled') {
@@ -975,8 +951,8 @@ export async function discoverBrandDomains(
 			for (const entry of aggregator.values()) {
 				if (isSubdomainOf(entry.domain, seedDomain)) continue;
 				const observations = buildEvidenceObservations(entry);
-				const hasTieredOwnershipObservation = observations.some((observation) =>
-					observation.tier === 0 || observation.tier === 1 || observation.tier === 2,
+				const hasTieredOwnershipObservation = observations.some(
+					(observation) => observation.tier === 0 || observation.tier === 1 || observation.tier === 2,
 				);
 				if (!hasTieredOwnershipObservation) continue;
 				if (clearsOwnershipGate(observations, { callerAsserted: callerAssertedDomains.has(entry.domain) })) return true;
@@ -993,13 +969,9 @@ export async function discoverBrandDomains(
 				? (tieredState.tier1Freshness.overallStaleness as string)
 				: undefined;
 		const tier1VeryStale = tier1FreshnessStaleness === 'very_stale';
-		const coveredByTiers = new Set(
-			tieredObservations.map((o) => o.candidate.trim().toLowerCase().replace(/\.$/, '')),
-		);
+		const coveredByTiers = new Set(tieredObservations.map((o) => o.candidate.trim().toLowerCase().replace(/\.$/, '')));
 		coveredByTiers.add(seedNormForTiered);
-		const callerNorm = candidateDomains
-			.map((dom) => dom.trim().toLowerCase().replace(/\.$/, ''))
-			.filter((dom) => dom.length > 0);
+		const callerNorm = candidateDomains.map((dom) => dom.trim().toLowerCase().replace(/\.$/, '')).filter((dom) => dom.length > 0);
 		const uncoveredCaller = callerNorm.some((dom) => !coveredByTiers.has(dom));
 		const tieredSurfaceable = hasTieredSurfaceableOwnershipCandidate();
 		const shouldRunTier3 = tier1VeryStale || !tieredSurfaceable || uncoveredCaller;
@@ -1081,13 +1053,9 @@ export async function discoverBrandDomains(
 	// Universe candidates feed the signal sweep, MINUS the ground-truth
 	// bypass set. Bypassed domains stay in the aggregator (already added
 	// above) but are never sent to the existing 12 signal probes.
-	const mergedCandidates = universe.candidates
-		.map((candidate) => candidate.domain)
-		.filter((d) => !groundTruthBypass.has(d));
+	const mergedCandidates = universe.candidates.map((candidate) => candidate.domain).filter((d) => !groundTruthBypass.has(d));
 	candidateBackedSignalBaselineProbes = Object.fromEntries(
-		signals
-			.filter((signal) => CANDIDATE_BACKED_SIGNALS.has(signal))
-			.map((signal) => [signal, mergedCandidates.length]),
+		signals.filter((signal) => CANDIDATE_BACKED_SIGNALS.has(signal)).map((signal) => [signal, mergedCandidates.length]),
 	);
 	if (plannerMode !== 'off') {
 		signalPlan = planBrandDiscoverySignals({
@@ -1111,26 +1079,28 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'san',
 			run: async () => {
-			const out = await runTrackedSignal<SanCorrelationResult>('san', () =>
-				d.correlateSans(seedDomain, {
-					...(options.certstream ? { certstream: options.certstream } : {}),
-					signal: options.signal,
-				}),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, certIds: value.certIds.length }),
-			);
-			if (!out.ok) {
-				signalStatus.san = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.san = { status: out.value.queryStatus };
-			firstOrderSanCandidates = out.value.coOwnedDomains.slice();
-			for (const dom of out.value.coOwnedDomains) {
-				addObservation(aggregator, dom, 'san', DEFAULT_SIGNAL_CONFIDENCE.san, {
-					seed: out.value.seedDomain,
-					certIds: out.value.certIds.slice(0, 5),
-				});
-			}
+				const out = await runTrackedSignal<SanCorrelationResult>(
+					'san',
+					() =>
+						d.correlateSans(seedDomain, {
+							...(options.certstream ? { certstream: options.certstream } : {}),
+							signal: options.signal,
+						}),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, certIds: value.certIds.length }),
+				);
+				if (!out.ok) {
+					signalStatus.san = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.san = { status: out.value.queryStatus };
+				firstOrderSanCandidates = out.value.coOwnedDomains.slice();
+				for (const dom of out.value.coOwnedDomains) {
+					addObservation(aggregator, dom, 'san', DEFAULT_SIGNAL_CONFIDENCE.san, {
+						seed: out.value.seedDomain,
+						certIds: out.value.certIds.slice(0, 5),
+					});
+				}
 			},
 		});
 	}
@@ -1139,23 +1109,24 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'ns',
 			run: async () => {
-			const nsCandidates = recordCandidateSignalProbes('ns', candidatesForSignal('ns'));
-			const out = await runTrackedSignal<NsCorrelationResult>('ns', () =>
-				d.correlateNs(seedDomain, { candidateDomains: nsCandidates, dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: nsCandidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.ns = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.ns = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'ns', c.confidence, {
-					sharedNs: c.sharedNs,
-					nsConfidence: c.confidence,
-				});
-			}
+				const nsCandidates = recordCandidateSignalProbes('ns', candidatesForSignal('ns'));
+				const out = await runTrackedSignal<NsCorrelationResult>(
+					'ns',
+					() => d.correlateNs(seedDomain, { candidateDomains: nsCandidates, dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: nsCandidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.ns = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.ns = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'ns', c.confidence, {
+						sharedNs: c.sharedNs,
+						nsConfidence: c.confidence,
+					});
+				}
 			},
 		});
 	}
@@ -1164,22 +1135,24 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'dmarc_rua',
 			run: async () => {
-			const out = await runTrackedSignal<DmarcRuaResult>('dmarc_rua', () => d.mineDmarcRua(seedDomain, { dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ ruaDomains: value.ruaDomains.length }),
-			);
-			if (!out.ok) {
-				signalStatus.dmarc_rua = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.dmarc_rua = { status: out.value.queryStatus };
-			for (const r of out.value.ruaDomains) {
-				if (r.classification !== 'related') continue;
-				addObservation(aggregator, r.domain, 'dmarc_rua', r.confidence, {
-					classification: r.classification,
-					externalAuthorization: r.externalAuthorization,
-				});
-			}
+				const out = await runTrackedSignal<DmarcRuaResult>(
+					'dmarc_rua',
+					() => d.mineDmarcRua(seedDomain, { dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ ruaDomains: value.ruaDomains.length }),
+				);
+				if (!out.ok) {
+					signalStatus.dmarc_rua = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.dmarc_rua = { status: out.value.queryStatus };
+				for (const r of out.value.ruaDomains) {
+					if (r.classification !== 'related') continue;
+					addObservation(aggregator, r.domain, 'dmarc_rua', r.confidence, {
+						classification: r.classification,
+						externalAuthorization: r.externalAuthorization,
+					});
+				}
 			},
 		});
 	}
@@ -1188,35 +1161,37 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'dkim_key_reuse',
 			run: async () => {
-			const dkimCandidates = recordCandidateSignalProbes('dkim_key_reuse', candidatesForSignal('dkim_key_reuse'));
-			const out = await runTrackedSignal<DkimKeyReuseResult>('dkim_key_reuse', () =>
-				d.detectDkimKeyReuse(seedDomain, dkimCandidates, {
-					...(dkimSelectors ? { selectors: dkimSelectors } : {}),
-					dnsContext: getDkimDnsContext(),
-					maxCandidates: depth === 'deep' ? 40 : 30,
-					candidateConcurrency: 4,
-					totalBudgetMs: 25_000,
-					signal: options.signal,
-				}),
-				(value) => value.queryStatus,
-				(value) => ({
-					discovered: value.coOwnedDomains.length,
-					probedCandidates: value.probedCandidates ?? dkimCandidates.length,
-					skippedCandidates: value.skippedCandidates ?? 0,
-					budgetExceeded: value.budgetExceeded === true,
-				}),
-			);
-			if (!out.ok) {
-				signalStatus.dkim_key_reuse = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.dkim_key_reuse = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'dkim_key_reuse', c.confidence, {
-					sharedSelectors: c.sharedSelectors,
-					sharedKeys: c.sharedKeys,
-				});
-			}
+				const dkimCandidates = recordCandidateSignalProbes('dkim_key_reuse', candidatesForSignal('dkim_key_reuse'));
+				const out = await runTrackedSignal<DkimKeyReuseResult>(
+					'dkim_key_reuse',
+					() =>
+						d.detectDkimKeyReuse(seedDomain, dkimCandidates, {
+							...(dkimSelectors ? { selectors: dkimSelectors } : {}),
+							dnsContext: getDkimDnsContext(),
+							maxCandidates: depth === 'deep' ? 40 : 30,
+							candidateConcurrency: 4,
+							totalBudgetMs: 25_000,
+							signal: options.signal,
+						}),
+					(value) => value.queryStatus,
+					(value) => ({
+						discovered: value.coOwnedDomains.length,
+						probedCandidates: value.probedCandidates ?? dkimCandidates.length,
+						skippedCandidates: value.skippedCandidates ?? 0,
+						budgetExceeded: value.budgetExceeded === true,
+					}),
+				);
+				if (!out.ok) {
+					signalStatus.dkim_key_reuse = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.dkim_key_reuse = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'dkim_key_reuse', c.confidence, {
+						sharedSelectors: c.sharedSelectors,
+						sharedKeys: c.sharedKeys,
+					});
+				}
 			},
 		});
 	}
@@ -1225,19 +1200,20 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'http_redirect',
 			run: async () => {
-			const out = await runTrackedSignal<HttpRedirectResult>('http_redirect', () =>
-				d.detectHttpRedirect(seedDomain, { candidateDomains: mergedCandidates }),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: mergedCandidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.http_redirect = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.http_redirect = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'http_redirect', c.confidence, c.evidence);
-			}
+				const out = await runTrackedSignal<HttpRedirectResult>(
+					'http_redirect',
+					() => d.detectHttpRedirect(seedDomain, { candidateDomains: mergedCandidates }),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: mergedCandidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.http_redirect = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.http_redirect = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'http_redirect', c.confidence, c.evidence);
+				}
 			},
 		});
 	}
@@ -1246,20 +1222,21 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'mx_overlap',
 			run: async () => {
-			const mxOverlapCandidates = recordCandidateSignalProbes('mx_overlap', candidatesForSignal('mx_overlap'));
-			const out = await runTrackedSignal<MxOverlapResult>('mx_overlap', () =>
-				d.detectMxOverlap(seedDomain, { candidateDomains: mxOverlapCandidates, dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: mxOverlapCandidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.mx_overlap = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.mx_overlap = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'mx_overlap', c.confidence, c.evidence);
-			}
+				const mxOverlapCandidates = recordCandidateSignalProbes('mx_overlap', candidatesForSignal('mx_overlap'));
+				const out = await runTrackedSignal<MxOverlapResult>(
+					'mx_overlap',
+					() => d.detectMxOverlap(seedDomain, { candidateDomains: mxOverlapCandidates, dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: mxOverlapCandidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.mx_overlap = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.mx_overlap = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'mx_overlap', c.confidence, c.evidence);
+				}
 			},
 		});
 	}
@@ -1268,28 +1245,27 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'txt_verification',
 			run: async () => {
-			const txtVerificationCandidates = recordCandidateSignalProbes('txt_verification', candidatesForSignal('txt_verification'));
-			const out = await runTrackedSignal<TxtVerificationResult>('txt_verification', () =>
-				d.detectSharedTxtVerifications(seedDomain, { candidateDomains: txtVerificationCandidates, dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: txtVerificationCandidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.txt_verification = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.txt_verification = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'txt_verification', c.confidence, {
-					sharedTxtVerifications: c.sharedTxtVerifications,
-				});
-				const entry = aggregator.get(c.domain.trim().toLowerCase().replace(/\.$/, ''));
-				if (entry) {
-					entry.sharedTxtVerifications = Array.from(
-						new Set([...entry.sharedTxtVerifications, ...c.sharedTxtVerifications]),
-					).sort();
+				const txtVerificationCandidates = recordCandidateSignalProbes('txt_verification', candidatesForSignal('txt_verification'));
+				const out = await runTrackedSignal<TxtVerificationResult>(
+					'txt_verification',
+					() => d.detectSharedTxtVerifications(seedDomain, { candidateDomains: txtVerificationCandidates, dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: txtVerificationCandidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.txt_verification = { status: 'failed', error: out.error };
+					return;
 				}
-			}
+				signalStatus.txt_verification = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'txt_verification', c.confidence, {
+						sharedTxtVerifications: c.sharedTxtVerifications,
+					});
+					const entry = aggregator.get(c.domain.trim().toLowerCase().replace(/\.$/, ''));
+					if (entry) {
+						entry.sharedTxtVerifications = Array.from(new Set([...entry.sharedTxtVerifications, ...c.sharedTxtVerifications])).sort();
+					}
+				}
 			},
 		});
 	}
@@ -1298,24 +1274,25 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'mx_platform',
 			run: async () => {
-			const mxPlatformCandidates = recordCandidateSignalProbes('mx_platform', candidatesForSignal('mx_platform'));
-			const out = await runTrackedSignal<MxPlatformResult>('mx_platform', () =>
-				d.detectSharedMxPlatform(seedDomain, { candidateDomains: mxPlatformCandidates, dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: mxPlatformCandidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.mx_platform = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.mx_platform = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'mx_platform', c.confidence, {
-					sharedMxPlatform: c.sharedMxPlatform,
-				});
-				const entry = aggregator.get(c.domain.trim().toLowerCase().replace(/\.$/, ''));
-				if (entry) entry.sharedMxPlatform = c.sharedMxPlatform;
-			}
+				const mxPlatformCandidates = recordCandidateSignalProbes('mx_platform', candidatesForSignal('mx_platform'));
+				const out = await runTrackedSignal<MxPlatformResult>(
+					'mx_platform',
+					() => d.detectSharedMxPlatform(seedDomain, { candidateDomains: mxPlatformCandidates, dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: mxPlatformCandidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.mx_platform = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.mx_platform = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'mx_platform', c.confidence, {
+						sharedMxPlatform: c.sharedMxPlatform,
+					});
+					const entry = aggregator.get(c.domain.trim().toLowerCase().replace(/\.$/, ''));
+					if (entry) entry.sharedMxPlatform = c.sharedMxPlatform;
+				}
 			},
 		});
 	}
@@ -1324,20 +1301,21 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'spf_include',
 			run: async () => {
-			const spfIncludeCandidates = recordCandidateSignalProbes('spf_include', candidatesForSignal('spf_include'));
-			const out = await runTrackedSignal<SpfIncludeResult>('spf_include', () =>
-				d.detectSpfInclude(seedDomain, { candidateDomains: spfIncludeCandidates, dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: spfIncludeCandidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.spf_include = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.spf_include = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'spf_include', c.confidence, c.evidence);
-			}
+				const spfIncludeCandidates = recordCandidateSignalProbes('spf_include', candidatesForSignal('spf_include'));
+				const out = await runTrackedSignal<SpfIncludeResult>(
+					'spf_include',
+					() => d.detectSpfInclude(seedDomain, { candidateDomains: spfIncludeCandidates, dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: spfIncludeCandidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.spf_include = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.spf_include = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'spf_include', c.confidence, c.evidence);
+				}
 			},
 		});
 	}
@@ -1346,27 +1324,29 @@ export async function discoverBrandDomains(
 	// different-apex include/redirect target as a same-organization candidate.
 	// Unlike `spf_include` (corroboration-only — needs a candidate to probe),
 	// this signal MINTS candidates straight from the seed's authoritative
-	// mail policy — the path that unlocks Nike-style brand families whose
+	// mail policy — the path that unlocks consumer-brand families whose
 	// regional ccTLD apexes appear only in the seed's `include:` chain.
 	if (signals.includes('spf_include_seed')) {
 		jobs.push({
 			name: 'spf_include_seed',
 			run: async () => {
-			const out = await runTrackedSignal<SeedSpfWalkResult>('spf_include_seed', () => d.extractSeedSpfIncludes(seedDomain, { dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ candidates: value.candidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.spf_include_seed = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.spf_include_seed = { status: out.value.queryStatus };
-			for (const c of out.value.candidates) {
-				addObservation(aggregator, c.apex, 'spf_include_seed', c.confidence, {
-					via: c.via,
-					depth: c.depth,
-				});
-			}
+				const out = await runTrackedSignal<SeedSpfWalkResult>(
+					'spf_include_seed',
+					() => d.extractSeedSpfIncludes(seedDomain, { dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ candidates: value.candidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.spf_include_seed = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.spf_include_seed = { status: out.value.queryStatus };
+				for (const c of out.value.candidates) {
+					addObservation(aggregator, c.apex, 'spf_include_seed', c.confidence, {
+						via: c.via,
+						depth: c.depth,
+					});
+				}
 			},
 		});
 	}
@@ -1375,20 +1355,21 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'cname_alignment',
 			run: async () => {
-			const cnameAlignmentCandidates = recordCandidateSignalProbes('cname_alignment', candidatesForSignal('cname_alignment'));
-			const out = await runTrackedSignal<CnameAlignmentResult>('cname_alignment', () =>
-				d.detectCnameAlignment(seedDomain, { candidateDomains: cnameAlignmentCandidates, dnsContext }),
-				(value) => value.queryStatus,
-				(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: cnameAlignmentCandidates.length }),
-			);
-			if (!out.ok) {
-				signalStatus.cname_alignment = { status: 'failed', error: out.error };
-				return;
-			}
-			signalStatus.cname_alignment = { status: out.value.queryStatus };
-			for (const c of out.value.coOwnedDomains) {
-				addObservation(aggregator, c.domain, 'cname_alignment', c.confidence, c.evidence);
-			}
+				const cnameAlignmentCandidates = recordCandidateSignalProbes('cname_alignment', candidatesForSignal('cname_alignment'));
+				const out = await runTrackedSignal<CnameAlignmentResult>(
+					'cname_alignment',
+					() => d.detectCnameAlignment(seedDomain, { candidateDomains: cnameAlignmentCandidates, dnsContext }),
+					(value) => value.queryStatus,
+					(value) => ({ discovered: value.coOwnedDomains.length, probedCandidates: cnameAlignmentCandidates.length }),
+				);
+				if (!out.ok) {
+					signalStatus.cname_alignment = { status: 'failed', error: out.error };
+					return;
+				}
+				signalStatus.cname_alignment = { status: out.value.queryStatus };
+				for (const c of out.value.coOwnedDomains) {
+					addObservation(aggregator, c.domain, 'cname_alignment', c.confidence, c.evidence);
+				}
 			},
 		});
 	}
@@ -1407,16 +1388,9 @@ export async function discoverBrandDomains(
 			probedCandidates: mergedCandidates.length,
 		});
 		await Promise.allSettled(jobs.map((j) => j.run()));
-		await finishPhase(
-			'signal_sweep',
-			options.signal?.aborted ? 'partial' : 'completed',
-			signalSweepStartedAtMs,
-			{
-				completedSignals: phaseTimings
-					.filter((phase) => jobs.some((job) => job.name === phase.name))
-					.map((phase) => phase.name),
-			},
-		);
+		await finishPhase('signal_sweep', options.signal?.aborted ? 'partial' : 'completed', signalSweepStartedAtMs, {
+			completedSignals: phaseTimings.filter((phase) => jobs.some((job) => job.name === phase.name)).map((phase) => phase.name),
+		});
 	}
 
 	// Budget gate: if the consumer's AbortController has fired while jobs were
@@ -1439,19 +1413,21 @@ export async function discoverBrandDomains(
 				firstOrderCandidates: firstOrderSanCandidates.length,
 			});
 		} else {
-			const recursiveOut = await runTrackedSignal<SanRecursiveResult>('san_recursive', () =>
-				d.correlateSansRecursive(seedDomain, firstOrderSanCandidates, {
-					certstream: options.certstream,
-					// Caps tightened (2026-05-19) to fit Cloudflare Worker CPU budget.
-					// Each candidate triggers a fresh crt.sh fetch (~200KB-2MB JSON parse
-					// for tier-1 brands), so 20 candidates × 8 concurrency was the single
-					// largest CPU sink in the walmart wedge. 10/4/15s keeps headroom for
-					// the remaining 11 signal probes + RDAP enrichment.
-					maxCandidates: 10,
-					concurrency: 4,
-					totalBudgetMs: 15_000,
-					signal: options.signal,
-				}),
+			const recursiveOut = await runTrackedSignal<SanRecursiveResult>(
+				'san_recursive',
+				() =>
+					d.correlateSansRecursive(seedDomain, firstOrderSanCandidates, {
+						certstream: options.certstream,
+						// Caps tightened (2026-05-19) to fit Cloudflare Worker CPU budget.
+						// Each candidate triggers a fresh crt.sh fetch (~200KB-2MB JSON parse
+						// for tier-1 brands), so 20 candidates × 8 concurrency was the single
+						// largest CPU sink in the bulk-portfolio wedge. 10/4/15s keeps headroom for
+						// the remaining 11 signal probes + RDAP enrichment.
+						maxCandidates: 10,
+						concurrency: 4,
+						totalBudgetMs: 15_000,
+						signal: options.signal,
+					}),
 				(value) => (value.queryStatus === 'budget_exceeded' ? 'partial' : value.queryStatus),
 				(value) => ({
 					probed: value.probed.length,
@@ -1619,9 +1595,7 @@ export async function discoverBrandDomains(
 	// Tier 3 count: in tiered mode, count surviving candidates that were NOT
 	// surfaced by Tier 0/1/2. Identified by domain set membership.
 	if (tieredState) {
-		const tieredApex = new Set(
-			tieredObservations.map((o) => o.candidate.trim().toLowerCase().replace(/\.$/, '')),
-		);
+		const tieredApex = new Set(tieredObservations.map((o) => o.candidate.trim().toLowerCase().replace(/\.$/, '')));
 		let tier3Count = 0;
 		for (const cand of surviving) {
 			if (!tieredApex.has(cand.domain)) tier3Count++;
@@ -1670,9 +1644,7 @@ export function formatDiscoverBrandDomains(result: CheckResult, format: OutputFo
 		for (const c of candidates) {
 			const conf = c.metadata?.combinedConfidence as number | undefined;
 			const signals = (c.metadata?.signals as string[] | undefined)?.join(',') ?? '';
-			lines.push(
-				`  - ${sanitizeOutputText(c.metadata?.candidate as string, 80)} (conf=${conf?.toFixed(2) ?? '?'}, signals=${signals})`,
-			);
+			lines.push(`  - ${sanitizeOutputText(c.metadata?.candidate as string, 80)} (conf=${conf?.toFixed(2) ?? '?'}, signals=${signals})`);
 		}
 		return lines.join('\n');
 	}

--- a/test/brand-audit-provider-sprawl.test.ts
+++ b/test/brand-audit-provider-sprawl.test.ts
@@ -36,9 +36,10 @@ describe('groupByProvider', () => {
 		});
 	});
 	it('returns multiple providers when NS list crosses orgs', () => {
-		expect(
-			groupByProvider(['a.ns.paypal.com', 'b.ns.paypal.com', 'pdns1.ultradns.net', 'pdns2.ultradns.com']),
-		).toEqual({ 'PayPal (in-house)': 2, 'UltraDNS (Vercara)': 2 });
+		expect(groupByProvider(['a.ns.paypal.com', 'b.ns.paypal.com', 'pdns1.ultradns.net', 'pdns2.ultradns.com'])).toEqual({
+			'paypal.com': 2,
+			'UltraDNS (Vercara)': 2,
+		});
 	});
 	it('deduplicates duplicate nameservers within input', () => {
 		expect(groupByProvider(['ns1.cloudflare.com', 'ns1.cloudflare.com'])).toEqual({ Cloudflare: 1 });
@@ -50,9 +51,7 @@ describe('isMultiProvider', () => {
 		expect(isMultiProvider(['ns-52.awsdns-52.com', 'ns-1234.awsdns-43.co.uk'])).toBe(false);
 	});
 	it('returns true for paypal-style UltraDNS + in-house', () => {
-		expect(
-			isMultiProvider(['pdns1.ultradns.net', 'pdns2.ultradns.com', 'a.ns.paypal.com', 'b.ns.paypal.com']),
-		).toBe(true);
+		expect(isMultiProvider(['pdns1.ultradns.net', 'pdns2.ultradns.com', 'a.ns.paypal.com', 'b.ns.paypal.com'])).toBe(true);
 	});
 	it('returns false for single-provider list', () => {
 		expect(isMultiProvider(['ns1.google.com', 'ns2.google.com', 'ns3.google.com'])).toBe(false);


### PR DESCRIPTION
## Summary

Phase 1 of a "no client names anywhere" sweep driven by enterprise sales / compliance review. This PR clears client-domain references from the source surface (`src/`, `scripts/`, `.github/`) and re-architects the repo-safety scanner so `policy.json` no longer needs to carry plaintext client names to function.

**Out of scope:** test fixtures, registrar partnership demo files, and `docs/client-setup.md`. Tests remain allowlisted via the `test/` prefix; those fixtures stay as-is per owner decision. The history rewrite + GitHub Support reference-cleanup are handled separately.

## Scanner changes

- `scanner-core.mjs`: new `forbiddenClientDomainsSha256` policy field. Scanner extracts hostname-like tokens from each line, generates tail suffixes, SHA-256s each, compares against the hashed list. Legacy `forbiddenClientDomains` (literal list) still works for survey-only flows.
- `policy.json`: swap the 14 plaintext client domains for their SHA-256 hashes.
- `scan-branch.mjs --with-client-domains`: simplified — only adds Tier-1 brand survey list (amazon/apple/github/google/microsoft) on top of the always-on hashed gate.

## Source redactions

| File | Change |
|---|---|
| `src/lib/spf-canary.ts` | `paypal.com`, `stripe.com` → `wikipedia.org`, `reddit.com` |
| `src/lib/brand-audit-provider-sprawl.ts` | Drop PayPal classifier rule; apex-2 fallback produces a generic provider label |
| `src/lib/brand-discovery-planner.ts` | Comment redaction |
| `src/lib/brand-audit-reaper.ts` | Comment redaction (`disney/walmart-class` → `tier-1-class`) |
| `src/lib/brand-audit-pdf-render.ts` | Comment redaction |
| `src/lib/brand-candidate-universe.ts` | Comment redaction |
| `src/queue/brand-audit-consumer.ts` | Two comment redactions |
| `src/tools/discover-brand-domains.ts` | `PHASE5_BOUNTY_HANDLES` → all client-name handles collapsed to `brand-*` placeholders; two inline comments redacted |
| `src/tenants/discovery/san-correlator.ts` | Comment redaction |
| `scripts/generate-consolidated-report.mjs` | Redact example in shadow-IT confidence note |

## Allowlist tightening

`src/lib/spf-canary.ts` and `src/lib/brand-audit-provider-sprawl.ts` removed from `policy.json` `allowedPaths` — they're clean now, so the scanner can gate future regressions on those files.

## Test impact

- `test/brand-audit-provider-sprawl.test.ts`: one expected-bucket-name update to match the new apex-2 fallback (PayPal classifier was the only test casualty of the redaction).

## Verification

- `npm run audit:repo-safety` → 0 findings
- `npm run typecheck` → clean
- Affected test cluster (provider-sprawl, repo-safety scanner/policy audits, plus broader run across 14 modified-file tests): 116/116 passing
- The diff is noisy because the project's PostToolUse formatter ran prettier on each edited file; the substantive changes are limited to the table above

## Note on formatter noise

Lots of lines show in the diff for files like `src/tools/discover-brand-domains.ts` and `src/queue/brand-audit-consumer.ts`. These are line-length reformat-only — prettier collapsed multi-line function signatures into single lines when the edit triggered the format hook. No logic changes outside the redactions listed above.

## Companion / follow-up

- GitHub Support reference-cleanup ticket (separate) covers PRs #157–172 plus Tier A/B/C additions identified earlier in the audit.
- Phase 2 (private fixtures repo for brand-audit tests) is **not** scheduled — owner's current call is to keep test fixtures in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)