### PR TITLE
chore: bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-05-25
+
+### Changed
+
+- **HTTP-security check attributes Cloudflare WAF interceptions served as HTTP 403.** Both JS challenges and access blocks (commonly served as 403) are now detected via `cf-ray`/`cf-mitigated` + body fingerprints and short-circuit with `checkStatus: 'error'` plus `wafEvent`/`wafKind` metadata, instead of falling into the generic "blocked by security appliance" path. Also fixes a `checkStatus` inconsistency between 200-served and 403-served challenges. No scoring change; wrapper-only (no `@blackveil/dns-checks` change). (#211)
+
 ## [3.0.0] - 2026-05-24
 
 Major bump: removes the `brand_audit_watch` MCP tool (breaking tool-surface change). All deployed to production across PRs #197, #200, #201, #202, #203.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.0.0",
+			"version": "3.1.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.0.0",
+	"version": "3.1.0",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "3.0.0",
+			"version": "3.1.0",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.0.0';
+export const SERVER_VERSION = '3.1.0';


### PR DESCRIPTION
Version bump to **3.1.0**, reflecting the Cloudflare 403 WAF block/challenge detection shipped in #211.

- All five version fields synced: `package.json`, `package-lock.json`, `SERVER_VERSION`, `server.json` (×2) + `CHANGELOG.md`.
- `@blackveil/dns-checks` unchanged (`1.1.3`) — #211 was wrapper-only.

**Already deployed to production manually** (Version `fb12b654`, `SERVER_VERSION=3.1.0`); npm + MCP-registry publish intentionally skipped (CI publish jobs are gated off pending the `NPM_TOKEN` rotation). This PR lands the bump on `main` so it doesn't drift from prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)