### PR TITLE
docs(brand-audit): fix stale 2-arg call invariant comment in queue consumer

### DIFF
--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -290,10 +290,15 @@ export async function processBrandAuditMessage(rawBody: unknown, deps: BrandAudi
 	}, BRAND_AUDIT_MESSAGE_TIMEOUT_MS);
 	let result: CheckResult | null = null;
 	let runtimeError: string | null = null;
-	// Tier closures: built once, passed as the 3rd `deps` arg ONLY when at
-	// least one closure is present. Skipping the arg on BSL self-hosts keeps
-	// the existing 2-arg `toHaveBeenCalledWith(...)` test assertions valid —
-	// vitest matches arg count exactly.
+	// Pipeline deps: built once, passed as the 3rd `deps` arg ONLY when at
+	// least one binding-backed field is present (any tier closure, whoisBinding,
+	// or certstream — see hasSingleDeps below). Skipping the arg keeps the
+	// existing 2-arg `toHaveBeenCalledWith(...)` test assertions valid for the
+	// many tests that mock no bindings — vitest matches arg count exactly. The
+	// 3-arg path activates when ANY single binding is provided, including on a
+	// BSL self-host with only BV_CERTSTREAM provisioned. Any new binding-backed
+	// pipeline dep must be added to BOTH the singleDeps spread AND the
+	// hasSingleDeps gate — they must enumerate the same set.
 	const singleDeps: BrandAuditSingleDeps = {
 		...(deps.tier0Lookup ? { tier0Lookup: deps.tier0Lookup } : {}),
 		...(deps.tier1Lookup ? { tier1Lookup: deps.tier1Lookup } : {}),


### PR DESCRIPTION
## Summary

The comment above \`singleDeps\` construction in \`processBrandAuditMessage\` (src/queue/brand-audit-consumer.ts:293-296) said:

> Tier closures: built once, passed as the 3rd \`deps\` arg ONLY when at least one closure is present. Skipping the arg on BSL self-hosts keeps the existing 2-arg \`toHaveBeenCalledWith(...)\` test assertions valid — vitest matches arg count exactly.

True when written. But the \`hasSingleDeps\` gate has since accumulated \`whoisBinding\` and (in #185) \`certstream\`, neither of which is a "tier closure." A BSL self-host with only \`BV_CERTSTREAM\` provisioned (a public binding, not operator-only) now takes the 3-arg path — directly contradicting the comment's stated invariant.

## Change

Rewrite the comment to describe the actual current contract:
- gate fires "when at least one binding-backed field is present"
- 2-arg path is preserved for tests that mock no bindings, not for "BSL self-hosts"
- maintainer rule: any new binding-backed pipeline dep must be added to BOTH the \`singleDeps\` spread AND the \`hasSingleDeps\` gate

## Test plan

- [x] \`npx vitest run test/queue/brand-audit-consumer.integration.test.ts\` — 18/18 pass (doc-only, no behavior change)
- [x] \`npm run typecheck\` clean

Doc-only PR. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)