### PR TITLE
test(deflake): pin clock in session-create rate-limit test

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -318,6 +318,11 @@ describe('DNS Security MCP Server', () => {
 		});
 
 		it('throttles excessive initialize calls from one IP', async () => {
+			// Pin the clock so all requests fall in one per-minute rate-limit window.
+			// The limiter keys its window by Math.floor(Date.now() / 60_000); a loop that
+			// straddles a wall-clock minute boundary splits the count across two windows so
+			// neither reaches the limit → flaky 200 instead of 429 (esp. under slow CI).
+			vi.spyOn(Date, 'now').mockReturnValue(Date.UTC(2026, 0, 1, 12, 30, 30));
 			let lastResponse: Response | undefined;
 			for (let i = 0; i < 31; i++) {
 				const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {


### PR DESCRIPTION
## Summary
Deflakes `test/index.spec.ts` → `throttles excessive initialize calls from one IP`, the intermittent `contract` CI failure (seen on #226: `expected 200 to be 429` at line 337).

**Root cause:** the session-create limiter keys its window by `Math.floor(Date.now() / 60_000)` (per-minute, wall-clock-aligned; same in the KV path and the QuotaCoordinator DO). The test loops 31 requests expecting the 31st to be throttled (limit = 30/min). When the loop straddled a real minute boundary, the count split across two windows and neither reached 30 → `200` instead of `429`. Not a product bug — test fragility.

**Fix:** `vi.spyOn(Date, 'now').mockReturnValue(...)` pins all 31 requests to one window. Restored by the existing `afterEach` (`vi.restoreAllMocks()`). Verified deterministic — **10/10** repeated runs pass; full `index.spec.ts` still green. Test-only, no runtime change, no deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)