### PR TITLE
fix(mcp): align tool surface with Anthropic Directory review criteria

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Changed
+
+- **Split `brand_audit_watch` into three single-purpose tools** — `list_brand_audit_watches` (read-only), `register_brand_audit_watch` (write), and `delete_brand_audit_watch` (destructive). **Breaking MCP surface change:** the `action`-discriminated `brand_audit_watch` tool is removed. Satisfies the Anthropic Directory rule that read and destructive operations live in separate tools. `delete_brand_audit_watch` now advertises `destructiveHint: true`. Behavior (owner-scoping, SSRF re-validation, 20-watch cap, per-tier quotas) is unchanged. Tool surface 60 → 62.
+- **Tool annotations carry a real `destructiveHint`** — `ToolDef` gained a `destructive?` flag; the previously hard-coded `destructiveHint: false` now reflects it. New audit `test/audits/tool-annotations.audit.test.ts` locks the directory review criteria (title present, names ≤64, read/destructive split, no prescriptive/injection language in descriptions).
+- **`scan_domain` description rewritten** to describe behavior factually instead of steering Claude ("Use this whenever…", "Start here…") — the latter is treated as prompt injection at directory review.
+- **`tools/list` wire response is MCP-spec-shaped** — server-specific `group`/`tier`/`scanIncluded` fields moved under the spec-sanctioned `_meta` object instead of leaking as top-level tool fields.
+
 ## [2.27.0] - 2026-05-23
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Guidance for Claude Code working in this repo.
 ## What is this?
 
 Blackveil DNS — source-available DNS & email security scanner, built as a Cloudflare Worker.
