### PR TITLE
feat(mcp): protocolVersion negotiation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.3] - 2026-05-26
+
+### Changed
+
+- Negotiate MCP `protocolVersion` in the `initialize` handler (supports `2025-06-18` + `2025-03-26`; defaults to `2025-06-18`, matching structuredContent/outputSchema). The server now echoes the client's requested version when supported, and otherwise (omitted, malformed, or unsupported) returns its latest, `2025-06-18`. Previously it unconditionally returned `2025-03-26`, which was behind the structuredContent/outputSchema features bv-mcp already ships (introduced in spec `2025-06-18`). No tool-count or input-schema change.
+
 ## [3.3.2] - 2026-05-26
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.2",
+	"version": "3.3.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.3.2",
+			"version": "3.3.3",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.2",
+	"version": "3.3.3",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.3.2",
+	"version": "3.3.3",
 	"packages": [
 		{
 			"registryType": "npm",
 			"identifier": "blackveil-dns",
-			"version": "3.3.2",
+			"version": "3.3.3",
 			"transport": {
 				"type": "stdio"
 			},

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.3.2';
+export const SERVER_VERSION = '3.3.3';

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -11,6 +11,29 @@ import type { AnalyticsClient } from '../lib/analytics';
 
 type JsonRpcPayload = ReturnType<typeof jsonRpcSuccess> | ReturnType<typeof jsonRpcError>;
 
+/**
+ * MCP protocol versions this server supports, newest first.
+ * `2025-06-18` introduced `structuredContent` / `outputSchema`, both of which bv-mcp ships,
+ * so it is the latest advertised version. `2025-03-26` is retained for backward compatibility.
+ */
+export const SUPPORTED_PROTOCOL_VERSIONS = ['2025-06-18', '2025-03-26'] as const;
+
+/** The newest protocol version this server supports — returned when the client's request can't be honored. */
+export const LATEST_PROTOCOL_VERSION = '2025-06-18';
+
+/**
+ * Negotiate the MCP protocol version for an `initialize` response.
+ * Per spec: echo the client's requested version when supported; otherwise return the server's latest.
+ *
+ * @param requested - The client's `params.protocolVersion` (untyped — may be absent or malformed).
+ * @returns A supported protocol-version string.
+ */
+export function negotiateProtocolVersion(requested: unknown): string {
+	return typeof requested === 'string' && (SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(requested)
+		? requested
+		: LATEST_PROTOCOL_VERSION;
+}
+
 export interface DispatchMcpMethodOptions {
 	id: string | number | null | undefined;
 	method: string;
@@ -122,7 +145,7 @@ export async function dispatchMcpMethod(options: DispatchMcpMethodOptions): Prom
 			return {
 				kind: 'success',
 				payload: jsonRpcSuccess(options.id, {
-					protocolVersion: '2025-03-26',
+					protocolVersion: negotiateProtocolVersion(options.params?.protocolVersion),
 					capabilities: {
 						tools: { listChanged: false },
 						resources: { subscribe: false, listChanged: false },

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -308,13 +308,28 @@ describe('DNS Security MCP Server', () => {
 			expect(body.id).toBe(1);
 			expect(body.result.serverInfo.name).toBe('Blackveil DNS');
 			expect(body.result.serverInfo.description).toBeTruthy();
-			expect(body.result.protocolVersion).toBe('2025-03-26');
+			// Request sent params:{} (no protocolVersion) → negotiation returns the server's latest.
+			expect(body.result.protocolVersion).toBe('2025-06-18');
 			expect(typeof body.result.instructions).toBe('string');
 			expect(body.result.instructions.length).toBeGreaterThan(0);
 			expect(body.result.capabilities.prompts).toEqual({ listChanged: false });
 			const sessionId = response.headers.get('mcp-session-id');
 			expect(sessionId).toBeTruthy();
 			expect(sessionId!.length).toBeGreaterThanOrEqual(32);
+		});
+
+		it('echoes the client-requested protocolVersion when supported', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-03-26' } }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as { result: { protocolVersion: string } };
+			expect(body.result.protocolVersion).toBe('2025-03-26');
 		});
 
 		it('throttles excessive initialize calls from one IP', async () => {
@@ -856,7 +871,8 @@ describe('DNS Security MCP Server', () => {
 			expect(response.headers.get('mcp-session-id')).toBeTruthy();
 			const text = await response.text();
 			expect(text).toContain('event: message');
-			expect(text).toContain('"protocolVersion":"2025-03-26"');
+			// Request sent params:{} (no protocolVersion) → negotiation returns the server's latest.
+			expect(text).toContain('"protocolVersion":"2025-06-18"');
 		});
 
 		it('GET /mcp returns SSE stream with valid session', async () => {
@@ -1114,7 +1130,8 @@ describe('DNS Security MCP Server', () => {
 			const payload = parseSseMessage<{
 				result: { protocolVersion: string; serverInfo: { name: string } };
 			}>(messageChunk);
-			expect(payload.result.protocolVersion).toBe('2025-03-26');
+			// Request sent params:{} (no protocolVersion) → negotiation returns the server's latest.
+			expect(payload.result.protocolVersion).toBe('2025-06-18');
 			expect(payload.result.serverInfo.name).toBe('Blackveil DNS');
 
 			const deleteRequest = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {

--- a/test/protocol-version-negotiation.spec.ts
+++ b/test/protocol-version-negotiation.spec.ts
@@ -1,0 +1,81 @@
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, it, expect, beforeEach } from 'vitest';
+import worker from '../src';
+import {
+	negotiateProtocolVersion,
+	SUPPORTED_PROTOCOL_VERSIONS,
+	LATEST_PROTOCOL_VERSION,
+} from '../src/mcp/dispatch';
+import { resetAllRateLimits, resetAllRateLimitsKv } from '../src/lib/rate-limiter';
+import { resetLegacySseState } from '../src/lib/legacy-sse';
+import { resetSessions } from '../src/lib/session';
+import { resetQuotaCoordinatorState } from '../src/lib/quota-coordinator';
+
+describe('negotiateProtocolVersion', () => {
+	it('exposes the supported versions newest-first with the latest matching the head', () => {
+		expect(SUPPORTED_PROTOCOL_VERSIONS).toEqual(['2025-06-18', '2025-03-26']);
+		expect(LATEST_PROTOCOL_VERSION).toBe('2025-06-18');
+		expect(SUPPORTED_PROTOCOL_VERSIONS[0]).toBe(LATEST_PROTOCOL_VERSION);
+	});
+
+	it('echoes a supported requested version', () => {
+		expect(negotiateProtocolVersion('2025-06-18')).toBe('2025-06-18');
+		expect(negotiateProtocolVersion('2025-03-26')).toBe('2025-03-26');
+	});
+
+	it('falls back to the latest version for an unsupported but well-formed version', () => {
+		expect(negotiateProtocolVersion('2024-11-05')).toBe('2025-06-18');
+	});
+
+	it('falls back to the latest version when the field is omitted', () => {
+		expect(negotiateProtocolVersion(undefined)).toBe('2025-06-18');
+	});
+
+	it('falls back to the latest version for non-string / garbage input', () => {
+		expect(negotiateProtocolVersion(42 as unknown)).toBe('2025-06-18');
+		expect(negotiateProtocolVersion(null)).toBe('2025-06-18');
+		expect(negotiateProtocolVersion({})).toBe('2025-06-18');
+		expect(negotiateProtocolVersion([])).toBe('2025-06-18');
+		expect(negotiateProtocolVersion('')).toBe('2025-06-18');
+	});
+});
+
+describe('initialize protocolVersion negotiation (integration)', () => {
+	beforeEach(async () => {
+		resetAllRateLimits();
+		resetSessions();
+		resetLegacySseState();
+		await resetQuotaCoordinatorState(env.QUOTA_COORDINATOR);
+		await resetAllRateLimitsKv(env.RATE_LIMIT);
+	});
+
+	async function initialize(params: Record<string, unknown>): Promise<string> {
+		const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params }),
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(response.status).toBe(200);
+		const body = (await response.json()) as { result: { protocolVersion: string } };
+		return body.result.protocolVersion;
+	}
+
+	it('echoes 2025-03-26 when the client requests it', async () => {
+		expect(await initialize({ protocolVersion: '2025-03-26' })).toBe('2025-03-26');
+	});
+
+	it('echoes 2025-06-18 when the client requests it', async () => {
+		expect(await initialize({ protocolVersion: '2025-06-18' })).toBe('2025-06-18');
+	});
+
+	it('returns the latest version when the client omits protocolVersion', async () => {
+		expect(await initialize({})).toBe('2025-06-18');
+	});
+
+	it('returns the latest version when the client requests an unsupported version', async () => {
+		expect(await initialize({ protocolVersion: '2024-11-05' })).toBe('2025-06-18');
+	});
+});

--- a/test/stdio.spec.ts
+++ b/test/stdio.spec.ts
@@ -9,7 +9,8 @@ describe('stdio MCP server', () => {
 			result: { protocolVersion: string; instructions: string; capabilities: { prompts: { listChanged: boolean } } };
 		};
 
-		expect(payload.result.protocolVersion).toBe('2025-03-26');
+		// Request sent params:{} (no protocolVersion) → negotiation returns the server's latest.
+		expect(payload.result.protocolVersion).toBe('2025-06-18');
 		expect(typeof payload.result.instructions).toBe('string');
 		expect(payload.result.instructions.length).toBeGreaterThan(0);
 		expect(payload.result.capabilities.prompts).toEqual({ listChanged: false });


### PR DESCRIPTION
## Summary

Implements MCP protocol-version negotiation in the `initialize` handler. Previously bv-mcp unconditionally returned `protocolVersion: '2025-03-26'` and ignored the client's requested version — but bv-mcp ships `structuredContent`/`outputSchema`, introduced in spec `2025-06-18`, so the declared version lagged the features.

## Behavior

`negotiateProtocolVersion(requested)`:
- Echoes the client's requested version when it's supported (`2025-06-18` or `2025-03-26`).
- Otherwise — omitted, malformed, or unsupported — returns the server's latest, `2025-06-18`.

New exports in `src/mcp/dispatch.ts`: `SUPPORTED_PROTOCOL_VERSIONS` (`['2025-06-18', '2025-03-26']`), `LATEST_PROTOCOL_VERSION` (`'2025-06-18'`), `negotiateProtocolVersion()`. The `initialize` case now uses `negotiateProtocolVersion(options.params?.protocolVersion)`.

## Tests (TDD)

- New `test/protocol-version-negotiation.spec.ts`: unit cases (supported echo, unsupported→latest, undefined/garbage→latest) + integration cases driving real `initialize` requests through the worker.
- Updated stale assertions that previously hardcoded `2025-03-26` on requests that send no `protocolVersion` (so now negotiate to `2025-06-18`): `test/index.spec.ts` (3 sites), `test/stdio.spec.ts` (1 site). Added an explicit echo case to `index.spec.ts`. The Claude Desktop test already sends `protocolVersion: '2025-03-26'` and correctly still asserts the echoed `2025-03-26` — unchanged.

## Version

Bumped 3.3.2 → 3.3.3 across `src/lib/server-version.ts`, `package.json`, `package-lock.json`, `server.json` (both version fields), `CHANGELOG.md`.

## Verification

- `npm run typecheck` clean
- `npm run lint` clean
- Full `npm test`: 4498 passed, 13 skipped (trailing pool-teardown WebSocket flake only)
- Tool count unchanged (73)

🤖 Generated with [Claude Code](https://claude.com/claude-code)