### PR TITLE
fix(takeover+whois): three resilience fixes — TLS-mismatch signal, Azure HTML deprovision variants, WHOIS Name:/Org: parser hardening

### DIFF
--- a/packages/dns-checks/src/__tests__/whois-parse.test.ts
+++ b/packages/dns-checks/src/__tests__/whois-parse.test.ts
@@ -170,6 +170,56 @@ Address			: Mustafa Kemal Mahallesi
 		expect(parseWhoisResponse(synthetic).registrar).toBeNull();
 	});
 
+	describe('Nominet-style continuation rejects structured sub-field lines (anthropic.eu regression)', () => {
+		// Bug: bv-whois shim returned `"Name: NETIM"` as the registrar for
+		// `anthropic.eu`. The label-only `Registrar:` branch was grabbing the
+		// next non-empty line verbatim, even when that line itself was a
+		// structured `Label:` field (e.g. EURid's `Name: NETIM`). Fix: reject
+		// continuation lines that look like a structured label-prefixed field
+		// and fall through to the registrar-name / sponsoring / organization
+		// fallback chain.
+
+		it('prefers a real `Registrar: <value>` elsewhere in the response over a structured continuation', () => {
+			// Positive case: a malformed continuation `Name: NETIM` exists but the
+			// modern-ICANN `Registrar: NameSilo, LLC` also appears. Resolver should
+			// emit the real value, not `Name: NETIM`.
+			const synthetic = `
+Domain: example.eu
+Registrar:
+Name: NETIM
+Website: https://www.netim.com
+
+Registrar: NameSilo, LLC
+`;
+			expect(parseWhoisResponse(synthetic).registrar).toBe('NameSilo, LLC');
+		});
+
+		it('returns null when the only registrar-ish line is a structured `Name:` continuation', () => {
+			// Negative case: nothing in the response identifies a usable registrar.
+			// Previously this returned `"Name: NETIM"`. Now it returns null.
+			const synthetic = `
+Domain: example.eu
+Registrar:
+Name: NETIM
+Website: https://www.netim.com
+`;
+			expect(parseWhoisResponse(synthetic).registrar).toBeNull();
+		});
+
+		it('also rejects `Organization:` / `Org:` style continuation lines', () => {
+			const synthetic = `
+Domain: example.eu
+Registrar:
+Organization: SomeRegistrar GmbH
+`;
+			// The Italian section-block branch (line 95+) handles `Registrar` (no
+			// colon) + indented `Organization:` correctly. Here the label has a
+			// colon, so the strict label-only branch fires and the structured
+			// continuation must be rejected.
+			expect(parseWhoisResponse(synthetic).registrar).toBeNull();
+		});
+	});
+
 	it('handles empty input gracefully', () => {
 		const result = parseWhoisResponse('');
 		expect(result.registrar).toBeNull();

--- a/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
+++ b/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
@@ -118,9 +118,42 @@ const TAKEOVER_FINGERPRINTS: { service: string; patterns: string[] }[] = [
 	// Azure Front Door / CDN / Storage all surface `<Code>ResourceNotFound</Code>`
 	// when the underlying endpoint is gone. `BlobNotFound` is Azure Blob
 	// specifically. `ContainerNotFound` is Azure Blob container-level.
-	{ service: 'afd.azureedge.net', patterns: ['<Code>ResourceNotFound</Code>', 'ResourceNotFound'] },
-	{ service: 'azureedge.net', patterns: ['<Code>ResourceNotFound</Code>', 'ResourceNotFound', "Our services aren't available right now"] },
-	{ service: 'azurefd.net', patterns: ["Our services aren't available right now", '<Code>ResourceNotFound</Code>'] },
+	// Azure CDN / Front Door deprovisioned endpoints surface ONE of two body
+	// shapes depending on which LB instance answers:
+	//   1. XML  — `<?xml ...?><Error><Code>ResourceNotFound</Code>...`
+	//   2. HTML — generic 404 page whose body references the internal
+	//             `df.onecloud.azure-test.net/Error/UE_404` redirect target and
+	//             carries a `<title>Page not found</title>` element.
+	// Probes against the same FQDN can hit either variant. Both patterns must
+	// be present so the second variant doesn't silently drop the finding.
+	{
+		service: 'afd.azureedge.net',
+		patterns: [
+			'df.onecloud.azure-test.net/Error/UE_404',
+			'<Code>ResourceNotFound</Code>',
+			'<title>Page not found</title>',
+			'ResourceNotFound',
+		],
+	},
+	{
+		service: 'azureedge.net',
+		patterns: [
+			'df.onecloud.azure-test.net/Error/UE_404',
+			'<Code>ResourceNotFound</Code>',
+			'<title>Page not found</title>',
+			'ResourceNotFound',
+			"Our services aren't available right now",
+		],
+	},
+	{
+		service: 'azurefd.net',
+		patterns: [
+			'df.onecloud.azure-test.net/Error/UE_404',
+			'<Code>ResourceNotFound</Code>',
+			'<title>Page not found</title>',
+			"Our services aren't available right now",
+		],
+	},
 	{
 		service: 'azurewebsites.net',
 		patterns: ['<title>404 Web Site not found</title>', '<title>Web App - Unavailable</title>', 'web-app-not-found.html'],

--- a/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
+++ b/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
@@ -324,11 +324,58 @@ export async function probeHttpFingerprint(fqdn: string, cname: string, fetchFn:
 				}
 			}
 		}
-	} catch {
-		// Timeout or network error — silently skip.
+	} catch (err) {
+		// TLS-SNI / cert-altname mismatch IS a deprovision signal: a properly
+		// provisioned endpoint serves a certificate whose SAN list includes the
+		// hostname it's being addressed by. When fetch throws a cert-altname
+		// error, the CNAME target is pointing at a cluster that has no
+		// configured certificate for this FQDN — i.e. the upstream tenant has
+		// been torn down. The exact error wording varies by runtime (workerd,
+		// Node 18/20/22, undici), so we match a permissive union of phrases
+		// that all describe the same condition.
+		const message = err instanceof Error ? err.message : typeof err === 'string' ? err : '';
+		if (isTlsCertAltnameMismatch(message)) {
+			return TLS_SNI_MISMATCH_DISPLAY;
+		}
+		// Other transport errors (timeout, DNS, connect refused) are not
+		// deprovision evidence — stay silent.
 	}
 
 	return null;
+}
+
+/**
+ * Sentinel display name returned by {@link probeHttpFingerprint} when the
+ * upstream cert doesn't cover the SNI hostname. Callers treat any non-null
+ * string as a CRITICAL takeover finding; this label flags the underlying
+ * signal type for the operator-visible finding text.
+ */
+export const TLS_SNI_MISMATCH_DISPLAY = 'TLS-SNI mismatch (deprovision signal)';
+
+/**
+ * Detect TLS cert SAN/altname mismatch error strings across runtimes:
+ *   - Node/undici:    `Hostname/IP does not match certificate's altnames: ...`
+ *   - Node code:      `ERR_TLS_CERT_ALTNAME_INVALID`
+ *   - workerd:        `unable to verify ... no alternative certificate subject name matches`
+ *   - OpenSSL-direct: `Hostname mismatch` / `certificate subject name does not match`
+ *
+ * Conservative union: only fire on phrases that uniquely describe a SAN/altname
+ * mismatch. We deliberately do NOT match generic `certificate` strings (which
+ * also appear in expired-cert / self-signed-cert errors that are not a clean
+ * deprovision signal).
+ */
+export function isTlsCertAltnameMismatch(message: string): boolean {
+	if (!message) return false;
+	const lower = message.toLowerCase();
+	return (
+		lower.includes('altname') ||
+		lower.includes('err_tls_cert_altname_invalid') ||
+		lower.includes('certificate subject name') ||
+		lower.includes('subject name matches') ||
+		lower.includes('hostname mismatch') ||
+		lower.includes("doesn't match the certificate") ||
+		lower.includes('does not match the certificate')
+	);
 }
 
 export async function scanSubdomainForTakeover(

--- a/packages/dns-checks/src/whois/parse.ts
+++ b/packages/dns-checks/src/whois/parse.ts
@@ -86,6 +86,16 @@ export function parseWhoisResponse(input: string): WhoisParseResult {
 				const nextRaw = lines[j].replace(/\r$/, '');
 				const next = nextRaw.replace(/^\s+/, '').replace(/\s+$/, '');
 				if (next.length === 0) continue;
+				// Reject continuation lines that look like a structured `Label:` or
+				// `Label: value` field (e.g. EURid's `Name: NETIM`, `Organization: ...`,
+				// `Website: ...`). These are sub-fields of a registrar block, not the
+				// registrar name itself. Emitting `Name: NETIM` verbatim as the
+				// registrar is the bug we observed against `anthropic.eu`. The
+				// fallback chain (registrarName / sponsoring / registrarOrganization /
+				// authorizedAgency) still scans the whole response and resolves the
+				// proper value when present elsewhere; when nothing else matches we
+				// correctly return null rather than a half-parsed string.
+				if (/^[A-Za-z][A-Za-z][\w .-]*:/.test(next)) break;
 				registrar = stripNominetTag(next);
 				break;
 			}

--- a/test/subdomain-takeover-analysis.spec.ts
+++ b/test/subdomain-takeover-analysis.spec.ts
@@ -158,6 +158,66 @@ describe('subdomain-takeover-analysis', () => {
 				expect(result).toBe('Azure Front Door');
 			});
 		});
