### PR TITLE
chore(mcp): server.json tool count + tool-list refresh doc

### DIFF
--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -396,6 +396,10 @@ Canonical tool names from `tools/list` remain unchanged.
 
 Important: raw JSON-RPC `tools/call` still requires `params.name` to be a tool identifier (`scan` or `scan_domain`), not a full phrase such as `scan example.com`.
 
+### Refreshing the tool list
+
+MCP clients fetch `tools/list` once when they connect and cache it for the lifetime of that connection. The tool set is static per deployment, so the server does not emit `tools/list_changed` notifications. To pick up tools added or removed by a server update, reconnect or restart your MCP client. This is why a client may briefly show a previous tool count right after a server update until it reconnects.
+
 ## Authentication
 
 Authenticated requests bypass per-IP rate limits and apply the caller's tier quota. Three authentication methods are supported:

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 	"name": "com.blackveilsecurity/dns",
-	"description": "DNS and email security scanner with 62 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"description": "DNS and email security scanner with 73 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
 	"repository": {
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"

--- a/test/audits/server-json-tool-count.audit.test.ts
+++ b/test/audits/server-json-tool-count.audit.test.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import serverJsonText from '../../server.json?raw';
+import { TOOLS } from '../../src/schemas/tool-definitions';
+
+describe('server.json tool count', () => {
+	it('keeps the MCP Registry description tool count in sync with TOOLS.length', () => {
+		const serverJson = JSON.parse(serverJsonText) as { description: string };
+		const match = serverJson.description.match(/(\d+) MCP tools/);
+
+		expect(match, 'server.json description must contain "N MCP tools"').not.toBeNull();
+		expect(Number(match![1])).toBe(TOOLS.length);
+	});
+});


### PR DESCRIPTION
## Summary

Two small MCP-config polish items. No runtime/worker code touched — registry manifest + docs + a guard test only. No version change (stays 3.3.2).

### Item A — fix stale tool count in `server.json` + guard it (TDD)
`server.json`'s `description` (the MCP Registry listing) said "62 MCP tools" — the actual count is **73** (`TOOLS.length`). Nothing guarded it, so it had drifted across releases.

- Added `test/audits/server-json-tool-count.audit.test.ts` — parses `server.json`, extracts N from `/(\d+) MCP tools/`, asserts the regex matched and `N === TOOLS.length`. Written first, confirmed red at 62, green after the fix.
- Fixed `server.json` description: `62 MCP tools` → `73 MCP tools`. Both `version` fields left at `3.3.2`.

### Item B — document tool-list refresh
Added `### Refreshing the tool list` to `docs/client-setup.md`: MCP clients fetch `tools/list` once per connection and cache it; the set is static per deployment (no `tools/list_changed`); reconnect/restart to pick up tool changes. `capabilities.tools.listChanged: false` is unchanged.

## Verification
- New audit: red (62) → green (73)
- `npx vitest run test/audits`: 270 passed / 1 skipped (the 6 WebSocket-teardown "errors" are the documented pool-teardown flake, not real failures)
- typecheck + lint clean
- Tool count stays 73; no version field changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)