### PR TITLE
fix(check-shadow-domains): A-record fallback when Phase 1 NS query is empty

### DIFF
--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -447,7 +447,30 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 	// Phase 1: Fast NS existence check — filter out unregistered variants
 	const registeredVariants = await filterByNsExistence(variants, dnsOpts);
 
-	// Classify unregistered variants immediately as info findings
+	// Phase 1.5: Fallback A-record check for variants Phase 1 rejected.
+	//
+	// Phase 1's NS query runs with tight PHASE1_DNS_OPTS (timeoutMs=2000, retries=0).
+	// Slow ccTLD authoritative servers — observed empirically on .nl — can exceed
+	// that window, producing an empty NS result that the classifier would otherwise
+	// treat as "unregistered". An A record is independent positive evidence that
+	// the domain is registered, so any variant with A>0 is routed to Phase 2
+	// (with prefetchedNs=[]) instead of being prematurely classified.
+	const candidateUnregistered = variants.filter((v) => !registeredVariants.has(v));
+	if (candidateUnregistered.length > 0) {
+		const aResults = await Promise.allSettled(
+			candidateUnregistered.map(async (variant) => ({
+				variant,
+				hasA: (await queryDnsRecords(variant, 'A', { ...dnsOpts, ...PHASE1_DNS_OPTS })).length > 0,
+			})),
+		);
+		for (const result of aResults) {
+			if (result.status === 'fulfilled' && result.value.hasA) {
+				registeredVariants.set(result.value.variant, []);
+			}
+		}
+	}
+
+	// Classify truly-unregistered variants (no NS AND no A) as info findings.
 	for (const variant of variants) {
 		if (!registeredVariants.has(variant)) {
 			findings.push(

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -331,7 +331,10 @@ describe('checkShadowDomains', () => {
 		expect(sharedNsFinding).toBeDefined();
 	});
 
-	it('should classify variant as unregistered when it has no NS records (Phase 1 filter)', async () => {
+	it('should classify variant as unregistered only when NS AND A are both empty (Phase 1 + 1.5 filter)', async () => {
+		// Updated semantics: a variant with no NS records is NOT immediately classified as
+		// unregistered. Phase 1.5 checks A as a fallback to avoid the slow-ccTLD false-negative
+		// trap. A variant is only classified as "unregistered" when both NS AND A are empty.
 		const target = 'example.com';
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
@@ -343,11 +346,10 @@ describe('checkShadowDomains', () => {
 				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
 			}
 
-			// example.net has MX but NO NS records — should not be detail-probed
+			// example.net is truly unregistered — NS empty, A empty, MX empty (the only state
+			// where the "unregistered" classification should fire).
 			if (name === 'example.net') {
-				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.shadow.com.']));
-				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
-				if (type === 'TXT' || type === '16') return Promise.resolve(emptyResponse());
+				return Promise.resolve(emptyResponse());
 			}
 			if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
 				return Promise.resolve(emptyResponse());
@@ -357,10 +359,6 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		// Without NS, example.net should NOT be critical
-		const critical = result.findings.find((f) => f.severity === 'critical' && f.detail.includes('example.net'));
-		expect(critical).toBeUndefined();
-
 		const unregistered = result.findings.find(
 			(f) => f.severity === 'info' && f.detail.includes('example.net') && /unregistered/i.test(f.title),
 		);
@@ -500,6 +498,42 @@ describe('checkShadowDomains — classification edge cases', () => {
 		// DMARC p=reject present so should NOT be critical
 		const critical = result.findings.find((f) => f.severity === 'critical' && f.detail.includes('example.net'));
 		expect(critical).toBeUndefined();
+	});
+
+	it('should NOT classify a variant as unregistered when NS empty but A resolves (slow-ccTLD safety net)', async () => {
+		// Reproduces the openai.nl false-negative: Phase 1 NS query returns empty (slow .nl
+		// authoritative server exceeds the 2s PHASE1 timeout) but the domain IS registered and
+		// resolves an A record. The classifier must use A as a fallback positive-existence signal
+		// rather than concluding "unregistered".
+		const target = 'example.com';
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+
+			if (name === target && (type === 'MX' || type === '15')) {
+				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			}
+
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(emptyResponse());
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.99']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mailrelay.example.net.']));
+				if (type === 'TXT' || type === '16') return Promise.resolve(emptyResponse());
+			}
+			if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
+				return Promise.resolve(emptyResponse());
+			}
+
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const wronglyUnregistered = result.findings.find(
+			(f) => f.detail.includes('example.net') && /does not appear to be registered/i.test(f.detail),
+		);
+		expect(wronglyUnregistered).toBeUndefined();
 	});
 
 	it('should classify RFC 7505 null MX (MX 0 .) as INFO non-mail, not as spoofable', async () => {


### PR DESCRIPTION
## Summary
- Phase 1's NS existence check uses tight \`PHASE1_DNS_OPTS\` (timeoutMs=2000, retries=0). Slow ccTLD authoritative servers can exceed that window, producing false-negative "unregistered" findings.
- Adds Phase 1.5 A-record fallback: variants Phase 1 rejected are A-checked with the same lean options. A>0 → routed to Phase 2. Only NS=0 AND A=0 → classified as truly unregistered.

## Empirical evidence
\`openai.nl\` reported "unregistered" by the tool; independent verification (Google DoH + Cloudflare DoH + local dig) confirmed it IS registered with NS=ZXCS, A=185.104.29.148, MX=spamrelay.zxcs.nl.

## Post-fix verification (already deployed)
Worker version \`9289d39f-394e-4527-a043-80ed8d7c7e65\` (deployed ahead of merge). Live re-run with force_refresh confirms:
- \`openai.nl\` now classified as "Shadow domain DMARC not enforcing" HIGH (accurate — has mail servers + DMARC=none)
- Unregistered count: 4 → 3 (only truly-unregistered apexes remain: openai.ai, openai.jp, openai.za)

## Test plan
- [x] New regression test for slow-ccTLD scenario (NS empty + A resolves)
- [x] Updated one pre-existing test that codified the false-negative behavior
- [x] Full shadow-domains spec: 30/30 passed
- [x] Deployed to prod + live re-run confirms expected behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)