### PR TITLE
fix(brand-audit): forward brandAuditQueue into pipeline deps so registrar-complement deep_scan fires

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -401,6 +401,12 @@ const TOOL_REGISTRY: Record<
 					certstream: ro?.certstream,
 					whoisBinding: ro?.whoisBinding,
 					enforceQuota: buildMonthlyEnforceQuota(ro),
+					// The brand-audit queue binding doubles as the CSC fast→full
+					// deep-scan trigger in the pipeline (brand-audit-pipeline.ts:1061).
+					// Without it, sync view='csc_complement' audits write only the
+					// fast payload and brand_audit_get_report can never surface the
+					// full enrichment.
+					...(ro?.brandAuditQueue ? { brandAuditQueue: ro.brandAuditQueue } : {}),
 					// Tier closures: forwarded through the pipeline → discoverBrandDomains
 					// seam. Undefined on BSL self-hosts → pipeline never calls the
 					// proprietary lookups.

--- a/src/lib/brand-audit-pipeline.ts
+++ b/src/lib/brand-audit-pipeline.ts
@@ -1059,7 +1059,20 @@ export async function runBrandAuditPipeline(
 		}
 
 		if (deps.brandAuditQueue) {
-			await deps.brandAuditQueue.send({ auditId, target: seedDomain, phase: 'deep_scan' }, { contentType: 'json' });
+			// Best-effort: a Queue send failure leaves the audit with only the
+			// csc_complement_fast payload already persisted just above. Letting
+			// the throw propagate would surface as a JSON-RPC error in the sync
+			// request path (despite csc_complement_fast being in step-store) and
+			// would tip the entire target row to `failed` in the queue consumer
+			// (caught at processBrandAuditMessage's outer try/catch). The cron
+			// reaper / brand_audit_get_report fallback to the fast payload
+			// already covers the durability gap. Mirrors the pdfQueue.send()
+			// best-effort policy at brand-audit-consumer.ts:425-429.
+			try {
+				await deps.brandAuditQueue.send({ auditId, target: seedDomain, phase: 'deep_scan' }, { contentType: 'json' });
+			} catch (err) {
+				console.warn('[csc-complement] deep_scan enqueue failed:', err);
+			}
 		}
 	}
 

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -303,8 +303,9 @@ export async function processBrandAuditMessage(rawBody: unknown, deps: BrandAudi
 		// The same brandAuditQueue binding that powers the Phase 2b retry-enqueue
 		// at line 416 doubles as the CSC fast→full deep-scan trigger inside the
 		// pipeline (brand-audit-pipeline.ts:1061). The send() signature there is
-		// `{ send(unknown): Promise<void> }`, narrower than the consumer's
-		// typed-message variant — the runtime shape is identical.
+		// `{ send(unknown): Promise<void> }`, wider (more permissive in input
+		// type) than the consumer's typed-message variant — the runtime shape
+		// is identical.
 		...(deps.brandAuditQueue ? { brandAuditQueue: deps.brandAuditQueue } : {}),
 	};
 	const hasSingleDeps =

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -305,8 +305,13 @@ export async function processBrandAuditMessage(rawBody: unknown, deps: BrandAudi
 		// pipeline (brand-audit-pipeline.ts:1061). The send() signature there is
 		// `{ send(unknown): Promise<void> }`, wider (more permissive in input
 		// type) than the consumer's typed-message variant — the runtime shape
-		// is identical.
-		...(deps.brandAuditQueue ? { brandAuditQueue: deps.brandAuditQueue } : {}),
+		// is identical. Gated on `!isRetry` because the primary pass already
+		// enqueued deep_scan #1; allowing the retry pass to enqueue deep_scan #2
+		// produces a race on csc_complement_full (last-write-wins UPSERT in the
+		// step-store, no MVCC). Consumer's own retry-enqueue path is already
+		// gated on `!isRetry` at line 411, so the consumer doesn't need
+		// brandAuditQueue on retry messages either.
+		...(deps.brandAuditQueue && !isRetry ? { brandAuditQueue: deps.brandAuditQueue } : {}),
 	};
 	const hasSingleDeps =
 		deps.tier0Lookup || deps.tier1Lookup || deps.tier2Lookup || deps.whoisBinding || deps.certstream || deps.brandAuditQueue;

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -300,8 +300,15 @@ export async function processBrandAuditMessage(rawBody: unknown, deps: BrandAudi
 		...(deps.tier2Lookup ? { tier2Lookup: deps.tier2Lookup } : {}),
 		...(deps.whoisBinding ? { whoisBinding: deps.whoisBinding } : {}),
 		...(deps.certstream ? { certstream: deps.certstream } : {}),
+		// The same brandAuditQueue binding that powers the Phase 2b retry-enqueue
+		// at line 416 doubles as the CSC fast→full deep-scan trigger inside the
+		// pipeline (brand-audit-pipeline.ts:1061). The send() signature there is
+		// `{ send(unknown): Promise<void> }`, narrower than the consumer's
+		// typed-message variant — the runtime shape is identical.
+		...(deps.brandAuditQueue ? { brandAuditQueue: deps.brandAuditQueue } : {}),
 	};
