### PR TITLE
feat(mcp): selection-steering descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.2] - 2026-05-26
+
+### Changed
+
+- Scan-included `check_*` tool descriptions reference `scan_domain` for selection steering. The emitted `tools/list` description of each of the 16 scan-included checks now ends with the factual suffix "Part of the scan_domain audit.", letting an LLM pick `scan_domain` for a full audit and an individual `check_*` for a single control. Descriptive, not prescriptive — the suffix trips no phrase in the directory-review prescriptive-language audit. Applied at the `TOOLS` build (not per-tool), so it auto-covers any future scan-included tool. No tool-count or input-schema change.
+
 ## [3.3.1] - 2026-05-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.3.1",
+			"version": "3.3.2",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.3.1",
+	"version": "3.3.2",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "3.3.1",
+			"version": "3.3.2",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.3.1';
+export const SERVER_VERSION = '3.3.2';

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -701,7 +701,7 @@ const CHECK_RESULT_OUTPUT_SCHEMA = buildCheckResultOutputJsonSchema();
 
 export const TOOLS: McpTool[] = Object.entries(TOOL_DEFS).map(([name, def]) => ({
 	name,
-	description: def.description,
+	description: def.scanIncluded ? `${def.description} Part of the scan_domain audit.` : def.description,
 	inputSchema: toInputSchema(def.schema),
 	...(NON_CHECK_RESULT_TOOLS.has(name) ? {} : { outputSchema: CHECK_RESULT_OUTPUT_SCHEMA }),
 	annotations: {

--- a/test/tool-selection-steering.spec.ts
+++ b/test/tool-selection-steering.spec.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Selection-steering descriptions: scan-included check_* tools carry a factual
+// reference to scan_domain so an LLM can pick scan_domain for a full audit and
+// the individual check_* tools for a single control — without prescriptive /
+// injection-style language (which the directory-review audit bans).
+//
+// The steering is DESCRIPTIVE, not prescriptive: it states a fact ("Part of the
+// scan_domain audit.") rather than instructing the model how to behave. The last
+// `it` block re-asserts the prescriptive-phrase gate against the emitted TOOLS so
+// a future edit to the suffix can't silently reintroduce banned language.
+
+import { describe, it, expect } from 'vitest';
+import { TOOLS } from '../src/schemas/tool-definitions';
+
+const SCAN_AUDIT_SUFFIX = ' Part of the scan_domain audit.';
+
+// Copied verbatim from test/audits/tool-annotations.audit.test.ts so this guard
+// tracks the actual gate rather than a paraphrase of it.
+const PRESCRIPTIVE_PHRASES = [
+	'use this when',
+	'use this to',
+	'start here',
+	'whenever',
+	'you must',
+	'you should',
+	'make sure to',
+	'be sure to',
+	'ignore previous',
+	'ignore the',
+	'disregard',
+	'system prompt',
+	'system instruction',
+];
+
+describe('tool selection-steering descriptions', () => {
+	it('every scan-included tool references scan_domain in its description', () => {
+		const scanIncluded = TOOLS.filter((t) => t.scanIncluded);
+		expect(scanIncluded.length).toBeGreaterThan(0);
+		for (const tool of scanIncluded) {
+			expect(tool.description, `${tool.name} should reference scan_domain`).toContain('scan_domain');
+		}
+	});
+
+	it('only scan-included tools carry the scan_domain audit suffix', () => {
+		for (const tool of TOOLS) {
+			if (tool.scanIncluded) continue;
+			expect(tool.description, `${tool.name} (not scan-included) must not carry the suffix`).not.toContain(SCAN_AUDIT_SUFFIX);
+		}
+	});
+
+	it('representative non-scan-included tools do not carry the suffix', () => {
+		const sample = ['scan_domain', 'generate_dmarc_record', 'osint_investigate_domain_start', 'cymru_asn'];
+		for (const name of sample) {
+			const tool = TOOLS.find((t) => t.name === name);
+			expect(tool, `${name} should exist`).toBeDefined();
+			expect(tool!.description, `${name} must not carry the suffix`).not.toContain(SCAN_AUDIT_SUFFIX);
+		}
+	});
+
+	it('scan_domain still conveys breadth', () => {
+		const scanDomain = TOOLS.find((t) => t.name === 'scan_domain');
+		expect(scanDomain).toBeDefined();
+		const desc = scanDomain!.description;
+		expect(desc).toContain('check_');
+		expect(/audit|broadest/i.test(desc), 'scan_domain should mention audit/breadth').toBe(true);
+	});
+
+	it('no emitted description contains prescriptive / injection-style language', () => {
+		for (const tool of TOOLS) {
+			const lower = tool.description.toLowerCase();
+			const hits = PRESCRIPTIVE_PHRASES.filter((p) => lower.includes(p));
+			expect(hits, `${tool.name} description steers with: ${hits.join(', ')}`).toEqual([]);
+		}
+	});
+});


### PR DESCRIPTION
## What

Append the factual suffix `Part of the scan_domain audit.` to the emitted `tools/list` description of the 16 scan-included `check_*` tools, so an LLM can pick `scan_domain` for a full audit and an individual `check_*` for a single control.

## How (DRY)

One-line change at the `TOOLS` build in `src/schemas/tool-definitions.ts`:

```ts
description: def.scanIncluded ? `${def.description} Part of the scan_domain audit.` : def.description,
```

Raw `TOOL_DEFS` descriptions are unchanged; only the emitted `McpTool.description` of scan-included tools gets the suffix. Auto-applies to any future scan-included tool.

## Constraint satisfied

The suffix is **descriptive, not prescriptive** — it states a fact rather than instructing the model. It contains none of the banned `PRESCRIPTIVE_PHRASES` enforced by `test/audits/tool-annotations.audit.test.ts`. The new spec re-asserts that gate against `TOOLS` (verbatim phrase list) so a future suffix edit can't reintroduce banned language.

## Affected tools (16)

check_mx, check_spf, check_dmarc, check_dkim, check_dnssec, check_ssl, check_mta_sts, check_ns, check_caa, check_bimi, check_tlsrpt, check_http_security, check_dane, check_dane_https, check_svcb_https, check_subdomailing

## Tests (TDD)

New `test/tool-selection-steering.spec.ts`: scan-included tools reference `scan_domain`; non-scan-included tools (incl. `scan_domain` itself, `generate_dmarc_record`, `osint_investigate_domain_start`, `cymru_asn`) lack the suffix; `scan_domain` still conveys breadth; no description contains prescriptive phrases.

- New spec + tool-annotations audit + readme-tool-surface audit + tool-metadata/tool-schemas specs: pass
- Full suite: 4487 passed / 13 skipped, 0 failures (trailing pool-teardown WebSocket flake only)
- typecheck + lint: clean
- Tool count unchanged at 73

## Version

Patch bump 3.3.1 → 3.3.2 across `server-version.ts`, `package.json` + lock, `server.json` (both fields), `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)