### PR TITLE
fix(check-shadow-domains): handle RFC 7505 null MX as explicit non-mail

### DIFF
--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -32,9 +32,23 @@ export const PHASE1_DNS_OPTS: QueryDnsOptions = {
 
 /** Global ccTLD set always appended. */
 const GLOBAL_TLDS = [
-	'.com', '.net', '.org', '.io', '.ai', '.co',
-	'.de', '.fr', '.nl', '.eu', '.co.uk', '.com.au',
-	'.ca', '.jp', '.in', '.sg', '.za',
+	'.com',
+	'.net',
+	'.org',
+	'.io',
+	'.ai',
+	'.co',
+	'.de',
+	'.fr',
+	'.nl',
+	'.eu',
+	'.co.uk',
+	'.com.au',
+	'.ca',
+	'.jp',
+	'.in',
+	'.sg',
+	'.za',
 ];
 
 /** Regional variant TLD sets by TLD family. */
@@ -102,13 +116,8 @@ export function generateVariants(brand: string, effectiveTld: string, primaryDom
  * Probe a single variant domain for NS, A, MX, SPF, and DMARC records.
  * All 5 DNS queries run in parallel with skipSecondaryConfirmation.
  */
-async function probeVariant(
-	variant: string,
-	dnsOpts: QueryDnsOptions,
-	prefetchedNs?: string[],
-): Promise<VariantProbeResult> {
-	const nsPromise: Promise<string[]> =
-		prefetchedNs !== undefined ? Promise.resolve(prefetchedNs) : queryDnsRecords(variant, 'NS', dnsOpts);
+async function probeVariant(variant: string, dnsOpts: QueryDnsOptions, prefetchedNs?: string[]): Promise<VariantProbeResult> {
+	const nsPromise: Promise<string[]> = prefetchedNs !== undefined ? Promise.resolve(prefetchedNs) : queryDnsRecords(variant, 'NS', dnsOpts);
 
 	const [nsResult, aResult, mxResult, txtResult, dmarcResult] = await Promise.allSettled([
 		nsPromise,
@@ -142,10 +151,7 @@ async function probeVariant(
  * Phase 1: Fast NS existence check for all variants in parallel.
  * Returns a Map of variant -> NS records for registered domains.
  */
-async function filterByNsExistence(
-	variants: string[],
-	dnsOpts: QueryDnsOptions,
-): Promise<Map<string, string[]>> {
+async function filterByNsExistence(variants: string[], dnsOpts: QueryDnsOptions): Promise<Map<string, string[]>> {
 	const registered = new Map<string, string[]>();
 	const results = await Promise.allSettled(
 		variants.map(async (variant) => {
@@ -184,17 +190,44 @@ function sharesNsWithPrimary(variantNs: string[], primaryNs: string[]): boolean 
 }
 
 /**
+ * RFC 7505 null MX detection. After `queryMxRecords`'s trailing-dot strip, the canonical
+ * null-MX target (`MX 0 .`) appears as an empty exchange; the older `MX 0 localhost.`
+ * convention used by some operators for the same intent appears as `'localhost'`. Both
+ * are explicit "this domain does not accept mail" declarations and MUST NOT be treated
+ * as evidence of a mail-active surface. Misclassifying them as "has mail servers"
+ * generates false-positive HIGH/CRITICAL findings on domains that have applied the
+ * recommended anti-spoofing posture for non-mail names.
+ */
+function isNullMxExchange(exchange: string): boolean {
+	const lowered = exchange.toLowerCase();
+	return lowered === '' || lowered === 'localhost';
+}
+
+/**
  * Classify a probed variant into a finding based on risk.
  * When the variant shares nameservers with the primary domain (indicating common ownership),
  * email-auth findings are downgraded one severity level.
  */
 function classifyVariant(probe: VariantProbeResult, primaryMx: string[], primaryNs: string[]): Finding {
 	const { variant, ns, mx, hasSpf, dmarcPolicy } = probe;
-	const hasMx = mx.length > 0;
+	const hasNullMxOnly = mx.length > 0 && mx.every(isNullMxExchange);
+	const hasMx = mx.length > 0 && !hasNullMxOnly;
 	const hasNs = ns.length > 0;
 	const sameOwner = sharesNsWithPrimary(ns, primaryNs);
 	const meta = { variant, ns, mx, hasSpf, dmarcPolicy };
 	const ownerNote = ' Likely same owner based on shared nameservers — still recommended to add DMARC.';
+
+	// RFC 7505 explicit non-mail posture — the domain is doing the right thing for a
+	// non-mail name. Don't pretend it's spoofable.
+	if (hasNullMxOnly) {
+		return createFinding(
+			'shadow_domains',
+			'Shadow domain explicit non-mail (RFC 7505)',
+			'info',
+			`${variant} declares an RFC 7505 null MX (priority 0 to "." or "localhost"), explicitly refusing mail. This is the recommended anti-spoofing posture for non-mail domains.`,
+			meta,
+		);
+	}
 
 	if (hasMx) {
 		if (!hasSpf && dmarcPolicy === null) {
@@ -234,9 +267,7 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], primary
 		if (dmarcPolicy === 'quarantine' || dmarcPolicy === 'reject') {
 			if (!isSameMxInfra(mx, primaryMx)) {
 				// Divergent MX infrastructure → medium
-				const divergentNote = sameOwner
-					? ` Shared nameservers suggest common ownership despite different mail servers.`
-					: '';
+				const divergentNote = sameOwner ? ` Shared nameservers suggest common ownership despite different mail servers.` : '';
 				return createFinding(
 					'shadow_domains',
 					'Shadow domain divergent mail infrastructure',
@@ -258,9 +289,7 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], primary
 
 		// DMARC present with unknown policy — treat as high-ish (SPF but unclear DMARC)
 		if (!isSameMxInfra(mx, primaryMx)) {
-			const divergentNote = sameOwner
-				? ` Shared nameservers suggest common ownership despite different mail servers.`
-				: '';
+			const divergentNote = sameOwner ? ` Shared nameservers suggest common ownership despite different mail servers.` : '';
 			return createFinding(
 				'shadow_domains',
 				'Shadow domain divergent mail infrastructure',
@@ -393,10 +422,7 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 	let primaryNs: string[] = [];
 	let primaryDnsUnavailable = false;
 	try {
-		const [mxResult, nsResult] = await Promise.allSettled([
-			queryMxRecords(domain, dnsOpts),
-			queryDnsRecords(domain, 'NS', dnsOpts),
-		]);
+		const [mxResult, nsResult] = await Promise.allSettled([queryMxRecords(domain, dnsOpts), queryDnsRecords(domain, 'NS', dnsOpts)]);
 		primaryMx = mxResult.status === 'fulfilled' ? mxResult.value.map((r) => r.exchange) : [];
 		primaryNs = nsResult.status === 'fulfilled' ? nsResult.value : [];
 		// If both queries rejected, treat as unavailable
@@ -455,9 +481,7 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 		}
 
 		const batch = registeredList.slice(i, i + batchSize);
-		const batchResults = await Promise.allSettled(
-			batch.map(([variant, ns]) => probeVariant(variant, dnsOpts, ns)),
-		);
+		const batchResults = await Promise.allSettled(batch.map(([variant, ns]) => probeVariant(variant, dnsOpts, ns)));
 
 		let failures = 0;
 		for (const result of batchResults) {

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -87,9 +87,7 @@ describe('checkShadowDomains', () => {
 
 		const result = await run(target);
 		expect(result.category).toBe('shadow_domains');
-		const critical = result.findings.find(
-			(f) => f.severity === 'critical' && f.detail.includes('example.net'),
-		);
+		const critical = result.findings.find((f) => f.severity === 'critical' && f.detail.includes('example.net'));
 		expect(critical).toBeDefined();
 		expect(critical!.title).toMatch(/fully spoofable/i);
 	});
@@ -120,9 +118,7 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const high = result.findings.find(
-			(f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title),
-		);
+		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
 		expect(high).toBeDefined();
 	});
 
@@ -152,9 +148,7 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const high = result.findings.find(
-			(f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title),
-		);
+		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title));
 		expect(high).toBeDefined();
 	});
 
@@ -182,9 +176,7 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const info = result.findings.find(
-			(f) => f.severity === 'info' && f.detail.includes('example.net') && /unregistered/i.test(f.title),
-		);
+		const info = result.findings.find((f) => f.severity === 'info' && f.detail.includes('example.net') && /unregistered/i.test(f.title));
 		expect(info).toBeDefined();
 	});
 
@@ -238,10 +230,7 @@ describe('checkShadowDomains', () => {
 
 		const result = await run(target);
 		// No finding should mention the primary domain in a variant-specific way
-		const primaryFinding = result.findings.find(
-			(f) =>
-				f.metadata?.variant === target,
-		);
+		const primaryFinding = result.findings.find((f) => f.metadata?.variant === target);
 		expect(primaryFinding).toBeUndefined();
 	});
 
@@ -273,9 +262,7 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const low = result.findings.find(
-			(f) => f.severity === 'low' && f.detail.includes('example.org') && /well-managed/i.test(f.title),
-		);
+		const low = result.findings.find((f) => f.severity === 'low' && f.detail.includes('example.org') && /well-managed/i.test(f.title));
 		expect(low).toBeDefined();
 	});
 
@@ -307,9 +294,7 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const medium = result.findings.find(
-			(f) => f.severity === 'medium' && f.detail.includes('example.org') && /divergent/i.test(f.title),
-		);
+		const medium = result.findings.find((f) => f.severity === 'medium' && f.detail.includes('example.org') && /divergent/i.test(f.title));
 		expect(medium).toBeDefined();
 	});
 
@@ -342,9 +327,7 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const sharedNsFinding = result.findings.find(
-			(f) => f.severity === 'info' && /shared.*NS/i.test(f.title),
-		);
+		const sharedNsFinding = result.findings.find((f) => f.severity === 'info' && /shared.*NS/i.test(f.title));
 		expect(sharedNsFinding).toBeDefined();
 	});
 
@@ -375,9 +358,7 @@ describe('checkShadowDomains', () => {
 
 		const result = await run(target);
 		// Without NS, example.net should NOT be critical
-		const critical = result.findings.find(
-			(f) => f.severity === 'critical' && f.detail.includes('example.net'),
-		);
+		const critical = result.findings.find((f) => f.severity === 'critical' && f.detail.includes('example.net'));
 		expect(critical).toBeUndefined();
 
 		const unregistered = result.findings.find(
@@ -517,10 +498,77 @@ describe('checkShadowDomains — classification edge cases', () => {
 
 		const result = await run(target);
 		// DMARC p=reject present so should NOT be critical
-		const critical = result.findings.find(
-			(f) => f.severity === 'critical' && f.detail.includes('example.net'),
-		);
+		const critical = result.findings.find((f) => f.severity === 'critical' && f.detail.includes('example.net'));
 		expect(critical).toBeUndefined();
+	});
+
+	it('should classify RFC 7505 null MX (MX 0 .) as INFO non-mail, not as spoofable', async () => {
+		const target = 'example.com';
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+
+			if (name === target && (type === 'MX' || type === '15')) {
+				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			}
+
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				// Null MX per RFC 7505: priority 0, target = root (".")
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['0 .']));
+				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 -all']));
+			}
+			if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
+				return Promise.resolve(emptyResponse()); // no DMARC, irrelevant when null MX
+			}
+
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const nullMxFinding = result.findings.find((f) => f.detail.includes('example.net') && /non-mail|RFC 7505/i.test(f.title));
+		expect(nullMxFinding).toBeDefined();
+		expect(nullMxFinding!.severity).toBe('info');
+		// Must NOT be classified as spoofable or weak-DMARC
+		const spoofable = result.findings.find((f) => f.detail.includes('example.net') && /spoofable|lacks DMARC|not enforcing/i.test(f.title));
+		expect(spoofable).toBeUndefined();
+	});
+
+	it('should classify legacy null MX (MX 0 localhost.) as INFO non-mail', async () => {
+		const target = 'example.com';
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+
+			if (name === target && (type === 'MX' || type === '15')) {
+				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			}
+
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				// Legacy null-MX convention: priority 0 → "localhost"
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['0 localhost.']));
+				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 -all']));
+			}
+			if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
+				return Promise.resolve(emptyResponse());
+			}
+
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const nullMxFinding = result.findings.find((f) => f.detail.includes('example.net') && /non-mail|RFC 7505/i.test(f.title));
+		expect(nullMxFinding).toBeDefined();
+		expect(nullMxFinding!.severity).toBe('info');
+		const wrongHigh = result.findings.find((f) => f.detail.includes('example.net') && f.severity !== 'info');
+		expect(wrongHigh).toBeUndefined();
 	});
 
 	it('should treat DMARC with no p= tag as p=none (high severity)', async () => {
@@ -551,9 +599,7 @@ describe('checkShadowDomains — classification edge cases', () => {
 
 		const result = await run(target);
 		// Missing p= tag should default to p=none, classified as high
-		const high = result.findings.find(
-			(f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title),
-		);
+		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title));
 		expect(high).toBeDefined();
 	});
 