-	const hasSingleDeps = deps.tier0Lookup || deps.tier1Lookup || deps.tier2Lookup || deps.whoisBinding || deps.certstream;
+	const hasSingleDeps =
+		deps.tier0Lookup || deps.tier1Lookup || deps.tier2Lookup || deps.whoisBinding || deps.certstream || deps.brandAuditQueue;
 	const singleOptions: BrandAuditSingleOptions = {
 		auditId: message.auditId,
 		stepStore,

--- a/test/audits/brand-audit-pipeline-deps-parity.audit.test.ts
+++ b/test/audits/brand-audit-pipeline-deps-parity.audit.test.ts
@@ -69,7 +69,11 @@ const REQUIRED_DEPS: Array<{ name: string; queuePattern: RegExp; handlerPattern:
 	},
 	{
 		name: 'brandAuditQueue',
-		queuePattern: /\.\.\.\(deps\.brandAuditQueue\s*\?\s*\{\s*brandAuditQueue:\s*deps\.brandAuditQueue\s*\}\s*:\s*\{\}\),?/,
+		// Queue side gated on `!isRetry` — primary pass enqueues the CSC deep_scan,
+		// retry pass would race against the primary's deep_scan worker
+		// (last-write-wins on csc_complement_full). See the matching test in
+		// brand-audit-consumer-retry.integration.test.ts.
+		queuePattern: /\.\.\.\(deps\.brandAuditQueue\s*&&\s*!isRetry\s*\?\s*\{\s*brandAuditQueue:\s*deps\.brandAuditQueue\s*\}\s*:\s*\{\}\),?/,
 		handlerPattern: /\.\.\.\(ro\?\.brandAuditQueue\s*\?\s*\{\s*brandAuditQueue:\s*ro\.brandAuditQueue\s*\}\s*:\s*\{\}\),?/,
 	},
 ];

