### PR TITLE
feat(mcp): structuredContent on tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.0] - 2026-05-26
+
+### Added
+
+- **MCP `structuredContent` on tool-call results.** Every tool that returns structured data now sets the MCP-standard `structuredContent` object on its `tools/call` result, giving all LLM/clients a reliable machine-readable channel. Arrays are wrapped as `{ results: [...] }` and scalars as `{ value: ... }` (MCP requires an object); `null`/`undefined` omits the field. Set independently of `format` — the legacy `<!-- STRUCTURED_RESULT … -->` comment in `content` is preserved for backward compatibility. Per-tool `outputSchema` declarations are intentionally out of scope (clients treat unschematized `structuredContent` as opaque JSON).
+
 ## [3.2.1] - 2026-05-26
 
 ### Removed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.2.1",
+	"version": "3.3.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.2.1",
+			"version": "3.3.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.2.1",
+	"version": "3.3.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.2.1",
+	"version": "3.3.0",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "3.2.1",
+			"version": "3.3.0",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/handlers/tool-formatters.ts
+++ b/src/handlers/tool-formatters.ts
@@ -30,6 +30,40 @@ export function buildToolContent(text: string, structuredData: unknown, format: 
 	return content;
 }
 
+/**
+ * Coerce arbitrary structured tool data into the MCP-standard `structuredContent`
+ * shape — which MUST be a JSON object (not an array or scalar) per MCP 2025-06-18.
+ *
+ * - `null`/`undefined` → `undefined` (field is omitted from the result).
+ * - array → `{ results: <array> }` (objects-only constraint).
+ * - plain object → returned as-is.
+ * - scalar (string/number/boolean) → `{ value: <scalar> }`.
+ */
+export function toStructuredContent(data: unknown): Record<string, unknown> | undefined {
+	if (data === null || data === undefined) return undefined;
+	if (Array.isArray(data)) return { results: data };
+	if (typeof data === 'object') return data as Record<string, unknown>;
+	return { value: data };
+}
+
+/**
+ * Build a full MCP tool-call result: the human-readable `content` array (with the
+ * backward-compat `STRUCTURED_RESULT` comment in `full` format) plus the
+ * MCP-standard `structuredContent` machine-readable channel.
+ *
+ * `structuredContent` is set regardless of `format` — it is a separate channel
+ * from `content`, and clients that don't support it simply ignore it.
+ */
+export function buildToolResult(
+	text: string,
+	structuredData: unknown,
+	format: OutputFormat,
+): { content: McpContent[]; structuredContent?: Record<string, unknown> } {
+	const content = buildToolContent(text, structuredData, format);
+	const sc = toStructuredContent(structuredData);
+	return sc === undefined ? { content } : { content, structuredContent: sc };
+}
+
 export function formatCheckResult(result: CheckResult, format: OutputFormat = 'full'): string {
 	const lines: string[] = [];
 	lines.push(`## ${result.category.toUpperCase()} Check`);

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -84,7 +84,7 @@ import {
 } from './tool-args';
 import type { OutputFormat } from './tool-args';
 import { buildLogContext, logToolFailure, logToolSuccess } from './tool-execution';
-import { formatCheckResult, mcpError, buildToolContent } from './tool-formatters';
+import { formatCheckResult, mcpError, buildToolResult } from './tool-formatters';
 import type { McpContent } from './tool-formatters';
 import { TOOLS } from '../schemas/tool-definitions';
 import type { McpTool } from '../schemas/tool-definitions';
@@ -92,6 +92,7 @@ import type { McpTool } from '../schemas/tool-definitions';
 /** MCP tools/call result */
 interface McpToolResult {
 	content: McpContent[];
+	structuredContent?: Record<string, unknown>;
 	isError?: boolean;
 }
 
@@ -900,7 +901,7 @@ export async function handleToolsCall(
 					logDetails,
 					cacheStatus,
 				});
-				return { content: buildToolContent(formatCheckResult(result, effectiveFormat), result, effectiveFormat) };
+				return buildToolResult(formatCheckResult(result, effectiveFormat), result, effectiveFormat);
 			}
 
 			switch (name) {
@@ -926,7 +927,7 @@ export async function handleToolsCall(
 						cacheStatus,
 					});
 					const structured = buildStructuredScanResult(result);
-					return { content: buildToolContent(formatScanReport(result, effectiveFormat), structured, effectiveFormat) };
+					return buildToolResult(formatScanReport(result, effectiveFormat), structured, effectiveFormat);
 				}
 				case 'batch_scan': {
 					const domains = validatedArgs.domains as string[];
@@ -955,7 +956,7 @@ export async function handleToolsCall(
 						logDetails: { totalDomains: batchResults.length },
 						severity: 'info',
 					});