@@ -586,9 +632,7 @@ describe('checkShadowDomains — classification edge cases', () => {
 
 		const result = await run(target);
 		// Should match as same infrastructure (low severity) despite trailing dot difference
-		const low = result.findings.find(
-			(f) => f.severity === 'low' && f.detail.includes('example.org') && /well-managed/i.test(f.title),
-		);
+		const low = result.findings.find((f) => f.severity === 'low' && f.detail.includes('example.org') && /well-managed/i.test(f.title));
 		expect(low).toBeDefined();
 		// Should NOT be medium/divergent
 		const divergent = result.findings.find(
@@ -636,14 +680,10 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 		const result = await run(target);
 		// Should be downgraded to high (not critical)
-		const critical = result.findings.find(
-			(f) => f.severity === 'critical' && f.detail.includes('example.net'),
-		);
+		const critical = result.findings.find((f) => f.severity === 'critical' && f.detail.includes('example.net'));
 		expect(critical).toBeUndefined();
 
-		const high = result.findings.find(
-			(f) => f.severity === 'high' && f.detail.includes('example.net') && /fully spoofable/i.test(f.title),
-		);
+		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /fully spoofable/i.test(f.title));
 		expect(high).toBeDefined();
 		expect(high!.detail).toContain('shared nameservers');
 	});