--- a/test/audits/brand-audit-pipeline-deps-parity.audit.test.ts
+++ b/test/audits/brand-audit-pipeline-deps-parity.audit.test.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Audit test: every binding-backed field on BrandAuditPipelineDeps that has an
+// env-sourced runtime option must be forwarded by BOTH call sites — the
+// synchronous brand_audit_single execute closure in src/handlers/tools.ts AND
+// the queue-consumer's processBrandAuditMessage in src/queue/brand-audit-consumer.ts.
+//
+// History: two latent forwarding gaps shipped silently because no test pinned
+// this parity — `certstream` (fixed in PR #185) and `brandAuditQueue` (fixed in
+// this PR). Both followed the same pattern: dep declared on the pipeline,
+// declared on ToolRuntimeOptions and/or BrandAuditConsumerDeps, populated by
+// src/index.ts from env, but never spread into the deps object actually passed
+// to brandAuditSingle / runBrandAuditPipeline. Each gap produced an asymmetric
+// runtime behavior (sync vs queued audits, or single vs batch) that was
+// invisible to type-checking and required production-evidence debugging to find.
+//
+// This audit catches the next instance at unit-test time by enumerating the
+// required deps and grepping both source files. It's source-text grep — fragile
+// to renames but cheap to update and stronger than nothing.
+//
+// Runs in the Cloudflare Workers test pool, so we use Vite's `?raw` source-file
+// imports rather than node:fs (which the Workers runtime doesn't expose).
+//
+// Per testing-methodology.md principle 4 — audit tests replace review checklists.
+
+import { describe, it, expect } from 'vitest';
+import queueSource from '../../src/queue/brand-audit-consumer.ts?raw';
+import handlerSource from '../../src/handlers/tools.ts?raw';
+
+/**
+ * Each entry: a field on BrandAuditPipelineDeps that is sourced from a
+ * Cloudflare binding / env variable at request or queue dispatch time.
+ *
+ * `queuePattern` matches the line in src/queue/brand-audit-consumer.ts's
+ * processBrandAuditMessage where the dep is conditionally spread into
+ * singleDeps. The shape is `...(deps.<name> ? { <name>: deps.<name> } : {}),`.
+ *
+ * `handlerPattern` matches the line in src/handlers/tools.ts's brand_audit_single
+ * execute closure where the dep is passed into brandAuditSingle's deps arg.
+ * Two shapes accepted because the closure mixes both styles:
+ *   - `<name>: ro?.<name>` (unconditional pass-through, used for certstream/whois)
+ *   - `...(ro?.<name> ? { <name>: ro.<name> } : {})` (conditional spread, tier closures)
+ */
+const REQUIRED_DEPS: Array<{ name: string; queuePattern: RegExp; handlerPattern: RegExp }> = [
+	{
+		name: 'certstream',
+		queuePattern: /\.\.\.\(deps\.certstream\s*\?\s*\{\s*certstream:\s*deps\.certstream\s*\}\s*:\s*\{\}\),?/,
+		handlerPattern: /certstream:\s*ro\?\.certstream/,
+	},
+	{
+		name: 'whoisBinding',
+		queuePattern: /\.\.\.\(deps\.whoisBinding\s*\?\s*\{\s*whoisBinding:\s*deps\.whoisBinding\s*\}\s*:\s*\{\}\),?/,
+		handlerPattern: /whoisBinding:\s*ro\?\.whoisBinding/,
+	},
+	{
+		name: 'tier0Lookup',
+		queuePattern: /\.\.\.\(deps\.tier0Lookup\s*\?\s*\{\s*tier0Lookup:\s*deps\.tier0Lookup\s*\}\s*:\s*\{\}\),?/,
+		handlerPattern: /\.\.\.\(ro\?\.tier0Lookup\s*\?\s*\{\s*tier0Lookup:\s*ro\.tier0Lookup\s*\}\s*:\s*\{\}\),?/,
+	},
+	{
+		name: 'tier1Lookup',
+		queuePattern: /\.\.\.\(deps\.tier1Lookup\s*\?\s*\{\s*tier1Lookup:\s*deps\.tier1Lookup\s*\}\s*:\s*\{\}\),?/,
+		handlerPattern: /\.\.\.\(ro\?\.tier1Lookup\s*\?\s*\{\s*tier1Lookup:\s*ro\.tier1Lookup\s*\}\s*:\s*\{\}\),?/,
+	},
+	{
+		name: 'tier2Lookup',
+		queuePattern: /\.\.\.\(deps\.tier2Lookup\s*\?\s*\{\s*tier2Lookup:\s*deps\.tier2Lookup\s*\}\s*:\s*\{\}\),?/,
+		handlerPattern: /\.\.\.\(ro\?\.tier2Lookup\s*\?\s*\{\s*tier2Lookup:\s*ro\.tier2Lookup\s*\}\s*:\s*\{\}\),?/,
+	},
+	{
+		name: 'brandAuditQueue',
+		queuePattern: /\.\.\.\(deps\.brandAuditQueue\s*\?\s*\{\s*brandAuditQueue:\s*deps\.brandAuditQueue\s*\}\s*:\s*\{\}\),?/,
+		handlerPattern: /\.\.\.\(ro\?\.brandAuditQueue\s*\?\s*\{\s*brandAuditQueue:\s*ro\.brandAuditQueue\s*\}\s*:\s*\{\}\),?/,
+	},
+];
+
+describe('brand-audit pipeline deps-surface parity audit', () => {
+	for (const dep of REQUIRED_DEPS) {
+		it(`forwards \`${dep.name}\` from the queue consumer's singleDeps construction`, () => {
+			expect(queueSource).toMatch(dep.queuePattern);
+		});
+
+		it(`forwards \`${dep.name}\` from the brand_audit_single handler's deps arg`, () => {
+			expect(handlerSource).toMatch(dep.handlerPattern);
+		});
+	}
+
+	it('queue consumer hasSingleDeps gate includes every required dep', () => {
+		// The 2-arg vs 3-arg call decision in processBrandAuditMessage is keyed on
+		// `hasSingleDeps`. Missing a dep here means a deploy with ONLY that dep
+		// would fall through to the 2-arg call and drop the dep silently.
+		const hasSingleDepsLine = queueSource.match(/const\s+hasSingleDeps\s*=\s*([^;]+);/);
+		expect(hasSingleDepsLine, 'could not locate hasSingleDeps declaration').toBeTruthy();
+		const gateExpr = hasSingleDepsLine![1];
+		for (const dep of REQUIRED_DEPS) {
+			expect(gateExpr, `hasSingleDeps must include deps.${dep.name}`).toMatch(new RegExp(`deps\\.${dep.name}\\b`));
+		}
+	});
+});

