### PR TITLE
feat(takeover): downgrade random-ID targets to MEDIUM (severity-by-claimability)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,6 +81,7 @@ Both publish together from `publish.yml` on version tags.
 **Timeouts**: scan 12s preserves partial results; per-check 8s.
 
 **Post-processing**:
+
 - Non-mail (no MX): parent DMARC `sp=`/`p=` → downgrade email-auth findings to `info`
 - No-send (SPF `noSendPolicy`): downgrade DKIM/MTA-STS/BIMI missing-record findings to `info`
 - BIMI rewritten for non-mail domains
@@ -111,6 +112,7 @@ Both publish together from `publish.yml` on version tags.
 ### Error surfacing
 
 `sanitizeErrorMessage()` in `lib/json-rpc.ts` allowlists prefixes:
+
 - `'Missing required'`, `'Invalid'`, `'Domain '`, `'Resource not found'`, `'Rate limit exceeded'`
 
 Anything else → generic fallback. New client-visible errors must start with one of these. Rate limit: HTTP 200 + JSON-RPC `code: -32029` (MCP spec) — not 429. `retry-after` header still set.
@@ -161,11 +163,11 @@ Idle TTL 2h, sliding refresh, KV + in-memory dual-write. Missing → 400; expire
 
 bv-web plan → OAuth tier claim → bv-mcp limits:
 
-| Plan | Tier | Scans/day | Concurrent | Support |
-|---|---|---|---|---|
-| free / starter | (none) | 50 | 3 | Community |
-| pro / business / MCP Developer | developer | 500 | 10 | Business / 48h |
-| enterprise / MCP Enterprise | enterprise | 10,000 | 25 | Enterprise / 4h |
+| Plan                           | Tier       | Scans/day | Concurrent | Support         |
+| ------------------------------ | ---------- | --------- | ---------- | --------------- |
+| free / starter                 | (none)     | 50        | 3          | Community       |
+| pro / business / MCP Developer | developer  | 500       | 10         | Business / 48h  |
+| enterprise / MCP Enterprise    | enterprise | 10,000    | 25         | Enterprise / 4h |
 
 Resolution in `src/oauth/entitlements.ts` via bv-web service binding `api/internal/mcp/oauth/authorize`. Mapping defined in bv-web `app/lib/services/mcp/oauth-entitlements.server.ts`. Static API keys never resolve `developer`/`enterprise` from OAuth — they map to `agent` (500/day, 5 concurrent).
 
