### PR TITLE
fix(recon): correct bv-recon intelligence-check contract (path, DNSCheckResult schema, 404 semantics)

### DIFF
--- a/src/lib/recon-binding.ts
+++ b/src/lib/recon-binding.ts
@@ -17,17 +17,16 @@ const RECON_TIMEOUT_MS = 8_000;
 
 export type ReconScanType = 'MALICIOUS_ASN' | 'CT_LOOKALIKE' | 'ATTACKER_INFRASTRUCTURE' | 'REALTIME_THREAT_FEED';
 
-/** Minimal, defensive shape of a bv-recon /osint/scan response. Extra fields ignored.
- *  `findings` is REQUIRED (not defaulted) so bodies lacking it fail validation. */
+/** Defensive shape of a bv-recon /osint/check DNSCheckResult response.
+ *  All fields optional/lenient so unknown extra fields never fail validation. */
 const ReconScanResponseSchema = z
 	.object({
-		findings: z.array(
-			z.object({
-				severity: z.string(),
-				title: z.string().optional(),
-				detail: z.string().optional(),
-			}),
-		),
+		checkType: z.string().optional(),
+		status: z.string().optional(),
+		score: z.number().nullable().optional(),
+		details: z.string().optional(),
+		records: z.array(z.unknown()).optional(),
+		metadata: z.record(z.string(), z.unknown()).optional(),
 	})
 	.passthrough();
 export type ReconScanResult = z.infer<typeof ReconScanResponseSchema>;
@@ -35,7 +34,7 @@ export type ReconScanResult = z.infer<typeof ReconScanResponseSchema>;
 /** Minimal shape of a bv-recon /packages/check response. */
 const PackageTrustResponseSchema = z
 	.object({
-		verdict: z.enum(['MALICIOUS', 'SUSPICIOUS', 'LOW_RISK', 'SAFE', 'UNKNOWN']),
+		verdict: z.string().optional(),
 		confidence: z.string().optional(),
 		signals: z
 			.array(z.object({ id: z.string().optional(), severity: z.string(), detail: z.string() }))
@@ -43,6 +42,14 @@ const PackageTrustResponseSchema = z
 	})
 	.passthrough();
 export type PackageTrustResult = z.infer<typeof PackageTrustResponseSchema>;
