### PR TITLE
fix(dns-transport): don't edge-cache secondary resolver confirmations (relates #199)

### DIFF
--- a/src/lib/dns-transport.ts
+++ b/src/lib/dns-transport.ts
@@ -236,7 +236,10 @@ export async function confirmWithSecondaryResolvers(
 		bvDnsUrl
 			? fetchDohOutcome(bvDnsUrl, timeoutMs, { token: opts!.secondaryDoh!.token, semaphore: sem })
 			: Promise.resolve({ kind: 'error', reason: 'network' } as const),
-		fetchDohOutcome(googleUrl, timeoutMs, { useEdgeCache: true, semaphore: sem }),
+		// No edge cache on the secondary: it's the rare fallback used precisely when
+		// the primary missed, so caching its responses risks persisting a transient
+		// empty at the edge for the cache TTL (#199).
+		fetchDohOutcome(googleUrl, timeoutMs, { semaphore: sem }),
 	];
 	const results = await Promise.allSettled(candidates);
 	for (const r of results) {

--- a/test/dns-transport.spec.ts
+++ b/test/dns-transport.spec.ts
@@ -648,6 +648,21 @@ describe('confirmWithSecondaryResolvers', () => {
 		expect((result as { kind?: string }).kind).toBe('unconfirmed');
 	});
 
+	it('does not edge-cache secondary (fallback) confirmations', async () => {
+		const calls: Array<{ url: string; init: RequestInit & { cf?: unknown } }> = [];
+		globalThis.fetch = vi.fn().mockImplementation(async (url: string, init: RequestInit & { cf?: unknown }) => {
+			calls.push({ url: String(url), init });
+			return { ok: true, status: 200, json: async () => ({ Status: 0, Answer: [] }) };
+		}) as unknown as typeof fetch;
+		const transport = await import('../src/lib/dns-transport');
+		await transport.confirmWithSecondaryResolvers('example.com', 'TXT', false, 2000);
+		// The secondary is the rare fallback used precisely when the primary missed;
+		// edge-caching its responses risks persisting a transient empty (#199).
+		const googleCall = calls.find((c) => c.url.includes('dns.google'));
+		expect(googleCall, 'expected a Google secondary fetch').toBeDefined();
+		expect(googleCall!.init?.cf).toBeUndefined();
+	});
+
 	it('returns a DohResponse when at least one secondary succeeds', async () => {
 		let calls = 0;
 		globalThis.fetch = vi.fn().mockImplementation(async () => {


### PR DESCRIPTION
## Summary

Hardening from the #199 secondary-confirmation investigation. `confirmWithSecondaryResolvers` passed `useEdgeCache: true` to the Google fallback fetch, which attaches `cf: { cacheEverything: true }`. The secondary is the **rare** path — taken only when the primary returns no typed answers — so edge-caching its responses risks persisting a transient empty at the edge for the cache TTL. That's the same stale-empty class behind the `check_dnssec_chain` false "unverified root" in #199.

**Change:** drop `useEdgeCache` on the secondary fetch so the fallback is always fresh.

- Negligible cost — the secondary path is rare by construction (primary-miss only).
- No change to confirmation semantics: a secondary's valid-empty response still confirms absence (the `:651-668` test behaviour is preserved).

## Not included

The investigation also floated returning `{ kind: 'unconfirmed' }` instead of a secondary's empty body. On review that would **reverse a deliberate, tested design decision** (`dns-transport.spec.ts:651-668` — "valid empty response → DohResponse, not unconfirmed") for **no observable downstream benefit** (empty either way). Deliberately omitted; see the #199 discussion.

## Test plan

- TDD: RED test asserts the Google secondary fetch carries no `cf` directive → GREEN.
- `dns-transport.spec.ts`: 27/27 pass (existing secondary-confirmation tests unchanged). Full suite: **4289 passed**, typecheck + lint clean.

Relates to #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
