### PR TITLE
chore: remotes-only MCP Registry listing (drop unpublishable npm packages stanza)

### DIFF
--- a/server.json
+++ b/server.json
@@ -7,25 +7,6 @@
 		"source": "github"
 	},
 	"version": "3.3.3",
-	"packages": [
-		{
-			"registryType": "npm",
-			"identifier": "blackveil-dns",
-			"version": "3.3.3",
-			"transport": {
-				"type": "stdio"
-			},
-			"environmentVariables": [
-				{
-					"description": "Blackveil API key (optional \u2014 free tier works without)",
-					"isRequired": false,
-					"format": "string",
-					"isSecret": true,
-					"name": "BV_API_KEY"
-				}
-			]
-		}
-	],
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Summary
Removes the npm `packages` stanza from `server.json`, making the MCP Registry listing **remotes-only** (hosted `streamable-http` endpoint).

**Why:** The MCP Registry runs a liveness check on every declared package version. `server.json` declared npm `blackveil-dns@3.3.3`, but npm publishing is disabled (`NPM_TOKEN` rotation) so only `2.13.0` exists on npm — `mcp-publisher publish` failed with `400 ... NPM package not found (404)`. The hosted endpoint (`https://dns-mcp.blackveilsecurity.com/mcp`) is the canonical live server and is always current, so the listing now advertises only that.

The registry listing is **already synced live** to `3.3.3` / "73 MCP tools" / remotes-only / `isLatest: true` via this change. This PR persists the matching `server.json` so the repo doesn't carry a stanza that would 400 the next publish.

**When npm publishing is restored:** re-add the `packages` stanza pinned to a version that actually exists on npm before publishing again.

## Test Plan
- [x] `mcp-publisher validate` passes
- [x] Live publish succeeded; `?version=latest` returns 3.3.3 / 73 tools / 0 packages / isLatest true
- [x] `server-json-tool-count` + `npm-publish-surface` audits pass (Node 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)