### PR TITLE
fix(brand-audit): SSRF/blocklist-validate watched domain at register time (closes #198)

### DIFF
--- a/src/tools/brand-audit-watch.ts
+++ b/src/tools/brand-audit-watch.ts
@@ -26,7 +26,7 @@
  */
 
 import { buildCheckResult, createFinding, type CheckResult } from '../lib/scoring';
-import { validateOutboundUrl } from '../lib/sanitize';
+import { validateOutboundUrl, validateDomain, sanitizeDomain } from '../lib/sanitize';
 import type { BrandAuditWatchInterval, BrandAuditWatchRow } from '../lib/db/brand-audit-schema';
 
 const CATEGORY = 'brand_discovery';
@@ -72,6 +72,13 @@ export async function registerBrandAuditWatch(
 	if (!args.interval || !['daily', 'weekly', 'monthly'].includes(args.interval)) {
 		return errorResult('invalidInput', 'interval must be one of daily|weekly|monthly.');
 	}
+	// SSRF/blocklist guard at register time. The watched domain is scanned on a
+	// recurring cron cadence, so reject reserved/IP/blocklisted targets here
+	// rather than storing a row that fails every cycle (#198).
+	const domainValidation = validateDomain(args.domain);
+	if (!domainValidation.valid) {
+		return errorResult('invalidInput', `Invalid domain: ${domainValidation.error ?? 'not allowed'}`);
+	}
 	if (args.webhook_url) {
 		const v = validateOutboundUrl(args.webhook_url);
 		if (!v.valid) {
@@ -95,7 +102,7 @@ export async function registerBrandAuditWatch(
 
 	const watchId = (deps.generateId ?? defaultGenerateId)();
 	const now = (deps.now ?? Date.now)();
-	const domain = args.domain.trim().toLowerCase();
+	const domain = sanitizeDomain(args.domain);
 
 	try {
 		await deps.db

--- a/test/brand-audit-watch.integration.test.ts
+++ b/test/brand-audit-watch.integration.test.ts
@@ -128,6 +128,23 @@ describe('register_brand_audit_watch', () => {
 		const error = result.findings.find((f) => f.metadata?.watchLimitExceeded === true);
 		expect(error).toBeDefined();
 	});
+
+	it('rejects a blocklisted / SSRF-class watched domain at register time (no INSERT)', async () => {
+		const { registerBrandAuditWatch } = await import('../src/tools/brand-audit-watch');
+		const { db, calls } = makeMockD1();
+		const deps = makeDeps({ db });
+
+		// An IP literal is rejected by validateDomain (SSRF/blocklist guard). It must
+		// be refused at register time rather than stored and failed every cron cycle.
+		const result = await registerBrandAuditWatch({ domain: '127.0.0.1', interval: 'daily' }, 'owner-1', deps);
+
+		const error = result.findings.find((f) => f.metadata?.invalidInput === true);
+		expect(error).toBeDefined();
+
+		// No row is written for a rejected domain.
+		const insert = calls.find((c) => c.sql.includes('INSERT INTO brand_audit_watches'));
+		expect(insert).toBeUndefined();
+	});
 });
 
 describe('list_brand_audit_watches', () => {


### PR DESCRIPTION
## Summary

Fixes **#198** — `register_brand_audit_watch` persisted the watched domain without an SSRF/blocklist check (only Zod format + `.trim().toLowerCase()`). Since the watched domain is scanned on a recurring cron cadence, a reserved/IP/blocklisted target would be stored and re-attempted every cycle.

- Added a `validateDomain()` gate in `registerBrandAuditWatch` before the per-principal cap check and `INSERT` — rejects with an `invalidInput` finding and **no DB write**.
- Stores the `sanitizeDomain()`-normalized (punycode) form instead of a bare `trim/lowercase`.

## Severity note (corrected during implementation)

`discoverBrandDomains` **already** validates the seed and **throws** on an invalid/blocklisted domain (`discover-brand-domains.ts:763`), so a bad watch was never actually scanned — the cron audit threw before any SSRF. The real harm was **junk rows + recurring failed audits** (hygiene / defense-in-depth), **not a live SSRF hole**. This change makes register **fail-fast** and keeps the watch table clean. (The original issue cited `brand_audit_batch_start` as the downstream guard, which the cron path actually bypasses — see the issue's review comment; the true guard is `discoverBrandDomains`.)

## Test plan

- TDD: RED test added (`register '127.0.0.1'` → `invalidInput` finding + no `INSERT`) before implementing.
- `brand-audit-watch.integration.test.ts`: 10/10 pass; existing register/list/delete + tool-surface cases unaffected.
- Full suite: **4288 passed**, typecheck + lint clean.
- No behavior change to `list_brand_audit_watches` / `delete_brand_audit_watch`.

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