-					return { content: buildToolContent(batchText, batchResults, effectiveFormat) };
+					return buildToolResult(batchText, batchResults, effectiveFormat);
 				}
 				case 'compare_domains': {
 					const domains = validatedArgs.domains as string[];
@@ -982,7 +983,7 @@ export async function handleToolsCall(
 						logDetails: { totalDomains: compareResults.domains.length, winner: compareResults.winner },
 						severity: 'info',
 					});
-					return { content: buildToolContent(compareText, compareResults, effectiveFormat) };
+					return buildToolResult(compareText, compareResults, effectiveFormat);
 				}
 				case 'compare_baseline': {
 					const baseline = extractBaseline(validatedArgs) as PolicyBaseline;
@@ -991,45 +992,45 @@ export async function handleToolsCall(
 					logResult = result.passed ? 'pass' : 'fail';
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: result.passed ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatBaselineResult(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatBaselineResult(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'generate_fix_plan': {
 					const plan = await generateFixPlan(validDomain, scanCacheKV, runtimeOptions);
 					logResult = plan.grade;
 					logDetails = plan;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatFixPlan(plan, effectiveFormat), plan, effectiveFormat) };
+					return buildToolResult(formatFixPlan(plan, effectiveFormat), plan, effectiveFormat);
 				}
 				case 'generate_spf_record': {
 					const includeProviders = extractIncludeProviders(validatedArgs);
 					const record = await generateSpfRecord(validDomain, includeProviders, buildDnsOptions(runtimeOptions));
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: 'generated', logDetails: record, severity: 'info' });
-					return { content: buildToolContent(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat) };
+					return buildToolResult(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat);
 				}
 				case 'generate_dmarc_record': {
 					const policy = typeof validatedArgs.policy === 'string' ? (validatedArgs.policy as 'none' | 'quarantine' | 'reject') : undefined;
 					const ruaEmail = typeof validatedArgs.rua_email === 'string' ? validatedArgs.rua_email : undefined;
 					const record = await generateDmarcRecord(validDomain, policy, ruaEmail, buildDnsOptions(runtimeOptions));
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: 'generated', logDetails: record, severity: 'info' });
-					return { content: buildToolContent(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat) };
+					return buildToolResult(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat);
 				}
 				case 'generate_dkim_config': {
 					const provider = typeof validatedArgs.provider === 'string' ? validatedArgs.provider : undefined;
 					const record = await generateDkimConfig(validDomain, provider);
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: 'generated', logDetails: record, severity: 'info' });
-					return { content: buildToolContent(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat) };
+					return buildToolResult(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat);
 				}
 				case 'generate_mta_sts_policy': {
 					const mxHosts = extractMxHosts(validatedArgs);
 					const record = await generateMtaStsPolicy(validDomain, mxHosts, buildDnsOptions(runtimeOptions));
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: 'generated', logDetails: record, severity: 'info' });
-					return { content: buildToolContent(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat) };
+					return buildToolResult(formatGeneratedRecord(record, effectiveFormat), record, effectiveFormat);
 				}
 				case 'get_benchmark': {
 					const profile = typeof validatedArgs.profile === 'string' ? validatedArgs.profile : 'mail_enabled';
 					const result = await getBenchmark(runtimeOptions?.profileAccumulator, profile);
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: result.status, logDetails: result, severity: 'info' });
-					return { content: buildToolContent(formatBenchmark(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatBenchmark(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'get_provider_insights': {
 					const provider = typeof validatedArgs.provider === 'string' ? validatedArgs.provider : '';
@@ -1039,14 +1040,14 @@ export async function handleToolsCall(
 					const profile = typeof validatedArgs.profile === 'string' ? validatedArgs.profile : 'mail_enabled';
 					const result = await getProviderInsights(runtimeOptions?.profileAccumulator, provider, profile);
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: result.status, logDetails: result, severity: 'info' });
-					return { content: buildToolContent(formatProviderInsights(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatProviderInsights(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'assess_spoofability': {
 					const result = await assessSpoofability(validDomain, buildDnsOptions(runtimeOptions));
 					logResult = result.riskLevel;
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: result.spoofabilityScore <= 30 ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatSpoofability(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatSpoofability(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'check_resolver_consistency': {
 					const recordType = extractRecordType(validatedArgs);
@@ -1055,7 +1056,7 @@ export async function handleToolsCall(
 					logResult = result.passed ? 'pass' : 'fail';
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: result.passed ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatResolverConsistency(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatResolverConsistency(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'explain_finding': {
 					let explainArgs: ReturnType<typeof extractExplainFindingArgs>;
@@ -1067,7 +1068,7 @@ export async function handleToolsCall(
 					const { checkType, status, details } = explainArgs;
 					const result = explainFinding(checkType, status, details);
 					logToolSuccess({ ...ctx(), status: 'pass', logResult: status, logDetails: { checkType, details }, severity: 'info' });
-					return { content: buildToolContent(formatExplanation(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatExplanation(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'validate_fix': {
 					const check = typeof validatedArgs.check === 'string' ? validatedArgs.check : '';
@@ -1076,14 +1077,14 @@ export async function handleToolsCall(
 					logResult = result.verdict;
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: result.verdict === 'fixed' ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatValidateFix(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatValidateFix(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'map_supply_chain': {
 					const result = await mapSupplyChain(validDomain, buildDnsOptions(runtimeOptions));
 					logResult = `${result.summary.totalProviders} providers`;
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatSupplyChain(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatSupplyChain(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'generate_rollout_plan': {
 					const targetPolicy =
@@ -1096,7 +1097,7 @@ export async function handleToolsCall(
 					logResult = result.atTarget ? 'at_target' : `${result.phases.length} phases`;
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatRolloutPlan(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatRolloutPlan(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'analyze_drift': {
 					const baselineStr = typeof validatedArgs.baseline === 'string' ? validatedArgs.baseline : '';
@@ -1130,35 +1131,35 @@ export async function handleToolsCall(
 					logResult = drift.classification;
 					logDetails = drift;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatDriftReport(drift, effectiveFormat), drift, effectiveFormat) };
+					return buildToolResult(formatDriftReport(drift, effectiveFormat), drift, effectiveFormat);
 				}
 				case 'resolve_spf_chain': {
 					const result = await resolveSpfChain(validDomain, buildDnsOptions(runtimeOptions));
 					logResult = result.overLimit ? 'over_limit' : 'ok';
 					logDetails = { totalLookups: result.totalLookups, maxDepth: result.maxDepth, issues: result.issues.length };
 					logToolSuccess({ ...ctx(), status: result.overLimit ? 'fail' : 'pass', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatSpfChain(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatSpfChain(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'discover_subdomains': {
 					const result = await discoverSubdomains(validDomain, runtimeOptions?.certstream, runtimeOptions?.certstreamAuthToken);
 					logResult = `${result.totalSubdomains} subdomains`;
 					logDetails = { totalSubdomains: result.totalSubdomains, issues: result.issues.length };
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatSubdomainDiscovery(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatSubdomainDiscovery(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'map_compliance': {
 					const result = await mapCompliance(validDomain, scanCacheKV, runtimeOptions);
 					logResult = 'mapped';
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatCompliance(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatCompliance(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'simulate_attack_paths': {
 					const result = await simulateAttackPaths(validDomain, buildDnsOptions(runtimeOptions));
 					logResult = `${result.totalPaths} paths, risk: ${result.overallRisk}`;
 					logDetails = { totalPaths: result.totalPaths, overallRisk: result.overallRisk };
 					logToolSuccess({ ...ctx(), status: result.overallRisk === 'low' ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
-					return { content: buildToolContent(formatAttackPaths(result, effectiveFormat), result, effectiveFormat) };
+					return buildToolResult(formatAttackPaths(result, effectiveFormat), result, effectiveFormat);
 				}
 				default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.2.1';
+export const SERVER_VERSION = '3.3.0';

--- a/test/tool-result-structured-content.spec.ts
+++ b/test/tool-result-structured-content.spec.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Unit + integration coverage for the MCP-standard `structuredContent` field on
+// tool-call results. `structuredContent` is a separate, format-independent
+// machine-readable channel (an OBJECT per MCP 2025-06-18). The legacy
+// `<!-- STRUCTURED_RESULT … -->` comment stays inside `content` for
+// backward-compat (full format only).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { setupFetchMock, mockTxtRecords } from './helpers/dns-mock';
+import { IN_MEMORY_CACHE } from '../src/lib/cache';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+describe('buildToolResult - structuredContent channel', () => {
+	it('wraps a plain object as-is and keeps the human text + STRUCTURED_RESULT comment (full)', async () => {
+		const { buildToolResult } = await import('../src/handlers/tool-formatters');
+		const out = buildToolResult('txt', { score: 100 }, 'full');
+
+		expect(out.structuredContent).toEqual({ score: 100 });
+		expect(out.content[0].text).toBe('txt');
+		// backward-compat comment still appended to content in full format
+		expect(out.content.some((c) => c.text.includes('STRUCTURED_RESULT'))).toBe(true);
+	});
+
+	it('wraps array data under a `results` key (structuredContent MUST be an object)', async () => {
+		const { buildToolResult } = await import('../src/handlers/tool-formatters');
+		const out = buildToolResult('txt', [{ a: 1 }, { a: 2 }], 'full');
+
+		expect(out.structuredContent).toEqual({ results: [{ a: 1 }, { a: 2 }] });
+	});
+
+	it('omits structuredContent entirely for null data', async () => {
+		const { buildToolResult } = await import('../src/handlers/tool-formatters');
+		const out = buildToolResult('txt', null, 'full');
+
+		expect('structuredContent' in out).toBe(false);
+	});
+
+	it('sets structuredContent independent of format (compact has no comment but still carries it)', async () => {
+		const { buildToolResult } = await import('../src/handlers/tool-formatters');
+		const out = buildToolResult('txt', { score: 50 }, 'compact');
+
+		// compact strips the embedded comment from content...
+		expect(out.content.some((c) => c.text.includes('STRUCTURED_RESULT'))).toBe(false);
+		// ...but structuredContent is a separate channel, always present
+		expect(out.structuredContent).toEqual({ score: 50 });
+	});
+
+	it('wraps a scalar under a `value` key', async () => {
+		const { buildToolResult } = await import('../src/handlers/tool-formatters');
+		const out = buildToolResult('txt', 'x', 'full');
+
+		expect(out.structuredContent).toEqual({ value: 'x' });
+	});
+});
+
+describe('structuredContent - integration through handleToolsCall', () => {
+	it('check_spf surfaces a CheckResult-shaped structuredContent object', async () => {
+		IN_MEMORY_CACHE.clear();
+		mockTxtRecords(['v=spf1 -all']);
+
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall({ name: 'check_spf', arguments: { domain: 'example.com' } });
+
+		expect(result.isError).toBeUndefined();
+		expect(result.structuredContent).toBeTypeOf('object');
+		const sc = result.structuredContent as Record<string, unknown>;
+		expect(sc.category).toBe('spf');
+		expect(typeof sc.score).toBe('number');
+		expect(typeof sc.passed).toBe('boolean');
+		expect(Array.isArray(sc.findings)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Adopt the MCP-standard `structuredContent` field on `tools/call` results. Until now the only machine-readable output was a non-standard `<!-- STRUCTURED_RESULT … -->` comment embedded in `content`, and only for non-interactive clients (`format=full`). This gives every LLM/client a reliable, spec-compliant structured channel.

Annotations were already done and are untouched.

## Changes

- **`tool-formatters.ts`**: new `buildToolResult(text, structuredData, format)` returning `{ content, structuredContent? }`, plus `toStructuredContent(data)` coercion. `buildToolContent` is unchanged and still drives `content` (including the backward-compat comment in `full` format).
- **`handlers/tools.ts`**: added `structuredContent?: Record<string, unknown>` to the `McpToolResult` envelope; migrated all **23** structured-data returns (`return { content: buildToolContent(...) }` → `return buildToolResult(...)`). This covers the 22 special-case switch tools plus the registry-driven `check_*` path (which serves all `check_*`, `cymru_asn`, `rdap_lookup`, `brand_audit_*`, `scan_buckets_*`, `osint_*`, etc.). Error and timeout returns are left as `{ content: [mcpError(...)], isError: true }` — no structured data.
- **Version bump 3.2.1 → 3.3.0** (additive capability): `SERVER_VERSION`, `package.json` + `package-lock.json`, `server.json` (both `version` fields), CHANGELOG.

## `toStructuredContent` rules (MCP 2025-06-18 requires an object)

- `null`/`undefined` → field omitted.
- array → `{ results: <array> }`.
- plain object → returned as-is.
- scalar → `{ value: <scalar> }`.

`structuredContent` is set independently of `format` — it is a separate channel; clients that don't support it ignore it.

## Backward compatibility

The `<!-- STRUCTURED_RESULT … -->` comment is preserved in `content` (full format only), so existing comment-parsing clients keep working.

## Deliberate scope

Per-tool `outputSchema` declarations in `TOOL_DEFS` are intentionally **out of scope** for this PR. MCP allows but does not require them; clients treat unschematized `structuredContent` as opaque JSON. Declaring output schemas can follow up.

## Tests (TDD)

New `test/tool-result-structured-content.spec.ts` (written first, watched fail, then implemented): 5 unit cases for the coercion/channel rules + 1 integration case dispatching `check_spf` through `handleToolsCall` and asserting a `CheckResult`-shaped `structuredContent` (`category`/`score`/`passed`/`findings`).

- New spec: 6/6 pass.
- `test/handlers-tools.spec.ts`, `test/audits/tool-annotations.audit.test.ts`, `test/contracts/*` (12 files): all pass.
- Full suite: 424 files / 4470 tests pass, 13 skipped. The trailing pool-teardown WebSocket-disconnect "errors" are the documented flake.
- `npm run typecheck` clean, `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)