### PR TITLE
fix(recon): default package-trust version to 'latest' (avoid bv-recon 400)

### DIFF
--- a/src/lib/recon-binding.ts
+++ b/src/lib/recon-binding.ts
@@ -232,15 +232,16 @@ export async function callReconPackageCheck(
 ): Promise<PackageTrustResult | null> {
 	if (!binding) return null;
 	try {
-		const qs = new URLSearchParams({ registry: params.registry, package: params.package });
-		if (params.version) qs.set('version', params.version);
+		// bv-recon's /packages/check requires a non-empty `version` (CheckQuerySchema).
+		// Default to 'latest' when the caller doesn't pin one — otherwise the request 400s.
+		const qs = new URLSearchParams({ registry: params.registry, package: params.package, version: params.version || 'latest' });
 		const resp = await binding.fetch(`https://bv-recon/packages/check?${qs.toString()}`, {
 			method: 'GET',
 			headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
 			signal: composeSignal(signal),
 		});
 		if (!resp.ok) return null;
-		const parsed = PackageTrustResponseSchema.safeParse(await resp.json());
+		const parsed = PackageTrustResponseSchema.safeParse(await resp.json().catch(() => null));
 		return parsed.success ? parsed.data : null;
 	} catch {
 		return null;


### PR DESCRIPTION
## Summary
Follow-up to #220. `check_package_trust` was returning "unavailable" because bv-recon's `/packages/check` requires a non-empty `version` (`CheckQuerySchema: version: z.string().min(1)`), but the helper omitted it when the caller didn't pin one → **HTTP 400** → fail-soft null.

Fix: `callReconPackageCheck` now defaults `version` to `latest` when unspecified.

## Verified live (prod `cfb17941`)
- `npm:zod` → **SAFE** (confidence MEDIUM)
- `npm:tslib` → **LOW RISK** (score 70)

All recon tools now return real data end-to-end.

## Test Plan
- [x] `npm run typecheck` clean
- [x] `test/check-package-trust.spec.ts` passes
- [x] Live verification (real verdicts returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)