### PR TITLE
feat(mcp): outputSchema on CheckResult tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.1] - 2026-05-26
+
+### Added
+
+- **MCP `outputSchema` on CheckResult-returning tools.** Follow-up to 3.3.0 (which deferred this): the registry-driven `check_*`/recon tools — every tool whose `tools/call` `structuredContent` is a `CheckResult` (51 tools) — now declare a lenient `outputSchema` in `tools/list`, letting strict MCP clients validate the `structuredContent` added in 3.3.0. The schema pins only the always-present keys (`category`, `score`, `passed`, `findings`) and permits any extra properties (`checkStatus`, `partial`, `metadata`, finding metadata), so any real CheckResult validates. Special-case tools that return custom shapes (`scan_domain`, `batch_scan`, `compare_domains`, `compare_baseline`, `generate_*`, etc.) intentionally declare no `outputSchema`. Additive — no tool-count or input-schema change.
+
 ## [3.3.0] - 2026-05-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.3.0",
+			"version": "3.3.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.3.0",
+	"version": "3.3.1",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "3.3.0",
+			"version": "3.3.1",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -106,6 +106,8 @@ interface WireTool {
 	name: string;
 	description: string;
 	inputSchema: McpTool['inputSchema'];
+	/** Present only for tools whose `structuredContent` is a `CheckResult`. */
+	outputSchema?: McpTool['outputSchema'];
 	annotations: McpTool['annotations'];
 	_meta: {
 		group: McpTool['group'];
@@ -124,6 +126,7 @@ export function handleToolsList(): { tools: WireTool[] } {
 			name: tool.name,
 			description: tool.description,
 			inputSchema: tool.inputSchema,
+			...(tool.outputSchema !== undefined && { outputSchema: tool.outputSchema }),
 			annotations: tool.annotations,
 			_meta: {
 				group: tool.group,

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.3.0';
+export const SERVER_VERSION = '3.3.1';

--- a/src/schemas/check-result-output.ts
+++ b/src/schemas/check-result-output.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Lenient MCP `outputSchema` for tools whose `structuredContent` is a `CheckResult`.
+ *
+ * v3.3.0 added `structuredContent` to tool-call results; for the registry-driven
+ * `check_*`/recon tools that source it from a `CheckResult`, this schema is what
+ * strict MCP clients validate the result against.
+ *
+ * **Contract requirement:** ANY real `CheckResult` MUST validate. `CheckResult`
+ * carries optional/wrapper-added fields (`checkStatus`, `partial`, `metadata`,
+ * extra finding metadata, and a `category` string that may sit outside the
+ * package enum), so this schema is deliberately additive: it pins only the four
+ * always-present keys (`category`, `score`, `passed`, `findings`) by type and
+ * permits any extra properties via `.loose()`. We do NOT reuse the package
+ * `CheckResultSchema` — that one is a strict object keyed to the `CheckCategory`
+ * enum and would reject extra keys / new categories, failing strict clients.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Lenient Zod schema for a `CheckResult`-shaped `structuredContent` payload.
+ * `.loose()` (Zod v4 passthrough) lets wrapper-added fields ride through.
+ */
+export const CheckResultOutputSchema = z
+	.object({
+		category: z.string(),
+		score: z.number(),
+		passed: z.boolean(),
+		findings: z.array(z.object({}).loose()),
+	})
+	.loose();
+
+/**
+ * The lenient CheckResult output schema as a JSON Schema object, derived via the
+ * same `z.toJSONSchema()` path used for tool `inputSchema` (with `$schema` stripped).
+ * Built once and shared across all CheckResult tools.
+ */
+export function buildCheckResultOutputJsonSchema(): {
+	type: string;
+	properties: Record<string, unknown>;
+	required?: string[];
+	[key: string]: unknown;
+} {
+	const jsonSchema = z.toJSONSchema(CheckResultOutputSchema) as Record<string, unknown>;
+	delete jsonSchema.$schema;
+	return jsonSchema as ReturnType<typeof buildCheckResultOutputJsonSchema>;
+}

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -38,6 +38,7 @@ import {
 	OsintInvestigationIdArgs,
 	TOOL_SCHEMA_MAP,
 } from './tool-args';
+import { buildCheckResultOutputJsonSchema } from './check-result-output';
 
 export type ToolGroup =
 	| 'email_auth'
@@ -59,6 +60,13 @@ export interface McpTool {
 		required?: string[];
 		[key: string]: unknown;
 	};
+	/**
+	 * MCP `outputSchema` for the tool's `structuredContent`. Present only on tools
+	 * whose `structuredContent` is a `CheckResult` (the registry-driven check/recon
+	 * tools); absent for special-case tools that return custom shapes. Lenient so any
+	 * real CheckResult validates — see `schemas/check-result-output.ts`.
+	 */
+	outputSchema?: McpTool['inputSchema'];
 	annotations?: {
 		title?: string;
 		readOnlyHint?: boolean;
@@ -653,10 +661,49 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 };
 
+/**
+ * Special-case tools whose `tools/call` `structuredContent` is NOT a `CheckResult`
+ * (custom shapes: scan reports, batch arrays, generated records, comparisons,
+ * baseline results, etc.). These dispatch outside the `TOOL_REGISTRY` CheckResult
+ * path in `handlers/tools.ts` and therefore get NO `outputSchema`.
+ *
+ * Every other tool flows through the registry path (`buildToolResult(..., result, ...)`
+ * where `result: CheckResult`), so its `structuredContent` IS a `CheckResult` and
+ * gets the lenient CheckResult `outputSchema`.
+ */
+const NON_CHECK_RESULT_TOOLS = new Set<string>([
+	'scan_domain',
+	'batch_scan',
+	'compare_domains',
+	'compare_baseline',
+	'generate_fix_plan',
+	'generate_spf_record',
+	'generate_dmarc_record',
+	'generate_dkim_config',
+	'generate_mta_sts_policy',
+	'get_benchmark',
+	'get_provider_insights',
+	'assess_spoofability',
+	'check_resolver_consistency',
+	'explain_finding',
+	'map_supply_chain',
+	'analyze_drift',
+	'validate_fix',
+	'generate_rollout_plan',
+	'resolve_spf_chain',
+	'discover_subdomains',
+	'map_compliance',
+	'simulate_attack_paths',
+]);
+
+/** Lenient CheckResult output schema — derived once, shared across all CheckResult tools. */
+const CHECK_RESULT_OUTPUT_SCHEMA = buildCheckResultOutputJsonSchema();
+
 export const TOOLS: McpTool[] = Object.entries(TOOL_DEFS).map(([name, def]) => ({
 	name,
 	description: def.description,
 	inputSchema: toInputSchema(def.schema),
+	...(NON_CHECK_RESULT_TOOLS.has(name) ? {} : { outputSchema: CHECK_RESULT_OUTPUT_SCHEMA }),
 	annotations: {
 		title: toolNameToTitle(name),
 		readOnlyHint: !def.mutating,

--- a/test/tool-output-schema.spec.ts
+++ b/test/tool-output-schema.spec.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// Coverage for the MCP `outputSchema` declared on tools whose `structuredContent`
+// is a `CheckResult` (v3.3.1). The critical assertion is the round-trip contract:
+// a real CheckResult emitted by dispatch MUST validate against the lenient schema,
+// or strict clients reject the result.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { TOOLS } from '../src/schemas/tool-definitions';
+import { CheckResultOutputSchema, buildCheckResultOutputJsonSchema } from '../src/schemas/check-result-output';
+import { handleToolsList } from '../src/handlers/tools';
+import { setupFetchMock, createDohResponse, mockTxtRecords } from './helpers/dns-mock';
+import { IN_MEMORY_CACHE } from '../src/lib/cache';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+/**
+ * The 22 special-case tools that return custom shapes (NOT a CheckResult) and
+ * therefore must NOT carry an `outputSchema`. Mirrors the EXCLUDE set: everything
+ * dispatched outside the TOOL_REGISTRY CheckResult path in handlers/tools.ts.
+ */
+const NON_CHECK_RESULT_TOOLS = new Set([
+	'scan_domain',
+	'batch_scan',
+	'compare_domains',
+	'compare_baseline',
+	'generate_fix_plan',
+	'generate_spf_record',
+	'generate_dmarc_record',
+	'generate_dkim_config',
+	'generate_mta_sts_policy',
+	'get_benchmark',
+	'get_provider_insights',
+	'assess_spoofability',
+	'check_resolver_consistency',
+	'explain_finding',
+	'map_supply_chain',
+	'analyze_drift',
+	'validate_fix',
+	'generate_rollout_plan',
+	'resolve_spf_chain',
+	'discover_subdomains',
+	'map_compliance',
+	'simulate_attack_paths',
+]);
+
+describe('CheckResult output schema (derived)', () => {
+	it('is an object schema requiring category/score/passed/findings', () => {
+		const schema = buildCheckResultOutputJsonSchema();
+		expect(schema.type).toBe('object');
+		expect(new Set(schema.required ?? [])).toEqual(new Set(['category', 'score', 'passed', 'findings']));
+		expect(schema.properties.category).toMatchObject({ type: 'string' });
+		expect(schema.properties.score).toMatchObject({ type: 'number' });
+		expect(schema.properties.passed).toMatchObject({ type: 'boolean' });
+		expect(schema.properties.findings).toMatchObject({ type: 'array' });
+	});
+
+	it('is lenient — does NOT set additionalProperties: false (extra props allowed)', () => {
+		const schema = buildCheckResultOutputJsonSchema();
+		expect(schema.additionalProperties).not.toBe(false);
+		expect(schema).not.toHaveProperty('$schema');
+	});
+
+	it('accepts a CheckResult with wrapper-added fields (checkStatus/partial/metadata)', () => {
+		const real = {
+			category: 'spf',
+			score: 80,
+			passed: true,
+			findings: [{ category: 'spf', title: 't', severity: 'low', detail: 'd', metadata: { a: 1 } }],
+			checkStatus: 'ok',
+			partial: false,
+			metadata: { foo: 'bar' },
+		};
+		expect(CheckResultOutputSchema.safeParse(real).success).toBe(true);
+	});
+
+	it('rejects a payload missing a required key', () => {
+		const bad = { category: 'mx', score: 0, findings: [] };
+		expect(CheckResultOutputSchema.safeParse(bad).success).toBe(false);
+	});
+});
+
+describe('outputSchema declarations on TOOLS', () => {
+	it('every non-CheckResult special-case tool has NO outputSchema', () => {
+		for (const name of NON_CHECK_RESULT_TOOLS) {
+			const tool = TOOLS.find((t) => t.name === name);
+			expect(tool, `tool ${name} should exist`).toBeDefined();
+			expect(tool?.outputSchema, `tool ${name} must not declare outputSchema`).toBeUndefined();
+		}
+	});
+
+	it('every other tool (the CheckResult set) HAS an outputSchema equal to the derived schema', () => {
+		const derived = buildCheckResultOutputJsonSchema();
+		const checkResultTools = TOOLS.filter((t) => !NON_CHECK_RESULT_TOOLS.has(t.name));
+		// Sanity: there should be 51 CheckResult tools (73 total − 22 excluded).
+		expect(checkResultTools).toHaveLength(51);
+		for (const tool of checkResultTools) {
+			expect(tool.outputSchema, `tool ${tool.name} must declare outputSchema`).toBeDefined();
+			expect(tool.outputSchema).toEqual(derived);
+		}
+	});
+
+	it('adding outputSchema does not change tool count', () => {
+		expect(TOOLS).toHaveLength(73);
+	});
+});
+
+describe('tools/list emits outputSchema for CheckResult tools only', () => {
+	it('CheckResult tools surface outputSchema; excluded tools omit the key', () => {
+		const { tools } = handleToolsList();
+		const byName = new Map(tools.map((t) => [t.name, t]));
+
+		const spf = byName.get('check_spf') as Record<string, unknown> | undefined;
+		expect(spf?.outputSchema).toBeDefined();
+		expect((spf?.outputSchema as { type?: string }).type).toBe('object');
+
+		const cymru = byName.get('cymru_asn') as Record<string, unknown> | undefined;
+		expect(cymru?.outputSchema).toBeDefined();
+
+		const scan = byName.get('scan_domain') as Record<string, unknown> | undefined;
+		expect(scan).toBeDefined();
+		expect('outputSchema' in (scan as object)).toBe(false);
+
+		const baseline = byName.get('compare_baseline') as Record<string, unknown> | undefined;
+		expect('outputSchema' in (baseline as object)).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Round-trip contract: real dispatch output MUST validate against the schema.
+// ---------------------------------------------------------------------------
+
+describe('round-trip — real structuredContent validates against CheckResultOutputSchema', () => {
+	async function call(name: string, args: Record<string, unknown>) {
+		IN_MEMORY_CACHE.clear();
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		return handleToolsCall({ name, arguments: args });
+	}
+
+	it('check_spf', async () => {
+		mockTxtRecords(['v=spf1 -all']);
+		const result = await call('check_spf', { domain: 'example.com' });
+		expect(result.isError).toBeUndefined();
+		const parsed = CheckResultOutputSchema.safeParse(result.structuredContent);
+		expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+	});
+
+	it('check_dmarc', async () => {
+		mockTxtRecords(['v=DMARC1; p=reject; rua=mailto:dmarc@example.com']);
+		const result = await call('check_dmarc', { domain: 'example.com' });
+		expect(result.isError).toBeUndefined();
+		const parsed = CheckResultOutputSchema.safeParse(result.structuredContent);
+		expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+	});
+
+	it('cymru_asn (no A records → still a CheckResult)', async () => {
+		// Empty DoH answers for every query — cymru_asn returns a CheckResult, not an error shape.
+		globalThis.fetch = vi.fn().mockResolvedValue(createDohResponse([], []));
+		const result = await call('cymru_asn', { domain: 'example.com' });
+		expect(result.isError).toBeUndefined();
+		const parsed = CheckResultOutputSchema.safeParse(result.structuredContent);
+		expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+	});
+
+	it('brand_audit_status unprovisioned (buildCheckResult fallback path)', async () => {
+		// No BRAND_AUDIT_DB binding in tests → registry returns buildCheckResult('brand_discovery', ...).
+		// Seals the operator-only async tools' structuredContent contract.
+		const result = await call('brand_audit_status', { auditId: 'aud_does_not_exist' });
+		expect(result.isError).toBeUndefined();
+		const parsed = CheckResultOutputSchema.safeParse(result.structuredContent);
+		expect(parsed.success, JSON.stringify(parsed.error?.issues)).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Declares MCP `outputSchema` on the bv-mcp tools whose `tools/call` `structuredContent` is a `CheckResult`, so strict clients can validate the structured channel added in v3.3.0. Bumps 3.3.0 → 3.3.1 (additive).

## Which tools

- **51 CheckResult tools** get `outputSchema`: every tool dispatched through the `TOOL_REGISTRY` path in `handlers/tools.ts` (`buildToolResult(formatCheckResult(result, …), result, …)` where `result: CheckResult`). The registry signature forces `execute → Promise<CheckResult>`, so all of them — including the operator-only async tools (`brand_audit_status`, `brand_audit_get_report`, `scan_buckets_*`, `osint_investigation_*`), whose unprovisioned paths use `buildCheckResult(...)` — are structurally CheckResults.
- **22 special-case tools** are excluded (no `outputSchema`): `scan_domain`, `batch_scan`, `compare_domains`, `compare_baseline`, all `generate_*`, `explain_finding`, `get_benchmark`, `get_provider_insights`, `assess_spoofability`, `check_resolver_consistency`, `validate_fix`, `map_supply_chain`, `generate_rollout_plan`, `analyze_drift`, `resolve_spf_chain`, `discover_subdomains`, `map_compliance`, `simulate_attack_paths`. These return custom shapes via their own formatters. `compare_baseline` was verified to return `BaselineResult` (no `category`/`score`/`findings`), confirming exclusion.

73 total tools unchanged (51 + 22).

## The schema (lenient)

A new minimal Zod schema in `src/schemas/check-result-output.ts` — NOT the package `CheckResultSchema`, which is strict and keyed to the `CheckCategory` enum (would reject extra keys and new categories). The lenient schema pins only `category`/`score`/`passed`/`findings` and uses `.loose()` so wrapper-added fields (`checkStatus`, `partial`, `metadata`, finding metadata) pass. Derived to JSON Schema via the same `z.toJSONSchema()` path as `inputSchema`; output has top-level `additionalProperties: {}` (permit-anything), not `false`.

## Tests (TDD)

`test/tool-output-schema.spec.ts` (written first, confirmed red before implementation):
- Derived schema is an object requiring the four keys and is lenient (no `additionalProperties: false`).
- All 51 CheckResult tools have `outputSchema`; the 22 excluded tools have none; count stays 73.
- `tools/list` (via `handleToolsList`) emits `outputSchema` for CheckResult tools and omits it for excluded ones.
- **Round-trip contract:** real dispatch of `check_spf`, `check_dmarc`, `cymru_asn`, and the unprovisioned `brand_audit_status` fallback — each result's `structuredContent` validates against the Zod schema via `safeParse(...).success`.

## Verification

- `npm run typecheck` clean
- `npm run lint` clean
- New spec + `handlers-tools` + `tool-metadata` + `tool-schemas` + `tool-definitions` + `tool-result-structured-content` + full `test/contracts` all pass
- Full `npm test`: 4481 passed, 13 skipped, 0 test failures (8 trailing miniflare WebSocket pool-teardown errors are the documented flake)

## Version surfaces

`server-version.ts`, `package.json`, `package-lock.json`, `server.json` (both `version` fields), `CHANGELOG.md` (`## [3.3.1]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)