### PR TITLE
feat(brand-discovery): paywall depth='deep' at developer tier or higher

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -647,6 +647,22 @@ export async function handleToolsCall(
 				}
 			}
 
+			// Tier gate: depth='deep' expands candidate seeding + enrichment fanout
+			// (roughly 3× the per-call compute cost of 'standard'). Pay-walled at
+			// developer tier or higher — same threshold as discovery_mode='tiered'.
+			// Defensive for brand_audit_* (free/agent already get 0 quota there);
+			// meaningful for discover_brand_domains where free callers have 1/day
+			// and could otherwise burn it on deep.
+			if (name === 'discover_brand_domains' || name === 'brand_audit_single' || name === 'brand_audit_batch_start') {
+				const requestedDepth = (validatedArgs as { depth?: string }).depth;
+				if (requestedDepth === 'deep') {
+					const tier = runtimeOptions?.authTier;
+					if (tier !== 'developer' && tier !== 'partner' && tier !== 'enterprise' && tier !== 'owner') {
+						return buildToolErrorResult("Invalid depth: 'deep' requires developer tier or higher");
+					}
+				}
+			}
+
 			// Dispatch to the appropriate tool — check registry first, then special cases
 			const registeredTool = TOOL_REGISTRY[name];
 			if (registeredTool) {

--- a/test/brand-audit-depth-gate.spec.ts
+++ b/test/brand-audit-depth-gate.spec.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Tier gate for `depth='deep'` on the brand-discovery surface.
+ *
+ * Background: `deep` discovery expands candidate seeding and enrichment fanout,
+ * roughly 3× the per-call compute and outbound-fetch cost of `standard`. The
+ * surface accepts it on three tools — `discover_brand_domains`,
+ * `brand_audit_single`, and `brand_audit_batch_start`. Pre-gate, a free caller
+ * could request `deep` at the per-tool quota limit (1/day for
+ * `discover_brand_domains`; brand_audit_* are already 0 for free/agent so the
+ * gate is redundant-but-defensive for those two).
+ *
+ * Pay-walled at developer tier or higher — same threshold as the
+ * `discovery_mode='tiered'` gate landed in PR #188.
+ *
+ * Mocks underlying tools so "accepts" tests don't hit real DNS/RDAP.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+const TOOLS_ACCEPTING_DEPTH = ['discover_brand_domains', 'brand_audit_single', 'brand_audit_batch_start'] as const;
+type ToolName = (typeof TOOLS_ACCEPTING_DEPTH)[number];
+
+function makeArgs(tool: ToolName, depth?: 'deep' | 'standard') {
+	const base = tool === 'brand_audit_batch_start' ? { domains: ['example.com'] } : { domain: 'example.com' };
+	return depth === undefined ? base : { ...base, depth };
+}
+
+const okResult = { category: 'brand_discovery', passed: true, score: 100, findings: [] };
+
+function mockUnderlyingTools() {
+	vi.doMock('../src/tools/discover-brand-domains', () => ({
+		discoverBrandDomains: vi.fn().mockResolvedValue(okResult),
+	}));
+	vi.doMock('../src/tools/brand-audit-single', () => ({
+		brandAuditSingle: vi.fn().mockResolvedValue(okResult),
+	}));
+	vi.doMock('../src/tools/brand-audit-batch-start', () => ({
+		brandAuditBatchStart: vi.fn().mockResolvedValue(okResult),
+	}));
+}
+
+describe('depth=deep tier gate', () => {
+	afterEach(() => {
+		vi.resetModules();
+		vi.doUnmock('../src/tools/discover-brand-domains');
+		vi.doUnmock('../src/tools/brand-audit-single');
+		vi.doUnmock('../src/tools/brand-audit-batch-start');
+	});
+
+	for (const tool of TOOLS_ACCEPTING_DEPTH) {
+		const args = makeArgs(tool, 'deep');
+
+		it(`rejects ${tool} depth='deep' when authTier is free`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'free' } as never);
+			expect(result.isError, `${tool}@free with depth=deep must error`).toBe(true);
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).toMatch(/^Error: Invalid depth: 'deep' requires developer tier or higher/);
+		});
+
+		it(`rejects ${tool} depth='deep' when authTier is agent`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'agent' } as never);
+			expect(result.isError, `${tool}@agent with depth=deep must error`).toBe(true);
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).toMatch(/^Error: Invalid depth: 'deep' requires developer tier or higher/);
+		});
+
+		it(`accepts ${tool} depth='deep' when authTier is developer`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'developer' } as never);
+			if (result.isError) {
+				const textContent = result.content[0];
+				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid depth: 'deep'/);
+			}
+		});
+
+		it(`accepts ${tool} depth='deep' when authTier is enterprise`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'enterprise' } as never);
+			if (result.isError) {
+				const textContent = result.content[0];
+				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid depth: 'deep'/);
+			}
+		});
+	}
+
+	it('omitting depth does not trigger the gate (free tier allowed)', async () => {
+		mockUnderlyingTools();
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall({ name: 'discover_brand_domains', arguments: makeArgs('discover_brand_domains') }, undefined, {
+			authTier: 'free',
+		} as never);
+		if (result.isError) {
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).not.toMatch(/^Error: Invalid depth/);
+		}
+	});
+
+	it("depth='standard' is never gated, regardless of tier", async () => {
+		mockUnderlyingTools();
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall(
+			{ name: 'discover_brand_domains', arguments: makeArgs('discover_brand_domains', 'standard') },
+			undefined,
+			{ authTier: 'free' } as never,
+		);
+		if (result.isError) {
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).not.toMatch(/^Error: Invalid depth/);
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Closes paywall-audit gap 2 (\`.dev/demos/PAYWALL-AUDIT.md\`). \`depth='deep'\` on the three brand-discovery tools is now gated at developer tier or higher — same threshold and pattern as PR #188's \`discovery_mode='tiered'\` gate.

\`depth='deep'\` expands candidate seeding + enrichment fanout, roughly 3× the per-call compute and outbound-fetch cost of \`standard\`. Pre-gate, a free caller could spend their 1/day \`discover_brand_domains\` quota on deep discovery (or, on a binding-provisioned deploy, against the Tier-0/1/2 pipeline).

## Changes

- \`src/handlers/tools.ts\`: new gate block in the \`executeDispatch\` closure, sitting alongside the existing view + discovery_mode gates. Rejects \`depth='deep'\` when \`authTier ∉ {developer, partner, enterprise, owner}\`.
- \`test/brand-audit-depth-gate.spec.ts\`: 14 cases (3 tools × 4 tiers + omit + standard). Mocks the underlying tool modules so the \"accepts\" tests don't hit real DNS/RDAP.

## Behavior

| caller tier | \`depth='deep'\` | \`depth='standard'\` / omitted |
|---|---|---|
| free, agent | **rejected** with \`Error: Invalid depth: 'deep' requires developer tier or higher\` | unchanged |
| developer, partner, enterprise, owner | unchanged | unchanged |

## Why \`developer+\` (matching #188's threshold)

- Cost: ~3× compute + outbound. Paying customers absorb this; free should not.
- Consistency: \`discovery_mode='tiered'\` already gates at developer+. Keeping the threshold uniform avoids \`free\` callers needing to remember which premium knob is gated where.
- For \`brand_audit_*\`, the gate is redundant-but-defensive — those tools already have 0 quota on free/agent. Real value is on \`discover_brand_domains\` where free has 1/day.

## Test plan

- [x] \`npx vitest run test/brand-audit-depth-gate.spec.ts\` — 14/14 pass
- [x] \`npm run typecheck\` clean
- [x] TDD: 6 \"rejects\" cases RED before the gate; all GREEN after

🤖 Generated with [Claude Code](https://claude.com/claude-code)