@@ -677,14 +717,10 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 		const result = await run(target);
 		// Should be downgraded to medium (not high)
-		const high = result.findings.find(
-			(f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title),
-		);
+		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
 		expect(high).toBeUndefined();
 
-		const medium = result.findings.find(
-			(f) => f.severity === 'medium' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title),
-		);
+		const medium = result.findings.find((f) => f.severity === 'medium' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
 		expect(medium).toBeDefined();
 		expect(medium!.detail).toContain('shared nameservers');
 	});
@@ -717,9 +753,7 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 		});
 
 		const result = await run(target);
-		const high = result.findings.find(
-			(f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title),
-		);
+		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title));
 		expect(high).toBeUndefined();
 
 		const medium = result.findings.find(
@@ -780,7 +814,8 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 			// Variant: DIFFERENT NS, MX + SPF but no DMARC
 			if (name === 'example.net') {
-				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.other-registrar.com.', 'ns2.other-registrar.com.']));
+				if (type === 'NS' || type === '2')
+					return Promise.resolve(nsRecords(name, ['ns1.other-registrar.com.', 'ns2.other-registrar.com.']));
 				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
 				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.shadow.com.']));
 				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 include:spf.provider.com -all']));
@@ -794,9 +829,7 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 		const result = await run(target);
 		// Should remain high (not downgraded)
-		const high = result.findings.find(
-			(f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title),
-		);
+		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
 		expect(high).toBeDefined();
 		expect(high!.detail).not.toContain('shared nameservers');
 	});


