### PR TITLE
docs(threat-model): STRIDE-A threat model of bv-mcp

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -181,6 +181,13 @@ regexes = [
 # ─── Global Allowlists ───────────────────────────────────────────────
 
 [allowlist]
+# Threat-model report-folder timestamps (YYYYMMDD-HHMMSS, e.g. the `report_folder`
+# in threat-inventory.json) trip the default `phone-number` rule. Benign date-shaped
+# values — allow the specific pattern while keeping secret scanning active on the docs.
+regexTarget = "line"
+regexes = [
+  '''threat-model-\d{8}-\d{6}''',
+]
 paths = [
   '''\.gitleaks\.toml$''',           # This config file itself
   '''\.githooks/''',                 # Hook config (contains patterns)

--- a/docs/threat-model/threat-model-20260524-114907/0-assessment.md
+++ b/docs/threat-model/threat-model-20260524-114907/0-assessment.md
@@ -1,5 +1,7 @@
 # Security Assessment
 
+> **Remediation status (updated 2026-05-25).** All findings have been addressed; STRIDE statuses and the coverage table now read `Mitigated`. Remediation is delivered by PR #208 (`fix/threat-model-findings`), **pending merge to `main`** — the risk rating below reflects the analyzed commit `7e23243` (pre-remediation), not the post-fix state. FIND-05 was a false positive (already mitigated on `main`). See PR #208 for deploy/cross-repo follow-ups.
+
 ---
 
 ## Report Files

--- a/docs/threat-model/threat-model-20260524-114907/0-assessment.md
+++ b/docs/threat-model/threat-model-20260524-114907/0-assessment.md
@@ -1,0 +1,162 @@
+# Security Assessment
+
+---
+
+## Report Files
+
+| File | Description |
+|------|-------------|
+| [0-assessment.md](0-assessment.md) | This document — executive summary, risk rating, action plan, metadata |
+| [0.1-architecture.md](0.1-architecture.md) | Architecture overview, components, scenarios, tech stack |
+| [1-threatmodel.md](1-threatmodel.md) | Threat model DFD diagram with element, flow, and boundary tables |
+| [1.1-threatmodel.mmd](1.1-threatmodel.mmd) | Pure Mermaid DFD source file |
+| [2-stride-analysis.md](2-stride-analysis.md) | Full STRIDE-A analysis for all components |
+| [3-findings.md](3-findings.md) | Prioritized security findings with remediation |
+| [1.2-threatmodel-summary.mmd](1.2-threatmodel-summary.mmd) | Summary DFD for large systems |
+
+---
+
+## Executive Summary
+
+Blackveil DNS (`bv-mcp`) is a publicly-exposed Cloudflare Worker that exposes ~80 DNS/email-security tools via an MCP server (JSON-RPC over Streamable HTTP), an OAuth 2.1 issuer for paid tiers, a multi-tenant subsystem, and internal service-binding routes. Because it is internet-facing and accepts unauthenticated free-tier traffic, its primary attack surface is the public `/mcp` and `/oauth/*` request path, with secondary surfaces in the service-binding `/internal/*` routes and Cloudflare-managed state (KV, D1, Durable Objects).
+
+The codebase demonstrates a mature security posture. Authentication uses constant-time key comparison and algorithm-pinned HS256 JWTs; outbound requests to attacker-influenced URLs pass through a dedicated SSRF guard (`safeFetch`) layered on a domain sanitizer and Cloudflare's `global_fetch_strictly_public` runtime control; abuse is bounded by multi-layer rate limiting, per-tool quotas, a global daily ceiling, and a fuzzing detector; and privacy-sensitive data (client IPs in access logs) is encrypted at the application layer. The majority of enumerated threats are already mitigated by these existing controls or by the Cloudflare platform.
+
+The analysis covers 23 system elements across 5 trust boundaries.
+
+### Risk Rating: Moderate
+
+The system has no identified critical or directly-exploitable authentication-bypass, injection, or remote-code-execution issues. The directly-exploitable (Tier 1) findings are abuse-resistance and hardening gaps — query-string credential exposure, distributed free-tier abuse, scanner-as-proxy misuse, and a spoofable OAuth issuer — none of which compromise confidentiality or integrity of other users' data on their own. The most material gap is operational: internal tool/analytics routes default to no bearer authentication (`REQUIRE_INTERNAL_AUTH` off by default), which must be enabled in production. Overall residual risk is Moderate, driven by abuse-resistance and configuration hardening rather than core vulnerabilities.
+
+> **Note on threat counts:** This analysis identified 78 threats across 21 components. This count reflects comprehensive STRIDE-A coverage, not systemic insecurity. Of these, **40 are directly exploitable** without prerequisites (Tier 1). The remaining 38 represent conditional risks and defense-in-depth considerations.
+
+---
+
+## Action Summary
+
+| Tier | Description | Threats | Findings | Priority |
+|------|-------------|---------|----------|----------|
+| [Tier 1](3-findings.md#tier-1--direct-exposure-no-prerequisites) | Directly exploitable | 40 | 11 | 🔴 Critical Risk |
+| [Tier 2](3-findings.md#tier-2--conditional-risk-authenticated--single-prerequisite) | Requires authenticated access | 22 | 5 | 🟠 Elevated Risk |
+| [Tier 3](3-findings.md#tier-3--defense-in-depth-prior-compromise--host-access) | Requires prior compromise | 16 | 1 | 🟡 Moderate Risk |
+| **Total** | | **78** | **17** | |
+
+### Priority by Tier and CVSS Score (Top 10)
+
+| Finding | Tier | CVSS Score | SDL Severity | Title |
+|---------|------|------------|-------------|-------|
+| [FIND-01](3-findings.md#find-01-api-key-accepted-via-api_key-query-parameter) | T1 | 5.3 | Moderate | API key accepted via `?api_key=` query parameter |
+| [FIND-02](3-findings.md#find-02-free-tier-abuse-via-distributed-ips-against-a-shared-global-budget) | T1 | 5.3 | Moderate | Free-tier abuse via distributed IPs against a shared global budget |
+| [FIND-03](3-findings.md#find-03-scanner-usable-as-a-reconnaissance--amplification-proxy) | T1 | 5.1 | Moderate | Scanner usable as a reconnaissance / amplification proxy |
+| [FIND-04](3-findings.md#find-04-oauth-issuer-derived-from-a-spoofable-host-header) | T1 | 4.8 | Moderate | OAuth issuer derived from a spoofable `Host` header |
+| [FIND-05](3-findings.md#find-05-open-oauth-dynamic-client-registration) | T1 | 4.3 | Low | Open OAuth dynamic client registration |
+| [FIND-06](3-findings.md#find-06-force_refresh-enables-cache-busting-amplification) | T1 | 3.7 | Low | `force_refresh` enables cache-busting amplification |
+| [FIND-07](3-findings.md#find-07-domain-validation-hardening-for-homoglyph--idn-inputs) | T1 | 3.1 | Low | Domain validation hardening for homoglyph / IDN inputs |
+| [FIND-08](3-findings.md#find-08-authentication-and-token-integrity-controls-existing-control) | T1 | 2.3 | Low | Authentication and token-integrity controls (existing control) |
+| [FIND-09](3-findings.md#find-09-ssrf-egress-controls-existing-control) | T1 | 2.3 | Low | SSRF egress controls (existing control) |
+| [FIND-10](3-findings.md#find-10-rate-limiting-quotas-and-dos-budgets-existing-control) | T1 | 2.3 | Low | Rate limiting, quotas, and DoS budgets (existing control) |
+
+### Quick Wins
+
+| Finding | Title | Why Quick |
+|---------|-------|-----------|
+| [FIND-01](3-findings.md#find-01-api-key-accepted-via-api_key-query-parameter) | API key accepted via `?api_key=` query parameter | Deprecation path already exists; set a cutoff and reject the query param. |
+| [FIND-04](3-findings.md#find-04-oauth-issuer-derived-from-a-spoofable-host-header) | OAuth issuer derived from a spoofable `Host` header | Single config value — set `OAUTH_ISSUER` in production. |
+| [FIND-05](3-findings.md#find-05-open-oauth-dynamic-client-registration) | Open OAuth dynamic client registration | Add a per-IP registration rate limit and storage TTL. |
+| [FIND-06](3-findings.md#find-06-force_refresh-enables-cache-busting-amplification) | `force_refresh` enables cache-busting amplification | Add a small sub-limit for `force_refresh` requests. |
+
+---
+
+## Analysis Context & Assumptions
+
+### Analysis Scope
+| Constraint | Description |
+|------------|-------------|
+| Scope | Source-level STRIDE-A threat model of the `bv-mcp` Cloudflare Worker, OAuth issuer, internal routes, scheduled/queue handlers, Durable Objects, and the `@blackveil/dns-checks` core. |
+| Excluded | Cloudflare platform internals; sibling-worker source (bv-web, certstream, whois, intel/enterprise bindings) treated as external trust targets; operator-only private bindings (`BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`, `BV_ENTERPRISE`) not in the public distribution. |
+| Focus Areas | Public request path (auth, SSRF, rate limiting, OAuth), internal-route isolation, secret handling, multi-tenant/brand-audit abuse surface. |
+
+### Infrastructure Context
+| Category | Discovered from Codebase | Findings Affected |
+|----------|--------------------------|-------------------|
+| Deployment | Public Cloudflare Worker; bindings in [wrangler.jsonc](../../../wrangler.jsonc); `global_fetch_strictly_public` enabled | FIND-04, FIND-09 |
+| Authentication | Static key + OAuth JWT in [src/lib/tier-auth.ts](../../../src/lib/tier-auth.ts), [src/oauth/](../../../src/oauth/) | FIND-01, FIND-08, FIND-13, FIND-15 |
+| SSRF controls | [src/lib/safe-fetch.ts](../../../src/lib/safe-fetch.ts), [src/lib/sanitize.ts](../../../src/lib/sanitize.ts), [src/lib/config.ts](../../../src/lib/config.ts) | FIND-07, FIND-09 |
+| Rate limiting / quotas | [src/lib/rate-limiter.ts](../../../src/lib/rate-limiter.ts), [src/lib/quota-coordinator.ts](../../../src/lib/quota-coordinator.ts) | FIND-02, FIND-03, FIND-06, FIND-10 |
+| Internal routes | [src/internal.ts](../../../src/internal.ts) (`isPublicInternetRequest`, `REQUIRE_INTERNAL_AUTH`) | FIND-12, FIND-16 |
+| State storage | KV/D1/DO; access-log encryption in [src/mcp/execute.ts](../../../src/mcp/execute.ts) | FIND-11, FIND-17 |
+
+### Needs Verification
+| Item | Question | What to Check | Why Uncertain |
+|------|----------|---------------|---------------|
+| `REQUIRE_INTERNAL_AUTH` | Is internal bearer auth enabled in production? | Production `wrangler` vars / `.dev/wrangler.deploy.jsonc` | Default is off in code; production value is not in the public repo. |
+| `OAUTH_ISSUER` | Is the issuer override set in production? | Production environment vars | Falls back to Host header when unset; prod value not in repo. |
+| IDN/homoglyph handling | Does `sanitizeDomain` fully normalize confusable domains? | Add unit tests for mixed-script/punycode inputs | No explicit confusable-detection tests observed. |
+| Trial-key / OAuth-code storage | Are these encrypted at the application layer? | [src/lib/trial-keys.ts](../../../src/lib/trial-keys.ts), [src/oauth/storage.ts](../../../src/oauth/storage.ts) | Only access-log IPs are app-encrypted; KV secrets rely on platform at-rest encryption. |
+
+### Finding Overrides
+| Finding ID | Original Severity | Override | Justification | New Status |
+|------------|-------------------|----------|---------------|------------|
+| — | — | — | No overrides applied. Update this section after review. | — |
+
+### Additional Notes
+
+The finding count (17) is moderate relative to the threat count (78) because most threats are already addressed by existing controls or the Cloudflare platform; four of the seventeen findings (FIND-08–11, FIND-16) are "existing control" entries that document strong controls for regression protection rather than gaps. Platform-mitigated threats account for ~6% of the total, below the 20% suspicion threshold. The `tenants/` subsystem and operator-only tiered-discovery bindings were treated as in-scope behaviorally but their private sibling workers were modeled as external trust targets.
+
+---
+
+## References Consulted
+
+### Security Standards
+| Standard | URL | How Used |
+|----------|-----|----------|
+| Microsoft SDL Bug Bar | https://www.microsoft.com/en-us/msrc/sdlbugbar | Severity classification |
+| OWASP Top 10:2025 | https://owasp.org/Top10/2025/ | Threat categorization |
+| CVSS 4.0 | https://www.first.org/cvss/v4.0/specification-document | Risk scoring |
+| CWE | https://cwe.mitre.org/ | Weakness classification |
+| STRIDE | https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats | Threat enumeration |
+| OWASP Agentic Security Initiative | https://genai.owasp.org/initiatives/#agenticsecurity | Tool-execution/agentic abuse review lens |
+
+### Component Documentation
+| Component | Documentation URL | Relevant Section |
+|-----------|------------------|------------------|
+| Cloudflare Workers | https://developers.cloudflare.com/workers/ | Runtime, bindings, `global_fetch_strictly_public` |
+| Model Context Protocol | https://modelcontextprotocol.io/specification | Streamable HTTP transport, JSON-RPC, OAuth profile |
+| Hono | https://hono.dev/ | Routing, CORS middleware |
+| DNS over HTTPS (RFC 8484) | https://www.rfc-editor.org/rfc/rfc8484 | DoH transport security |
+| OAuth 2.1 / PKCE (RFC 7636) | https://www.rfc-editor.org/rfc/rfc7636 | Authorization-code + PKCE flow |
+
+---
+
+## Report Metadata
+
+| Field | Value |
+|-------|-------|
+| Source Location | `/Applications/Github/bv-mcp` |
+| Git Repository | `https://github.com/MadaBurns/bv-mcp.git` |
+| Git Branch | `main` |
+| Git Commit | `7e23243` (`2026-05-24 23:32:40 +1200`) |
+| Model | `claude-opus-4-7[1m]` |
+| Machine Name | `Adams-MacBook-Pro.local` |
+| Analysis Started | `2026-05-24 11:49:07 UTC` |
+| Analysis Completed | `2026-05-24 12:13:43 UTC` |
+| Duration | `~25 minutes` |
+| Output Folder | `docs/threat-model/threat-model-20260524-114907` |
+| Prompt | `run the threat-model-analyst on bv-mcp` |
+
+---
+
+## Classification Reference
+
+| Classification | Values |
+|---------------|--------|
+| **Exploitability Tiers** | **T1** Direct Exposure (no prerequisites) · **T2** Conditional Risk (single prerequisite) · **T3** Defense-in-Depth (multiple prerequisites or infrastructure access) |
+| **STRIDE + Abuse** | **S** Spoofing · **T** Tampering · **R** Repudiation · **I** Information Disclosure · **D** Denial of Service · **E** Elevation of Privilege · **A** Abuse (feature misuse) |
+| **SDL Severity** | `Critical` · `Important` · `Moderate` · `Low` |
+| **Remediation Effort** | `Low` · `Medium` · `High` |
+| **Mitigation Type** | `Redesign` · `Standard Mitigation` · `Custom Mitigation` · `Existing Control` · `Accept Risk` · `Transfer Risk` |
+| **Threat Status** | `Open` · `Mitigated` · `Platform` |
+| **Incremental Tags** | `[Existing]` · `[Fixed]` · `[Partial]` · `[New]` · `[Removed]` (incremental reports only) |
+| **CVSS** | CVSS 4.0 vector with `CVSS:4.0/` prefix |
+| **CWE** | Hyperlinked CWE ID (e.g., [CWE-306](https://cwe.mitre.org/data/definitions/306.html)) |
+| **OWASP** | OWASP Top 10:2025 mapping (e.g., A01:2025 – Broken Access Control) |

--- a/docs/threat-model/threat-model-20260524-114907/0.1-architecture.md
+++ b/docs/threat-model/threat-model-20260524-114907/0.1-architecture.md
@@ -1,0 +1,309 @@
+# Architecture Overview
+
+## System Purpose
+
+Blackveil DNS (`bv-mcp`) is a source-available DNS & email-security scanner delivered as a Cloudflare Worker. It exposes ~80 security tools through a Model Context Protocol (MCP) server over Streamable HTTP (JSON-RPC 2.0) at a public endpoint, plus an OAuth 2.1 issuer for paid tiers, a multi-tenant subsystem, and internal service-binding routes for sibling BlackVeil workers. Users are MCP clients (LLM IDEs, agents, `claude_*` clients) running unauthenticated free-tier scans or authenticated paid scans, and BlackVeil operators managing trial keys and OAuth grants.
+
+## Key Components
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| McpClient | External Interactor | MCP client (LLM IDE/agent) calling `/mcp` over JSON-RPC; may be unauthenticated (free tier) or bearer/OAuth authenticated |
+| Operator | External Interactor | BlackVeil operator using the static `BV_API_KEY` (owner tier) or driving `/internal/*` via the bv-web service binding |
+| HonoWorker | Process | Edge HTTP router (`src/index.ts`); CORS/Origin checks, body-size limits, route gating, error wrapping |
+| TierAuthResolver | Process | Resolves caller tier (`src/lib/tier-auth.ts`): constant-time `BV_API_KEY` compare, OAuth JWT verify, trial-key/bv-web lookup, `OWNER_ALLOW_IPS` gate |
+| OAuthIssuer | Process | OAuth 2.1 issuer (`src/oauth/`): register, authorize, PKCE token exchange, HS256 JWT signing/validation, entitlements |
+| McpExecutor | Process | MCP request pipeline (`src/mcp/execute.ts` + `dispatch.ts`): session validation, per-tier rate/quota application, method routing |
+| ToolsHandler | Process | Tool registry + execution (`src/handlers/tools.ts`): lists/dispatches ~80 `check_*`/scan tools |
+| DomainSanitizer | Process | Input validation/SSRF guard (`src/lib/sanitize.ts` + `config.ts` blocklists): `validateDomain`, `sanitizeDomain`, `validateOutboundUrl` |
+| SafeFetch | Process | Egress SSRF guard (`src/lib/safe-fetch.ts`): HTTPS-only, manual redirects, RFC1918/reserved/rebinding rejection for attacker-influenced URLs |
+| DnsResolver | Process | DoH egress (`src/lib/dns-transport.ts`, `dns-multi-resolver.ts`): Cloudflare DoH primary, `BV_DOH_ENDPOINT` secondary, Google fallback |
+| RateLimiter | Process | Limits/quotas + abuse detection (`src/lib/rate-limiter.ts`, `fuzzing-detector.ts`): per-IP min/hr, per-tool daily, global ceiling, fuzzing scoring |
+| InternalRouter | Process | Service-binding surface (`src/internal.ts`): `/internal/tools/*`, `/internal/oauth/grants`, `/internal/trial-keys/*`, guarded by `isPublicInternetRequest` |
+| BrandAuditPipeline | Process | Brand-audit orchestration (`src/lib/brand-audit-pipeline.ts`) + cron/queue (`src/scheduled.ts`, queue consumer): tiered discovery, registrar/CT/WHOIS enrichment |
+| QuotaCoordinator | Process | Durable Object (`src/lib/quota-coordinator.ts`): cross-isolate rate-limit/global-quota coordination with circuit-breaker fallback |
+| ProfileAccumulator | Process | Durable Object (`src/lib/profile-accumulator.ts`): adaptive-scoring EMA persistence per profile+provider |
+| SessionStoreKV | Data Store | KV `SESSION_STORE`: session records, OAuth authorization codes, JWT JTI revocation markers |
+| ScanCacheKV | Data Store | KV `SCAN_CACHE`: cached scan/check results keyed by domain |
+| RateLimitKV | Data Store | KV `RATE_LIMIT`: rate-limit counters, fuzzing counters, trial keys |
+| IntelligenceDB | Data Store | D1 `INTELLIGENCE_DB`: MCP access logs with AES-GCM-encrypted IP evidence, ~90-day retention |
+| BvWeb | External Service | Sibling worker (service binding): `validate-key` and OAuth entitlements resolution |
+| PublicDoH | External Service | Public DoH resolvers (Cloudflare `cloudflare-dns.com`, Google fallback) for DNS queries |
+| CertTransparency | External Service | `BV_CERTSTREAM` binding + crt.sh fallback for CT-log subdomain/SAN enumeration |
+| WhoisRdap | External Service | `BV_WHOIS` binding + RDAP fallback for registration data |
+
+## Component Diagram
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef service fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+    linkStyle default stroke:#666666,stroke-width:2px
+
+    McpClient(["McpClient"]):::external
+    Operator(["Operator"]):::external
+
+    subgraph Worker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker["HonoWorker"]:::service
+        TierAuthResolver["TierAuthResolver"]:::service
+        OAuthIssuer["OAuthIssuer"]:::service
+        McpExecutor["McpExecutor"]:::service
+        ToolsHandler["ToolsHandler"]:::service
+        DomainSanitizer["DomainSanitizer"]:::service
+        SafeFetch["SafeFetch"]:::service
+        DnsResolver["DnsResolver"]:::service
+        RateLimiter["RateLimiter"]:::service
+        InternalRouter["InternalRouter"]:::service
+        BrandAuditPipeline["BrandAuditPipeline"]:::service
+    end
+
+    subgraph DOs["Durable Objects"]
+        QuotaCoordinator["QuotaCoordinator"]:::service
+        ProfileAccumulator["ProfileAccumulator"]:::service
+    end
+
+    subgraph Storage["Cloudflare Platform Storage"]
+        SessionStoreKV[("SessionStoreKV")]:::datastore
+        ScanCacheKV[("ScanCacheKV")]:::datastore
+        RateLimitKV[("RateLimitKV")]:::datastore
+        IntelligenceDB[("IntelligenceDB")]:::datastore
+    end
+
+    subgraph BvServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::service
+    end
+
+    PublicDoH(["PublicDoH"]):::external
+    CertTransparency(["CertTransparency"]):::external
+    WhoisRdap(["WhoisRdap"]):::external
+
+    McpClient -->|"JSON-RPC (HTTPS)"| HonoWorker
+    Operator -->|"Service binding"| InternalRouter
+    HonoWorker -->|"Resolve tier"| TierAuthResolver
+    HonoWorker -->|"OAuth flows"| OAuthIssuer
+    HonoWorker -->|"MCP requests"| McpExecutor
+    TierAuthResolver -->|"Validate key"| BvWeb
+    OAuthIssuer -->|"Entitlements"| BvWeb
+    McpExecutor -->|"Limits/quota"| RateLimiter
+    McpExecutor -->|"Dispatch"| ToolsHandler
+    RateLimiter -->|"Coordinate"| QuotaCoordinator
+    ToolsHandler -->|"Validate domain"| DomainSanitizer
+    ToolsHandler -->|"DNS queries"| DnsResolver
+    ToolsHandler -->|"Fetch (BIMI/redirects)"| SafeFetch
+    ToolsHandler -->|"Brand audits"| BrandAuditPipeline
+    ToolsHandler -->|"Adaptive weights"| ProfileAccumulator
+    DnsResolver -->|"DoH"| PublicDoH
+    BrandAuditPipeline -->|"CT logs"| CertTransparency
+    BrandAuditPipeline -->|"WHOIS/RDAP"| WhoisRdap
+    McpExecutor -->|"Sessions/codes"| SessionStoreKV
+    ToolsHandler -->|"Cache"| ScanCacheKV
+    RateLimiter -->|"Counters"| RateLimitKV
+    McpExecutor -->|"Access logs"| IntelligenceDB
+
+    style Worker fill:#f0f4ff,stroke:#2171b5,stroke-width:2px,stroke-dasharray: 5 5
+    style DOs fill:#f0f4ff,stroke:#2171b5,stroke-width:2px,stroke-dasharray: 5 5
+    style Storage fill:#f0fff0,stroke:#238b45,stroke-width:2px,stroke-dasharray: 5 5
+    style BvServices fill:#fff8f0,stroke:#d94701,stroke-width:2px,stroke-dasharray: 5 5
+```
+
+## Top Scenarios
+
+### Scenario 1: Unauthenticated free-tier domain scan
+
+An MCP client calls `tools/call` for `scan_domain` over `/mcp`. The worker checks Origin, resolves tier (free if no token), validates the session, applies per-IP and per-tool rate limits, sanitizes the domain, runs DNS checks over DoH, caches the result, and returns a graded report.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'background': '#ffffff',
+  'actorBkg': '#6baed6', 'actorBorder': '#2171b5', 'actorTextColor': '#000000',
+  'signalColor': '#666666', 'signalTextColor': '#666666',
+  'noteBkgColor': '#fdae61', 'noteBorderColor': '#d94701', 'noteTextColor': '#000000',
+  'activationBkgColor': '#ddeeff', 'activationBorderColor': '#2171b5'
+}}}%%
+sequenceDiagram
+    actor McpClient
+    participant HonoWorker
+    participant TierAuthResolver
+    participant McpExecutor
+    participant ToolsHandler
+    participant DomainSanitizer
+    participant DnsResolver
+    participant PublicDoH
+
+    McpClient->>HonoWorker: POST /mcp tools/call scan_domain
+    activate HonoWorker
+    Note over HonoWorker: Origin check, 10 KB body limit
+    HonoWorker->>TierAuthResolver: Resolve tier (no token -> free)
+    HonoWorker->>McpExecutor: Validated JSON-RPC
+    activate McpExecutor
+    Note over McpExecutor: Session validate + per-IP/per-tool rate limit
+    McpExecutor->>ToolsHandler: Dispatch scan_domain
+    activate ToolsHandler
+    ToolsHandler->>DomainSanitizer: validateDomain(domain)
+    Note over DomainSanitizer: Reject IP literals, localhost, rebinding hosts
+    ToolsHandler->>DnsResolver: queryDns(records)
+    DnsResolver->>PublicDoH: DoH GET (TLS)
+    PublicDoH-->>DnsResolver: DNS answers
+    DnsResolver-->>ToolsHandler: Records
+    ToolsHandler-->>McpExecutor: Graded CheckResult (cached)
+    deactivate ToolsHandler
+    McpExecutor-->>HonoWorker: JSON-RPC result
+    deactivate McpExecutor
+    HonoWorker-->>McpClient: 200 (sanitized errors)
+    deactivate HonoWorker
+```
+
+### Scenario 2: OAuth 2.1 paid-tier token issuance
+
+A paid MCP client completes the OAuth authorization-code + PKCE flow. The issuer resolves entitlements from bv-web, mints an HS256 JWT carrying a tier claim, and subsequent `/mcp` calls present it as a bearer token that `TierAuthResolver` verifies.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'background': '#ffffff',
+  'actorBkg': '#6baed6', 'actorBorder': '#2171b5', 'actorTextColor': '#000000',
+  'signalColor': '#666666', 'signalTextColor': '#666666',
+  'noteBkgColor': '#fdae61', 'noteBorderColor': '#d94701', 'noteTextColor': '#000000',
+  'activationBkgColor': '#ddeeff', 'activationBorderColor': '#2171b5'
+}}}%%
+sequenceDiagram
+    actor McpClient
+    participant OAuthIssuer
+    participant BvWeb
+    participant SessionStoreKV
+    participant TierAuthResolver
+
+    McpClient->>OAuthIssuer: GET /oauth/authorize (PKCE challenge)
+    activate OAuthIssuer
+    OAuthIssuer->>BvWeb: Resolve plan -> tier entitlement
+    BvWeb-->>OAuthIssuer: Tier (developer/enterprise)
+    OAuthIssuer->>SessionStoreKV: Store auth code + challenge
+    OAuthIssuer-->>McpClient: redirect with code
+    deactivate OAuthIssuer
+    McpClient->>OAuthIssuer: POST /oauth/token (code + verifier)
+    activate OAuthIssuer
+    Note over OAuthIssuer: PKCE S256 verify; sign HS256 JWT (tier claim, jti)
+    OAuthIssuer-->>McpClient: access_token (JWT)
+    deactivate OAuthIssuer
+    McpClient->>TierAuthResolver: /mcp with Bearer JWT
+    Note over TierAuthResolver: Verify alg=HS256, signature, exp/iss/aud, jti not revoked
+```
+
+### Scenario 3: Brand audit with tiered discovery
+
+An authenticated client requests a brand audit. The pipeline enumerates candidate domains via CT logs and WHOIS/RDAP (and optional private intel bindings), enqueues deep-scan work, and aggregates results under per-tier quotas.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'background': '#ffffff',
+  'actorBkg': '#6baed6', 'actorBorder': '#2171b5', 'actorTextColor': '#000000',
+  'signalColor': '#666666', 'signalTextColor': '#666666',
+  'noteBkgColor': '#fdae61', 'noteBorderColor': '#d94701', 'noteTextColor': '#000000',
+  'activationBkgColor': '#ddeeff', 'activationBorderColor': '#2171b5'
+}}}%%
+sequenceDiagram
+    actor McpClient
+    participant ToolsHandler
+    participant BrandAuditPipeline
+    participant CertTransparency
+    participant WhoisRdap
+
+    McpClient->>ToolsHandler: tools/call brand_audit (authenticated)
+    activate ToolsHandler
+    Note over ToolsHandler: Per-tier daily quota check
+    ToolsHandler->>BrandAuditPipeline: Run audit (watched domain validated)
+    activate BrandAuditPipeline
+    BrandAuditPipeline->>CertTransparency: Enumerate SAN siblings
+    CertTransparency-->>BrandAuditPipeline: Candidate domains
+    BrandAuditPipeline->>WhoisRdap: Registration lookups
+    WhoisRdap-->>BrandAuditPipeline: Registrar/ownership signals
+    BrandAuditPipeline-->>ToolsHandler: Aggregated findings
+    deactivate BrandAuditPipeline
+    ToolsHandler-->>McpClient: Brand report
+    deactivate ToolsHandler
+```
+
+### Scenario 4: Internal service-binding tool call
+
+A sibling worker (bv-web) calls `/internal/tools/call` via service binding. `isPublicInternetRequest` rejects any request carrying public proxy headers; credential-minting routes additionally require a `BV_WEB_INTERNAL_KEY` bearer.
+
+### Scenario 5: Scheduled cron (fuzzing alerts + brand reaper)
+
+Every 15 minutes the cron handler reads fuzzing counters, emits `fuzzing_suspected` alerts to `ALERT_WEBHOOK_URL`, runs analytics anomaly checks, and reaps stale brand-audit jobs.
+
+## Technology Stack
+
+| Layer | Technologies |
+|-------|--------------|
+| Languages | TypeScript (strict, ES2024) |
+| Frameworks | Hono v4, Model Context Protocol (JSON-RPC 2.0 Streamable HTTP), Zod v4 |
+| Data Stores | Cloudflare KV (RATE_LIMIT, SCAN_CACHE, SESSION_STORE), D1 (BRAND_AUDIT_DB, INTELLIGENCE_DB), R2 (BRAND_REPORTS), Durable Objects (QuotaCoordinator, ProfileAccumulator), Analytics Engine |
+| Infrastructure | Cloudflare Workers (edge), Wrangler 4.x, service bindings (bv-web, certstream, whois, intel), Queues, cron triggers |
+| Security | Constant-time XOR over SHA-256 (`tier-auth.ts`), HS256 OAuth JWT (`oauth/jwt.ts`), PKCE S256, SSRF allow/deny (`safe-fetch.ts`, `config.ts`), domain sanitization (`sanitize.ts`), rate limiting + global quota DO, fuzzing detector, AES-GCM access-log IP encryption, error allowlist (`json-rpc.ts`), `global_fetch_strictly_public` Worker flag |
+
+## Deployment Model
+
+`bv-mcp` is a single Cloudflare Worker deployed to the global edge and reachable over HTTPS (TLS terminated by Cloudflare) at a public hostname (`dns-mcp.blackveilsecurity.com`). The public surface is `POST/GET/DELETE /mcp`, the legacy SSE endpoints, `/oauth/*`, `/.well-known/oauth-*`, `/health`, and `/badge/:domain`. The `/internal/*` surface is reachable only via Cloudflare service bindings from sibling workers — public requests are rejected by `isPublicInternetRequest`. State lives in Cloudflare-managed KV, D1, R2, Queues, and two Durable Objects; none of these expose network listeners and are reachable only through in-account bindings. External egress is TLS-only to public DoH resolvers, CT logs, and RDAP/WHOIS, plus service-binding RPC to BlackVeil workers.
+
+**Deployment Classification:** `NETWORK_SERVICE`
+
+### Component Exposure Table
+
+| Component | Listens On | Auth Required | Reachability | Min Prerequisite | Derived Tier |
+|-----------|------------|---------------|--------------|------------------|-------------|
+| McpClient | N/A — no listener | N/A | External | Host/OS Access | T3 |
+| Operator | N/A — no listener | N/A | External | Host/OS Access | T3 |
+| HonoWorker | 0.0.0.0:443 (CF edge) | No (free tier allowed) | External | None | T1 |
+| TierAuthResolver | via HonoWorker (no own listener) | No (it is the auth) | External | None | T1 |
+| OAuthIssuer | 0.0.0.0:443 `/oauth/*` | No (registration/authorize/token public) | External | None | T1 |
+| McpExecutor | via HonoWorker (no own listener) | No (free tier allowed) | External | None | T1 |
+| ToolsHandler | via HonoWorker (no own listener) | No (free tier allowed) | External | None | T1 |
+| DomainSanitizer | N/A — invoked in request path | No | External | None | T1 |
+| SafeFetch | N/A — egress library | No | External | None | T1 |
+| DnsResolver | N/A — egress library | No | External | None | T1 |
+| RateLimiter | N/A — invoked in request path | No | External | None | T1 |
+| InternalRouter | service binding only | Conditional (lenient default; strict for credential-minting) | Internal Only | Internal Network | T2 |
+| BrandAuditPipeline | via tools/call + queue/cron | Yes (paid tier quota) | External | Authenticated User | T2 |
+| QuotaCoordinator | N/A — DO binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| ProfileAccumulator | N/A — DO binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| SessionStoreKV | N/A — KV binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| ScanCacheKV | N/A — KV binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| RateLimitKV | N/A — KV binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| IntelligenceDB | N/A — D1 binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| BvWeb | service binding (sibling worker) | Yes (`BV_WEB_INTERNAL_KEY`) | Internal Only | Internal Network | T2 |
+| PublicDoH | external (TLS egress target) | N/A (TLS) | Internal Only | Internal Network | T2 |
+| CertTransparency | service binding + crt.sh (TLS) | N/A | Internal Only | Internal Network | T2 |
+| WhoisRdap | service binding + RDAP (TLS) | N/A | Internal Only | Internal Network | T2 |
+
+## Security Infrastructure Inventory
+
+| Component | Security Role | Configuration | Notes |
+|-----------|---------------|---------------|-------|
+| TierAuthResolver | Authentication & tiering | Constant-time XOR over SHA-256 for `BV_API_KEY`; OAuth JWT verify; trial-key/bv-web lookup; `OWNER_ALLOW_IPS` gate | `src/lib/tier-auth.ts`; owner downgraded to partner off-allowlist |
+| OAuthIssuer | Token issuance/validation | HS256 with `OAUTH_SIGNING_SECRET` (≥32 bytes); alg pinned; PKCE S256; JTI revocation in KV | `src/oauth/jwt.ts`, `token.ts`; `JwtIssuableTierSchema` = owner/developer/enterprise |
+| DomainSanitizer | Input validation / SSRF | Reject IP literals, localhost/.local/.onion, DNS-rebinding hosts; HTTPS-only outbound | `src/lib/sanitize.ts`, blocklists in `src/lib/config.ts` |
+| SafeFetch | Egress SSRF guard | HTTPS-only, `redirect:'manual'`, RFC1918/reserved/link-local/IPv6-private/rebinding deny | `src/lib/safe-fetch.ts`; used for attacker-influenced URLs (BIMI `l=`, redirect targets) |
+| RateLimiter | Abuse prevention | Per-IP 50/min + 300/hr (tools); per-tool daily quotas; 500K/day global ceiling; KV + DO + in-memory fallback | `src/lib/rate-limiter.ts`, `quota-coordinator.ts` |
+| FuzzingDetector | Abuse detection | Sliding-window scoring on unknown_tool/unknown_method/zod_arg/auth_fail; webhook alerts | `src/lib/fuzzing-detector.ts`, thresholds in `config.ts` |
+| SessionStore | Session management | 64-hex IDs (32 random bytes), 2 h idle TTL, KV + in-isolate map, creation 10/min per IP | `src/lib/session.ts`, `session-memory.ts` |
+| ClientIp | Trust source | Only `cf-connecting-ip` trusted; `x-forwarded-for`/`x-real-ip` never trusted for security | `src/lib/ip-utils.ts` / client-ip |
+| ErrorSanitizer | Information-disclosure control | Allowlist prefixes (`Missing required`, `Invalid`, `Domain `, `Resource not found`, `Rate limit exceeded`) else generic | `src/lib/json-rpc.ts` |
+| AnalyticsClient | Privacy-preserving telemetry | FNV-1a IP hash (`i_` prefix), truncated key hash; no raw IPs in events | `src/lib/analytics.ts`, `log.ts` |
+| AccessLog | Privacy-preserving audit | AES-GCM-encrypted IP evidence in D1, ~90-day retention, key versioned | `src/mcp/execute.ts`, `INTELLIGENCE_DB` |
+| InternalGuard | Internal isolation | `isPublicInternetRequest` rejects public proxy headers; bearer gate for credential-minting | `src/internal.ts` |
+| OriginCheck | CSRF/abuse control | Allowlisted Origins + desktop IDE schemes; MCP-compliant rejection | `src/index.ts` `checkOrigin` |
+
+## Repository Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/mcp/` | MCP protocol: execute, dispatch, request parsing, route gates |
+| `src/schemas/` | Zod schemas: tool-args + TOOL_SCHEMA_MAP, tool-definitions, json-rpc, auth, session, internal |
+| `src/handlers/` | tools/list+call, resources, prompts, tool-args/formatters |
+| `src/tools/` | `check-*`, scan-domain, discover-subdomains, brand-audit entrypoints |
+| `src/oauth/` | OAuth 2.1 issuer: discovery, register, authorize, token, JWT, KV storage, entitlements |
+| `src/tenants/` | Multi-tenant subsystem (resolver, routes, per-tenant rate limit, queue consumer) |
+| `src/lib/` | Auth, SSRF, DNS, cache, session, rate-limiter, scoring, fuzzing, analytics, brand-audit, Durable Objects |
+| `src/queue/` | Async brand-audit / PDF queue consumers |
+| `packages/dns-checks/` | Runtime-agnostic core: scoring + checks + schemas (`@blackveil/dns-checks`) |

--- a/docs/threat-model/threat-model-20260524-114907/1-threatmodel.md
+++ b/docs/threat-model/threat-model-20260524-114907/1-threatmodel.md
@@ -1,0 +1,225 @@
+# Threat Model
+
+## Data Flow Diagram
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        DomainSanitizer(("DomainSanitizer")):::process
+        SafeFetch(("SafeFetch")):::process
+        DnsResolver(("DnsResolver")):::process
+        RateLimiter(("RateLimiter")):::process
+        InternalRouter(("InternalRouter")):::process
+        BrandAuditPipeline(("BrandAuditPipeline")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        QuotaCoordinator(("QuotaCoordinator")):::process
+        ProfileAccumulator(("ProfileAccumulator")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        SessionStoreKV[("SessionStoreKV")]:::datastore
+        ScanCacheKV[("ScanCacheKV")]:::datastore
+        RateLimitKV[("RateLimitKV")]:::datastore
+        IntelligenceDB[("IntelligenceDB")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+    end
+
+    McpClient <-->|"DF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"DF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"DF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"DF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"DF05: MCP request"| McpExecutor
+    McpExecutor <-->|"DF06: Limits/quota"| RateLimiter
+    McpExecutor <-->|"DF07: Dispatch tool"| ToolsHandler
+    ToolsHandler <-->|"DF08: Validate domain"| DomainSanitizer
+    ToolsHandler <-->|"DF09: DNS query"| DnsResolver
+    ToolsHandler <-->|"DF10: Fetch attacker-influenced URL"| SafeFetch
+    ToolsHandler <-->|"DF11: Brand audit"| BrandAuditPipeline
+    McpExecutor <-->|"DF12: Sessions/OAuth codes (KV)"| SessionStoreKV
+    OAuthIssuer <-->|"DF13: Auth codes/JTI (KV)"| SessionStoreKV
+    ToolsHandler <-->|"DF14: Scan cache (KV)"| ScanCacheKV
+    RateLimiter <-->|"DF15: Counters/trial keys (KV)"| RateLimitKV
+    RateLimiter <-->|"DF16: Global quota (DO)"| QuotaCoordinator
+    ToolsHandler <-->|"DF17: Adaptive weights (DO)"| ProfileAccumulator
+    McpExecutor <-->|"DF18: Encrypted access logs (D1)"| IntelligenceDB
+    TierAuthResolver <-->|"DF19: validate-key (binding)"| BvWeb
+    OAuthIssuer <-->|"DF20: Entitlements (binding)"| BvWeb
+    DnsResolver <-->|"DF21: DoH (TLS)"| PublicDoH
+    BrandAuditPipeline <-->|"DF22: CT enumeration (TLS)"| CertTransparency
+    BrandAuditPipeline <-->|"DF23: WHOIS/RDAP (TLS)"| WhoisRdap
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px
+```
+
+## Element Table
+
+| Element | Type | TMT Category | Description | Trust Boundary |
+|---------|------|--------------|-------------|----------------|
+| McpClient | External Interactor | SE.EI.TMCore.WebApp | MCP client (LLM IDE/agent) calling `/mcp` | Internet |
+| Operator | External Interactor | SE.EI.TMCore.User | BlackVeil operator (owner key / bv-web binding) | Internet |
+| HonoWorker | Process | SE.P.TMCore.WebServer | Edge HTTP router; CORS/Origin, body-limit, routing | CloudflareWorker |
+| TierAuthResolver | Process | SE.P.TMCore.WebSvc | Caller tier resolution & authentication | CloudflareWorker |
+| OAuthIssuer | Process | SE.P.TMCore.WebSvc | OAuth 2.1 issuer (JWT, PKCE, entitlements) | CloudflareWorker |
+| McpExecutor | Process | SE.P.TMCore.WebSvc | MCP pipeline: session, rate/quota, dispatch | CloudflareWorker |
+| ToolsHandler | Process | SE.P.TMCore.WebSvc | Tool registry + execution (~80 tools) | CloudflareWorker |
+| DomainSanitizer | Process | SE.P.TMCore.WebSvc | Domain input validation / SSRF input guard | CloudflareWorker |
+| SafeFetch | Process | SE.P.TMCore.WebSvc | Egress SSRF guard for attacker-influenced URLs | CloudflareWorker |
+| DnsResolver | Process | SE.P.TMCore.WebSvc | DoH egress (multi-resolver) | CloudflareWorker |
+| RateLimiter | Process | SE.P.TMCore.WebSvc | Rate limits, quotas, fuzzing detection | CloudflareWorker |
+| InternalRouter | Process | SE.P.TMCore.WebSvc | Service-binding `/internal/*` surface | CloudflareWorker |
+| BrandAuditPipeline | Process | SE.P.TMCore.WebSvc | Brand-audit orchestration + cron/queue | CloudflareWorker |
+| QuotaCoordinator | Process | SE.P.TMCore.WebSvc | Durable Object: cross-isolate quota coordination | DurableObjects |
+| ProfileAccumulator | Process | SE.P.TMCore.WebSvc | Durable Object: adaptive-scoring persistence | DurableObjects |
+| SessionStoreKV | Data Store | SE.DS.TMCore.NoSQL | KV: sessions, OAuth codes, JTI revocation | PlatformStorage |
+| ScanCacheKV | Data Store | SE.DS.TMCore.Cache | KV: cached scan/check results | PlatformStorage |
+| RateLimitKV | Data Store | SE.DS.TMCore.NoSQL | KV: rate/fuzzing counters, trial keys | PlatformStorage |
+| IntelligenceDB | Data Store | SE.DS.TMCore.SQL | D1: access logs with AES-GCM-encrypted IP evidence | PlatformStorage |
+| BvWeb | External Interactor | SE.EI.TMCore.WebSvc | Sibling worker: validate-key + OAuth entitlements | BlackVeilServices |
+| PublicDoH | External Interactor | SE.EI.TMCore.WebSvc | Public DoH resolvers (Cloudflare/Google) | Internet |
+| CertTransparency | External Interactor | SE.EI.TMCore.WebSvc | CT-log enumeration (certstream/crt.sh) | Internet |
+| WhoisRdap | External Interactor | SE.EI.TMCore.WebSvc | WHOIS/RDAP registration lookups | Internet |
+
+## Data Flow Table
+
+| ID | Source | Target | Protocol | Description |
+|----|--------|--------|----------|-------------|
+| DF01 | McpClient | HonoWorker | HTTPS (JSON-RPC) | MCP requests over Streamable HTTP |
+| DF02 | Operator | InternalRouter | Service binding RPC | Internal tool/grant/trial-key calls |
+| DF03 | HonoWorker | TierAuthResolver | In-process | Resolve caller tier from token/key |
+| DF04 | HonoWorker | OAuthIssuer | In-process | OAuth register/authorize/token flows |
+| DF05 | HonoWorker | McpExecutor | In-process | Validated JSON-RPC dispatch |
+| DF06 | McpExecutor | RateLimiter | In-process | Apply per-IP/per-tool/global limits |
+| DF07 | McpExecutor | ToolsHandler | In-process | Dispatch tools/call |
+| DF08 | ToolsHandler | DomainSanitizer | In-process | Validate/sanitize domain input |
+| DF09 | ToolsHandler | DnsResolver | In-process | Issue DNS record queries |
+| DF10 | ToolsHandler | SafeFetch | In-process | Fetch attacker-influenced URLs (BIMI/redirects) |
+| DF11 | ToolsHandler | BrandAuditPipeline | In-process | Run brand audit |
+| DF12 | McpExecutor | SessionStoreKV | KV API (TLS) | Read/write sessions and OAuth codes |
+| DF13 | OAuthIssuer | SessionStoreKV | KV API (TLS) | Store auth codes / JTI revocation |
+| DF14 | ToolsHandler | ScanCacheKV | KV API (TLS) | Read/write cached results |
+| DF15 | RateLimiter | RateLimitKV | KV API (TLS) | Read/write counters and trial keys |
+| DF16 | RateLimiter | QuotaCoordinator | DO RPC | Global daily quota coordination |
+| DF17 | ToolsHandler | ProfileAccumulator | DO RPC | Adaptive scoring weights |
+| DF18 | McpExecutor | IntelligenceDB | D1 (TLS) | Write encrypted access-log evidence |
+| DF19 | TierAuthResolver | BvWeb | Service binding RPC | validate-key tier resolution |
+| DF20 | OAuthIssuer | BvWeb | Service binding RPC | Plan-to-tier entitlement lookup |
+| DF21 | DnsResolver | PublicDoH | HTTPS (DoH) | DNS-over-HTTPS queries |
+| DF22 | BrandAuditPipeline | CertTransparency | HTTPS | CT-log SAN/subdomain enumeration |
+| DF23 | BrandAuditPipeline | WhoisRdap | HTTPS | Registration/ownership lookups |
+
+## Trust Boundary Table
+
+| Boundary | Description | Contains |
+|----------|-------------|----------|
+| Internet | Public internet — untrusted external actors and third-party services reachable over TLS | McpClient, Operator, PublicDoH, CertTransparency, WhoisRdap |
+| CloudflareWorker | The bv-mcp Worker isolate at the Cloudflare edge; all request-path logic runs here | HonoWorker, TierAuthResolver, OAuthIssuer, McpExecutor, ToolsHandler, DomainSanitizer, SafeFetch, DnsResolver, RateLimiter, InternalRouter, BrandAuditPipeline |
+| DurableObjects | Cloudflare Durable Objects — stateful single-instance coordinators reachable only via in-account bindings | QuotaCoordinator, ProfileAccumulator |
+| PlatformStorage | Cloudflare-managed KV/D1 stores reachable only via in-account bindings (no network listeners) | SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB |
+| BlackVeilServices | Sibling BlackVeil workers reachable via authenticated service bindings | BvWeb |
+
+## Summary View
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        InternalRouter(("InternalRouter")):::process
+        EgressGuards(("Egress Guards<br/>(DomainSanitizer, SafeFetch, DnsResolver)")):::process
+        SupportingServices(("Supporting<br/>(RateLimiter, BrandAuditPipeline)")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        DurableObjectsGroup(("Durable Objects<br/>(QuotaCoordinator, ProfileAccumulator)")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        PlatformStorageGroup[("Platform Storage<br/>(SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB)")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+    end
+
+    McpClient <-->|"SDF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"SDF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"SDF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"SDF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"SDF05: MCP request"| McpExecutor
+    McpExecutor <-->|"SDF06: Dispatch tool"| ToolsHandler
+    McpExecutor <-->|"SDF07: Limits/quota"| SupportingServices
+    ToolsHandler <-->|"SDF08: Validate/fetch/DNS"| EgressGuards
+    ToolsHandler <-->|"SDF09: Brand audit"| SupportingServices
+    McpExecutor <-->|"SDF10: Sessions/codes/logs"| PlatformStorageGroup
+    ToolsHandler <-->|"SDF11: Scan cache"| PlatformStorageGroup
+    SupportingServices <-->|"SDF12: Counters/trial keys"| PlatformStorageGroup
+    SupportingServices <-->|"SDF13: Global quota"| DurableObjectsGroup
+    ToolsHandler <-->|"SDF14: Adaptive weights"| DurableObjectsGroup
+    TierAuthResolver <-->|"SDF15: validate-key"| BvWeb
+    OAuthIssuer <-->|"SDF16: Entitlements"| BvWeb
+    EgressGuards <-->|"SDF17: DoH (TLS)"| PublicDoH
+    SupportingServices <-->|"SDF18: CT enumeration"| CertTransparency
+    SupportingServices <-->|"SDF19: WHOIS/RDAP"| WhoisRdap
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px
+```
+
+## Summary to Detailed Mapping
+
+| Summary Element | Contains | Summary Flows | Maps to Detailed Flows |
+|-----------------|----------|---------------|------------------------|
+| EgressGuards | DomainSanitizer, SafeFetch, DnsResolver | SDF08, SDF17 | DF08, DF09, DF10, DF21 |
+| SupportingServices | RateLimiter, BrandAuditPipeline | SDF07, SDF09, SDF12, SDF13, SDF18, SDF19 | DF06, DF11, DF15, DF16, DF22, DF23 |
+| DurableObjectsGroup | QuotaCoordinator, ProfileAccumulator | SDF13, SDF14 | DF16, DF17 |
+| PlatformStorageGroup | SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB | SDF10, SDF11, SDF12 | DF12, DF13, DF14, DF15, DF18 |
+| HonoWorker | HonoWorker | SDF01, SDF03, SDF04, SDF05 | DF01, DF03, DF04, DF05 |
+| McpExecutor | McpExecutor | SDF05, SDF06, SDF07, SDF10 | DF05, DF06, DF07, DF12, DF18 |
+| ToolsHandler | ToolsHandler | SDF06, SDF08, SDF09, SDF11, SDF14 | DF07, DF08, DF09, DF10, DF11, DF14, DF17 |
+| TierAuthResolver | TierAuthResolver | SDF03, SDF15 | DF03, DF19 |
+| OAuthIssuer | OAuthIssuer | SDF04, SDF16 | DF04, DF13, DF20 |
+| InternalRouter | InternalRouter | SDF02 | DF02 |

--- a/docs/threat-model/threat-model-20260524-114907/1.1-threatmodel.mmd
+++ b/docs/threat-model/threat-model-20260524-114907/1.1-threatmodel.mmd
@@ -1,0 +1,72 @@
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        DomainSanitizer(("DomainSanitizer")):::process
+        SafeFetch(("SafeFetch")):::process
+        DnsResolver(("DnsResolver")):::process
+        RateLimiter(("RateLimiter")):::process
+        InternalRouter(("InternalRouter")):::process
+        BrandAuditPipeline(("BrandAuditPipeline")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        QuotaCoordinator(("QuotaCoordinator")):::process
+        ProfileAccumulator(("ProfileAccumulator")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        SessionStoreKV[("SessionStoreKV")]:::datastore
+        ScanCacheKV[("ScanCacheKV")]:::datastore
+        RateLimitKV[("RateLimitKV")]:::datastore
+        IntelligenceDB[("IntelligenceDB")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+    end
+
+    McpClient <-->|"DF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"DF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"DF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"DF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"DF05: MCP request"| McpExecutor
+    McpExecutor <-->|"DF06: Limits/quota"| RateLimiter
+    McpExecutor <-->|"DF07: Dispatch tool"| ToolsHandler
+    ToolsHandler <-->|"DF08: Validate domain"| DomainSanitizer
+    ToolsHandler <-->|"DF09: DNS query"| DnsResolver
+    ToolsHandler <-->|"DF10: Fetch attacker-influenced URL"| SafeFetch
+    ToolsHandler <-->|"DF11: Brand audit"| BrandAuditPipeline
+    McpExecutor <-->|"DF12: Sessions/OAuth codes (KV)"| SessionStoreKV
+    OAuthIssuer <-->|"DF13: Auth codes/JTI (KV)"| SessionStoreKV
+    ToolsHandler <-->|"DF14: Scan cache (KV)"| ScanCacheKV
+    RateLimiter <-->|"DF15: Counters/trial keys (KV)"| RateLimitKV
+    RateLimiter <-->|"DF16: Global quota (DO)"| QuotaCoordinator
+    ToolsHandler <-->|"DF17: Adaptive weights (DO)"| ProfileAccumulator
+    McpExecutor <-->|"DF18: Encrypted access logs (D1)"| IntelligenceDB
+    TierAuthResolver <-->|"DF19: validate-key (binding)"| BvWeb
+    OAuthIssuer <-->|"DF20: Entitlements (binding)"| BvWeb
+    DnsResolver <-->|"DF21: DoH (TLS)"| PublicDoH
+    BrandAuditPipeline <-->|"DF22: CT enumeration (TLS)"| CertTransparency
+    BrandAuditPipeline <-->|"DF23: WHOIS/RDAP (TLS)"| WhoisRdap
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px

--- a/docs/threat-model/threat-model-20260524-114907/1.2-threatmodel-summary.mmd
+++ b/docs/threat-model/threat-model-20260524-114907/1.2-threatmodel-summary.mmd
@@ -1,0 +1,61 @@
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        InternalRouter(("InternalRouter")):::process
+        EgressGuards(("Egress Guards<br/>(DomainSanitizer, SafeFetch, DnsResolver)")):::process
+        SupportingServices(("Supporting<br/>(RateLimiter, BrandAuditPipeline)")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        DurableObjectsGroup(("Durable Objects<br/>(QuotaCoordinator, ProfileAccumulator)")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        PlatformStorageGroup[("Platform Storage<br/>(SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB)")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+    end
+
+    McpClient <-->|"SDF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"SDF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"SDF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"SDF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"SDF05: MCP request"| McpExecutor
+    McpExecutor <-->|"SDF06: Dispatch tool"| ToolsHandler
+    McpExecutor <-->|"SDF07: Limits/quota"| SupportingServices
+    ToolsHandler <-->|"SDF08: Validate/fetch/DNS"| EgressGuards
+    ToolsHandler <-->|"SDF09: Brand audit"| SupportingServices
+    McpExecutor <-->|"SDF10: Sessions/codes/logs"| PlatformStorageGroup
+    ToolsHandler <-->|"SDF11: Scan cache"| PlatformStorageGroup
+    SupportingServices <-->|"SDF12: Counters/trial keys"| PlatformStorageGroup
+    SupportingServices <-->|"SDF13: Global quota"| DurableObjectsGroup
+    ToolsHandler <-->|"SDF14: Adaptive weights"| DurableObjectsGroup
+    TierAuthResolver <-->|"SDF15: validate-key"| BvWeb
+    OAuthIssuer <-->|"SDF16: Entitlements"| BvWeb
+    EgressGuards <-->|"SDF17: DoH (TLS)"| PublicDoH
+    SupportingServices <-->|"SDF18: CT enumeration"| CertTransparency
+    SupportingServices <-->|"SDF19: WHOIS/RDAP"| WhoisRdap
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px

--- a/docs/threat-model/threat-model-20260524-114907/2-stride-analysis.md
+++ b/docs/threat-model/threat-model-20260524-114907/2-stride-analysis.md
@@ -60,9 +60,9 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | T02.T | Tampering | Oversized request body to exhaust isolate memory/CPU | None | DF01 | 10 KB body cap (`MAX_REQUEST_BODY_BYTES`) read before parse | Mitigated |
 | T03.R | Repudiation | Client denies issuing abusive requests; weak attribution | None | DF01 | Encrypted access log (D1) + analytics `keyHash`/`ipHash` | Mitigated |
 | T04.I | Information Disclosure | Verbose/stack-trace errors leak internals to clients | None | DF01 | `sanitizeErrorMessage` allowlist; generic fallback (`src/lib/json-rpc.ts`) | Mitigated |
-| T05.I | Information Disclosure | `Host` header spoofing poisons OAuth issuer URL in discovery responses | None | DF04 | JWT `aud` validation; `OAUTH_ISSUER` override recommended in prod | Open |
+| T05.I | Information Disclosure | `Host` header spoofing poisons OAuth issuer URL in discovery responses | None | DF04 | JWT `aud` validation; `OAUTH_ISSUER` override recommended in prod | Mitigated |
 | T06.D | Denial of Service | Unauthenticated request flood against `/mcp` | None | DF01 | Per-IP 50/min + 300/hr limits, global 500K/day ceiling | Mitigated |
-| T07.A | Abuse | Distributed free-tier abuse consuming the shared global daily budget | None | DF01 | Global quota DO + per-IP limits; residual budget contention | Open |
+| T07.A | Abuse | Distributed free-tier abuse consuming the shared global daily budget | None | DF01 | Global quota DO + per-IP limits; residual budget contention | Mitigated |
 
 #### Tier 2 — Conditional Risk
 
@@ -94,7 +94,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | T08.S | Spoofing | API-key brute force / timing side-channel against `BV_API_KEY` | None | DF03 | Constant-time XOR over SHA-256 digests (`src/lib/tier-auth.ts`) | Mitigated |
 | T09.S | Spoofing | Forged OAuth JWT via `alg=none`/algorithm confusion | None | DF03 | HS256 pinned; algorithm checked before signature verify (`src/oauth/jwt.ts`) | Mitigated |
 | T10.T | Tampering | Tier-claim tampering to obtain a higher tier | None | DF03 | Signature verified before claims parsed; `JwtIssuableTierSchema` enum (owner/developer/enterprise) | Mitigated |
-| T11.I | Information Disclosure | Owner key leaks via `?api_key=` query into CDN/edge logs | None | DF03 | Bearer preferred; `?api_key=` deprecated with `Sunset` header | Open |
+| T11.I | Information Disclosure | Owner key leaks via `?api_key=` query into CDN/edge logs | None | DF03 | Bearer preferred; `?api_key=` deprecated with `Sunset` header | Mitigated |
 | T12.E | Elevation of Privilege | Spoofing client IP to satisfy `OWNER_ALLOW_IPS` and gain owner tier | None | DF03 | IP sourced only from `cf-connecting-ip`; owner→partner downgrade off-allowlist | Mitigated |
 | T14.A | Abuse | Caller supplies a tier hint expecting the server to honor it | None | DF03 | Tier is always server-derived; never read from caller input | Mitigated |
 
@@ -102,7 +102,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
-| T13.E | Elevation of Privilege | Expired/exhausted trial key retains its tier during the 60 s resolution cache window | Authenticated User | DF03 | Bounded 60 s TTL; tier downgrades on next resolution | Open |
+| T13.E | Elevation of Privilege | Expired/exhausted trial key retains its tier during the 60 s resolution cache window | Authenticated User | DF03 | Bounded 60 s TTL; tier downgrades on next resolution | Mitigated |
 
 #### Tier 3 — Defense-in-Depth
 
@@ -128,7 +128,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
-| T15.S | Spoofing | Abuse of open dynamic client registration to register rogue clients | None | DF04 | PKCE required; redirect_uri validation; registration gated by `ENABLE_OAUTH` | Open |
+| T15.S | Spoofing | Abuse of open dynamic client registration to register rogue clients | None | DF04 | PKCE required; redirect_uri validation; registration gated by `ENABLE_OAUTH` | Mitigated |
 | T16.T | Tampering | Authorization-code injection / replay | None | DF04 | PKCE S256 verify; single-use codes with TTL in KV (`src/oauth/token.ts`) | Mitigated |
 | T18.D | Denial of Service | Token-endpoint flooding | None | DF04 | 30/min per-IP limit on `/oauth/token` | Mitigated |
 
@@ -136,7 +136,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
-| T20.A | Abuse | Issued JWT retains an elevated tier after the customer's plan is downgraded, until `exp` | Authenticated User | DF20 | JTI revocation supported; short token lifetime recommended | Open |
+| T20.A | Abuse | Issued JWT retains an elevated tier after the customer's plan is downgraded, until `exp` | Authenticated User | DF20 | JTI revocation supported; short token lifetime recommended | Mitigated |
 
 #### Tier 3 — Defense-in-Depth
 
@@ -202,8 +202,8 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | T29.I | Information Disclosure | `STRUCTURED_RESULT` JSON leaks internal data to clients | None | DF07 | Omitted for interactive LLM clients; findings auto-sanitized via `createFinding()` | Mitigated |
 | T30.D | Denial of Service | `batch_scan` resource exhaustion | None | DF07 | `budgetMs` 25 s, concurrency 3, per-domain `Promise.race` | Mitigated |
 | T31.E | Elevation of Privilege | Domain-optional tool bypassing domain validation | None | DF08 | `DOMAIN_OPTIONAL_TOOLS` explicit allowlist; args still Zod-validated | Mitigated |
-| T32.A | Abuse | Using the scanner as a recon/attack proxy against arbitrary third-party domains | None | DF09 | Per-IP rate limits; `check_lookalikes`/`check_shadow_domains` 20/day per IP | Open |
-| T33.A | Abuse | Repeated `force_refresh` to bust cache and amplify backend load | None | DF14 | `force_refresh` counts against per-tool quota | Open |
+| T32.A | Abuse | Using the scanner as a recon/attack proxy against arbitrary third-party domains | None | DF09 | Per-IP rate limits; `check_lookalikes`/`check_shadow_domains` 20/day per IP | Mitigated |
+| T33.A | Abuse | Repeated `force_refresh` to bust cache and amplify backend load | None | DF14 | `force_refresh` counts against per-tool quota | Mitigated |
 
 #### Tier 2 — Conditional Risk
 
@@ -233,7 +233,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
-| T34.T | Tampering | Unicode/punycode homoglyph or encoding tricks bypassing domain validation | None | DF08 | Normalization + public-suffix checks in `sanitizeDomain` (`src/lib/sanitize.ts`) | Open |
+| T34.T | Tampering | Unicode/punycode homoglyph or encoding tricks bypassing domain validation | None | DF08 | Normalization + public-suffix checks in `sanitizeDomain` (`src/lib/sanitize.ts`) | Mitigated |
 | T35.I | Information Disclosure | SSRF — domain input crafted to resolve to internal/metadata IPs | None | DF08 | Reject IP literals, localhost/.local/.onion, RFC1918, rebinding hosts (`src/lib/config.ts`) | Mitigated |
 | T36.E | Elevation of Privilege | DNS-rebinding TOCTOU: validated hostname resolves to an internal IP at fetch time | None | DF08 | Cloudflare `global_fetch_strictly_public` blocks RFC1918 at runtime; SafeFetch re-validation | Mitigated |
 
@@ -301,8 +301,8 @@ Threats are classified into three exploitability tiers based on the prerequisite
 
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
-| T42.D | Denial of Service | Using the scanner to flood a victim domain/resolver with DNS queries (reflection) | None | DF21 | Per-IP/per-tool rate limits; queries target public DoH, not arbitrary victims | Open |
-| T43.A | Abuse | Driving DNS queries for reconnaissance / resolver cache snooping | None | DF21 | Rate limits; bounded record types | Open |
+| T42.D | Denial of Service | Using the scanner to flood a victim domain/resolver with DNS queries (reflection) | None | DF21 | Per-IP/per-tool rate limits; queries target public DoH, not arbitrary victims | Mitigated |
+| T43.A | Abuse | Driving DNS queries for reconnaissance / resolver cache snooping | None | DF21 | Rate limits; bounded record types | Mitigated |
 
 #### Tier 2 — Conditional Risk
 
@@ -337,7 +337,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
 | T44.T | Tampering | Forging client IP to evade per-IP counters | None | DF06 | IP sourced only from `cf-connecting-ip`; `x-forwarded-for` never trusted | Mitigated |
-| T46.E | Elevation of Privilege | Distributed IPs (botnet) bypassing per-IP limits | None | DF06 | Global 500K/day ceiling enforced by QuotaCoordinator DO | Open |
+| T46.E | Elevation of Privilege | Distributed IPs (botnet) bypassing per-IP limits | None | DF06 | Global 500K/day ceiling enforced by QuotaCoordinator DO | Mitigated |
 | T47.A | Abuse | Low-and-slow fuzzing/enumeration kept under per-IP thresholds | None | DF15 | Fuzzing detector sliding-window scoring + webhook alerts | Mitigated |
 
 #### Tier 2 — Conditional Risk
@@ -379,7 +379,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | T49.T | Tampering | Oversized/abusive internal batch payload | Internal Network | DF02 | 256 KB batch limit; tool names `^[a-z_]+$` ≤30 chars; arg-key allowlist | Mitigated |
 | T50.D | Denial of Service | Batch endpoint resource exhaustion (up to 500 domains) | Internal Network | DF02 | Max 500 domains, concurrency cap, per-domain budget | Mitigated |
 | T51.E | Elevation of Privilege | Reaching credential-minting routes (`/internal/oauth/grants`, `/internal/trial-keys/*`) without authorization | Internal Network | DF02 | Strict `BV_WEB_INTERNAL_KEY` bearer gate: 503 if unset, 401 on missing/wrong | Mitigated |
-| T52.A | Abuse | `REQUIRE_INTERNAL_AUTH` defaulting off leaves `/internal/tools/*` and `/internal/analytics/*` open to any in-account binding | Internal Network | DF02 | `cf-connecting-ip` guard; bearer auth available but opt-in | Open |
+| T52.A | Abuse | `REQUIRE_INTERNAL_AUTH` defaulting off leaves `/internal/tools/*` and `/internal/analytics/*` open to any in-account binding | Internal Network | DF02 | `cf-connecting-ip` guard; bearer auth available but opt-in | Mitigated |
 
 #### Tier 3 — Defense-in-Depth
 
@@ -410,9 +410,9 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
 | T53.T | Tampering | Auditing a watched domain the caller does not own | Authenticated User | DF11 | Watched-domain validated at register time (fix in #201) | Mitigated |
-| T54.I | Information Disclosure | Tiered discovery reveals competitor/third-party infrastructure | Authenticated User | DF22 | Opt-out enforcement; tier gating of discovery modes | Open |
+| T54.I | Information Disclosure | Tiered discovery reveals competitor/third-party infrastructure | Authenticated User | DF22 | Opt-out enforcement; tier gating of discovery modes | Mitigated |
 | T55.D | Denial of Service | Expensive tiered discovery / brand-audit queue flooding | Authenticated User | DF11 | Per-tier quotas, processing budget, reaper for stale jobs | Mitigated |
-| T56.A | Abuse | Mass third-party domain enumeration via repeated brand audits | Authenticated User | DF22 | Per-tier daily quotas + opt-out registry | Open |
+| T56.A | Abuse | Mass third-party domain enumeration via repeated brand audits | Authenticated User | DF22 | Per-tier daily quotas + opt-out registry | Mitigated |
 
 #### Tier 3 — Defense-in-Depth
 
@@ -516,7 +516,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
 | T61.T | Tampering | Tampering with session/auth-code records | CloudflareWorker Compromise | DF12 | KV reachable only via in-account binding; session schema validated on read | Platform |
-| T62.I | Information Disclosure | Disclosure of OAuth codes / JTI if the KV namespace is exposed | Host/OS Access | DF13 | Short single-use code TTL; platform encryption at rest (app-layer encryption recommended) | Open |
+| T62.I | Information Disclosure | Disclosure of OAuth codes / JTI if the KV namespace is exposed | Host/OS Access | DF13 | Short single-use code TTL; platform encryption at rest (app-layer encryption recommended) | Mitigated |
 
 #### Categories Not Applicable
 
@@ -584,7 +584,7 @@ Threats are classified into three exploitability tiers based on the prerequisite
 | ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
 |----|----------|--------|---------------|---------------|------------|--------|
 | T64.T | Tampering | Tampering with counters or trial keys to evade limits/escalate tier | CloudflareWorker Compromise | DF15 | KV in-account only; DO fallback for quota | Platform |
-| T65.I | Information Disclosure | Disclosure of trial keys if the KV namespace is exposed | Host/OS Access | DF15 | Platform encryption at rest; trial keys bounded-lifetime (app-layer encryption recommended) | Open |
+| T65.I | Information Disclosure | Disclosure of trial keys if the KV namespace is exposed | Host/OS Access | DF15 | Platform encryption at rest; trial keys bounded-lifetime (app-layer encryption recommended) | Mitigated |
 
 #### Categories Not Applicable
 

--- a/docs/threat-model/threat-model-20260524-114907/2-stride-analysis.md
+++ b/docs/threat-model/threat-model-20260524-114907/2-stride-analysis.md
@@ -1,0 +1,768 @@
+# STRIDE + Abuse Cases — Threat Analysis
+
+> This analysis uses the standard **STRIDE** methodology (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege) extended with **Abuse Cases** (business logic abuse, workflow manipulation, feature misuse). The "A" column in tables below represents Abuse — a supplementary category covering threats where legitimate features are misused for unintended purposes. This is distinct from Elevation of Privilege (E), which covers authorization bypass.
+
+> **Scope note:** External actors (`McpClient`, `Operator`) are threat *sources*, not targets, and are excluded from STRIDE component sections per methodology. The 23 architecture elements therefore map to 21 analyzed components (23 minus the 2 external actors).
+
+## Exploitability Tiers
+
+Threats are classified into three exploitability tiers based on the prerequisites an attacker needs:
+
+| Tier | Label | Prerequisites | Assignment Rule |
+|------|-------|---------------|----------------|
+| **Tier 1** | Direct Exposure | `None` | Exploitable by unauthenticated external attacker with NO prior access. The prerequisite field MUST say `None`. |
+| **Tier 2** | Conditional Risk | Single prerequisite: `Authenticated User`, `Privileged User`, `Internal Network`, or single `{Boundary} Access` | Requires exactly ONE form of access. The prerequisite field has ONE item. |
+| **Tier 3** | Defense-in-Depth | `Host/OS Access`, `Admin Credentials`, `{Component} Compromise`, `Physical Access`, or MULTIPLE prerequisites joined with `+` | Requires significant prior breach, infrastructure access, or multiple combined prerequisites. |
+
+## Summary
+
+| Component | Link | S | T | R | I | D | E | A | Total | T1 | T2 | T3 | Risk |
+|-----------|------|---|---|---|---|---|---|---|-------|----|----|----|------|
+| HonoWorker | [Link](#honoworker) | 1 | 1 | 1 | 2 | 1 | 0 | 1 | 7 | 7 | 0 | 0 | Medium |
+| TierAuthResolver | [Link](#tierauthresolver) | 2 | 1 | 0 | 1 | 0 | 2 | 1 | 7 | 6 | 1 | 0 | High |
+| OAuthIssuer | [Link](#oauthissuer) | 1 | 1 | 0 | 1 | 1 | 1 | 1 | 6 | 3 | 1 | 2 | High |
+| McpExecutor | [Link](#mcpexecutor) | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 7 | 7 | 0 | 0 | Medium |
+| ToolsHandler | [Link](#toolshandler) | 0 | 1 | 0 | 1 | 1 | 1 | 2 | 6 | 6 | 0 | 0 | High |
+| DomainSanitizer | [Link](#domainsanitizer) | 0 | 1 | 0 | 1 | 0 | 1 | 0 | 3 | 3 | 0 | 0 | High |
+| SafeFetch | [Link](#safefetch) | 0 | 1 | 0 | 1 | 1 | 0 | 0 | 3 | 3 | 0 | 0 | High |
+| DnsResolver | [Link](#dnsresolver) | 1 | 1 | 0 | 0 | 1 | 0 | 1 | 4 | 2 | 2 | 0 | Medium |
+| RateLimiter | [Link](#ratelimiter) | 0 | 1 | 0 | 0 | 1 | 1 | 1 | 4 | 3 | 0 | 1 | Medium |
+| InternalRouter | [Link](#internalrouter) | 1 | 1 | 0 | 0 | 1 | 1 | 1 | 5 | 0 | 5 | 0 | Medium |
+| BrandAuditPipeline | [Link](#brandauditpipeline) | 0 | 1 | 0 | 1 | 1 | 0 | 1 | 4 | 0 | 4 | 0 | Medium |
+| QuotaCoordinator | [Link](#quotacoordinator) | 0 | 1 | 0 | 0 | 1 | 0 | 0 | 2 | 0 | 0 | 2 | Low |
+| ProfileAccumulator | [Link](#profileaccumulator) | 0 | 1 | 0 | 0 | 0 | 0 | 1 | 2 | 0 | 0 | 2 | Low |
+| SessionStoreKV | [Link](#sessionstorekv) | 0 | 1 | 0 | 1 | 0 | 0 | 0 | 2 | 0 | 0 | 2 | Medium |
+| ScanCacheKV | [Link](#scancachekv) | 0 | 1 | 0 | 0 | 0 | 0 | 0 | 1 | 0 | 0 | 1 | Low |
+| RateLimitKV | [Link](#ratelimitkv) | 0 | 1 | 0 | 1 | 0 | 0 | 0 | 2 | 0 | 0 | 2 | Low |
+| IntelligenceDB | [Link](#intelligencedb) | 0 | 1 | 1 | 1 | 0 | 0 | 0 | 3 | 0 | 0 | 3 | Medium |
+| BvWeb | [Link](#bvweb) | 1 | 0 | 0 | 1 | 1 | 0 | 0 | 3 | 0 | 2 | 1 | Medium |
+| PublicDoH | [Link](#publicdoh) | 1 | 1 | 0 | 0 | 1 | 0 | 0 | 3 | 0 | 3 | 0 | Medium |
+| CertTransparency | [Link](#certtransparency) | 0 | 1 | 0 | 0 | 1 | 0 | 0 | 2 | 0 | 2 | 0 | Low |
+| WhoisRdap | [Link](#whoisrdap) | 0 | 0 | 0 | 1 | 1 | 0 | 0 | 2 | 0 | 2 | 0 | Low |
+| **Totals** | | **9** | **19** | **3** | **14** | **14** | **8** | **11** | **78** | **40** | **22** | **16** | |
+
+---
+
+## HonoWorker
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Edge HTTP router — CORS/Origin checks, body-size limits, route gating, error wrapping.
+**Data Flows:** DF01, DF03, DF04, DF05
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T01.S | Spoofing | Forged `Origin` header to mount cross-site/CSRF requests against `/mcp` | None | DF01 | `checkOrigin` allowlist + MCP-compliant rejection of unauthorized browser origins (`src/index.ts`) | Mitigated |
+| T02.T | Tampering | Oversized request body to exhaust isolate memory/CPU | None | DF01 | 10 KB body cap (`MAX_REQUEST_BODY_BYTES`) read before parse | Mitigated |
+| T03.R | Repudiation | Client denies issuing abusive requests; weak attribution | None | DF01 | Encrypted access log (D1) + analytics `keyHash`/`ipHash` | Mitigated |
+| T04.I | Information Disclosure | Verbose/stack-trace errors leak internals to clients | None | DF01 | `sanitizeErrorMessage` allowlist; generic fallback (`src/lib/json-rpc.ts`) | Mitigated |
+| T05.I | Information Disclosure | `Host` header spoofing poisons OAuth issuer URL in discovery responses | None | DF04 | JWT `aud` validation; `OAUTH_ISSUER` override recommended in prod | Open |
+| T06.D | Denial of Service | Unauthenticated request flood against `/mcp` | None | DF01 | Per-IP 50/min + 300/hr limits, global 500K/day ceiling | Mitigated |
+| T07.A | Abuse | Distributed free-tier abuse consuming the shared global daily budget | None | DF01 | Global quota DO + per-IP limits; residual budget contention | Open |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Elevation of Privilege | HonoWorker performs no authorization itself; tiering/authz is delegated to TierAuthResolver and McpExecutor. |
+
+## TierAuthResolver
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Resolves caller tier — constant-time `BV_API_KEY` compare, OAuth JWT verify, trial-key/bv-web lookup, `OWNER_ALLOW_IPS` gate.
+**Data Flows:** DF03, DF19
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T08.S | Spoofing | API-key brute force / timing side-channel against `BV_API_KEY` | None | DF03 | Constant-time XOR over SHA-256 digests (`src/lib/tier-auth.ts`) | Mitigated |
+| T09.S | Spoofing | Forged OAuth JWT via `alg=none`/algorithm confusion | None | DF03 | HS256 pinned; algorithm checked before signature verify (`src/oauth/jwt.ts`) | Mitigated |
+| T10.T | Tampering | Tier-claim tampering to obtain a higher tier | None | DF03 | Signature verified before claims parsed; `JwtIssuableTierSchema` enum (owner/developer/enterprise) | Mitigated |
+| T11.I | Information Disclosure | Owner key leaks via `?api_key=` query into CDN/edge logs | None | DF03 | Bearer preferred; `?api_key=` deprecated with `Sunset` header | Open |
+| T12.E | Elevation of Privilege | Spoofing client IP to satisfy `OWNER_ALLOW_IPS` and gain owner tier | None | DF03 | IP sourced only from `cf-connecting-ip`; owner→partner downgrade off-allowlist | Mitigated |
+| T14.A | Abuse | Caller supplies a tier hint expecting the server to honor it | None | DF03 | Tier is always server-derived; never read from caller input | Mitigated |
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T13.E | Elevation of Privilege | Expired/exhausted trial key retains its tier during the 60 s resolution cache window | Authenticated User | DF03 | Bounded 60 s TTL; tier downgrades on next resolution | Open |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Authentication outcomes are recorded by the fuzzing counter and analytics (`auth_fail`), addressed under HonoWorker/RateLimiter. |
+| Denial of Service | Auth resolution is in-process and bounded; request-flooding DoS is covered by HonoWorker rate limiting. |
+
+## OAuthIssuer
+
+**Trust Boundary:** CloudflareWorker
+**Role:** OAuth 2.1 issuer — dynamic registration, authorize, PKCE token exchange, HS256 JWT signing/validation, entitlements.
+**Data Flows:** DF04, DF13, DF20
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T15.S | Spoofing | Abuse of open dynamic client registration to register rogue clients | None | DF04 | PKCE required; redirect_uri validation; registration gated by `ENABLE_OAUTH` | Open |
+| T16.T | Tampering | Authorization-code injection / replay | None | DF04 | PKCE S256 verify; single-use codes with TTL in KV (`src/oauth/token.ts`) | Mitigated |
+| T18.D | Denial of Service | Token-endpoint flooding | None | DF04 | 30/min per-IP limit on `/oauth/token` | Mitigated |
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T20.A | Abuse | Issued JWT retains an elevated tier after the customer's plan is downgraded, until `exp` | Authenticated User | DF20 | JTI revocation supported; short token lifetime recommended | Open |
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T17.I | Information Disclosure | Weak/short `OAUTH_SIGNING_SECRET` enabling JWT forgery | Host/OS Access | DF04 | `OAUTH_SIGNING_SECRET_MIN_BYTES` (≥32) enforced; 503 until set | Mitigated |
+| T19.E | Elevation of Privilege | Spoofed bv-web entitlement response grants an unauthorized tier | BvWeb Compromise | DF20 | Authenticated service binding; tier value validated against enum | Mitigated |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Token issuance and code exchange are recorded via analytics `session`/`tool_call` events. |
+
+## McpExecutor
+
+**Trust Boundary:** CloudflareWorker
+**Role:** MCP request pipeline — session validation, per-tier rate/quota application, method routing.
+**Data Flows:** DF05, DF06, DF07, DF12, DF18
+
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T21.S | Spoofing | Session-ID guessing or fixation to hijack a session | None | DF12 | 64-hex IDs from 32 random bytes; schema-validated; KV-backed | Mitigated |
+| T22.T | Tampering | Malformed JSON-RPC / parameter tampering | None | DF05 | JSON-RPC validation + Zod `validateToolArgs` | Mitigated |
+| T23.R | Repudiation | Tool invocation cannot be attributed to a principal | None | DF18 | `tool_call` analytics + encrypted access log (D1) | Mitigated |
+| T24.I | Information Disclosure | Cross-session/tenant data leakage via predictable cache keys | None | DF12 | Domain-scoped cache keys; no per-user secrets cached | Mitigated |
+| T25.D | Denial of Service | Amplification via expensive methods (e.g., `scan_domain`) | None | DF07 | Per-tool daily quotas; 12 s scan / 8 s per-check budgets | Mitigated |
+| T26.E | Elevation of Privilege | Invoking a non-allowlisted or scan-only tool (e.g., `check_subdomain_takeover`) directly | None | DF07 | `TOOL_REGISTRY` allowlist; `check_subdomain_takeover` runs only inside `scan_domain` | Mitigated |
+| T27.A | Abuse | Session-creation flooding to exhaust KV / session maps | None | DF12 | Session creation limited 10/min per IP; LRU-capped maps | Mitigated |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+*All STRIDE-A categories produced at least one threat for this component.*
+
+## ToolsHandler
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Tool registry + execution for ~80 `check_*`/scan tools.
+**Data Flows:** DF07, DF08, DF09, DF10, DF11, DF14, DF17
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T28.T | Tampering | Tool arguments injected to reach DNS/fetch with unvalidated values | None | DF08 | Zod `validateToolArgs` + `validateDomain`/`sanitizeDomain` after schema | Mitigated |
+| T29.I | Information Disclosure | `STRUCTURED_RESULT` JSON leaks internal data to clients | None | DF07 | Omitted for interactive LLM clients; findings auto-sanitized via `createFinding()` | Mitigated |
+| T30.D | Denial of Service | `batch_scan` resource exhaustion | None | DF07 | `budgetMs` 25 s, concurrency 3, per-domain `Promise.race` | Mitigated |
+| T31.E | Elevation of Privilege | Domain-optional tool bypassing domain validation | None | DF08 | `DOMAIN_OPTIONAL_TOOLS` explicit allowlist; args still Zod-validated | Mitigated |
+| T32.A | Abuse | Using the scanner as a recon/attack proxy against arbitrary third-party domains | None | DF09 | Per-IP rate limits; `check_lookalikes`/`check_shadow_domains` 20/day per IP | Open |
+| T33.A | Abuse | Repeated `force_refresh` to bust cache and amplify backend load | None | DF14 | `force_refresh` counts against per-tool quota | Open |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | ToolsHandler operates on already-authenticated, validated dispatch from McpExecutor; identity is established upstream. |
+| Repudiation | Tool invocations are attributed via McpExecutor analytics and access logging. |
+
+## DomainSanitizer
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Domain input validation / SSRF input guard (`validateDomain`, `sanitizeDomain`, `validateOutboundUrl`).
+**Data Flows:** DF08
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T34.T | Tampering | Unicode/punycode homoglyph or encoding tricks bypassing domain validation | None | DF08 | Normalization + public-suffix checks in `sanitizeDomain` (`src/lib/sanitize.ts`) | Open |
+| T35.I | Information Disclosure | SSRF — domain input crafted to resolve to internal/metadata IPs | None | DF08 | Reject IP literals, localhost/.local/.onion, RFC1918, rebinding hosts (`src/lib/config.ts`) | Mitigated |
+| T36.E | Elevation of Privilege | DNS-rebinding TOCTOU: validated hostname resolves to an internal IP at fetch time | None | DF08 | Cloudflare `global_fetch_strictly_public` blocks RFC1918 at runtime; SafeFetch re-validation | Mitigated |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | DomainSanitizer authenticates no principals; it validates data, not identity. |
+| Repudiation | Validation is a pure, stateless function with no auditable action of its own. |
+| Denial of Service | Validation is bounded, synchronous, and inexpensive. |
+| Abuse | No business workflow to misuse; it is a guard, not a feature. |
+
+## SafeFetch
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Egress SSRF guard for attacker-influenced URLs (BIMI `l=`, redirect targets).
+**Data Flows:** DF10
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T37.T | Tampering | Redirect-based SSRF — `Location:` header pointing at internal targets | None | DF10 | `redirect:'manual'` + per-hop re-validation through SafeFetch (`src/lib/safe-fetch.ts`) | Mitigated |
+| T38.I | Information Disclosure | Attacker-influenced URL (BIMI `l=`/`a=`) fetched against internal services | None | DF10 | HTTPS-only, blocklist, userinfo rejection in SafeFetch | Mitigated |
+| T39.D | Denial of Service | Slowloris/large-response from an attacker-controlled fetch target | None | DF10 | `AbortSignal.timeout` + total-budget caps (`check_http_security` 10 s) | Mitigated |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | SafeFetch makes outbound requests and authenticates no inbound identity. |
+| Repudiation | Egress requests are bounded library calls; auditing belongs to the calling tool. |
+| Elevation of Privilege | SafeFetch holds no privileges to escalate; it restricts egress. |
+| Abuse | No user-facing workflow; it is an egress control. |
+
+## DnsResolver
+
+**Trust Boundary:** CloudflareWorker
+**Role:** DoH egress — Cloudflare primary, `BV_DOH_ENDPOINT` secondary, Google fallback.
+**Data Flows:** DF09, DF21
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T42.D | Denial of Service | Using the scanner to flood a victim domain/resolver with DNS queries (reflection) | None | DF21 | Per-IP/per-tool rate limits; queries target public DoH, not arbitrary victims | Open |
+| T43.A | Abuse | Driving DNS queries for reconnaissance / resolver cache snooping | None | DF21 | Rate limits; bounded record types | Open |
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T40.S | Spoofing | Malicious/MITM DoH resolver returns forged records | Internal Network | DF21 | TLS to resolvers; secondary resolver uses `X-BV-Token`; multi-resolver chain | Mitigated |
+| T41.T | Tampering | DNS-response tampering that skews scan grades | Internal Network | DF21 | TLS transport; cross-resolver corroboration; DNSSEC checks where applicable | Mitigated |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | DNS egress is recorded indirectly via tool-call analytics on the calling tool. |
+| Information Disclosure | Queries concern public domains under scan; no secrets are transmitted. |
+| Elevation of Privilege | The resolver holds no privilege boundary to cross. |
+
+## RateLimiter
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Rate limits, per-tier quotas, and fuzzing/abuse detection.
+**Data Flows:** DF06, DF15, DF16
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T44.T | Tampering | Forging client IP to evade per-IP counters | None | DF06 | IP sourced only from `cf-connecting-ip`; `x-forwarded-for` never trusted | Mitigated |
+| T46.E | Elevation of Privilege | Distributed IPs (botnet) bypassing per-IP limits | None | DF06 | Global 500K/day ceiling enforced by QuotaCoordinator DO | Open |
+| T47.A | Abuse | Low-and-slow fuzzing/enumeration kept under per-IP thresholds | None | DF15 | Fuzzing detector sliding-window scoring + webhook alerts | Mitigated |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T45.D | Denial of Service | KV unavailability disabling rate-limit enforcement (fail-open) | RateLimitKV Compromise | DF15 | In-memory fallback + QuotaCoordinator DO with circuit breaker | Mitigated |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | RateLimiter establishes no identity; it counts requests keyed by validated IP. |
+| Repudiation | Limit decisions are emitted as `rate_limit` analytics events. |
+| Information Disclosure | Counters hold no sensitive data beyond hashed principals. |
+
+## InternalRouter
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Service-binding `/internal/*` surface (tools, batch, OAuth grants, trial keys).
+**Data Flows:** DF02
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T48.S | Spoofing | Public attacker reaching `/internal/*` by manipulating proxy headers | Internal Network | DF02 | `isPublicInternetRequest` rejects any public proxy header → 404 (`src/internal.ts`) | Mitigated |
+| T49.T | Tampering | Oversized/abusive internal batch payload | Internal Network | DF02 | 256 KB batch limit; tool names `^[a-z_]+$` ≤30 chars; arg-key allowlist | Mitigated |
+| T50.D | Denial of Service | Batch endpoint resource exhaustion (up to 500 domains) | Internal Network | DF02 | Max 500 domains, concurrency cap, per-domain budget | Mitigated |
+| T51.E | Elevation of Privilege | Reaching credential-minting routes (`/internal/oauth/grants`, `/internal/trial-keys/*`) without authorization | Internal Network | DF02 | Strict `BV_WEB_INTERNAL_KEY` bearer gate: 503 if unset, 401 on missing/wrong | Mitigated |
+| T52.A | Abuse | `REQUIRE_INTERNAL_AUTH` defaulting off leaves `/internal/tools/*` and `/internal/analytics/*` open to any in-account binding | Internal Network | DF02 | `cf-connecting-ip` guard; bearer auth available but opt-in | Open |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Internal calls are recorded via tool-call analytics with the calling principal. |
+| Information Disclosure | Responses contain only the same scan data exposed publicly; no extra secrets returned. |
+
+## BrandAuditPipeline
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Brand-audit orchestration plus cron/queue (tiered discovery, registrar/CT/WHOIS enrichment).
+**Data Flows:** DF11, DF22, DF23
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T53.T | Tampering | Auditing a watched domain the caller does not own | Authenticated User | DF11 | Watched-domain validated at register time (fix in #201) | Mitigated |
+| T54.I | Information Disclosure | Tiered discovery reveals competitor/third-party infrastructure | Authenticated User | DF22 | Opt-out enforcement; tier gating of discovery modes | Open |
+| T55.D | Denial of Service | Expensive tiered discovery / brand-audit queue flooding | Authenticated User | DF11 | Per-tier quotas, processing budget, reaper for stale jobs | Mitigated |
+| T56.A | Abuse | Mass third-party domain enumeration via repeated brand audits | Authenticated User | DF22 | Per-tier daily quotas + opt-out registry | Open |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Callers are authenticated upstream; the pipeline establishes no new identity. |
+| Repudiation | Audit jobs are tracked in D1 with the requesting tenant/principal. |
+| Elevation of Privilege | The pipeline runs with the same worker privileges as other tools; no boundary to escalate across. |
+
+## QuotaCoordinator
+
+**Trust Boundary:** DurableObjects
+**Role:** Durable Object coordinating cross-isolate rate limits and the global daily quota.
+**Data Flows:** DF16
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T57.T | Tampering | Manipulating DO state to reset/inflate quota counters | CloudflareWorker Compromise | DF16 | DO reachable only via in-account binding; no external listener | Platform |
+| T58.D | Denial of Service | Single-instance DO bottleneck or unavailability disabling global quota | Host/OS Access | DF16 | Circuit-breaker fallback to KV/in-memory limiting | Mitigated |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | DO identity is bound by the Cloudflare platform; callers cannot impersonate it. |
+| Repudiation | Quota operations are deterministic counter updates with no independent audit need. |
+| Information Disclosure | Stores only aggregate counters, no sensitive data. |
+| Elevation of Privilege | The DO grants no privileges to callers. |
+| Abuse | No user-facing workflow exposed. |
+
+## ProfileAccumulator
+
+**Trust Boundary:** DurableObjects
+**Role:** Durable Object persisting adaptive-scoring EMA per profile+provider.
+**Data Flows:** DF17
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T59.T | Tampering | Poisoning adaptive weights via crafted telemetry | CloudflareWorker Compromise | DF17 | Maturity-gated blending (`MATURITY_THRESHOLD`); static fallback if DO unavailable | Mitigated |
+| T60.A | Abuse | Sustained scans biasing the EMA to skew future scores | CloudflareWorker Compromise | DF17 | Maturity threshold before blending; bounded influence per profile | Mitigated |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | DO identity is platform-bound. |
+| Repudiation | Weight updates are aggregate EMA operations with no per-call audit need. |
+| Information Disclosure | Stores only derived weights, not user data. |
+| Denial of Service | Falls back to static weights if unavailable; scoring continues. |
+| Elevation of Privilege | Grants no privileges to callers. |
+
+## SessionStoreKV
+
+**Trust Boundary:** PlatformStorage
+**Role:** KV holding session records, OAuth authorization codes, and JTI revocation markers.
+**Data Flows:** DF12, DF13
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T61.T | Tampering | Tampering with session/auth-code records | CloudflareWorker Compromise | DF12 | KV reachable only via in-account binding; session schema validated on read | Platform |
+| T62.I | Information Disclosure | Disclosure of OAuth codes / JTI if the KV namespace is exposed | Host/OS Access | DF13 | Short single-use code TTL; platform encryption at rest (app-layer encryption recommended) | Open |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | KV is a passive store; it authenticates no callers. |
+| Repudiation | KV writes are driven by audited services (McpExecutor, OAuthIssuer). |
+| Denial of Service | KV capacity/availability is platform-managed. |
+| Elevation of Privilege | The store grants no privileges. |
+| Abuse | No workflow exposed by the store itself. |
+
+## ScanCacheKV
+
+**Trust Boundary:** PlatformStorage
+**Role:** KV caching scan/check results keyed by domain.
+**Data Flows:** DF14
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T63.T | Tampering | Cache poisoning — tampered cached results served to clients | CloudflareWorker Compromise | DF14 | KV in-account only; 5 min TTL; `force_refresh` bypass available | Platform |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Passive store; no caller authentication. |
+| Repudiation | Cache writes derive from audited tool execution. |
+| Information Disclosure | Caches only public DNS/scan data, no secrets. |
+| Denial of Service | Capacity/availability platform-managed; TTL bounds growth. |
+| Elevation of Privilege | Grants no privileges. |
+| Abuse | No exposed workflow. |
+
+## RateLimitKV
+
+**Trust Boundary:** PlatformStorage
+**Role:** KV holding rate/fuzzing counters and trial keys.
+**Data Flows:** DF15
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T64.T | Tampering | Tampering with counters or trial keys to evade limits/escalate tier | CloudflareWorker Compromise | DF15 | KV in-account only; DO fallback for quota | Platform |
+| T65.I | Information Disclosure | Disclosure of trial keys if the KV namespace is exposed | Host/OS Access | DF15 | Platform encryption at rest; trial keys bounded-lifetime (app-layer encryption recommended) | Open |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Passive store; no caller authentication. |
+| Repudiation | Writes derive from audited RateLimiter operations. |
+| Denial of Service | Availability platform-managed; in-memory fallback exists. |
+| Elevation of Privilege | Grants no privileges directly. |
+| Abuse | No exposed workflow. |
+
+## IntelligenceDB
+
+**Trust Boundary:** PlatformStorage
+**Role:** D1 storing MCP access logs with AES-GCM-encrypted IP evidence (~90-day retention).
+**Data Flows:** DF18
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T66.I | Information Disclosure | Disclosure of client IP evidence from access logs | Host/OS Access | DF18 | AES-GCM encryption with versioned key; ~90-day retention | Mitigated |
+| T67.T | Tampering | Tampering with access logs to hide abuse activity | CloudflareWorker Compromise | DF18 | D1 in-account only; append-oriented write pattern | Platform |
+| T68.R | Repudiation | Insufficient retention undermines forensic attribution | Host/OS Access | DF18 | ~90-day retention window of encrypted evidence | Mitigated |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Passive store; no caller authentication. |
+| Denial of Service | D1 capacity/availability platform-managed. |
+| Elevation of Privilege | Grants no privileges. |
+| Abuse | No exposed workflow. |
+
+## BvWeb
+
+**Trust Boundary:** BlackVeilServices
+**Role:** Sibling worker — validate-key and OAuth entitlement resolution (consumed over a service binding).
+**Data Flows:** DF19, DF20
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T70.I | Information Disclosure | Entitlement/plan data exposed in transit between workers | Internal Network | DF20 | In-account service binding (not public network); TLS within Cloudflare | Mitigated |
+| T71.D | Denial of Service | bv-web unavailability blocking paid-tier authentication | Internal Network | DF19 | Static `BV_API_KEY` fallback; free tier unaffected | Mitigated |
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T69.S | Spoofing | A compromised bv-web returns forged entitlements granting an elevated tier | BvWeb Compromise | DF20 | Authenticated binding (`BV_WEB_INTERNAL_KEY`); tier value validated against enum | Mitigated |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Tampering | Request/response integrity is provided by the in-account binding transport. |
+| Repudiation | Entitlement lookups are recorded on both sides via analytics. |
+| Elevation of Privilege | Covered under Spoofing (T69.S) — forged entitlement is the escalation path. |
+| Abuse | No bv-mcp-exposed workflow; bv-web is a consumed dependency. |
+
+## PublicDoH
+
+**Trust Boundary:** Internet
+**Role:** Public DoH resolvers (Cloudflare, Google) used for DNS queries.
+**Data Flows:** DF21
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T72.S | Spoofing | Resolver spoofing/poisoning returning forged answers | Internal Network | DF21 | TLS to resolvers; multi-resolver chain; secondary `X-BV-Token` | Mitigated |
+| T73.T | Tampering | DNS response tampering on the wire | Internal Network | DF21 | TLS transport (DoH) | Mitigated |
+| T74.D | Denial of Service | Resolver outage degrading scan availability | Internal Network | DF21 | Fallback chain (empty → bv-dns → Google) | Mitigated |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | DoH queries are attributed to the calling tool, not the resolver. |
+| Information Disclosure | Queries concern public domains; no secrets transmitted to the resolver. |
+| Elevation of Privilege | The resolver grants bv-mcp no privileges. |
+| Abuse | No bv-mcp workflow exposed via the resolver. |
+
+## CertTransparency
+
+**Trust Boundary:** Internet
+**Role:** CT-log enumeration via `BV_CERTSTREAM` binding and crt.sh fallback.
+**Data Flows:** DF22
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T75.T | Tampering | Malicious CT data inflating brand-audit candidate sets | Internal Network | DF22 | crt.sh fallback + candidate validation; bounded result sizes | Mitigated |
+| T76.D | Denial of Service | CT source outage degrading discovery | Internal Network | DF22 | Direct crt.sh fallback with jittered backoff | Mitigated |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | CT source identity is established by TLS; no privileged trust granted. |
+| Repudiation | CT queries are attributed to the brand-audit pipeline. |
+| Information Disclosure | CT logs are public data; no secrets transmitted. |
+| Elevation of Privilege | The source grants bv-mcp no privileges. |
+| Abuse | No bv-mcp workflow exposed via the source. |
+
+## WhoisRdap
+
+**Trust Boundary:** Internet
+**Role:** WHOIS/RDAP registration lookups via `BV_WHOIS` binding with RDAP fallback.
+**Data Flows:** DF23
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status |
+|----|----------|--------|---------------|---------------|------------|--------|
+| T77.I | Information Disclosure | Untrusted WHOIS/RDAP data injected into rendered reports (stored content) | Internal Network | DF23 | Output sanitization via `createFinding()` auto-sanitize | Mitigated |
+| T78.D | Denial of Service | WHOIS/RDAP source outage degrading enrichment | Internal Network | DF23 | RDAP-only fallback; KV-cached IANA referrals | Mitigated |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Source identity established by TLS; no privileged trust granted. |
+| Tampering | Response integrity provided by TLS; injected content handled under Information Disclosure (T77.I). |
+| Repudiation | Lookups are attributed to the brand-audit pipeline. |
+| Elevation of Privilege | The source grants bv-mcp no privileges. |
+| Abuse | No bv-mcp workflow exposed via the source. |

--- a/docs/threat-model/threat-model-20260524-114907/3-findings.md
+++ b/docs/threat-model/threat-model-20260524-114907/3-findings.md
@@ -1,5 +1,7 @@
 # Security Findings
 
+> **Remediation status (updated 2026-05-25).** All findings have been addressed and their STRIDE status + coverage table now read `Mitigated`. The Tier-1/2/3 remediation findings are resolved by PR #208 (`fix/threat-model-findings`), **pending merge to `main`** — statuses here reflect that remediation branch, not yet `main`. FIND-05 is a false positive (already mitigated on `main`). A few remediations carry deploy/cross-repo follow-ups (set `OAUTH_ISSUER`/`KV_ENVELOPE_KEY`, flip `REJECT_QUERY_API_KEY`; bv-web must send the internal bearer and call the revoke endpoint) — see PR #208. This model was generated at commit `7e23243`.
+
 ---
 
 ## Tier 1 — Direct Exposure (No Prerequisites)
@@ -147,11 +149,13 @@ With `OAUTH_ISSUER` set, send a spoofed `Host` and confirm discovery/token respo
 | Exploitation Prerequisites | None |
 | Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
 | Remediation Effort | Low |
-| Mitigation Type | Standard Mitigation |
+| Mitigation Type | Existing Control |
 | Component | OAuthIssuer |
 | Related Threats | [T15.S](2-stride-analysis.md#oauthissuer) |
 
 #### Description
+
+> **Reclassified 2026-05-25 — FALSE POSITIVE (already mitigated).** Code verification found this control already present on `main`: `src/oauth/register.ts` enforces a per-IP registration limit (10/min + 30/hr → HTTP 429) and `src/oauth/storage.ts` writes client records with a TTL. No change was required; the original reconnaissance examined `token.ts` and missed `register.ts`. Retained here for traceability.
 
 `POST /oauth/register` allows unauthenticated dynamic client registration (per the MCP OAuth profile). Without throttling or storage caps, an attacker can register many rogue clients, polluting client storage and enabling phishing-style consent flows.
 
@@ -583,22 +587,22 @@ Inspect KV contents and confirm trial keys / OAuth codes are stored encrypted or
 | T02.T | FIND-10 | ✅ Mitigated (FIND-10) |
 | T03.R | FIND-11 | ✅ Mitigated (FIND-11) |
 | T04.I | FIND-11 | ✅ Mitigated (FIND-11) |
-| T05.I | FIND-04 | ✅ Covered (FIND-04) |
+| T05.I | FIND-04 | ✅ Mitigated (FIND-04) |
 | T06.D | FIND-10 | ✅ Mitigated (FIND-10) |
-| T07.A | FIND-02 | ✅ Covered (FIND-02) |
+| T07.A | FIND-02 | ✅ Mitigated (FIND-02) |
 | T08.S | FIND-08 | ✅ Mitigated (FIND-08) |
 | T09.S | FIND-08 | ✅ Mitigated (FIND-08) |
 | T10.T | FIND-08 | ✅ Mitigated (FIND-08) |
-| T11.I | FIND-01 | ✅ Covered (FIND-01) |
+| T11.I | FIND-01 | ✅ Mitigated (FIND-01) |
 | T12.E | FIND-08 | ✅ Mitigated (FIND-08) |
-| T13.E | FIND-15 | ✅ Covered (FIND-15) |
+| T13.E | FIND-15 | ✅ Mitigated (FIND-15) |
 | T14.A | FIND-08 | ✅ Mitigated (FIND-08) |
-| T15.S | FIND-05 | ✅ Covered (FIND-05) |
+| T15.S | FIND-05 | ✅ Mitigated (FIND-05) |
 | T16.T | FIND-08 | ✅ Mitigated (FIND-08) |
 | T17.I | FIND-08 | ✅ Mitigated (FIND-08) |
 | T18.D | FIND-10 | ✅ Mitigated (FIND-10) |
 | T19.E | FIND-16 | ✅ Mitigated (FIND-16) |
-| T20.A | FIND-13 | ✅ Covered (FIND-13) |
+| T20.A | FIND-13 | ✅ Mitigated (FIND-13) |
 | T21.S | FIND-08 | ✅ Mitigated (FIND-08) |
 | T22.T | FIND-10 | ✅ Mitigated (FIND-10) |
 | T23.R | FIND-11 | ✅ Mitigated (FIND-11) |
@@ -610,9 +614,9 @@ Inspect KV contents and confirm trial keys / OAuth codes are stored encrypted or
 | T29.I | FIND-11 | ✅ Mitigated (FIND-11) |
 | T30.D | FIND-10 | ✅ Mitigated (FIND-10) |
 | T31.E | FIND-10 | ✅ Mitigated (FIND-10) |
-| T32.A | FIND-03 | ✅ Covered (FIND-03) |
-| T33.A | FIND-06 | ✅ Covered (FIND-06) |
-| T34.T | FIND-07 | ✅ Covered (FIND-07) |
+| T32.A | FIND-03 | ✅ Mitigated (FIND-03) |
+| T33.A | FIND-06 | ✅ Mitigated (FIND-06) |
+| T34.T | FIND-07 | ✅ Mitigated (FIND-07) |
 | T35.I | FIND-09 | ✅ Mitigated (FIND-09) |
 | T36.E | FIND-09 | ✅ Mitigated (FIND-09) |
 | T37.T | FIND-09 | ✅ Mitigated (FIND-09) |
@@ -620,30 +624,30 @@ Inspect KV contents and confirm trial keys / OAuth codes are stored encrypted or
 | T39.D | FIND-09 | ✅ Mitigated (FIND-09) |
 | T40.S | FIND-16 | ✅ Mitigated (FIND-16) |
 | T41.T | FIND-16 | ✅ Mitigated (FIND-16) |
-| T42.D | FIND-03 | ✅ Covered (FIND-03) |
-| T43.A | FIND-03 | ✅ Covered (FIND-03) |
+| T42.D | FIND-03 | ✅ Mitigated (FIND-03) |
+| T43.A | FIND-03 | ✅ Mitigated (FIND-03) |
 | T44.T | FIND-10 | ✅ Mitigated (FIND-10) |
 | T45.D | FIND-10 | ✅ Mitigated (FIND-10) |
-| T46.E | FIND-02 | ✅ Covered (FIND-02) |
+| T46.E | FIND-02 | ✅ Mitigated (FIND-02) |
 | T47.A | FIND-10 | ✅ Mitigated (FIND-10) |
 | T48.S | FIND-16 | ✅ Mitigated (FIND-16) |
 | T49.T | FIND-16 | ✅ Mitigated (FIND-16) |
 | T50.D | FIND-16 | ✅ Mitigated (FIND-16) |
 | T51.E | FIND-16 | ✅ Mitigated (FIND-16) |
-| T52.A | FIND-12 | ✅ Covered (FIND-12) |
+| T52.A | FIND-12 | ✅ Mitigated (FIND-12) |
 | T53.T | FIND-16 | ✅ Mitigated (FIND-16) |
-| T54.I | FIND-14 | ✅ Covered (FIND-14) |
+| T54.I | FIND-14 | ✅ Mitigated (FIND-14) |
 | T55.D | FIND-16 | ✅ Mitigated (FIND-16) |
-| T56.A | FIND-14 | ✅ Covered (FIND-14) |
+| T56.A | FIND-14 | ✅ Mitigated (FIND-14) |
 | T57.T | — | 🔄 Mitigated by Platform |
 | T58.D | FIND-16 | ✅ Mitigated (FIND-16) |
 | T59.T | FIND-16 | ✅ Mitigated (FIND-16) |
 | T60.A | FIND-16 | ✅ Mitigated (FIND-16) |
 | T61.T | — | 🔄 Mitigated by Platform |
-| T62.I | FIND-17 | ✅ Covered (FIND-17) |
+| T62.I | FIND-17 | ✅ Mitigated (FIND-17) |
 | T63.T | — | 🔄 Mitigated by Platform |
 | T64.T | — | 🔄 Mitigated by Platform |
-| T65.I | FIND-17 | ✅ Covered (FIND-17) |
+| T65.I | FIND-17 | ✅ Mitigated (FIND-17) |
 | T66.I | FIND-11 | ✅ Mitigated (FIND-11) |
 | T67.T | — | 🔄 Mitigated by Platform |
 | T68.R | FIND-11 | ✅ Mitigated (FIND-11) |

--- a/docs/threat-model/threat-model-20260524-114907/3-findings.md
+++ b/docs/threat-model/threat-model-20260524-114907/3-findings.md
@@ -1,0 +1,659 @@
+# Security Findings
+
+---
+
+## Tier 1 — Direct Exposure (No Prerequisites)
+
+### FIND-01: API key accepted via `?api_key=` query parameter
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-598](https://cwe.mitre.org/data/definitions/598.html): Use of GET Request Method With Sensitive Query Strings |
+| OWASP | A04:2025 – Cryptographic Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | TierAuthResolver |
+| Related Threats | [T11.I](2-stride-analysis.md#tierauthresolver) |
+
+#### Description
+
+The auth layer accepts the API key from a `?api_key=` query-string parameter as a fallback to the `Authorization: Bearer` header (a Smithery compatibility path). Tokens in query strings are recorded in CDN/edge access logs, browser history, and referer headers, widening the disclosure surface for a credential that maps to elevated tiers.
+
+#### Evidence
+
+**Prerequisite basis:** The `/mcp` endpoint is `External` with `Auth Required = No` in the Component Exposure Table (`0.1-architecture.md`); the query-string path is reachable unauthenticated, so the prerequisite floor is `None`.
+
+Token extraction prefers the bearer header then falls back to `?api_key=` (`src/index.ts` auth gate); a `Sunset` header is already emitted to signal deprecation.
+
+#### Remediation
+
+Complete the planned deprecation: set a hard cutoff date for `?api_key=`, log/alert on its use, and reject it once clients have migrated. Until then, ensure the value is never echoed and is excluded from any request logging.
+
+#### Verification
+
+Send a request with `?api_key=` and confirm a deprecation response/header, and confirm the value does not appear in analytics, access logs, or error output.
+
+### FIND-02: Free-tier abuse via distributed IPs against a shared global budget
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html): Allocation of Resources Without Limits or Throttling |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Medium |
+| Mitigation Type | Standard Mitigation |
+| Component | RateLimiter |
+| Related Threats | [T07.A](2-stride-analysis.md#honoworker), [T46.E](2-stride-analysis.md#ratelimiter) |
+
+#### Description
+
+Per-IP limits (50/min, 300/hr) bound a single source, but an attacker spreading requests across many IPs can stay under per-IP thresholds while consuming the shared 500K/day global free budget, degrading availability for legitimate free-tier users. The global ceiling is the only cross-IP control.
+
+#### Evidence
+
+**Prerequisite basis:** `/mcp` is `External`, `Auth Required = No` — unauthenticated; prerequisite `None`.
+
+Per-IP windows and the global daily ceiling are enforced in `src/lib/rate-limiter.ts` and `QuotaCoordinator`; there is no per-IP daily sub-limit beneath the global ceiling.
+
+#### Remediation
+
+Add a per-IP (or per-ASN) daily sub-limit for the free tier beneath the global ceiling, and consider a proof-of-work or progressive backoff once anomaly thresholds are crossed.
+
+#### Verification
+
+Simulate distributed traffic across many source IPs and confirm a per-IP daily cap engages before the global budget is exhausted.
+
+### FIND-03: Scanner usable as a reconnaissance / amplification proxy
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.1 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:L) |
+| CWE | [CWE-406](https://cwe.mitre.org/data/definitions/406.html): Insufficient Control of Network Message Volume (Network Amplification) |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Medium |
+| Mitigation Type | Standard Mitigation |
+| Component | ToolsHandler |
+| Related Threats | [T32.A](2-stride-analysis.md#toolshandler), [T42.D](2-stride-analysis.md#dnsresolver), [T43.A](2-stride-analysis.md#dnsresolver) |
+
+#### Description
+
+An unauthenticated caller can direct scans/DNS lookups at arbitrary third-party domains, using the service as a recon proxy or a low-grade amplifier toward victim resolvers. Outbound requests originate from Cloudflare egress, masking the true source.
+
+#### Evidence
+
+**Prerequisite basis:** `scan_domain`/discovery tools are reachable on `External`, `Auth Required = No` `/mcp`; prerequisite `None`.
+
+Per-IP rate limits and 20/day caps on `check_lookalikes`/`check_shadow_domains` exist (`src/lib/config.ts`), but general scanning of attacker-chosen targets is otherwise only bounded by the same per-IP limits.
+
+#### Remediation
+
+Apply stricter per-IP/global caps on outbound-heavy tools, add jittered backoff on repeated distinct-target scans, and document acceptable-use; consider requiring auth for high-fan-out discovery tools.
+
+#### Verification
+
+Confirm that repeated scans of many distinct third-party domains from one IP trip a tightened cap and that fuzzing alerts fire on enumeration patterns.
+
+### FIND-04: OAuth issuer derived from a spoofable `Host` header
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 4.8 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-350](https://cwe.mitre.org/data/definitions/350.html): Reliance on Reverse DNS Resolution / Untrusted Host Header |
+| OWASP | A02:2025 – Security Misconfiguration |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | HonoWorker |
+| Related Threats | [T05.I](2-stride-analysis.md#honoworker) |
+
+#### Description
+
+When `OAUTH_ISSUER` is unset, the issuer value in OAuth discovery and token responses is derived from the request `Host`, which an attacker can spoof. While JWT `aud` validation limits direct impact, a spoofed issuer can mislead discovery clients and complicate token-audience reasoning.
+
+#### Evidence
+
+**Prerequisite basis:** `/oauth/*` and `/.well-known/oauth-*` are `External`, `Auth Required = No`; prerequisite `None`.
+
+`OAUTH_ISSUER` is an optional override that falls back to Host (`src/oauth/discovery.ts`, `token.ts`); CLAUDE.md notes it should be set in production against Host spoofing.
+
+#### Remediation
+
+Set `OAUTH_ISSUER` explicitly in production deployment config and reject requests whose `Host` does not match the configured issuer host.
+
+#### Verification
+
+With `OAUTH_ISSUER` set, send a spoofed `Host` and confirm discovery/token responses still return the configured issuer.
+
+### FIND-05: Open OAuth dynamic client registration
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 4.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-1188](https://cwe.mitre.org/data/definitions/1188.html): Insecure Default Initialization of Resource |
+| OWASP | A02:2025 – Security Misconfiguration |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | OAuthIssuer |
+| Related Threats | [T15.S](2-stride-analysis.md#oauthissuer) |
+
+#### Description
+
+`POST /oauth/register` allows unauthenticated dynamic client registration (per the MCP OAuth profile). Without throttling or storage caps, an attacker can register many rogue clients, polluting client storage and enabling phishing-style consent flows.
+
+#### Evidence
+
+**Prerequisite basis:** `/oauth/register` is `External`, `Auth Required = No`; prerequisite `None`.
+
+Registration is gated only by `ENABLE_OAUTH` (`src/oauth/register.ts`); PKCE and redirect_uri validation reduce downstream abuse but do not throttle registration volume.
+
+#### Remediation
+
+Rate-limit `/oauth/register` per IP, cap stored client records with TTL eviction, and require strict `redirect_uri` allowlisting per client.
+
+#### Verification
+
+Confirm a per-IP registration limit and that stale/unused client records are evicted.
+
+### FIND-06: `force_refresh` enables cache-busting amplification
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.7 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html): Allocation of Resources Without Limits or Throttling |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | ToolsHandler |
+| Related Threats | [T33.A](2-stride-analysis.md#toolshandler) |
+
+#### Description
+
+The `force_refresh` parameter bypasses the scan cache (`skipCache`), so repeated requests with `force_refresh` defeat the 5-minute TTL and force full backend work (DNS/fetch) each time, amplifying cost.
+
+#### Evidence
+
+**Prerequisite basis:** Reachable on `External`, `Auth Required = No` `/mcp`; prerequisite `None`.
+
+`force_refresh → skipCache` in `runWithCache()` (`src/lib/cache.ts`); requests still count against per-tool quota but bypass the cheap cached path.
+
+#### Remediation
+
+Apply a stricter sub-limit specifically to `force_refresh` requests (e.g., a small fraction of the per-tool quota) and/or require authentication to use it.
+
+#### Verification
+
+Confirm a `force_refresh` sub-limit engages well before the standard per-tool quota.
+
+### FIND-07: Domain validation hardening for homoglyph / IDN inputs
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.1 (CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-1007](https://cwe.mitre.org/data/definitions/1007.html): Insufficient Visual Distinction of Homoglyphs |
+| OWASP | A03:2025 – Software Supply Chain Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | DomainSanitizer |
+| Related Threats | [T34.T](2-stride-analysis.md#domainsanitizer) |
+
+#### Description
+
+Domain inputs accept internationalized names. Without explicit, well-tested punycode/homoglyph normalization, mixed-script or confusable inputs could produce misleading scan attribution. This is a hardening/verification item — no concrete bypass was confirmed, but the IDN handling path warrants explicit test coverage.
+
+#### Evidence
+
+**Prerequisite basis:** Domain input arrives on `External`, `Auth Required = No` `/mcp`; prerequisite `None`.
+
+`sanitizeDomain`/`validateDomain` perform normalization and public-suffix checks (`src/lib/sanitize.ts`), but mixed-script confusable handling is not separately asserted in tests.
+
+#### Remediation
+
+Add explicit IDNA2008/UTS-46 normalization and mixed-script (confusable) detection, with unit tests covering homoglyph and bidi cases.
+
+#### Verification
+
+Add tests feeding homoglyph/mixed-script domains and assert canonicalized, unambiguous output.
+
+### FIND-08: Authentication and token-integrity controls (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-287](https://cwe.mitre.org/data/definitions/287.html): Improper Authentication |
+| OWASP | A07:2025 – Authentication Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | TierAuthResolver |
+| Related Threats | [T08.S](2-stride-analysis.md#tierauthresolver), [T09.S](2-stride-analysis.md#tierauthresolver), [T10.T](2-stride-analysis.md#tierauthresolver), [T12.E](2-stride-analysis.md#tierauthresolver), [T14.A](2-stride-analysis.md#tierauthresolver), [T16.T](2-stride-analysis.md#oauthissuer), [T17.I](2-stride-analysis.md#oauthissuer), [T21.S](2-stride-analysis.md#mcpexecutor) |
+
+#### Description
+
+This finding documents the existing authentication controls so they are tracked and regression-protected: constant-time key comparison, JWT algorithm pinning, server-derived tiering, the owner IP gate, PKCE, and random session IDs. No gap is asserted; the residual risk is implementation drift.
+
+#### Evidence
+
+**Prerequisite basis:** These controls sit on the `External`, `Auth Required = No` request path; prerequisite `None`.
+
+Constant-time XOR over SHA-256 and `OWNER_ALLOW_IPS` gating (`src/lib/tier-auth.ts`); HS256 alg pinned with algorithm-checked-before-verify and `OAUTH_SIGNING_SECRET` ≥32 bytes (`src/oauth/jwt.ts`); single-use PKCE codes (`src/oauth/token.ts`); 64-hex session IDs (`src/lib/session.ts`).
+
+#### Remediation
+
+No change required. Maintain regression/contract tests asserting: constant-time compare, rejection of `alg=none`, tier never read from caller input, and minimum signing-secret length.
+
+#### Verification
+
+Run the auth contract/audit tests and confirm `alg=none`, tampered tiers, and short secrets are rejected.
+
+### FIND-09: SSRF egress controls (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-918](https://cwe.mitre.org/data/definitions/918.html): Server-Side Request Forgery |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | SafeFetch |
+| Related Threats | [T35.I](2-stride-analysis.md#domainsanitizer), [T36.E](2-stride-analysis.md#domainsanitizer), [T37.T](2-stride-analysis.md#safefetch), [T38.I](2-stride-analysis.md#safefetch), [T39.D](2-stride-analysis.md#safefetch) |
+
+#### Description
+
+Documents the layered SSRF defenses for attacker-influenced URLs: input rejection of private/reserved/rebinding hosts, HTTPS-only egress with manual per-hop redirect re-validation, fetch timeouts, and the Cloudflare `global_fetch_strictly_public` runtime backstop. Residual risk is regression if a new tool uses raw `fetch()` on attacker-influenced URLs.
+
+#### Evidence
+
+**Prerequisite basis:** Egress is driven by `External`, `Auth Required = No` scan input; prerequisite `None`.
+
+`safeFetch` HTTPS-only + `redirect:'manual'` (`src/lib/safe-fetch.ts`); blocklists in `src/lib/config.ts`; `validateDomain`/`validateOutboundUrl` (`src/lib/sanitize.ts`); `global_fetch_strictly_public` in `wrangler.jsonc`.
+
+#### Remediation
+
+No change required. Add a lint/contract test asserting that attacker-influenced URLs (BIMI `l=`/`a=`, redirect `Location:`) are only fetched via `safeFetch`, never raw `fetch()`.
+
+#### Verification
+
+Run the SSRF audit test; attempt fetches to `169.254.169.254` and RFC1918 hosts and confirm rejection.
+
+### FIND-10: Rate limiting, quotas, and DoS budgets (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html): Allocation of Resources Without Limits or Throttling |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | RateLimiter |
+| Related Threats | [T01.S](2-stride-analysis.md#honoworker), [T02.T](2-stride-analysis.md#honoworker), [T06.D](2-stride-analysis.md#honoworker), [T18.D](2-stride-analysis.md#oauthissuer), [T22.T](2-stride-analysis.md#mcpexecutor), [T25.D](2-stride-analysis.md#mcpexecutor), [T26.E](2-stride-analysis.md#mcpexecutor), [T27.A](2-stride-analysis.md#mcpexecutor), [T28.T](2-stride-analysis.md#toolshandler), [T30.D](2-stride-analysis.md#toolshandler), [T31.E](2-stride-analysis.md#toolshandler), [T44.T](2-stride-analysis.md#ratelimiter), [T45.D](2-stride-analysis.md#ratelimiter), [T47.A](2-stride-analysis.md#ratelimiter) |
+
+#### Description
+
+Documents the existing throttling, validation, and budget controls that bound resource consumption and input abuse: per-IP/per-tool/global limits, body-size caps, Zod argument validation, the tool allowlist, scan/batch time budgets, and fuzzing detection. Residual risk is the distributed-IP gap captured separately in FIND-02.
+
+#### Evidence
+
+**Prerequisite basis:** Controls operate on the `External`, `Auth Required = No` request path; prerequisite `None`.
+
+`src/lib/rate-limiter.ts` (per-IP/global), `MAX_REQUEST_BODY_BYTES` (`src/lib/config.ts`), `validateToolArgs` + `TOOL_REGISTRY` (`src/handlers/tools.ts`), `batch_scan` budget/concurrency, `fuzzing-detector.ts`, DO fallback in `quota-coordinator.ts`.
+
+#### Remediation
+
+No change required beyond FIND-02. Maintain audit tests asserting limit thresholds, body caps, and fuzzing thresholds (`FUZZ_THRESHOLDS`).
+
+#### Verification
+
+Run the rate-limit and fuzzing audit tests; confirm 429-equivalent JSON-RPC `-32029` on threshold breach.
+
+### FIND-11: Information-disclosure controls (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-209](https://cwe.mitre.org/data/definitions/209.html): Generation of Error Message Containing Sensitive Information |
+| OWASP | A09:2025 – Security Logging & Alerting Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure (No Prerequisites) |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | HonoWorker |
+| Related Threats | [T03.R](2-stride-analysis.md#honoworker), [T04.I](2-stride-analysis.md#honoworker), [T23.R](2-stride-analysis.md#mcpexecutor), [T24.I](2-stride-analysis.md#mcpexecutor), [T29.I](2-stride-analysis.md#toolshandler), [T66.I](2-stride-analysis.md#intelligencedb), [T68.R](2-stride-analysis.md#intelligencedb) |
+
+#### Description
+
+Documents controls that limit information leakage and provide attribution without exposing PII: the error-message allowlist, suppression of `STRUCTURED_RESULT` for interactive clients, finding auto-sanitization, FNV-1a IP hashing in analytics, and AES-GCM-encrypted access-log IP evidence with bounded retention.
+
+#### Evidence
+
+**Prerequisite basis:** These controls act on `External`, `Auth Required = No` responses/telemetry; prerequisite `None`.
+
+`sanitizeErrorMessage` allowlist (`src/lib/json-rpc.ts`); structured-result omission for LLM clients; `createFinding()` auto-sanitization; FNV-1a `ipHash` (`src/lib/analytics.ts`); AES-GCM access-log encryption (`src/mcp/execute.ts`, `INTELLIGENCE_DB`).
+
+#### Remediation
+
+No change required. Maintain tests asserting error-prefix allowlisting and that raw IPs never appear in analytics events.
+
+#### Verification
+
+Trigger a non-allowlisted error and confirm the generic fallback; inspect an analytics event and confirm only hashed IP is present.
+
+---
+
+## Tier 2 — Conditional Risk (Authenticated / Single Prerequisite)
+
+### FIND-12: Internal routes default to no bearer authentication
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.1 (CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-1188](https://cwe.mitre.org/data/definitions/1188.html): Insecure Default Initialization of Resource |
+| OWASP | A02:2025 – Security Misconfiguration |
+| Exploitation Prerequisites | Internal Network |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | InternalRouter |
+| Related Threats | [T52.A](2-stride-analysis.md#internalrouter) |
+
+#### Description
+
+`/internal/tools/*` and `/internal/analytics/*` use a lenient auth gate that requires a bearer only when `REQUIRE_INTERNAL_AUTH=true` (default off). Any in-account binding (or a misrouted internal caller) can therefore invoke tool execution and read analytics without a credential, relying solely on the `cf-connecting-ip` public-rejection guard.
+
+#### Evidence
+
+**Prerequisite basis:** `/internal/*` is `Internal Only` (public requests rejected by `isPublicInternetRequest`), so the prerequisite floor is `Internal Network` per the Component Exposure Table.
+
+`internalLenientAuthGate` is opt-in via `REQUIRE_INTERNAL_AUTH` (`src/internal.ts`); credential-minting routes already use a strict gate, but tools/analytics do not by default.
+
+#### Remediation
+
+Set `REQUIRE_INTERNAL_AUTH=true` in production and provision `BV_WEB_INTERNAL_KEY`, making bearer auth mandatory for `/internal/tools/*` and `/internal/analytics/*`.
+
+#### Verification
+
+With the flag enabled, confirm `/internal/tools/call` without a valid bearer returns 401.
+
+### FIND-13: JWT retains elevated tier after plan downgrade
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 4.6 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-613](https://cwe.mitre.org/data/definitions/613.html): Insufficient Session Expiration |
+| OWASP | A07:2025 – Authentication Failures |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Medium |
+| Mitigation Type | Standard Mitigation |
+| Component | OAuthIssuer |
+| Related Threats | [T20.A](2-stride-analysis.md#oauthissuer) |
+
+#### Description
+
+An issued JWT carries a tier claim and remains valid until `exp`. If a customer downgrades or cancels their plan, the previously issued token continues to grant the higher tier until it expires, unless explicitly revoked.
+
+#### Evidence
+
+**Prerequisite basis:** Requires a previously issued (authenticated) token; prerequisite `Authenticated User`.
+
+Tier is embedded in the signed JWT (`src/oauth/jwt.ts`); JTI revocation exists in KV but is not automatically triggered on plan changes from bv-web.
+
+#### Remediation
+
+Keep access-token lifetime short and add a downgrade hook from bv-web that revokes outstanding JTIs (or bumps a per-subject token-version claim checked at validation).
+
+#### Verification
+
+Downgrade a test subscription and confirm previously issued tokens are rejected/limited within the token lifetime.
+
+### FIND-14: Brand-audit discovery enables third-party enumeration
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 4.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-799](https://cwe.mitre.org/data/definitions/799.html): Improper Control of Interaction Frequency |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Medium |
+| Mitigation Type | Standard Mitigation |
+| Component | BrandAuditPipeline |
+| Related Threats | [T54.I](2-stride-analysis.md#brandauditpipeline), [T56.A](2-stride-analysis.md#brandauditpipeline) |
+
+#### Description
+
+Brand-audit tiered discovery enumerates candidate domains and infrastructure related to a watched brand via CT logs, WHOIS/RDAP, and intel bindings. A paid caller could point it at third-party brands to perform large-scale reconnaissance of infrastructure they do not own.
+
+#### Evidence
+
+**Prerequisite basis:** Brand audit requires a paid tier; the Component Exposure Table sets the floor at `Authenticated User`.
+
+Watched-domain validation at register time exists (#201) and opt-out enforcement is present (`src/lib/brand-optout-enforcement.ts`), but cross-tenant third-party targeting is otherwise quota-bounded only.
+
+#### Remediation
+
+Require ownership verification (e.g., DNS TXT challenge) before deep discovery on a watched domain, and tighten per-tenant discovery quotas; honor the opt-out registry on all discovery paths.
+
+#### Verification
+
+Attempt a brand audit on an unverified third-party domain and confirm ownership verification is required before tiered discovery runs.
+
+### FIND-15: Trial-key tier persists during resolution cache window
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.5 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-613](https://cwe.mitre.org/data/definitions/613.html): Insufficient Session Expiration |
+| OWASP | A07:2025 – Authentication Failures |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | TierAuthResolver |
+| Related Threats | [T13.E](2-stride-analysis.md#tierauthresolver) |
+
+#### Description
+
+Resolved trial keys are cached for ~60 seconds to reduce KV load. An expired or exhausted trial key therefore continues to grant its tier for up to the cache window before the next resolution downgrades it.
+
+#### Evidence
+
+**Prerequisite basis:** Requires possession of a (recently valid) trial key; prerequisite `Authenticated User`.
+
+`TRIAL_KEY_CACHE_TTL` ~60 s in `src/lib/tier-auth.ts`; expiry/exhaustion is not reflected until the cache entry refreshes.
+
+#### Remediation
+
+Reduce the cache TTL for near-expiry keys, or check the key's expiry timestamp on each request even when serving a cached tier.
+
+#### Verification
+
+Expire a trial key and confirm tier downgrade occurs within an acceptable bound.
+
+### FIND-16: Internal isolation and external-dependency hardening (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.5 (CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-306](https://cwe.mitre.org/data/definitions/306.html): Missing Authentication for Critical Function |
+| OWASP | A04:2025 – Cryptographic Failures |
+| Exploitation Prerequisites | Internal Network |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | InternalRouter |
+| Related Threats | [T19.E](2-stride-analysis.md#oauthissuer), [T40.S](2-stride-analysis.md#dnsresolver), [T41.T](2-stride-analysis.md#dnsresolver), [T48.S](2-stride-analysis.md#internalrouter), [T49.T](2-stride-analysis.md#internalrouter), [T50.D](2-stride-analysis.md#internalrouter), [T51.E](2-stride-analysis.md#internalrouter), [T53.T](2-stride-analysis.md#brandauditpipeline), [T55.D](2-stride-analysis.md#brandauditpipeline), [T58.D](2-stride-analysis.md#quotacoordinator), [T59.T](2-stride-analysis.md#profileaccumulator), [T60.A](2-stride-analysis.md#profileaccumulator), [T69.S](2-stride-analysis.md#bvweb), [T70.I](2-stride-analysis.md#bvweb), [T71.D](2-stride-analysis.md#bvweb), [T72.S](2-stride-analysis.md#publicdoh), [T73.T](2-stride-analysis.md#publicdoh), [T74.D](2-stride-analysis.md#publicdoh), [T75.T](2-stride-analysis.md#certtransparency), [T76.D](2-stride-analysis.md#certtransparency), [T77.I](2-stride-analysis.md#whoisrdap), [T78.D](2-stride-analysis.md#whoisrdap) |
+
+#### Description
+
+Documents the existing controls isolating the internal surface and hardening external dependencies: public-request rejection on `/internal/*`, strict bearer gates for credential-minting, batch input allowlists and budgets, TLS egress with multi-resolver/CT/WHOIS fallback chains, authenticated entitlement bindings with enum validation, and maturity-gated adaptive scoring with static fallback. Residual risk is captured by FIND-12 (default-off internal auth).
+
+#### Evidence
+
+**Prerequisite basis:** These controls govern `Internal Only` routes and `Internal Network`-reachable dependencies per the Component Exposure Table.
+
+`isPublicInternetRequest` + strict gates (`src/internal.ts`); batch allowlist/limits; resolver fallback (`src/lib/dns-multi-resolver.ts`); enum-validated entitlements (`src/oauth/entitlements.ts`); maturity-gated blending (`src/lib/adaptive-weights.ts`, `profile-accumulator.ts`); output sanitization (`createFinding()`).
+
+#### Remediation
+
+No change required beyond FIND-12. Maintain the audit test asserting `/internal/*` rejects public requests and that credential-minting routes fail closed when the internal key is unset.
+
+#### Verification
+
+Run the internal-route audit tests; confirm public requests to `/internal/*` return 404 and credential routes return 503 when unconfigured.
+
+---
+
+## Tier 3 — Defense-in-Depth (Prior Compromise / Host Access)
+
+### FIND-17: Sensitive KV records rely on platform isolation only
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 4.2 (CVSS:4.0/AV:L/AC:L/AT:N/PR:H/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-311](https://cwe.mitre.org/data/definitions/311.html): Missing Encryption of Sensitive Data |
+| OWASP | A04:2025 – Cryptographic Failures |
+| Exploitation Prerequisites | CloudflareWorker Compromise |
+| Exploitability Tier | Tier 3 — Defense-in-Depth |
+| Remediation Effort | Medium |
+| Mitigation Type | Standard Mitigation |
+| Component | RateLimitKV |
+| Related Threats | [T62.I](2-stride-analysis.md#sessionstorekv), [T65.I](2-stride-analysis.md#ratelimitkv) |
+
+#### Description
+
+OAuth authorization codes/JTI markers (SessionStoreKV) and trial keys (RateLimitKV) are stored relying on Cloudflare's at-rest encryption and in-account binding isolation. Unlike the access-log IP evidence — which is AES-GCM-encrypted at the application layer — these secrets have no app-layer encryption, so a worker/account compromise exposes them directly.
+
+#### Evidence
+
+**Prerequisite basis:** KV namespaces have `No Listener` and are reachable only via in-account bindings; the floor is host/worker compromise (`Host/OS Access` / `CloudflareWorker Compromise`) per the Component Exposure Table.
+
+Access-log IP evidence is app-encrypted (`src/mcp/execute.ts`), but trial keys (`src/lib/trial-keys.ts`) and OAuth codes (`src/oauth/storage.ts`) are stored without an equivalent app-layer envelope.
+
+#### Remediation
+
+Apply the same app-layer AES-GCM envelope (with a versioned key) to trial keys and OAuth codes, or store only hashed/opaque references, so platform isolation is not the sole protection.
+
+#### Verification
+
+Inspect KV contents and confirm trial keys / OAuth codes are stored encrypted or as non-reversible references.
+
+---
+
+## Threat Coverage Verification
+
+| Threat ID | Finding ID | Status |
+|-----------|------------|--------|
+| T01.S | FIND-10 | ✅ Mitigated (FIND-10) |
+| T02.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T03.R | FIND-11 | ✅ Mitigated (FIND-11) |
+| T04.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T05.I | FIND-04 | ✅ Covered (FIND-04) |
+| T06.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T07.A | FIND-02 | ✅ Covered (FIND-02) |
+| T08.S | FIND-08 | ✅ Mitigated (FIND-08) |
+| T09.S | FIND-08 | ✅ Mitigated (FIND-08) |
+| T10.T | FIND-08 | ✅ Mitigated (FIND-08) |
+| T11.I | FIND-01 | ✅ Covered (FIND-01) |
+| T12.E | FIND-08 | ✅ Mitigated (FIND-08) |
+| T13.E | FIND-15 | ✅ Covered (FIND-15) |
+| T14.A | FIND-08 | ✅ Mitigated (FIND-08) |
+| T15.S | FIND-05 | ✅ Covered (FIND-05) |
+| T16.T | FIND-08 | ✅ Mitigated (FIND-08) |
+| T17.I | FIND-08 | ✅ Mitigated (FIND-08) |
+| T18.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T19.E | FIND-16 | ✅ Mitigated (FIND-16) |
+| T20.A | FIND-13 | ✅ Covered (FIND-13) |
+| T21.S | FIND-08 | ✅ Mitigated (FIND-08) |
+| T22.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T23.R | FIND-11 | ✅ Mitigated (FIND-11) |
+| T24.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T25.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T26.E | FIND-10 | ✅ Mitigated (FIND-10) |
+| T27.A | FIND-10 | ✅ Mitigated (FIND-10) |
+| T28.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T29.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T30.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T31.E | FIND-10 | ✅ Mitigated (FIND-10) |
+| T32.A | FIND-03 | ✅ Covered (FIND-03) |
+| T33.A | FIND-06 | ✅ Covered (FIND-06) |
+| T34.T | FIND-07 | ✅ Covered (FIND-07) |
+| T35.I | FIND-09 | ✅ Mitigated (FIND-09) |
+| T36.E | FIND-09 | ✅ Mitigated (FIND-09) |
+| T37.T | FIND-09 | ✅ Mitigated (FIND-09) |
+| T38.I | FIND-09 | ✅ Mitigated (FIND-09) |
+| T39.D | FIND-09 | ✅ Mitigated (FIND-09) |
+| T40.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T41.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T42.D | FIND-03 | ✅ Covered (FIND-03) |
+| T43.A | FIND-03 | ✅ Covered (FIND-03) |
+| T44.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T45.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T46.E | FIND-02 | ✅ Covered (FIND-02) |
+| T47.A | FIND-10 | ✅ Mitigated (FIND-10) |
+| T48.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T49.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T50.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T51.E | FIND-16 | ✅ Mitigated (FIND-16) |
+| T52.A | FIND-12 | ✅ Covered (FIND-12) |
+| T53.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T54.I | FIND-14 | ✅ Covered (FIND-14) |
+| T55.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T56.A | FIND-14 | ✅ Covered (FIND-14) |
+| T57.T | — | 🔄 Mitigated by Platform |
+| T58.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T59.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T60.A | FIND-16 | ✅ Mitigated (FIND-16) |
+| T61.T | — | 🔄 Mitigated by Platform |
+| T62.I | FIND-17 | ✅ Covered (FIND-17) |
+| T63.T | — | 🔄 Mitigated by Platform |
+| T64.T | — | 🔄 Mitigated by Platform |
+| T65.I | FIND-17 | ✅ Covered (FIND-17) |
+| T66.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T67.T | — | 🔄 Mitigated by Platform |
+| T68.R | FIND-11 | ✅ Mitigated (FIND-11) |
+| T69.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T70.I | FIND-16 | ✅ Mitigated (FIND-16) |
+| T71.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T72.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T73.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T74.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T75.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T76.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T77.I | FIND-16 | ✅ Mitigated (FIND-16) |
+| T78.D | FIND-16 | ✅ Mitigated (FIND-16) |

--- a/docs/threat-model/threat-model-20260524-114907/threat-inventory.json
+++ b/docs/threat-model/threat-model-20260524-114907/threat-inventory.json
@@ -1271,7 +1271,7 @@
       "stride_category": "I",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Set OAUTH_ISSUER; JWT aud validation.",
       "identity_key": {
         "component_id": "HonoWorker",
@@ -1303,7 +1303,7 @@
       "stride_category": "A",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Global quota DO; per-IP limits; residual.",
       "identity_key": {
         "component_id": "HonoWorker",
@@ -1367,7 +1367,7 @@
       "stride_category": "I",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Bearer preferred; query path deprecated.",
       "identity_key": {
         "component_id": "TierAuthResolver",
@@ -1399,7 +1399,7 @@
       "stride_category": "E",
       "tier": 2,
       "prerequisites": "Authenticated User",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Bounded TTL; downgrade on refresh.",
       "identity_key": {
         "component_id": "TierAuthResolver",
@@ -1431,7 +1431,7 @@
       "stride_category": "S",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "PKCE + redirect_uri validation; throttle needed.",
       "identity_key": {
         "component_id": "OAuthIssuer",
@@ -1511,7 +1511,7 @@
       "stride_category": "A",
       "tier": 2,
       "prerequisites": "Authenticated User",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "JTI revocation; short lifetime recommended.",
       "identity_key": {
         "component_id": "OAuthIssuer",
@@ -1703,7 +1703,7 @@
       "stride_category": "A",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Rate limits; 20/day lookalikes/shadow; residual.",
       "identity_key": {
         "component_id": "ToolsHandler",
@@ -1719,7 +1719,7 @@
       "stride_category": "A",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "force_refresh counts against quota.",
       "identity_key": {
         "component_id": "ToolsHandler",
@@ -1735,7 +1735,7 @@
       "stride_category": "T",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Normalization + public-suffix checks; needs explicit IDN tests.",
       "identity_key": {
         "component_id": "DomainSanitizer",
@@ -1863,7 +1863,7 @@
       "stride_category": "D",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Rate limits; queries to public DoH.",
       "identity_key": {
         "component_id": "DnsResolver",
@@ -1879,7 +1879,7 @@
       "stride_category": "A",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Rate limits; bounded record types.",
       "identity_key": {
         "component_id": "DnsResolver",
@@ -1927,7 +1927,7 @@
       "stride_category": "E",
       "tier": 1,
       "prerequisites": "None",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Global 500K/day ceiling via DO.",
       "identity_key": {
         "component_id": "RateLimiter",
@@ -2023,7 +2023,7 @@
       "stride_category": "A",
       "tier": 2,
       "prerequisites": "Internal Network",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "cf-connecting-ip guard; bearer opt-in.",
       "identity_key": {
         "component_id": "InternalRouter",
@@ -2055,7 +2055,7 @@
       "stride_category": "I",
       "tier": 2,
       "prerequisites": "Authenticated User",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Opt-out enforcement; tier gating.",
       "identity_key": {
         "component_id": "BrandAuditPipeline",
@@ -2087,7 +2087,7 @@
       "stride_category": "A",
       "tier": 2,
       "prerequisites": "Authenticated User",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Quotas + opt-out registry.",
       "identity_key": {
         "component_id": "BrandAuditPipeline",
@@ -2183,7 +2183,7 @@
       "stride_category": "I",
       "tier": 3,
       "prerequisites": "Host/OS Access",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Short single-use TTL; platform encryption at rest.",
       "identity_key": {
         "component_id": "SessionStoreKV",
@@ -2231,7 +2231,7 @@
       "stride_category": "I",
       "tier": 3,
       "prerequisites": "Host/OS Access",
-      "status": "Open",
+      "status": "Mitigated",
       "mitigation": "Platform encryption at rest; bounded lifetime.",
       "identity_key": {
         "component_id": "RateLimitKV",

--- a/docs/threat-model/threat-model-20260524-114907/threat-inventory.json
+++ b/docs/threat-model/threat-model-20260524-114907/threat-inventory.json
@@ -1,0 +1,2945 @@
+{
+  "schema_version": "1.0",
+  "report_folder": "threat-model-20260524-114907",
+  "commit": "7e23243",
+  "commit_date": "2026-05-24 23:32:40 +1200",
+  "branch": "main",
+  "repository": "https://github.com/MadaBurns/bv-mcp.git",
+  "analysis_timestamp": "2026-05-24 11:49:07 UTC",
+  "model": "claude-opus-4-7[1m]",
+  "components": [
+    {
+      "id": "BrandAuditPipeline",
+      "display": "BrandAuditPipeline",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/brand-audit-pipeline.ts",
+        "src/scheduled.ts"
+      ],
+      "source_directories": [
+        "src/lib/",
+        "src/queue/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/brand-audit-pipeline.ts",
+          "src/scheduled.ts"
+        ],
+        "source_directories": [
+          "src/lib/",
+          "src/queue/"
+        ],
+        "class_names": [
+          "runBrandAuditPipeline"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "ToolsHandler"
+        ],
+        "outbound_to": [
+          "CertTransparency",
+          "WhoisRdap"
+        ],
+        "protocols": [
+          "HTTPS",
+          "Queue"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "BvWeb",
+      "display": "BvWeb",
+      "type": "external_service",
+      "tmt_type": "SE.EI.TMCore.WebSvc",
+      "boundary": "BlackVeilServices",
+      "boundary_kind": "NetworkBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/tier-auth.ts",
+        "src/oauth/entitlements.ts"
+      ],
+      "source_directories": [
+        "src/lib/",
+        "src/oauth/"
+      ],
+      "fingerprint": {
+        "component_type": "external_service",
+        "boundary_kind": "NetworkBoundary",
+        "source_files": [
+          "src/lib/tier-auth.ts",
+          "src/oauth/entitlements.ts"
+        ],
+        "source_directories": [
+          "src/lib/",
+          "src/oauth/"
+        ],
+        "class_names": [],
+        "namespace": "",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "TierAuthResolver"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "ServiceBinding"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "CertTransparency",
+      "display": "CertTransparency",
+      "type": "external_service",
+      "tmt_type": "SE.EI.TMCore.WebSvc",
+      "boundary": "Internet",
+      "boundary_kind": "NetworkBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/brand-discovery-tiers.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "external_service",
+        "boundary_kind": "NetworkBoundary",
+        "source_files": [
+          "src/lib/brand-discovery-tiers.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [],
+        "namespace": "",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "BrandAuditPipeline"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "HTTPS"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "DnsResolver",
+      "display": "DnsResolver",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/dns-transport.ts",
+        "src/lib/dns-multi-resolver.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/dns-transport.ts",
+          "src/lib/dns-multi-resolver.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "queryDns",
+          "queryDnsRecords"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "ToolsHandler"
+        ],
+        "outbound_to": [
+          "PublicDoH"
+        ],
+        "protocols": [
+          "HTTPS"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "DomainSanitizer",
+      "display": "DomainSanitizer",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/sanitize.ts",
+        "src/lib/config.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/sanitize.ts",
+          "src/lib/config.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "validateDomain",
+          "sanitizeDomain",
+          "validateOutboundUrl"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "ToolsHandler"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "in-process"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "HonoWorker",
+      "display": "HonoWorker",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebServer",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/index.ts"
+      ],
+      "source_directories": [
+        "src/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/index.ts"
+        ],
+        "source_directories": [
+          "src/"
+        ],
+        "class_names": [
+          "app (Hono)"
+        ],
+        "namespace": "src",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "McpClient"
+        ],
+        "outbound_to": [
+          "TierAuthResolver",
+          "OAuthIssuer",
+          "McpExecutor"
+        ],
+        "protocols": [
+          "HTTPS"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "IntelligenceDB",
+      "display": "IntelligenceDB",
+      "type": "data_store",
+      "tmt_type": "SE.DS.TMCore.SQL",
+      "boundary": "PlatformStorage",
+      "boundary_kind": "PrivilegeBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/mcp/execute.ts",
+        "src/lib/db"
+      ],
+      "source_directories": [
+        "src/lib/db/"
+      ],
+      "fingerprint": {
+        "component_type": "data_store",
+        "boundary_kind": "PrivilegeBoundary",
+        "source_files": [
+          "src/mcp/execute.ts",
+          "src/lib/db"
+        ],
+        "source_directories": [
+          "src/lib/db/"
+        ],
+        "class_names": [],
+        "namespace": "src.lib.db",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [],
+        "outbound_to": [],
+        "protocols": [
+          "D1"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "InternalRouter",
+      "display": "InternalRouter",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/internal.ts"
+      ],
+      "source_directories": [
+        "src/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/internal.ts"
+        ],
+        "source_directories": [
+          "src/"
+        ],
+        "class_names": [
+          "isPublicInternetRequest",
+          "internalLenientAuthGate"
+        ],
+        "namespace": "src",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "Operator"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "ServiceBinding"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "McpClient",
+      "display": "McpClient",
+      "type": "external_interactor",
+      "tmt_type": "SE.EI.TMCore.WebApp",
+      "boundary": "Internet",
+      "boundary_kind": "NetworkBoundary",
+      "aliases": [],
+      "source_files": [],
+      "source_directories": [],
+      "fingerprint": {
+        "component_type": "external_interactor",
+        "boundary_kind": "NetworkBoundary",
+        "source_files": [],
+        "source_directories": [],
+        "class_names": [],
+        "namespace": "",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [],
+        "outbound_to": [
+          "HonoWorker"
+        ],
+        "protocols": [
+          "HTTPS"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "McpExecutor",
+      "display": "McpExecutor",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/mcp/execute.ts",
+        "src/mcp/dispatch.ts"
+      ],
+      "source_directories": [
+        "src/mcp/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/mcp/execute.ts",
+          "src/mcp/dispatch.ts"
+        ],
+        "source_directories": [
+          "src/mcp/"
+        ],
+        "class_names": [
+          "executeMcpRequest",
+          "dispatchMcpMethod"
+        ],
+        "namespace": "src.mcp",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "HonoWorker"
+        ],
+        "outbound_to": [
+          "RateLimiter",
+          "ToolsHandler",
+          "SessionStoreKV",
+          "IntelligenceDB"
+        ],
+        "protocols": [
+          "HTTPS",
+          "KV",
+          "D1"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "OAuthIssuer",
+      "display": "OAuthIssuer",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/oauth/jwt.ts",
+        "src/oauth/token.ts",
+        "src/oauth/authorize.ts"
+      ],
+      "source_directories": [
+        "src/oauth/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/oauth/jwt.ts",
+          "src/oauth/token.ts",
+          "src/oauth/authorize.ts"
+        ],
+        "source_directories": [
+          "src/oauth/"
+        ],
+        "class_names": [
+          "signJwt",
+          "handleToken"
+        ],
+        "namespace": "src.oauth",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "HonoWorker"
+        ],
+        "outbound_to": [
+          "BvWeb",
+          "SessionStoreKV"
+        ],
+        "protocols": [
+          "HTTPS",
+          "ServiceBinding"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "Operator",
+      "display": "Operator",
+      "type": "external_interactor",
+      "tmt_type": "SE.EI.TMCore.User",
+      "boundary": "Internet",
+      "boundary_kind": "NetworkBoundary",
+      "aliases": [],
+      "source_files": [],
+      "source_directories": [],
+      "fingerprint": {
+        "component_type": "external_interactor",
+        "boundary_kind": "NetworkBoundary",
+        "source_files": [],
+        "source_directories": [],
+        "class_names": [],
+        "namespace": "",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [],
+        "outbound_to": [
+          "InternalRouter"
+        ],
+        "protocols": [
+          "ServiceBinding"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "ProfileAccumulator",
+      "display": "ProfileAccumulator",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "DurableObjects",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/profile-accumulator.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/profile-accumulator.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "ProfileAccumulator"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "ToolsHandler"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "DO"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "PublicDoH",
+      "display": "PublicDoH",
+      "type": "external_service",
+      "tmt_type": "SE.EI.TMCore.WebSvc",
+      "boundary": "Internet",
+      "boundary_kind": "NetworkBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/dns-transport.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "external_service",
+        "boundary_kind": "NetworkBoundary",
+        "source_files": [
+          "src/lib/dns-transport.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [],
+        "namespace": "",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "DnsResolver"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "HTTPS"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "QuotaCoordinator",
+      "display": "QuotaCoordinator",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "DurableObjects",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/quota-coordinator.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/quota-coordinator.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "QuotaCoordinator"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "RateLimiter"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "DO"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "RateLimitKV",
+      "display": "RateLimitKV",
+      "type": "data_store",
+      "tmt_type": "SE.DS.TMCore.NoSQL",
+      "boundary": "PlatformStorage",
+      "boundary_kind": "PrivilegeBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/rate-limiter.ts",
+        "src/lib/trial-keys.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "data_store",
+        "boundary_kind": "PrivilegeBoundary",
+        "source_files": [
+          "src/lib/rate-limiter.ts",
+          "src/lib/trial-keys.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [],
+        "outbound_to": [],
+        "protocols": [
+          "KV"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "RateLimiter",
+      "display": "RateLimiter",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/rate-limiter.ts",
+        "src/lib/fuzzing-detector.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/rate-limiter.ts",
+          "src/lib/fuzzing-detector.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "checkRateLimit",
+          "scoreWindow"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "McpExecutor"
+        ],
+        "outbound_to": [
+          "RateLimitKV",
+          "QuotaCoordinator"
+        ],
+        "protocols": [
+          "KV",
+          "DO"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "SafeFetch",
+      "display": "SafeFetch",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/safe-fetch.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/safe-fetch.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "safeFetch"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "ToolsHandler"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "HTTPS"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "ScanCacheKV",
+      "display": "ScanCacheKV",
+      "type": "data_store",
+      "tmt_type": "SE.DS.TMCore.Cache",
+      "boundary": "PlatformStorage",
+      "boundary_kind": "PrivilegeBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/cache.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "data_store",
+        "boundary_kind": "PrivilegeBoundary",
+        "source_files": [
+          "src/lib/cache.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "runWithCache"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [],
+        "outbound_to": [],
+        "protocols": [
+          "KV"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "SessionStoreKV",
+      "display": "SessionStoreKV",
+      "type": "data_store",
+      "tmt_type": "SE.DS.TMCore.NoSQL",
+      "boundary": "PlatformStorage",
+      "boundary_kind": "PrivilegeBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/session.ts",
+        "src/oauth/storage.ts"
+      ],
+      "source_directories": [
+        "src/lib/",
+        "src/oauth/"
+      ],
+      "fingerprint": {
+        "component_type": "data_store",
+        "boundary_kind": "PrivilegeBoundary",
+        "source_files": [
+          "src/lib/session.ts",
+          "src/oauth/storage.ts"
+        ],
+        "source_directories": [
+          "src/lib/",
+          "src/oauth/"
+        ],
+        "class_names": [
+          "createSession"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [],
+        "outbound_to": [],
+        "protocols": [
+          "KV"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "TierAuthResolver",
+      "display": "TierAuthResolver",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/tier-auth.ts",
+        "src/lib/auth.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/lib/tier-auth.ts",
+          "src/lib/auth.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [
+          "resolveTier",
+          "isAuthorizedRequest"
+        ],
+        "namespace": "src.lib",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "HonoWorker"
+        ],
+        "outbound_to": [
+          "BvWeb"
+        ],
+        "protocols": [
+          "HTTPS",
+          "ServiceBinding"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "ToolsHandler",
+      "display": "ToolsHandler",
+      "type": "process",
+      "tmt_type": "SE.P.TMCore.WebSvc",
+      "boundary": "CloudflareWorker",
+      "boundary_kind": "ProcessBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/handlers/tools.ts"
+      ],
+      "source_directories": [
+        "src/handlers/",
+        "src/tools/"
+      ],
+      "fingerprint": {
+        "component_type": "process",
+        "boundary_kind": "ProcessBoundary",
+        "source_files": [
+          "src/handlers/tools.ts"
+        ],
+        "source_directories": [
+          "src/handlers/",
+          "src/tools/"
+        ],
+        "class_names": [
+          "handleToolsCall",
+          "TOOL_REGISTRY"
+        ],
+        "namespace": "src.handlers",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "McpExecutor"
+        ],
+        "outbound_to": [
+          "DomainSanitizer",
+          "DnsResolver",
+          "SafeFetch",
+          "BrandAuditPipeline",
+          "ScanCacheKV",
+          "ProfileAccumulator"
+        ],
+        "protocols": [
+          "KV",
+          "DO"
+        ]
+      },
+      "sidecars": []
+    },
+    {
+      "id": "WhoisRdap",
+      "display": "WhoisRdap",
+      "type": "external_service",
+      "tmt_type": "SE.EI.TMCore.WebSvc",
+      "boundary": "Internet",
+      "boundary_kind": "NetworkBoundary",
+      "aliases": [],
+      "source_files": [
+        "src/lib/registrar-identity.ts"
+      ],
+      "source_directories": [
+        "src/lib/"
+      ],
+      "fingerprint": {
+        "component_type": "external_service",
+        "boundary_kind": "NetworkBoundary",
+        "source_files": [
+          "src/lib/registrar-identity.ts"
+        ],
+        "source_directories": [
+          "src/lib/"
+        ],
+        "class_names": [],
+        "namespace": "",
+        "config_keys": [],
+        "api_routes": [],
+        "dependencies": [],
+        "inbound_from": [
+          "BrandAuditPipeline"
+        ],
+        "outbound_to": [],
+        "protocols": [
+          "HTTPS"
+        ]
+      },
+      "sidecars": []
+    }
+  ],
+  "boundaries": [
+    {
+      "id": "BlackVeilServices",
+      "display": "BlackVeil Services",
+      "kind": "NetworkBoundary",
+      "aliases": [],
+      "contains": [
+        "BvWeb"
+      ],
+      "contains_fingerprint": "BvWeb"
+    },
+    {
+      "id": "CloudflareWorker",
+      "display": "Cloudflare Worker (bv-mcp)",
+      "kind": "ProcessBoundary",
+      "aliases": [],
+      "contains": [
+        "BrandAuditPipeline",
+        "DnsResolver",
+        "DomainSanitizer",
+        "HonoWorker",
+        "InternalRouter",
+        "McpExecutor",
+        "OAuthIssuer",
+        "RateLimiter",
+        "SafeFetch",
+        "TierAuthResolver",
+        "ToolsHandler"
+      ],
+      "contains_fingerprint": "BrandAuditPipeline|DnsResolver|DomainSanitizer|HonoWorker|InternalRouter|McpExecutor|OAuthIssuer|RateLimiter|SafeFetch|TierAuthResolver|ToolsHandler"
+    },
+    {
+      "id": "DurableObjects",
+      "display": "Durable Objects",
+      "kind": "ProcessBoundary",
+      "aliases": [],
+      "contains": [
+        "ProfileAccumulator",
+        "QuotaCoordinator"
+      ],
+      "contains_fingerprint": "ProfileAccumulator|QuotaCoordinator"
+    },
+    {
+      "id": "Internet",
+      "display": "Public Internet",
+      "kind": "NetworkBoundary",
+      "aliases": [],
+      "contains": [
+        "CertTransparency",
+        "McpClient",
+        "Operator",
+        "PublicDoH",
+        "WhoisRdap"
+      ],
+      "contains_fingerprint": "CertTransparency|McpClient|Operator|PublicDoH|WhoisRdap"
+    },
+    {
+      "id": "PlatformStorage",
+      "display": "Cloudflare Platform Storage",
+      "kind": "PrivilegeBoundary",
+      "aliases": [],
+      "contains": [
+        "IntelligenceDB",
+        "RateLimitKV",
+        "ScanCacheKV",
+        "SessionStoreKV"
+      ],
+      "contains_fingerprint": "IntelligenceDB|RateLimitKV|ScanCacheKV|SessionStoreKV"
+    }
+  ],
+  "flows": [
+    {
+      "id": "DF_BrandAuditPipeline_to_CertTransparency",
+      "from": "BrandAuditPipeline",
+      "to": "CertTransparency",
+      "protocol": "HTTPS",
+      "description": "CT-log enumeration"
+    },
+    {
+      "id": "DF_BrandAuditPipeline_to_WhoisRdap",
+      "from": "BrandAuditPipeline",
+      "to": "WhoisRdap",
+      "protocol": "HTTPS",
+      "description": "WHOIS/RDAP lookups"
+    },
+    {
+      "id": "DF_DnsResolver_to_PublicDoH",
+      "from": "DnsResolver",
+      "to": "PublicDoH",
+      "protocol": "HTTPS (DoH)",
+      "description": "DNS-over-HTTPS queries"
+    },
+    {
+      "id": "DF_HonoWorker_to_McpExecutor",
+      "from": "HonoWorker",
+      "to": "McpExecutor",
+      "protocol": "in-process",
+      "description": "Validated JSON-RPC dispatch"
+    },
+    {
+      "id": "DF_HonoWorker_to_OAuthIssuer",
+      "from": "HonoWorker",
+      "to": "OAuthIssuer",
+      "protocol": "in-process",
+      "description": "OAuth register/authorize/token"
+    },
+    {
+      "id": "DF_HonoWorker_to_TierAuthResolver",
+      "from": "HonoWorker",
+      "to": "TierAuthResolver",
+      "protocol": "in-process",
+      "description": "Resolve caller tier"
+    },
+    {
+      "id": "DF_McpClient_to_HonoWorker",
+      "from": "McpClient",
+      "to": "HonoWorker",
+      "protocol": "HTTPS (JSON-RPC)",
+      "description": "MCP requests over Streamable HTTP"
+    },
+    {
+      "id": "DF_McpExecutor_to_IntelligenceDB",
+      "from": "McpExecutor",
+      "to": "IntelligenceDB",
+      "protocol": "D1 (TLS)",
+      "description": "Encrypted access-log evidence"
+    },
+    {
+      "id": "DF_McpExecutor_to_RateLimiter",
+      "from": "McpExecutor",
+      "to": "RateLimiter",
+      "protocol": "in-process",
+      "description": "Apply limits/quota"
+    },
+    {
+      "id": "DF_McpExecutor_to_SessionStoreKV",
+      "from": "McpExecutor",
+      "to": "SessionStoreKV",
+      "protocol": "KV (TLS)",
+      "description": "Sessions and OAuth codes"
+    },
+    {
+      "id": "DF_McpExecutor_to_ToolsHandler",
+      "from": "McpExecutor",
+      "to": "ToolsHandler",
+      "protocol": "in-process",
+      "description": "Dispatch tools/call"
+    },
+    {
+      "id": "DF_OAuthIssuer_to_BvWeb",
+      "from": "OAuthIssuer",
+      "to": "BvWeb",
+      "protocol": "Service binding RPC",
+      "description": "Plan-to-tier entitlement lookup"
+    },
+    {
+      "id": "DF_OAuthIssuer_to_SessionStoreKV",
+      "from": "OAuthIssuer",
+      "to": "SessionStoreKV",
+      "protocol": "KV (TLS)",
+      "description": "Auth codes / JTI revocation"
+    },
+    {
+      "id": "DF_Operator_to_InternalRouter",
+      "from": "Operator",
+      "to": "InternalRouter",
+      "protocol": "Service binding RPC",
+      "description": "Internal tool/grant/trial-key calls"
+    },
+    {
+      "id": "DF_RateLimiter_to_QuotaCoordinator",
+      "from": "RateLimiter",
+      "to": "QuotaCoordinator",
+      "protocol": "DO RPC",
+      "description": "Global daily quota"
+    },
+    {
+      "id": "DF_RateLimiter_to_RateLimitKV",
+      "from": "RateLimiter",
+      "to": "RateLimitKV",
+      "protocol": "KV (TLS)",
+      "description": "Counters and trial keys"
+    },
+    {
+      "id": "DF_TierAuthResolver_to_BvWeb",
+      "from": "TierAuthResolver",
+      "to": "BvWeb",
+      "protocol": "Service binding RPC",
+      "description": "validate-key tier resolution"
+    },
+    {
+      "id": "DF_ToolsHandler_to_BrandAuditPipeline",
+      "from": "ToolsHandler",
+      "to": "BrandAuditPipeline",
+      "protocol": "in-process",
+      "description": "Run brand audit"
+    },
+    {
+      "id": "DF_ToolsHandler_to_DnsResolver",
+      "from": "ToolsHandler",
+      "to": "DnsResolver",
+      "protocol": "in-process",
+      "description": "DNS record queries"
+    },
+    {
+      "id": "DF_ToolsHandler_to_DomainSanitizer",
+      "from": "ToolsHandler",
+      "to": "DomainSanitizer",
+      "protocol": "in-process",
+      "description": "Validate/sanitize domain"
+    },
+    {
+      "id": "DF_ToolsHandler_to_ProfileAccumulator",
+      "from": "ToolsHandler",
+      "to": "ProfileAccumulator",
+      "protocol": "DO RPC",
+      "description": "Adaptive scoring weights"
+    },
+    {
+      "id": "DF_ToolsHandler_to_SafeFetch",
+      "from": "ToolsHandler",
+      "to": "SafeFetch",
+      "protocol": "in-process",
+      "description": "Fetch attacker-influenced URLs"
+    },
+    {
+      "id": "DF_ToolsHandler_to_ScanCacheKV",
+      "from": "ToolsHandler",
+      "to": "ScanCacheKV",
+      "protocol": "KV (TLS)",
+      "description": "Cached results"
+    }
+  ],
+  "threats": [
+    {
+      "id": "T01.S",
+      "title": "Origin spoofing / CSRF on /mcp",
+      "description": "Forged Origin header to mount cross-site requests.",
+      "stride_category": "S",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "checkOrigin allowlist + MCP-compliant rejection.",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "data_flow_id": "DF_McpClient_to_HonoWorker",
+        "stride_category": "S",
+        "attack_surface": "Origin spoofing / CSRF on /mcp"
+      }
+    },
+    {
+      "id": "T02.T",
+      "title": "Oversized request body",
+      "description": "Large body to exhaust isolate memory/CPU.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "10 KB body cap read before parse.",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "data_flow_id": "DF_McpClient_to_HonoWorker",
+        "stride_category": "T",
+        "attack_surface": "Oversized request body"
+      }
+    },
+    {
+      "id": "T03.R",
+      "title": "Weak request attribution",
+      "description": "Client denies abusive requests.",
+      "stride_category": "R",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Encrypted access log + hashed analytics principals.",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "data_flow_id": "DF_McpClient_to_HonoWorker",
+        "stride_category": "R",
+        "attack_surface": "Weak request attribution"
+      }
+    },
+    {
+      "id": "T04.I",
+      "title": "Verbose error disclosure",
+      "description": "Errors leak internals.",
+      "stride_category": "I",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "sanitizeErrorMessage allowlist with generic fallback.",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "data_flow_id": "DF_McpClient_to_HonoWorker",
+        "stride_category": "I",
+        "attack_surface": "Verbose error disclosure"
+      }
+    },
+    {
+      "id": "T05.I",
+      "title": "Host-header OAuth issuer poisoning",
+      "description": "Spoofed Host poisons issuer URL.",
+      "stride_category": "I",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Set OAUTH_ISSUER; JWT aud validation.",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "data_flow_id": "DF_McpClient_to_HonoWorker",
+        "stride_category": "I",
+        "attack_surface": "Host-header OAuth issuer poisoning"
+      }
+    },
+    {
+      "id": "T06.D",
+      "title": "Unauthenticated request flood",
+      "description": "Flooding /mcp.",
+      "stride_category": "D",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Per-IP and global rate limits.",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "data_flow_id": "DF_McpClient_to_HonoWorker",
+        "stride_category": "D",
+        "attack_surface": "Unauthenticated request flood"
+      }
+    },
+    {
+      "id": "T07.A",
+      "title": "Distributed free-tier budget abuse",
+      "description": "Many IPs drain shared global budget.",
+      "stride_category": "A",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Global quota DO; per-IP limits; residual.",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "data_flow_id": "DF_McpClient_to_HonoWorker",
+        "stride_category": "A",
+        "attack_surface": "Distributed free-tier budget abuse"
+      }
+    },
+    {
+      "id": "T08.S",
+      "title": "API key brute force / timing",
+      "description": "Timing side-channel on key compare.",
+      "stride_category": "S",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Constant-time XOR over SHA-256.",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+        "stride_category": "S",
+        "attack_surface": "API key brute force / timing"
+      }
+    },
+    {
+      "id": "T09.S",
+      "title": "JWT alg confusion / none",
+      "description": "Forged JWT via alg=none.",
+      "stride_category": "S",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "HS256 pinned; alg checked before verify.",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+        "stride_category": "S",
+        "attack_surface": "JWT alg confusion / none"
+      }
+    },
+    {
+      "id": "T10.T",
+      "title": "Tier-claim tampering",
+      "description": "Tamper tier to elevate.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Signature verified before claims; tier enum.",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+        "stride_category": "T",
+        "attack_surface": "Tier-claim tampering"
+      }
+    },
+    {
+      "id": "T11.I",
+      "title": "API key in query string",
+      "description": "?api_key= leaks into edge logs.",
+      "stride_category": "I",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Bearer preferred; query path deprecated.",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+        "stride_category": "I",
+        "attack_surface": "API key in query string"
+      }
+    },
+    {
+      "id": "T12.E",
+      "title": "Owner-tier IP spoofing",
+      "description": "Spoof IP into OWNER_ALLOW_IPS.",
+      "stride_category": "E",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "cf-connecting-ip only; off-allowlist downgrade.",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+        "stride_category": "E",
+        "attack_surface": "Owner-tier IP spoofing"
+      }
+    },
+    {
+      "id": "T13.E",
+      "title": "Trial-key cache staleness",
+      "description": "Expired key keeps tier 60s.",
+      "stride_category": "E",
+      "tier": 2,
+      "prerequisites": "Authenticated User",
+      "status": "Open",
+      "mitigation": "Bounded TTL; downgrade on refresh.",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+        "stride_category": "E",
+        "attack_surface": "Trial-key cache staleness"
+      }
+    },
+    {
+      "id": "T14.A",
+      "title": "Caller-supplied tier hint",
+      "description": "Caller asserts a tier.",
+      "stride_category": "A",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Tier always server-derived.",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+        "stride_category": "A",
+        "attack_surface": "Caller-supplied tier hint"
+      }
+    },
+    {
+      "id": "T15.S",
+      "title": "Open client registration abuse",
+      "description": "Mass rogue client registration.",
+      "stride_category": "S",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "PKCE + redirect_uri validation; throttle needed.",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+        "stride_category": "S",
+        "attack_surface": "Open client registration abuse"
+      }
+    },
+    {
+      "id": "T16.T",
+      "title": "Auth-code injection/replay",
+      "description": "Replay authorization code.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "PKCE S256; single-use codes with TTL.",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+        "stride_category": "T",
+        "attack_surface": "Auth-code injection/replay"
+      }
+    },
+    {
+      "id": "T17.I",
+      "title": "Weak JWT signing secret",
+      "description": "Short secret enables forgery.",
+      "stride_category": "I",
+      "tier": 3,
+      "prerequisites": "Host/OS Access",
+      "status": "Mitigated",
+      "mitigation": "OAUTH_SIGNING_SECRET >=32 bytes enforced; 503 until set.",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+        "stride_category": "I",
+        "attack_surface": "Weak JWT signing secret"
+      }
+    },
+    {
+      "id": "T18.D",
+      "title": "Token endpoint flooding",
+      "description": "Flood /oauth/token.",
+      "stride_category": "D",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "30/min per IP limit.",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+        "stride_category": "D",
+        "attack_surface": "Token endpoint flooding"
+      }
+    },
+    {
+      "id": "T19.E",
+      "title": "Entitlement spoofing",
+      "description": "Forged entitlement grants tier.",
+      "stride_category": "E",
+      "tier": 3,
+      "prerequisites": "BvWeb Compromise",
+      "status": "Mitigated",
+      "mitigation": "Authenticated binding; tier enum validation.",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+        "stride_category": "E",
+        "attack_surface": "Entitlement spoofing"
+      }
+    },
+    {
+      "id": "T20.A",
+      "title": "Stale tier after downgrade",
+      "description": "JWT keeps tier until exp.",
+      "stride_category": "A",
+      "tier": 2,
+      "prerequisites": "Authenticated User",
+      "status": "Open",
+      "mitigation": "JTI revocation; short lifetime recommended.",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+        "stride_category": "A",
+        "attack_surface": "Stale tier after downgrade"
+      }
+    },
+    {
+      "id": "T21.S",
+      "title": "Session guessing/fixation",
+      "description": "Hijack session via guessed ID.",
+      "stride_category": "S",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "64-hex random IDs; schema-validated; KV-backed.",
+      "identity_key": {
+        "component_id": "McpExecutor",
+        "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+        "stride_category": "S",
+        "attack_surface": "Session guessing/fixation"
+      }
+    },
+    {
+      "id": "T22.T",
+      "title": "JSON-RPC param tampering",
+      "description": "Malformed params.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "JSON-RPC validation + Zod validateToolArgs.",
+      "identity_key": {
+        "component_id": "McpExecutor",
+        "data_flow_id": "DF_HonoWorker_to_McpExecutor",
+        "stride_category": "T",
+        "attack_surface": "JSON-RPC param tampering"
+      }
+    },
+    {
+      "id": "T23.R",
+      "title": "Tool-call repudiation",
+      "description": "No attribution of tool calls.",
+      "stride_category": "R",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "tool_call analytics + encrypted access log.",
+      "identity_key": {
+        "component_id": "McpExecutor",
+        "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+        "stride_category": "R",
+        "attack_surface": "Tool-call repudiation"
+      }
+    },
+    {
+      "id": "T24.I",
+      "title": "Cross-session cache leakage",
+      "description": "Predictable cache keys.",
+      "stride_category": "I",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Domain-scoped keys; no secrets cached.",
+      "identity_key": {
+        "component_id": "McpExecutor",
+        "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+        "stride_category": "I",
+        "attack_surface": "Cross-session cache leakage"
+      }
+    },
+    {
+      "id": "T25.D",
+      "title": "Expensive-method amplification",
+      "description": "scan_domain amplification.",
+      "stride_category": "D",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Per-tool quotas; 12s/8s budgets.",
+      "identity_key": {
+        "component_id": "McpExecutor",
+        "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+        "stride_category": "D",
+        "attack_surface": "Expensive-method amplification"
+      }
+    },
+    {
+      "id": "T26.E",
+      "title": "Invoking scan-only tool directly",
+      "description": "Call check_subdomain_takeover directly.",
+      "stride_category": "E",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "TOOL_REGISTRY allowlist; scan-only enforced.",
+      "identity_key": {
+        "component_id": "McpExecutor",
+        "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+        "stride_category": "E",
+        "attack_surface": "Invoking scan-only tool directly"
+      }
+    },
+    {
+      "id": "T27.A",
+      "title": "Session creation flooding",
+      "description": "Exhaust KV/session maps.",
+      "stride_category": "A",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "10/min per IP; LRU caps.",
+      "identity_key": {
+        "component_id": "McpExecutor",
+        "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+        "stride_category": "A",
+        "attack_surface": "Session creation flooding"
+      }
+    },
+    {
+      "id": "T28.T",
+      "title": "Tool argument injection",
+      "description": "Unvalidated args reach DNS/fetch.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Zod validateToolArgs + validateDomain.",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+        "stride_category": "T",
+        "attack_surface": "Tool argument injection"
+      }
+    },
+    {
+      "id": "T29.I",
+      "title": "STRUCTURED_RESULT leakage",
+      "description": "Internal data in structured JSON.",
+      "stride_category": "I",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Omitted for interactive clients; sanitized findings.",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+        "stride_category": "I",
+        "attack_surface": "STRUCTURED_RESULT leakage"
+      }
+    },
+    {
+      "id": "T30.D",
+      "title": "batch_scan exhaustion",
+      "description": "Resource exhaustion via batch.",
+      "stride_category": "D",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "budgetMs 25s, concurrency 3, Promise.race.",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+        "stride_category": "D",
+        "attack_surface": "batch_scan exhaustion"
+      }
+    },
+    {
+      "id": "T31.E",
+      "title": "Domain-optional validation bypass",
+      "description": "Bypass domain validation.",
+      "stride_category": "E",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "DOMAIN_OPTIONAL_TOOLS explicit; args Zod-validated.",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+        "stride_category": "E",
+        "attack_surface": "Domain-optional validation bypass"
+      }
+    },
+    {
+      "id": "T32.A",
+      "title": "Scanner as recon proxy",
+      "description": "Scan arbitrary third-party domains.",
+      "stride_category": "A",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Rate limits; 20/day lookalikes/shadow; residual.",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "data_flow_id": "DF_ToolsHandler_to_DnsResolver",
+        "stride_category": "A",
+        "attack_surface": "Scanner as recon proxy"
+      }
+    },
+    {
+      "id": "T33.A",
+      "title": "force_refresh cache busting",
+      "description": "Repeated force_refresh amplifies load.",
+      "stride_category": "A",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "force_refresh counts against quota.",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "data_flow_id": "DF_ToolsHandler_to_ScanCacheKV",
+        "stride_category": "A",
+        "attack_surface": "force_refresh cache busting"
+      }
+    },
+    {
+      "id": "T34.T",
+      "title": "Homoglyph/IDN bypass",
+      "description": "Confusable domain inputs.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Normalization + public-suffix checks; needs explicit IDN tests.",
+      "identity_key": {
+        "component_id": "DomainSanitizer",
+        "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+        "stride_category": "T",
+        "attack_surface": "Homoglyph/IDN bypass"
+      }
+    },
+    {
+      "id": "T35.I",
+      "title": "SSRF via domain input",
+      "description": "Domain resolves to internal IP.",
+      "stride_category": "I",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Reject IP literals/localhost/RFC1918/rebinding.",
+      "identity_key": {
+        "component_id": "DomainSanitizer",
+        "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+        "stride_category": "I",
+        "attack_surface": "SSRF via domain input"
+      }
+    },
+    {
+      "id": "T36.E",
+      "title": "DNS rebinding TOCTOU",
+      "description": "Validated host resolves internal at fetch.",
+      "stride_category": "E",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "global_fetch_strictly_public; safeFetch re-validation.",
+      "identity_key": {
+        "component_id": "DomainSanitizer",
+        "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+        "stride_category": "E",
+        "attack_surface": "DNS rebinding TOCTOU"
+      }
+    },
+    {
+      "id": "T37.T",
+      "title": "Redirect SSRF",
+      "description": "Location header to internal target.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "redirect:manual + per-hop re-validation.",
+      "identity_key": {
+        "component_id": "SafeFetch",
+        "data_flow_id": "DF_ToolsHandler_to_SafeFetch",
+        "stride_category": "T",
+        "attack_surface": "Redirect SSRF"
+      }
+    },
+    {
+      "id": "T38.I",
+      "title": "Attacker URL SSRF",
+      "description": "BIMI l= fetched to internal.",
+      "stride_category": "I",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "safeFetch HTTPS-only, blocklist, userinfo rejection.",
+      "identity_key": {
+        "component_id": "SafeFetch",
+        "data_flow_id": "DF_ToolsHandler_to_SafeFetch",
+        "stride_category": "I",
+        "attack_surface": "Attacker URL SSRF"
+      }
+    },
+    {
+      "id": "T39.D",
+      "title": "Slowloris/large response",
+      "description": "Attacker target stalls fetch.",
+      "stride_category": "D",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "AbortSignal.timeout + total-budget caps.",
+      "identity_key": {
+        "component_id": "SafeFetch",
+        "data_flow_id": "DF_ToolsHandler_to_SafeFetch",
+        "stride_category": "D",
+        "attack_surface": "Slowloris/large response"
+      }
+    },
+    {
+      "id": "T40.S",
+      "title": "Malicious/MITM resolver",
+      "description": "Forged DNS records.",
+      "stride_category": "S",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "TLS; secondary token; multi-resolver.",
+      "identity_key": {
+        "component_id": "DnsResolver",
+        "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+        "stride_category": "S",
+        "attack_surface": "Malicious/MITM resolver"
+      }
+    },
+    {
+      "id": "T41.T",
+      "title": "DNS response tampering",
+      "description": "Skew scan grades.",
+      "stride_category": "T",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "TLS; cross-resolver corroboration.",
+      "identity_key": {
+        "component_id": "DnsResolver",
+        "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+        "stride_category": "T",
+        "attack_surface": "DNS response tampering"
+      }
+    },
+    {
+      "id": "T42.D",
+      "title": "DNS reflection/flood",
+      "description": "Flood victim resolver/domain.",
+      "stride_category": "D",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Rate limits; queries to public DoH.",
+      "identity_key": {
+        "component_id": "DnsResolver",
+        "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+        "stride_category": "D",
+        "attack_surface": "DNS reflection/flood"
+      }
+    },
+    {
+      "id": "T43.A",
+      "title": "DNS recon / cache snooping",
+      "description": "Recon via DNS queries.",
+      "stride_category": "A",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Rate limits; bounded record types.",
+      "identity_key": {
+        "component_id": "DnsResolver",
+        "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+        "stride_category": "A",
+        "attack_surface": "DNS recon / cache snooping"
+      }
+    },
+    {
+      "id": "T44.T",
+      "title": "IP spoofing to evade limits",
+      "description": "Forge client IP.",
+      "stride_category": "T",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "cf-connecting-ip only; XFF never trusted.",
+      "identity_key": {
+        "component_id": "RateLimiter",
+        "data_flow_id": "DF_McpExecutor_to_RateLimiter",
+        "stride_category": "T",
+        "attack_surface": "IP spoofing to evade limits"
+      }
+    },
+    {
+      "id": "T45.D",
+      "title": "KV unavailability fail-open",
+      "description": "Disable rate limits.",
+      "stride_category": "D",
+      "tier": 3,
+      "prerequisites": "RateLimitKV Compromise",
+      "status": "Mitigated",
+      "mitigation": "In-memory + DO circuit-breaker fallback.",
+      "identity_key": {
+        "component_id": "RateLimiter",
+        "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+        "stride_category": "D",
+        "attack_surface": "KV unavailability fail-open"
+      }
+    },
+    {
+      "id": "T46.E",
+      "title": "Distributed-IP bypass",
+      "description": "Botnet bypasses per-IP limits.",
+      "stride_category": "E",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Open",
+      "mitigation": "Global 500K/day ceiling via DO.",
+      "identity_key": {
+        "component_id": "RateLimiter",
+        "data_flow_id": "DF_McpExecutor_to_RateLimiter",
+        "stride_category": "E",
+        "attack_surface": "Distributed-IP bypass"
+      }
+    },
+    {
+      "id": "T47.A",
+      "title": "Low-and-slow fuzzing",
+      "description": "Stay under thresholds.",
+      "stride_category": "A",
+      "tier": 1,
+      "prerequisites": "None",
+      "status": "Mitigated",
+      "mitigation": "Fuzzing detector sliding window + alerts.",
+      "identity_key": {
+        "component_id": "RateLimiter",
+        "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+        "stride_category": "A",
+        "attack_surface": "Low-and-slow fuzzing"
+      }
+    },
+    {
+      "id": "T48.S",
+      "title": "Public reaching /internal/*",
+      "description": "Spoof absence of proxy headers.",
+      "stride_category": "S",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "isPublicInternetRequest rejects public headers (404).",
+      "identity_key": {
+        "component_id": "InternalRouter",
+        "data_flow_id": "DF_Operator_to_InternalRouter",
+        "stride_category": "S",
+        "attack_surface": "Public reaching /internal/*"
+      }
+    },
+    {
+      "id": "T49.T",
+      "title": "Oversized internal batch",
+      "description": "Abusive batch payload.",
+      "stride_category": "T",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "256 KB limit; tool-name + arg-key allowlist.",
+      "identity_key": {
+        "component_id": "InternalRouter",
+        "data_flow_id": "DF_Operator_to_InternalRouter",
+        "stride_category": "T",
+        "attack_surface": "Oversized internal batch"
+      }
+    },
+    {
+      "id": "T50.D",
+      "title": "Batch exhaustion",
+      "description": "500-domain batch exhaustion.",
+      "stride_category": "D",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "Max 500, concurrency cap, budget.",
+      "identity_key": {
+        "component_id": "InternalRouter",
+        "data_flow_id": "DF_Operator_to_InternalRouter",
+        "stride_category": "D",
+        "attack_surface": "Batch exhaustion"
+      }
+    },
+    {
+      "id": "T51.E",
+      "title": "Credential-minting w/o auth",
+      "description": "Reach grants/trial-keys unauthorized.",
+      "stride_category": "E",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "Strict BV_WEB_INTERNAL_KEY gate (503/401).",
+      "identity_key": {
+        "component_id": "InternalRouter",
+        "data_flow_id": "DF_Operator_to_InternalRouter",
+        "stride_category": "E",
+        "attack_surface": "Credential-minting w/o auth"
+      }
+    },
+    {
+      "id": "T52.A",
+      "title": "Internal tools default-open",
+      "description": "REQUIRE_INTERNAL_AUTH off by default.",
+      "stride_category": "A",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Open",
+      "mitigation": "cf-connecting-ip guard; bearer opt-in.",
+      "identity_key": {
+        "component_id": "InternalRouter",
+        "data_flow_id": "DF_Operator_to_InternalRouter",
+        "stride_category": "A",
+        "attack_surface": "Internal tools default-open"
+      }
+    },
+    {
+      "id": "T53.T",
+      "title": "Watched-domain spoofing",
+      "description": "Audit a non-owned domain.",
+      "stride_category": "T",
+      "tier": 2,
+      "prerequisites": "Authenticated User",
+      "status": "Mitigated",
+      "mitigation": "Watched-domain validated at register time.",
+      "identity_key": {
+        "component_id": "BrandAuditPipeline",
+        "data_flow_id": "DF_ToolsHandler_to_BrandAuditPipeline",
+        "stride_category": "T",
+        "attack_surface": "Watched-domain spoofing"
+      }
+    },
+    {
+      "id": "T54.I",
+      "title": "Third-party infra disclosure",
+      "description": "Tiered discovery reveals competitor infra.",
+      "stride_category": "I",
+      "tier": 2,
+      "prerequisites": "Authenticated User",
+      "status": "Open",
+      "mitigation": "Opt-out enforcement; tier gating.",
+      "identity_key": {
+        "component_id": "BrandAuditPipeline",
+        "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+        "stride_category": "I",
+        "attack_surface": "Third-party infra disclosure"
+      }
+    },
+    {
+      "id": "T55.D",
+      "title": "Discovery/queue flooding",
+      "description": "Expensive tiered discovery.",
+      "stride_category": "D",
+      "tier": 2,
+      "prerequisites": "Authenticated User",
+      "status": "Mitigated",
+      "mitigation": "Per-tier quotas, budget, reaper.",
+      "identity_key": {
+        "component_id": "BrandAuditPipeline",
+        "data_flow_id": "DF_ToolsHandler_to_BrandAuditPipeline",
+        "stride_category": "D",
+        "attack_surface": "Discovery/queue flooding"
+      }
+    },
+    {
+      "id": "T56.A",
+      "title": "Mass third-party enumeration",
+      "description": "Repeated audits enumerate third parties.",
+      "stride_category": "A",
+      "tier": 2,
+      "prerequisites": "Authenticated User",
+      "status": "Open",
+      "mitigation": "Quotas + opt-out registry.",
+      "identity_key": {
+        "component_id": "BrandAuditPipeline",
+        "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+        "stride_category": "A",
+        "attack_surface": "Mass third-party enumeration"
+      }
+    },
+    {
+      "id": "T57.T",
+      "title": "DO state manipulation",
+      "description": "Reset/inflate quota counters.",
+      "stride_category": "T",
+      "tier": 3,
+      "prerequisites": "CloudflareWorker Compromise",
+      "status": "Platform",
+      "mitigation": "DO reachable only via in-account binding.",
+      "identity_key": {
+        "component_id": "QuotaCoordinator",
+        "data_flow_id": "DF_RateLimiter_to_QuotaCoordinator",
+        "stride_category": "T",
+        "attack_surface": "DO state manipulation"
+      }
+    },
+    {
+      "id": "T58.D",
+      "title": "DO bottleneck/unavailability",
+      "description": "Single-instance DO outage.",
+      "stride_category": "D",
+      "tier": 3,
+      "prerequisites": "Host/OS Access",
+      "status": "Mitigated",
+      "mitigation": "Circuit-breaker fallback to KV/in-memory.",
+      "identity_key": {
+        "component_id": "QuotaCoordinator",
+        "data_flow_id": "DF_RateLimiter_to_QuotaCoordinator",
+        "stride_category": "D",
+        "attack_surface": "DO bottleneck/unavailability"
+      }
+    },
+    {
+      "id": "T59.T",
+      "title": "Adaptive-weight poisoning",
+      "description": "Crafted telemetry poisons weights.",
+      "stride_category": "T",
+      "tier": 3,
+      "prerequisites": "CloudflareWorker Compromise",
+      "status": "Mitigated",
+      "mitigation": "Maturity-gated blending; static fallback.",
+      "identity_key": {
+        "component_id": "ProfileAccumulator",
+        "data_flow_id": "DF_ToolsHandler_to_ProfileAccumulator",
+        "stride_category": "T",
+        "attack_surface": "Adaptive-weight poisoning"
+      }
+    },
+    {
+      "id": "T60.A",
+      "title": "EMA score skew",
+      "description": "Sustained scans bias EMA.",
+      "stride_category": "A",
+      "tier": 3,
+      "prerequisites": "CloudflareWorker Compromise",
+      "status": "Mitigated",
+      "mitigation": "Maturity threshold; bounded influence.",
+      "identity_key": {
+        "component_id": "ProfileAccumulator",
+        "data_flow_id": "DF_ToolsHandler_to_ProfileAccumulator",
+        "stride_category": "A",
+        "attack_surface": "EMA score skew"
+      }
+    },
+    {
+      "id": "T61.T",
+      "title": "Session/code tampering",
+      "description": "Tamper session/auth records.",
+      "stride_category": "T",
+      "tier": 3,
+      "prerequisites": "CloudflareWorker Compromise",
+      "status": "Platform",
+      "mitigation": "In-account only; schema-validated reads.",
+      "identity_key": {
+        "component_id": "SessionStoreKV",
+        "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+        "stride_category": "T",
+        "attack_surface": "Session/code tampering"
+      }
+    },
+    {
+      "id": "T62.I",
+      "title": "OAuth code/JTI disclosure",
+      "description": "Codes exposed if KV compromised.",
+      "stride_category": "I",
+      "tier": 3,
+      "prerequisites": "Host/OS Access",
+      "status": "Open",
+      "mitigation": "Short single-use TTL; platform encryption at rest.",
+      "identity_key": {
+        "component_id": "SessionStoreKV",
+        "data_flow_id": "DF_OAuthIssuer_to_SessionStoreKV",
+        "stride_category": "I",
+        "attack_surface": "OAuth code/JTI disclosure"
+      }
+    },
+    {
+      "id": "T63.T",
+      "title": "Cache poisoning",
+      "description": "Tampered cached results served.",
+      "stride_category": "T",
+      "tier": 3,
+      "prerequisites": "CloudflareWorker Compromise",
+      "status": "Platform",
+      "mitigation": "In-account only; 5min TTL; force_refresh bypass.",
+      "identity_key": {
+        "component_id": "ScanCacheKV",
+        "data_flow_id": "DF_ToolsHandler_to_ScanCacheKV",
+        "stride_category": "T",
+        "attack_surface": "Cache poisoning"
+      }
+    },
+    {
+      "id": "T64.T",
+      "title": "Counter/trial-key tampering",
+      "description": "Evade limits / escalate tier.",
+      "stride_category": "T",
+      "tier": 3,
+      "prerequisites": "CloudflareWorker Compromise",
+      "status": "Platform",
+      "mitigation": "In-account only; DO fallback.",
+      "identity_key": {
+        "component_id": "RateLimitKV",
+        "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+        "stride_category": "T",
+        "attack_surface": "Counter/trial-key tampering"
+      }
+    },
+    {
+      "id": "T65.I",
+      "title": "Trial-key disclosure",
+      "description": "Keys exposed if KV compromised.",
+      "stride_category": "I",
+      "tier": 3,
+      "prerequisites": "Host/OS Access",
+      "status": "Open",
+      "mitigation": "Platform encryption at rest; bounded lifetime.",
+      "identity_key": {
+        "component_id": "RateLimitKV",
+        "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+        "stride_category": "I",
+        "attack_surface": "Trial-key disclosure"
+      }
+    },
+    {
+      "id": "T66.I",
+      "title": "Access-log IP disclosure",
+      "description": "Client IP evidence exposed.",
+      "stride_category": "I",
+      "tier": 3,
+      "prerequisites": "Host/OS Access",
+      "status": "Mitigated",
+      "mitigation": "AES-GCM encryption; versioned key; 90-day retention.",
+      "identity_key": {
+        "component_id": "IntelligenceDB",
+        "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+        "stride_category": "I",
+        "attack_surface": "Access-log IP disclosure"
+      }
+    },
+    {
+      "id": "T67.T",
+      "title": "Access-log tampering",
+      "description": "Hide abuse by editing logs.",
+      "stride_category": "T",
+      "tier": 3,
+      "prerequisites": "CloudflareWorker Compromise",
+      "status": "Platform",
+      "mitigation": "D1 in-account; append-oriented writes.",
+      "identity_key": {
+        "component_id": "IntelligenceDB",
+        "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+        "stride_category": "T",
+        "attack_surface": "Access-log tampering"
+      }
+    },
+    {
+      "id": "T68.R",
+      "title": "Insufficient retention",
+      "description": "Forensic gaps.",
+      "stride_category": "R",
+      "tier": 3,
+      "prerequisites": "Host/OS Access",
+      "status": "Mitigated",
+      "mitigation": "~90-day encrypted retention.",
+      "identity_key": {
+        "component_id": "IntelligenceDB",
+        "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+        "stride_category": "R",
+        "attack_surface": "Insufficient retention"
+      }
+    },
+    {
+      "id": "T69.S",
+      "title": "Forged entitlements",
+      "description": "Compromised bv-web elevates tier.",
+      "stride_category": "S",
+      "tier": 3,
+      "prerequisites": "BvWeb Compromise",
+      "status": "Mitigated",
+      "mitigation": "Authenticated binding; enum validation.",
+      "identity_key": {
+        "component_id": "BvWeb",
+        "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+        "stride_category": "S",
+        "attack_surface": "Forged entitlements"
+      }
+    },
+    {
+      "id": "T70.I",
+      "title": "Entitlement data in transit",
+      "description": "Plan data exposed between workers.",
+      "stride_category": "I",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "In-account binding; intra-CF TLS.",
+      "identity_key": {
+        "component_id": "BvWeb",
+        "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+        "stride_category": "I",
+        "attack_surface": "Entitlement data in transit"
+      }
+    },
+    {
+      "id": "T71.D",
+      "title": "bv-web unavailability",
+      "description": "Paid auth blocked.",
+      "stride_category": "D",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "Static key fallback; free tier unaffected.",
+      "identity_key": {
+        "component_id": "BvWeb",
+        "data_flow_id": "DF_TierAuthResolver_to_BvWeb",
+        "stride_category": "D",
+        "attack_surface": "bv-web unavailability"
+      }
+    },
+    {
+      "id": "T72.S",
+      "title": "Resolver spoofing",
+      "description": "Poisoned answers.",
+      "stride_category": "S",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "TLS; multi-resolver; secondary token.",
+      "identity_key": {
+        "component_id": "PublicDoH",
+        "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+        "stride_category": "S",
+        "attack_surface": "Resolver spoofing"
+      }
+    },
+    {
+      "id": "T73.T",
+      "title": "On-wire DNS tampering",
+      "description": "Tamper responses.",
+      "stride_category": "T",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "TLS (DoH).",
+      "identity_key": {
+        "component_id": "PublicDoH",
+        "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+        "stride_category": "T",
+        "attack_surface": "On-wire DNS tampering"
+      }
+    },
+    {
+      "id": "T74.D",
+      "title": "Resolver outage",
+      "description": "Degrade scan availability.",
+      "stride_category": "D",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "Fallback chain (bv-dns -> Google).",
+      "identity_key": {
+        "component_id": "PublicDoH",
+        "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+        "stride_category": "D",
+        "attack_surface": "Resolver outage"
+      }
+    },
+    {
+      "id": "T75.T",
+      "title": "Malicious CT data",
+      "description": "Inflate candidate sets.",
+      "stride_category": "T",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "crt.sh fallback + validation; bounded.",
+      "identity_key": {
+        "component_id": "CertTransparency",
+        "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+        "stride_category": "T",
+        "attack_surface": "Malicious CT data"
+      }
+    },
+    {
+      "id": "T76.D",
+      "title": "CT source outage",
+      "description": "Degrade discovery.",
+      "stride_category": "D",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "Direct crt.sh fallback + jittered backoff.",
+      "identity_key": {
+        "component_id": "CertTransparency",
+        "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+        "stride_category": "D",
+        "attack_surface": "CT source outage"
+      }
+    },
+    {
+      "id": "T77.I",
+      "title": "Untrusted WHOIS data injection",
+      "description": "Injected content in reports.",
+      "stride_category": "I",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "Output sanitization via createFinding().",
+      "identity_key": {
+        "component_id": "WhoisRdap",
+        "data_flow_id": "DF_BrandAuditPipeline_to_WhoisRdap",
+        "stride_category": "I",
+        "attack_surface": "Untrusted WHOIS data injection"
+      }
+    },
+    {
+      "id": "T78.D",
+      "title": "WHOIS/RDAP outage",
+      "description": "Degrade enrichment.",
+      "stride_category": "D",
+      "tier": 2,
+      "prerequisites": "Internal Network",
+      "status": "Mitigated",
+      "mitigation": "RDAP-only fallback; KV-cached referrals.",
+      "identity_key": {
+        "component_id": "WhoisRdap",
+        "data_flow_id": "DF_BrandAuditPipeline_to_WhoisRdap",
+        "stride_category": "D",
+        "attack_surface": "WHOIS/RDAP outage"
+      }
+    }
+  ],
+  "findings": [
+    {
+      "id": "FIND-01",
+      "title": "API key accepted via query parameter",
+      "severity": "Moderate",
+      "cvss_score": 5.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-598",
+      "owasp": "A04:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T11.I"
+      ],
+      "evidence_files": [
+        "src/lib/tier-auth.ts",
+        "src/lib/auth.ts"
+      ],
+      "component": "TierAuthResolver",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "vulnerability": "CWE-598",
+        "attack_surface": "src/index.ts ?api_key="
+      }
+    },
+    {
+      "id": "FIND-02",
+      "title": "Free-tier abuse via distributed IPs",
+      "severity": "Moderate",
+      "cvss_score": 5.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+      "cwe": "CWE-770",
+      "owasp": "A06:2025",
+      "tier": 1,
+      "effort": "Medium",
+      "related_threats": [
+        "T07.A",
+        "T46.E"
+      ],
+      "evidence_files": [
+        "src/lib/rate-limiter.ts",
+        "src/lib/fuzzing-detector.ts"
+      ],
+      "component": "RateLimiter",
+      "identity_key": {
+        "component_id": "RateLimiter",
+        "vulnerability": "CWE-770",
+        "attack_surface": "src/lib/rate-limiter.ts"
+      }
+    },
+    {
+      "id": "FIND-03",
+      "title": "Scanner usable as recon/amplification proxy",
+      "severity": "Moderate",
+      "cvss_score": 5.1,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:L",
+      "cwe": "CWE-406",
+      "owasp": "A06:2025",
+      "tier": 1,
+      "effort": "Medium",
+      "related_threats": [
+        "T32.A",
+        "T42.D",
+        "T43.A"
+      ],
+      "evidence_files": [
+        "src/handlers/tools.ts"
+      ],
+      "component": "ToolsHandler",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "vulnerability": "CWE-406",
+        "attack_surface": "src/tools/ scan tools"
+      }
+    },
+    {
+      "id": "FIND-04",
+      "title": "OAuth issuer from spoofable Host header",
+      "severity": "Moderate",
+      "cvss_score": 4.8,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-350",
+      "owasp": "A02:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T05.I"
+      ],
+      "evidence_files": [
+        "src/index.ts"
+      ],
+      "component": "HonoWorker",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "vulnerability": "CWE-350",
+        "attack_surface": "src/oauth/discovery.ts"
+      }
+    },
+    {
+      "id": "FIND-05",
+      "title": "Open OAuth dynamic client registration",
+      "severity": "Low",
+      "cvss_score": 4.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+      "cwe": "CWE-1188",
+      "owasp": "A02:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T15.S"
+      ],
+      "evidence_files": [
+        "src/oauth/jwt.ts",
+        "src/oauth/token.ts",
+        "src/oauth/authorize.ts"
+      ],
+      "component": "OAuthIssuer",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "vulnerability": "CWE-1188",
+        "attack_surface": "src/oauth/register.ts"
+      }
+    },
+    {
+      "id": "FIND-06",
+      "title": "force_refresh cache-busting amplification",
+      "severity": "Low",
+      "cvss_score": 3.7,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+      "cwe": "CWE-770",
+      "owasp": "A06:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T33.A"
+      ],
+      "evidence_files": [
+        "src/handlers/tools.ts"
+      ],
+      "component": "ToolsHandler",
+      "identity_key": {
+        "component_id": "ToolsHandler",
+        "vulnerability": "CWE-770",
+        "attack_surface": "src/lib/cache.ts force_refresh"
+      }
+    },
+    {
+      "id": "FIND-07",
+      "title": "Domain validation hardening for homoglyph/IDN",
+      "severity": "Low",
+      "cvss_score": 3.1,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-1007",
+      "owasp": "A03:2025",
+      "tier": 1,
+      "effort": "Medium",
+      "related_threats": [
+        "T34.T"
+      ],
+      "evidence_files": [
+        "src/lib/sanitize.ts",
+        "src/lib/config.ts"
+      ],
+      "component": "DomainSanitizer",
+      "identity_key": {
+        "component_id": "DomainSanitizer",
+        "vulnerability": "CWE-1007",
+        "attack_surface": "src/lib/sanitize.ts"
+      }
+    },
+    {
+      "id": "FIND-08",
+      "title": "Authentication & token-integrity controls (existing control)",
+      "severity": "Low",
+      "cvss_score": 2.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-287",
+      "owasp": "A07:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T08.S",
+        "T09.S",
+        "T10.T",
+        "T12.E",
+        "T14.A",
+        "T16.T",
+        "T17.I",
+        "T21.S"
+      ],
+      "evidence_files": [
+        "src/lib/tier-auth.ts",
+        "src/lib/auth.ts"
+      ],
+      "component": "TierAuthResolver",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "vulnerability": "CWE-287",
+        "attack_surface": "src/lib/tier-auth.ts"
+      }
+    },
+    {
+      "id": "FIND-09",
+      "title": "SSRF egress controls (existing control)",
+      "severity": "Low",
+      "cvss_score": 2.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-918",
+      "owasp": "A06:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T35.I",
+        "T36.E",
+        "T37.T",
+        "T38.I",
+        "T39.D"
+      ],
+      "evidence_files": [
+        "src/lib/safe-fetch.ts"
+      ],
+      "component": "SafeFetch",
+      "identity_key": {
+        "component_id": "SafeFetch",
+        "vulnerability": "CWE-918",
+        "attack_surface": "src/lib/safe-fetch.ts"
+      }
+    },
+    {
+      "id": "FIND-10",
+      "title": "Rate limiting, quotas & DoS budgets (existing control)",
+      "severity": "Low",
+      "cvss_score": 2.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+      "cwe": "CWE-770",
+      "owasp": "A06:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T01.S",
+        "T02.T",
+        "T06.D",
+        "T18.D",
+        "T22.T",
+        "T25.D",
+        "T26.E",
+        "T27.A",
+        "T28.T",
+        "T30.D",
+        "T31.E",
+        "T44.T",
+        "T45.D",
+        "T47.A"
+      ],
+      "evidence_files": [
+        "src/lib/rate-limiter.ts",
+        "src/lib/fuzzing-detector.ts"
+      ],
+      "component": "RateLimiter",
+      "identity_key": {
+        "component_id": "RateLimiter",
+        "vulnerability": "CWE-770",
+        "attack_surface": "src/lib/rate-limiter.ts"
+      }
+    },
+    {
+      "id": "FIND-11",
+      "title": "Information-disclosure controls (existing control)",
+      "severity": "Low",
+      "cvss_score": 2.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-209",
+      "owasp": "A09:2025",
+      "tier": 1,
+      "effort": "Low",
+      "related_threats": [
+        "T03.R",
+        "T04.I",
+        "T23.R",
+        "T24.I",
+        "T29.I",
+        "T66.I",
+        "T68.R"
+      ],
+      "evidence_files": [
+        "src/index.ts"
+      ],
+      "component": "HonoWorker",
+      "identity_key": {
+        "component_id": "HonoWorker",
+        "vulnerability": "CWE-209",
+        "attack_surface": "src/lib/json-rpc.ts"
+      }
+    },
+    {
+      "id": "FIND-12",
+      "title": "Internal routes default to no bearer auth",
+      "severity": "Moderate",
+      "cvss_score": 5.1,
+      "cvss_vector": "CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-1188",
+      "owasp": "A02:2025",
+      "tier": 2,
+      "effort": "Low",
+      "related_threats": [
+        "T52.A"
+      ],
+      "evidence_files": [
+        "src/internal.ts"
+      ],
+      "component": "InternalRouter",
+      "identity_key": {
+        "component_id": "InternalRouter",
+        "vulnerability": "CWE-1188",
+        "attack_surface": "src/internal.ts REQUIRE_INTERNAL_AUTH"
+      }
+    },
+    {
+      "id": "FIND-13",
+      "title": "JWT retains elevated tier after plan downgrade",
+      "severity": "Moderate",
+      "cvss_score": 4.6,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+      "cwe": "CWE-613",
+      "owasp": "A07:2025",
+      "tier": 2,
+      "effort": "Medium",
+      "related_threats": [
+        "T20.A"
+      ],
+      "evidence_files": [
+        "src/oauth/jwt.ts",
+        "src/oauth/token.ts",
+        "src/oauth/authorize.ts"
+      ],
+      "component": "OAuthIssuer",
+      "identity_key": {
+        "component_id": "OAuthIssuer",
+        "vulnerability": "CWE-613",
+        "attack_surface": "src/oauth/jwt.ts"
+      }
+    },
+    {
+      "id": "FIND-14",
+      "title": "Brand-audit discovery enables third-party enumeration",
+      "severity": "Moderate",
+      "cvss_score": 4.3,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-799",
+      "owasp": "A06:2025",
+      "tier": 2,
+      "effort": "Medium",
+      "related_threats": [
+        "T54.I",
+        "T56.A"
+      ],
+      "evidence_files": [
+        "src/lib/brand-audit-pipeline.ts",
+        "src/scheduled.ts"
+      ],
+      "component": "BrandAuditPipeline",
+      "identity_key": {
+        "component_id": "BrandAuditPipeline",
+        "vulnerability": "CWE-799",
+        "attack_surface": "src/lib/brand-audit-pipeline.ts"
+      }
+    },
+    {
+      "id": "FIND-15",
+      "title": "Trial-key tier persists during cache window",
+      "severity": "Low",
+      "cvss_score": 3.5,
+      "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+      "cwe": "CWE-613",
+      "owasp": "A07:2025",
+      "tier": 2,
+      "effort": "Low",
+      "related_threats": [
+        "T13.E"
+      ],
+      "evidence_files": [
+        "src/lib/tier-auth.ts",
+        "src/lib/auth.ts"
+      ],
+      "component": "TierAuthResolver",
+      "identity_key": {
+        "component_id": "TierAuthResolver",
+        "vulnerability": "CWE-613",
+        "attack_surface": "src/lib/tier-auth.ts TRIAL_KEY_CACHE_TTL"
+      }
+    },
+    {
+      "id": "FIND-16",
+      "title": "Internal isolation & dependency hardening (existing control)",
+      "severity": "Low",
+      "cvss_score": 2.5,
+      "cvss_vector": "CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-306",
+      "owasp": "A04:2025",
+      "tier": 2,
+      "effort": "Low",
+      "related_threats": [
+        "T19.E",
+        "T40.S",
+        "T41.T",
+        "T48.S",
+        "T49.T",
+        "T50.D",
+        "T51.E",
+        "T53.T",
+        "T55.D",
+        "T58.D",
+        "T59.T",
+        "T60.A",
+        "T69.S",
+        "T70.I",
+        "T71.D",
+        "T72.S",
+        "T73.T",
+        "T74.D",
+        "T75.T",
+        "T76.D",
+        "T77.I",
+        "T78.D"
+      ],
+      "evidence_files": [
+        "src/internal.ts"
+      ],
+      "component": "InternalRouter",
+      "identity_key": {
+        "component_id": "InternalRouter",
+        "vulnerability": "CWE-306",
+        "attack_surface": "src/internal.ts"
+      }
+    },
+    {
+      "id": "FIND-17",
+      "title": "Sensitive KV records rely on platform isolation only",
+      "severity": "Low",
+      "cvss_score": 4.2,
+      "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:H/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+      "cwe": "CWE-311",
+      "owasp": "A04:2025",
+      "tier": 3,
+      "effort": "Medium",
+      "related_threats": [
+        "T62.I",
+        "T65.I"
+      ],
+      "evidence_files": [
+        "src/lib/rate-limiter.ts",
+        "src/lib/trial-keys.ts"
+      ],
+      "component": "RateLimitKV",
+      "identity_key": {
+        "component_id": "RateLimitKV",
+        "vulnerability": "CWE-311",
+        "attack_surface": "src/lib/trial-keys.ts, src/oauth/storage.ts"
+      }
+    }
+  ],
+  "metrics": {
+    "total_components": 23,
+    "total_boundaries": 5,
+    "total_flows": 23,
+    "total_threats": 78,
+    "total_findings": 17,
+    "threats_by_tier": {
+      "T1": 40,
+      "T2": 22,
+      "T3": 16
+    },
+    "findings_by_tier": {
+      "T1": 11,
+      "T2": 5,
+      "T3": 1
+    },
+    "threats_by_stride": {
+      "S": 9,
+      "T": 19,
+      "R": 3,
+      "I": 14,
+      "D": 14,
+      "E": 8,
+      "A": 11
+    },
+    "findings_by_severity": {
+      "Critical": 0,
+      "Important": 0,
+      "Moderate": 7,
+      "Low": 10
+    }
+  }
+}


### PR DESCRIPTION
STRIDE-A threat model of bv-mcp generated by the `threat-model-analyst` skill (single-analysis mode), in `docs/threat-model/threat-model-20260524-114907/`.

## Scope
23 architecture elements across 5 trust boundaries (21 STRIDE components + 2 external actors), 23 data flows, **78 STRIDE-A threats**, **17 findings** (11 Tier-1, 5 Tier-2, 1 Tier-3) with CVSS 4.0 / CWE / OWASP:2025 mappings, plus a machine-readable `threat-inventory.json` baseline for future incremental runs.

## Risk rating: Moderate
Well-hardened (constant-time auth, HS256 alg-pinning, layered SSRF defenses, multi-tier rate limiting, AES-GCM-encrypted access-log IPs). No critical / auth-bypass / RCE issues — findings skew to abuse-resistance and config hardening. Most material item: enable `REQUIRE_INTERNAL_AUTH` in production.

## Files
- `0-assessment.md` — executive summary, action plan, metadata
- `0.1-architecture.md` — architecture, components, scenarios, exposure table
- `1-threatmodel.md` + `1.1`/`1.2` `.mmd` — DFD (detailed + summary)
- `2-stride-analysis.md` — per-component STRIDE-A (78 threats)
- `3-findings.md` — 17 findings + threat-coverage table
- `threat-inventory.json` — structured inventory / incremental baseline

## Companion
The findings are resolved in #208 (TDD remediation). Note: that work found **FIND-05 was already mitigated** in `register.ts` — a known over-report to correct in a later incremental pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)