### PR TITLE
feat(brand-discovery): paywall discovery_mode='tiered' at developer tier or higher

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -631,6 +631,22 @@ export async function handleToolsCall(
 				}
 			}
 
+			// Tier gate: discovery_mode='tiered' activates the Tier-0/1/2 lookups
+			// against private BV_INFRA_GRAPH, BV_INTEL_GATEWAY, and BV_ENTERPRISE
+			// service bindings (operator-deploy only). Pay-walled at developer
+			// tier or higher to match the premium nature of those data sources.
+			// On BSL self-hosts the bindings are unprovisioned and the pipeline
+			// degrades to classic regardless, so this gate is a no-op there.
+			if (name === 'discover_brand_domains' || name === 'brand_audit_single' || name === 'brand_audit_batch_start') {
+				const requestedMode = (validatedArgs as { discovery_mode?: string }).discovery_mode;
+				if (requestedMode === 'tiered') {
+					const tier = runtimeOptions?.authTier;
+					if (tier !== 'developer' && tier !== 'partner' && tier !== 'enterprise' && tier !== 'owner') {
+						return buildToolErrorResult("Invalid discovery_mode: 'tiered' requires developer tier or higher");
+					}
+				}
+			}
+
 			// Dispatch to the appropriate tool — check registry first, then special cases
 			const registeredTool = TOOL_REGISTRY[name];
 			if (registeredTool) {

--- a/test/brand-audit-discovery-mode-gate.spec.ts
+++ b/test/brand-audit-discovery-mode-gate.spec.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tier gate for `discovery_mode='tiered'` on the brand-discovery surface.
+ *
+ * Background: `tiered` discovery activates Tier-0/1/2 lookups against the
+ * private BV_INFRA_GRAPH, BV_INTEL_GATEWAY, and BV_ENTERPRISE service
+ * bindings (operator-deploy only). Premium data sources behind a public
+ * tool surface — pay-walling them mirrors the `view='csc_complement'` gate
+ * at handlers/tools.ts and brings discover_brand_domains, brand_audit_single,
+ * and brand_audit_batch_start into parity. On BSL self-hosts, the bindings
+ * aren't provisioned and the pipeline degrades to classic; the gate is a
+ * no-op there because the underlying capability never existed.
+ *
+ * Mocks underlying tools so the "accepts" tests don't hit real DNS/RDAP.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+const TOOLS_ACCEPTING_DISCOVERY_MODE = ['discover_brand_domains', 'brand_audit_single', 'brand_audit_batch_start'] as const;
+
+type ToolName = (typeof TOOLS_ACCEPTING_DISCOVERY_MODE)[number];
+
+function makeArgs(tool: ToolName, discovery_mode?: 'tiered' | 'classic') {
+	const base = tool === 'brand_audit_batch_start' ? { domains: ['example.com'] } : { domain: 'example.com' };
+	return discovery_mode === undefined ? base : { ...base, discovery_mode };
+}
+
+const okResult = {
+	category: 'brand_discovery',
+	passed: true,
+	score: 100,
+	findings: [],
+};
+
+function mockUnderlyingTools() {
+	vi.doMock('../src/tools/discover-brand-domains', () => ({
+		discoverBrandDomains: vi.fn().mockResolvedValue(okResult),
+	}));
+	vi.doMock('../src/tools/brand-audit-single', () => ({
+		brandAuditSingle: vi.fn().mockResolvedValue(okResult),
+	}));
+	vi.doMock('../src/tools/brand-audit-batch-start', () => ({
+		brandAuditBatchStart: vi.fn().mockResolvedValue(okResult),
+	}));
+}
+
+describe('discovery_mode=tiered tier gate', () => {
+	afterEach(() => {
+		vi.resetModules();
+		vi.doUnmock('../src/tools/discover-brand-domains');
+		vi.doUnmock('../src/tools/brand-audit-single');
+		vi.doUnmock('../src/tools/brand-audit-batch-start');
+	});
+
+	for (const tool of TOOLS_ACCEPTING_DISCOVERY_MODE) {
+		const args = makeArgs(tool, 'tiered');
+
+		it(`rejects ${tool} discovery_mode='tiered' when authTier is free`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'free' } as never);
+			expect(result.isError, `${tool}@free with discovery_mode=tiered must error`).toBe(true);
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires developer tier or higher/);
+		});
+
+		it(`rejects ${tool} discovery_mode='tiered' when authTier is agent`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'agent' } as never);
+			expect(result.isError, `${tool}@agent with discovery_mode=tiered must error`).toBe(true);
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires developer tier or higher/);
+		});
+
+		it(`accepts ${tool} discovery_mode='tiered' when authTier is developer`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'developer' } as never);
+			if (result.isError) {
+				const textContent = result.content[0];
+				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid discovery_mode: 'tiered'/);
+			}
+		});
+
+		it(`accepts ${tool} discovery_mode='tiered' when authTier is enterprise`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'enterprise' } as never);
+			if (result.isError) {
+				const textContent = result.content[0];
+				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid discovery_mode: 'tiered'/);
+			}
+		});
+	}
+
+	it('omitting discovery_mode does not trigger the gate (free tier allowed)', async () => {
+		mockUnderlyingTools();
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall({ name: 'discover_brand_domains', arguments: makeArgs('discover_brand_domains') }, undefined, {
+			authTier: 'free',
+		} as never);
+		if (result.isError) {
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).not.toMatch(/^Error: Invalid discovery_mode/);
+		}
+	});
+
+	it("discovery_mode='classic' is never gated, regardless of tier", async () => {
+		mockUnderlyingTools();
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall(
+			{ name: 'discover_brand_domains', arguments: makeArgs('discover_brand_domains', 'classic') },
+			undefined,
+			{ authTier: 'free' } as never,
+		);
+		if (result.isError) {
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).not.toMatch(/^Error: Invalid discovery_mode/);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes the paywall gap surfaced in the post-#186 paywall audit (Gap 1 in `.dev/demos/PAYWALL-AUDIT.md`).

`discovery_mode='tiered'` activates Tier-0/1/2 lookups against the private `BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`, and `BV_ENTERPRISE` service bindings. On the BlackVeil-production deploy where those bindings are provisioned, a `free`-tier caller could request `discovery_mode='tiered'` and get the enriched response at 1/day per IP via `discover_brand_domains`. That's a paywall inversion — premium data sources accessible to free callers, just throttled.

Mirrors the `view='registrar_complement'` gate (`src/handlers/tools.ts:622-632`) and applies the same pattern to `discovery_mode='tiered'`.

## Changes

- `src/handlers/tools.ts`: new gate block in the `executeDispatch` closure that rejects `discovery_mode='tiered'` when `authTier ∉ {developer, partner, enterprise, owner}`. Sits alongside the existing registrar-complement view gate.
- `test/brand-audit-discovery-mode-gate.spec.ts`: 14 new tests covering all three tools × free/agent/developer/enterprise combinations + omit + classic edge cases. Mocks the underlying tool modules (`discoverBrandDomains`, `brandAuditSingle`, `brandAuditBatchStart`) so the "accepts" tests don't hit real DNS/RDAP.

## Behavior

| caller tier | discovery_mode | result |
|---|---|---|
| free, agent | `'tiered'` | **rejected** with `Error: Invalid discovery_mode: 'tiered' requires developer tier or higher` |
| developer, partner, enterprise, owner | `'tiered'` | passes the gate; executes normally |
| any tier | `'classic'` or omitted | unchanged behavior |

## On BSL self-hosts

The private bindings aren't provisioned there, so the pipeline previously degraded to classic regardless. The gate is effectively a no-op — it just rejects the request before the degraded execution would have happened. No functional change for self-hosts.

## Test plan

- [x] `npx vitest run test/brand-audit-discovery-mode-gate.spec.ts` — 14/14 pass
- [x] `npx vitest run test/brand-audit-discovery-mode-gate.spec.ts test/brand-audit-view-gate.spec.ts test/brand-audit-single.test.ts test/queue/ test/audits/` — 269 passed, 1 skipped (6 unhandled errors are the documented "pool-teardown noise" known flake per CLAUDE.md)
- [x] `npm run typecheck` clean
- [x] TDD: 6 "rejects" cases were RED before the gate; all GREEN after

🤖 Generated with [Claude Code](https://claude.com/claude-code)