--- a/test/audits/brand-audit-pipeline-deps-parity.audit.test.ts
+++ b/test/audits/brand-audit-pipeline-deps-parity.audit.test.ts
@@ -74,6 +74,35 @@ const REQUIRED_DEPS: Array<{ name: string; queuePattern: RegExp; handlerPattern:
 	},
 ];
 
+/**
+ * Pipeline deps that are deliberately ASYMMETRIC — forwarded by one call site
+ * but intentionally NOT the other. Encoding the asymmetry explicitly so a
+ * future drop in one direction or accidental add in the other gets flagged.
+ *
+ * Currently only `enforceQuota`: the sync `brand_audit_single` handler passes
+ * `buildMonthlyEnforceQuota(ro)` so a single per-request invocation debits the
+ * monthly quota for the principal. `brand_audit_batch_start` already debits
+ * the quota atomically for ALL targets at submission time, so the queue
+ * consumer MUST NOT debit again per-target — that would double-bill
+ * customers against their monthly cap.
+ */
+const INTENTIONALLY_ASYMMETRIC: Array<{
+	name: string;
+	side: 'handler-only' | 'queue-only';
+	presentPattern: RegExp;
+	absentSourceTag: 'queue' | 'handler';
+	rationale: string;
+}> = [
+	{
+		name: 'enforceQuota',
+		side: 'handler-only',
+		presentPattern: /enforceQuota:\s*buildMonthlyEnforceQuota\(ro\)/,
+		absentSourceTag: 'queue',
+		rationale:
+			'brand_audit_batch_start atomically debits the monthly quota for all targets at submission time; queue consumer must not double-bill per-target.',
+	},
+];
+
 describe('brand-audit pipeline deps-surface parity audit', () => {
 	for (const dep of REQUIRED_DEPS) {
 		it(`forwards \`${dep.name}\` from the queue consumer's singleDeps construction`, () => {
@@ -82,6 +111,24 @@ describe('brand-audit pipeline deps-surface parity audit', () => {
 
 		it(`forwards \`${dep.name}\` from the brand_audit_single handler's deps arg`, () => {
 			expect(handlerSource).toMatch(dep.handlerPattern);
+		});
+	}
+
+	for (const dep of INTENTIONALLY_ASYMMETRIC) {
+		const presentSrc = dep.side === 'handler-only' ? handlerSource : queueSource;
+		const absentSrc = dep.absentSourceTag === 'queue' ? queueSource : handlerSource;
+		const presentLabel = dep.side === 'handler-only' ? 'handler' : 'queue consumer';
+		const absentLabel = dep.absentSourceTag;
+
+		it(`\`${dep.name}\` is present on the ${presentLabel} side (${dep.side})`, () => {
+			expect(presentSrc, dep.rationale).toMatch(dep.presentPattern);
+		});
+
+		it(`\`${dep.name}\` is intentionally absent on the ${absentLabel} side (${dep.rationale})`, () => {
+			// Match the name appearing as a deps-property assignment specifically —
+			// substring-grep alone would false-positive on import names, types, etc.
+			const queueAssignmentPattern = new RegExp(`\\b${dep.name}\\s*:\\s*(deps\\.|ro\\.)${dep.name}\\b`);
+			expect(absentSrc).not.toMatch(queueAssignmentPattern);
 		});
 	}
 

--- a/test/brand-audit-csc-pipeline.integration.test.ts
+++ b/test/brand-audit-csc-pipeline.integration.test.ts
@@ -273,6 +273,51 @@ describe('runBrandAuditPipeline with view=csc_complement', () => {
 		expect(enqueued[0]).toMatchObject({ auditId: 'audit-1', target: 'ford.com', phase: 'deep_scan' });
 	});
 
+	it('does not propagate Queue send failures — deep_scan enqueue is best-effort', async () => {
+		// Before brandAuditQueue was forwarded into pipeline deps, line 1061 was
+		// dead in production. Activating it (PR #186) means a transient Cloudflare
+		// Queues send() rejection — backpressure, regional issue, write-rate cap —
+		// would propagate out of runBrandAuditPipeline. The queue consumer would
+		// catch the throw at processBrandAuditMessage and flip the entire target
+		// row to `failed` even though csc_complement_fast was already persisted.
+		// The sync request path would surface a JSON-RPC error to the client even
+		// though the same fast result is in step-store. Both are user-visible
+		// regressions caused by a transient infrastructure blip.
+		//
+		// Policy: same as pdfQueue.send() at brand-audit-consumer.ts:425-429 —
+		// best-effort, log on failure, never abort the audit.
+		setupEnrichmentFetchMock(['ford.co.uk']);
+
+		const brandAuditQueue = {
+			send: async (): Promise<void> => {
+				throw new Error('queue backpressure');
+			},
+		};
+
+		const { runBrandAuditPipeline } = await import('../src/lib/brand-audit-pipeline');
+
+		const discoverBrandDomains = async () =>
+			makeDiscoveryResult('ford.com', [{ domain: 'ford.co.uk', signals: ['dkim_key_reuse', 'san'] }]);
+		const checkRdapLookup = async (domain: string) => {
+			if (domain === 'ford.co.uk') return makeRdapResult('GoDaddy.com, LLC');
+			return makeRdapResult('CSC Corporate Domains, Inc.');
+		};
+
+		const result = await runBrandAuditPipeline(
+			'ford.com',
+			{ view: 'csc_complement', auditId: 'audit-1' },
+			{
+				brandAuditQueue,
+				discoverBrandDomains: discoverBrandDomains as never,
+				checkRdapLookup: checkRdapLookup as never,
+			},
+		);
+
+		// Pipeline returns normally; csc_complement_fast is attached to the result.
+		expect(result).toBeDefined();
+		expect((result as unknown as { cscComplement?: unknown }).cscComplement).toBeDefined();
+	});
+
 	it('runs runDeepScanFromStepStore and merges to csc_complement_full', async () => {
 		const stored = new Map<string, unknown>();
 		const stepStore = {

--- a/test/brand-audit-view-gate.spec.ts
+++ b/test/brand-audit-view-gate.spec.ts
@@ -81,4 +81,38 @@ describe('view=csc_complement tier gate', () => {
 		const parsed = BrandAuditSingleArgs.parse({ domain: 'example.com' });
 		expect(parsed.view).toBeUndefined();
 	});
+
+	it('forwards ro.brandAuditQueue into brand_audit_single pipeline deps (CSC deep_scan enqueue)', async () => {
+		// brand-audit-pipeline.ts:1061 only enqueues the {phase:'deep_scan'}
+		// follow-up message when deps.brandAuditQueue is present. The synchronous
+		// brand_audit_single tool runs in the request path, so it must forward
+		// ro.brandAuditQueue (constructed from env.BRAND_AUDIT_QUEUE in
+		// src/index.ts) into the pipeline deps — otherwise sync audits with
+		// view='csc_complement' write only csc_complement_fast and never trigger
+		// the deep-scan job that fills csc_complement_full.
+		let brandAuditSingleMock: ReturnType<typeof vi.fn>;
+		vi.doMock('../src/tools/brand-audit-single', () => {
+			brandAuditSingleMock = vi.fn().mockResolvedValue({
+				category: 'brand_discovery',
+				passed: true,
+				score: 100,
+				findings: [],
+			});
+			return { brandAuditSingle: brandAuditSingleMock };
+		});
+
+		const brandAuditQueue = { send: vi.fn().mockResolvedValue(undefined) };
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		await handleToolsCall(
+			{ name: 'brand_audit_single', arguments: { domain: 'example.com', view: 'csc_complement' } },
+			undefined,
+			{ authTier: 'enterprise', brandAuditQueue } as never,
+		);
+
+		expect(brandAuditSingleMock!).toHaveBeenCalledWith(
+			'example.com',
+			expect.anything(),
+			expect.objectContaining({ brandAuditQueue }),
+		);
+	});
 });

--- a/test/queue/brand-audit-consumer-retry.integration.test.ts
+++ b/test/queue/brand-audit-consumer-retry.integration.test.ts
@@ -22,7 +22,11 @@ interface AuditTargetRow {
 	completed_at: number | null;
 }
 
-interface StepKey { auditId: string; target: string; step: string }
+interface StepKey {
+	auditId: string;
+	target: string;
+	step: string;
+}
 function stepKey(k: StepKey): string {
 	return `${k.auditId}\0${k.target}\0${k.step}`;
 }
@@ -62,14 +66,21 @@ function makeMockD1(initial: { target: AuditTargetRow & { result_json?: string |
 				},
 				async run() {
 					if (sql.includes('INSERT INTO brand_audit_steps')) {
-						const [auditId, target, step, status, payload, errorVal] = binds as [string, string, string, string, string | null, string | null];
+						const [auditId, target, step, status, payload, errorVal] = binds as [
+							string,
+							string,
+							string,
+							string,
+							string | null,
+							string | null,
+						];
 						steps.set(stepKey({ auditId, target, step }), { status, payload_json: payload, error: errorVal });
 						return { success: true, meta: { changes: 1 } };
 					}
 					if (sql.includes('UPDATE brand_audit_targets')) {
 						// Atomic claim: parameterized predicate `status = ?` with the
 						// expected value bound as the third arg.
-						if (sql.includes('SET status = \'running\' WHERE audit_id = ? AND target = ? AND status = ?')) {
+						if (sql.includes("SET status = 'running' WHERE audit_id = ? AND target = ? AND status = ?")) {
 							const expected = binds[2] as AuditTargetRow['status'];
 							if (targetRow.status !== expected) return { success: true, meta: { changes: 0 } };
 							targetRow.status = 'running';
@@ -88,7 +99,12 @@ function makeMockD1(initial: { target: AuditTargetRow & { result_json?: string |
 						// preservation test can assert on them. Capture the consumer's
 						// `now` bind (4th position) so tests can assert it reflects
 						// completion time, not message-start time.
-						const [newStatus, resultJson, errorVal, completedAt] = binds as [AuditTargetRow['status'], string | null, string | null, number];
+						const [newStatus, resultJson, errorVal, completedAt] = binds as [
+							AuditTargetRow['status'],
+							string | null,
+							string | null,
+							number,
+						];
 						targetRow.status = newStatus;
 						if (resultJson !== undefined) targetRow.result_json = resultJson;
 						if (errorVal !== undefined) targetRow.error = errorVal;
@@ -101,7 +117,9 @@ function makeMockD1(initial: { target: AuditTargetRow & { result_json?: string |
 					}
 					return { success: true, meta: { changes: 1 } };
 				},
-				async all() { return { results: [], success: true, meta: {} }; },
+				async all() {
+					return { results: [], success: true, meta: {} };
+				},
 			};
 			return stmt;
 		},
@@ -159,7 +177,11 @@ function makeOrchestrator(returnValue: unknown) {
 function makeQueue() {
 	const sent: Array<{ msg: unknown }> = [];
 	return {
-		binding: { async send(msg: unknown) { sent.push({ msg }); } },
+		binding: {
+			async send(msg: unknown) {
+				sent.push({ msg });
+			},
+		},
 		sent,
 	};
 }
@@ -168,7 +190,10 @@ function makeQueue() {
 function makeWebhook() {
 	const calls: Array<{ url: string }> = [];
 	return {
-		fn: async (url: string, _payload: unknown) => { calls.push({ url }); return true; },
+		fn: async (url: string, _payload: unknown) => {
+			calls.push({ url });
+			return true;
+		},
 		calls,
 	};
 }
@@ -235,7 +260,11 @@ describe('processBrandAuditMessage — Phase 2b retry orchestration', () => {
 		const orchestrator = makeOrchestrator(resultWithLookupFailed);
 		const queue = makeQueue();
 		const pdfQueue = { sent: [] as Array<{ msg: unknown }> };
-		const pdfBinding = { async send(msg: unknown) { pdfQueue.sent.push({ msg }); } };
+		const pdfBinding = {
+			async send(msg: unknown) {
+				pdfQueue.sent.push({ msg });
+			},
+		};
 
 		await processBrandAuditMessage(
 			{ auditId: 'aud-1', target: 'example.com', format: 'markdown' },
@@ -281,7 +310,9 @@ describe('processBrandAuditMessage — Phase 2b retry orchestration', () => {
 		});
 
 		const orchestrator = {
-			fn: async () => { throw new Error('retry pass blew up'); },
+			fn: async () => {
+				throw new Error('retry pass blew up');
+			},
 			calls: [] as never[],
 		};
 		const queue = makeQueue();
@@ -321,5 +352,38 @@ describe('processBrandAuditMessage — Phase 2b retry orchestration', () => {
 		expect(orchestrator.calls[0].opts.force_refresh).toBe(true);
 		expect(getCounter().completed_targets, 'retry pass must NOT bump completed_targets').toBe(0);
 		expect(queue.sent, 'retry pass cannot enqueue another retry').toEqual([]);
+	});
+
+	it('retry pass does NOT forward brandAuditQueue into pipeline deps (prevents double CSC deep_scan enqueue)', async () => {
+		// Scenario: primary pass with view='csc_complement' enqueues deep_scan #1
+		// (from brand-audit-pipeline.ts:1061). If the retry pass also forwarded
+		// brandAuditQueue, it would re-enter the CSC branch with force_refresh=true,
+		// re-write csc_complement_fast, and enqueue deep_scan #2 — producing a race
+		// where two runDeepScanFromStepStore workers contend on csc_complement_full
+		// (last-write-wins UPSERT, no MVCC). Gate at the consumer side: the
+		// brandAuditQueue dep is forwarded to the pipeline only on the primary
+		// (non-retry) pass. The consumer's own retry-enqueue path is already
+		// gated on !isRetry at brand-audit-consumer.ts:411, so the consumer
+		// doesn't need brandAuditQueue on retry messages either.
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db } = makeMockD1({ target: { status: 'completed', completed_at: 1000 } });
+		const brandAuditSingle = vi.fn().mockResolvedValue({ category: 'brand_discovery', score: 100, findings: [] });
+		const queue = makeQueue();
+
+		await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'example.com', format: 'json', view: 'csc_complement', retry_attempt: 1 },
+			{ db, brandAuditSingle, brandAuditQueue: queue.binding, now: () => 1_750_000_000_000 },
+		);
+
+		// brandAuditSingle should have been called. The third arg (deps) MUST NOT
+		// contain brandAuditQueue — otherwise the retry pass would re-enqueue a
+		// deep_scan message that races deep_scan #1 from the primary pass.
+		expect(brandAuditSingle).toHaveBeenCalledOnce();
+		const callArgs = brandAuditSingle.mock.calls[0];
+		// Two-arg form (no deps) is fine — that's the default when no bindings are present.
+		// If the 3-arg form is used, deps must NOT carry brandAuditQueue.
+		if (callArgs.length >= 3) {
+			expect(callArgs[2]).not.toHaveProperty('brandAuditQueue');
+		}
 	});
 });

--- a/test/queue/brand-audit-consumer.integration.test.ts
+++ b/test/queue/brand-audit-consumer.integration.test.ts
@@ -247,6 +247,32 @@ describe('processBrandAuditMessage', () => {
 		);
 	});
 
+	it('passes the brandAuditQueue binding into brandAuditSingle deps for queued audits (CSC deep_scan enqueue)', async () => {
+		// The pipeline at brand-audit-pipeline.ts:1061 only enqueues the
+		// {phase:'deep_scan'} message when deps.brandAuditQueue is present.
+		// Without this forwarding, queued view='csc_complement' audits write
+		// csc_complement_fast only — brand_audit_get_report falls back to the
+		// fast payload and the deep-scan-derived enrichment never materializes.
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db } = makeMockD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 1, total_targets: 1 },
+		});
+		const brandAuditSingle = vi.fn().mockResolvedValue({ category: 'brand_discovery', score: 100, findings: [] });
+		const brandAuditQueue = { send: vi.fn().mockResolvedValue(undefined) };
+
+		await processBrandAuditMessage(
+			{ auditId: 'aud-1', target: 'example.com', format: 'json', view: 'csc_complement' },
+			{ db, brandAuditSingle, brandAuditQueue, now: () => 1_750_000_000_000 },
+		);
+
+		expect(brandAuditSingle).toHaveBeenCalledWith(
+			'example.com',
+			expect.objectContaining({ auditId: 'aud-1' }),
+			expect.objectContaining({ brandAuditQueue }),
+		);
+	});
+
 	it('passes auditId and a D1-backed stepStore into brandAuditSingle', async () => {
 		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
 		const { db, calls } = makeMockD1({


### PR DESCRIPTION
## Summary

Same class of deps-surface gap as #185 — a pipeline binding declared on `BrandAuditPipelineDeps`, populated by `src/index.ts` from env, declared on the runtime-options shape, but never spread into the deps object actually passed to `brandAuditSingle` / `runBrandAuditPipeline`. Surfaced during the post-#185 review pass.

The pipeline at `src/lib/brand-audit-pipeline.ts:1061` only enqueues the `{ phase: 'deep_scan' }` follow-up message when `deps.brandAuditQueue` is present. Neither call site forwarded it:

- `src/handlers/tools.ts` brand_audit_single execute closure was passing `certstream`, `whoisBinding`, `enforceQuota`, tier0/1/2 — but not `brandAuditQueue`.
- `src/queue/brand-audit-consumer.ts` `processBrandAuditMessage` built singleDeps from tier closures + whoisBinding + certstream — but not `brandAuditQueue`, even though `BrandAuditConsumerDeps` already holds one (used for Phase 2b retry-enqueue at line 416).

Result: every `view='registrar_complement'` audit, from BOTH the synchronous MCP path and the queue path, persisted `registrar_complement_fast` to the step-store and never triggered the deep-scan job that produces `registrar_complement_full`. `brand_audit_get_report` falls back to the fast payload at get-report.ts:187 and customers never saw the deep-scan enrichment.

## Changes

- `src/handlers/tools.ts`: spread `ro.brandAuditQueue` into brand_audit_single's pipeline deps.
- `src/queue/brand-audit-consumer.ts`: spread `deps.brandAuditQueue` into singleDeps and include it in the `hasSingleDeps` gate so 2-arg-vs-3-arg call selection stays correct on certstream-only deploys.
- Regression tests for each call site (mirror the certstream pattern from #185).
- **New audit test** `test/audits/brand-audit-pipeline-deps-parity.audit.test.ts` enumerates every binding-backed pipeline dep (`certstream`, `whoisBinding`, `tier0Lookup`, `tier1Lookup`, `tier2Lookup`, `brandAuditQueue`) and grep-asserts both call sites forward each one — plus the `hasSingleDeps` gate covers each. Catches the next instance of this pattern at test-time instead of in production traces.

## Why it didn't fail typecheck

The pipeline's `brandAuditQueue?: { send(unknown): Promise<void> }` is an optional field. Both call sites' deps literals are valid without it. Type-checker has no way to know there's a runtime semantic relationship between "the env binding exists" and "this pipeline dep should be populated."

## Test plan

- [x] `npx vitest run test/queue/brand-audit-consumer.integration.test.ts test/brand-audit-view-gate.spec.ts test/audits/brand-audit-pipeline-deps-parity.audit.test.ts` — 36/36 pass
- [x] `npx vitest run test/queue/ test/audits/brand-audit-pipeline-deps-parity.audit.test.ts test/brand-audit-pipeline.test.ts test/brand-audit-pipeline-lookup-failed.test.ts test/brand-audit-view-gate.spec.ts test/brand-audit-single.test.ts test/index.spec.ts test/chaos/brand-audit-consumer.chaos.test.ts` — 169/169 pass
- [x] `npm run typecheck` clean
- [x] TDD: both per-call-site tests RED before the implementation, GREEN after. Audit test fails immediately if any future PR drops a forwarding line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)