### PR TITLE
docs: bv-recon MCP tools + BV_RECON binding

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Guidance for Claude Code working in this repo.
 ## What is this?
 
 Blackveil DNS — source-available DNS & email security scanner, built as a Cloudflare Worker.
-62 tools exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` runs only inside `scan_domain`. Listed on the MCP Registry as `com.blackveilsecurity/dns`.
+74 tools exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` runs only inside `scan_domain`. Listed on the MCP Registry as `com.blackveilsecurity/dns`.
 
 **Version sync** when bumping: `SERVER_VERSION` (`src/lib/server-version.ts`), `version` in `package.json` + `package-lock.json`, `version` AND `packages[0].version` in `server.json` (both fields — foot-gun), and `[X.Y.Z]` heading in `CHANGELOG.md`.
 
@@ -64,6 +64,10 @@ packages/dns-checks/  — Runtime-agnostic core: scoring/ + checks/ + schemas/
 - **`src/tools/`**: MCP wrappers + orchestration needing Workers features (KV, DO, bindings). Depends on `@blackveil/dns-checks` via npm — keep backward compat.
 
 Both publish together from `publish.yml` on version tags.
+
+### Recon tools (operator-deploy only)
+
+12 tools (`check_package_trust`, `check_realtime_threat_feed`, `scan_buckets_start/status/findings`, `osint_investigate_domain/infrastructure/supply_chain/username/email_start`, `osint_investigation_status/report`) call bv-recon via the `BV_RECON` service binding (`src/lib/recon-binding.ts`). They degrade to `unprovisioned` on BSL self-hosts where the binding is absent — the fail-soft wrapper never throws. The async tools (`scan_buckets_start`, `osint_investigate_*_start`) use a start → poll pattern: start returns an ID, poll via `*_status`, retrieve via `*_findings`/`*_report`. `cymru_asn`, `check_lookalikes`, and `check_fast_flux` gain optional bv-recon enrichment when the binding is present.
 
 ### Request flow
 
@@ -305,6 +309,8 @@ ignored env only; never commit it or paste it into workflow logs.
 | `BV_INFRA_GRAPH`                                                     | Service          | **Operator-deploy only.** Tier-1 infrastructure-graph lookup for `discovery_mode='tiered'`. Not packaged with the public distribution — wired via `.dev/wrangler.deploy.jsonc`. Absent → tiered pipeline falls back to classic sweep                              |
 | `BV_INTEL_GATEWAY`                                                   | Service          | **Operator-deploy only.** Tier-2 declared-evidence lookups for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc`                                                                                                               |
 | `BV_ENTERPRISE`                                                      | Service          | **Operator-deploy only.** Tier-0 portfolio + enterprise tenant data for `discovery_mode='tiered'`. Private BlackVeil binding; not in public `wrangler.jsonc`                                                                                                      |
+| `BV_RECON`                                                           | Service          | **Operator-deploy only.** bv-recon OSINT/recon worker — powers the recon tools (`check_package_trust`, `check_realtime_threat_feed`, `scan_buckets_*`, `osint_investigate_*`/`osint_investigation_*`) + optional enrichment of `cymru_asn`/`check_lookalikes`/`check_fast_flux`. Fail-soft when absent (tools return `unprovisioned`). Not in public `wrangler.jsonc`. |
+| `BV_RECON_KEY`                                                       | Secret           | Bearer token for bv-recon's admin routes (= bv-recon `ADMIN_API_KEY` / its dedicated `BV_MCP_KEY`).                                                                                                                                                              |
 | `BRAND_AUDIT_DISCOVERY_MODE_DEFAULT`                                 | var              | **Operator-deploy only.** When set to `"tiered"` (the BlackVeil-production default), flips the runtime default for callers that omit `discovery_mode`. Unset on BSL self-hosts → public schema default `'classic'` wins. Set only in `.dev/wrangler.deploy.jsonc` |
 | `SCORING_CONFIG`                                                     | var              | JSON scoring overrides                                                                                                                                                                                                                                            |
 | `CF_ACCOUNT_ID` / `CF_ANALYTICS_TOKEN`                               | var / Secret     | Alerting query auth                                                                                                                                                                                                                                               |

--- a/README.md
+++ b/README.md
@@ -102,8 +102,6 @@ Transport support:
   map_supply_chain      check_rbl               brand_audit_single    generate_rollout_plan
   analyze_drift         cymru_asn               brand_audit_batch_
   resolve_spf_chain     rdap_lookup               start
-                        check_package_trust
-                        check_realtime_threat_feed
   discover_subdomains   check_nsec_             brand_audit_status
   map_compliance          walkability           brand_audit_get_
   simulate_attack_paths check_dnssec_chain        report
@@ -114,6 +112,20 @@ Transport support:
 
   + check_subdomain_takeover (standalone tool + internal — runs inside scan_domain)
   + check_authoritative_dns_infra and check_root_server_set (authoritative DNS infrastructure profile)
+
+  Operator-deploy only (BV_RECON binding; degrade to unprovisioned on self-hosted BSL deployments):
+  + check_package_trust          — package ecosystem trust check via bv-recon
+  + check_realtime_threat_feed   — curated intel-gateway threat feed lookup
+  + scan_buckets_start           — async cloud-bucket discovery scan (start → poll → findings)
+  + scan_buckets_status          — poll status of a running bucket scan
+  + scan_buckets_findings        — retrieve findings for a completed bucket scan
+  + osint_investigate_domain_start          — async domain OSINT investigation (start → poll → report)
+  + osint_investigate_infrastructure_start  — async deep-infrastructure OSINT (domain, IP, or org)
+  + osint_investigate_supply_chain_start    — async supply-chain OSINT investigation
+  + osint_investigate_username_start        — async username OSINT (owner/enterprise tier only)
+  + osint_investigate_email_start           — async email OSINT (owner/enterprise tier only)
+  + osint_investigation_status   — poll status of any running OSINT investigation
+  + osint_investigation_report   — retrieve report for a completed OSINT investigation
 ```
 
 ### Authoritative DNS infrastructure


### PR DESCRIPTION
## Summary

- Updates CLAUDE.md tool count from 62 → 74
- Adds `BV_RECON` (Service) and `BV_RECON_KEY` (Secret) rows to the bindings table in CLAUDE.md
- Adds a concise "Recon tools (operator-deploy only)" architecture note in CLAUDE.md covering the fail-soft pattern, async start→poll flow, and enrichment of `cymru_asn`/`check_lookalikes`/`check_fast_flux`
- Adds all 12 recon tools to the README tools section in a dedicated operator-only block (`check_package_trust`, `check_realtime_threat_feed`, `scan_buckets_*`, `osint_investigate_*_start`, `osint_investigation_status/report`); removes `check_package_trust`/`check_realtime_threat_feed` from the Infrastructure grid column (they belong in the operator-only block)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run test/audits/readme-tool-surface.audit.test.ts test/tool-metadata.spec.ts` — 2 test files, 6 tests, all passed
- No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)