### PR TITLE
fix(brand-audit): thread BV_CERTSTREAM through queue consumer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -946,6 +946,7 @@ export default {
 				brandAuditQueue,
 				discoveryModeDefault,
 				whoisBinding: e.BV_WHOIS as Fetcher | undefined,
+				certstream: e.BV_CERTSTREAM as Fetcher | undefined,
 				internalCall,
 				...tierLookups,
 			};

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -152,6 +152,14 @@ export interface BrandAuditConsumerDeps {
 	/** Optional service binding for registrar WHOIS fallback in queued audits. */
 	whoisBinding?: { fetch: typeof fetch };
 	/**
+	 * Optional bv-certstream-worker service binding. Threaded into the
+	 * SAN-signal path of `discoverBrandDomains` (via the pipeline) so queued
+	 * audits use the dedicated CT-log binding instead of the public crt.sh
+	 * fallback. The sync MCP path threads `ro.certstream` here; without this
+	 * the queue path silently degraded to crt.sh for every batched audit.
+	 */
+	certstream?: { fetch: typeof fetch };
+	/**
 	 * Optional internal-call closure for the CSC deep-scan queue job.
 	 * Wraps handleToolsCall so the deep-scan orchestrator can invoke scan_domain
 	 * and discover_subdomains without going through HTTP framing. Constructed at
@@ -291,8 +299,9 @@ export async function processBrandAuditMessage(rawBody: unknown, deps: BrandAudi
 		...(deps.tier1Lookup ? { tier1Lookup: deps.tier1Lookup } : {}),
 		...(deps.tier2Lookup ? { tier2Lookup: deps.tier2Lookup } : {}),
 		...(deps.whoisBinding ? { whoisBinding: deps.whoisBinding } : {}),
+		...(deps.certstream ? { certstream: deps.certstream } : {}),
 	};
-	const hasSingleDeps = deps.tier0Lookup || deps.tier1Lookup || deps.tier2Lookup || deps.whoisBinding;
+	const hasSingleDeps = deps.tier0Lookup || deps.tier1Lookup || deps.tier2Lookup || deps.whoisBinding || deps.certstream;
 	const singleOptions: BrandAuditSingleOptions = {
 		auditId: message.auditId,
 		stepStore,

--- a/test/queue/brand-audit-consumer.integration.test.ts
+++ b/test/queue/brand-audit-consumer.integration.test.ts
@@ -220,6 +220,33 @@ describe('processBrandAuditMessage', () => {
 		);
 	});
 
+	it('passes the certstream service binding into brandAuditSingle deps for queued audits', async () => {
+		// Parity with the synchronous path (`handlers/tools.ts` brand_audit_single
+		// execute closure threads `ro.certstream` into the pipeline deps). Without
+		// this, the SAN signal in `discoverBrandDomains` falls back to the public
+		// crt.sh fetch path for every queued audit, while sync calls use the
+		// dedicated BV_CERTSTREAM binding. The deps-surface divergence is the
+		// latent-correctness gap; this test pins parity.
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db } = makeMockD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 1, total_targets: 1 },
+		});
+		const brandAuditSingle = vi.fn().mockResolvedValue({ category: 'brand_discovery', score: 100, findings: [] });
+		const certstream = { fetch: vi.fn() as unknown as typeof fetch };
+
+		await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'example.com', format: 'json' },
+			{ db, brandAuditSingle, certstream, now: () => 1_750_000_000_000 },
+		);
+
+		expect(brandAuditSingle).toHaveBeenCalledWith(
+			'example.com',
+			expect.objectContaining({ auditId: 'aud-1' }),
+			expect.objectContaining({ certstream }),
+		);
+	});
+
 	it('passes auditId and a D1-backed stepStore into brandAuditSingle', async () => {
 		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
 		const { db, calls } = makeMockD1({


### PR DESCRIPTION
## Summary

Latent deps-surface divergence between the synchronous and queued brand-audit paths. The synchronous MCP path threaded `ro.certstream` into `runBrandAuditPipeline` deps; the queue consumer did not. Result: queued audits silently fell back to the public crt.sh path for the SAN signal in `discoverBrandDomains`, while sync calls used the dedicated `BV_CERTSTREAM` service binding.

Three call-site fixes:
- `BrandAuditConsumerDeps` now accepts `certstream?: { fetch: typeof fetch }` (`src/queue/brand-audit-consumer.ts:151-159`).
- `processBrandAuditMessage` threads `deps.certstream` into the `singleDeps` it passes to `brandAuditSingle`, and includes it in the `hasSingleDeps` gate so the 3rd-arg call shape stays consistent with the existing 2-arg vs 3-arg branching.
- `src/index.ts` queue construction populates `certstream: e.BV_CERTSTREAM as Fetcher | undefined` alongside `whoisBinding` in the consumer deps object.

## Why this is correct-but-non-symptom-fixing

This was investigated as the prime suspect for a reported "ownership-classifier divergence between batch and single" symptom. The investigation **does not bear that out** — for openai.com on disk, the batch and synchronous paths produce identical 6 candidates with identical bucket assignments (`consolidated=3 shadowIt=1 indeterminate=2 impersonation=0`). See investigation evidence in `.dev/demos/full-audit-20260523-v2/brandaudit-openai.com.txt` vs `.dev/demos/openai/audit-result.json`.

The reported "0 OWNED across 13 vendors" claim originates from an uncommitted aggregator script that produced `.dev/demos/verify-all-13-v2/aggregate.json`, which has `brand_owned: []` even for vendors where the pipeline emitted 40+ ownership classifications (nvidia.com). That aggregator is the bug — separate fix.

But this PR is a real correctness gap on its own merits — the queue path should not silently degrade SAN-signal infrastructure relative to the sync path. Closes the deps-surface parity gap.

## Test plan

- [x] `npx vitest run test/queue/brand-audit-consumer.integration.test.ts` — 18/18 pass, including the new `'passes the certstream service binding into brandAuditSingle deps for queued audits'` regression
- [x] `npx vitest run test/queue/ test/brand-audit-pipeline.test.ts test/brand-audit-pipeline-lookup-failed.test.ts test/index.spec.ts` — 132/132 pass
- [x] `npm run typecheck` clean
- [x] Failing-test-first (TDD): test was RED before the wiring fix; turned GREEN after the consumer + index.ts changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)