### PR TITLE
fix(tools): distinguish DNS lookup failures from negative results (dnssec_chain root, discover_subdomains)

### DIFF
--- a/src/tools/check-dnssec-chain.ts
+++ b/src/tools/check-dnssec-chain.ts
@@ -40,8 +40,13 @@ const WEAK_ALGORITHMS = new Set([1, 3, 5, 6, 7]);
 /** DS digest type names. */
 const DIGEST_TYPES: Record<number, string> = { 1: 'SHA-1', 2: 'SHA-256', 4: 'SHA-384' };
 
-/** Linkage status between DS and DNSKEY at a zone. */
-type LinkageStatus = 'linked' | 'no_ds' | 'no_dnskey' | 'broken';
+/**
+ * Linkage status between DS and DNSKEY at a zone.
+ * `unverified` is reserved for the root trust anchor when its DNSKEY could not
+ * be retrieved — the root is always signed, so an empty result is a retrieval
+ * failure, never a broken chain.
+ */
+type LinkageStatus = 'linked' | 'no_ds' | 'no_dnskey' | 'broken' | 'unverified';
 
 /** Parsed DS record fields. */
 interface ParsedDs {
@@ -167,8 +172,10 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 			// DNSKEY query failed — treat as no DNSKEY
 		}
 
-		// Determine linkage (root always has no_ds since we skip DS query)
-		const linkage = zone === '.' ? (dnskeyRecords.length > 0 ? 'linked' : 'no_dnskey') : determineLinkage(dsRecords, dnskeyRecords);
+		// Determine linkage. The root has no parent DS; an empty root DNSKEY means
+		// the trust anchor could not be retrieved (transient), NOT a broken chain.
+		const linkage: LinkageStatus =
+			zone === '.' ? (dnskeyRecords.length > 0 ? 'linked' : 'unverified') : determineLinkage(dsRecords, dnskeyRecords);
 
 		// Collect algorithm names
 		const allAlgs = new Set<number>();
@@ -211,7 +218,9 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 	const reachedTarget = lastZone?.zone === domain;
 	// Chain is complete only if we reached the target AND it's not broken AND the target zone is actually signed
 	const targetSigned = reachedTarget && (lastZone.dsRecords.length > 0 || lastZone.dnskeyRecords.length > 0);
-	const chainComplete = reachedTarget && !chainBroken && targetSigned;
+	// The root trust anchor must have been retrieved for the chain to be "complete".
+	const rootVerified = zoneResults.find((z) => z.zone === '.')?.linkage === 'linked';
+	const chainComplete = reachedTarget && !chainBroken && targetSigned && rootVerified;
 
 	// --- Findings ---
 
@@ -230,6 +239,21 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 				),
 			);
 		}
+	}
+
+	// Root trust-anchor retrieval failure (informational — NOT a chain break).
+	// The root zone is always signed, so an empty DNSKEY result means a transient
+	// resolver/cache failure rather than an actually-broken chain.
+	if (zoneResults.find((z) => z.zone === '.')?.linkage === 'unverified') {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Root trust anchor unverified',
+				'info',
+				'Could not retrieve the root zone (.) DNSKEY, so the chain of trust could not be verified all the way to the trust anchor. The root zone is always signed — an empty result indicates a transient resolver/cache issue, not a broken chain.',
+				{ zone: '.', linkage: 'unverified' },
+			),
+		);
 	}
 
 	// Weak algorithm finding (medium severity)

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -18,10 +18,50 @@ const MAX_SUBDOMAINS = 100;
 
 /** Common subdomain prefixes that are expected infrastructure. */
 const COMMON_SUBDOMAINS = new Set([
-	'www', 'api', 'mail', 'smtp', 'imap', 'pop', 'pop3', 'ftp', 'ns', 'ns1', 'ns2', 'ns3', 'ns4',
-	'dns', 'mx', 'mx1', 'mx2', 'webmail', 'vpn', 'remote', 'cdn', 'static', 'assets', 'img',
-	'images', 'media', 'docs', 'help', 'support', 'admin', 'portal', 'login', 'sso', 'auth',
-	'app', 'dashboard', 'status', 'blog', 'shop', 'store', 'dev', 'staging', 'test', 'beta',
+	'www',
+	'api',
+	'mail',
+	'smtp',
+	'imap',
+	'pop',
+	'pop3',
+	'ftp',
+	'ns',
+	'ns1',
+	'ns2',
+	'ns3',
+	'ns4',
+	'dns',
+	'mx',
+	'mx1',
+	'mx2',
+	'webmail',
+	'vpn',
+	'remote',
+	'cdn',
+	'static',
+	'assets',
+	'img',
+	'images',
+	'media',
+	'docs',
+	'help',
+	'support',
+	'admin',
+	'portal',
+	'login',
+	'sso',
+	'auth',
+	'app',
+	'dashboard',
+	'status',
+	'blog',
+	'shop',
+	'store',
+	'dev',
+	'staging',
+	'test',
+	'beta',
 ]);
 
 /** Threshold for flagging many issuers. */
