### PR TITLE
feat(scoring): per-category penalty cap (closes open follow-up from PR #182)

### DIFF
--- a/packages/dns-checks/src/__tests__/scoring/scoring-model.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-model.spec.ts
@@ -24,6 +24,56 @@ describe('scoring-model', () => {
 	});
 });
 
+describe('CATEGORY_PENALTY_CAPS — subdomain_takeover', () => {
+	const mediums = (n: number) =>
+		Array.from({ length: n }, (_, i) => createFinding('subdomain_takeover', `Dangling CNAME #${i + 1}`, 'medium', 'operational drift'));
+
+	it('1 MEDIUM → unsaturated (no cap hit): 85/100', () => {
+		expect(computeCategoryScore(mediums(1), 'subdomain_takeover')).toBe(85);
+	});
+
+	it('5 MEDIUM = 75 penalty → cap exactly at floor: 25/100', () => {
+		expect(computeCategoryScore(mediums(5), 'subdomain_takeover')).toBe(25);
+	});
+
+	it('9 MEDIUM (x.ai cluster pattern) = 135 raw → capped at 75 → 25/100 (no longer 0)', () => {
+		expect(computeCategoryScore(mediums(9), 'subdomain_takeover')).toBe(25);
+	});
+
+	it('1 CRITICAL = 40 penalty → unsaturated: 60/100 (no cap hit)', () => {
+		const findings = [createFinding('subdomain_takeover', 'Verified takeover', 'critical', 'fingerprint match')];
+		expect(computeCategoryScore(findings, 'subdomain_takeover')).toBe(60);
+	});
+
+	it('1 CRITICAL + 5 MEDIUM = 115 raw → capped at 75 → 25/100', () => {
+		const findings = [createFinding('subdomain_takeover', 'Verified takeover', 'critical', 'fingerprint match'), ...mediums(5)];
+		expect(computeCategoryScore(findings, 'subdomain_takeover')).toBe(25);
+	});
+
+	it('2 CRITICAL = 80 raw → capped at 75 → 25/100', () => {
+		const findings = [
+			createFinding('subdomain_takeover', 'Verified takeover #1', 'critical', 'fingerprint match'),
+			createFinding('subdomain_takeover', 'Verified takeover #2', 'critical', 'fingerprint match'),
+		];
+		expect(computeCategoryScore(findings, 'subdomain_takeover')).toBe(25);
+	});
+
+	it('preserves discriminative power: 9 MEDIUM (25) > 0 (the saturated floor)', () => {
+		const nineMedium = computeCategoryScore(mediums(9), 'subdomain_takeover');
+		expect(nineMedium).toBe(25);
+		expect(nineMedium).toBeGreaterThan(0);
+	});
+
+	it('omitting category retains the original uncapped-then-clamped behavior', () => {
+		expect(computeCategoryScore(mediums(9))).toBe(0);
+	});
+
+	it('non-takeover categories unaffected by the cap (e.g., 9 MEDIUM DMARC saturates to 0)', () => {
+		const findings = Array.from({ length: 9 }, (_, i) => createFinding('dmarc', `Issue ${i + 1}`, 'medium', 'detail'));
+		expect(computeCategoryScore(findings, 'dmarc')).toBe(0);
+	});
+});
+
 describe('CATEGORY_TIERS', () => {
 	it('classifies all categories into tiers', () => {
 		expect(Object.keys(CATEGORY_TIERS)).toHaveLength(25);

--- a/packages/dns-checks/src/scoring/model.ts
+++ b/packages/dns-checks/src/scoring/model.ts
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { CheckCategory, CheckResult, CheckStatus, Finding, Severity } from '../types';
-import { CATEGORY_DISPLAY_WEIGHTS, SEVERITY_PENALTIES } from '../types';
+import { CATEGORY_DISPLAY_WEIGHTS, CATEGORY_PENALTY_CAPS, SEVERITY_PENALTIES } from '../types';
 
 export type { CheckCategory, CheckResult, CheckStatus, Finding, Severity };
-export { CATEGORY_DISPLAY_WEIGHTS, SEVERITY_PENALTIES };
+export { CATEGORY_DISPLAY_WEIGHTS, CATEGORY_PENALTY_CAPS, SEVERITY_PENALTIES };
 
 export type { CategoryTier } from '../types';
 export { CATEGORY_TIERS } from '../types';
@@ -66,13 +66,29 @@ function withConfidenceMetadata(finding: Finding): Finding {
 /**
  * Compute the score for a single check category based on its findings.
  * Starts at 100 and deducts points based on finding severities.
+ *
+ * When `category` is supplied and present in `CATEGORY_PENALTY_CAPS`, the
+ * total penalty is capped before clamping — this preserves discriminative
+ * power between "many same-class findings" and "single catastrophic finding"
+ * in categories like `subdomain_takeover` where a single upstream resource
+ * deletion can produce many same-class findings (e.g., one AWS NLB deletion
+ * orphaning 9 subdomains). Categories without a cap retain the legacy
+ * uncapped-then-clamped behavior.
+ *
+ * Backwards-compatible: omitting `category` keeps the original behavior.
  */
-export function computeCategoryScore(findings: Finding[]): number {
-	let score = 100;
+export function computeCategoryScore(findings: Finding[], category?: CheckCategory): number {
+	let penalty = 0;
 	for (const finding of findings) {
-		score -= SEVERITY_PENALTIES[finding.severity];
+		penalty += SEVERITY_PENALTIES[finding.severity];
 	}
-	return Math.max(0, Math.min(100, score));
+	if (category !== undefined) {
+		const cap = CATEGORY_PENALTY_CAPS[category];
+		if (cap !== undefined && penalty > cap) {
+			penalty = cap;
+		}
+	}
+	return Math.max(0, Math.min(100, 100 - penalty));
 }
 
 /** Regex for detecting missing control patterns in finding text. */
@@ -87,9 +103,11 @@ export function scoreIndicatesMissingControl(findings: Finding[]): boolean {
 	return findings.some((f) => {
 		const isMissingPattern = MISSING_CONTROL_REGEX.test(f.detail) || MISSING_CONTROL_REGEX.test(f.title);
 		const confidence = (f.metadata?.confidence as string) ?? inferFindingConfidence(f);
-		return isMissingPattern
-			&& (f.severity === 'critical' || f.severity === 'high')
-			&& (confidence === 'deterministic' || confidence === 'verified');
+		return (
+			isMissingPattern &&
+			(f.severity === 'critical' || f.severity === 'high') &&
+			(confidence === 'deterministic' || confidence === 'verified')
+		);
 	});
 }
 
@@ -101,9 +119,9 @@ export function scoreIndicatesMissingControl(findings: Finding[]): boolean {
  */
 export function buildCheckResult(category: CheckCategory, findings: Finding[]): CheckResult {
 	const normalizedFindings = findings.map(withConfidenceMetadata);
-	const score = computeCategoryScore(normalizedFindings);
-	const hasMissingControl = scoreIndicatesMissingControl(normalizedFindings)
-		|| normalizedFindings.some((f) => f.metadata?.missingControl === true);
+	const score = computeCategoryScore(normalizedFindings, category);
+	const hasMissingControl =
+		scoreIndicatesMissingControl(normalizedFindings) || normalizedFindings.some((f) => f.metadata?.missingControl === true);
 	const passed = score >= 50 && !hasMissingControl;
 	return {
 		category,

--- a/packages/dns-checks/src/types.ts
+++ b/packages/dns-checks/src/types.ts
@@ -8,11 +8,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 // DNS query function — dependency injection interface
-export type DNSQueryFunction = (
-	domain: string,
-	recordType: string,
-	options?: { timeout?: number }
-) => Promise<string[]>;
+export type DNSQueryFunction = (domain: string, recordType: string, options?: { timeout?: number }) => Promise<string[]>;
 
 /**
  * Raw DoH-style DNS response for checks that need the AD flag or full Answer array.
@@ -31,17 +27,14 @@ export type RawDNSQueryFunction = (
 	domain: string,
 	recordType: string,
 	dnssecFlag?: boolean,
-	options?: { timeout?: number }
+	options?: { timeout?: number },
 ) => Promise<RawDNSResponse>;
 
 /**
  * Fetch function — dependency injection interface for HTTP-based checks.
  * Matches the standard fetch() API signature.
  */
-export type FetchFunction = (
-	url: string,
-	init?: RequestInit
-) => Promise<Response>;
+export type FetchFunction = (url: string, init?: RequestInit) => Promise<Response>;
 
 export type Severity = 'critical' | 'high' | 'medium' | 'low' | 'info';
 export type FindingConfidence = 'deterministic' | 'heuristic' | 'verified';
@@ -172,4 +165,27 @@ export const SEVERITY_PENALTIES: Record<Severity, number> = {
 	medium: 15,
 	low: 5,
 	info: 0,
+};
+
+/**
+ * Maximum total penalty per category. When a category accumulates many findings of the
+ * same class, the raw penalty sum can exceed the base score (100) and saturate the
+ * category score at 0 — losing the distinction between "many same-class findings" and
+ * "one truly catastrophic finding".
+ *
+ * This map caps per-category penalty BEFORE clamping to [0, 100]. Categories omitted
+ * from the map retain the legacy uncapped-then-clamped behavior, preserving all
+ * existing test expectations across the non-takeover category surface.
+ *
+ * Initial coverage: only `subdomain_takeover`. The takeover sweep is the one category
+ * where a single upstream resource deletion (e.g., the x.ai AWS NLB cluster: 9 dangling
+ * subdomains) routinely produces many same-class findings, all of which represent
+ * the SAME operational miss rather than independent compounding risks.
+ *
+ * Cap = 75 means: even with 5+ MEDIUM findings (15×5=75) or 2 CRITICAL findings
+ * (40×2=80→75), the category score floors at 25/100 rather than 0/100. Preserves
+ * discriminative power between "broken" (25-49) and "system-critical missing" (0).
+ */
+export const CATEGORY_PENALTY_CAPS: Partial<Record<CheckCategory, number>> = {
+	subdomain_takeover: 75,
 };


### PR DESCRIPTION
## Summary

Closes the open follow-up flagged in PR #182's plan: scoring saturation for many-of-a-kind findings.

The x.ai case study generates 9 dangling-CNAME findings (all MEDIUM, all from one deleted AWS NLB) → −135 penalty → clamped to 0/100. Same floor a single 100-point catastrophe would produce. No way to tell "9 operational-drift findings" from "the whole category is broken."

This PR adds `CATEGORY_PENALTY_CAPS` to bound per-category penalty before clamping. Initial coverage: only `subdomain_takeover` (cap = 75 → floor = 25/100).

## Discriminative bands

| Findings | Old score | New score |
|---|---|---|
| 1 MEDIUM | 85 | 85 |
| 5 MEDIUM (cap hit exactly) | 25 | 25 |
| **9 MEDIUM (x.ai pattern)** | **0** | **25 ← fix** |
| 1 CRITICAL | 60 | 60 |
| **1 CRITICAL + 5 MEDIUM** | **0** | **25 ← fix** |
| 2 CRITICAL | 20 | 25 |

## Backwards compatibility

- `computeCategoryScore(findings, category?)` — category parameter is **optional**; omitting it preserves the original uncapped-then-clamped behavior. Every existing call site that doesn't have a category in scope works unchanged.
- `buildCheckResult` already knows the category and now passes it through.
- Non-takeover categories (DMARC, SPF, etc.) NOT in `CATEGORY_PENALTY_CAPS` retain their current behavior — 9 × MEDIUM DMARC findings still saturate at 0. Pinned by negative regression test.

## Why narrow scope (subdomain_takeover only)

The takeover sweep is the one category where a single upstream resource deletion routinely produces many findings of the same class (e.g., x.ai's 9 dangling subdomains, all from one NLB deletion). Other categories' findings are typically independent — broadening the cap there would change long-pinned test expectations without solving an actual saturation problem.

If additional categories develop the same anti-pattern, adding them is a one-line change to the `CATEGORY_PENALTY_CAPS` map plus regression tests.

## Test plan

- [x] 9 new regression tests pinning the cap math (every band in the table above + negative DMARC saturation test + backwards-compatible omit-category test)
- [x] 16/16 in `scoring-model.spec.ts` (was 8; added 8)
- [x] 190/190 across the wider takeover + scoring sweep (10 specs)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)