### PR TITLE
fix(dnssec-chain): skip caching unverified-root results so transient empties self-heal (relates #199)

### DIFF
--- a/src/tools/check-dnssec-chain.ts
+++ b/src/tools/check-dnssec-chain.ts
@@ -304,5 +304,13 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 		}),
 	);
 
-	return buildCheckResult(CATEGORY, findings) as CheckResult;
+	const result = buildCheckResult(CATEGORY, findings) as CheckResult;
+	// A transient root-DNSKEY retrieval failure leaves the chain unverified. Mark
+	// the result partial so the dispatch cache predicate skips it — otherwise a
+	// one-off empty would be cached and served as a stale "unverified" result for
+	// the cache TTL (#199).
+	if (zoneResults.find((z) => z.zone === '.')?.linkage === 'unverified') {
+		result.partial = true;
+	}
+	return result;
 }

--- a/test/check-dnssec-chain.spec.ts
+++ b/test/check-dnssec-chain.spec.ts
@@ -94,6 +94,8 @@ describe('checkDnssecChain', () => {
 		const infoFinding = result.findings.find((f) => f.severity === 'info' && f.metadata?.chainComplete === true);
 		expect(infoFinding).toBeDefined();
 		expect(infoFinding!.metadata!.adFlag).toBe(true);
+		// A fully-verified chain is complete and stays cacheable.
+		expect(result.partial).toBeFalsy();
 	});
 
 	it('unsigned domain reports no DS', async () => {
@@ -163,6 +165,11 @@ describe('checkDnssecChain', () => {
 		expect(rootNote).toBeDefined();
 		expect(rootNote!.severity).not.toBe('high');
 		expect(rootNote!.detail).not.toMatch(/DS record exists but no DNSKEY/i);
+
+		// An unverified-root result is incomplete (transient retrieval failure) and
+		// must NOT be cached — marking it partial makes the dispatch cache predicate
+		// skip it, so a one-off empty can't persist and be served stale (#199).
+		expect(result.partial).toBe(true);
 	});
 
 	it('maps algorithm 8 to RSA-SHA256', async () => {


### PR DESCRIPTION
## Summary

Fixes the **persistence** half of #199. `check_dnssec_chain` occasionally fetched an empty root `DNSKEY` (a transient retrieval failure — the root is always signed). The resulting "Root trust anchor unverified" was written to the tool-result cache and served as a **stale false-negative for the whole TTL**, even though re-querying returns the correct chain.

**Fix:** mark the result `partial: true` when the root linkage is `unverified`. The dispatch cache predicate `runWithCacheTracked(..., (r) => !r.partial)` already skips caching partial results, so a one-off empty no longer persists — the next request re-queries fresh and self-heals. (Same pattern `check-lookalikes` already uses for timeouts.)

## How this was diagnosed

`cf-cache-status` telemetry (deployed to prod, captured via `wrangler tail`, then reverted) **refuted the original edge-cache hypothesis**:
- `cf-cache-status: null` on every DoH response; fresh root `DNSKEY` returns **3 records** (`hasTyped:true`, no secondary).
- The false "unverified" results came back in **293ms with zero DNS activity** = stale cache hits.

Full write-up on #199.

## Scope (honest)

- **Fixes:** the user-visible persistence (repeated false "unverified").
- **Does not fix:** the rarer underlying transient (why the root query is *occasionally* empty — suspected in `confirmWithSecondaryResolvers`). That now **self-heals on the next request** instead of sticking for the TTL; it remains noted on #199 for a follow-up.

## Test plan

- TDD: RED test asserts an unverified-root result is `partial` (won't be cached); guard test asserts a fully-verified chain stays non-`partial` (cacheable).
- `check-dnssec-chain.spec.ts`: 7/7 pass. Full suite: **4288 passed**, typecheck + lint clean.

Relates to #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
