### PR TITLE
docs(config): clarify intentional partner ≥ enterprise daily-cap inversion for brand_audit_*

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -140,6 +140,14 @@ export const TIER_DAILY_LIMITS: Record<McpApiKeyTier, number> = {
 /**
  * Per-tool daily limit overrides for specific tiers.
  * When a tier+tool combo exists here, it takes precedence over the flat TIER_DAILY_LIMITS value.
+ *
+ * Note on brand_audit_* daily caps: partner=200, enterprise=500 is intentional
+ * even though partner > enterprise in the generic TIER_DAILY_LIMITS hierarchy.
+ * Brand audits are multi-minute operations metered on a MONTHLY budget
+ * (BRAND_AUDIT_QUOTAS: partner=200/month, enterprise=500/month). The daily
+ * cap mirrors the monthly budget so a customer can't burn their entire
+ * monthly quota in one day — the daily ≤ monthly invariant matters more
+ * than the cross-tier daily ordering for these specific tools.
  */
 export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string, number>>> = {
 	partner: {


### PR DESCRIPTION
## Summary

Closes paywall-audit gap 6 (\`.dev/demos/PAYWALL-AUDIT.md\`). Adds a JSDoc explaining why \`TIER_TOOL_DAILY_LIMITS.partner.brand_audit_single = 200\` is below \`TIER_TOOL_DAILY_LIMITS.enterprise.brand_audit_single = 500\` — opposite of every other tool's partner > enterprise daily-cap ordering.

The inversion is intentional and well-grounded:

- Brand audits are multi-minute operations, metered on a **monthly** budget (\`BRAND_AUDIT_QUOTAS.partner = 200/month, enterprise = 500/month\`).
- Daily cap mirrors monthly budget so no customer can burn the entire month in one day.
- For other tools (single-digit-second DNS checks), the partner > enterprise daily ordering reflects partner's higher-volume / enterprise-redistribution semantics.

Without this comment, the next reader-without-context will flag this as a bug, send a PR \"fixing\" it, and break partner-tier billing.

## Test plan

- [x] One-line JSDoc addition. No code/behavior change.
- [x] No new tests needed (the audit-test landed in #190 already pins the intentional values).

🤖 Generated with [Claude Code](https://claude.com/claude-code)