@@ -174,6 +176,7 @@ Resolution in `src/oauth/entitlements.ts` via bv-web service binding `api/intern
 `/internal/*` guarded by `cf-connecting-ip` presence (`isPublicInternetRequest()` in `src/internal.ts`). Public requests → 404. Batch endpoint: tool names `/^[a-z_]+$/` max 30 chars, arg keys allowlisted. `/internal/tools/call` enforces 10 KB body limit pre-parse.
 
 **Bearer auth (defense-in-depth)**:
+
 - `/internal/trial-keys/*`, `/internal/oauth/grants` (credential-minting) → strict gate: 503 if `BV_WEB_INTERNAL_KEY` unset, 401 on missing/wrong bearer.
 - `/internal/tools/*`, `/internal/analytics/*` → `internalLenientAuthGate`, opt-in via `REQUIRE_INTERNAL_AUTH=true`.
 
@@ -267,10 +270,10 @@ ignored env only; never commit it or paste it into workflow logs.
 
 `/internal/tools/call` accepts `{ name, arguments }` → `{ content, isError? }`. `/internal/tools/batch` runs one tool across many domains (max 500, concurrency 1–50, 256 KB body). `?format=structured` returns raw `CheckResult` per domain.
 
-| Layer | Public `/mcp` | Internal `/internal/*` |
-|---|:---:|:---:|
-| CORS, Origin, Auth, Rate limiting, Sessions, JSON-RPC, Body limit | ✓ | — |
-| Tool execution, Caching, Analytics, SSRF | ✓ | ✓ |
+| Layer                                                             | Public `/mcp` | Internal `/internal/*` |
+| ----------------------------------------------------------------- | :-----------: | :--------------------: |
+| CORS, Origin, Auth, Rate limiting, Sessions, JSON-RPC, Body limit |       ✓       |           —            |
+| Tool execution, Caching, Analytics, SSRF                          |       ✓       |           ✓            |
 
 ## Deployment
 
@@ -282,36 +285,37 @@ ignored env only; never commit it or paste it into workflow logs.
 
 ## Bindings
 
-| Binding | Type | Purpose |
-|---|---|---|
-| `BV_API_KEY` | Secret | Static bearer auth → `owner` tier |
-| `ENABLE_OAUTH` | var | `true` to expose OAuth routes |
-| `ENABLE_OWNER_OAUTH` | var | Owner consent page (operator deploys only) |
-| `OWNER_ALLOW_IPS` | var | IPs allowed for `owner`; mismatch → `partner` |
-| `OAUTH_SIGNING_SECRET` | Secret | HS256 ≥32 bytes. Required when `ENABLE_OAUTH=true` (`oauthAvailability` gate returns 503 until set) |
-| `OAUTH_ISSUER` | var | Optional override; falls back to Host (set in prod against Host spoofing) |
-| `ALLOWED_ORIGINS` | var | Allowed Origins (CSV) |
-| `RATE_LIMIT` / `SCAN_CACHE` / `SESSION_STORE` | KV | Required in prod |
-| `QUOTA_COORDINATOR` | DO | Distributed rate limiting |
-| `PROFILE_ACCUMULATOR` | DO | Adaptive weights (optional) |
-| `MCP_ANALYTICS` | Analytics Engine | Telemetry (fail-open) |
-| `PROVIDER_SIGNATURES_URL` | var | Provider signatures source |
-| `BV_DOH_ENDPOINT` / `BV_DOH_TOKEN` | var / Secret | Custom secondary DoH (`X-BV-Token`) |
-| `BV_CERTSTREAM` | Service | CT logs: `/enumerate` (discover_subdomains, scan) + `/sans` (brand SAN siblings). Direct-crt.sh fallback w/ jittered backoff |
-| `BV_WHOIS` | Service | WHOIS/43 shim; optional, RDAP-only fallback. KV-cached IANA referrals |
-| `BV_INFRA_GRAPH` | Service | **Operator-deploy only.** Tier-1 infrastructure-graph lookup for `discovery_mode='tiered'`. Not packaged with the public distribution — wired via `.dev/wrangler.deploy.jsonc`. Absent → tiered pipeline falls back to classic sweep |
-| `BV_INTEL_GATEWAY` | Service | **Operator-deploy only.** Tier-2 declared-evidence lookups for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc` |
-| `BV_ENTERPRISE` | Service | **Operator-deploy only.** Tier-0 portfolio + enterprise tenant data for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc` |
-| `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT` | var | **Operator-deploy only.** When set to `"tiered"` (the BlackVeil-production default), flips the runtime default for callers that omit `discovery_mode`. Unset on BSL self-hosts → public schema default `'classic'` wins. Set only in `.dev/wrangler.deploy.jsonc` |
-| `SCORING_CONFIG` | var | JSON scoring overrides |
-| `CF_ACCOUNT_ID` / `CF_ANALYTICS_TOKEN` | var / Secret | Alerting query auth |
-| `ALERT_WEBHOOK_URL` / `ALERT_*_THRESHOLD` / `ALERT_LOOKBACK_MINUTES` | var | Cron alerts |
+| Binding                                                              | Type             | Purpose                                                                                                                                                                                                                                                           |
+| -------------------------------------------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `BV_API_KEY`                                                         | Secret           | Static bearer auth → `owner` tier                                                                                                                                                                                                                                 |
+| `ENABLE_OAUTH`                                                       | var              | `true` to expose OAuth routes                                                                                                                                                                                                                                     |
+| `ENABLE_OWNER_OAUTH`                                                 | var              | Owner consent page (operator deploys only)                                                                                                                                                                                                                        |
+| `OWNER_ALLOW_IPS`                                                    | var              | IPs allowed for `owner`; mismatch → `partner`                                                                                                                                                                                                                     |
+| `OAUTH_SIGNING_SECRET`                                               | Secret           | HS256 ≥32 bytes. Required when `ENABLE_OAUTH=true` (`oauthAvailability` gate returns 503 until set)                                                                                                                                                               |
+| `OAUTH_ISSUER`                                                       | var              | Optional override; falls back to Host (set in prod against Host spoofing)                                                                                                                                                                                         |
+| `ALLOWED_ORIGINS`                                                    | var              | Allowed Origins (CSV)                                                                                                                                                                                                                                             |
+| `RATE_LIMIT` / `SCAN_CACHE` / `SESSION_STORE`                        | KV               | Required in prod                                                                                                                                                                                                                                                  |
+| `QUOTA_COORDINATOR`                                                  | DO               | Distributed rate limiting                                                                                                                                                                                                                                         |
+| `PROFILE_ACCUMULATOR`                                                | DO               | Adaptive weights (optional)                                                                                                                                                                                                                                       |
+| `MCP_ANALYTICS`                                                      | Analytics Engine | Telemetry (fail-open)                                                                                                                                                                                                                                             |
+| `PROVIDER_SIGNATURES_URL`                                            | var              | Provider signatures source                                                                                                                                                                                                                                        |
+| `BV_DOH_ENDPOINT` / `BV_DOH_TOKEN`                                   | var / Secret     | Custom secondary DoH (`X-BV-Token`)                                                                                                                                                                                                                               |
+| `BV_CERTSTREAM`                                                      | Service          | CT logs: `/enumerate` (discover_subdomains, scan) + `/sans` (brand SAN siblings). Direct-crt.sh fallback w/ jittered backoff                                                                                                                                      |
+| `BV_WHOIS`                                                           | Service          | WHOIS/43 shim; optional, RDAP-only fallback. KV-cached IANA referrals                                                                                                                                                                                             |
+| `BV_INFRA_GRAPH`                                                     | Service          | **Operator-deploy only.** Tier-1 infrastructure-graph lookup for `discovery_mode='tiered'`. Not packaged with the public distribution — wired via `.dev/wrangler.deploy.jsonc`. Absent → tiered pipeline falls back to classic sweep                              |
+| `BV_INTEL_GATEWAY`                                                   | Service          | **Operator-deploy only.** Tier-2 declared-evidence lookups for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc`                                                                                                               |
+| `BV_ENTERPRISE`                                                      | Service          | **Operator-deploy only.** Tier-0 portfolio + enterprise tenant data for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc`                                                                                                      |
+| `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT`                                 | var              | **Operator-deploy only.** When set to `"tiered"` (the BlackVeil-production default), flips the runtime default for callers that omit `discovery_mode`. Unset on BSL self-hosts → public schema default `'classic'` wins. Set only in `.dev/wrangler.deploy.jsonc` |
+| `SCORING_CONFIG`                                                     | var              | JSON scoring overrides                                                                                                                                                                                                                                            |
+| `CF_ACCOUNT_ID` / `CF_ANALYTICS_TOKEN`                               | var / Secret     | Alerting query auth                                                                                                                                                                                                                                               |
+| `ALERT_WEBHOOK_URL` / `ALERT_*_THRESHOLD` / `ALERT_LOOKBACK_MINUTES` | var              | Cron alerts                                                                                                                                                                                                                                                       |
 
 ## Analytics
 
 Four event types: `mcp_request`, `tool_call`, `rate_limit`, `session`. Queries in `analytics-queries.ts`. Scheduled handler (`scheduled.ts`) every 15 min: anomaly alerts + `handleFuzzingScan`. Optional — requires `CF_ACCOUNT_ID` + `CF_ANALYTICS_TOKEN` + `ALERT_WEBHOOK_URL`.
 
 **Blob layout** (keep in sync when adding dimensions):
+
 - `mcp_request`: method, transport, status, auth-flag, jsonrpc-flag, country, clientType, authTier, sessionHash, keyHash, **ipHash** (blob11; FNV-1a `i_` prefix — lossy, equal IPs hash equally)
 - `tool_call`: toolName, status, isError, domainFingerprint, country, clientType, authTier, cacheStatus, keyHash, **ipHash** (blob10)
 - `rate_limit`: limitType, toolName, country, authTier
@@ -329,3 +333,4 @@ Client detection (`client-detection.ts`): `claude_mobile`, `claude_code`, `curso
 - **Shadow Domains**: shared NS (≥2 overlap) → severity downgrade with ownership signal
 - **TXT Hygiene**: record accumulation tiered (25+ → medium, 15–24 → low); duplicate verifications consolidated
 - **Non-mail SPF** (`check_mx`): no MX → verifies `v=spf1 -all`; missing SPF → medium, non-reject → low
+- **Subdomain takeover severity**: dangling-CNAME findings whose target hostname embeds a provider-assigned random ID (AWS ELB ID, CloudFront distribution ID, API Gateway ID) downgrade from HIGH to MEDIUM — those represent operational drift rather than active takeover vectors because the namespace label can't be deterministically reclaimed. Implemented in `classifyTargetNamespace()` in `packages/dns-checks/src/checks/subdomain-takeover-analysis.ts`.

--- a/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
+++ b/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
@@ -218,6 +218,46 @@ export function isThirdPartyTakeoverService(cname: string): boolean {
 }
 
 /**
+ * Pattern → severity-impact classification for the CNAME target hostname.
+ *
+ * - `random`: the hostname embeds a provider-assigned ID (load-balancer ID,
+ *   CloudFront distribution ID, API Gateway ID). The namespace label is not
+ *   user-controlled and cannot be deterministically reclaimed by another
+ *   tenant; the dangling-CNAME finding represents operational drift, not an
+ *   active takeover vector.
+ * - `claimable`: the hostname is in a known takeover-prone service AND its
+ *   label is user-chosen (S3 buckets, AzureEdge endpoints, GitHub Pages
+ *   sites, Heroku apps, etc.). A new tenant CAN claim this namespace label
+ *   and serve content at the dangling subdomain.
+ * - `unknown`: pattern not in either bucket — caller should treat as the
+ *   conservative default (HIGH severity).
+ */
+export type TargetClaimability = 'random' | 'claimable' | 'unknown';
+
+const RANDOM_TARGET_PATTERNS: RegExp[] = [
+	// AWS ELB (classic + ALB + NLB): 32+ hex chars + dash + decimal random
+	/^[a-f0-9]{32,}-\d+\.[a-z0-9-]+\.elb\.amazonaws\.com$/i,
+	// CloudFront distribution ID: 12-14 lowercase alphanumeric, no dashes
+	/^[a-z0-9]{12,14}\.cloudfront\.net$/i,
+	// API Gateway ID: exactly 10 alphanumeric chars
+	/^[a-z0-9]{10}\.execute-api\.[a-z0-9-]+\.amazonaws\.com$/i,
+	// Azure Container Apps environment suffix:
+	// <name>.<env-name>-<hex>.<region>.azurecontainerapps.io
+	// The hex suffix on the env name is provider-assigned, even though the
+	// leading <name> isn't.
+	/^[a-z0-9-]+\.[a-z0-9-]+-[a-f0-9]{8}\.[a-z0-9-]+\.azurecontainerapps\.io$/i,
+];
+
+export function classifyTargetNamespace(cname: string): TargetClaimability {
+	const normalized = cname.replace(/\.$/, '').toLowerCase();
+	for (const re of RANDOM_TARGET_PATTERNS) {
+		if (re.test(normalized)) return 'random';
+	}
+	if (isThirdPartyTakeoverService(normalized)) return 'claimable';
+	return 'unknown';
+}
+
+/**
  * Probe an HTTP endpoint for known takeover fingerprints.
  * Returns the matched display-name for the deprovisioned service, or null.
  *

--- a/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
+++ b/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
@@ -322,13 +322,24 @@ export async function scanSubdomainForTakeover(
 			try {
 				const targetAddresses = await queryDNS(cname, 'A', { timeout });
 				if (targetAddresses.length === 0) {
+					const claimability = classifyTargetNamespace(cname);
+					const isRandom = claimability === 'random';
+					const severity: 'medium' | 'high' = isRandom ? 'medium' : 'high';
+					const severityRationale = isRandom ? 'random_target_id' : 'claimable_target_name';
+					const detail = isRandom
+						? `Subdomain ${fqdn} points to ${cname}, which does not resolve. The target hostname embeds a provider-assigned random ID (load-balancer / distribution / API-gateway ID), so it is unlikely to be reclaimable by another tenant — this is operational drift rather than an active takeover vector. Verify whether the upstream resource should be re-created or the DNS pointer removed.`
+						: `Subdomain ${fqdn} points to ${cname}, which does not resolve. This is a potential subdomain takeover vector and should be manually validated with authorized claim testing.`;
 					findings.push(
-						createTakeoverFinding(
-							`Dangling CNAME: ${fqdn} → ${cname}`,
-							'high',
-							`Subdomain ${fqdn} points to ${cname}, which does not resolve. This is a potential subdomain takeover vector and should be manually validated with authorized claim testing.`,
-							'potential',
-							['cname_target_unresolved'],
+						createFinding(
+							'subdomain_takeover',
+							isRandom ? `Dangling CNAME (operational drift): ${fqdn} → ${cname}` : `Dangling CNAME: ${fqdn} → ${cname}`,
+							severity,
+							detail,
+							{
+								verificationStatus: 'potential',
+								evidence: ['cname_target_unresolved'],
+								severityRationale,
+							},
 						),
 					);
 					continue;

--- a/test/subdomain-takeover-analysis.spec.ts
+++ b/test/subdomain-takeover-analysis.spec.ts
@@ -181,4 +181,51 @@ describe('subdomain-takeover-analysis', () => {
 			expect(c('some-random-cname.example.org')).toBe('unknown');
 		});
 	});
+
+	describe('severity refinement by target claimability', () => {
+		it('emits MEDIUM (not HIGH) when CNAME target is an AWS NLB random-ID', async () => {
+			const dns = makeDNS({
+				'models.example.com|CNAME': ['ab74714963781430da5c4d9a29a6ee3c-1355387950.us-east-1.elb.amazonaws.com.'],
+				'ab74714963781430da5c4d9a29a6ee3c-1355387950.us-east-1.elb.amazonaws.com|A': [],
+			});
+			const fetchFn = vi.fn();
+			const findings = await scanSubdomainForTakeover('example.com', 'models', dns, fetchFn);
+			expect(findings).toHaveLength(1);
+			expect(findings[0].severity).toBe('medium');
+			expect(findings[0].metadata?.verificationStatus).toBe('potential');
+			expect(findings[0].metadata?.severityRationale).toBe('random_target_id');
+			expect(findings[0].detail).toContain('operational drift');
+		});
+
+		it('emits MEDIUM when CNAME target is a CloudFront distribution ID', async () => {
+			const dns = makeDNS({
+				'blog.example.com|CNAME': ['d2b532lzynlqb7.cloudfront.net.'],
+				'd2b532lzynlqb7.cloudfront.net|A': [],
+			});
+			const findings = await scanSubdomainForTakeover('example.com', 'blog', dns, vi.fn());
+			expect(findings[0].severity).toBe('medium');
+			expect(findings[0].metadata?.severityRationale).toBe('random_target_id');
+		});
+
+		it('keeps HIGH when CNAME target is a user-chosen S3 bucket name', async () => {
+			const dns = makeDNS({
+				'assets.example.com|CNAME': ['my-company-assets.s3.amazonaws.com.'],
+				'my-company-assets.s3.amazonaws.com|A': [],
+			});
+			const findings = await scanSubdomainForTakeover('example.com', 'assets', dns, vi.fn());
+			expect(findings[0].severity).toBe('high');
+			expect(findings[0].metadata?.severityRationale).toBe('claimable_target_name');
+		});
+
+		it('keeps HIGH (conservative default) when target namespace is unknown', async () => {
+			const dns = makeDNS({
+				'preview.example.com|CNAME': ['cname.vercel-dns.com.'],
+				'cname.vercel-dns.com|A': [],
+			});
+			const findings = await scanSubdomainForTakeover('example.com', 'preview', dns, vi.fn());
+			// vercel-dns.com IS in the takeover-services list → claimable
+			expect(findings[0].severity).toBe('high');
+			expect(findings[0].metadata?.severityRationale).toBe('claimable_target_name');
+		});
+	});
 });

--- a/test/subdomain-takeover-analysis.spec.ts
+++ b/test/subdomain-takeover-analysis.spec.ts
@@ -228,4 +228,36 @@ describe('subdomain-takeover-analysis', () => {
 			expect(findings[0].metadata?.severityRationale).toBe('claimable_target_name');
 		});
 	});
+
+	describe('x.ai models cluster regression (TDD plan 2026-05-23)', () => {
+		it('the 9 dangling models.x.ai subdomains all classify as MEDIUM operational drift', async () => {
+			const NLB = 'ab74714963781430da5c4d9a29a6ee3c-1355387950.us-east-1.elb.amazonaws.com';
+			// Full FQDNs — scanSubdomainForTakeover treats any dot-containing
+			// `subdomain` arg as a full FQDN (CT-enumeration call shape).
+			const subdomains = [
+				'aurora-sglang.us-east-1.models.x.ai',
+				'aurora-upsampler-sglang.us-east-1.models.x.ai',
+				'enterprise-api-grok-2-1212.us-east-1.models.x.ai',
+				'grok-3-5-code-0625.us-east-1.models.x.ai',
+				'grok-4-code-0630.us-east-1.models.x.ai',
+				'embedding-10m-0806-enterprise.us-east-1.models.x.ai',
+				'fte5-embedding-0806-api.us-east-1.models.x.ai',
+				'fte5-v2-fast-embedding-0806-api.us-east-1.models.x.ai',
+				'fte5-embedding-250707-api.us-east-1.models.x.ai',
+			];
+			const dnsMap: Record<string, string[]> = { [`${NLB}|A`]: [] };
+			for (const s of subdomains) {
+				dnsMap[`${s}|CNAME`] = [`${NLB}.`];
+			}
+			const dns = makeDNS(dnsMap);
+
+			const findings = (await Promise.all(subdomains.map((s) => scanSubdomainForTakeover('x.ai', s, dns, vi.fn())))).flat();
+
+			expect(findings).toHaveLength(9);
+			for (const f of findings) {
+				expect(f.severity).toBe('medium');
+				expect(f.metadata?.severityRationale).toBe('random_target_id');
+			}
+		});
+	});
 });

--- a/test/subdomain-takeover-analysis.spec.ts
+++ b/test/subdomain-takeover-analysis.spec.ts
@@ -126,4 +126,59 @@ describe('subdomain-takeover-analysis', () => {
 			expect(result).toBeNull();
 		});
 	});
+
+	describe('classifyTargetNamespace', () => {
+		async function fn() {
+			const m = await import('../packages/dns-checks/src/checks/subdomain-takeover-analysis');
+			return m.classifyTargetNamespace;
+		}
+
+		it('classifies AWS NLB/ALB random-ID targets as "random"', async () => {
+			const c = await fn();
+			expect(c('ab74714963781430da5c4d9a29a6ee3c-1355387950.us-east-1.elb.amazonaws.com')).toBe('random');
+			expect(c('a1234567890abcdef0123456789abcdef-0987654321.eu-west-1.elb.amazonaws.com')).toBe('random');
+		});
+
+		it('classifies CloudFront distribution IDs as "random"', async () => {
+			const c = await fn();
+			expect(c('d2b532lzynlqb7.cloudfront.net')).toBe('random');
+			expect(c('e1abc23def45gh.cloudfront.net')).toBe('random');
+		});
+
+		it('classifies API Gateway IDs as "random"', async () => {
+			const c = await fn();
+			expect(c('a1b2c3d4e5.execute-api.us-east-1.amazonaws.com')).toBe('random');
+		});
+
+		it('classifies Azure Container Apps random-environment IDs as "random"', async () => {
+			const c = await fn();
+			expect(c('chatgpt-slack.jollybeach-2c1b6a13.centralus.azurecontainerapps.io')).toBe('random');
+		});
+
+		it('classifies user-chosen S3 bucket names as "claimable"', async () => {
+			const c = await fn();
+			expect(c('my-company-assets.s3.amazonaws.com')).toBe('claimable');
+			expect(c('staging-bucket.s3.us-east-1.amazonaws.com')).toBe('claimable');
+		});
+
+		it('classifies user-chosen Azure endpoint names as "claimable"', async () => {
+			const c = await fn();
+			expect(c('openaiassets.afd.azureedge.net')).toBe('claimable');
+			expect(c('mystorage.blob.core.windows.net')).toBe('claimable');
+			expect(c('myapp.azurewebsites.net')).toBe('claimable');
+		});
+
+		it('classifies GitHub Pages / Heroku / Vercel as "claimable"', async () => {
+			const c = await fn();
+			expect(c('my-repo.github.io')).toBe('claimable');
+			expect(c('my-app.herokuapp.com')).toBe('claimable');
+			expect(c('preview-abc.vercel.app')).toBe('claimable');
+		});
+
+		it('returns "unknown" for non-takeover-service targets', async () => {
+			const c = await fn();
+			expect(c('lb.internal.example.com')).toBe('unknown');
+			expect(c('some-random-cname.example.org')).toBe('unknown');
+		});
+	});
 });


### PR DESCRIPTION
## Summary

Refines subdomain-takeover severity classification so HIGH is reserved for dangling CNAMEs whose target hostname has a **user-claimable namespace label** (S3 buckets, AzureEdge endpoints, GitHub Pages, Heroku apps, etc.). Targets whose hostname embeds a **provider-assigned random ID** (AWS NLB/ALB ID, CloudFront distribution ID, API Gateway ID, Azure Container Apps env suffix) downgrade to MEDIUM with the framing "operational drift, not active takeover vector" — the search space is too large for an attacker to deterministically claim the same ID.

Verified-fingerprint findings (CRITICAL) and CNAME-resolution-error findings (HIGH) are unchanged. Unknown target patterns keep HIGH (conservative default).

## Commits

1. **`feat(dns-checks): add classifyTargetNamespace for severity refinement`** — new pure classifier in `packages/dns-checks/src/checks/subdomain-takeover-analysis.ts`. Pattern-matches AWS ELB IDs, CloudFront distribution IDs, API Gateway IDs, and Azure Container Apps env hex suffixes as `'random'`; falls back to `isThirdPartyTakeoverService()` for `'claimable'`; else `'unknown'`. 8 new unit tests.
2. **`feat(takeover): downgrade dangling-CNAME to MEDIUM when target ID is randomized`** — `scanSubdomainForTakeover` consults the classifier in the `targetAddresses.length === 0` branch. Emits MEDIUM + `severityRationale: 'random_target_id'` + "operational drift" detail for random targets; HIGH + `severityRationale: 'claimable_target_name'` otherwise. 4 new integration tests.
3. **`test(takeover): pin x.ai models.x.ai cluster as 9 MEDIUM findings`** — regression test for the deck case study: all 9 dangling subdomains under `models.x.ai` pointing at the same AWS NLB now classify as 9 × MEDIUM (was 9 × HIGH).
4. **`docs(claude.md): document takeover severity-by-claimability rule`** — adds a False Positive Reduction bullet pointing at `classifyTargetNamespace()`.

## Test plan

- [x] `npm run typecheck` clean
- [x] `npx vitest run test/subdomain-takeover-analysis.spec.ts test/check-subdomain-takeover.spec.ts test/rate-limit-chaos.spec.ts` — 67/67 passing
- [ ] Post-deploy chaos test against `x.ai` confirms 9 MEDIUM findings (operator follow-up; not part of this PR)

## Notes / deviations

- Task 3 plan listed subdomain strings ending in `.models` (e.g. `aurora-sglang.us-east-1.models`) and constructed map keys with `${s}.x.ai|CNAME`. The scanner's CT-enumeration path treats any dot-containing `subdomain` arg as a full FQDN (no apex appended), so the test as written produced 0 findings. Fixed by giving each subdomain its full `.x.ai` suffix and keying the map with `${s}|CNAME`. Same intent — 9 dangling MEDIUM findings — just matches the actual code path.

## Out of scope

After this change, 9 × MEDIUM = -135 penalty still clamps to category score 0. That's a scoring-engine concern (per-category penalty cap / log curve), filed separately if desired.