### PR TITLE
docs(claude-md): correct static-key tier resolution and agent daily limit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,7 @@ bv-web plan → OAuth tier claim → bv-mcp limits:
 | pro / business / MCP Developer | developer  | 500       | 10         | Business / 48h  |
 | enterprise / MCP Enterprise    | enterprise | 10,000    | 25         | Enterprise / 4h |
 
-Resolution in `src/oauth/entitlements.ts` via bv-web service binding `api/internal/mcp/oauth/authorize`. Mapping defined in bv-web `app/lib/services/mcp/oauth-entitlements.server.ts`. Static API keys never resolve `developer`/`enterprise` from OAuth — they map to `agent` (500/day, 5 concurrent).
+Resolution in `src/oauth/entitlements.ts` via bv-web service binding `api/internal/mcp/oauth/authorize`. Mapping defined in bv-web `app/lib/services/mcp/oauth-entitlements.server.ts`. The local static `BV_API_KEY` resolves to `owner` tier (`src/lib/tier-auth.ts:246-253`), with the `OWNER_ALLOW_IPS` IP gate downgrading to `partner` when the client IP isn't allowlisted. The `agent` tier (200/day, 5 concurrent) is reachable only via the bv-web `validate-key` service binding, when bv-web returns that tier for a non-paying key.
 
 ### Internal routes
 


### PR DESCRIPTION
## Summary

Doc-only fixes for two inaccuracies surfaced by the paywall audit (`.dev/demos/PAYWALL-AUDIT.md` gaps 3 & 4).

The \"Paid OAuth tiers\" section of CLAUDE.md previously said:

> Static API keys never resolve \`developer\`/\`enterprise\` from OAuth — they map to \`agent\` (500/day, 5 concurrent).

Both claims were wrong:

1. **Static-key tier**: \`src/lib/tier-auth.ts:246-253\` resolves a successful \`BV_API_KEY\` match to \`owner\` (with \`OWNER_ALLOW_IPS\` IP-gate downgrading to \`partner\`). The \`agent\` tier is only reachable via the bv-web \`validate-key\` service binding. The earlier \"Auth\" section of CLAUDE.md already states \`BV_API_KEY → owner\` correctly; this PR makes the later paragraph consistent.

2. **agent daily limit**: \`TIER_DAILY_LIMITS.agent = 200\` (\`src/lib/config.ts:133\`), not 500. The 5-concurrent number was correct.

No code or runtime behavior changes.

## Test plan

- [x] \`grep -n agent CLAUDE.md\` — only the corrected paragraph mentions agent's daily quota
- [x] Cross-checked against \`src/lib/tier-auth.ts\` and \`src/lib/config.ts\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)