### PR TITLE
feat(tools): expose check_subdomain_takeover as standalone MCP tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 [![GitHub stars](https://img.shields.io/github/stars/MadaBurns/bv-mcp?style=flat&logo=github)](https://github.com/MadaBurns/bv-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
-[![MCP tools](https://img.shields.io/badge/MCP%20tools-59-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
+[![MCP tools](https://img.shields.io/badge/MCP%20tools-60-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-blue)](https://modelcontextprotocol.io/)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com/)
@@ -25,7 +25,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 
 **Claude Desktop** (one-click install):
 
-Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 59-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
+Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 60-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
 
 **Claude Code** (one command):
 
@@ -65,7 +65,7 @@ Transport support:
 
 ## What you get
 
-- **59 MCP tools with 18 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, brand discovery, and authoritative DNS infrastructure
+- **60 MCP tools with 18 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, brand discovery, and authoritative DNS infrastructure
 - **Maturity staging** — Stage 0-4 classification (Unprotected to Hardened) with score-based capping to prevent inflated labels
 - **Trust surface analysis** — detects shared SaaS platforms (Google, M365, SendGrid) and cross-references DMARC enforcement to determine real exposure
 - **Guided remediation** — `generate_fix_plan` produces provider-aware prioritized actions; record generators output ready-to-publish records; `validate_fix` confirms whether a fix was applied successfully
@@ -81,7 +81,7 @@ Transport support:
 ## Tools
 
 ```
-  59 MCP tools · 7 prompts · 6 resources
+  60 MCP tools · 7 prompts · 6 resources
 
   Email Auth             Infrastructure          Brand & Threats       Meta
  ─────────────          ──────────────          ───────────────       ───────────────
@@ -109,7 +109,7 @@ Transport support:
                         check_authoritative_dns_infra
                         check_root_server_set
 
-  + check_subdomain_takeover (internal — runs inside scan_domain)
+  + check_subdomain_takeover (standalone tool + internal — runs inside scan_domain)
   + check_authoritative_dns_infra and check_root_server_set (authoritative DNS infrastructure profile)
 ```
 
@@ -202,14 +202,14 @@ For full hosted setup examples, stdio usage, OAuth setup, and legacy fallback en
 
 ## Pricing
 
-| | **Free** | **Pro** | **Enterprise** |
-|---|---|---|---|
-| **Price** | $0 | $39/mo | [Contact us](https://blackveilsecurity.com) |
-| **Scans/day** | 5 | 500 | 10,000+ |
-| **Checks/day** | 25 | 5,000 | Unlimited |
-| **Rate limit** | 50 req/min | None | None |
-| **API access** | Yes | Yes | Yes |
-| **MCP access** | Yes | Yes | Yes |
+|                | **Free**   | **Pro** | **Enterprise**                              |
+| -------------- | ---------- | ------- | ------------------------------------------- |
+| **Price**      | $0         | $39/mo  | [Contact us](https://blackveilsecurity.com) |
+| **Scans/day**  | 5          | 500     | 10,000+                                     |
+| **Checks/day** | 25         | 5,000   | Unlimited                                   |
+| **Rate limit** | 50 req/min | None    | None                                        |
+| **API access** | Yes        | Yes     | Yes                                         |
+| **MCP access** | Yes        | Yes     | Yes                                         |
 
 ---
 
@@ -217,13 +217,13 @@ For full hosted setup examples, stdio usage, OAuth setup, and legacy fallback en
 
 These demonstrate core functionality — paste any of them into Claude with the Blackveil DNS connector enabled:
 
-| Prompt | What it does |
-|--------|-------------|
-| `Scan blackveilsecurity.com and tell me what needs fixing` | Full security audit — score, grade, prioritized findings |
-| `Compare the email security of google.com and microsoft.com` | Side-by-side comparison of two domains' postures |
-| `Generate a DMARC record for example.com with reject policy` | Produces a ready-to-publish DNS record |
-| `What attack paths exist for example.com?` | Enumerates spoofing, takeover, and hijack vectors |
-| `Map example.com's compliance against NIST 800-177` | Maps findings to compliance framework controls |
+| Prompt                                                       | What it does                                             |
+| ------------------------------------------------------------ | -------------------------------------------------------- |
+| `Scan blackveilsecurity.com and tell me what needs fixing`   | Full security audit — score, grade, prioritized findings |
+| `Compare the email security of google.com and microsoft.com` | Side-by-side comparison of two domains' postures         |
+| `Generate a DMARC record for example.com with reject policy` | Produces a ready-to-publish DNS record                   |
+| `What attack paths exist for example.com?`                   | Enumerates spoofing, takeover, and hijack vectors        |
+| `Map example.com's compliance against NIST 800-177`          | Maps findings to compliance framework controls           |
 
 ---
 

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -4,7 +4,7 @@ These settings must be configured manually in the GitHub web UI.
 
 ## Repository description
 
-Set to: `Source-available DNS & email security scanner for MCP clients. 59 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
+Set to: `Source-available DNS & email security scanner for MCP clients. 60 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
 
 ## Repository topics
 

--- a/src/handlers/resources.ts
+++ b/src/handlers/resources.ts
@@ -67,7 +67,7 @@ const RESOURCES: McpResource[] = [
 const RESOURCE_CONTENT: Record<string, string> = {
 	'dns-security://guides/security-checks': `# DNS Security Checks
 
-59 MCP tools, including 30 \`check_*\` tools and \`scan_domain\` across 18 scan categories.
+60 MCP tools, including 30 \`check_*\` tools and \`scan_domain\` across 18 scan categories.
 
 ## Tool -> Category Mapping
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -5,6 +5,7 @@ import type { QueryDnsOptions, SecondaryDohConfig } from '../lib/dns-types';
 import { runWithCacheTracked } from '../lib/cache';
 import { sanitizeErrorMessage } from '../lib/json-rpc';
 import { checkSpf } from '../tools/check-spf';
+import { checkSubdomainTakeover } from '../tools/check-subdomain-takeover';
 import { checkDmarc } from '../tools/check-dmarc';
 import { checkDkim } from '../tools/check-dkim';
 import { checkDnssec } from '../tools/check-dnssec';
@@ -31,7 +32,13 @@ import { compareDomains, formatDomainComparison } from '../tools/compare-domains
 import { explainFinding, formatExplanation } from '../tools/explain-finding';
 import { compareBaseline, formatBaselineResult } from '../tools/compare-baseline';
 import { generateFixPlan, formatFixPlan } from '../tools/generate-fix-plan';
-import { generateSpfRecord, generateDmarcRecord, generateDkimConfig, generateMtaStsPolicy, formatGeneratedRecord } from '../tools/generate-records';
+import {
+	generateSpfRecord,
+	generateDmarcRecord,
+	generateDkimConfig,
+	generateMtaStsPolicy,
+	formatGeneratedRecord,
+} from '../tools/generate-records';
 import { getBenchmark, getProviderInsights, formatBenchmark, formatProviderInsights } from '../tools/intelligence';
 import { assessSpoofability, formatSpoofability } from '../tools/assess-spoofability';
 import { checkResolverConsistency, formatResolverConsistency } from '../tools/check-resolver-consistency';
@@ -61,7 +68,20 @@ import { brandAuditWatch } from '../tools/brand-audit-watch';
 import { createD1BrandAuditStepStore } from '../lib/brand-audit-step-store';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
-import { extractAndValidateDomain, extractBaseline, extractDkimSelector, extractExplainFindingArgs, extractForceRefresh, extractFormat, extractIncludeProviders, extractMxHosts, extractRecordType, extractScanProfile, normalizeToolName, validateToolArgs } from './tool-args';
+import {
+	extractAndValidateDomain,
+	extractBaseline,
+	extractDkimSelector,
+	extractExplainFindingArgs,
+	extractForceRefresh,
+	extractFormat,
+	extractIncludeProviders,
+	extractMxHosts,
+	extractRecordType,
+	extractScanProfile,
+	normalizeToolName,
+	validateToolArgs,
+} from './tool-args';
 import type { OutputFormat } from './tool-args';
 import { buildLogContext, logToolFailure, logToolSuccess } from './tool-execution';
 import { formatCheckResult, mcpError, buildToolContent } from './tool-formatters';
@@ -171,7 +191,9 @@ function buildDnsOptions(runtimeOptions?: ToolRuntimeOptions): QueryDnsOptions |
  * brand_audit_batch_start as a first-line check; the monthly enforcement
  * applies on top.
  */
-function buildMonthlyEnforceQuota(ro?: ToolRuntimeOptions): ((count: number) => Promise<{ allowed: boolean; remaining?: number; limit?: number; retryAfterMs?: number }>) | undefined {
+function buildMonthlyEnforceQuota(
+	ro?: ToolRuntimeOptions,
+): ((count: number) => Promise<{ allowed: boolean; remaining?: number; limit?: number; retryAfterMs?: number }>) | undefined {
 	if (!ro?.rateLimitKv || !ro.principalId || !ro.authTier) return undefined;
 	const tier = ro.authTier as import('../lib/config').McpApiKeyTier;
 	const kv = ro.rateLimitKv;
@@ -184,11 +206,15 @@ function buildMonthlyEnforceQuota(ro?: ToolRuntimeOptions): ((count: number) => 
 
 async function dynamicCheckMx(domain: string, runtimeOptions?: ToolRuntimeOptions): Promise<CheckResult> {
 	const { checkMx } = await import('../tools/check-mx');
-	return checkMx(domain, {
-		providerSignaturesUrl: runtimeOptions?.providerSignaturesUrl,
-		providerSignaturesAllowedHosts: runtimeOptions?.providerSignaturesAllowedHosts,
-		providerSignaturesSha256: runtimeOptions?.providerSignaturesSha256,
-	}, buildDnsOptions(runtimeOptions));
+	return checkMx(
+		domain,
+		{
+			providerSignaturesUrl: runtimeOptions?.providerSignaturesUrl,
+			providerSignaturesAllowedHosts: runtimeOptions?.providerSignaturesAllowedHosts,
+			providerSignaturesSha256: runtimeOptions?.providerSignaturesSha256,
+		},
+		buildDnsOptions(runtimeOptions),
+	);
 }
 
 /**
@@ -223,23 +249,53 @@ const TOOL_REGISTRY: Record<
 	check_bimi: { cacheKey: () => 'bimi', execute: (d, _args, ro) => checkBimi(d, buildDnsOptions(ro)) },
 	check_tlsrpt: { cacheKey: () => 'tlsrpt', execute: (d, _args, ro) => checkTlsrpt(d, buildDnsOptions(ro)) },
 	check_lookalikes: { cacheKey: () => 'lookalikes', execute: (d) => checkLookalikes(d), cacheTtlSeconds: 3600 },
-	check_shadow_domains: { cacheKey: () => 'shadow_domains', execute: (d, _args, ro) => checkShadowDomains(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
+	check_shadow_domains: {
+		cacheKey: () => 'shadow_domains',
+		execute: (d, _args, ro) => checkShadowDomains(d, buildDnsOptions(ro)),
+		cacheTtlSeconds: 3600,
+	},
 	check_txt_hygiene: { cacheKey: () => 'txt_hygiene', execute: (d, _args, ro) => checkTxtHygiene(d, buildDnsOptions(ro)) },
 	check_http_security: { cacheKey: () => 'http_security', execute: (d) => checkHttpSecurity(d) },
 	check_dane: { cacheKey: () => 'dane', execute: (d, _args, ro) => checkDane(d, buildDnsOptions(ro)) },
 	check_dane_https: { cacheKey: () => 'dane_https', execute: (d, _args, ro) => checkDaneHttps(d, buildDnsOptions(ro)) },
 	check_svcb_https: { cacheKey: () => 'svcb_https', execute: (d, _args, ro) => checkSvcbHttps(d, buildDnsOptions(ro)) },
-	check_mx_reputation: { cacheKey: () => 'mx_reputation', execute: (d, _args, ro) => checkMxReputation(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
+	check_mx_reputation: {
+		cacheKey: () => 'mx_reputation',
+		execute: (d, _args, ro) => checkMxReputation(d, buildDnsOptions(ro)),
+		cacheTtlSeconds: 3600,
+	},
 	check_srv: { cacheKey: () => 'srv', execute: (d, _args, ro) => checkSrv(d, buildDnsOptions(ro)) },
 	check_zone_hygiene: { cacheKey: () => 'zone_hygiene', execute: (d, _args, ro) => checkZoneHygiene(d, buildDnsOptions(ro)) },
 	check_subdomailing: { cacheKey: () => 'subdomailing', execute: (d, _args, ro) => checkSubdomailing(d, buildDnsOptions(ro)) },
 	check_dbl: { cacheKey: () => 'dbl', execute: (d, _args, ro) => checkDbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	check_rbl: { cacheKey: () => 'rbl', execute: (d, _args, ro) => checkRbl(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
 	cymru_asn: { cacheKey: () => 'asn', execute: (d, _args, ro) => checkCymruAsn(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
-	rdap_lookup: { cacheKey: () => 'rdap', execute: (d, _args, ro) => checkRdapLookup(d, { whoisBinding: ro?.whoisBinding }), cacheTtlSeconds: 3600 },
-	check_nsec_walkability: { cacheKey: () => 'nsec_walkability', execute: (d, _args, ro) => checkNsecWalkability(d, buildDnsOptions(ro)), cacheTtlSeconds: 3600 },
+	rdap_lookup: {
+		cacheKey: () => 'rdap',
+		execute: (d, _args, ro) => checkRdapLookup(d, { whoisBinding: ro?.whoisBinding }),
+		cacheTtlSeconds: 3600,
+	},
+	check_nsec_walkability: {
+		cacheKey: () => 'nsec_walkability',
+		execute: (d, _args, ro) => checkNsecWalkability(d, buildDnsOptions(ro)),
+		cacheTtlSeconds: 3600,
+	},
 	check_dnssec_chain: { cacheKey: () => 'dnssec_chain', execute: (d, _args, ro) => checkDnssecChain(d, buildDnsOptions(ro)) },
-	check_fast_flux: { cacheKey: () => 'fast_flux', execute: (d, args, ro) => checkFastFlux(d, (args.rounds as number | undefined) ?? 3, buildDnsOptions(ro)) },
+	check_fast_flux: {
+		cacheKey: () => 'fast_flux',
+		execute: (d, args, ro) => checkFastFlux(d, (args.rounds as number | undefined) ?? 3, buildDnsOptions(ro)),
+	},
+	check_subdomain_takeover: {
+		cacheKey: (args) => {
+			const subs = Array.isArray(args.subdomains) ? (args.subdomains as string[]) : null;
+			// Cache key folds caller-supplied list size so callers passing CT inventories don't collide with default sweeps.
+			return subs && subs.length > 0 ? `subdomain_takeover:custom:${subs.length}` : 'subdomain_takeover:default';
+		},
+		execute: (d, args, ro) => {
+			const subs = Array.isArray(args.subdomains) ? (args.subdomains as string[]) : undefined;
+			return checkSubdomainTakeover(d, buildDnsOptions(ro), subs ? { subdomains: subs } : undefined);
+		},
+	},
 	check_authoritative_dns_infra: {
 		cacheKey: () => 'authoritative_dns_infra',
 		execute: (d, _args, ro) => checkAuthoritativeDnsInfra(d, { infraProbe: ro?.infraProbe }),
@@ -272,7 +328,11 @@ const TOOL_REGISTRY: Record<
 			discoverBrandDomains(
 				d,
 				{
-					signals: args.signals as Parameters<typeof discoverBrandDomains>[1] extends infer O ? (O extends { signals?: infer S } ? S : undefined) : undefined,
+					signals: args.signals as Parameters<typeof discoverBrandDomains>[1] extends infer O
+						? O extends { signals?: infer S }
+							? S
+							: undefined
+						: undefined,
 					depth: args.depth as 'standard' | 'deep' | undefined,
 					planner_mode: args.planner_mode as 'off' | 'observe' | 'enforce' | undefined,
 					discovery_mode: args.discovery_mode as 'classic' | 'tiered' | undefined,
@@ -309,11 +369,7 @@ const TOOL_REGISTRY: Record<
 			// the env-default (`BRAND_AUDIT_DISCOVERY_MODE_DEFAULT`) flips classic→tiered
 			// on BlackVeil production deploys. Schema default falls back to `classic`.
 			const discoveryMode =
-				typeof args.discovery_mode === 'string'
-					? args.discovery_mode
-					: ro?.discoveryModeDefault === 'tiered'
-						? 'tiered'
-						: 'classic';
+				typeof args.discovery_mode === 'string' ? args.discovery_mode : ro?.discoveryModeDefault === 'tiered' ? 'tiered' : 'classic';
 			const aliases = (args.brand_aliases as string[] | undefined) ?? [];
 			const candDomains = (args.candidate_domains as string[] | undefined) ?? [];
 			const aliasHash = aliases.length === 0 ? '0' : `${aliases.length}:${aliases.slice().sort().join('|').slice(0, 64)}`;
@@ -323,32 +379,36 @@ const TOOL_REGISTRY: Record<
 		},
 		execute: (d, args, ro) => {
 			const deadlineMs = Date.now() + BRAND_AUDIT_SINGLE_SYNC_HANDOFF_MS;
-			return brandAuditSingle(d, {
-				format: args.format as 'json' | 'markdown' | 'both' | undefined,
-				min_confidence: args.min_confidence as number | undefined,
-				depth: args.depth as 'standard' | 'deep' | undefined,
-				planner_mode: args.planner_mode as 'off' | 'observe' | 'enforce' | undefined,
-				discovery_mode: args.discovery_mode as 'classic' | 'tiered' | undefined,
-				brand_aliases: args.brand_aliases as string[] | undefined,
-				candidate_domains: args.candidate_domains as string[] | undefined,
-				view: args.view as 'standard' | 'csc_complement' | undefined,
-				// T13 — propagate the BlackVeil-production runtime override.
-				// Pipeline only honours it when the caller omits `discovery_mode`;
-				// undefined on BSL self-hosts (schema default `'classic'` wins).
-				...(ro?.discoveryModeDefault ? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: ro.discoveryModeDefault } } : {}),
-				deadlineMs,
-				timeoutBehavior: 'async_handoff',
-			}, {
-				certstream: ro?.certstream,
-				whoisBinding: ro?.whoisBinding,
-				enforceQuota: buildMonthlyEnforceQuota(ro),
-				// Tier closures: forwarded through the pipeline → discoverBrandDomains
-				// seam. Undefined on BSL self-hosts → pipeline never calls the
-				// proprietary lookups.
-				...(ro?.tier0Lookup ? { tier0Lookup: ro.tier0Lookup } : {}),
-				...(ro?.tier1Lookup ? { tier1Lookup: ro.tier1Lookup } : {}),
-				...(ro?.tier2Lookup ? { tier2Lookup: ro.tier2Lookup } : {}),
-			});
+			return brandAuditSingle(
+				d,
+				{
+					format: args.format as 'json' | 'markdown' | 'both' | undefined,
+					min_confidence: args.min_confidence as number | undefined,
+					depth: args.depth as 'standard' | 'deep' | undefined,
+					planner_mode: args.planner_mode as 'off' | 'observe' | 'enforce' | undefined,
+					discovery_mode: args.discovery_mode as 'classic' | 'tiered' | undefined,
+					brand_aliases: args.brand_aliases as string[] | undefined,
+					candidate_domains: args.candidate_domains as string[] | undefined,
+					view: args.view as 'standard' | 'csc_complement' | undefined,
+					// T13 — propagate the BlackVeil-production runtime override.
+					// Pipeline only honours it when the caller omits `discovery_mode`;
+					// undefined on BSL self-hosts (schema default `'classic'` wins).
+					...(ro?.discoveryModeDefault ? { env: { BRAND_AUDIT_DISCOVERY_MODE_DEFAULT: ro.discoveryModeDefault } } : {}),
+					deadlineMs,
+					timeoutBehavior: 'async_handoff',
+				},
+				{
+					certstream: ro?.certstream,
+					whoisBinding: ro?.whoisBinding,
+					enforceQuota: buildMonthlyEnforceQuota(ro),
+					// Tier closures: forwarded through the pipeline → discoverBrandDomains
+					// seam. Undefined on BSL self-hosts → pipeline never calls the
+					// proprietary lookups.
+					...(ro?.tier0Lookup ? { tier0Lookup: ro.tier0Lookup } : {}),
+					...(ro?.tier1Lookup ? { tier1Lookup: ro.tier1Lookup } : {}),
+					...(ro?.tier2Lookup ? { tier2Lookup: ro.tier2Lookup } : {}),
+				},
+			);
 		},
 		cacheTtlSeconds: 3600,
 	},
@@ -401,13 +461,9 @@ const TOOL_REGISTRY: Record<
 			if (!db) {
 				const { buildCheckResult, createFinding } = await import('../lib/scoring');
 				return buildCheckResult('brand_discovery', [
-					createFinding(
-						'brand_discovery',
-						'Brand audit status unavailable',
-						'high',
-						'BRAND_AUDIT_DB binding is not provisioned.',
-						{ unprovisioned: true },
-					),
+					createFinding('brand_discovery', 'Brand audit status unavailable', 'high', 'BRAND_AUDIT_DB binding is not provisioned.', {
+						unprovisioned: true,
+					}),
 				]);
 			}
 			return brandAuditStatus(String(args.auditId ?? ''), principalId, { db, stepStore: createD1BrandAuditStepStore(db) });
@@ -417,27 +473,26 @@ const TOOL_REGISTRY: Record<
 	brand_audit_get_report: {
 		// Mutable read — do not cache. Before completion this can return notReady,
 		// and after completion the PDF sidecar URL/pending state can change.
-		cacheKey: (args, ro) => `brand_audit_report:${ro?.principalId ?? ro?.keyHash ?? 'anon'}:${String(args.auditId ?? '')}:${String(args.target ?? '')}`,
+		cacheKey: (args, ro) =>
+			`brand_audit_report:${ro?.principalId ?? ro?.keyHash ?? 'anon'}:${String(args.auditId ?? '')}:${String(args.target ?? '')}`,
 		execute: async (_domain, args, ro) => {
 			const db = ro?.brandAuditDb;
 			const principalId = ro?.principalId ?? ro?.keyHash ?? 'anonymous';
 			if (!db) {
 				const { buildCheckResult, createFinding } = await import('../lib/scoring');
 				return buildCheckResult('brand_discovery', [
-					createFinding(
-						'brand_discovery',
-						'Brand audit get-report unavailable',
-						'high',
-						'BRAND_AUDIT_DB binding is not provisioned.',
-						{ unprovisioned: true },
-					),
+					createFinding('brand_discovery', 'Brand audit get-report unavailable', 'high', 'BRAND_AUDIT_DB binding is not provisioned.', {
+						unprovisioned: true,
+					}),
 				]);
 			}
-			return brandAuditGetReport(
-				{ auditId: String(args.auditId ?? ''), target: args.target as string | undefined },
-				principalId,
-				{ db, bucket: ro?.brandReportsR2 as { createSignedUrl?: (input: { key: string; expiresInSeconds: number }) => Promise<string> } | undefined, stepStore: createD1BrandAuditStepStore(db) },
-			);
+			return brandAuditGetReport({ auditId: String(args.auditId ?? ''), target: args.target as string | undefined }, principalId, {
+				db,
+				bucket: ro?.brandReportsR2 as
+					| { createSignedUrl?: (input: { key: string; expiresInSeconds: number }) => Promise<string> }
+					| undefined,
+				stepStore: createD1BrandAuditStepStore(db),
+			});
 		},
 		cacheable: false,
 	},
@@ -450,13 +505,9 @@ const TOOL_REGISTRY: Record<
 			if (!db) {
 				const { buildCheckResult, createFinding } = await import('../lib/scoring');
 				return buildCheckResult('brand_discovery', [
-					createFinding(
-						'brand_discovery',
-						'Brand audit watch unavailable',
-						'high',
-						'BRAND_AUDIT_DB binding is not provisioned.',
-						{ unprovisioned: true },
-					),
+					createFinding('brand_discovery', 'Brand audit watch unavailable', 'high', 'BRAND_AUDIT_DB binding is not provisioned.', {
+						unprovisioned: true,
+					}),
 				]);
 			}
 			return brandAuditWatch(
@@ -541,10 +592,17 @@ export async function handleToolsCall(
 		// Extract and validate domain for tools that need it
 		// (skip for explain_finding, get_benchmark, get_provider_insights which don't require a domain)
 		const DOMAIN_OPTIONAL_TOOLS = new Set([
-			'explain_finding', 'get_benchmark', 'get_provider_insights', 'batch_scan', 'compare_domains',
+			'explain_finding',
+			'get_benchmark',
+			'get_provider_insights',
+			'batch_scan',
+			'compare_domains',
 			'check_root_server_set',
 			// v2.21+ brand-audit tools — take `domains[]`, `auditId`, or `action` instead of `domain`.
-			'brand_audit_batch_start', 'brand_audit_status', 'brand_audit_get_report', 'brand_audit_watch',
+			'brand_audit_batch_start',
+			'brand_audit_status',
+			'brand_audit_get_report',
+			'brand_audit_watch',
 		]);
 		if (!DOMAIN_OPTIONAL_TOOLS.has(name)) {
 			domain = extractAndValidateDomain(validatedArgs);
@@ -618,7 +676,14 @@ export async function handleToolsCall(
 					// (was 'n/a' for every scan_domain call before — drowned the leaf
 					// tools' real hit-rate signal in the .dev/analytics-30d.mjs report).
 					const cacheStatus: 'hit' | 'miss' = result.cached ? 'hit' : 'miss';
-					logToolSuccess({ ...ctx(), status: result.score.overall >= 50 ? 'pass' : 'fail', logResult, logDetails, severity: 'info', cacheStatus });
+					logToolSuccess({
+						...ctx(),
+						status: result.score.overall >= 50 ? 'pass' : 'fail',
+						logResult,
+						logDetails,
+						severity: 'info',
+						cacheStatus,
+					});
 					const structured = buildStructuredScanResult(result);
 					return { content: buildToolContent(formatScanReport(result, effectiveFormat), structured, effectiveFormat) };
 				}
@@ -640,7 +705,13 @@ export async function handleToolsCall(
 						},
 					});
 					const batchText = formatBatchScan(batchResults, effectiveFormat);
-					logToolSuccess({ ...ctx(), status: 'pass', logResult: `${batchResults.filter((r) => !r.error).length}/${batchResults.length} domains`, logDetails: { totalDomains: batchResults.length }, severity: 'info' });
+					logToolSuccess({
+						...ctx(),
+						status: 'pass',
+						logResult: `${batchResults.filter((r) => !r.error).length}/${batchResults.length} domains`,
+						logDetails: { totalDomains: batchResults.length },
+						severity: 'info',
+					});
 					return { content: buildToolContent(batchText, batchResults, effectiveFormat) };
 				}
 				case 'compare_domains': {
@@ -659,7 +730,13 @@ export async function handleToolsCall(
 						},
 					});
 					const compareText = formatDomainComparison(compareResults, effectiveFormat);
-					logToolSuccess({ ...ctx(), status: 'pass', logResult: `${Object.keys(compareResults.scores).length}/${compareResults.domains.length} domains compared`, logDetails: { totalDomains: compareResults.domains.length, winner: compareResults.winner }, severity: 'info' });
+					logToolSuccess({
+						...ctx(),
+						status: 'pass',
+						logResult: `${Object.keys(compareResults.scores).length}/${compareResults.domains.length} domains compared`,
+						logDetails: { totalDomains: compareResults.domains.length, winner: compareResults.winner },
+						severity: 'info',
+					});
 					return { content: buildToolContent(compareText, compareResults, effectiveFormat) };
 				}
 				case 'compare_baseline': {
@@ -685,7 +762,7 @@ export async function handleToolsCall(
 					return { content: buildToolContent(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat) };
 				}
 				case 'generate_dmarc_record': {
-					const policy = typeof validatedArgs.policy === 'string' ? validatedArgs.policy as 'none' | 'quarantine' | 'reject' : undefined;
+					const policy = typeof validatedArgs.policy === 'string' ? (validatedArgs.policy as 'none' | 'quarantine' | 'reject') : undefined;
 					const ruaEmail = typeof validatedArgs.rua_email === 'string' ? validatedArgs.rua_email : undefined;
 					const record = await generateDmarcRecord(validDomain, policy, ruaEmail, buildDnsOptions(runtimeOptions));
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: 'generated', logDetails: record, severity: 'info' });
@@ -757,86 +834,90 @@ export async function handleToolsCall(
 					return { content: buildToolContent(formatValidateFix(result, effectiveFormat), result, effectiveFormat) };
 				}
 				case 'map_supply_chain': {
-						const result = await mapSupplyChain(validDomain, buildDnsOptions(runtimeOptions));
-						logResult = `${result.summary.totalProviders} providers`;
-						logDetails = result;
-						logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-						return { content: buildToolContent(formatSupplyChain(result, effectiveFormat), result, effectiveFormat) };
-					}
-					case 'generate_rollout_plan': {
-						const targetPolicy = typeof validatedArgs.target_policy === 'string'
-							? validatedArgs.target_policy as 'quarantine' | 'reject'
-							: 'reject';
-						const timeline = typeof validatedArgs.timeline === 'string'
-							? validatedArgs.timeline as 'aggressive' | 'standard' | 'conservative'
+					const result = await mapSupplyChain(validDomain, buildDnsOptions(runtimeOptions));
+					logResult = `${result.summary.totalProviders} providers`;
+					logDetails = result;
+					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
+					return { content: buildToolContent(formatSupplyChain(result, effectiveFormat), result, effectiveFormat) };
+				}
+				case 'generate_rollout_plan': {
+					const targetPolicy =
+						typeof validatedArgs.target_policy === 'string' ? (validatedArgs.target_policy as 'quarantine' | 'reject') : 'reject';
+					const timeline =
+						typeof validatedArgs.timeline === 'string'
+							? (validatedArgs.timeline as 'aggressive' | 'standard' | 'conservative')
 							: 'standard';
-						const result = await generateRolloutPlan(validDomain, targetPolicy, timeline, buildDnsOptions(runtimeOptions));
-						logResult = result.atTarget ? 'at_target' : `${result.phases.length} phases`;
-						logDetails = result;
-						logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-						return { content: buildToolContent(formatRolloutPlan(result, effectiveFormat), result, effectiveFormat) };
-					}
-					case 'analyze_drift': {
-						const baselineStr = typeof validatedArgs.baseline === 'string' ? validatedArgs.baseline : '';
+					const result = await generateRolloutPlan(validDomain, targetPolicy, timeline, buildDnsOptions(runtimeOptions));
+					logResult = result.atTarget ? 'at_target' : `${result.phases.length} phases`;
+					logDetails = result;
+					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
+					return { content: buildToolContent(formatRolloutPlan(result, effectiveFormat), result, effectiveFormat) };
+				}
+				case 'analyze_drift': {
+					const baselineStr = typeof validatedArgs.baseline === 'string' ? validatedArgs.baseline : '';
 
-						let baselineScore: import('../lib/scoring-model').ScanScore;
-						if (baselineStr === 'cached') {
-							const cacheKey = `cache:${validDomain}`;
-							const cached = scanCacheKV ? await import('../lib/cache').then((m) => m.cacheGet<import('../tools/scan-domain').ScanDomainResult>(cacheKey, scanCacheKV)) : undefined;
-							if (!cached) {
-								return buildToolErrorResult(`Invalid baseline: no cached scan found for ${validDomain}. Run scan_domain first or provide a baseline JSON.`);
-							}
-							baselineScore = cached.score;
-						} else {
-							try {
-								const parsed = JSON.parse(baselineStr);
-								if (typeof parsed?.overall !== 'number' || typeof parsed?.grade !== 'string' || !Array.isArray(parsed?.findings)) {
-									return buildToolErrorResult('Invalid baseline: JSON must contain overall (number), grade (string), and findings (array).');
-								}
-								baselineScore = parsed;
-							} catch {
-								return buildToolErrorResult('Invalid baseline: could not parse JSON. Provide a valid ScanScore JSON or "cached".');
-							}
+					let baselineScore: import('../lib/scoring-model').ScanScore;
+					if (baselineStr === 'cached') {
+						const cacheKey = `cache:${validDomain}`;
+						const cached = scanCacheKV
+							? await import('../lib/cache').then((m) => m.cacheGet<import('../tools/scan-domain').ScanDomainResult>(cacheKey, scanCacheKV))
+							: undefined;
+						if (!cached) {
+							return buildToolErrorResult(
+								`Invalid baseline: no cached scan found for ${validDomain}. Run scan_domain first or provide a baseline JSON.`,
+							);
 						}
+						baselineScore = cached.score;
+					} else {
+						try {
+							const parsed = JSON.parse(baselineStr);
+							if (typeof parsed?.overall !== 'number' || typeof parsed?.grade !== 'string' || !Array.isArray(parsed?.findings)) {
+								return buildToolErrorResult('Invalid baseline: JSON must contain overall (number), grade (string), and findings (array).');
+							}
+							baselineScore = parsed;
+						} catch {
+							return buildToolErrorResult('Invalid baseline: could not parse JSON. Provide a valid ScanScore JSON or "cached".');
+						}
+					}
 
-						const scanResult = await scanDomain(validDomain, scanCacheKV, runtimeOptions);
-						const drift = computeDrift(validDomain, baselineScore, scanResult.score);
-						logResult = drift.classification;
-						logDetails = drift;
-						logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-						return { content: buildToolContent(formatDriftReport(drift, effectiveFormat), drift, effectiveFormat) };
-					}
-					case 'resolve_spf_chain': {
-						const result = await resolveSpfChain(validDomain, buildDnsOptions(runtimeOptions));
-						logResult = result.overLimit ? 'over_limit' : 'ok';
-						logDetails = { totalLookups: result.totalLookups, maxDepth: result.maxDepth, issues: result.issues.length };
-						logToolSuccess({ ...ctx(), status: result.overLimit ? 'fail' : 'pass', logResult, logDetails, severity: 'info' });
-						return { content: buildToolContent(formatSpfChain(result, effectiveFormat), result, effectiveFormat) };
-					}
-					case 'discover_subdomains': {
-						const result = await discoverSubdomains(validDomain, runtimeOptions?.certstream);
-						logResult = `${result.totalSubdomains} subdomains`;
-						logDetails = { totalSubdomains: result.totalSubdomains, issues: result.issues.length };
-						logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-						return { content: buildToolContent(formatSubdomainDiscovery(result, effectiveFormat), result, effectiveFormat) };
-					}
-					case 'map_compliance': {
-						const result = await mapCompliance(validDomain, scanCacheKV, runtimeOptions);
-						logResult = 'mapped';
-						logDetails = result;
-						logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-						return { content: buildToolContent(formatCompliance(result, effectiveFormat), result, effectiveFormat) };
-					}
-					case 'simulate_attack_paths': {
-						const result = await simulateAttackPaths(validDomain, buildDnsOptions(runtimeOptions));
-						logResult = `${result.totalPaths} paths, risk: ${result.overallRisk}`;
-						logDetails = { totalPaths: result.totalPaths, overallRisk: result.overallRisk };
-						logToolSuccess({ ...ctx(), status: result.overallRisk === 'low' ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
-						return { content: buildToolContent(formatAttackPaths(result, effectiveFormat), result, effectiveFormat) };
-					}
-					default:
-						logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-						return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all ${TOOLS.length} available tools.`);
+					const scanResult = await scanDomain(validDomain, scanCacheKV, runtimeOptions);
+					const drift = computeDrift(validDomain, baselineScore, scanResult.score);
+					logResult = drift.classification;
+					logDetails = drift;
+					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
+					return { content: buildToolContent(formatDriftReport(drift, effectiveFormat), drift, effectiveFormat) };
+				}
+				case 'resolve_spf_chain': {
+					const result = await resolveSpfChain(validDomain, buildDnsOptions(runtimeOptions));
+					logResult = result.overLimit ? 'over_limit' : 'ok';
+					logDetails = { totalLookups: result.totalLookups, maxDepth: result.maxDepth, issues: result.issues.length };
+					logToolSuccess({ ...ctx(), status: result.overLimit ? 'fail' : 'pass', logResult, logDetails, severity: 'info' });
+					return { content: buildToolContent(formatSpfChain(result, effectiveFormat), result, effectiveFormat) };
+				}
+				case 'discover_subdomains': {
+					const result = await discoverSubdomains(validDomain, runtimeOptions?.certstream);
+					logResult = `${result.totalSubdomains} subdomains`;
+					logDetails = { totalSubdomains: result.totalSubdomains, issues: result.issues.length };
+					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
+					return { content: buildToolContent(formatSubdomainDiscovery(result, effectiveFormat), result, effectiveFormat) };
+				}
+				case 'map_compliance': {
+					const result = await mapCompliance(validDomain, scanCacheKV, runtimeOptions);
+					logResult = 'mapped';
+					logDetails = result;
+					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
+					return { content: buildToolContent(formatCompliance(result, effectiveFormat), result, effectiveFormat) };
+				}
+				case 'simulate_attack_paths': {
+					const result = await simulateAttackPaths(validDomain, buildDnsOptions(runtimeOptions));
+					logResult = `${result.totalPaths} paths, risk: ${result.overallRisk}`;
+					logDetails = { totalPaths: result.totalPaths, overallRisk: result.overallRisk };
+					logToolSuccess({ ...ctx(), status: result.overallRisk === 'low' ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
+					return { content: buildToolContent(formatAttackPaths(result, effectiveFormat), result, effectiveFormat) };
+				}
+				default:
+					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all ${TOOLS.length} available tools.`);
 			}
 		};
 
@@ -848,11 +929,18 @@ export async function handleToolsCall(
 		if (err instanceof Error && err.message === '__tool_timeout__') {
 			logToolFailure({ ...ctx(), error: 'Tool call timed out', args });
 			return {
-				content: [mcpError(`${name} timed out after ${TOOL_CALL_TIMEOUT_MS / 1000}s. Try a simpler check or retry — cached partial results make retries faster.`)],
+				content: [
+					mcpError(
+						`${name} timed out after ${TOOL_CALL_TIMEOUT_MS / 1000}s. Try a simpler check or retry — cached partial results make retries faster.`,
+					),
+				],
 				isError: true,
 			};
 		}
-		const message = sanitizeErrorMessage(err, `An unexpected error occurred while running ${name}. Retry the request — transient DNS failures are common.`);
+		const message = sanitizeErrorMessage(
+			err,
+			`An unexpected error occurred while running ${name}. Retry the request — transient DNS failures are common.`,
+		);
 		logToolFailure({ ...ctx(), error: err, args });
 		return buildToolErrorResult(message);
 	}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -250,6 +250,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_nsec_walkability: 10,
 	check_dnssec_chain: 10,
 	check_fast_flux: 3,
+	check_subdomain_takeover: 10,
 	check_authoritative_dns_infra: 25,
 	check_root_server_set: 25,
 	discover_brand_domains: 1,
@@ -364,7 +365,7 @@ export function parsePerCheckTimeout(envValue?: string): number {
 // ─── OAuth 2.1 (Phase 0 — shared constants) ─────────────────────────────────
 export const OAUTH_CODE_TTL_SECONDS = 60; // KV minimum TTL is 60s; auth codes are short-lived
 export const OAUTH_CLIENT_TTL_SECONDS = 60 * 60 * 24 * 365; // 1 year, refreshed on use
-export const OAUTH_JWT_TTL_SECONDS = 60 * 60 * 24 * 90;     // 90 days
+export const OAUTH_JWT_TTL_SECONDS = 60 * 60 * 24 * 90; // 90 days
 export const OAUTH_JWT_CLOCK_SKEW_SECONDS = 30;
 export const OAUTH_CONSENT_RATE_LIMIT = 5;
 export const OAUTH_CONSENT_RATE_WINDOW_SECONDS = 60 * 15;

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -250,7 +250,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_nsec_walkability: 10,
 	check_dnssec_chain: 10,
 	check_fast_flux: 3,
-	check_subdomain_takeover: 10,
+	check_subdomain_takeover: 25,
 	check_authoritative_dns_infra: 25,
 	check_root_server_set: 25,
 	discover_brand_domains: 1,

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -15,120 +15,161 @@ import {
 } from './primitives';
 
 /** Domain + optional format — shared by most check tools. */
-export const BaseDomainArgs = z.object({
-	domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const BaseDomainArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** scan_domain */
-export const ScanDomainArgs = z.object({
-	domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
-	profile: ProfileSchema.optional().describe('Scoring profile. Default "auto" detects.'),
-	force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh scan. Useful after DNS changes.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const ScanDomainArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
+		profile: ProfileSchema.optional().describe('Scoring profile. Default "auto" detects.'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh scan. Useful after DNS changes.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** batch_scan */
-export const BatchScanArgs = z.object({
-	domains: z.array(z.string().min(1).max(253)).min(1).max(10).describe('Domains to scan (max 10 per request)'),
-	force_refresh: z.boolean().optional().describe('Bypass cache and run fresh scans.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const BatchScanArgs = z
+	.object({
+		domains: z.array(z.string().min(1).max(253)).min(1).max(10).describe('Domains to scan (max 10 per request)'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run fresh scans.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** compare_domains */
-export const CompareDomainsArgs = z.object({
-	domains: z.array(z.string().min(1).max(253)).min(2).max(5).describe('Domains to compare (2–5 domains)'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const CompareDomainsArgs = z
+	.object({
+		domains: z.array(z.string().min(1).max(253)).min(2).max(5).describe('Domains to compare (2–5 domains)'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** check_dkim */
-export const CheckDkimArgs = z.object({
-	domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
-	selector: DkimSelectorSchema.optional().describe('DKIM selector. Omit to probe common ones.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const CheckDkimArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
+		selector: DkimSelectorSchema.optional().describe('DKIM selector. Omit to probe common ones.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** check_resolver_consistency */
-export const CheckResolverConsistencyArgs = z.object({
-	domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
-	record_type: RecordTypeSchema.optional().describe('Record type. Omit for A/AAAA/MX/TXT/NS.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const CheckResolverConsistencyArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
+		record_type: RecordTypeSchema.optional().describe('Record type. Omit for A/AAAA/MX/TXT/NS.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** check_root_server_set */
-export const RootServerSetArgs = z.object({
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const RootServerSetArgs = z
+	.object({
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** generate_spf_record */
-export const GenerateSpfArgs = z.object({
-	domain: DomainSchema.describe('Domain (e.g., example.com)'),
-	// SafeLabelSchema provides min(1)/max(253); .regex() adds a stacking refinement in Zod v4 (does not override).
-	include_providers: z.array(SafeLabelSchema.regex(/^[a-z0-9._-]+$/i)).max(15).optional().describe('Providers to include (e.g., ["google"]).'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const GenerateSpfArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain (e.g., example.com)'),
+		// SafeLabelSchema provides min(1)/max(253); .regex() adds a stacking refinement in Zod v4 (does not override).
+		include_providers: z
+			.array(SafeLabelSchema.regex(/^[a-z0-9._-]+$/i))
+			.max(15)
+			.optional()
+			.describe('Providers to include (e.g., ["google"]).'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** generate_dmarc_record */
-export const GenerateDmarcArgs = z.object({
-	domain: DomainSchema.describe('Domain (e.g., example.com)'),
-	policy: DmarcPolicySchema.optional().describe('Policy (default "reject").'),
-	rua_email: z.string().max(254).optional().describe('Report email. Default: dmarc-reports@{domain}.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const GenerateDmarcArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain (e.g., example.com)'),
+		policy: DmarcPolicySchema.optional().describe('Policy (default "reject").'),
+		rua_email: z.string().max(254).optional().describe('Report email. Default: dmarc-reports@{domain}.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** generate_dkim_config */
-export const GenerateDkimConfigArgs = z.object({
-	domain: DomainSchema.describe('Domain (e.g., example.com)'),
-	provider: z.string().max(100).optional().describe('Provider (e.g., "google"). Omit for generic.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const GenerateDkimConfigArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain (e.g., example.com)'),
+		provider: z.string().max(100).optional().describe('Provider (e.g., "google"). Omit for generic.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** generate_mta_sts_policy */
-export const GenerateMtaStsArgs = z.object({
-	domain: DomainSchema.describe('Domain (e.g., example.com)'),
-	// SafeLabelSchema provides min(1)/max(253); .regex() adds a stacking refinement in Zod v4 (does not override).
-	mx_hosts: z.array(SafeLabelSchema.regex(/^[^\s\x00-\x1f\x7f]*$/)).max(20).optional().describe('MX hosts. Omit to detect from DNS.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const GenerateMtaStsArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain (e.g., example.com)'),
+		// SafeLabelSchema provides min(1)/max(253); .regex() adds a stacking refinement in Zod v4 (does not override).
+		mx_hosts: z
+			.array(SafeLabelSchema.regex(/^[^\s\x00-\x1f\x7f]*$/))
+			.max(20)
+			.optional()
+			.describe('MX hosts. Omit to detect from DNS.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** explain_finding */
-export const ExplainFindingArgs = z.object({
-	checkType: z.string().min(1).max(100).describe("Check type (e.g., 'SPF', 'DMARC')."),
-	status: ExplainStatusSchema.describe('Finding severity or status.'),
-	details: z.string().max(2000).optional().describe('Additional detail from check result.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const ExplainFindingArgs = z
+	.object({
+		checkType: z.string().min(1).max(100).describe("Check type (e.g., 'SPF', 'DMARC')."),
+		status: ExplainStatusSchema.describe('Finding severity or status.'),
+		details: z.string().max(2000).optional().describe('Additional detail from check result.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** compare_baseline */
-export const CompareBaselineArgs = z.object({
-	domain: DomainSchema.describe('Domain to scan and compare.'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-	baseline: z.object({
-		grade: GradeSchema.optional().describe('Min grade (e.g., "B+").'),
-		score: z.number().min(0).max(100).optional().describe('Min score (0-100).'),
-		require_dmarc_enforce: z.boolean().optional().describe('Require DMARC enforce.'),
-		require_spf: z.boolean().optional().describe('Require SPF.'),
-		require_dkim: z.boolean().optional().describe('Require DKIM.'),
-		require_dnssec: z.boolean().optional().describe('Require DNSSEC.'),
-		require_mta_sts: z.boolean().optional().describe('Require MTA-STS.'),
-		require_caa: z.boolean().optional().describe('Require CAA.'),
-		max_critical_findings: z.number().int().min(0).optional().describe('Max critical findings (default 0).'),
-		max_high_findings: z.number().int().min(0).optional().describe('Max high findings allowed.'),
-	}).passthrough().describe('Policy baseline requirements.'),
-}).passthrough();
+export const CompareBaselineArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to scan and compare.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+		baseline: z
+			.object({
+				grade: GradeSchema.optional().describe('Min grade (e.g., "B+").'),
+				score: z.number().min(0).max(100).optional().describe('Min score (0-100).'),
+				require_dmarc_enforce: z.boolean().optional().describe('Require DMARC enforce.'),
+				require_spf: z.boolean().optional().describe('Require SPF.'),
+				require_dkim: z.boolean().optional().describe('Require DKIM.'),
+				require_dnssec: z.boolean().optional().describe('Require DNSSEC.'),
+				require_mta_sts: z.boolean().optional().describe('Require MTA-STS.'),
+				require_caa: z.boolean().optional().describe('Require CAA.'),
+				max_critical_findings: z.number().int().min(0).optional().describe('Max critical findings (default 0).'),
+				max_high_findings: z.number().int().min(0).optional().describe('Max high findings allowed.'),
+			})
+			.passthrough()
+			.describe('Policy baseline requirements.'),
+	})
+	.passthrough();
 
 /** get_benchmark */
-export const GetBenchmarkArgs = z.object({
-	profile: BenchmarkProfileSchema.optional().describe('Profile to benchmark (default "mail_enabled").'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const GetBenchmarkArgs = z
+	.object({
+		profile: BenchmarkProfileSchema.optional().describe('Profile to benchmark (default "mail_enabled").'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** get_provider_insights */
-export const GetProviderInsightsArgs = z.object({
-	provider: z.string().min(1).max(200).describe('Provider (e.g., "google workspace").'),
-	profile: BenchmarkProfileSchema.optional().describe('Profile (default "mail_enabled").'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const GetProviderInsightsArgs = z
+	.object({
+		provider: z.string().min(1).max(200).describe('Provider (e.g., "google workspace").'),
+		profile: BenchmarkProfileSchema.optional().describe('Profile (default "mail_enabled").'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** assess_spoofability — same as BaseDomainArgs */
 export const AssessSpoofabilityArgs = BaseDomainArgs;
@@ -136,50 +177,80 @@ export const AssessSpoofabilityArgs = BaseDomainArgs;
 /** generate_fix_plan — same as BaseDomainArgs */
 export const GenerateFixPlanArgs = BaseDomainArgs;
 
-const CheckNameSchema = z.string().transform((v) => v.toLowerCase().trim()).pipe(
-	z.enum(['spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta_sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http_security', 'dane']),
-);
+const CheckNameSchema = z
+	.string()
+	.transform((v) => v.toLowerCase().trim())
+	.pipe(z.enum(['spf', 'dmarc', 'dkim', 'dnssec', 'ssl', 'mta_sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http_security', 'dane']));
 
-const TimelineSchema = z.string().transform((v) => v.toLowerCase()).pipe(
-	z.enum(['aggressive', 'standard', 'conservative']),
-);
+const TimelineSchema = z
+	.string()
+	.transform((v) => v.toLowerCase())
+	.pipe(z.enum(['aggressive', 'standard', 'conservative']));
 
-const TargetPolicySchema = z.string().transform((v) => v.toLowerCase()).pipe(
-	z.enum(['quarantine', 'reject']),
-);
+const TargetPolicySchema = z
+	.string()
+	.transform((v) => v.toLowerCase())
+	.pipe(z.enum(['quarantine', 'reject']));
 
 /** validate_fix */
-export const ValidateFixArgs = z.object({
-	domain: DomainSchema.describe('Domain to validate the fix for'),
-	check: CheckNameSchema.describe('Check name to re-run (e.g., "dmarc", "spf")'),
-	expected: z.string().max(1000).optional().describe('Expected DNS record value to verify against'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const ValidateFixArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to validate the fix for'),
+		check: CheckNameSchema.describe('Check name to re-run (e.g., "dmarc", "spf")'),
+		expected: z.string().max(1000).optional().describe('Expected DNS record value to verify against'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** map_supply_chain — same as BaseDomainArgs */
 export const MapSupplyChainArgs = BaseDomainArgs;
 
 /** analyze_drift */
-export const AnalyzeDriftArgs = z.object({
-	domain: DomainSchema.describe('Domain to analyze drift for'),
-	baseline: z.string().min(1).max(50_000).describe('Previous ScanScore JSON or "cached" to use last cached scan'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const AnalyzeDriftArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to analyze drift for'),
+		baseline: z.string().min(1).max(50_000).describe('Previous ScanScore JSON or "cached" to use last cached scan'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** generate_rollout_plan */
-export const GenerateRolloutPlanArgs = z.object({
-	domain: DomainSchema.describe('Domain to generate rollout plan for'),
-	target_policy: TargetPolicySchema.optional().describe('Target DMARC policy (default: reject)'),
-	timeline: TimelineSchema.optional().describe('Rollout speed: aggressive, standard, conservative (default: standard)'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const GenerateRolloutPlanArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to generate rollout plan for'),
+		target_policy: TargetPolicySchema.optional().describe('Target DMARC policy (default: reject)'),
+		timeline: TimelineSchema.optional().describe('Rollout speed: aggressive, standard, conservative (default: standard)'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** check_fast_flux — domain + rounds + format */
-export const CheckFastFluxArgs = z.object({
-	domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
-	rounds: z.number().int().min(3).max(5).optional().describe('Number of query rounds (3-5, default 3).'),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+export const CheckFastFluxArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
+		rounds: z.number().int().min(3).max(5).optional().describe('Number of query rounds (3-5, default 3).'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
+
+/**
+ * check_subdomain_takeover — sweep an explicit subdomain list (or fall back to
+ * a 15-name built-in list of common labels) for dangling CNAMEs and
+ * provider-deprovisioned takeover fingerprints.
+ */
+export const CheckSubdomainTakeoverArgs = z
+	.object({
+		domain: DomainSchema.describe('Domain to check (e.g., example.com).'),
+		subdomains: z
+			.array(z.string().min(1).max(253))
+			.max(1000)
+			.optional()
+			.describe(
+				'Optional explicit subdomain list (full FQDNs or short labels). When provided (deduped, capped at 1000), this list is swept instead of the 15-name built-in. Source from Certificate-Transparency enumeration or brand-audit discovery.',
+			),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** Brand-discovery signal kinds (case-insensitive). */
 const DiscoverSignalSchema = z
@@ -218,42 +289,48 @@ const BrandCandidateDomainsArg = z
 	.describe('Optional candidate domains supplied by the caller for corroboration.');
 
 /** discover_brand_domains — seed + optional signal set + candidate seed list. */
-export const DiscoverBrandDomainsArgs = z.object({
-	domain: DomainSchema.describe('Seed domain whose brand portfolio to expand (e.g., example.com).'),
-	signals: z
-		.array(DiscoverSignalSchema)
-		.min(1)
-		.max(12)
-		.optional()
-		.describe('Signal modules to invoke. Defaults to all 12 discovery/enrichment signals.'),
-	depth: BrandAuditDepthSchema.optional().describe('Discovery depth. standard is default; deep expands candidate seeding and enrichment fanout.'),
-	planner_mode: BrandAuditPlannerModeSchema.optional().describe('Planner mode for staged discovery fanout. observe emits metrics; enforce applies candidate-backed signal caps.'),
-	brand_aliases: BrandAliasesArg,
-	candidate_domains: BrandCandidateDomainsArg,
-	dkim_selectors: z
-		.array(z.string().min(1).max(63))
-		.max(50)
-		.optional()
-		.describe('Optional DKIM selectors to probe. Defaults to a built-in common-selector list.'),
-	min_confidence: z
-		.number()
-		.min(0)
-		.max(1)
-		.optional()
-		.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
-	discovery_mode: z
-		.enum(['classic', 'tiered'])
-		.default('classic')
-		.describe(
-			'Discovery mode. "classic" (default, BSL-licensed) runs the public signal-sweep pipeline. ' +
-				'"tiered" layers Tier 0 (tenant-declared portfolio), Tier 1 (infrastructure-graph), and ' +
-				'Tier 2 (declared-evidence) lookups in front of the legacy sweep, falling back to Tier 3 ' +
-				'(the existing sweep) only on cache miss / very_stale fingerprint / uncovered caller ' +
-				'candidates. Tiered mode requires private BlackVeil service bindings — BSL self-hosts ' +
-				'should leave this on "classic".',
+export const DiscoverBrandDomainsArgs = z
+	.object({
+		domain: DomainSchema.describe('Seed domain whose brand portfolio to expand (e.g., example.com).'),
+		signals: z
+			.array(DiscoverSignalSchema)
+			.min(1)
+			.max(12)
+			.optional()
+			.describe('Signal modules to invoke. Defaults to all 12 discovery/enrichment signals.'),
+		depth: BrandAuditDepthSchema.optional().describe(
+			'Discovery depth. standard is default; deep expands candidate seeding and enrichment fanout.',
 		),
-	format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
-}).passthrough();
+		planner_mode: BrandAuditPlannerModeSchema.optional().describe(
+			'Planner mode for staged discovery fanout. observe emits metrics; enforce applies candidate-backed signal caps.',
+		),
+		brand_aliases: BrandAliasesArg,
+		candidate_domains: BrandCandidateDomainsArg,
+		dkim_selectors: z
+			.array(z.string().min(1).max(63))
+			.max(50)
+			.optional()
+			.describe('Optional DKIM selectors to probe. Defaults to a built-in common-selector list.'),
+		min_confidence: z
+			.number()
+			.min(0)
+			.max(1)
+			.optional()
+			.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
+		discovery_mode: z
+			.enum(['classic', 'tiered'])
+			.default('classic')
+			.describe(
+				'Discovery mode. "classic" (default, BSL-licensed) runs the public signal-sweep pipeline. ' +
+					'"tiered" layers Tier 0 (tenant-declared portfolio), Tier 1 (infrastructure-graph), and ' +
+					'Tier 2 (declared-evidence) lookups in front of the legacy sweep, falling back to Tier 3 ' +
+					'(the existing sweep) only on cache miss / very_stale fingerprint / uncovered caller ' +
+					'candidates. Tiered mode requires private BlackVeil service bindings — BSL self-hosts ' +
+					'should leave this on "classic".',
+			),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough();
 
 /** Brand-audit output mode — JSON, Markdown, or both. Distinct from FormatSchema's `full|compact`. */
 export const BrandAuditFormatSchema = z
@@ -264,75 +341,93 @@ export const BrandAuditFormatSchema = z
 export const BrandAuditViewSchema = z.enum(['standard', 'csc_complement']);
 
 /** brand_audit_single — sync brand-portfolio audit for one target. */
-export const BrandAuditSingleArgs = z.object({
-	domain: DomainSchema.describe('Target domain to audit (e.g., apple.com).'),
-	format: BrandAuditFormatSchema.optional().describe('Inline output mode. Defaults to "both".'),
-	min_confidence: z
-		.number()
-		.min(0)
-		.max(1)
-		.optional()
-		.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
-	depth: BrandAuditDepthSchema.optional().describe('Discovery depth. standard is default; deep expands candidate seeding and enrichment fanout.'),
-	planner_mode: BrandAuditPlannerModeSchema.optional().describe('Planner mode for staged discovery fanout. observe emits metrics; enforce applies candidate-backed signal caps.'),
-	brand_aliases: BrandAliasesArg,
-	candidate_domains: BrandCandidateDomainsArg,
-	view: BrandAuditViewSchema.optional().describe(
-		"Output view mode. 'csc_complement' produces a CSC-tuned payload; requires enterprise tier. Default 'standard'.",
-	),
-}).passthrough();
+export const BrandAuditSingleArgs = z
+	.object({
+		domain: DomainSchema.describe('Target domain to audit (e.g., apple.com).'),
+		format: BrandAuditFormatSchema.optional().describe('Inline output mode. Defaults to "both".'),
+		min_confidence: z
+			.number()
+			.min(0)
+			.max(1)
+			.optional()
+			.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
+		depth: BrandAuditDepthSchema.optional().describe(
+			'Discovery depth. standard is default; deep expands candidate seeding and enrichment fanout.',
+		),
+		planner_mode: BrandAuditPlannerModeSchema.optional().describe(
+			'Planner mode for staged discovery fanout. observe emits metrics; enforce applies candidate-backed signal caps.',
+		),
+		brand_aliases: BrandAliasesArg,
+		candidate_domains: BrandCandidateDomainsArg,
+		view: BrandAuditViewSchema.optional().describe(
+			"Output view mode. 'csc_complement' produces a CSC-tuned payload; requires enterprise tier. Default 'standard'.",
+		),
+	})
+	.passthrough();
 
 /** brand_audit_batch_start — enqueue async brand audits for up to 50 targets. */
-export const BrandAuditBatchStartArgs = z.object({
-	domains: z
-		.array(z.string().min(1).max(253))
-		.min(1)
-		.max(50)
-		.describe('Domains to audit (max 50 per batch). Duplicates are merged.'),
-	format: BrandAuditFormatSchema.optional().describe('Inline output mode. Defaults to "both".'),
-	min_confidence: z
-		.number()
-		.min(0)
-		.max(1)
-		.optional()
-		.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
-	depth: BrandAuditDepthSchema.optional().describe('Discovery depth. standard is default; deep expands candidate seeding and enrichment fanout.'),
-	planner_mode: BrandAuditPlannerModeSchema.optional().describe('Planner mode for staged discovery fanout. observe emits metrics; enforce applies candidate-backed signal caps.'),
-	brand_aliases: BrandAliasesArg,
-	candidate_domains: BrandCandidateDomainsArg,
-	discovery_mode: z
-		.enum(['classic', 'tiered'])
-		.optional()
-		.describe('Brand-discovery pipeline mode. classic = legacy sweep; tiered = tenant/graph/evidence wrappers first (BlackVeil-internal).'),
-	view: BrandAuditViewSchema.optional().describe(
-		"Output view mode. 'csc_complement' produces a CSC-tuned payload; requires enterprise tier. Default 'standard'.",
-	),
-}).passthrough();
+export const BrandAuditBatchStartArgs = z
+	.object({
+		domains: z.array(z.string().min(1).max(253)).min(1).max(50).describe('Domains to audit (max 50 per batch). Duplicates are merged.'),
+		format: BrandAuditFormatSchema.optional().describe('Inline output mode. Defaults to "both".'),
+		min_confidence: z
+			.number()
+			.min(0)
+			.max(1)
+			.optional()
+			.describe('Drop candidates whose combined confidence falls below this threshold (0-1, default 0.5).'),
+		depth: BrandAuditDepthSchema.optional().describe(
+			'Discovery depth. standard is default; deep expands candidate seeding and enrichment fanout.',
+		),
+		planner_mode: BrandAuditPlannerModeSchema.optional().describe(
+			'Planner mode for staged discovery fanout. observe emits metrics; enforce applies candidate-backed signal caps.',
+		),
+		brand_aliases: BrandAliasesArg,
+		candidate_domains: BrandCandidateDomainsArg,
+		discovery_mode: z
+			.enum(['classic', 'tiered'])
+			.optional()
+			.describe(
+				'Brand-discovery pipeline mode. classic = legacy sweep; tiered = tenant/graph/evidence wrappers first (BlackVeil-internal).',
+			),
+		view: BrandAuditViewSchema.optional().describe(
+			"Output view mode. 'csc_complement' produces a CSC-tuned payload; requires enterprise tier. Default 'standard'.",
+		),
+	})
+	.passthrough();
 
 /** brand_audit_status — poll status of an enqueued audit. */
-export const BrandAuditStatusArgs = z.object({
-	auditId: z.string().min(1).max(64).describe('Audit ID returned by brand_audit_batch_start.'),
-}).passthrough();
+export const BrandAuditStatusArgs = z
+	.object({
+		auditId: z.string().min(1).max(64).describe('Audit ID returned by brand_audit_batch_start.'),
+	})
+	.passthrough();
 
 /** brand_audit_get_report — fetch result JSON for an audit or single target. */
-export const BrandAuditGetReportArgs = z.object({
-	auditId: z.string().min(1).max(64).describe('Audit ID returned by brand_audit_batch_start.'),
-	target: z
-		.string()
-		.min(1)
-		.max(253)
-		.optional()
-		.describe('Specific target domain. Omit for audit-level aggregate.'),
-}).passthrough();
+export const BrandAuditGetReportArgs = z
+	.object({
+		auditId: z.string().min(1).max(64).describe('Audit ID returned by brand_audit_batch_start.'),
+		target: z.string().min(1).max(253).optional().describe('Specific target domain. Omit for audit-level aggregate.'),
+	})
+	.passthrough();
 
 /** brand_audit_watch — register/list/delete recurring brand-audit watches. */
-export const BrandAuditWatchArgs = z.object({
-	action: z.enum(['register', 'list', 'delete']).describe("Action: 'register' creates a new watch, 'list' returns the caller's watches, 'delete' removes one."),
-	domain: DomainSchema.optional().describe('Domain to watch. Required for action=register.'),
-	interval: z.enum(['daily', 'weekly', 'monthly']).optional().describe('Recurrence interval. Required for action=register.'),
-	webhook_url: z.string().url().max(2048).optional().describe('Optional webhook URL — POSTed on classification drift. Re-validated for SSRF at both register and delivery time.'),
-	watchId: z.string().min(1).max(64).optional().describe('Watch ID returned by action=register. Required for action=delete.'),
-}).passthrough();
+export const BrandAuditWatchArgs = z
+	.object({
+		action: z
+			.enum(['register', 'list', 'delete'])
+			.describe("Action: 'register' creates a new watch, 'list' returns the caller's watches, 'delete' removes one."),
+		domain: DomainSchema.optional().describe('Domain to watch. Required for action=register.'),
+		interval: z.enum(['daily', 'weekly', 'monthly']).optional().describe('Recurrence interval. Required for action=register.'),
+		webhook_url: z
+			.string()
+			.url()
+			.max(2048)
+			.optional()
+			.describe('Optional webhook URL — POSTed on classification drift. Re-validated for SSRF at both register and delivery time.'),
+		watchId: z.string().min(1).max(64).optional().describe('Watch ID returned by action=register. Required for action=delete.'),
+	})
+	.passthrough();
 
 /**
  * Map of every tool name to its Zod argument schema.
@@ -390,6 +485,7 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	check_nsec_walkability: BaseDomainArgs,
 	check_dnssec_chain: BaseDomainArgs,
 	check_fast_flux: CheckFastFluxArgs,
+	check_subdomain_takeover: CheckSubdomainTakeoverArgs,
 	check_authoritative_dns_infra: BaseDomainArgs,
 	check_root_server_set: RootServerSetArgs,
 	discover_brand_domains: DiscoverBrandDomainsArgs,

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -21,6 +21,7 @@ import {
 	AnalyzeDriftArgs,
 	GenerateRolloutPlanArgs,
 	CheckFastFluxArgs,
+	CheckSubdomainTakeoverArgs,
 	RootServerSetArgs,
 	DiscoverBrandDomainsArgs,
 	BrandAuditSingleArgs,
@@ -31,7 +32,15 @@ import {
 	TOOL_SCHEMA_MAP,
 } from './tool-args';
 
-export type ToolGroup = 'email_auth' | 'infrastructure' | 'brand_threats' | 'dns_hygiene' | 'intelligence' | 'remediation' | 'meta' | 'discovery';
+export type ToolGroup =
+	| 'email_auth'
+	| 'infrastructure'
+	| 'brand_threats'
+	| 'dns_hygiene'
+	| 'intelligence'
+	| 'remediation'
+	| 'meta'
+	| 'discovery';
 export type ToolTier = 'core' | 'protective' | 'hardening';
 
 export interface McpTool {
@@ -67,7 +76,32 @@ interface ToolDef {
 }
 
 /** DNS/security acronyms that should be uppercased in human-readable tool titles. */
-const KNOWN_ACRONYMS = new Set(['mx', 'spf', 'dmarc', 'dkim', 'dns', 'dnssec', 'ssl', 'mta', 'sts', 'ns', 'caa', 'bimi', 'tlsrpt', 'http', 'https', 'dane', 'svcb', 'srv', 'txt', 'doh', 'rpm', 'dbl', 'rdap', 'nsec']);
+const KNOWN_ACRONYMS = new Set([
+	'mx',
+	'spf',
+	'dmarc',
+	'dkim',
+	'dns',
+	'dnssec',
+	'ssl',
+	'mta',
+	'sts',
+	'ns',
+	'caa',
+	'bimi',
+	'tlsrpt',
+	'http',
+	'https',
+	'dane',
+	'svcb',
+	'srv',
+	'txt',
+	'doh',
+	'rpm',
+	'dbl',
+	'rdap',
+	'nsec',
+]);
 
 /** Convert a snake_case tool name to a human-readable title. e.g. "check_mta_sts" → "Check MTA STS" */
 function toolNameToTitle(name: string): string {
@@ -216,7 +250,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	scan_domain: {
 		description:
-			'Look up any domain to get a full DNS and email security audit. Use this whenever a user mentions a domain name, asks to check/scan/lookup/analyze a domain, or wants to know about a domain\'s security posture. Returns score, grade, maturity stage, and prioritized findings. Start here for any domain-related question.',
+			"Look up any domain to get a full DNS and email security audit. Use this whenever a user mentions a domain name, asks to check/scan/lookup/analyze a domain, or wants to know about a domain's security posture. Returns score, grade, maturity stage, and prioritized findings. Start here for any domain-related question.",
 		schema: ScanDomainArgs,
 		group: 'meta',
 		scanIncluded: false,
@@ -335,7 +369,8 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		scanIncluded: false,
 	},
 	map_supply_chain: {
-		description: 'Map third-party service dependencies from DNS records. Correlates SPF, NS, TXT verifications, SRV services, and CAA to show who can send as you, control your DNS, and what services are integrated.',
+		description:
+			'Map third-party service dependencies from DNS records. Correlates SPF, NS, TXT verifications, SRV services, and CAA to show who can send as you, control your DNS, and what services are integrated.',
 		schema: MapSupplyChainArgs,
 		group: 'intelligence',
 		scanIncluded: false,
@@ -359,31 +394,36 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		scanIncluded: false,
 	},
 	resolve_spf_chain: {
-		description: 'Trace the full SPF include chain for a domain. Recursively resolves all includes, shows lookup count, tree depth, and flags circular includes or exceeding the 10-lookup limit.',
+		description:
+			'Trace the full SPF include chain for a domain. Recursively resolves all includes, shows lookup count, tree depth, and flags circular includes or exceeding the 10-lookup limit.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,
 	},
 	discover_subdomains: {
-		description: 'Find subdomains of a domain using Certificate Transparency logs. Reveals shadow IT, forgotten services, and unauthorized certificate issuance.',
+		description:
+			'Find subdomains of a domain using Certificate Transparency logs. Reveals shadow IT, forgotten services, and unauthorized certificate issuance.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,
 	},
 	map_compliance: {
-		description: 'Map scan findings to compliance frameworks: NIST 800-177, PCI DSS 4.0, SOC 2, CIS Controls. Shows pass/fail/partial status per control.',
+		description:
+			'Map scan findings to compliance frameworks: NIST 800-177, PCI DSS 4.0, SOC 2, CIS Controls. Shows pass/fail/partial status per control.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,
 	},
 	simulate_attack_paths: {
-		description: 'Analyze current DNS posture and enumerate specific attack paths an adversary could exploit, with severity, feasibility, steps, and mitigations.',
+		description:
+			'Analyze current DNS posture and enumerate specific attack paths an adversary could exploit, with severity, feasibility, steps, and mitigations.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,
 	},
 	check_dbl: {
-		description: 'Check domain reputation against DNS-based Domain Block Lists (Spamhaus DBL, URIBL, SURBL). Returns listing status with decoded return codes.',
+		description:
+			'Check domain reputation against DNS-based Domain Block Lists (Spamhaus DBL, URIBL, SURBL). Returns listing status with decoded return codes.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,
@@ -430,6 +470,14 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		group: 'intelligence',
 		scanIncluded: false,
 	},
+	check_subdomain_takeover: {
+		description:
+			'Sweep an explicit subdomain list (or a built-in 15-name list of common labels) for dangling CNAMEs and provider-deprovisioned takeover fingerprints. Pair with discover_subdomains for full-inventory coverage. Detects 16 provider families (AWS S3/CloudFront, Azure Front Door/CDN/Blob/App Service, GCP Cloud Storage, Heroku, GitHub Pages, Vercel, Firebase, Shopify, etc.).',
+		schema: CheckSubdomainTakeoverArgs,
+		group: 'infrastructure',
+		tier: 'protective',
+		scanIncluded: false,
+	},
 	check_authoritative_dns_infra: {
 		description:
 			'Check authoritative DNS infrastructure posture for a hostname. Uses BV_INFRA_PROBE when available for raw DNS, routing, RPKI, and vantage-point evidence.',
@@ -455,14 +503,14 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	brand_audit_single: {
 		description:
-			"Run a full brand audit on a single target with optional standard/deep discovery depth, brand aliases, and caller-supplied candidate domains. Discovers brand-related domains, looks up registrar + registrant for each candidate, and classifies each into consolidated, real registrar-sprawl shadowIt, authorized vendor dependency, indeterminate, or impersonation relationships. Gated tier-wide by monthly BRAND_AUDIT_QUOTAS (free/agent=0, developer=50, partner=200, enterprise=500, owner=unlimited).",
+			'Run a full brand audit on a single target with optional standard/deep discovery depth, brand aliases, and caller-supplied candidate domains. Discovers brand-related domains, looks up registrar + registrant for each candidate, and classifies each into consolidated, real registrar-sprawl shadowIt, authorized vendor dependency, indeterminate, or impersonation relationships. Gated tier-wide by monthly BRAND_AUDIT_QUOTAS (free/agent=0, developer=50, partner=200, enterprise=500, owner=unlimited).',
 		schema: BrandAuditSingleArgs,
 		group: 'discovery',
 		scanIncluded: false,
 	},
 	brand_audit_batch_start: {
 		description:
-			"Enqueue an async brand audit across up to 50 target domains with optional standard/deep discovery depth, brand aliases, and caller-supplied candidate domains. Returns { auditId, queuedAt, targetCount, etaSeconds } immediately; poll with brand_audit_status and fetch results with brand_audit_get_report once complete. Each target consumes 1 unit of the monthly BRAND_AUDIT_QUOTAS budget.",
+			'Enqueue an async brand audit across up to 50 target domains with optional standard/deep discovery depth, brand aliases, and caller-supplied candidate domains. Returns { auditId, queuedAt, targetCount, etaSeconds } immediately; poll with brand_audit_status and fetch results with brand_audit_get_report once complete. Each target consumes 1 unit of the monthly BRAND_AUDIT_QUOTAS budget.',
 		schema: BrandAuditBatchStartArgs,
 		group: 'discovery',
 		scanIncluded: false,
@@ -476,14 +524,14 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	brand_audit_get_report: {
 		description:
-			"Fetch the result JSON for a completed brand audit. With `target` set, returns the per-target CheckResult; without, returns the audit-level aggregate. Returns notReady when polling against an in-flight audit. Phase 3 will add R2 signed-URL PDF retrieval; this v2.19.0 version returns inline JSON only.",
+			'Fetch the result JSON for a completed brand audit. With `target` set, returns the per-target CheckResult; without, returns the audit-level aggregate. Returns notReady when polling against an in-flight audit. Phase 3 will add R2 signed-URL PDF retrieval; this v2.19.0 version returns inline JSON only.',
 		schema: BrandAuditGetReportArgs,
 		group: 'discovery',
 		scanIncluded: false,
 	},
 	brand_audit_watch: {
 		description:
-			"Register, list, or delete recurring brand-audit watches. Watches run on a daily/weekly/monthly cadence via the scheduled cron tick — each run enqueues a fresh brand_audit_batch_start and (when configured) POSTs a diff webhook on classification drift. Owner-scoped; per-principal cap of 20 active watches. Phase 4 (v2.21.0+).",
+			'Register, list, or delete recurring brand-audit watches. Watches run on a daily/weekly/monthly cadence via the scheduled cron tick — each run enqueues a fresh brand_audit_batch_start and (when configured) POSTs a diff webhook on classification drift. Owner-scoped; per-principal cap of 20 active watches. Phase 4 (v2.21.0+).',
 		schema: BrandAuditWatchArgs,
 		group: 'discovery',
 		scanIncluded: false,

--- a/test/audits/readme-tool-surface.audit.test.ts
+++ b/test/audits/readme-tool-surface.audit.test.ts
@@ -12,7 +12,7 @@ describe('README tool surface', () => {
 	it('keeps published tool counts and authoritative DNS infra tools current', () => {
 		const toolCount = TOOLS.length;
 
-		expect(toolCount).toBe(59);
+		expect(toolCount).toBe(60);
 		expect(readme).toContain(`MCP%20tools-${toolCount}`);
 		expect(readme).toContain(`current ${toolCount}-tool surface`);
 		expect(readme).toContain(`${toolCount} MCP tools`);
@@ -22,7 +22,7 @@ describe('README tool surface', () => {
 	});
 
 	it('keeps supporting docs aligned with the authoritative DNS infra surface', () => {
-		expect(githubSettings).toContain('59 MCP tools');
+		expect(githubSettings).toContain('60 MCP tools');
 		expect(scoringDocs).toContain('Authoritative DNS Infrastructure');
 		expect(scoringDocs).toContain('authoritative_dns_infra');
 		expect(packageReadme).toContain('authoritative_dns_infra');

--- a/test/chaos/varied-domain-all-tools.chaos.test.ts
+++ b/test/chaos/varied-domain-all-tools.chaos.test.ts
@@ -52,16 +52,18 @@ function apex(domain: string): string {
 }
 
 function textResponse(body: string, status = 200, headers?: Headers): Response {
-	const responseHeaders = headers ?? new Headers({
-		'content-security-policy': "default-src 'self'",
-		'cross-origin-opener-policy': 'same-origin',
-		'cross-origin-resource-policy': 'same-origin',
-		'permissions-policy': 'geolocation=()',
-		'referrer-policy': 'no-referrer',
-		'strict-transport-security': 'max-age=31536000; includeSubDomains',
-		'x-content-type-options': 'nosniff',
-		'x-frame-options': 'DENY',
-	});
+	const responseHeaders =
+		headers ??
+		new Headers({
+			'content-security-policy': "default-src 'self'",
+			'cross-origin-opener-policy': 'same-origin',
+			'cross-origin-resource-policy': 'same-origin',
+			'permissions-policy': 'geolocation=()',
+			'referrer-policy': 'no-referrer',
+			'strict-transport-security': 'max-age=31536000; includeSubDomains',
+			'x-content-type-options': 'nosniff',
+			'x-frame-options': 'DENY',
+		});
 	return {
 		ok: status >= 200 && status < 300,
 		status,
@@ -138,11 +140,20 @@ function dohAnswers(name: string, type: string): Array<{ name: string; type: num
 	}
 	if (type === 'A') {
 		if (
-			/\.(dbl\.spamhaus\.org|multi\.uribl\.com|multi\.surbl\.org|zen\.spamhaus\.org|bl\.spamcop\.net|uceprotect\.net|mailspike\.net|b\.barracudacentral\.org|psbl\.surriel\.com|dnsbl\.sorbs\.net)$/.test(normalized)
+			/\.(dbl\.spamhaus\.org|multi\.uribl\.com|multi\.surbl\.org|zen\.spamhaus\.org|bl\.spamcop\.net|uceprotect\.net|mailspike\.net|b\.barracudacentral\.org|psbl\.surriel\.com|dnsbl\.sorbs\.net)$/.test(
+				normalized,
+			)
 		) {
 			return [];
 		}
-		return [{ name, type: recordType, TTL: normalized.includes('flux') ? 30 : 300, data: normalized.startsWith('mx1.') ? '198.51.100.25' : '192.0.2.10' }];
+		return [
+			{
+				name,
+				type: recordType,
+				TTL: normalized.includes('flux') ? 30 : 300,
+				data: normalized.startsWith('mx1.') ? '198.51.100.25' : '192.0.2.10',
+			},
+		];
 	}
 	if (type === 'AAAA') {
 		return [];
@@ -258,7 +269,7 @@ function makeCertstreamBinding(): { fetch: typeof fetch } {
 function makeWhoisBinding(): { fetch: typeof fetch } {
 	return {
 		fetch: vi.fn(async (input: string | URL | Request, init?: RequestInit) => {
-			const body = typeof init?.body === 'string' ? JSON.parse(init.body) as { domain?: string } : {};
+			const body = typeof init?.body === 'string' ? (JSON.parse(init.body) as { domain?: string }) : {};
 			const registrar = body.domain?.includes('brand') ? 'MarkMonitor Inc.' : 'Example Registrar LLC';
 			return jsonResponse({ registrar, source: 'whois' });
 		}) as unknown as typeof fetch,
@@ -298,7 +309,10 @@ function makeToolCases(): ToolCase[] {
 		{ name: 'scan_domain', arguments: { domain: nextDomain(), profile: 'auto', force_refresh: true, format: 'full' } },
 		{ name: 'batch_scan', arguments: { domains: baseDomains.slice(0, 4), force_refresh: true, format: 'compact' } },
 		{ name: 'compare_domains', arguments: { domains: baseDomains.slice(1, 4), format: 'compact' } },
-		{ name: 'compare_baseline', arguments: { domain: nextDomain(), baseline: { grade: 'B', require_spf: true, max_high_findings: 3 }, format: 'compact' } },
+		{
+			name: 'compare_baseline',
+			arguments: { domain: nextDomain(), baseline: { grade: 'B', require_spf: true, max_high_findings: 3 }, format: 'compact' },
+		},
 		{ name: 'check_shadow_domains', arguments: domainArgs() },
 		{ name: 'check_txt_hygiene', arguments: domainArgs() },
 		{ name: 'check_mx_reputation', arguments: domainArgs() },
@@ -306,7 +320,10 @@ function makeToolCases(): ToolCase[] {
 		{ name: 'check_zone_hygiene', arguments: domainArgs() },
 		{ name: 'generate_fix_plan', arguments: domainArgs() },
 		{ name: 'generate_spf_record', arguments: { domain: nextDomain(), include_providers: ['google'], format: 'compact' } },
-		{ name: 'generate_dmarc_record', arguments: { domain: nextDomain(), policy: 'reject', rua_email: 'dmarc@example.com', format: 'compact' } },
+		{
+			name: 'generate_dmarc_record',
+			arguments: { domain: nextDomain(), policy: 'reject', rua_email: 'dmarc@example.com', format: 'compact' },
+		},
 		{ name: 'generate_dkim_config', arguments: { domain: nextDomain(), provider: 'google', format: 'compact' } },
 		{ name: 'generate_mta_sts_policy', arguments: { domain: nextDomain(), mx_hosts: ['mx1.example.com'], format: 'compact' } },
 		{ name: 'get_benchmark', arguments: { profile: 'mail_enabled', format: 'compact' } },
@@ -317,7 +334,10 @@ function makeToolCases(): ToolCase[] {
 		{ name: 'map_supply_chain', arguments: domainArgs() },
 		{ name: 'analyze_drift', arguments: { domain: nextDomain(), baseline: baselineScore, format: 'compact' } },
 		{ name: 'validate_fix', arguments: { domain: nextDomain(), check: 'dmarc', expected: 'v=DMARC1', format: 'compact' } },
-		{ name: 'generate_rollout_plan', arguments: { domain: nextDomain(), target_policy: 'reject', timeline: 'standard', format: 'compact' } },
+		{
+			name: 'generate_rollout_plan',
+			arguments: { domain: nextDomain(), target_policy: 'reject', timeline: 'standard', format: 'compact' },
+		},
 		{ name: 'resolve_spf_chain', arguments: domainArgs() },
 		{ name: 'discover_subdomains', arguments: domainArgs() },
 		{ name: 'map_compliance', arguments: domainArgs() },
@@ -329,6 +349,7 @@ function makeToolCases(): ToolCase[] {
 		{ name: 'check_nsec_walkability', arguments: domainArgs() },
 		{ name: 'check_dnssec_chain', arguments: domainArgs() },
 		{ name: 'check_fast_flux', arguments: { domain: nextDomain(), rounds: 3, format: 'compact' } },
+		{ name: 'check_subdomain_takeover', arguments: { domain: nextDomain(), format: 'compact' } },
 		{ name: 'check_authoritative_dns_infra', arguments: domainArgs() },
 		{ name: 'check_root_server_set', arguments: { format: 'compact' } },
 		{
@@ -343,7 +364,10 @@ function makeToolCases(): ToolCase[] {
 			},
 		},
 		{ name: 'brand_audit_single', arguments: { domain: 'brand-example.net', format: 'json', min_confidence: 1 } },
-		{ name: 'brand_audit_batch_start', arguments: { domains: ['brand-example.net', 'secure.example.com'], format: 'json', min_confidence: 0.9 } },
+		{
+			name: 'brand_audit_batch_start',
+			arguments: { domains: ['brand-example.net', 'secure.example.com'], format: 'json', min_confidence: 0.9 },
+		},
 		{ name: 'brand_audit_status', arguments: { auditId: 'chaos-audit-1' } },
 		{ name: 'brand_audit_get_report', arguments: { auditId: 'chaos-audit-1', target: 'brand-example.net' } },
 		{ name: 'brand_audit_watch', arguments: { action: 'list' } },
@@ -354,7 +378,7 @@ function structuredPayload(result: ToolResult): Record<string, unknown> | null {
 	const block = result.content.find((entry) => entry.type === 'text' && 'text' in entry && entry.text.includes('STRUCTURED_RESULT'));
 	if (!block || !('text' in block)) return null;
 	const match = block.text.match(/<!-- STRUCTURED_RESULT\n(.*)\nSTRUCTURED_RESULT -->/s);
-	return match ? JSON.parse(match[1]) as Record<string, unknown> : null;
+	return match ? (JSON.parse(match[1]) as Record<string, unknown>) : null;
 }
 
 describe('chaos: varied-domain all-tools scanning', () => {
@@ -371,7 +395,9 @@ describe('chaos: varied-domain all-tools scanning', () => {
 
 	it('keeps the all-tools chaos matrix in lockstep with the registry', () => {
 		const registryNames = TOOLS.map((tool) => tool.name).sort();
-		const caseNames = makeToolCases().map((entry) => entry.name).sort();
+		const caseNames = makeToolCases()
+			.map((entry) => entry.name)
+			.sort();
 		expect(caseNames).toEqual(registryNames);
 	});
 
@@ -405,9 +431,12 @@ describe('chaos: varied-domain all-tools scanning', () => {
 		expect(scanPayload?.domain).toBe(scanCase.arguments.domain);
 
 		const statuses = scanPayload?.checkStatuses as Record<string, string>;
-		const expectedScanCategories = TOOLS
-			.filter((tool) => tool.scanIncluded)
-			.map((tool) => tool.name.replace(/^check_/, '').replace(/^cymru_asn$/, 'asn').replace(/^rdap_lookup$/, 'rdap'));
+		const expectedScanCategories = TOOLS.filter((tool) => tool.scanIncluded).map((tool) =>
+			tool.name
+				.replace(/^check_/, '')
+				.replace(/^cymru_asn$/, 'asn')
+				.replace(/^rdap_lookup$/, 'rdap'),
+		);
 		for (const category of expectedScanCategories) {
 			expect(statuses).toHaveProperty(category);
 		}

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -527,7 +527,7 @@ describe('handleToolsList', () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(59);
+		expect(result.tools).toHaveLength(60);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -353,7 +353,7 @@ describe('DNS Security MCP Server', () => {
 			const response = await worker.fetch(request, env, ctx);
 			await waitOnExecutionContext(ctx);
 			const body = (await response.json()) as { result: { tools: Array<{ name: string }> } };
-			expect(body.result.tools).toHaveLength(59);
+			expect(body.result.tools).toHaveLength(60);
 			const toolNames = body.result.tools.map((t) => t.name);
 			expect(toolNames).toContain('check_spf');
 			expect(toolNames).toContain('check_dmarc');

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -155,7 +155,7 @@ describe('GetProviderInsightsArgs', () => {
 
 describe('TOOL_SCHEMA_MAP', () => {
 	it('has 59 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(59);
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(60);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -3,7 +3,7 @@ import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
 	it('has 59 tools', () => {
-		expect(TOOLS).toHaveLength(59);
+		expect(TOOLS).toHaveLength(60);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/tool-metadata.spec.ts
+++ b/test/tool-metadata.spec.ts
@@ -20,6 +20,6 @@ describe('tool metadata', () => {
 	});
 
 	it('has exactly 59 tools', () => {
-		expect(TOOLS).toHaveLength(59);
+		expect(TOOLS).toHaveLength(60);
 	});
 });

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -10,27 +10,70 @@ import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../src/handlers/tool-schemas';
 import type { ToolGroup, ToolTier } from '../src/handlers/tool-schemas';
 
-const VALID_GROUPS: ToolGroup[] = ['email_auth', 'infrastructure', 'brand_threats', 'dns_hygiene', 'intelligence', 'remediation', 'meta', 'discovery'];
+const VALID_GROUPS: ToolGroup[] = [
+	'email_auth',
+	'infrastructure',
+	'brand_threats',
+	'dns_hygiene',
+	'intelligence',
+	'remediation',
+	'meta',
+	'discovery',
+];
 const VALID_TIERS: ToolTier[] = ['core', 'protective', 'hardening'];
 
 /** Tools included in scan_domain parallel orchestration (excludes check_subdomain_takeover which is internal). */
 const SCAN_DOMAIN_TOOL_NAMES = new Set([
-	'check_spf', 'check_dmarc', 'check_dkim', 'check_dnssec', 'check_ssl',
-	'check_mta_sts', 'check_ns', 'check_caa', 'check_bimi', 'check_tlsrpt',
-	'check_http_security', 'check_dane', 'check_dane_https', 'check_svcb_https', 'check_mx',
+	'check_spf',
+	'check_dmarc',
+	'check_dkim',
+	'check_dnssec',
+	'check_ssl',
+	'check_mta_sts',
+	'check_ns',
+	'check_caa',
+	'check_bimi',
+	'check_tlsrpt',
+	'check_http_security',
+	'check_dane',
+	'check_dane_https',
+	'check_svcb_https',
+	'check_mx',
 	'check_subdomailing',
 ]);
 
 /** Tools that are standalone-only or non-scoring orchestration/meta tools. */
 const NON_SCAN_TOOL_NAMES = new Set([
-	'check_lookalikes', 'check_shadow_domains', 'check_txt_hygiene',
-	'check_mx_reputation', 'check_srv', 'check_zone_hygiene', 'check_resolver_consistency',
-	'check_authoritative_dns_infra', 'check_root_server_set',
-	'scan_domain', 'batch_scan', 'compare_domains', 'compare_baseline', 'generate_fix_plan', 'generate_spf_record',
-	'generate_dmarc_record', 'generate_dkim_config', 'generate_mta_sts_policy',
-	'get_benchmark', 'get_provider_insights', 'assess_spoofability', 'explain_finding',
-	'map_supply_chain', 'analyze_drift', 'validate_fix', 'generate_rollout_plan',
-	'resolve_spf_chain', 'discover_subdomains', 'map_compliance', 'simulate_attack_paths',
+	'check_lookalikes',
+	'check_shadow_domains',
+	'check_txt_hygiene',
+	'check_mx_reputation',
+	'check_srv',
+	'check_zone_hygiene',
+	'check_resolver_consistency',
+	'check_authoritative_dns_infra',
+	'check_root_server_set',
+	'scan_domain',
+	'batch_scan',
+	'compare_domains',
+	'compare_baseline',
+	'generate_fix_plan',
+	'generate_spf_record',
+	'generate_dmarc_record',
+	'generate_dkim_config',
+	'generate_mta_sts_policy',
+	'get_benchmark',
+	'get_provider_insights',
+	'assess_spoofability',
+	'explain_finding',
+	'map_supply_chain',
+	'analyze_drift',
+	'validate_fix',
+	'generate_rollout_plan',
+	'resolve_spf_chain',
+	'discover_subdomains',
+	'map_compliance',
+	'simulate_attack_paths',
 	'check_dbl',
 	'check_rbl',
 	'cymru_asn',
@@ -38,6 +81,7 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'check_nsec_walkability',
 	'check_dnssec_chain',
 	'check_fast_flux',
+	'check_subdomain_takeover',
 	'discover_brand_domains',
 	'brand_audit_single',
 	'brand_audit_batch_start',
@@ -48,7 +92,7 @@ const NON_SCAN_TOOL_NAMES = new Set([
 
 describe('tool-schemas metadata', () => {
 	it('exports exactly 59 tools', () => {
-		expect(TOOLS).toHaveLength(59);
+		expect(TOOLS).toHaveLength(60);
 	});
 
 	it('all tool names are unique', () => {
@@ -93,7 +137,9 @@ describe('tool-schemas metadata', () => {
 	});
 
 	it('all scoring check tools have a tier (except check_resolver_consistency)', () => {
-		const checkTools = TOOLS.filter((t) => t.name.startsWith('check_') && t.name !== 'check_resolver_consistency' && t.group !== 'intelligence');
+		const checkTools = TOOLS.filter(
+			(t) => t.name.startsWith('check_') && t.name !== 'check_resolver_consistency' && t.group !== 'intelligence',
+		);
 		for (const tool of checkTools) {
 			expect(tool.tier, `${tool.name} is a scoring check but is missing a tier`).toBeDefined();
 		}


### PR DESCRIPTION
## Summary

Tool count 59 → 60. Lifts the "runs only inside `scan_domain`" constraint so external callers can pass a CT-enumerated subdomain list and get full-inventory takeover findings — the natural pairing with `discover_subdomains` and the brand-audit pipeline.

### Schema

```ts
{
  domain: string (required, validated),
  subdomains?: string[] (max 1000, full FQDNs or short labels — deduped server-side),
  format?: 'full' | 'compact',
}
```

When `subdomains` is provided, the cache key uses a distinct prefix so caller-supplied sweeps don't collide with the default `KNOWN_SUBDOMAINS` sweeps.

### Usage pattern

```
1. discover_subdomains  -> CT enumeration (e.g., 436 OpenAI subdomains)
2. check_subdomain_takeover { domain, subdomains: [<from step 1>] }
3. -> Full-inventory dangling-CNAME + provider-deprovisioned findings
```

This is the pattern that surfaces the remaining partner-deck findings the previous `KNOWN_SUBDOMAINS`-only path missed:
- `slack.openai.com`, `arena.openai.com`, `onboard.openai.com` (DNS-NXDOMAIN, not in default list)
- 9 dangling subdomains under `models.x.ai` (deleted AWS NLB cluster)

PR #180 already deployed the expanded 16-provider fingerprint dictionary; `cdn.openai.com` (Azure Front Door `ResourceNotFound`) and `blog.openai.com` (CloudFront NXDOMAIN) are already being caught via the default-15 path.

## Test plan

- [x] 213 affected tests pass (16 spec files including takeover, tool-metadata, tool-schemas, tool-args, tool-definitions)
- [x] 144 additional tests in `index.spec.ts` + `handlers-tools.spec.ts` pass (tool-count bumps 59 → 60)
- [x] `tsc --noEmit` clean
- [x] Post-merge chaos test: invoke `check_subdomain_takeover` with `{ domain: 'x.ai', subdomains: [<9 dangling models.x.ai entries>] }` against the deployed worker — should surface all 9 dangling CNAMEs

🤖 Generated with [Claude Code](https://claude.com/claude-code)