+
+		describe('TLS-SNI mismatch as deprovision signal (Fix #3)', () => {
+			// When the upstream cert doesn't cover the SNI hostname, fetch throws
+			// before a body can be inspected. Pre-fix this was swallowed silently;
+			// post-fix it returns a sentinel string so the caller emits a CRITICAL
+			// finding (a healthy endpoint would have a valid cert for itself).
+
+			it('returns the TLS sentinel when fetch throws a cert-altname error (Node/undici style)', async () => {
+				const fetchFn = vi.fn(async () => {
+					throw new Error("Hostname/IP does not match certificate's altnames: " + "Host: app.example.com. is not in the cert's altnames");
+				});
+				const result = await probeHttpFingerprint('app.example.com', 'old-app.herokuapp.com', fetchFn);
+				expect(result).not.toBeNull();
+				expect(result).toContain('TLS');
+			});
+
+			it('returns the TLS sentinel for the workerd-style "subject name matches" wording', async () => {
+				// This is the exact string shape the task brief pinned as the regression test.
+				const fetchFn = vi.fn(async () => {
+					throw new Error('unable to verify the first certificate; ... no alternative certificate subject name matches');
+				});
+				const result = await probeHttpFingerprint('app.example.com', 'old-app.herokuapp.com', fetchFn);
+				expect(result).not.toBeNull();
+				expect(result).toContain('TLS');
+			});
+
+			it('returns the TLS sentinel for ERR_TLS_CERT_ALTNAME_INVALID node-code style', async () => {
+				const fetchFn = vi.fn(async () => {
+					throw new Error('TLS error: ERR_TLS_CERT_ALTNAME_INVALID');
+				});
+				const result = await probeHttpFingerprint('app.example.com', 'old-app.herokuapp.com', fetchFn);
+				expect(result).toContain('TLS');
+			});
+
+			it('still returns null for non-TLS errors (timeout, DNS, connect refused)', async () => {
+				// Generic transport failures are not deprovision evidence — silent skip.
+				for (const msg of ['fetch aborted', 'connect ECONNREFUSED 127.0.0.1:443', 'getaddrinfo ENOTFOUND', 'The operation was aborted.']) {
+					const fetchFn = vi.fn(async () => {
+						throw new Error(msg);
+					});
+					const result = await probeHttpFingerprint('app.example.com', 'old-app.herokuapp.com', fetchFn);
+					expect(result).toBeNull();
+				}
+			});
+
+			it('scanSubdomainForTakeover surfaces the TLS-mismatch path as a CRITICAL finding', async () => {
+				const dns = makeDNS({
+					'gone.example.com|CNAME': ['old-app.herokuapp.com.'],
+					'old-app.herokuapp.com|A': ['54.243.180.1'], // target resolves; cert is the issue
+				});
+				const fetchFn = vi.fn(async () => {
+					throw new Error("Hostname/IP does not match certificate's altnames");
+				});
+				const findings = await scanSubdomainForTakeover('example.com', 'gone', dns, fetchFn);
+				expect(findings).toHaveLength(1);
+				expect(findings[0].severity).toBe('critical');
+				expect(findings[0].title).toContain('TLS');
+				expect(findings[0].metadata?.verificationStatus).toBe('verified');
+			});
+		});
 	});
 
 	describe('classifyTargetNamespace', () => {

--- a/test/subdomain-takeover-analysis.spec.ts
+++ b/test/subdomain-takeover-analysis.spec.ts
@@ -125,6 +125,39 @@ describe('subdomain-takeover-analysis', () => {
 			const result = await probeHttpFingerprint('cdn.example.com', 'example-assets.azureedge.net', fetchFn);
 			expect(result).toBeNull();
 		});
+
+		describe('Azure CDN / Front Door HTML deprovision-response variant', () => {
+			// Observed against `openaiassets.afd.azureedge.net`: the same FQDN
+			// returns either an XML `ResourceNotFound` body OR an HTML "Page not
+			// found" page referencing `df.onecloud.azure-test.net/Error/UE_404`
+			// depending on which LB instance answers. Pre-fix the HTML variant
+			// silently fell through and the finding was dropped.
+
+			it('matches the HTML "Page not found" variant (no XML ResourceNotFound)', async () => {
+				const htmlBody =
+					'<!DOCTYPE html><html><head><title>Page not found</title></head>' +
+					'<body><p>Reference: df.onecloud.azure-test.net/Error/UE_404</p></body></html>';
+				const fetchFn = fetchReturning(htmlBody);
+				const result = await probeHttpFingerprint('cdn.example.com', 'openaiassets.afd.azureedge.net', fetchFn);
+				expect(result).toBe('Azure Front Door');
+			});
+
+			it('matches the HTML variant against bare azureedge.net (CDN service)', async () => {
+				const htmlBody = '<html><head><title>Page not found</title></head><body></body></html>';
+				const fetchFn = fetchReturning(htmlBody);
+				const result = await probeHttpFingerprint('static.example.com', 'example.azureedge.net', fetchFn);
+				expect(result).toBe('Azure CDN');
+			});
+
+			it('matches the df.onecloud azure-test.net redirect reference alone', async () => {
+				// The internal redirect target string is a robust signal even when
+				// the <title> is rewritten by an intermediate LB.
+				const htmlBody = '<html><body>See df.onecloud.azure-test.net/Error/UE_404</body></html>';
+				const fetchFn = fetchReturning(htmlBody);
+				const result = await probeHttpFingerprint('cdn.example.com', 'openaiassets.afd.azureedge.net', fetchFn);
+				expect(result).toBe('Azure Front Door');
+			});
+		});
 	});
 
 	describe('classifyTargetNamespace', () => {


### PR DESCRIPTION
## Summary

Three independent resilience fixes for the takeover-detection and WHOIS-shim paths. Each landed as its own commit with regression tests.

### 1. WHOIS parser: reject structured sub-field continuation as registrar value (`4d32629`)

Pre-fix, the Nominet-style `Registrar:` label-only branch in `parseWhoisResponse` greedily took the next non-empty line verbatim. When the registry response shape was `Registrar:\nName: NETIM\n...` (EURid / EU TLD), the parser emitted `"Name: NETIM"` as the registrar — observed against `anthropic.eu` during fact-check while authoritative RDAP said the domain was unregistered.

Fix: in the label-only branch, if the next non-empty line itself looks like a structured `Label:` / `Label: value` field, refuse it and fall through to the `registrarName / sponsoring / registrarOrganization / authorizedAgency` chain. When nothing else matches the parser correctly returns `null` instead of a half-parsed string.

### 2. Azure CDN / Front Door HTML deprovision-response variant (`b62985e`)

Same Azure FQDN can return EITHER an XML `<Code>ResourceNotFound</Code>` body OR an HTML page with `<title>Page not found</title>` + a `df.onecloud.azure-test.net/Error/UE_404` reference, depending on which LB instance answers. The existing fingerprints caught only the XML form, so future scans of the same endpoint can silently miss the same finding due to LB variance.

Fix: extended the `afd.azureedge.net`, `azureedge.net`, and `azurefd.net` entries in `TAKEOVER_FINGERPRINTS` with both HTML patterns (longer/more-specific first per the existing ordering convention).

### 3. TLS-SNI mismatch as deprovision signal (`aa6fbee`)

Pre-fix, `probeHttpFingerprint`'s `try { ... } catch {}` silently swallowed TLS cert-altname mismatch errors. But that condition IS a deprovision signal: a properly provisioned endpoint serves a certificate whose SAN list includes the hostname it's being addressed by.

Fix: in the catch block, recognise the TLS-SAN/altname mismatch wording across runtimes (workerd / Node 18-22 / undici) via a permissive union of substring matches. On match, return a sentinel display name `'TLS-SNI mismatch (deprovision signal)'` so the caller emits a CRITICAL finding. Generic transport errors (timeout, DNS, connect refused) still silently skip — no false positives.

## Test plan

- [x] `npx vitest run test/subdomain-takeover-analysis.spec.ts` → **35 passed** (27 → 35, +8 new tests: 3 Azure HTML variant, 5 TLS-SNI)
- [x] `cd packages/dns-checks && npx vitest run src/__tests__/whois-parse.test.ts` → **40 passed** (37 → 40, +3 new tests: positive `NameSilo` resolution, negative `Name: NETIM` only → null, `Organization:` continuation rejected)
- [x] Wider sweep: `npx vitest run test/subdomain-takeover-analysis.spec.ts test/check-subdomain-takeover.spec.ts test/rate-limit-chaos.spec.ts test/chaos/varied-domain-all-tools.chaos.test.ts` → **77 passed**
- [x] Full `packages/dns-checks` suite: **272 passed**
- [x] Full `packages/bv-whois` suite: **48 passed**
- [x] `npm run typecheck` clean
- [x] `npx tsc --noEmit` clean in both `packages/dns-checks` and `packages/bv-whois`
- [x] `npm -w packages/dns-checks run build` clean (esbuild build success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)