+
+/**
+ * Returns true when a DNSCheckResult status indicates a threat signal.
+ * Benign statuses ('info', 'pass', 'ok', 'low', undefined) return false.
+ */
+export function isReconHit(status: string | undefined): boolean {
+	return !!status && ['warning', 'fail', 'critical', 'high', 'medium'].includes(status.toLowerCase());
+}
 
 function composeSignal(caller?: AbortSignal): AbortSignal {
 	const t = AbortSignal.timeout(RECON_TIMEOUT_MS);
@@ -62,13 +69,20 @@ export async function callReconScan(
 		if (target.domain) qs.set('domain', target.domain);
 		if (target.ip) qs.set('ip', target.ip);
 		if (target.asn != null) qs.set('asn', String(target.asn));
-		const resp = await binding.fetch(`https://bv-recon/osint/scan?${qs.toString()}`, {
+		const resp = await binding.fetch(`https://bv-recon/osint/check?${qs.toString()}`, {
 			method: 'GET',
 			headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
 			signal: composeSignal(signal),
 		});
 		if (!resp.ok) return null;
-		const parsed = ReconScanResponseSchema.safeParse(await resp.json());
+		const bodyText = await resp.text();
+		let body: unknown = null;
+		try {
+			body = JSON.parse(bodyText);
+		} catch {
+			body = null;
+		}
+		const parsed = ReconScanResponseSchema.safeParse(body);
 		return parsed.success ? parsed.data : null;
 	} catch {
 		return null;

--- a/src/lib/recon-binding.ts
+++ b/src/lib/recon-binding.ts
@@ -74,6 +74,14 @@ export async function callReconScan(
 			headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
 			signal: composeSignal(signal),
 		});
+		// A 404 from the intelligence /check means the threat feed has no entry for
+		// this target — i.e. no adverse intel (benign), NOT a provisioning failure.
+		// Return a benign result so callers render "no hits" instead of "unavailable".
+		// (The route 404 is fixed + regression-tested in bv-recon, so a 404 here is a
+		// data miss, not a misroute.) Other non-2xx (5xx/auth) stay null → unavailable.
+		if (resp.status === 404) {
+			return { status: 'info', details: 'No threat-intelligence match for this target.' };
+		}
 		if (!resp.ok) return null;
 		const parsed = ReconScanResponseSchema.safeParse(await resp.json().catch(() => null));
 		return parsed.success ? parsed.data : null;

--- a/src/lib/recon-binding.ts
+++ b/src/lib/recon-binding.ts
@@ -75,14 +75,7 @@ export async function callReconScan(
 			signal: composeSignal(signal),
 		});
 		if (!resp.ok) return null;
-		const bodyText = await resp.text();
-		let body: unknown = null;
-		try {
-			body = JSON.parse(bodyText);
-		} catch {
-			body = null;
-		}
-		const parsed = ReconScanResponseSchema.safeParse(body);
+		const parsed = ReconScanResponseSchema.safeParse(await resp.json().catch(() => null));
 		return parsed.success ? parsed.data : null;
 	} catch {
 		return null;

--- a/src/tools/check-cymru-asn.ts
+++ b/src/tools/check-cymru-asn.ts
@@ -9,7 +9,7 @@
 import { queryDnsRecords, queryTxtRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { isValidIPv4, reverseIPv4 } from '../lib/ip-utils';
-import { callReconScan } from '../lib/recon-binding';
+import { callReconScan, isReconHit } from '../lib/recon-binding';
 import type { ReconBinding } from '../lib/recon-binding';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory } from '../lib/scoring';
@@ -203,14 +203,14 @@ export async function checkCymruAsn(
 	// Recon enrichment: additive-only, fail-soft
 	if (reconOptions.reconBinding) {
 		const reconResult = await callReconScan(reconOptions.reconBinding, reconOptions.reconAuthToken, 'MALICIOUS_ASN', { domain });
-		const hit = reconResult?.findings.find((f) => ['medium', 'high', 'critical'].includes(f.severity));
+		const hit = reconResult && isReconHit(reconResult.status);
 		if (hit) {
 			findings.push(
 				createFinding(
 					CATEGORY,
 					'Malicious-ASN intel corroboration',
 					'medium',
-					hit.detail ?? hit.title ?? `Threat intelligence corroborates malicious-ASN signal for ${domain}.`,
+					reconResult.details ?? `Threat intelligence corroborates malicious-ASN signal for ${domain}.`,
 					{ domain, reconEnriched: true },
 				),
 			);

--- a/src/tools/check-fast-flux.ts
+++ b/src/tools/check-fast-flux.ts
@@ -13,7 +13,7 @@
 
 import { queryDns } from '../lib/dns';
 import type { DnsAnswer, QueryDnsOptions } from '../lib/dns-types';
-import { callReconScan } from '../lib/recon-binding';
+import { callReconScan, isReconHit } from '../lib/recon-binding';
 import type { ReconBinding } from '../lib/recon-binding';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory, Finding } from '../lib/scoring';
@@ -170,14 +170,14 @@ export async function checkFastFlux(
 	// Recon enrichment: additive-only, fail-soft
 	if (reconOptions.reconBinding) {
 		const reconResult = await callReconScan(reconOptions.reconBinding, reconOptions.reconAuthToken, 'ATTACKER_INFRASTRUCTURE', { domain });
-		const hit = reconResult?.findings.find((f) => ['medium', 'high', 'critical'].includes(f.severity));
+		const hit = reconResult && isReconHit(reconResult.status);
 		if (hit) {
 			findings.push(
 				createFinding(
 					CATEGORY,
 					'Attacker-infrastructure intel corroboration',
 					'medium',
-					hit.detail ?? hit.title ?? `External threat-intel flagged related infrastructure.`,
+					reconResult.details ?? `External threat-intel flagged related infrastructure.`,
 					{ domain, reconEnriched: true },
 				),
 			);

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -9,7 +9,7 @@
 
 import { queryDnsRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
-import { callReconScan } from '../lib/recon-binding';
+import { callReconScan, isReconHit } from '../lib/recon-binding';
 import type { ReconBinding } from '../lib/recon-binding';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
@@ -383,14 +383,14 @@ async function checkLookalikesCore(
 	// Recon enrichment: additive-only, fail-soft
 	if (reconOptions.reconBinding) {
 		const reconResult = await callReconScan(reconOptions.reconBinding, reconOptions.reconAuthToken, 'CT_LOOKALIKE', { domain });
-		const hit = reconResult?.findings.find((f) => ['medium', 'high', 'critical'].includes(f.severity));
+		const hit = reconResult && isReconHit(reconResult.status);
 		if (hit) {
 			findings.push(
 				createFinding(
 					'lookalikes',
 					'CT-observed lookalike corroboration',
 					'medium',
-					hit.detail ?? hit.title ?? `Threat intelligence corroborates CT-observed lookalike signal for ${domain}.`,
+					reconResult.details ?? `Threat intelligence corroborates CT-observed lookalike signal for ${domain}.`,
 					{ domain, reconEnriched: true },
 				),
 			);

--- a/src/tools/check-package-trust.ts
+++ b/src/tools/check-package-trust.ts
@@ -52,18 +52,19 @@ export async function checkPackageTrust(args: PackageTrustArgs, options: Package
 		return buildCheckResult(CATEGORY, findings) as CheckResult;
 	}
 
-	const severity = VERDICT_SEVERITY[verdict.verdict] ?? 'info';
+	const verdictLabel = verdict.verdict ?? 'UNKNOWN';
+	const severity = VERDICT_SEVERITY[verdictLabel] ?? 'info';
 	findings.push(
 		createFinding(
 			CATEGORY,
-			`Package verdict: ${verdict.verdict}`,
+			`Package verdict: ${verdictLabel}`,
 			severity,
-			`${args.registry}:${args.package}${args.version ? `@${args.version}` : ''} → ${verdict.verdict} (confidence ${verdict.confidence ?? 'unknown'}).`,
+			`${args.registry}:${args.package}${args.version ? `@${args.version}` : ''} → ${verdictLabel} (confidence ${verdict.confidence ?? 'unknown'}).`,
 			{
 				registry: args.registry,
 				package: args.package,
 				version: args.version ?? null,
-				verdict: verdict.verdict,
+				verdict: verdictLabel,
 				confidence: verdict.confidence ?? null,
 			},
 		),

--- a/src/tools/check-realtime-threat-feed.ts
+++ b/src/tools/check-realtime-threat-feed.ts
@@ -8,15 +8,23 @@
  */
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory } from '../lib/scoring';
-import { callReconScan, type ReconBinding } from '../lib/recon-binding';
+import { callReconScan, isReconHit, type ReconBinding } from '../lib/recon-binding';
 
 const CATEGORY = 'realtime_threat_feed' as CheckCategory;
-
-const ALLOWED_SEVERITIES = ['critical', 'high', 'medium', 'low', 'info'] as const;
 
 export interface RealtimeThreatFeedOptions {
 	reconBinding?: ReconBinding;
 	reconAuthToken?: string;
+}
+
+/** Map a DNSCheckResult status to a finding severity for threat-feed hits. */
+function hitSeverity(status: string | undefined): 'critical' | 'high' | 'medium' {
+	const s = (status ?? '').toLowerCase();
+	if (s === 'critical') return 'critical';
+	if (s === 'high') return 'high';
+	if (s === 'medium') return 'medium';
+	// warning / fail / other hit statuses → high
+	return 'high';
 }
 
 /**
@@ -46,19 +54,27 @@ export async function checkRealtimeThreatFeed(domain: string, options: RealtimeT
 		return buildCheckResult(CATEGORY, findings) as CheckResult;
 	}
 
-	if (scan.findings.length === 0) {
+	if (isReconHit(scan.status)) {
+		const sev = hitSeverity(scan.status);
 		findings.push(
-			createFinding(CATEGORY, 'No realtime threat-feed hits', 'info', `${domain} has no matches in the BlackVeil realtime threat intelligence feed.`, {
-				domain,
-			}),
+			createFinding(
+				CATEGORY,
+				'Realtime threat-feed hit',
+				sev,
+				scan.details ?? 'Threat intelligence flagged this domain.',
+				{ domain, status: scan.status, ...scan.metadata },
+			),
 		);
 	} else {
-		for (const f of scan.findings) {
-			const sev = (ALLOWED_SEVERITIES as readonly string[]).includes(f.severity) ? (f.severity as (typeof ALLOWED_SEVERITIES)[number]) : 'info';
-			findings.push(
-				createFinding(CATEGORY, f.title ?? 'Threat-feed hit', sev, f.detail ?? f.title ?? 'Realtime threat-feed match.', { domain }),
-			);
-		}
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'No realtime threat-feed hits',
+				'info',
+				scan.details ?? 'No active threat-feed matches.',
+				{ domain },
+			),
+		);
 	}
 
 	return buildCheckResult(CATEGORY, findings) as CheckResult;

--- a/test/check-cymru-asn-recon-enrichment.integration.test.ts
+++ b/test/check-cymru-asn-recon-enrichment.integration.test.ts
@@ -64,9 +64,15 @@ function buildCymruFetchMock(domain: string, ip: string, originTxtValue: string,
 // Recon binding mock helper
 // ---------------------------------------------------------------------------
 
-function makeReconBinding(findings: Array<{ severity: string; title?: string; detail?: string }>) {
+function makeReconHitBinding(detail: string) {
 	return {
-		fetch: vi.fn(async () => new Response(JSON.stringify({ findings }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'MALICIOUS_ASN', status: 'warning', details: detail }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+	};
+}
+
+function makeReconBenignBinding() {
+	return {
+		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'MALICIOUS_ASN', status: 'info', details: 'nothing serious' }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
 	};
 }
 
@@ -91,7 +97,7 @@ describe('checkCymruAsn recon enrichment', () => {
 		expect(enriched).toHaveLength(0);
 	});
 
-	it('enriched: adds corroboration finding when recon returns a high-severity hit', async () => {
+	it('enriched: adds corroboration finding when recon returns a hit status', async () => {
 		buildCymruFetchMock(
 			'example.com',
 			'93.184.216.34',
@@ -100,7 +106,7 @@ describe('checkCymruAsn recon enrichment', () => {
 			'15169 | US | arin | 2007-03-19 | GOOGLE - Google LLC, US',
 		);
 
-		const reconBinding = makeReconBinding([{ severity: 'high', title: 'Known malicious ASN', detail: 'ASN 15169 flagged in threat feed' }]);
+		const reconBinding = makeReconHitBinding('ASN 15169 flagged in threat feed');
 
 		const { checkCymruAsn } = await import('../src/tools/check-cymru-asn');
 		const result = await checkCymruAsn('example.com', undefined, { reconBinding, reconAuthToken: 'tok' });
@@ -112,7 +118,7 @@ describe('checkCymruAsn recon enrichment', () => {
 		expect(enriched[0].detail).toContain('ASN 15169 flagged in threat feed');
 	});
 
-	it('enriched: no corroboration finding when recon returns only info-severity hits', async () => {
+	it('enriched: no corroboration finding when recon returns a benign status', async () => {
 		buildCymruFetchMock(
 			'example.com',
 			'93.184.216.34',
@@ -121,7 +127,7 @@ describe('checkCymruAsn recon enrichment', () => {
 			'15169 | US | arin | 2007-03-19 | GOOGLE - Google LLC, US',
 		);
 
-		const reconBinding = makeReconBinding([{ severity: 'info', title: 'Low priority note', detail: 'nothing serious' }]);
+		const reconBinding = makeReconBenignBinding();
 
 		const { checkCymruAsn } = await import('../src/tools/check-cymru-asn');
 		const result = await checkCymruAsn('example.com', undefined, { reconBinding, reconAuthToken: 'tok' });

--- a/test/check-fast-flux-recon-enrichment.integration.test.ts
+++ b/test/check-fast-flux-recon-enrichment.integration.test.ts
@@ -51,9 +51,15 @@ function buildStableFetchMock(domain: string) {
 // Recon binding mock helper
 // ---------------------------------------------------------------------------
 
-function makeReconBinding(findings: Array<{ severity: string; title?: string; detail?: string }>) {
+function makeReconHitBinding(detail: string) {
 	return {
-		fetch: vi.fn(async () => new Response(JSON.stringify({ findings }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'ATTACKER_INFRASTRUCTURE', status: 'warning', details: detail }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+	};
+}
+
+function makeReconBenignBinding() {
+	return {
+		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'ATTACKER_INFRASTRUCTURE', status: 'info', details: 'nothing serious' }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
 	};
 }
 
@@ -72,10 +78,10 @@ describe('checkFastFlux recon enrichment', () => {
 		expect(enriched).toHaveLength(0);
 	});
 
-	it('enriched: adds corroboration finding when recon returns a high-severity hit', async () => {
+	it('enriched: adds corroboration finding when recon returns a hit status', async () => {
 		buildStableFetchMock('example.com');
 
-		const reconBinding = makeReconBinding([{ severity: 'high', title: 'Attacker infra', detail: 'Infrastructure linked to known threat actor.' }]);
+		const reconBinding = makeReconHitBinding('Infrastructure linked to known threat actor.');
 
 		const { checkFastFlux } = await import('../src/tools/check-fast-flux');
 		const result = await checkFastFlux('example.com', 3, undefined, 0, { reconBinding, reconAuthToken: 'tok' });
@@ -87,10 +93,10 @@ describe('checkFastFlux recon enrichment', () => {
 		expect(enriched[0].detail).toContain('Infrastructure linked to known threat actor.');
 	});
 
-	it('enriched: no corroboration finding when recon returns only info-severity hits', async () => {
+	it('enriched: no corroboration finding when recon returns a benign status', async () => {
 		buildStableFetchMock('example.com');
 
-		const reconBinding = makeReconBinding([{ severity: 'info', title: 'Low priority note', detail: 'nothing serious' }]);
+		const reconBinding = makeReconBenignBinding();
 
 		const { checkFastFlux } = await import('../src/tools/check-fast-flux');
 		const result = await checkFastFlux('example.com', 3, undefined, 0, { reconBinding, reconAuthToken: 'tok' });

--- a/test/check-lookalikes-recon-enrichment.integration.test.ts
+++ b/test/check-lookalikes-recon-enrichment.integration.test.ts
@@ -49,9 +49,15 @@ function buildLookalikeFetchMock() {
 // Recon binding mock helper
 // ---------------------------------------------------------------------------
 
-function makeReconBinding(findings: Array<{ severity: string; title?: string; detail?: string }>) {
+function makeReconHitBinding(detail: string) {
 	return {
-		fetch: vi.fn(async () => new Response(JSON.stringify({ findings }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'CT_LOOKALIKE', status: 'warning', details: detail }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+	};
+}
+
+function makeReconBenignBinding() {
+	return {
+		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'CT_LOOKALIKE', status: 'info', details: 'nothing serious' }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
 	};
 }
 
@@ -70,12 +76,10 @@ describe('checkLookalikes recon enrichment', () => {
 		expect(enriched).toHaveLength(0);
 	});
 
-	it('enriched: adds corroboration finding when recon returns a high-severity hit', async () => {
+	it('enriched: adds corroboration finding when recon returns a hit status', async () => {
 		buildLookalikeFetchMock();
 
-		const reconBinding = makeReconBinding([
-			{ severity: 'high', title: 'CT-observed lookalike', detail: 'Certificate transparency logs show lookalike activity for test.com' },
-		]);
+		const reconBinding = makeReconHitBinding('Certificate transparency logs show lookalike activity for test.com');
 
 		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
 		const result = await checkLookalikes('test.com', { reconBinding, reconAuthToken: 'tok' });
@@ -87,10 +91,10 @@ describe('checkLookalikes recon enrichment', () => {
 		expect(enriched[0].detail).toContain('Certificate transparency logs show lookalike activity');
 	});
 
-	it('enriched: no corroboration finding when recon returns only info-severity hits', async () => {
+	it('enriched: no corroboration finding when recon returns a benign status', async () => {
 		buildLookalikeFetchMock();
 
-		const reconBinding = makeReconBinding([{ severity: 'info', title: 'Low priority note', detail: 'nothing serious' }]);
+		const reconBinding = makeReconBenignBinding();
 
 		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
 		const result = await checkLookalikes('test.com', { reconBinding, reconAuthToken: 'tok' });

--- a/test/check-realtime-threat-feed.spec.ts
+++ b/test/check-realtime-threat-feed.spec.ts
@@ -17,14 +17,14 @@ describe('checkRealtimeThreatFeed', () => {
 
 	it('surfaces a high finding when the feed reports a hit', async () => {
 		const { checkRealtimeThreatFeed } = await import('../src/tools/check-realtime-threat-feed');
-		const binding = reconBinding({ findings: [{ severity: 'high', title: 'Live threat-feed hit', detail: 'seen 2026-05-24' }] });
+		const binding = reconBinding({ checkType: 'REALTIME_THREAT_FEED', status: 'warning', details: 'seen 2026-05-24' });
 		const r = await checkRealtimeThreatFeed('evil.com', { reconBinding: binding, reconAuthToken: 'tok' });
 		expect(r.findings.some(f => f.severity === 'high')).toBe(true);
 	});
 
-	it('reports a clean result when the feed returns no findings', async () => {
+	it('reports a clean result when the feed returns a benign status', async () => {
 		const { checkRealtimeThreatFeed } = await import('../src/tools/check-realtime-threat-feed');
-		const binding = reconBinding({ findings: [] });
+		const binding = reconBinding({ checkType: 'REALTIME_THREAT_FEED', status: 'info', details: 'No active threat-feed matches.' });
 		const r = await checkRealtimeThreatFeed('good.com', { reconBinding: binding, reconAuthToken: 'tok' });
 		expect(r.passed).toBe(true);
 	});

--- a/test/recon-binding.spec.ts
+++ b/test/recon-binding.spec.ts
@@ -39,6 +39,14 @@ describe('callReconScan', () => {
 		expect(out).toBeNull();
 	});
 
+	it('returns a benign info result on 404 (no threat-feed entry — not a failure)', async () => {
+		const { callReconScan } = await fresh();
+		const binding = bindingReturning({ error: 'not found' }, 404);
+		const out = await callReconScan(binding, 'tok', 'REALTIME_THREAT_FEED', { domain: 'clean.example' });
+		expect(out).not.toBeNull();
+		expect(out?.status).toBe('info');
+	});
+
 	it('returns null when the body is not an object (non-parseable shape)', async () => {
 		const { callReconScan } = await fresh();
 		// A JSON array is not an object — Zod .object() rejects it

--- a/test/recon-binding.spec.ts
+++ b/test/recon-binding.spec.ts
@@ -24,10 +24,10 @@ describe('callReconScan', () => {
 
 	it('forwards type + target as query params and a bearer token', async () => {
 		const { callReconScan } = await fresh();
-		const binding = bindingReturning({ findings: [] });
+		const binding = bindingReturning({ checkType: 'CT_LOOKALIKE', status: 'info', details: 'ok' });
 		await callReconScan(binding, 'secret-tok', 'CT_LOOKALIKE', { domain: 'example.com' });
 		const [url, init] = binding.fetch.mock.calls[0];
-		expect(String(url)).toContain('/osint/scan?type=CT_LOOKALIKE');
+		expect(String(url)).toContain('/osint/check?type=CT_LOOKALIKE');
 		expect(String(url)).toContain('domain=example.com');
 		expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer secret-tok' });
 	});
@@ -39,17 +39,18 @@ describe('callReconScan', () => {
 		expect(out).toBeNull();
 	});
 
-	it('returns null when the body fails schema validation', async () => {
+	it('returns null when the body is not an object (non-parseable shape)', async () => {
 		const { callReconScan } = await fresh();
-		const binding = bindingReturning({ unexpected: true });
+		// A JSON array is not an object — Zod .object() rejects it
+		const binding = { fetch: vi.fn(async () => new Response(JSON.stringify([1, 2, 3]), { status: 200, headers: { 'Content-Type': 'application/json' } })) };
 		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' });
 		expect(out).toBeNull();
 	});
 
-	it('parses a valid scan body', async () => {
+	it('parses a valid DNSCheckResult body', async () => {
 		const { callReconScan } = await fresh();
-		const binding = bindingReturning({ findings: [{ severity: 'high', title: 'Malicious ASN', detail: 'AS9009' }] });
+		const binding = bindingReturning({ checkType: 'REALTIME_THREAT_FEED', status: 'info', details: 'Threat intelligence lookup returned status 404.', records: [], metadata: { domain: 'wikipedia.org', breachesFound: [] } });
 		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' });
-		expect(out?.findings[0]?.severity).toBe('high');
+		expect(out?.status).toBe('info');
 	});
 });


### PR DESCRIPTION
## Summary

Fixes the bv-mcp side of the recon-intelligence integration so the `/osint/check`-backed tools (`check_realtime_threat_feed` + the `cymru_asn`/`check_lookalikes`/`check_fast_flux` enrichments) actually function against the deployed bv-recon. Companion to bv-web #534 (dual-key auth) and #536 (scanner mount-404 fix). **Already deployed to prod** (Version `38f35eb4`) — this PR reconciles `main` with production.

### What was wrong (found via live debugging)
1. **Wrong endpoint:** the helper called `/osint/scan` (runs *all* checks, ignores `type`) instead of `/osint/check?type=&domain=` (single check). Fixed to `/osint/check`.
2. **Wrong response schema:** the helper required a top-level `findings[]` array, but bv-recon returns a `DNSCheckResult` (`{checkType, status, score, details, records, metadata}`). Rewrote `ReconScanResponseSchema` to the real shape and added `isReconHit(status)`; the 4 consuming tools now interpret `status`/`details` instead of `findings`.
3. **404 semantics:** a 404 from the intelligence check means "no threat-feed entry for this target" (benign), not a provisioning failure. Now returns a benign `status:'info'` result → tools render **"No threat-feed hits"** instead of "unavailable". Other non-2xx (5xx/auth) still fail-soft to unavailable.
4. Made `PackageTrustResponseSchema.verdict` lenient; removed temporary diagnostic logging.

### Verified live (prod)
- `check_realtime_threat_feed` for clean domains → ✅ "No realtime threat-feed hits" (benign), no longer "unavailable".
- Full chain confirmed: `BV_RECON` binding → bearer auth → `/osint/check` routing → `DNSCheckResult` parsing.

## Test Plan
- [x] `npm run typecheck` clean
- [x] `test/recon-binding.spec.ts` (incl. new 404→benign case) + the 4 tool/enrichment specs pass
- [x] Live verification against prod

## Notes / follow-ups
- `check_package_trust` uses a *different* endpoint (`/packages/check`) and still shows "unavailable" — separate cause, not addressed here.
- A cleaner long-term fix for #3 is bv-recon wrapping the intel-gateway 404 as a benign 200 `DNSCheckResult` (consistent with its cached path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)