### PR DESCRIPTION
## Summary
- `queryMxRecords` strips trailing dots, so `MX 0 .` arrives as `exchange=""` and `MX 0 localhost.` as `exchange="localhost"`. The previous classifier treated any non-empty `mx[]` as "has mail servers", producing false-positive HIGH and CRITICAL findings on domains that had applied the recommended anti-spoofing posture for non-mail names (RFC 7505).
- Adds `isNullMxExchange()` helper and a new INFO-severity finding "Shadow domain explicit non-mail (RFC 7505)" for the corrected case.
- Two regression tests cover the canonical `0 .` form and the legacy `0 localhost.` convention.

## Empirical evidence
Fact-checking the OpenAI/Anthropic registrar-complement demo identified 7 false-positive HIGH findings caused by this bug:
- OpenAI: `openai.eu` (1)
- Anthropic: `anthropic.de`, `anthropic.io`, `anthropic.app`, `anthropic.com.au`, `anthropic.net`, `anthropic.nl` (6)

All 7 declare null MX + `SPF -all` — the **gold-standard** non-mail posture, not weak DMARC.

## Post-fix verification (already deployed)
Fix deployed to prod 2026-05-23 (version `e920f1aa-f689-4a50-82ca-e19ee34030e0`). Live re-run confirms:
- OpenAI HIGH: 7 → 6
- Anthropic HIGH: 10 → 4
- New INFO "explicit non-mail (RFC 7505)" findings: 1 OpenAI + 6 Anthropic (exact match)
- CRITICAL counts unchanged (those have real MX; classification accurate)

39/39 post-deploy chaos tests passed across 5 no-auth suites (service-resilience, database-resilience, worker-health, concurrent-load, queue-resilience).

## Test plan
- [x] Two new regression tests in \`test/check-shadow-domains.spec.ts\` ("RFC 7505" and "0 localhost." cases)
- [x] Full \`check-shadow-domains.spec.ts\` suite: 29/29 passed
- [x] Deployed to prod ahead of merge — empirical re-run confirms expected behavior
- [x] Chaos suite green across 5 suites
- [ ] CI required checks (build-and-test, Secret & PII scan, Dependency audit, File hygiene check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)