@@ -63,6 +103,12 @@ export interface SubdomainDiscoveryResult {
 	expiredCerts: number;
 	uniqueIssuers: string[];
 	issues: SubdomainIssue[];
+	/**
+	 * True when the Certificate Transparency source could not be queried (e.g.
+	 * crt.sh returned a non-OK status or the request failed). Distinguishes a
+	 * lookup failure from a successful query that genuinely found no subdomains.
+	 */
+	sourceUnavailable?: boolean;
 }
 
 /** Extract CN= value from an issuer_name string (e.g. "C=US, O=Let's Encrypt, CN=R3" -> "R3"). */
@@ -103,10 +149,7 @@ interface CertstreamEnumerateResponse {
  * @param certstream - Optional bv-certstream-worker service binding
  * @returns Subdomain discovery result with metadata and issues
  */
-export async function discoverSubdomains(
-	domain: string,
-	certstream?: { fetch: typeof fetch },
-): Promise<SubdomainDiscoveryResult> {
+export async function discoverSubdomains(domain: string, certstream?: { fetch: typeof fetch }): Promise<SubdomainDiscoveryResult> {
 	// Fast path: use certstream service binding
 	if (certstream) {
 		const result = await queryCertstream(domain, certstream);
@@ -129,12 +172,12 @@ export async function discoverSubdomains(
 		clearTimeout(timeoutId);
 
 		if (!response.ok) {
-			return emptyResult(domain);
+			return emptyResult(domain, true);
 		}
 
 		entries = (await response.json()) as CrtShEntry[];
 	} catch {
-		return emptyResult(domain);
+		return emptyResult(domain, true);
 	}
 
 	if (!Array.isArray(entries) || entries.length === 0) {
@@ -155,7 +198,10 @@ export async function discoverSubdomains(
 		if (!entry.name_value) continue;
 
 		// Split name_value on newlines — one cert can cover multiple names
-		const names = entry.name_value.split('\n').map((n) => n.trim().toLowerCase()).filter(Boolean);
+		const names = entry.name_value
+			.split('\n')
+			.map((n) => n.trim().toLowerCase())
+			.filter(Boolean);
 		const issuer = extractIssuerCN(entry.issuer_name ?? '');
 		const notBefore = entry.not_before ?? '';
 		const notAfter = entry.not_after ?? '';
@@ -291,18 +337,14 @@ export async function discoverSubdomains(
 }
 
 /** Query bv-certstream-worker via service binding. Returns null on failure. */
-async function queryCertstream(
-	domain: string,
-	certstream: { fetch: typeof fetch },
-): Promise<SubdomainDiscoveryResult | null> {
+async function queryCertstream(domain: string, certstream: { fetch: typeof fetch }): Promise<SubdomainDiscoveryResult | null> {
 	try {
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), CRT_SH_TIMEOUT_MS);
 
-		const response = await certstream.fetch(
-			`https://certstream/enumerate?domain=${encodeURIComponent(domain)}`,
-			{ signal: controller.signal },
-		);
+		const response = await certstream.fetch(`https://certstream/enumerate?domain=${encodeURIComponent(domain)}`, {
+			signal: controller.signal,
+		});
 
 		clearTimeout(timeoutId);
 
@@ -382,8 +424,11 @@ async function queryCertstream(
 	}
 }
 
-/** Build an empty result for when crt.sh is unavailable or returns no data. */
-function emptyResult(domain: string): SubdomainDiscoveryResult {
+/**
+ * Build an empty result. `sourceUnavailable` distinguishes a CT lookup failure
+ * (crt.sh non-OK / network error) from a successful query that found nothing.
+ */
+function emptyResult(domain: string, sourceUnavailable = false): SubdomainDiscoveryResult {
 	return {
 		domain,
 		totalSubdomains: 0,
@@ -393,11 +438,15 @@ function emptyResult(domain: string): SubdomainDiscoveryResult {
 		expiredCerts: 0,
 		uniqueIssuers: [],
 		issues: [],
+		sourceUnavailable,
 	};
 }
 
 /** Format subdomain discovery result as human-readable text. */
 export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, format: OutputFormat = 'full'): string {
+	if (result.sourceUnavailable) {
+		return `Subdomain Discovery: ${result.domain} — Certificate Transparency source unavailable (the CT log endpoint returned an error or was unreachable); could not enumerate subdomains. This does not mean the domain has no subdomains — retry shortly.`;
+	}
 	if (result.totalSubdomains === 0) {
 		return `Subdomain Discovery: ${result.domain} — no subdomains found in Certificate Transparency logs`;
 	}
@@ -412,9 +461,7 @@ export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, forma
 /** Compact format: concise one-line-per-subdomain output. */
 function formatCompact(result: SubdomainDiscoveryResult): string {
 	const lines: string[] = [];
-	lines.push(
-		`Subdomain Discovery: ${result.domain} — ${result.totalSubdomains} subdomains (${result.totalCertificates} certificates)`,
-	);
+	lines.push(`Subdomain Discovery: ${result.domain} — ${result.totalSubdomains} subdomains (${result.totalCertificates} certificates)`);
 	if (result.uniqueIssuers.length > 0) {
 		lines.push(`Issuers: ${result.uniqueIssuers.map((i) => sanitizeOutputText(i, 60)).join(', ')}`);
 	}
@@ -450,9 +497,7 @@ function formatCompact(result: SubdomainDiscoveryResult): string {
 function formatFull(result: SubdomainDiscoveryResult): string {
 	const lines: string[] = [];
 	lines.push(`# Subdomain Discovery: ${result.domain}`);
-	lines.push(
-		`Total: ${result.totalSubdomains} subdomains across ${result.totalCertificates} certificates`,
-	);
+	lines.push(`Total: ${result.totalSubdomains} subdomains across ${result.totalCertificates} certificates`);
 	lines.push(`Issuers: ${result.uniqueIssuers.map((i) => sanitizeOutputText(i, 60)).join(', ')}`);
 	lines.push(`Wildcards: ${result.wildcardCerts} | Expired: ${result.expiredCerts}`);
 	lines.push('');
@@ -477,8 +522,7 @@ function formatFull(result: SubdomainDiscoveryResult): string {
 	if (result.issues.length > 0) {
 		lines.push('## Issues');
 		for (const issue of result.issues) {
-			const icon =
-				issue.severity === 'high' ? '🔴' : issue.severity === 'medium' ? '🟠' : issue.severity === 'low' ? '🟡' : '🔵';
+			const icon = issue.severity === 'high' ? '🔴' : issue.severity === 'medium' ? '🟠' : issue.severity === 'low' ? '🟡' : '🔵';
 			lines.push(`${icon} [${issue.severity.toUpperCase()}] ${sanitizeOutputText(issue.detail, 300)}`);
 		}
 	}

--- a/test/check-dnssec-chain.spec.ts
+++ b/test/check-dnssec-chain.spec.ts
@@ -39,7 +39,11 @@ function emptyDnskeyResponse(zone: string) {
 
 /** Build an A-record response with AD flag. */
 function adResponse(domain: string, ad: boolean) {
-	return createDohResponse([{ name: domain, type: RecordType.A }], [{ name: domain, type: RecordType.A, TTL: 300, data: '93.184.216.34' }], { ad });
+	return createDohResponse(
+		[{ name: domain, type: RecordType.A }],
+		[{ name: domain, type: RecordType.A, TTL: 300, data: '93.184.216.34' }],
+		{ ad },
+	);
 }
 
 /**
@@ -129,6 +133,36 @@ describe('checkDnssecChain', () => {
 		const highFinding = result.findings.find((f) => f.severity === 'high');
 		expect(highFinding).toBeDefined();
 		expect(highFinding!.detail).toMatch(/broken|no DNSKEY|mismatch/i);
+	});
+
+	it('empty root DNSKEY (trust-anchor retrieval failure) does NOT report a broken chain', async () => {
+		// The root is a global trust anchor and is ALWAYS signed. An empty DNSKEY
+		// result for "." can only mean the query failed/was-served-empty (e.g. the
+		// prod edge-cache emptiness) — never that the chain is broken. The rest of
+		// the chain (com, example.com) is fully signed here.
+		mockDnsFetch({
+			'.:DNSKEY': emptyDnskeyResponse('.'),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			'example.com:DS': dsResponse('example.com', ['54321 8 2 DDEEFF00']),
+			'example.com:DNSKEY': dnskeyResponse('example.com', ['257 3 8 AwEAAexample...']),
+			'example.com:A': adResponse('example.com', true),
+		});
+
+		const result = await run();
+
+		// No false HIGH "broken chain at ." finding.
+		const brokenHigh = result.findings.find((f) => f.severity === 'high' && /broken/i.test(f.title));
+		expect(brokenHigh).toBeUndefined();
+
+		// Root unverifiability is surfaced as a non-high note — NOT the (root-inaccurate)
+		// "DS record exists but no DNSKEY found" message.
+		const rootNote = result.findings.find(
+			(f) => /root/i.test(f.title) && /unverif|could not|trust anchor/i.test(`${f.title} ${f.detail ?? ''}`),
+		);
+		expect(rootNote).toBeDefined();
+		expect(rootNote!.severity).not.toBe('high');
+		expect(rootNote!.detail).not.toMatch(/DS record exists but no DNSKEY/i);
 	});
 
 	it('maps algorithm 8 to RSA-SHA256', async () => {

--- a/test/discover-subdomains.spec.ts
+++ b/test/discover-subdomains.spec.ts
@@ -102,9 +102,7 @@ describe('discoverSubdomains', () => {
 		expect(oldSub!.isExpired).toBe(true);
 
 		// Should have an expired_subdomain issue
-		const expiredIssue = result.issues.find(
-			(i) => i.type === 'expired_subdomain' && i.detail.includes('old.example.com'),
-		);
+		const expiredIssue = result.issues.find((i) => i.type === 'expired_subdomain' && i.detail.includes('old.example.com'));
 		expect(expiredIssue).toBeDefined();
 		expect(expiredIssue!.severity).toBe('medium');
 	});
@@ -116,6 +114,8 @@ describe('discoverSubdomains', () => {
 		expect(result.totalSubdomains).toBe(0);
 		expect(result.subdomains).toHaveLength(0);
 		expect(result.totalCertificates).toBe(0);
+		// Distinguish "source unavailable" from "queried, none found".
+		expect(result.sourceUnavailable).toBe(true);
 	});
 
 	it('should handle crt.sh returning an error status', async () => {
@@ -124,6 +124,15 @@ describe('discoverSubdomains', () => {
 
 		expect(result.totalSubdomains).toBe(0);
 		expect(result.subdomains).toHaveLength(0);
+		expect(result.sourceUnavailable).toBe(true);
+	});
+
+	it('marks a successful-but-empty crt.sh query as available (none found, not unavailable)', async () => {
+		mockCrtSh([]);
+		const result = await run();
+
+		expect(result.totalSubdomains).toBe(0);
+		expect(result.sourceUnavailable).toBeFalsy();
 	});
 
 	it('should filter out the bare domain (only returns subdomains)', async () => {
@@ -253,6 +262,24 @@ describe('formatSubdomainDiscovery', () => {
 		const { formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
 		return formatSubdomainDiscovery;
 	}
+
+	it('reports CT source unavailable distinctly from "none found"', async () => {
+		const formatSubdomainDiscovery = await getFormatter();
+		const result = {
+			domain: 'github.com',
+			totalSubdomains: 0,
+			totalCertificates: 0,
+			subdomains: [],
+			wildcardCerts: 0,
+			expiredCerts: 0,
+			uniqueIssuers: [],
+			issues: [],
+			sourceUnavailable: true,
+		};
+		const output = formatSubdomainDiscovery(result, 'full');
+		expect(output).toMatch(/unavailable|could not/i);
+		expect(output).not.toMatch(/no subdomains found/i);
+	});
 
 	it('should format compact output correctly', async () => {
 		const formatSubdomainDiscovery = await getFormatter();


### PR DESCRIPTION
## Summary

Fixes two bugs found during the full-tool production QA pass. Both stem from the same defect pattern — **reporting a definitive negative result when the underlying lookup actually failed** — so both fixes distinguish *lookup-failure* from *confirmed-absent*.

| Tool | Before | After |
|---|---|---|
| **check_dnssec_chain** | Empty root `.` DNSKEY → false **HIGH "Broken DNSSEC chain at ."** (with a message that's wrong for the root — the root has no DS) | Root is a trust anchor (always signed); empty DNSKEY → non-HIGH **"Root trust anchor unverified"** info note. `chainComplete` now requires a verified root. The "DS exists but no DNSKEY" message now only applies to non-root zones, where it's accurate. |
| **discover_subdomains** | crt.sh **HTTP 502** / fetch error → **"no subdomains found"** (false-definitive) | New `sourceUnavailable` flag → **"Certificate Transparency source unavailable … retry shortly"**. A successful-but-empty query still says "none found". |

## Root-cause isolation

- **dnssec_chain:** a real-network test in the **workerd** runtime (same engine as prod) proved the bv-mcp code is correct — `.`/`com`/`cloudflare.com` DNSKEY/DS all return records. The prod emptiness is **edge-only**, traced to `cf: { cacheEverything: true }` on the primary DoH fetch. That underlying issue is tracked in **#199**; this PR fixes the false-positive *logic*, which is correct under any theory of why prod is empty.
- **discover_subdomains:** workerd test showed **crt.sh returns 502** (the CT fallback is down). The code handled it gracefully but mislabeled it.

## ⚠️ Honest scope
- These fixes stop the tools from **lying**. They do **not** restore full function: `check_dnssec_chain` still won't walk past the TLD in prod until **#199** (edge cache) is resolved, and `discover_subdomains` still depends on CT sources (crt.sh / `BV_CERTSTREAM`) being up.

## Test plan
- TDD: RED tests added for the empty-root-DNSKEY case and the crt.sh-unavailable case, then implemented to green.
- `check-dnssec-chain.spec.ts` (7) + `discover-subdomains.spec.ts` (20) pass; existing non-root "broken linkage" + "fully signed chain" cases still pass.
- Full suite: **4287 passed**, typecheck + lint clean.

Relates to #199 (prod edge-cache root cause for the DNSKEY/DS emptiness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
