### PR TITLE
chore: bump version to 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.1.1] - 2026-05-25
+
+### Fixed
+
+- **Scoring no longer fluctuates on transient check failures.** A check whose execution failed (`checkStatus` timeout/error — e.g. a cold-start HTTP fetch timeout) is now **excluded from the weighted score (renormalized) and surfaced as n/a** in `notApplicableCategories`, instead of being forced to `0` and dragging the overall score. Genuinely-missing controls (`missingControl`) still count. Eliminates the 0↔real score swing observed on cold-start scans (e.g. blackveilsecurity.com HTTP Security). (#213)
+
 ## [3.1.0] - 2026-05-25
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.1.0",
+	"version": "3.1.1",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "3.1.0",
+			"version": "3.1.1",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.1.0';
+export const SERVER_VERSION = '3.1.1';


### PR DESCRIPTION
Patch bump **3.1.0 → 3.1.1**, versioning the inconclusive-exclusion scoring fix (#213) shipped after 3.1.0.

- All five version fields synced (package.json, package-lock.json, SERVER_VERSION, server.json ×2) + CHANGELOG `[3.1.1]`.
- `@blackveil/dns-checks` unchanged (`1.1.3`) — not republished (npm/registry publish is gated off).

**Already deployed to production** (Version `4dcb2d77`, `serverInfo.version=3.1.1`). This PR lands the bump on `main` so it doesn't drift from prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)