### PR TITLE
fix(scoring): exclude inconclusive checks instead of zeroing them

### DIFF
--- a/packages/dns-checks/src/checks/check-http-security.ts
+++ b/packages/dns-checks/src/checks/check-http-security.ts
@@ -101,6 +101,11 @@ export async function checkHTTPSecurity(
 ): Promise<CheckResult> {
 	const timeoutMs = options?.timeout ?? HTTPS_TIMEOUT_MS;
 	const findings: Finding[] = [];
+	// Set when the headers could not actually be evaluated (inconclusive execution, not a real
+	// header gap). The scoring engine treats checkStatus 'timeout'/'error' as a transient failure
+	// and EXCLUDES the category from scoring (renormalized) rather than zeroing it — so a flaky
+	// fetch can't make the overall score fluctuate between a real value and 0.
+	let inconclusive: 'timeout' | 'error' | undefined;
 
 	try {
 		let response = await fetchFn(`https://${domain}`, {
@@ -117,6 +122,7 @@ export async function checkHTTPSecurity(
 			// 200-299: analyze headers normally
 			findings.push(...analyzeSecurityHeaders(response.headers));
 		} else if (response.status === 0 || response.status >= 500) {
+			inconclusive = 'error';
 			findings.push(
 				createFinding(
 					'http_security',
@@ -135,6 +141,7 @@ export async function checkHTTPSecurity(
 				const followed = await followRedirects(getResponse, fetchFn, timeoutMs);
 				findings.push(...analyzeSecurityHeaders(followed.headers));
 			} else {
+				inconclusive = 'error';
 				findings.push(
 					createFinding(
 						'http_security',
@@ -146,6 +153,7 @@ export async function checkHTTPSecurity(
 				);
 			}
 		} else if (response.status === 401) {
+			inconclusive = 'error';
 			findings.push(
 				createFinding(
 					'http_security',
@@ -157,6 +165,7 @@ export async function checkHTTPSecurity(
 			);
 		} else {
 			// Other 4xx (404, 429, etc.) — blocked or rejected
+			inconclusive = 'error';
 			findings.push(
 				createFinding(
 					'http_security',
@@ -168,10 +177,12 @@ export async function checkHTTPSecurity(
 			);
 		}
 	} catch (err) {
-		const message =
-			err instanceof Error && (err.message.includes('timeout') || err.message.includes('abort'))
-				? 'Connection timed out'
-				: 'Connection failed';
+		// AbortSignal.timeout throws a DOMException named 'TimeoutError' (message "The operation
+		// timed out"); also match abort/timeout phrasings from other runtimes.
+		const e = err as { name?: string; message?: string };
+		const isTimeout = e?.name === 'TimeoutError' || /timed?\s*out|abort|timeout/i.test(e?.message ?? '');
+		inconclusive = isTimeout ? 'timeout' : 'error';
+		const message = isTimeout ? 'Connection timed out' : 'Connection failed';
 		findings.push(
 			createFinding(
 				'http_security',
@@ -183,5 +194,6 @@ export async function checkHTTPSecurity(
 		);
 	}
 
-	return buildCheckResult('http_security', findings);
+	const result = buildCheckResult('http_security', findings);
+	return inconclusive ? { ...result, checkStatus: inconclusive } : result;
 }

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -133,6 +133,19 @@ function buildGenericContext(
 		}
 	}
 
+	// --- Build transientFailures map ---
+	// A check whose execution failed (checkStatus 'timeout'/'error') is INCONCLUSIVE — we
+	// couldn't measure it. That is distinct from a genuinely-missing control (missingControl).
+	// Exclude inconclusive categories from the weighted score (renormalized over the rest)
+	// rather than scoring them 0, so a transient fetch/DNS failure doesn't make the overall
+	// score fluctuate. See generic.ts: transientFailures keys are skipped in the tier partition.
+	const transientFailures: Record<string, boolean> = {};
+	for (const result of results) {
+		if (result.checkStatus === 'timeout' || result.checkStatus === 'error') {
+			transientFailures[result.category] = true;
+		}
+	}
+
 	// --- Build hardeningPassed map ---
 	// The original engine iterates ALL hardening categories from CATEGORY_TIERS (not just
 	// those with results). It uses hardeningCount = total hardening categories.
@@ -208,6 +221,7 @@ function buildGenericContext(
 		tierMap: { ...CATEGORY_TIERS },
 		weights,
 		missingControls,
+		transientFailures,
 		hardeningPassed,
 		criticalCategories: [...criticalCategories],
 		emailBonusEligible,
@@ -257,10 +271,21 @@ export function computeScanScore(results: CheckResult[], context?: DomainContext
 		};
 	}
 
-	// Populate category scores from actual results
+	// Populate category scores from actual results. Transient (checkStatus 'timeout'/'error')
+	// checks are INCONCLUSIVE — exclude them from the category-score output (shown as n/a, never
+	// a misleading 0) and from the finding counts; buildGenericContext also excludes them from
+	// the weighted overall score via transientFailures.
+	const transientCategories = new Set<CheckCategory>();
 	for (const result of results) {
+		if (result.checkStatus === 'timeout' || result.checkStatus === 'error') {
+			transientCategories.add(result.category);
+			continue;
+		}
 		categoryScores[result.category] = result.score;
 		allFindings.push(...result.findings);
+	}
+	for (const cat of transientCategories) {
+		delete (categoryScores as Partial<Record<CheckCategory, number>>)[cat];
 	}
 
 	// Build the generic context and delegate to the generic engine

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -96,6 +96,13 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 			}
 		}
 	}
+	// Transient/inconclusive checks (checkStatus timeout/error) are excluded from the score by the
+	// engine — surface them as n/a (not a misleading 0) so the report reflects "could not measure".
+	for (const check of result.checks) {
+		if ((check.checkStatus === 'timeout' || check.checkStatus === 'error') && !notApplicableCategories.includes(check.category)) {
+			notApplicableCategories.push(check.category);
+		}
+	}
 
 	return {
 		domain: result.domain,

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -473,4 +473,26 @@ describe('checkHttpSecurity — dual-fetch header union', () => {
 			expect(result.findings.some((f) => f.metadata?.wafEvent === 'cloudflare')).toBe(false);
 		});
 	});
+
+	describe('inconclusive fetches set checkStatus (so scoring excludes them, not zeroes)', () => {
+		it('a connection timeout sets checkStatus=timeout', async () => {
+			globalThis.fetch = vi.fn().mockRejectedValue(new Error('The operation timed out'));
+			const result = await run();
+			expect(result.checkStatus).toBe('timeout');
+			expect(result.score).toBe(0); // local category score is 0, but the engine excludes it from the overall
+		});
+
+		it('a generic connection failure sets checkStatus=error', async () => {
+			globalThis.fetch = vi.fn().mockRejectedValue(new Error('network unreachable'));
+			const result = await run();
+			expect(result.checkStatus).toBe('error');
+		});
+
+		it('a 403 block with no usable GET sets checkStatus=error (inconclusive, not a real 0)', async () => {
+			globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403, headers: new Headers() });
+			const result = await run();
+			expect(result.checkStatus).toBe('error');
+			expect(result.findings.some((f) => f.title === 'HTTP check blocked by security appliance')).toBe(true);
+		});
+	});
 });

--- a/test/scoring-engine.spec.ts
+++ b/test/scoring-engine.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { scoreToGrade, computeScanScore, IMPORTANCE_WEIGHTS, CORE_WEIGHTS, PROTECTIVE_WEIGHTS } from '@blackveil/dns-checks/scoring';
-import { buildCheckResult, createFinding, CATEGORY_DISPLAY_WEIGHTS, type CheckCategory } from '@blackveil/dns-checks/scoring';
+import { buildCheckResult, createFinding, CATEGORY_DISPLAY_WEIGHTS, type CheckCategory, type CheckResult } from '@blackveil/dns-checks/scoring';
 
 describe('scoring-engine', () => {
 	it('maps numeric scores to expected grade bands', () => {
@@ -129,6 +129,38 @@ describe('scoring v2 three-tier', () => {
 			// Scores 50-54 should be D, not E
 			expect(scoreToGrade(50)).toBe('D');
 			expect(scoreToGrade(54)).toBe('D');
+		});
+	});
+
+	describe('transient check failures are excluded from scoring, not zeroed', () => {
+		const passingCore = (): CheckResult[] => [
+			{ ...buildCheckResult('spf', []), score: 100, passed: true },
+			{ ...buildCheckResult('dmarc', []), score: 100, passed: true },
+			{ ...buildCheckResult('dkim', []), score: 100, passed: true },
+			{ ...buildCheckResult('dnssec', []), score: 100, passed: true },
+			{ ...buildCheckResult('ssl', []), score: 100, passed: true },
+		];
+
+		it('a transient http_security failure (checkStatus=timeout) does NOT lower the overall', () => {
+			const baseline = computeScanScore(passingCore());
+			const httpTimeout: CheckResult = { ...buildCheckResult('http_security', []), score: 0, passed: false, checkStatus: 'timeout' };
+			const withTransient = computeScanScore([...passingCore(), httpTimeout]);
+			// Excluded & renormalized → identical to the baseline, NOT dragged toward 0.
+			expect(withTransient.overall).toBe(baseline.overall);
+			expect(withTransient.categoryScores.http_security).toBeUndefined();
+		});
+
+		it('a transient failure with checkStatus=error is also excluded', () => {
+			const baseline = computeScanScore(passingCore());
+			const httpErr: CheckResult = { ...buildCheckResult('http_security', []), score: 0, passed: false, checkStatus: 'error' };
+			expect(computeScanScore([...passingCore(), httpErr]).overall).toBe(baseline.overall);
+		});
+
+		it('a CONCLUSIVE low score (checkStatus completed) still counts against the overall', () => {
+			const baseline = computeScanScore(passingCore());
+			const httpBad: CheckResult = { ...buildCheckResult('http_security', [createFinding('http_security', 'No CSP', 'medium', 'missing')]), score: 0, passed: false };
+			// Genuinely measured 0 (no transient status) must still drag the score down.
+			expect(computeScanScore([...passingCore(), httpBad]).overall).toBeLessThan(baseline.overall);
 		});
 	});
 });


### PR DESCRIPTION
## Problem
A transient HTTP/DNS fetch failure made a check return `checkStatus: 'timeout'/'error'` with score **0**, which dragged the overall scan score and **fluctuated** it. Measured over 10 back-to-back fresh scans: `blackveilsecurity.com` HTTP Security came back `0` twice (cold-start) and `85` eight times; external hosts were stable. Scoring a "couldn't measure" as `0` conflates it with "control absent".

## Fix
- **`scoring/engine.ts`** — inconclusive checks (`checkStatus` `timeout`/`error`) now feed the engine's existing `transientFailures` lever: the category is **excluded from the weighted score (renormalized)** and **omitted from `categoryScores`**, rather than scored 0. Genuinely-missing controls (`missingControl`, `checkStatus` completed) still count — the execution-failure vs control-gap distinction is preserved.
- **`checks/check-http-security.ts`** — fetch-failure branches (connection timeout/failed, WAF/appliance block, 401, 5xx, other 4xx) set `checkStatus` so the engine sees them as inconclusive. Timeout detection hardened (`TimeoutError` / "timed out").
- **`scan/format-report.ts`** — inconclusive categories surfaced in `notApplicableCategories` (shown **n/a**, never a misleading 0).

## Result
A flaky fetch now yields **"measured" or "n/a (excluded)"** — never a `0` that swings the grade. Wrapper-only changes plus the scoring core; behavior changes **only** for scans where a check execution-failed (previously dragged to 0, now excluded).

## Tests
TDD (RED→GREEN). 6 new tests: 3 in `scoring-engine.spec.ts` (transient excluded; conclusive 0 still counts) + 3 in `check-http-security.spec.ts` (timeout/error/blocked set `checkStatus`). Full suite **4393 pass**; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
