### PR TITLE
fix(rdap): correct .app/.dev URL, expand ccTLD fallback, parallelize pipeline lookups

### DIFF
--- a/src/lib/brand-audit-pipeline.ts
+++ b/src/lib/brand-audit-pipeline.ts
@@ -16,10 +16,7 @@ import {
 import { validateSprawlItem } from './sprawl-invariants';
 import { evaluateDefensiveRegistration } from './brand-defensive-registration';
 import type { BrandEvidenceObservation } from './brand-evidence';
-import {
-	discoverBrandDomains as defaultDiscoverBrandDomains,
-	type BrandDiscoveryProgressEvent,
-} from '../tools/discover-brand-domains';
+import { discoverBrandDomains as defaultDiscoverBrandDomains, type BrandDiscoveryProgressEvent } from '../tools/discover-brand-domains';
 import { checkRdapLookup as defaultCheckRdapLookup, type RdapCheckOptions } from '../tools/check-rdap-lookup';
 import type { BrandAuditStepStore } from './brand-audit-step-store';
 import type { Tier0Result } from './brand-tier0-enterprise';
@@ -435,9 +432,7 @@ function graphEvidenceFromObservations(
 		if (obs.tier !== 1) continue;
 		const md = obs.metadata;
 		if (!isRecord(md)) continue;
-		const signalTypes = Array.isArray(md.signalTypes)
-			? md.signalTypes.filter((value): value is string => typeof value === 'string')
-			: [];
+		const signalTypes = Array.isArray(md.signalTypes) ? md.signalTypes.filter((value): value is string => typeof value === 'string') : [];
 		const numSharedSignals = md.numSharedSignals;
 		const maxSpecificity = md.maxSpecificity;
 		if (signalTypes.length === 0 || typeof numSharedSignals !== 'number' || typeof maxSpecificity !== 'number') continue;
@@ -454,9 +449,7 @@ function graphEvidenceFromObservations(
 
 /** Pull registrar + registrant out of a check-rdap-lookup result, mirroring `scripts/brand-audit-brand-audit.spec.ts:lookupRegistrar`. */
 function extractRegistrar(rdap: CheckResult): RegistrarLookup {
-	const populated = rdap.findings.find(
-		(f) => isMeaningfulRegistrar(f.metadata?.registrar),
-	);
+	const populated = rdap.findings.find((f) => isMeaningfulRegistrar(f.metadata?.registrar));
 	const registrantFinding = rdap.findings.find(
 		(f) => typeof f.metadata?.registrant === 'string' && (f.metadata.registrant as string).length > 0,
 	);
@@ -469,7 +462,13 @@ function extractRegistrar(rdap: CheckResult): RegistrarLookup {
 			source === 'lookup_failed' && typeof populated.metadata?.registrarFailureReason === 'string'
 				? populated.metadata.registrarFailureReason
 				: null;
-		return { registrar: (populated.metadata!.registrar as string).trim(), registrarIanaId, registrarSource: source, registrant, registrarFailureReason };
+		return {
+			registrar: (populated.metadata!.registrar as string).trim(),
+			registrarIanaId,
+			registrarSource: source,
+			registrant,
+			registrarFailureReason,
+		};
 	}
 	const lastWithSource = [...rdap.findings].reverse().find((f) => typeof f.metadata?.registrarSource === 'string');
 	const source = (lastWithSource?.metadata?.registrarSource as RegistrarSource | undefined) ?? 'unknown';
@@ -514,7 +513,9 @@ function unknownRegistrarLookup(): RegistrarLookup {
 }
 
 function hasRegistrarIndependentEvidence(domain: string, seedDomain: string, signals: string[]): boolean {
-	return domain === seedDomain || domain.endsWith(`.${seedDomain}`) || signals.some((signal) => STRONG_REGISTRAR_INDEPENDENT_SIGNALS.has(signal));
+	return (
+		domain === seedDomain || domain.endsWith(`.${seedDomain}`) || signals.some((signal) => STRONG_REGISTRAR_INDEPENDENT_SIGNALS.has(signal))
+	);
 }
 
 function isRegistrarSource(value: unknown): value is RegistrarSource {
@@ -533,9 +534,7 @@ function readRegistrarLookup(value: unknown): RegistrarLookup | null {
 	const registrant = typeof value.registrant === 'string' ? value.registrant : null;
 	const registrarIanaId = typeof value.registrarIanaId === 'string' ? value.registrarIanaId : null;
 	const registrarFailureReason =
-		value.registrarSource === 'lookup_failed' && typeof value.registrarFailureReason === 'string'
-			? value.registrarFailureReason
-			: null;
+		value.registrarSource === 'lookup_failed' && typeof value.registrarFailureReason === 'string' ? value.registrarFailureReason : null;
 	return { registrar: value.registrar, registrarIanaId, registrarSource: value.registrarSource, registrant, registrarFailureReason };
 }
 
@@ -586,35 +585,30 @@ async function lookupCandidateRegistrars(
 	const statusForLookup = (lookup: RegistrarLookup): CandidateRegistrarLookupStatus =>
 		lookup.registrarSource === 'lookup_failed' ? 'needs_retry' : 'completed';
 
-	if (deadlineMs === undefined && !signal) {
-		const candidates = await mapConcurrent(candidateFindings, RDAP_CONCURRENCY, async (f) => {
-			const candidate = f.metadata!.candidate as string;
-			const lookup = await safeRegistrarLookup(candidate, deps, signal);
-			return { candidate, lookup, status: statusForLookup(lookup) };
-		});
-		return { candidates, partial: false, skippedCandidates: [], rdapQueries: candidates.length };
-	}
-
-	const candidates: CandidateRegistrarLookup[] = [];
+	// Concurrent path — used whether or not a deadline is set. The serial fallback
+	// that lived here caused late candidates in a 40-domain audit to ghost-abort
+	// (RDAP_TIMEOUT_MS × N is far longer than any sane audit deadline). Concurrency
+	// is bounded by RDAP_CONCURRENCY; each task does a per-task deadline check
+	// before issuing the RDAP fetch so skipped slots still surface as
+	// 'skipped_deadline' rather than 'lookup_failed/caller_aborted'.
 	const skippedCandidates: string[] = [];
 	let partial = false;
-	for (const finding of candidateFindings) {
-		const candidate = finding.metadata!.candidate as string;
+	const results = await mapConcurrent(candidateFindings, RDAP_CONCURRENCY, async (f) => {
+		const candidate = f.metadata!.candidate as string;
 		if (aborted() || (deadlineMs !== undefined && now() >= deadlineMs)) {
 			partial = true;
 			skippedCandidates.push(candidate);
-			candidates.push({ candidate, lookup: unknownRegistrarLookup(), status: 'skipped_deadline' });
-			continue;
+			return { candidate, lookup: unknownRegistrarLookup(), status: 'skipped_deadline' as const };
 		}
 		const lookup = await safeRegistrarLookup(candidate, deps, signal);
-		candidates.push({ candidate, lookup, status: statusForLookup(lookup) });
-	}
+		return { candidate, lookup, status: statusForLookup(lookup) };
+	});
 
 	return {
-		candidates,
+		candidates: results,
 		partial,
 		skippedCandidates,
-		rdapQueries: candidates.filter((entry) => entry.status === 'completed' || entry.status === 'needs_retry').length,
+		rdapQueries: results.filter((entry) => entry.status === 'completed' || entry.status === 'needs_retry').length,
 	};
 }
 
@@ -724,9 +718,7 @@ export async function runBrandAuditPipeline(
 			...(deps.tier1Lookup ? { tier1Lookup: deps.tier1Lookup } : {}),
 			...(deps.tier2Lookup ? { tier2Lookup: deps.tier2Lookup } : {}),
 		} as Parameters<typeof discover>[2];
-		discovery = hasTierDeps
-			? await discover(seedDomain, discoveryOpts, discoveryDeps)
-			: await discover(seedDomain, discoveryOpts);
+		discovery = hasTierDeps ? await discover(seedDomain, discoveryOpts, discoveryDeps) : await discover(seedDomain, discoveryOpts);
 		throwIfAborted();
 		await stepStore?.put({ auditId, target: seedDomain, step: 'discovery', status: 'completed', payload: discovery });
 		recordStep(stepTimings, 'discovery', 'completed', discoveryStartedAtMs, now());
@@ -777,9 +769,7 @@ export async function runBrandAuditPipeline(
 		recordStep(stepTimings, 'registrar_enrichment', candidateLookups.partial ? 'partial' : 'completed', registrarStartedAtMs, now());
 	}
 	const { targetLookup } = registrarEnrichment;
-	const lookupByCandidate = new Map(
-		registrarEnrichment.candidates.map((entry) => [normalizeDomainKey(entry.candidate), entry]),
-	);
+	const lookupByCandidate = new Map(registrarEnrichment.candidates.map((entry) => [normalizeDomainKey(entry.candidate), entry]));
 	const buildPerformance = () =>
 		summarizeBrandAuditMetrics({
 			startedAtMs: auditStartedAtMs,
@@ -861,9 +851,7 @@ export async function runBrandAuditPipeline(
 		// candidate finding's metadata; callers that don't yet populate them get
 		// the safe defaults ([], null, 0) and the new branches simply don't fire.
 		const md = f.metadata!;
-		const sharedTxtVerifications = Array.isArray(md.sharedTxtVerifications)
-			? (md.sharedTxtVerifications as string[])
-			: [];
+		const sharedTxtVerifications = Array.isArray(md.sharedTxtVerifications) ? (md.sharedTxtVerifications as string[]) : [];
 		const sharedMxPlatform = typeof md.sharedMxPlatform === 'string' ? (md.sharedMxPlatform as string) : null;
 		const lookalikeScore = typeof md.lookalikeScore === 'number' ? (md.lookalikeScore as number) : 0;
 		const callerAsserted = Array.isArray(md.candidateSeedSources) && (md.candidateSeedSources as string[]).includes('caller_candidate');
@@ -1071,10 +1059,7 @@ export async function runBrandAuditPipeline(
 		}
 
 		if (deps.brandAuditQueue) {
-			await deps.brandAuditQueue.send(
-				{ auditId, target: seedDomain, phase: 'deep_scan' },
-				{ contentType: 'json' },
-			);
+			await deps.brandAuditQueue.send({ auditId, target: seedDomain, phase: 'deep_scan' }, { contentType: 'json' });
 		}
 	}
 

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -59,27 +59,41 @@ export const FALLBACK_RDAP_SERVERS: Record<string, string> = {
 	co: 'https://rdap.nic.co/',
 	// ME Registry
 	me: 'https://rdap.nic.me/',
-	// Google Registry
-	app: 'https://www.registry.google/rdap/',
-	dev: 'https://www.registry.google/rdap/',
+	// Google Registry — pubapi is the canonical RDAP endpoint; www.registry.google returns 404.
+	app: 'https://pubapi.registry.google/rdap/',
+	dev: 'https://pubapi.registry.google/rdap/',
 	// XYZ.COM LLC
 	xyz: 'https://rdap.nic.xyz/',
+	// ccTLDs reachable via IANA bootstrap — hardcoded here as failsafe for when
+	// the bootstrap fetch is negative-cached (transient data.iana.org outage).
+	ca: 'https://rdap.ca.fury.ca/rdap/',
+	cz: 'https://rdap.nic.cz/',
+	fr: 'https://rdap.nic.fr/',
+	in: 'https://rdap.nixiregistry.in/rdap/',
+	nl: 'https://rdap.sidn.nl/',
+	no: 'https://rdap.norid.no/',
+	pl: 'https://rdap.dns.pl/',
+	sg: 'https://rdap.sgnic.sg/rdap/',
+	uk: 'https://rdap.nominet.uk/uk/',
 };
 
 /** TTL for a successful IANA bootstrap fetch (6h). */
 const BOOTSTRAP_TTL_MS = 6 * 60 * 60 * 1000;
 
-/** TTL for a failed bootstrap fetch (1m) — short so transient blips recover, long enough to avoid hammering IANA during an outage. */
-const BOOTSTRAP_FAILURE_TTL_MS = 60 * 1000;
+/** TTL for a failed bootstrap fetch (10s) — short so transient blips recover quickly. The hardcoded fallback map covers the common-TLD path during the negative-cache window. */
+const BOOTSTRAP_FAILURE_TTL_MS = 10 * 1000;
 
 /** Module-level bootstrap state (per isolate lifetime). */
 let bootstrapState: { value: Record<string, string>; fetchedAt: number } | null = null;
 let bootstrapFailure: { failedAt: number } | null = null;
+/** In-flight bootstrap fetch — concurrent RDAP calls share a single IANA request. */
+let bootstrapInFlight: Promise<Record<string, string>> | null = null;
 
 /** Reset bootstrap cache — exported for test isolation. */
 export function _resetBootstrapCache(): void {
 	bootstrapState = null;
 	bootstrapFailure = null;
+	bootstrapInFlight = null;
 }
 
 /** Timeout for all outbound RDAP fetches (ms). */
@@ -95,10 +109,10 @@ interface RdapEvent {
 }
 
 interface RdapVcardProperty {
-	0: string;  // property name
-	1: Record<string, unknown>;  // parameters
-	2: string;  // type
-	3: unknown;  // value
+	0: string; // property name
+	1: Record<string, unknown>; // parameters
+	2: string; // type
+	3: unknown; // value
 }
 
 interface RdapEntity {
@@ -130,40 +144,48 @@ async function fetchBootstrap(): Promise<Record<string, string>> {
 	if (bootstrapFailure && now - bootstrapFailure.failedAt < BOOTSTRAP_FAILURE_TTL_MS) {
 		return {};
 	}
+	if (bootstrapInFlight) {
+		return bootstrapInFlight;
+	}
 
-	try {
-		const resp = await fetch(IANA_BOOTSTRAP_URL, {
-			redirect: 'manual',
-			signal: AbortSignal.timeout(RDAP_TIMEOUT_MS),
-			headers: { Accept: 'application/json' },
-		});
-		if (!resp.ok) {
-			bootstrapFailure = { failedAt: now };
-			return {};
-		}
+	bootstrapInFlight = (async () => {
+		try {
+			const resp = await fetch(IANA_BOOTSTRAP_URL, {
+				redirect: 'manual',
+				signal: AbortSignal.timeout(RDAP_TIMEOUT_MS),
+				headers: { Accept: 'application/json' },
+			});
+			if (!resp.ok) {
+				bootstrapFailure = { failedAt: Date.now() };
+				return {};
+			}
 
-		const data = (await resp.json()) as { services?: [string[], string[]][] };
-		const map: Record<string, string> = {};
+			const data = (await resp.json()) as { services?: [string[], string[]][] };
+			const map: Record<string, string> = {};
 
-		if (Array.isArray(data.services)) {
-			for (const [tlds, urls] of data.services) {
-				if (!Array.isArray(tlds) || !Array.isArray(urls) || urls.length === 0) continue;
-				const serverUrl = urls[0];
-				for (const tld of tlds) {
-					if (typeof tld === 'string' && typeof serverUrl === 'string') {
-						map[tld.toLowerCase()] = serverUrl;
+			if (Array.isArray(data.services)) {
+				for (const [tlds, urls] of data.services) {
+					if (!Array.isArray(tlds) || !Array.isArray(urls) || urls.length === 0) continue;
+					const serverUrl = urls[0];
+					for (const tld of tlds) {
+						if (typeof tld === 'string' && typeof serverUrl === 'string') {
+							map[tld.toLowerCase()] = serverUrl;
+						}
 					}
 				}
 			}
-		}
 
-		bootstrapState = { value: map, fetchedAt: now };
-		bootstrapFailure = null;
-		return map;
-	} catch {
-		bootstrapFailure = { failedAt: now };
-		return {};
-	}
+			bootstrapState = { value: map, fetchedAt: Date.now() };
+			bootstrapFailure = null;
+			return map;
+		} catch {
+			bootstrapFailure = { failedAt: Date.now() };
+			return {};
+		} finally {
+			bootstrapInFlight = null;
+		}
+	})();
+	return bootstrapInFlight;
 }
 
 /**
@@ -308,11 +330,14 @@ async function fetchRdapResponse(rdapUrl: string, callerSignal?: AbortSignal): P
 		lastResponse = resp;
 		await sleep(parseRetryAfterMs(resp.headers.get('Retry-After')), callerSignal);
 	}
-	return lastResponse ?? fetch(rdapUrl, {
-		redirect: 'manual',
-		signal: composeFetchSignal(callerSignal),
-		headers: { Accept: 'application/rdap+json, application/json' },
-	});
+	return (
+		lastResponse ??
+		fetch(rdapUrl, {
+			redirect: 'manual',
+			signal: composeFetchSignal(callerSignal),
+			headers: { Accept: 'application/rdap+json, application/json' },
+		})
+	);
 }
 
 /** Find an event by action name. */
@@ -335,12 +360,7 @@ const WhoisFallbackPayloadSchema = z.object({
 });
 type WhoisFallbackPayload = z.infer<typeof WhoisFallbackPayloadSchema>;
 
-const WHOIS_REGISTRAR_LABELS = [
-	'Registrar',
-	'Registrar Name',
-	'Sponsoring Registrar',
-	'Registrar Organization',
-] as const;
+const WHOIS_REGISTRAR_LABELS = ['Registrar', 'Registrar Name', 'Sponsoring Registrar', 'Registrar Organization'] as const;
 
 function escapeRegExp(value: string): string {
 	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -417,9 +437,7 @@ function reconcileWithWhois(rdap: RegistrarOutcome, w: WhoisFallbackPayload | nu
 	if (w?.source === 'redacted') return { source: 'redacted' };
 	if (w?.source === 'notfound') return { source: 'notfound' };
 	if (w?.source === 'error') {
-		return rdap.source === 'lookup_failed'
-			? rdap
-			: { source: 'lookup_failed', failureReason: 'whois_error' };
+		return rdap.source === 'lookup_failed' ? rdap : { source: 'lookup_failed', failureReason: 'whois_error' };
 	}
 	// w === null (binding absent): RDAP outcome stands.
 	return rdap;
@@ -502,10 +520,16 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 	const rdapServerUrl = await resolveRdapServer(tld);
 	if (!rdapServerUrl) {
 		findings.push(
-			createFinding(CATEGORY, 'No RDAP server found', 'info', `No RDAP server found for TLD ".${tld}". RDAP data unavailable for this domain.`, {
-				domain,
-				tld,
-			}),
+			createFinding(
+				CATEGORY,
+				'No RDAP server found',
+				'info',
+				`No RDAP server found for TLD ".${tld}". RDAP data unavailable for this domain.`,
+				{
+					domain,
+					tld,
+				},
+			),
 		);
 		// Deterministic: TLD has no RDAP server. Not transient — keep as 'unknown'
 		// (or whichever WHOIS provides). reconcileWithWhois handles the rest.
@@ -523,15 +547,19 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 
 		if (!resp.ok) {
 			findings.push(
-				createFinding(CATEGORY, 'RDAP lookup failed', 'info', `RDAP server returned HTTP ${resp.status} for ${domain}. Registration data unavailable.`, {
-					domain,
-					httpStatus: resp.status,
-				}),
+				createFinding(
+					CATEGORY,
+					'RDAP lookup failed',
+					'info',
+					`RDAP server returned HTTP ${resp.status} for ${domain}. Registration data unavailable.`,
+					{
+						domain,
+						httpStatus: resp.status,
+					},
+				),
 			);
 			const whois = await fetchWhoisRegistrar(domain, options.whoisBinding, callerSignal);
-			findings.push(
-				buildWhoisFallbackFinding(domain, whois, { source: 'lookup_failed', failureReason: `rdap_http_${resp.status}` }),
-			);
+			findings.push(buildWhoisFallbackFinding(domain, whois, { source: 'lookup_failed', failureReason: `rdap_http_${resp.status}` }));
 			return buildCheckResult(CATEGORY, findings) as CheckResult;
 		}
 
@@ -571,10 +599,7 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 		// failure. So pass 'unknown' as the RDAP-side outcome (NOT lookup_failed); WHOIS
 		// can still elevate to deterministic answer or 'whois_error'.
 		const reconciled = reconcileWithWhois({ source: 'unknown' }, whois);
-		const outcome: RegistrarOutcome =
-			reconciled.source === 'lookup_failed'
-				? { source: 'redacted' }
-				: reconciled;
+		const outcome: RegistrarOutcome = reconciled.source === 'lookup_failed' ? { source: 'redacted' } : reconciled;
 		registrarSource = outcome.source;
 		registrarFailureReason = outcome.failureReason;
 		if (whois?.registrar) registrarName = whois.registrar;

--- a/test/check-rdap-lookup.spec.ts
+++ b/test/check-rdap-lookup.spec.ts
@@ -31,19 +31,25 @@ function makeRdapResponse(overrides: Record<string, unknown> = {}) {
 			{
 				objectClassName: 'entity',
 				roles: ['registrar'],
-				vcardArray: ['vcard', [
-					['version', {}, 'text', '4.0'],
-					['fn', {}, 'text', 'Example Registrar Inc.'],
-				]],
+				vcardArray: [
+					'vcard',
+					[
+						['version', {}, 'text', '4.0'],
+						['fn', {}, 'text', 'Example Registrar Inc.'],
+					],
+				],
 			},
 			{
 				objectClassName: 'entity',
 				roles: ['registrant'],
-				vcardArray: ['vcard', [
-					['version', {}, 'text', '4.0'],
-					['fn', {}, 'text', 'ACME Corporation'],
-					['adr', {}, 'text', ['', '', '123 Main St', 'Springfield', 'IL', '62704', 'US']],
-				]],
+				vcardArray: [
+					'vcard',
+					[
+						['version', {}, 'text', '4.0'],
+						['fn', {}, 'text', 'ACME Corporation'],
+						['adr', {}, 'text', ['', '', '123 Main St', 'Springfield', 'IL', '62704', 'US']],
+					],
+				],
 			},
 		],
 		...overrides,
@@ -56,10 +62,12 @@ function mockFetchRouter(routes: Record<string, () => unknown>) {
 		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 		for (const [pattern, handler] of Object.entries(routes)) {
 			if (url.includes(pattern)) {
-				return Promise.resolve(new Response(JSON.stringify(handler()), {
-					status: 200,
-					headers: { 'Content-Type': 'application/rdap+json' },
-				}));
+				return Promise.resolve(
+					new Response(JSON.stringify(handler()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/rdap+json' },
+					}),
+				);
 			}
 		}
 		return Promise.resolve(new Response('Not Found', { status: 404 }));
@@ -94,32 +102,44 @@ describe('checkRdapLookup', () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 			if (url.includes('data.iana.org/rdap/dns.json')) {
-				return Promise.resolve(new Response(JSON.stringify(makeBootstrap([[['global'], ['https://rdap.identitydigital.services/rdap/']]])), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}));
+				return Promise.resolve(
+					new Response(JSON.stringify(makeBootstrap([[['global'], ['https://rdap.identitydigital.services/rdap/']]])), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					}),
+				);
 			}
 			if (url.includes('rdap.identitydigital.services')) {
 				rdapAttempts++;
 				if (rdapAttempts === 1) {
 					return Promise.resolve(new Response('Too Many Requests', { status: 429, headers: { 'Retry-After': '0' } }));
 				}
-				return Promise.resolve(new Response(JSON.stringify(makeRdapResponse({
-					ldhName: 'stripe.global',
-					entities: [
+				return Promise.resolve(
+					new Response(
+						JSON.stringify(
+							makeRdapResponse({
+								ldhName: 'stripe.global',
+								entities: [
+									{
+										objectClassName: 'entity',
+										roles: ['registrar'],
+										vcardArray: [
+											'vcard',
+											[
+												['version', {}, 'text', '4.0'],
+												['fn', {}, 'text', 'SafeNames Ltd.'],
+											],
+										],
+									},
+								],
+							}),
+						),
 						{
-							objectClassName: 'entity',
-							roles: ['registrar'],
-							vcardArray: ['vcard', [
-								['version', {}, 'text', '4.0'],
-								['fn', {}, 'text', 'SafeNames Ltd.'],
-							]],
+							status: 200,
+							headers: { 'Content-Type': 'application/rdap+json' },
 						},
-					],
-				})), {
-					status: 200,
-					headers: { 'Content-Type': 'application/rdap+json' },
-				}));
+					),
+				);
 			}
 			return Promise.resolve(new Response('Not Found', { status: 404 }));
 		});
@@ -139,19 +159,25 @@ describe('checkRdapLookup', () => {
 				{
 					objectClassName: 'entity',
 					roles: ['registrar'],
-					vcardArray: ['vcard', [
-						['version', {}, 'text', '4.0'],
-						['fn', {}, 'text', 'Namecheap Inc.'],
-					]],
+					vcardArray: [
+						'vcard',
+						[
+							['version', {}, 'text', '4.0'],
+							['fn', {}, 'text', 'Namecheap Inc.'],
+						],
+					],
 				},
 				{
 					objectClassName: 'entity',
 					roles: ['registrant'],
-					vcardArray: ['vcard', [
-						['version', {}, 'text', '4.0'],
-						['fn', {}, 'text', 'REDACTED FOR PRIVACY'],
-						['adr', {}, 'text', ['', '', 'REDACTED FOR PRIVACY', '', '', '', 'REDACTED FOR PRIVACY']],
-					]],
+					vcardArray: [
+						'vcard',
+						[
+							['version', {}, 'text', '4.0'],
+							['fn', {}, 'text', 'REDACTED FOR PRIVACY'],
+							['adr', {}, 'text', ['', '', 'REDACTED FOR PRIVACY', '', '', '', 'REDACTED FOR PRIVACY']],
+						],
+					],
 				},
 			],
 		});
@@ -196,10 +222,12 @@ describe('checkRdapLookup', () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 			if (url.includes('data.iana.org/rdap/dns.json')) {
-				return Promise.resolve(new Response(JSON.stringify(makeBootstrap()), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}));
+				return Promise.resolve(
+					new Response(JSON.stringify(makeBootstrap()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					}),
+				);
 			}
 			// Simulate timeout on RDAP domain lookup
 			return Promise.reject(new DOMException('The operation was aborted', 'AbortError'));
@@ -215,16 +243,20 @@ describe('checkRdapLookup', () => {
 		const fetchSpy = vi.fn().mockImplementation((input: string | URL | Request, _init?: RequestInit) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 			if (url.includes('data.iana.org/rdap/dns.json')) {
-				return Promise.resolve(new Response(JSON.stringify(makeBootstrap()), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}));
+				return Promise.resolve(
+					new Response(JSON.stringify(makeBootstrap()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					}),
+				);
 			}
 			if (url.includes('rdap.verisign.com')) {
-				return Promise.resolve(new Response(JSON.stringify(makeRdapResponse()), {
-					status: 200,
-					headers: { 'Content-Type': 'application/rdap+json' },
-				}));
+				return Promise.resolve(
+					new Response(JSON.stringify(makeRdapResponse()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/rdap+json' },
+					}),
+				);
 			}
 			return Promise.resolve(new Response('Not Found', { status: 404 }));
 		});
@@ -280,18 +312,22 @@ describe('checkRdapLookup', () => {
 	it('extracts registrar organization from RDAP vcard org when fn is absent', async () => {
 		globalThis.fetch = mockFetchRouter({
 			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
-			'rdap.verisign.com': () => makeRdapResponse({
-				entities: [
-					{
-						objectClassName: 'entity',
-						roles: ['registrar'],
-						vcardArray: ['vcard', [
-							['version', {}, 'text', '4.0'],
-							['org', {}, 'text', 'Synthetic Registrar Org LLC'],
-						]],
-					},
-				],
-			}),
+			'rdap.verisign.com': () =>
+				makeRdapResponse({
+					entities: [
+						{
+							objectClassName: 'entity',
+							roles: ['registrar'],
+							vcardArray: [
+								'vcard',
+								[
+									['version', {}, 'text', '4.0'],
+									['org', {}, 'text', 'Synthetic Registrar Org LLC'],
+								],
+							],
+						},
+					],
+				}),
 		});
 
 		const result = await run();
@@ -302,19 +338,23 @@ describe('checkRdapLookup', () => {
 	it('extracts registrar IANA ID from RDAP registrar entity publicIds', async () => {
 		globalThis.fetch = mockFetchRouter({
 			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
-			'rdap.verisign.com': () => makeRdapResponse({
-				entities: [
-					{
-						objectClassName: 'entity',
-						roles: ['registrar'],
-						publicIds: [{ type: 'IANA Registrar ID', identifier: '299' }],
-						vcardArray: ['vcard', [
-							['version', {}, 'text', '4.0'],
-							['fn', {}, 'text', 'Corporation Service Company'],
-						]],
-					},
-				],
-			}),
+			'rdap.verisign.com': () =>
+				makeRdapResponse({
+					entities: [
+						{
+							objectClassName: 'entity',
+							roles: ['registrar'],
+							publicIds: [{ type: 'IANA Registrar ID', identifier: '299' }],
+							vcardArray: [
+								'vcard',
+								[
+									['version', {}, 'text', '4.0'],
+									['fn', {}, 'text', 'Corporation Service Company'],
+								],
+							],
+						},
+					],
+				}),
 		});
 
 		const result = await run();
@@ -326,19 +366,23 @@ describe('checkRdapLookup', () => {
 	it('extracts registrar from RDAP entity publicIds even without registrar role', async () => {
 		globalThis.fetch = mockFetchRouter({
 			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
-			'rdap.verisign.com': () => makeRdapResponse({
-				entities: [
-					{
-						objectClassName: 'entity',
-						roles: ['technical'],
-						publicIds: [{ type: 'IANA Registrar ID', identifier: '9999' }],
-						vcardArray: ['vcard', [
-							['version', {}, 'text', '4.0'],
-							['fn', {}, 'text', 'Synthetic PublicId Registrar LLC'],
-						]],
-					},
-				],
-			}),
+			'rdap.verisign.com': () =>
+				makeRdapResponse({
+					entities: [
+						{
+							objectClassName: 'entity',
+							roles: ['technical'],
+							publicIds: [{ type: 'IANA Registrar ID', identifier: '9999' }],
+							vcardArray: [
+								'vcard',
+								[
+									['version', {}, 'text', '4.0'],
+									['fn', {}, 'text', 'Synthetic PublicId Registrar LLC'],
+								],
+							],
+						},
+					],
+				}),
 		});
 
 		const result = await run();
@@ -353,11 +397,12 @@ describe('checkRdapLookup', () => {
 			'rdap.verisign.com': () => makeRdapResponse({ entities: [] }),
 		});
 		const whoisBinding = {
-			fetch: vi.fn(async () =>
-				new Response(JSON.stringify({ registrar: 'WHOIS Fallback Registrar Inc.', source: 'whois' }), {
-					status: 200,
-					headers: { 'Content-Type': 'application/json' },
-				}),
+			fetch: vi.fn(
+				async () =>
+					new Response(JSON.stringify({ registrar: 'WHOIS Fallback Registrar Inc.', source: 'whois' }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					}),
 			),
 		};
 
@@ -381,11 +426,12 @@ describe('checkRdapLookup', () => {
 			'rdap.verisign.com': () => makeRdapResponse({ entities: [] }),
 		});
 		const whoisBinding = {
-			fetch: vi.fn(async () =>
-				new Response(`Domain Name: EXAMPLE.COM\n${label}: ${registrar}\nUpdated Date: 2026-01-01T00:00:00Z\n`, {
-					status: 200,
-					headers: { 'Content-Type': 'text/plain' },
-				}),
+			fetch: vi.fn(
+				async () =>
+					new Response(`Domain Name: EXAMPLE.COM\n${label}: ${registrar}\nUpdated Date: 2026-01-01T00:00:00Z\n`, {
+						status: 200,
+						headers: { 'Content-Type': 'text/plain' },
+					}),
 			),
 		};
 
@@ -404,11 +450,12 @@ describe('checkRdapLookup', () => {
 			'rdap.verisign.com': () => makeRdapResponse({ entities: [] }),
 		});
 		const whoisBinding = {
-			fetch: vi.fn(async () =>
-				new Response('Domain Name: EXAMPLE.COM\nRegistrar URL: https://registrar.example.test\n', {
-					status: 200,
-					headers: { 'Content-Type': 'text/plain' },
-				}),
+			fetch: vi.fn(
+				async () =>
+					new Response('Domain Name: EXAMPLE.COM\nRegistrar URL: https://registrar.example.test\n', {
+						status: 200,
+						headers: { 'Content-Type': 'text/plain' },
+					}),
 			),
 		};
 
@@ -421,5 +468,78 @@ describe('checkRdapLookup', () => {
 		const fallbackFinding = result.findings.find((f) => f.metadata?.registrarSource === 'redacted');
 		expect(fallbackFinding?.metadata?.registrarFailureReason).toBeUndefined();
 		expect(whoisBinding.fetch).toHaveBeenCalledOnce();
+	});
+
+	describe('FALLBACK_RDAP_SERVERS', () => {
+		it('.app and .dev point at pubapi.registry.google (not the dead www.registry.google host)', async () => {
+			const { FALLBACK_RDAP_SERVERS } = await import('../src/tools/check-rdap-lookup');
+			expect(FALLBACK_RDAP_SERVERS.app).toBe('https://pubapi.registry.google/rdap/');
+			expect(FALLBACK_RDAP_SERVERS.dev).toBe('https://pubapi.registry.google/rdap/');
+			expect(FALLBACK_RDAP_SERVERS.app).not.toContain('www.registry.google');
+		});
+
+		it('covers the ccTLDs the brand-audit hits most often without bootstrap (.uk, .nl, .de via WHOIS, .ca, .sg, .fr, .jp via WHOIS, .in, .au)', async () => {
+			const { FALLBACK_RDAP_SERVERS } = await import('../src/tools/check-rdap-lookup');
+			// Covered by IANA bootstrap → also pinned in our hardcoded fallback.
+			for (const tld of ['uk', 'nl', 'ca', 'sg', 'fr', 'in', 'au', 'pl', 'no', 'cz']) {
+				expect(FALLBACK_RDAP_SERVERS[tld], `missing fallback for .${tld}`).toMatch(/^https:\/\//);
+			}
+		});
+
+		it('every fallback URL is HTTPS and ends with /', async () => {
+			const { FALLBACK_RDAP_SERVERS } = await import('../src/tools/check-rdap-lookup');
+			for (const [tld, url] of Object.entries(FALLBACK_RDAP_SERVERS)) {
+				expect(url.startsWith('https://'), `.${tld} → ${url} not https`).toBe(true);
+				expect(url.endsWith('/'), `.${tld} → ${url} missing trailing slash`).toBe(true);
+			}
+		});
+	});
+
+	describe('bootstrap in-flight dedup', () => {
+		it('concurrent RDAP calls share a single IANA bootstrap fetch (not N concurrent fetches)', async () => {
+			let bootstrapFetchCount = 0;
+			let resolveBootstrap: (v: Response) => void = () => {};
+			const bootstrapPromise = new Promise<Response>((r) => {
+				resolveBootstrap = r;
+			});
+
+			globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+				const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+				if (url.includes('data.iana.org/rdap/dns.json')) {
+					bootstrapFetchCount++;
+					return bootstrapPromise;
+				}
+				return Promise.resolve(
+					new Response(JSON.stringify(makeRdapResponse()), {
+						status: 200,
+						headers: { 'Content-Type': 'application/rdap+json' },
+					}),
+				);
+			});
+
+			const mod = await import('../src/tools/check-rdap-lookup');
+			mod._resetBootstrapCache();
+
+			// Fire three concurrent lookups before bootstrap resolves
+			const p1 = mod.checkRdapLookup('a.com');
+			const p2 = mod.checkRdapLookup('b.com');
+			const p3 = mod.checkRdapLookup('c.com');
+
+			// Let microtasks flush so all three calls reach fetchBootstrap()
+			await Promise.resolve();
+			await Promise.resolve();
+
+			expect(bootstrapFetchCount).toBe(1);
+
+			resolveBootstrap(
+				new Response(JSON.stringify(makeBootstrap()), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}),
+			);
+
+			await Promise.all([p1, p2, p3]);
+			expect(bootstrapFetchCount).toBe(1);
+		});
 	});
 });


### PR DESCRIPTION
## Summary

Three independent fixes that together resolve the `Registrar lookup failed · source: lookup_failed` strings that appeared in the brand-audit per-vendor reports for `.app`, `.dev`, `.uk`, `.nl`, `.de`, `.group`, `.tools` domains.

- **Stale `.app` / `.dev` URL.** `FALLBACK_RDAP_SERVERS` pointed at `https://www.registry.google/rdap/` which returns HTTP 404; Google's canonical endpoint is `pubapi.registry.google/rdap/`. Verified against the live IANA bootstrap.
- **Backfill common-ccTLD coverage.** Added `.uk`, `.nl`, `.ca`, `.sg`, `.fr`, `.in`, `.pl`, `.no`, `.cz` to the hardcoded fallback map (URLs cross-checked against IANA). Closes the bootstrap-down-→-`unknown`-→-reconcile-with-whois-error-→-`lookup_failed` chain for those TLDs.
- **`lookupCandidateRegistrars()` ran serially under deadline.** Old loop did one RDAP at a time (~10–20s worst case per candidate); on 40-candidate audits, late candidates always saw the outer deadline fire mid-fetch → `lookup_failed / caller_aborted`. Now uses `mapConcurrent(RDAP_CONCURRENCY=10)` with per-task deadline check; skipped slots correctly surface as `skipped_deadline` (unknown source), not `lookup_failed`.

Also: bootstrap fetch now de-duplicates in-flight requests (concurrent RDAP calls share one IANA fetch) and shortens the negative-cache TTL from 60s → 10s so transient `data.iana.org` blips recover faster.

## Test plan

- [x] Existing 51 tests across `check-rdap-lookup` + `brand-audit-pipeline` specs pass unchanged.
- [x] New regression coverage: `.app` URL pin, ccTLD fallback presence, every URL HTTPS+trailing-slash, concurrent-bootstrap dedup (3 lookups → 1 fetch).
- [x] Wider sweep: 180 tests across all `brand-audit-*` + `registrar-coverage.audit.test.ts` pass.
- [x] `tsc --noEmit` clean.

Post-merge chaos test: run the deployed `rdap_lookup` tool against `openai.group`, `openai.tools`, `anthropic.app`, `anthropic.co.uk`, `openai.nl` — all five must return source=`rdap` (deterministic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)