-57 tools exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` runs only inside `scan_domain`. Listed on the MCP Registry as `com.blackveilsecurity/dns`.
+62 tools exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` runs only inside `scan_domain`. Listed on the MCP Registry as `com.blackveilsecurity/dns`.
 
 **Version sync** when bumping: `SERVER_VERSION` (`src/lib/server-version.ts`), `version` in `package.json` + `package-lock.json`, `version` AND `packages[0].version` in `server.json` (both fields — foot-gun), and `[X.Y.Z]` heading in `CHANGELOG.md`.
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 [![GitHub stars](https://img.shields.io/github/stars/MadaBurns/bv-mcp?style=flat&logo=github)](https://github.com/MadaBurns/bv-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
-[![MCP tools](https://img.shields.io/badge/MCP%20tools-60-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
+[![MCP tools](https://img.shields.io/badge/MCP%20tools-62-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-2025--03--26-blue)](https://modelcontextprotocol.io/)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com/)
@@ -25,7 +25,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 
 **Claude Desktop** (one-click install):
 
-Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 60-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
+Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 62-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
 
 **Claude Code** (one command):
 
@@ -65,7 +65,7 @@ Transport support:
 
 ## What you get
 
-- **60 MCP tools with 18 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, brand discovery, and authoritative DNS infrastructure
+- **62 MCP tools with 18 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, brand discovery, and authoritative DNS infrastructure
 - **Maturity staging** — Stage 0-4 classification (Unprotected to Hardened) with score-based capping to prevent inflated labels
 - **Trust surface analysis** — detects shared SaaS platforms (Google, M365, SendGrid) and cross-references DMARC enforcement to determine real exposure
 - **Guided remediation** — `generate_fix_plan` produces provider-aware prioritized actions; record generators output ready-to-publish records; `validate_fix` confirms whether a fix was applied successfully
@@ -81,7 +81,7 @@ Transport support:
 ## Tools
 
 ```
-  60 MCP tools · 7 prompts · 6 resources
+  62 MCP tools · 7 prompts · 6 resources
 
   Email Auth             Infrastructure          Brand & Threats       Meta
  ─────────────          ──────────────          ───────────────       ───────────────
@@ -105,9 +105,10 @@ Transport support:
   discover_subdomains   check_nsec_             brand_audit_status
   map_compliance          walkability           brand_audit_get_
   simulate_attack_paths check_dnssec_chain        report
-                        check_fast_flux         brand_audit_watch
+                        check_fast_flux         list_brand_audit_watches
                         check_authoritative_dns_infra
-                        check_root_server_set
+                        check_root_server_set   register_brand_audit_watch
+                                                delete_brand_audit_watch
 
   + check_subdomain_takeover (standalone tool + internal — runs inside scan_domain)
   + check_authoritative_dns_infra and check_root_server_set (authoritative DNS infrastructure profile)

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -4,7 +4,7 @@ These settings must be configured manually in the GitHub web UI.
 
 ## Repository description
 
-Set to: `Source-available DNS & email security scanner for MCP clients. 60 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
+Set to: `Source-available DNS & email security scanner for MCP clients. 62 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
 
 ## Repository topics
 

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 	"name": "com.blackveilsecurity/dns",
-	"description": "DNS and email security scanner with 60 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"description": "DNS and email security scanner with 62 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
 	"repository": {
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"

--- a/src/handlers/resources.ts
+++ b/src/handlers/resources.ts
@@ -24,19 +24,19 @@ interface McpResourceContent {
 
 /** Static resource definitions */
 const RESOURCES: McpResource[] = [
- {
-   uri: 'dns-security://guides/security-checks',
-   name: 'DNS Security Checks Guide',
-   description:
-		 'Overview of all DNS/email security checks performed by Blackveil DNS, including SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, and Subdomain Takeover.',
-   mimeType: 'text/markdown',
- },
- {
-   uri: 'dns-security://guides/scoring',
-   name: 'Scoring Methodology',
-   description: 'How DNS/email security scores and grades are calculated, including category weights and severity penalties.',
-   mimeType: 'text/markdown',
- },
+	{
+		uri: 'dns-security://guides/security-checks',
+		name: 'DNS Security Checks Guide',
+		description:
+			'Overview of all DNS/email security checks performed by Blackveil DNS, including SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, and Subdomain Takeover.',
+		mimeType: 'text/markdown',
+	},
+	{
+		uri: 'dns-security://guides/scoring',
+		name: 'Scoring Methodology',
+		description: 'How DNS/email security scores and grades are calculated, including category weights and severity penalties.',
+		mimeType: 'text/markdown',
+	},
 	{
 		uri: 'dns-security://guides/record-types',
 		name: 'Supported DNS Record Types',
@@ -109,7 +109,7 @@ const RESOURCE_CONTENT: Record<string, string> = {
 ## Composite Tools
 
 - **\`scan_domain\`** - 18 scan categories in parallel, returns score + grade + prioritized findings
-- **Brand audit tools** - \`discover_brand_domains\`, \`brand_audit_single\`, \`brand_audit_batch_start\`, \`brand_audit_status\`, \`brand_audit_get_report\`, \`brand_audit_watch\`
+- **Brand audit tools** - \`discover_brand_domains\`, \`brand_audit_single\`, \`brand_audit_batch_start\`, \`brand_audit_status\`, \`brand_audit_get_report\`, \`list_brand_audit_watches\`, \`register_brand_audit_watch\`, \`delete_brand_audit_watch\`
 - **\`explain_finding\`** - plain-language context + remediation for any finding
 - **\`compare_baseline\`** - pass/fail against minimum security standards
 `,

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -64,7 +64,7 @@ import { brandAuditSingle } from '../tools/brand-audit-single';
 import { brandAuditBatchStart } from '../tools/brand-audit-batch-start';
 import { brandAuditStatus } from '../tools/brand-audit-status';
 import { brandAuditGetReport } from '../tools/brand-audit-get-report';
-import { brandAuditWatch } from '../tools/brand-audit-watch';
+import { registerBrandAuditWatch, listBrandAuditWatches, deleteBrandAuditWatch } from '../tools/brand-audit-watch';
 import { createD1BrandAuditStepStore } from '../lib/brand-audit-step-store';
 import type { PolicyBaseline } from '../tools/compare-baseline';
 import type { AnalyticsClient } from '../lib/analytics';
@@ -96,11 +96,41 @@ interface McpToolResult {
 }
 
 /**
- * Handle the MCP tools/list method.
- * Returns all available tool definitions.
+ * MCP-spec-shaped tool descriptor as sent over the wire. Server-specific
+ * metadata (functional group, scoring tier, scan inclusion) is nested under
+ * `_meta` — the spec-sanctioned extension point — rather than leaked as
+ * top-level fields the MCP `Tool` shape does not define.
  */
-export function handleToolsList(): { tools: McpTool[] } {
-	return { tools: TOOLS };
+interface WireTool {
+	name: string;
+	description: string;
+	inputSchema: McpTool['inputSchema'];
+	annotations: McpTool['annotations'];
+	_meta: {
+		group: McpTool['group'];
+		tier?: McpTool['tier'];
+		scanIncluded: boolean;
+	};
+}
+
+/**
+ * Handle the MCP tools/list method.
+ * Returns all available tool definitions in MCP-spec shape.
+ */
+export function handleToolsList(): { tools: WireTool[] } {
+	return {
+		tools: TOOLS.map((tool) => ({
+			name: tool.name,
+			description: tool.description,
+			inputSchema: tool.inputSchema,
+			annotations: tool.annotations,
+			_meta: {
+				group: tool.group,
+				...(tool.tier !== undefined && { tier: tool.tier }),
+				scanIncluded: tool.scanIncluded,
+			},
+		})),
+	};
 }
 
 /** Wrapper for dynamic check_mx import (required for test mock isolation) */
@@ -215,6 +245,16 @@ async function dynamicCheckMx(domain: string, runtimeOptions?: ToolRuntimeOption
 		},
 		buildDnsOptions(runtimeOptions),
 	);
+}
+
+/** Shared `unprovisioned` result for the brand-audit watch tools when BRAND_AUDIT_DB is absent. */
+async function brandAuditWatchUnprovisioned(): Promise<CheckResult> {
+	const { buildCheckResult, createFinding } = await import('../lib/scoring');
+	return buildCheckResult('brand_discovery', [
+		createFinding('brand_discovery', 'Brand audit watch unavailable', 'high', 'BRAND_AUDIT_DB binding is not provisioned.', {
+			unprovisioned: true,
+		}),
+	]);
 }
 
 /**
@@ -502,31 +542,44 @@ const TOOL_REGISTRY: Record<
 		},
 		cacheable: false,
 	},
-	brand_audit_watch: {
+	list_brand_audit_watches: {
+		// Read-only, but watch state is mutable — never cache.
+		cacheKey: () => `__nocache__:list_brand_audit_watches:${crypto.randomUUID()}`,
+		execute: async (_domain, _args, ro) => {
+			const db = ro?.brandAuditDb;
+			const principalId = ro?.principalId ?? ro?.keyHash ?? 'anonymous';
+			if (!db) return brandAuditWatchUnprovisioned();
+			return listBrandAuditWatches(principalId, { db });
+		},
+		cacheTtlSeconds: 0,
+	},
+	register_brand_audit_watch: {
 		// Mutating tool — random UUID keeps every call a cache-miss.
-		cacheKey: () => `__nocache__:brand_audit_watch:${crypto.randomUUID()}`,
+		cacheKey: () => `__nocache__:register_brand_audit_watch:${crypto.randomUUID()}`,
 		execute: async (_domain, args, ro) => {
 			const db = ro?.brandAuditDb;
 			const principalId = ro?.principalId ?? ro?.keyHash ?? 'anonymous';
-			if (!db) {
-				const { buildCheckResult, createFinding } = await import('../lib/scoring');
-				return buildCheckResult('brand_discovery', [
-					createFinding('brand_discovery', 'Brand audit watch unavailable', 'high', 'BRAND_AUDIT_DB binding is not provisioned.', {
-						unprovisioned: true,
-					}),
-				]);
-			}
-			return brandAuditWatch(
+			if (!db) return brandAuditWatchUnprovisioned();
+			return registerBrandAuditWatch(
 				{
-					action: args.action as 'register' | 'list' | 'delete',
 					domain: args.domain as string | undefined,
 					interval: args.interval as 'daily' | 'weekly' | 'monthly' | undefined,
 					webhook_url: args.webhook_url as string | undefined,
-					watchId: args.watchId as string | undefined,
 				},
 				principalId,
 				{ db },
 			);
+		},
+		cacheTtlSeconds: 0,
+	},
+	delete_brand_audit_watch: {
+		// Destructive tool — random UUID keeps every call a cache-miss.
+		cacheKey: () => `__nocache__:delete_brand_audit_watch:${crypto.randomUUID()}`,
+		execute: async (_domain, args, ro) => {
+			const db = ro?.brandAuditDb;
+			const principalId = ro?.principalId ?? ro?.keyHash ?? 'anonymous';
+			if (!db) return brandAuditWatchUnprovisioned();
+			return deleteBrandAuditWatch({ watchId: args.watchId as string | undefined }, principalId, { db });
 		},
 		cacheTtlSeconds: 0,
 	},
@@ -604,11 +657,13 @@ export async function handleToolsCall(
 			'batch_scan',
 			'compare_domains',
 			'check_root_server_set',
-			// v2.21+ brand-audit tools — take `domains[]`, `auditId`, or `action` instead of `domain`.
+			// v2.21+ brand-audit tools — take `domains[]`, `auditId`, or `watchId` instead of a required `domain`.
 			'brand_audit_batch_start',
 			'brand_audit_status',
 			'brand_audit_get_report',
-			'brand_audit_watch',
+			'list_brand_audit_watches',
+			'register_brand_audit_watch',
+			'delete_brand_audit_watch',
 		]);
 		if (!DOMAIN_OPTIONAL_TOOLS.has(name)) {
 			domain = extractAndValidateDomain(validatedArgs);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -180,28 +180,36 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		brand_audit_batch_start: 200,
 		brand_audit_status: 10_000,
 		brand_audit_get_report: 10_000,
-		brand_audit_watch: 100,
+		list_brand_audit_watches: 100,
+		register_brand_audit_watch: 100,
+		delete_brand_audit_watch: 100,
 	},
 	developer: {
 		brand_audit_single: 50,
 		brand_audit_batch_start: 50,
 		brand_audit_status: 5_000,
 		brand_audit_get_report: 5_000,
-		brand_audit_watch: 20,
+		list_brand_audit_watches: 20,
+		register_brand_audit_watch: 20,
+		delete_brand_audit_watch: 20,
 	},
 	enterprise: {
 		brand_audit_single: 500,
 		brand_audit_batch_start: 500,
 		brand_audit_status: 25_000,
 		brand_audit_get_report: 25_000,
-		brand_audit_watch: 100,
+		list_brand_audit_watches: 100,
+		register_brand_audit_watch: 100,
+		delete_brand_audit_watch: 100,
 	},
 	agent: {
 		brand_audit_single: 0,
 		brand_audit_batch_start: 0,
 		brand_audit_status: 0,
 		brand_audit_get_report: 0,
-		brand_audit_watch: 0,
+		list_brand_audit_watches: 0,
+		register_brand_audit_watch: 0,
+		delete_brand_audit_watch: 0,
 	},
 };
 
@@ -266,7 +274,9 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	brand_audit_batch_start: 0,
 	brand_audit_status: 0,
 	brand_audit_get_report: 0,
-	brand_audit_watch: 0,
+	list_brand_audit_watches: 0,
+	register_brand_audit_watch: 0,
+	delete_brand_audit_watch: 0,
 };
 
 /** Tools intentionally governed by per-IP rate limits only (no per-tool free-tier quota). Audited by test/audits/tool-quota-coverage.audit.test.ts. */

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -411,21 +411,27 @@ export const BrandAuditGetReportArgs = z
 	})
 	.passthrough();
 
-/** brand_audit_watch — register/list/delete recurring brand-audit watches. */
-export const BrandAuditWatchArgs = z
+/** list_brand_audit_watches — enumerate the caller's recurring brand-audit watches. */
+export const ListBrandAuditWatchesArgs = z.object({}).passthrough();
+
+/** register_brand_audit_watch — create a recurring brand-audit watch. */
+export const RegisterBrandAuditWatchArgs = z
 	.object({
-		action: z
-			.enum(['register', 'list', 'delete'])
-			.describe("Action: 'register' creates a new watch, 'list' returns the caller's watches, 'delete' removes one."),
-		domain: DomainSchema.optional().describe('Domain to watch. Required for action=register.'),
-		interval: z.enum(['daily', 'weekly', 'monthly']).optional().describe('Recurrence interval. Required for action=register.'),
+		domain: DomainSchema.describe('Domain to watch.'),
+		interval: z.enum(['daily', 'weekly', 'monthly']).describe('Recurrence interval.'),
 		webhook_url: z
 			.string()
 			.url()
 			.max(2048)
 			.optional()
 			.describe('Optional webhook URL — POSTed on classification drift. Re-validated for SSRF at both register and delivery time.'),
-		watchId: z.string().min(1).max(64).optional().describe('Watch ID returned by action=register. Required for action=delete.'),
+	})
+	.passthrough();
+
+/** delete_brand_audit_watch — remove a recurring brand-audit watch the caller owns. */
+export const DeleteBrandAuditWatchArgs = z
+	.object({
+		watchId: z.string().min(1).max(64).describe('Watch ID returned by register_brand_audit_watch.'),
 	})
 	.passthrough();
 
@@ -493,5 +499,7 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	brand_audit_batch_start: BrandAuditBatchStartArgs,
 	brand_audit_status: BrandAuditStatusArgs,
 	brand_audit_get_report: BrandAuditGetReportArgs,
-	brand_audit_watch: BrandAuditWatchArgs,
+	list_brand_audit_watches: ListBrandAuditWatchesArgs,
+	register_brand_audit_watch: RegisterBrandAuditWatchArgs,
+	delete_brand_audit_watch: DeleteBrandAuditWatchArgs,
 };

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -28,7 +28,9 @@ import {
 	BrandAuditBatchStartArgs,
 	BrandAuditStatusArgs,
 	BrandAuditGetReportArgs,
-	BrandAuditWatchArgs,
+	ListBrandAuditWatchesArgs,
+	RegisterBrandAuditWatchArgs,
+	DeleteBrandAuditWatchArgs,
 	TOOL_SCHEMA_MAP,
 } from './tool-args';
 
@@ -74,6 +76,8 @@ interface ToolDef {
 	tier?: ToolTier;
 	scanIncluded: boolean;
 	mutating?: boolean;
+	/** True when the tool deletes or overwrites data → drives `destructiveHint`. Implies `mutating`. */
+	destructive?: boolean;
 }
 
 /** DNS/security acronyms that should be uppercased in human-readable tool titles. */
@@ -242,16 +246,16 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		tier: 'protective',
 		scanIncluded: false,
 	},
-		check_subdomailing: {
-			description: 'Detect SubdoMailing risk by analyzing SPF include chain for takeover-vulnerable domains.',
-			schema: BaseDomainArgs,
+	check_subdomailing: {
+		description: 'Detect SubdoMailing risk by analyzing SPF include chain for takeover-vulnerable domains.',
+		schema: BaseDomainArgs,
 		group: 'email_auth',
 		tier: 'protective',
 		scanIncluded: true,
 	},
 	scan_domain: {
 		description:
-			"Look up any domain to get a full DNS and email security audit. Use this whenever a user mentions a domain name, asks to check/scan/lookup/analyze a domain, or wants to know about a domain's security posture. Returns score, grade, maturity stage, and prioritized findings. Start here for any domain-related question.",
+			'Runs a full DNS and email security audit for a domain, aggregating every scan-included check in parallel: SPF, DKIM, DMARC, DNSSEC, TLS/SSL, MTA-STS, CAA, BIMI, subdomain takeover, and more. Returns an overall score, letter grade, maturity stage, and prioritized findings. The broadest single-domain tool; the individual check_* tools each cover one control in isolation.',
 		schema: ScanDomainArgs,
 		group: 'meta',
 		scanIncluded: false,
@@ -531,13 +535,29 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		group: 'discovery',
 		scanIncluded: false,
 	},
-	brand_audit_watch: {
+	list_brand_audit_watches: {
 		description:
-			'Register, list, or delete recurring brand-audit watches. Watches run on a daily/weekly/monthly cadence via the scheduled cron tick — each run enqueues a fresh brand_audit_batch_start and (when configured) POSTs a diff webhook on classification drift. Owner-scoped; per-principal cap of 20 active watches. Phase 4 (v2.21.0+).',
-		schema: BrandAuditWatchArgs,
+			"Returns the caller's recurring brand-audit watches: watchId, domain, interval, webhook presence, last-run time, and active state. Owner-scoped. Read-only.",
+		schema: ListBrandAuditWatchesArgs,
+		group: 'discovery',
+		scanIncluded: false,
+	},
+	register_brand_audit_watch: {
+		description:
+			'Creates a recurring brand-audit watch for a domain on a daily/weekly/monthly cadence. Each run enqueues a fresh brand_audit_batch_start and (when a webhook is configured) POSTs a diff webhook on classification drift. Returns the new watchId. Owner-scoped; per-principal cap of 20 active watches.',
+		schema: RegisterBrandAuditWatchArgs,
 		group: 'discovery',
 		scanIncluded: false,
 		mutating: true,
+	},
+	delete_brand_audit_watch: {
+		description:
+			'Permanently removes a recurring brand-audit watch by watchId. Owner-scoped — a watchId owned by another principal surfaces as notFound. Returns confirmation of deletion.',
+		schema: DeleteBrandAuditWatchArgs,
+		group: 'discovery',
+		scanIncluded: false,
+		mutating: true,
+		destructive: true,
 	},
 };
 
@@ -548,7 +568,7 @@ export const TOOLS: McpTool[] = Object.entries(TOOL_DEFS).map(([name, def]) => (
 	annotations: {
 		title: toolNameToTitle(name),
 		readOnlyHint: !def.mutating,
-		destructiveHint: false,
+		destructiveHint: Boolean(def.destructive),
 		idempotentHint: !def.mutating,
 		openWorldHint: true,
 	},

--- a/src/tools/brand-audit-watch.ts
+++ b/src/tools/brand-audit-watch.ts
@@ -1,13 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * brand_audit_watch — register / list / delete recurring brand-audit watches.
+ * Brand-audit watch tools — register / list / delete recurring brand-audit watches.
  *
- * One MCP tool with an `action` discriminator (mirroring the bv-web pattern
- * for routes that fan out across CRUD verbs without exploding the registry).
- * Owner-scoped: a caller's principalId is bound at every operation, and any
- * cross-owner attempt surfaces as `notFound` (never `accessDenied`) to defend
- * against ID enumeration.
+ * Originally a single `action`-discriminated `brand_audit_watch` tool; split
+ * into three single-purpose MCP tools (`register_brand_audit_watch`,
+ * `list_brand_audit_watches`, `delete_brand_audit_watch`) so that read and
+ * destructive operations live in separate tools per the Anthropic Directory
+ * review criteria. Owner-scoped: a caller's principalId is bound at every
+ * operation, and any cross-owner attempt surfaces as `notFound` (never
+ * `accessDenied`) to defend against ID enumeration.
  *
  * Watch storage: `brand_audit_watches` in BRAND_AUDIT_DB. The cron tick in
  * `src/scheduled.ts` enumerates active rows, enqueues
@@ -32,17 +34,17 @@ const CATEGORY = 'brand_discovery';
 /** Hard cap on active watches per principal. */
 const MAX_WATCHES_PER_OWNER = 20;
 
-export type BrandAuditWatchAction = 'register' | 'list' | 'delete';
-
-export interface BrandAuditWatchArgs {
-	action: BrandAuditWatchAction;
-	/** Required for register. */
+export interface RegisterBrandAuditWatchArgs {
+	/** Domain to watch. */
 	domain?: string;
-	/** Required for register. */
+	/** Recurrence interval. */
 	interval?: BrandAuditWatchInterval;
-	/** Optional webhook URL for register; null/undefined → logging-only watch. */
+	/** Optional webhook URL; null/undefined → logging-only watch. */
 	webhook_url?: string;
-	/** Required for delete. */
+}
+
+export interface DeleteBrandAuditWatchArgs {
+	/** Watch ID returned by register_brand_audit_watch. */
 	watchId?: string;
 }
 
@@ -55,31 +57,17 @@ export interface BrandAuditWatchDeps {
 }
 
 function errorResult(flag: string, message: string, extra: Record<string, unknown> = {}): CheckResult {
-	return buildCheckResult(CATEGORY, [
-		createFinding(CATEGORY, `Brand audit watch: ${flag}`, 'high', message, { [flag]: true, ...extra }),
-	]);
+	return buildCheckResult(CATEGORY, [createFinding(CATEGORY, `Brand audit watch: ${flag}`, 'high', message, { [flag]: true, ...extra })]);
 }
 
-export async function brandAuditWatch(
-	args: BrandAuditWatchArgs,
+/** Create a new recurring brand-audit watch. */
+export async function registerBrandAuditWatch(
+	args: RegisterBrandAuditWatchArgs,
 	ownerId: string,
 	deps: BrandAuditWatchDeps,
 ): Promise<CheckResult> {
-	switch (args.action) {
-		case 'register':
-			return registerWatch(args, ownerId, deps);
-		case 'list':
-			return listWatches(ownerId, deps);
-		case 'delete':
-			return deleteWatch(args, ownerId, deps);
-		default:
-			return errorResult('invalidInput', `Unknown action: ${String((args as { action?: string }).action ?? '')}`);
-	}
-}
-
-async function registerWatch(args: BrandAuditWatchArgs, ownerId: string, deps: BrandAuditWatchDeps): Promise<CheckResult> {
 	if (!args.domain || typeof args.domain !== 'string') {
-		return errorResult('invalidInput', 'domain is required for action=register.');
+		return errorResult('invalidInput', 'domain is required.');
 	}
 	if (!args.interval || !['daily', 'weekly', 'monthly'].includes(args.interval)) {
 		return errorResult('invalidInput', 'interval must be one of daily|weekly|monthly.');
@@ -117,10 +105,7 @@ async function registerWatch(args: BrandAuditWatchArgs, ownerId: string, deps: B
 			.bind(watchId, ownerId, domain, args.interval, args.webhook_url ?? null, 1, now)
 			.run();
 	} catch (err) {
-		return errorResult(
-			'persistenceFailure',
-			`Failed to register watch: ${err instanceof Error ? err.message : String(err)}`,
-		);
+		return errorResult('persistenceFailure', `Failed to register watch: ${err instanceof Error ? err.message : String(err)}`);
 	}
 
 	return buildCheckResult(CATEGORY, [
@@ -141,7 +126,8 @@ async function registerWatch(args: BrandAuditWatchArgs, ownerId: string, deps: B
 	]);
 }
 
-async function listWatches(ownerId: string, deps: BrandAuditWatchDeps): Promise<CheckResult> {
+/** List the caller's recurring brand-audit watches. */
+export async function listBrandAuditWatches(ownerId: string, deps: BrandAuditWatchDeps): Promise<CheckResult> {
 	const rows = await deps.db
 		.prepare(
 			'SELECT id, owner_id, domain, interval, webhook_url, last_run_at, last_classification_hash, active, created_at FROM brand_audit_watches WHERE owner_id = ? ORDER BY created_at DESC',
@@ -160,35 +146,34 @@ async function listWatches(ownerId: string, deps: BrandAuditWatchDeps): Promise<
 	}));
 
 	return buildCheckResult(CATEGORY, [
-		createFinding(
-			CATEGORY,
-			`Brand audit watches: ${watches.length}`,
-			'info',
-			`${watches.length} watch(es) for principal.`,
-			{ summary: true, count: watches.length, watches },
-		),
+		createFinding(CATEGORY, `Brand audit watches: ${watches.length}`, 'info', `${watches.length} watch(es) for principal.`, {
+			summary: true,
+			count: watches.length,
+			watches,
+		}),
 	]);
 }
 
-async function deleteWatch(args: BrandAuditWatchArgs, ownerId: string, deps: BrandAuditWatchDeps): Promise<CheckResult> {
+/** Delete a recurring brand-audit watch the caller owns. */
+export async function deleteBrandAuditWatch(
+	args: DeleteBrandAuditWatchArgs,
+	ownerId: string,
+	deps: BrandAuditWatchDeps,
+): Promise<CheckResult> {
 	if (!args.watchId || typeof args.watchId !== 'string') {
-		return errorResult('invalidInput', 'watchId is required for action=delete.');
+		return errorResult('invalidInput', 'watchId is required.');
 	}
 
-	const existing = (await deps.db
-		.prepare('SELECT owner_id FROM brand_audit_watches WHERE id = ? LIMIT 1')
-		.bind(args.watchId)
-		.first()) as { owner_id: string } | null;
+	const existing = (await deps.db.prepare('SELECT owner_id FROM brand_audit_watches WHERE id = ? LIMIT 1').bind(args.watchId).first()) as {
+		owner_id: string;
+	} | null;
 
 	if (!existing || existing.owner_id !== ownerId) {
 		// notFound — never confirm existence of a row the caller doesn't own.
 		return errorResult('notFound', `No watch with id ${args.watchId}.`, { watchId: args.watchId });
 	}
 
-	await deps.db
-		.prepare('DELETE FROM brand_audit_watches WHERE id = ? AND owner_id = ?')
-		.bind(args.watchId, ownerId)
-		.run();
+	await deps.db.prepare('DELETE FROM brand_audit_watches WHERE id = ? AND owner_id = ?').bind(args.watchId, ownerId).run();
 
 	return buildCheckResult(CATEGORY, [
 		createFinding(CATEGORY, `Brand audit watch deleted: ${args.watchId}`, 'info', '', {

--- a/test/audits/readme-tool-surface.audit.test.ts
+++ b/test/audits/readme-tool-surface.audit.test.ts
@@ -12,7 +12,7 @@ describe('README tool surface', () => {
 	it('keeps published tool counts and authoritative DNS infra tools current', () => {
 		const toolCount = TOOLS.length;
 
-		expect(toolCount).toBe(60);
+		expect(toolCount).toBe(62);
 		expect(readme).toContain(`MCP%20tools-${toolCount}`);
 		expect(readme).toContain(`current ${toolCount}-tool surface`);
 		expect(readme).toContain(`${toolCount} MCP tools`);
@@ -22,7 +22,7 @@ describe('README tool surface', () => {
 	});
 
 	it('keeps supporting docs aligned with the authoritative DNS infra surface', () => {
-		expect(githubSettings).toContain('60 MCP tools');
+		expect(githubSettings).toContain('62 MCP tools');
 		expect(scoringDocs).toContain('Authoritative DNS Infrastructure');
 		expect(scoringDocs).toContain('authoritative_dns_infra');
 		expect(packageReadme).toContain('authoritative_dns_infra');

--- a/test/audits/tier-tool-daily-limits.audit.test.ts
+++ b/test/audits/tier-tool-daily-limits.audit.test.ts
@@ -25,7 +25,9 @@ const BRAND_AUDIT_TOOLS = [
 	'brand_audit_batch_start',
 	'brand_audit_status',
 	'brand_audit_get_report',
-	'brand_audit_watch',
+	'list_brand_audit_watches',
+	'register_brand_audit_watch',
+	'delete_brand_audit_watch',
 ] as const;
 
 describe('TIER_DAILY_LIMITS audit (flat per-tier defaults)', () => {
@@ -70,7 +72,9 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 			brand_audit_batch_start: 50,
 			brand_audit_status: 5_000,
 			brand_audit_get_report: 5_000,
-			brand_audit_watch: 20,
+			list_brand_audit_watches: 20,
+			register_brand_audit_watch: 20,
+			delete_brand_audit_watch: 20,
 		});
 	});
 
@@ -81,7 +85,9 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 			brand_audit_batch_start: 500,
 			brand_audit_status: 25_000,
 			brand_audit_get_report: 25_000,
-			brand_audit_watch: 100,
+			list_brand_audit_watches: 100,
+			register_brand_audit_watch: 100,
+			delete_brand_audit_watch: 100,
 		});
 	});
 
@@ -93,7 +99,9 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 		const partnerOverrides = TIER_TOOL_DAILY_LIMITS.partner ?? {};
 		expect(partnerOverrides.brand_audit_single).toBe(200);
 		expect(partnerOverrides.brand_audit_batch_start).toBe(200);
-		expect(partnerOverrides.brand_audit_watch).toBe(100);
+		expect(partnerOverrides.list_brand_audit_watches).toBe(100);
+		expect(partnerOverrides.register_brand_audit_watch).toBe(100);
+		expect(partnerOverrides.delete_brand_audit_watch).toBe(100);
 		// Non-brand_audit partner overrides exist too; we only lock the brand-audit
 		// subset here to keep the audit scoped to the paywall-relevant rows.
 	});
@@ -143,7 +151,9 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 			'brand_audit_batch_start',
 			'brand_audit_status',
 			'brand_audit_get_report',
-			'brand_audit_watch',
+			'list_brand_audit_watches',
+			'register_brand_audit_watch',
+			'delete_brand_audit_watch',
 		]);
 		expect(new Set(Object.keys(partner))).toEqual(expectedKeys);
 	});

--- a/test/audits/tool-annotations.audit.test.ts
+++ b/test/audits/tool-annotations.audit.test.ts
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Audit test: every MCP tool satisfies the Anthropic Directory review criteria
+// for annotations, naming, and description hygiene.
+//
+// Background: https://claude.com/docs/connectors/building/review-criteria makes
+// the following pass/fail requirements for tools exposed over MCP:
+//   - tool names must be <= 64 characters
+//   - every tool must carry a `title` and the `readOnlyHint`/`destructiveHint`
+//     annotations (they drive auto-permissions in the host)
+//   - read and destructive operations must live in separate tools, and a
+//     destructive tool must advertise `destructiveHint: true`
+//   - descriptions must describe behaviour, not steer Claude's behaviour
+//     ("use this whenever…", "you must…", "start here…") — prescriptive
+//     language is treated as prompt injection at review time
+//
+// Per testing-methodology.md principle 4 — audit tests replace review
+// checklists. Without this lock, a new tool can silently ship a missing
+// annotation or an injection-flavoured description that only surfaces when a
+// human reviewer rejects the directory submission.
+
+import { describe, it, expect } from 'vitest';
+import { TOOLS } from '../../src/schemas/tool-definitions';
+
+/**
+ * Case-insensitive phrases that instruct Claude how to behave rather than
+ * describe what the tool does. Factual cross-references ("poll with
+ * brand_audit_status", "returns …") are intentionally NOT matched.
+ */
+const PRESCRIPTIVE_PHRASES = [
+	'use this when',
+	'use this to',
+	'start here',
+	'whenever',
+	'you must',
+	'you should',
+	'make sure to',
+	'be sure to',
+	'ignore previous',
+	'ignore the',
+	'disregard',
+	'system prompt',
+	'system instruction',
+];
+
+describe('tool annotations & description hygiene (directory review criteria)', () => {
+	it('every tool has a non-empty title annotation', () => {
+		for (const tool of TOOLS) {
+			expect(tool.annotations?.title, `${tool.name} is missing annotations.title`).toBeTruthy();
+		}
+	});
+
+	it('every tool name is <= 64 characters', () => {
+		for (const tool of TOOLS) {
+			expect(tool.name.length, `${tool.name} exceeds the 64-char limit`).toBeLessThanOrEqual(64);
+		}
+	});
+
+	it('every tool defines readOnlyHint and destructiveHint as booleans', () => {
+		for (const tool of TOOLS) {
+			expect(typeof tool.annotations?.readOnlyHint, `${tool.name}.readOnlyHint`).toBe('boolean');
+			expect(typeof tool.annotations?.destructiveHint, `${tool.name}.destructiveHint`).toBe('boolean');
+		}
+	});
+
+	it('a destructive tool is never also read-only', () => {
+		for (const tool of TOOLS) {
+			if (tool.annotations?.destructiveHint) {
+				expect(tool.annotations.readOnlyHint, `${tool.name} is both destructive and read-only`).toBe(false);
+			}
+		}
+	});
+
+	it('no tool description contains prescriptive / injection-style language', () => {
+		for (const tool of TOOLS) {
+			const lower = tool.description.toLowerCase();
+			const hits = PRESCRIPTIVE_PHRASES.filter((p) => lower.includes(p));
+			expect(hits, `${tool.name} description steers Claude with: ${hits.join(', ')}`).toEqual([]);
+		}
+	});
+});

--- a/test/brand-audit-watch.integration.test.ts
+++ b/test/brand-audit-watch.integration.test.ts
@@ -1,12 +1,14 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Tests for the brand_audit_watch MCP tool.
+ * Tests for the brand-audit watch MCP tools.
  *
- * Three actions on a single tool surface:
- *   - register: create a new watch row in brand_audit_watches
- *   - list:     enumerate the caller's active watches
- *   - delete:   remove a watch (owner-scoped — can't delete another owner's)
+ * The single `action`-discriminated `brand_audit_watch` tool was split into
+ * three single-purpose tools to satisfy the Anthropic Directory requirement
+ * that read and destructive operations live in separate tools:
+ *   - list_brand_audit_watches   (read-only)  — enumerate the caller's watches
+ *   - register_brand_audit_watch (write)      — create a new watch row
+ *   - delete_brand_audit_watch   (destructive)— remove a watch (owner-scoped)
  *
  * Webhook URL is validated for SSRF at register time AND at delivery time
  * (cron handler). At register, the SSRF check is done via the canonical
@@ -15,6 +17,7 @@
 
 import { describe, it, expect } from 'vitest';
 import type { BrandAuditWatchDeps } from '../src/tools/brand-audit-watch';
+import { TOOLS } from '../src/schemas/tool-definitions';
 
 interface D1Call {
 	sql: string;
@@ -67,14 +70,14 @@ function makeDeps(over: Partial<BrandAuditWatchDeps> = {}): BrandAuditWatchDeps 
 	};
 }
 
-describe('brandAuditWatch — register', () => {
+describe('register_brand_audit_watch', () => {
 	it('creates a row and returns the watch id', async () => {
-		const { brandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { registerBrandAuditWatch } = await import('../src/tools/brand-audit-watch');
 		const { db, calls } = makeMockD1();
 		const deps = makeDeps({ db });
 
-		const result = await brandAuditWatch(
-			{ action: 'register', domain: 'apple.com', interval: 'weekly', webhook_url: 'https://hooks.example.com/abc' },
+		const result = await registerBrandAuditWatch(
+			{ domain: 'apple.com', interval: 'weekly', webhook_url: 'https://hooks.example.com/abc' },
 			'owner-1',
 			deps,
 		);
@@ -92,12 +95,12 @@ describe('brandAuditWatch — register', () => {
 	});
 
 	it('rejects a webhook URL that fails SSRF validation (private IP)', async () => {
-		const { brandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { registerBrandAuditWatch } = await import('../src/tools/brand-audit-watch');
 		const { db } = makeMockD1();
 		const deps = makeDeps({ db });
 
-		const result = await brandAuditWatch(
-			{ action: 'register', domain: 'apple.com', interval: 'daily', webhook_url: 'http://10.0.0.1/internal' },
+		const result = await registerBrandAuditWatch(
+			{ domain: 'apple.com', interval: 'daily', webhook_url: 'http://10.0.0.1/internal' },
 			'owner-1',
 			deps,
 		);
@@ -106,15 +109,11 @@ describe('brandAuditWatch — register', () => {
 	});
 
 	it('accepts register without webhook_url (logging-only watch)', async () => {
-		const { brandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { registerBrandAuditWatch } = await import('../src/tools/brand-audit-watch');
 		const { db, calls } = makeMockD1();
 		const deps = makeDeps({ db });
 
-		const result = await brandAuditWatch(
-			{ action: 'register', domain: 'apple.com', interval: 'monthly' },
-			'owner-1',
-			deps,
-		);
+		const result = await registerBrandAuditWatch({ domain: 'apple.com', interval: 'monthly' }, 'owner-1', deps);
 		const summary = result.findings.find((f) => f.metadata?.summary === true);
 		expect(summary?.metadata?.watchId).toBeDefined();
 		const insert = calls.find((c) => c.sql.includes('INSERT INTO brand_audit_watches'));
@@ -122,44 +121,72 @@ describe('brandAuditWatch — register', () => {
 	});
 
 	it('refuses to register when the principal already has 20 watches (cap)', async () => {
-		const { brandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { registerBrandAuditWatch } = await import('../src/tools/brand-audit-watch');
 		const { db } = makeMockD1({ existingCount: 20 });
 		const deps = makeDeps({ db });
-		const result = await brandAuditWatch(
-			{ action: 'register', domain: 'apple.com', interval: 'daily' },
-			'owner-1',
-			deps,
-		);
+		const result = await registerBrandAuditWatch({ domain: 'apple.com', interval: 'daily' }, 'owner-1', deps);
 		const error = result.findings.find((f) => f.metadata?.watchLimitExceeded === true);
 		expect(error).toBeDefined();
 	});
 });
 
-describe('brandAuditWatch — list', () => {
+describe('list_brand_audit_watches', () => {
 	it("returns the caller's active watches", async () => {
-		const { brandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { listBrandAuditWatches } = await import('../src/tools/brand-audit-watch');
 		const rows = [
-			{ id: 'w-1', owner_id: 'owner-1', domain: 'apple.com', interval: 'weekly', webhook_url: null, last_run_at: null, last_classification_hash: null, active: 1, created_at: 1 },
-			{ id: 'w-2', owner_id: 'owner-1', domain: 'brand-zeta.example.com', interval: 'monthly', webhook_url: 'https://hooks.example.com/a', last_run_at: 2, last_classification_hash: 'a'.repeat(64), active: 1, created_at: 2 },
+			{
+				id: 'w-1',
+				owner_id: 'owner-1',
+				domain: 'apple.com',
+				interval: 'weekly',
+				webhook_url: null,
+				last_run_at: null,
+				last_classification_hash: null,
+				active: 1,
+				created_at: 1,
+			},
+			{
+				id: 'w-2',
+				owner_id: 'owner-1',
+				domain: 'brand-zeta.example.com',
+				interval: 'monthly',
+				webhook_url: 'https://hooks.example.com/a',
+				last_run_at: 2,
+				last_classification_hash: 'a'.repeat(64),
+				active: 1,
+				created_at: 2,
+			},
 		];
 		const { db } = makeMockD1({ existing: rows });
 		const deps = makeDeps({ db });
 
-		const result = await brandAuditWatch({ action: 'list' }, 'owner-1', deps);
+		const result = await listBrandAuditWatches('owner-1', deps);
 		const summary = result.findings.find((f) => f.metadata?.summary === true);
-		expect((summary?.metadata?.watches as unknown[])).toHaveLength(2);
+		expect(summary?.metadata?.watches as unknown[]).toHaveLength(2);
 	});
 });
 
-describe('brandAuditWatch — delete', () => {
+describe('delete_brand_audit_watch', () => {
 	it('deletes a watch owned by the caller', async () => {
-		const { brandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { deleteBrandAuditWatch } = await import('../src/tools/brand-audit-watch');
 		const { db, calls } = makeMockD1({
-			existing: [{ id: 'w-1', owner_id: 'owner-1', domain: 'apple.com', interval: 'weekly', webhook_url: null, last_run_at: null, last_classification_hash: null, active: 1, created_at: 1 }],
+			existing: [
+				{
+					id: 'w-1',
+					owner_id: 'owner-1',
+					domain: 'apple.com',
+					interval: 'weekly',
+					webhook_url: null,
+					last_run_at: null,
+					last_classification_hash: null,
+					active: 1,
+					created_at: 1,
+				},
+			],
 		});
 		const deps = makeDeps({ db });
 
-		const result = await brandAuditWatch({ action: 'delete', watchId: 'w-1' }, 'owner-1', deps);
+		const result = await deleteBrandAuditWatch({ watchId: 'w-1' }, 'owner-1', deps);
 		const summary = result.findings.find((f) => f.metadata?.summary === true);
 		expect(summary?.metadata?.deleted).toBe(true);
 		const del = calls.find((c) => c.sql.includes('DELETE FROM brand_audit_watches'));
@@ -168,15 +195,44 @@ describe('brandAuditWatch — delete', () => {
 	});
 
 	it("refuses to delete another owner's watch (notFound, not accessDenied)", async () => {
-		const { brandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { deleteBrandAuditWatch } = await import('../src/tools/brand-audit-watch');
 		const { db } = makeMockD1({
-			existing: [{ id: 'w-2', owner_id: 'owner-other', domain: 'x.com', interval: 'daily', webhook_url: null, last_run_at: null, last_classification_hash: null, active: 1, created_at: 1 }],
+			existing: [
+				{
+					id: 'w-2',
+					owner_id: 'owner-other',
+					domain: 'x.com',
+					interval: 'daily',
+					webhook_url: null,
+					last_run_at: null,
+					last_classification_hash: null,
+					active: 1,
+					created_at: 1,
+				},
+			],
 		});
 		const deps = makeDeps({ db });
-		const result = await brandAuditWatch({ action: 'delete', watchId: 'w-2' }, 'owner-1', deps);
+		const result = await deleteBrandAuditWatch({ watchId: 'w-2' }, 'owner-1', deps);
 		const notFound = result.findings.find((f) => f.metadata?.notFound === true);
 		const accessDenied = result.findings.find((f) => f.metadata?.accessDenied === true);
 		expect(notFound).toBeDefined();
 		expect(accessDenied).toBeUndefined();
+	});
+});
+
+describe('brand-audit watch tool surface (directory read/write split)', () => {
+	const byName = (n: string) => TOOLS.find((t) => t.name === n);
+
+	it('exposes three single-purpose tools and removes the catch-all', () => {
+		expect(byName('brand_audit_watch')).toBeUndefined();
+		expect(byName('list_brand_audit_watches')).toBeDefined();
+		expect(byName('register_brand_audit_watch')).toBeDefined();
+		expect(byName('delete_brand_audit_watch')).toBeDefined();
+	});
+
+	it('annotates each tool by its operation kind', () => {
+		expect(byName('list_brand_audit_watches')?.annotations).toMatchObject({ readOnlyHint: true, destructiveHint: false });
+		expect(byName('register_brand_audit_watch')?.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: false });
+		expect(byName('delete_brand_audit_watch')?.annotations).toMatchObject({ readOnlyHint: false, destructiveHint: true });
 	});
 });

--- a/test/chaos/varied-domain-all-tools.chaos.test.ts
+++ b/test/chaos/varied-domain-all-tools.chaos.test.ts
@@ -370,7 +370,9 @@ function makeToolCases(): ToolCase[] {
 		},
 		{ name: 'brand_audit_status', arguments: { auditId: 'chaos-audit-1' } },
 		{ name: 'brand_audit_get_report', arguments: { auditId: 'chaos-audit-1', target: 'brand-example.net' } },
-		{ name: 'brand_audit_watch', arguments: { action: 'list' } },
+		{ name: 'list_brand_audit_watches', arguments: {} },
+		{ name: 'register_brand_audit_watch', arguments: { domain: 'brand-example.net', interval: 'weekly' } },
+		{ name: 'delete_brand_audit_watch', arguments: { watchId: 'chaos-watch-1' } },
 	];
 }
 

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect, afterEach, vi } from 'vitest';
-import { setupFetchMock, createDohResponse, mockTxtRecords, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse } from './helpers/dns-mock';
+import {
+	setupFetchMock,
+	createDohResponse,
+	mockTxtRecords,
+	txtResponse,
+	nsResponse,
+	caaResponse,
+	dnssecResponse,
+	httpResponse,
+} from './helpers/dns-mock';
 import { IN_MEMORY_CACHE } from '../src/lib/cache';
 
 const { restore } = setupFetchMock();
@@ -148,13 +157,13 @@ describe('handleToolsCall - dispatch routing', () => {
 	});
 
 	it('check_dnssec with valid domain returns content', async () => {
-		globalThis.fetch = vi.fn().mockResolvedValue(
-			createDohResponse(
-				[{ name: 'example.com', type: 1 }],
-				[{ name: 'example.com', type: 1, TTL: 300, data: '192.0.2.1' }],
-				{ ad: true },
-			),
-		);
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				createDohResponse([{ name: 'example.com', type: 1 }], [{ name: 'example.com', type: 1, TTL: 300, data: '192.0.2.1' }], {
+					ad: true,
+				}),
+			);
 		const result = await call('check_dnssec', { domain: 'example.com' });
 		expect(result.isError).toBeUndefined();
 		expect(result.content).toHaveLength(2);
@@ -209,7 +218,12 @@ describe('handleToolsCall - dispatch routing', () => {
 					json: () => Promise.resolve({}),
 				} as unknown as Response);
 			}
-			return Promise.resolve({ ok: true, status: 200, text: () => Promise.resolve('OK'), json: () => Promise.resolve({}) } as unknown as Response);
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				text: () => Promise.resolve('OK'),
+				json: () => Promise.resolve({}),
+			} as unknown as Response);
 		});
 		const result = await call('check_mta_sts', { domain: 'example.com' });
 		expect(result.isError).toBeUndefined();
@@ -224,7 +238,12 @@ describe('handleToolsCall - dispatch routing', () => {
 				return Promise.resolve(nsResponse('example.com', ['ns1.example.com.', 'ns2.example.com.']));
 			}
 			if (url.includes('type=SOA') || url.includes('type=6')) {
-				return Promise.resolve(createDohResponse([{ name: 'example.com', type: 6 }], [{ name: 'example.com', type: 6, TTL: 300, data: 'ns1.example.com. admin.example.com. 2024010101 3600 600 604800 300' }]));
+				return Promise.resolve(
+					createDohResponse(
+						[{ name: 'example.com', type: 6 }],
+						[{ name: 'example.com', type: 6, TTL: 300, data: 'ns1.example.com. admin.example.com. 2024010101 3600 600 604800 300' }],
+					),
+				);
 			}
 			return Promise.resolve(createDohResponse([], []));
 		});
@@ -248,7 +267,9 @@ describe('handleToolsCall - per-tool cache TTL', () => {
 		};
 		const { handleToolsCall } = await import('../src/handlers/tools');
 		await handleToolsCall({ name: 'check_lookalikes', arguments: { domain: 'example.com' } }, mockKV as unknown as KVNamespace);
-		const lookalikesPut = mockKV.put.mock.calls.find((c: unknown[]) => (c[0] as string).includes('lookalikes') && !(c[0] as string).endsWith(':computing'));
+		const lookalikesPut = mockKV.put.mock.calls.find(
+			(c: unknown[]) => (c[0] as string).includes('lookalikes') && !(c[0] as string).endsWith(':computing'),
+		);
 		expect(lookalikesPut).toBeDefined();
 		expect(lookalikesPut![2]).toEqual({ expirationTtl: 3600 });
 	});
@@ -261,7 +282,9 @@ describe('handleToolsCall - per-tool cache TTL', () => {
 		};
 		const { handleToolsCall } = await import('../src/handlers/tools');
 		await handleToolsCall({ name: 'check_spf', arguments: { domain: 'example.com' } }, mockKV as unknown as KVNamespace);
-		const spfPut = mockKV.put.mock.calls.find((c: unknown[]) => (c[0] as string).includes('spf') && !(c[0] as string).endsWith(':computing'));
+		const spfPut = mockKV.put.mock.calls.find(
+			(c: unknown[]) => (c[0] as string).includes('spf') && !(c[0] as string).endsWith(':computing'),
+		);
 		expect(spfPut).toBeDefined();
 		expect(spfPut![2]).toEqual({ expirationTtl: 300 });
 	});
@@ -315,11 +338,10 @@ describe('handleToolsCall - per-tool cache TTL', () => {
 		};
 
 		const { handleToolsCall } = await import('../src/handlers/tools');
-		await handleToolsCall(
-			{ name: 'brand_audit_status', arguments: { auditId: 'aud-1' } },
-			mockKV as unknown as KVNamespace,
-			{ brandAuditDb: db as unknown as D1Database, principalId: 'owner-1' },
-		);
+		await handleToolsCall({ name: 'brand_audit_status', arguments: { auditId: 'aud-1' } }, mockKV as unknown as KVNamespace, {
+			brandAuditDb: db as unknown as D1Database,
+			principalId: 'owner-1',
+		});
 
 		const statusPut = mockKV.put.mock.calls.find((c: unknown[]) => (c[0] as string).includes('brand_audit_status'));
 		expect(statusPut).toBeUndefined();
@@ -500,7 +522,12 @@ describe('formatCheckResult - via handleToolsCall', () => {
 
 			if (url.includes('type=CNAME') || url.includes('type=5')) {
 				if (url.includes('staging.example.com')) {
-					return Promise.resolve(createDohResponse([{ name: 'staging.example.com', type: 5 }], [{ name: 'staging.example.com', type: 5, TTL: 300, data: 'old-app.herokuapp.com.' }]));
+					return Promise.resolve(
+						createDohResponse(
+							[{ name: 'staging.example.com', type: 5 }],
+							[{ name: 'staging.example.com', type: 5, TTL: 300, data: 'old-app.herokuapp.com.' }],
+						),
+					);
 				}
 				return Promise.resolve(createDohResponse([{ name: 'example.com', type: 5 }], []));
 			}
@@ -523,11 +550,11 @@ describe('formatCheckResult - via handleToolsCall', () => {
 // -- handleToolsList --
 
 describe('handleToolsList', () => {
-	it('returns an object with a tools array of 60 entries', async () => {
+	it('returns an object with a tools array of 62 entries', async () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(60);
+		expect(result.tools).toHaveLength(62);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {
@@ -540,6 +567,21 @@ describe('handleToolsList', () => {
 			expect(tool.description.length, `${tool.name}: description must not be empty`).toBeGreaterThan(0);
 			expect(typeof tool.inputSchema, `${tool.name}: inputSchema must be object`).toBe('object');
 			expect(tool.inputSchema).not.toBeNull();
+		}
+	});
+
+	it('exposes only MCP-spec fields, nesting custom metadata under _meta', async () => {
+		const { handleToolsList } = await import('../src/handlers/tools');
+		const { tools } = handleToolsList();
+		const SPEC_FIELDS = new Set(['name', 'title', 'description', 'inputSchema', 'outputSchema', 'annotations', '_meta']);
+		for (const tool of tools) {
+			for (const key of Object.keys(tool)) {
+				expect(SPEC_FIELDS.has(key), `${tool.name}: non-spec wire field "${key}"`).toBe(true);
+			}
+			const meta = (tool as { _meta?: Record<string, unknown> })._meta;
+			expect(meta, `${tool.name}: missing _meta`).toBeDefined();
+			expect(typeof meta?.group, `${tool.name}: _meta.group`).toBe('string');
+			expect(typeof meta?.scanIncluded, `${tool.name}: _meta.scanIncluded`).toBe('boolean');
 		}
 	});
 
@@ -592,8 +634,7 @@ describe('handleToolsCall - format routing', () => {
 		expect(result.isError).toBeUndefined();
 		const text = result.content[0].text;
 		// Full mode includes emoji icons for severity
-		const hasSeverityIcon =
-			text.includes('ℹ️') || text.includes('⚠️') || text.includes('🔶') || text.includes('🔴') || text.includes('🚨');
+		const hasSeverityIcon = text.includes('ℹ️') || text.includes('⚠️') || text.includes('🔶') || text.includes('🔴') || text.includes('🚨');
 		expect(hasSeverityIcon).toBe(true);
 	});
 
@@ -726,11 +767,10 @@ describe('handleToolsCall - caching behaviour', () => {
 			put: vi.fn().mockResolvedValue(undefined),
 		};
 		const { handleToolsCall } = await import('../src/handlers/tools');
-		await handleToolsCall(
-			{ name: 'check_spf', arguments: { domain: 'example.com' } },
-			mockKV as unknown as KVNamespace,
+		await handleToolsCall({ name: 'check_spf', arguments: { domain: 'example.com' } }, mockKV as unknown as KVNamespace);
+		const spfPut = mockKV.put.mock.calls.find(
+			(c: unknown[]) => (c[0] as string).includes('spf') && !(c[0] as string).endsWith(':computing'),
 		);
-		const spfPut = mockKV.put.mock.calls.find((c: unknown[]) => (c[0] as string).includes('spf') && !(c[0] as string).endsWith(':computing'));
 		expect(spfPut).toBeDefined();
 		// Default TTL is 300s
 		expect(spfPut![2]).toEqual({ expirationTtl: 300 });
@@ -772,11 +812,11 @@ describe('handleToolsCall - resultCapture', () => {
 		mockTxtRecords(['v=spf1 -all']);
 		let captured: unknown = null;
 		const { handleToolsCall } = await import('../src/handlers/tools');
-		const result = await handleToolsCall(
-			{ name: 'check_spf', arguments: { domain: 'example.com' } },
-			undefined,
-			{ resultCapture: (r) => { captured = r; } },
-		);
+		const result = await handleToolsCall({ name: 'check_spf', arguments: { domain: 'example.com' } }, undefined, {
+			resultCapture: (r) => {
+				captured = r;
+			},
+		});
 		expect(result.isError).toBeUndefined();
 		expect(captured).not.toBeNull();
 		expect((captured as Record<string, unknown>).category).toBe('spf');
@@ -833,12 +873,11 @@ describe('handleToolsCall - additional registry tool routing', () => {
 	});
 
 	it('check_txt_hygiene with valid domain returns content', async () => {
-		globalThis.fetch = vi.fn().mockResolvedValue(
-			createDohResponse(
-				[{ name: 'example.com', type: 16 }],
-				[{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }],
-			),
-		);
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				createDohResponse([{ name: 'example.com', type: 16 }], [{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }]),
+			);
 		const result = await call('check_txt_hygiene', { domain: 'example.com' });
 		expect(result.isError).toBeUndefined();
 		expect(result.content).toHaveLength(2);
@@ -940,10 +979,7 @@ describe('handleToolsCall - non-registry tool routing', () => {
 				);
 			}
 			return Promise.resolve(
-				createDohResponse(
-					[{ name: 'example.com', type: 16 }],
-					[{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }],
-				),
+				createDohResponse([{ name: 'example.com', type: 16 }], [{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }]),
 			);
 		});
 		const result = await call('assess_spoofability', { domain: 'example.com' });
@@ -953,12 +989,14 @@ describe('handleToolsCall - non-registry tool routing', () => {
 	});
 
 	it('generate_spf_record with valid domain returns an SPF record', async () => {
-		globalThis.fetch = vi.fn().mockResolvedValue(
-			createDohResponse(
-				[{ name: 'example.com', type: 16 }],
-				[{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 include:_spf.google.com -all"' }],
-			),
-		);
+		globalThis.fetch = vi
+			.fn()
+			.mockResolvedValue(
+				createDohResponse(
+					[{ name: 'example.com', type: 16 }],
+					[{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 include:_spf.google.com -all"' }],
+				),
+			);
 		const result = await call('generate_spf_record', { domain: 'example.com' });
 		expect(result.isError).toBeUndefined();
 		expect(result.content).toHaveLength(2);
@@ -1044,10 +1082,7 @@ describe('handleToolsCall - non-registry tool routing', () => {
 				);
 			}
 			return Promise.resolve(
-				createDohResponse(
-					[{ name: 'example.com', type: 16 }],
-					[{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }],
-				),
+				createDohResponse([{ name: 'example.com', type: 16 }], [{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }]),
 			);
 		});
 		const result = await call('simulate_attack_paths', { domain: 'example.com' });
@@ -1071,10 +1106,7 @@ describe('handleToolsCall - non-registry tool routing', () => {
 				);
 			}
 			return Promise.resolve(
-				createDohResponse(
-					[{ name: 'example.com', type: 16 }],
-					[{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }],
-				),
+				createDohResponse([{ name: 'example.com', type: 16 }], [{ name: 'example.com', type: 16, TTL: 300, data: '"v=spf1 -all"' }]),
 			);
 		});
 		const result = await call('map_supply_chain', { domain: 'example.com' });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -351,7 +351,7 @@ describe('DNS Security MCP Server', () => {
 			const response = await worker.fetch(request, env, ctx);
 			await waitOnExecutionContext(ctx);
 			const body = (await response.json()) as { result: { tools: Array<{ name: string }> } };
-			expect(body.result.tools).toHaveLength(60);
+			expect(body.result.tools).toHaveLength(62);
 			const toolNames = body.result.tools.map((t) => t.name);
 			expect(toolNames).toContain('check_spf');
 			expect(toolNames).toContain('check_dmarc');

--- a/test/schemas/tool-args.spec.ts
+++ b/test/schemas/tool-args.spec.ts
@@ -154,8 +154,8 @@ describe('GetProviderInsightsArgs', () => {
 });
 
 describe('TOOL_SCHEMA_MAP', () => {
-	it('has 60 tools', () => {
-		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(60);
+	it('has 62 tools', () => {
+		expect(Object.keys(TOOL_SCHEMA_MAP)).toHaveLength(62);
 	});
 	it('all values are Zod schemas', () => {
 		for (const schema of Object.values(TOOL_SCHEMA_MAP)) {

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -2,8 +2,8 @@ import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../../src/schemas/tool-definitions';
 
 describe('TOOLS', () => {
-	it('has 60 tools', () => {
-		expect(TOOLS).toHaveLength(60);
+	it('has 62 tools', () => {
+		expect(TOOLS).toHaveLength(62);
 	});
 
 	it('every tool has required fields', () => {

--- a/test/tool-metadata.spec.ts
+++ b/test/tool-metadata.spec.ts
@@ -19,7 +19,7 @@ describe('tool metadata', () => {
 		}
 	});
 
-	it('has exactly 60 tools', () => {
-		expect(TOOLS).toHaveLength(60);
+	it('has exactly 62 tools', () => {
+		expect(TOOLS).toHaveLength(62);
 	});
 });

--- a/test/tool-schemas.spec.ts
+++ b/test/tool-schemas.spec.ts
@@ -87,12 +87,14 @@ const NON_SCAN_TOOL_NAMES = new Set([
 	'brand_audit_batch_start',
 	'brand_audit_status',
 	'brand_audit_get_report',
-	'brand_audit_watch',
+	'list_brand_audit_watches',
+	'register_brand_audit_watch',
+	'delete_brand_audit_watch',
 ]);
 
 describe('tool-schemas metadata', () => {
-	it('exports exactly 60 tools', () => {
-		expect(TOOLS).toHaveLength(60);
+	it('exports exactly 62 tools', () => {
+		expect(TOOLS).toHaveLength(62);
 	});
 
 	it('all tool names are unique', () => {


### PR DESCRIPTION
## Summary

Audits the MCP server against [Anthropic's MCP review criteria](https://claude.com/docs/connectors/building/review-criteria) and fixes the findings, following TDD.

| Finding | Fix |
|---|---|
| `brand_audit_watch` mixed read/write/destructive in one `action`-discriminated tool | Split into `list_brand_audit_watches` (read), `register_brand_audit_watch` (write), `delete_brand_audit_watch` (destructive) |
| `destructiveHint` hard-coded `false` for every tool | Added `destructive?` flag to `ToolDef` → real `destructiveHint` |
| `scan_domain` description steered Claude (injection-style language) | Rewritten to factual behavior description |
| `group`/`tier`/`scanIncluded` leaked as top-level `tools/list` fields | Nested under spec-sanctioned `_meta` |
| No audit guarded these criteria | New `test/audits/tool-annotations.audit.test.ts` |

## ⚠️ Breaking change

`brand_audit_watch` is **removed**; callers migrate to the three new tools. Behavior (owner-scoping, SSRF re-validation, 20-watch cap, per-tier quotas) is unchanged. Verified no Blackveil client (`bv-claude-dns`, `blackveil-dns-action`, `bv-web`) consumes the removed top-level `tools/list` fields, so the `_meta` move is safe.

This is at least a **minor** version bump per semver. An `[Unreleased]` CHANGELOG entry is added; the actual version bump is left to the release process.

## Test plan

- New `tool-annotations` audit (RED on `scan_domain` → GREEN) ✅
- `brand-audit-watch.integration.test.ts` rewritten for the 3 tools + tool-surface assertions ✅
- `handlers-tools` `_meta` wire-shape test ✅
- Count assertions, `tier-tool-daily-limits`, and `readme-tool-surface` audits updated ✅
- Full suite: **4284 passed**, typecheck + lint clean on changed files ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
