### PR TITLE
test(audit): lock free-tier daily limit at 0 for brand_audit_* family

### DIFF
--- a/test/audits/brand-audit-quota.audit.test.ts
+++ b/test/audits/brand-audit-quota.audit.test.ts
@@ -13,7 +13,24 @@
 
 import { describe, it, expect } from 'vitest';
 import { BRAND_AUDIT_QUOTAS } from '../../src/lib/brand-audit-quota';
-import { TIER_DAILY_LIMITS } from '../../src/lib/config';
+import { FREE_TOOL_DAILY_LIMITS, TIER_DAILY_LIMITS } from '../../src/lib/config';
+
+// The brand_audit_* family is a paid feature. Free/unauthenticated callers are
+// blocked at TWO independent gates: the per-tool free daily limit (this set, the
+// first-line gate every unauthenticated tools/call hits) and the monthly
+// BRAND_AUDIT_QUOTAS budget (the in-tool gate). The monthly gate's free=0 is
+// locked below; without these assertions a future FREE_TOOL_DAILY_LIMITS edit
+// could silently re-open the daily gate, leaving only the monthly quota — which
+// itself fails open if the auth tier/KV bindings are absent.
+const FREE_BLOCKED_BRAND_TOOLS = [
+	'brand_audit_single',
+	'brand_audit_batch_start',
+	'brand_audit_status',
+	'brand_audit_get_report',
+	'register_brand_audit_watch',
+	'list_brand_audit_watches',
+	'delete_brand_audit_watch',
+] as const;
 
 describe('brand-audit-quota audit', () => {
 	it('covers every McpApiKeyTier in TIER_DAILY_LIMITS', () => {
@@ -25,6 +42,12 @@ describe('brand-audit-quota audit', () => {
 	it('free and agent tiers are excluded (paid feature, not part of static-key allowance)', () => {
 		expect(BRAND_AUDIT_QUOTAS.free).toBe(0);
 		expect(BRAND_AUDIT_QUOTAS.agent).toBe(0);
+	});
+
+	it('brand_audit_* family is hard-blocked (0/day) in the free-tier daily gate', () => {
+		for (const tool of FREE_BLOCKED_BRAND_TOOLS) {
+			expect(FREE_TOOL_DAILY_LIMITS[tool], `FREE_TOOL_DAILY_LIMITS.${tool} must be 0 (free tier blocked)`).toBe(0);
+		}
 	});
 
 	it('owner tier is unlimited', () => {


### PR DESCRIPTION
## Summary
Adds an audit assertion locking `FREE_TOOL_DAILY_LIMITS` at **0** for the `brand_audit_*` family (`brand_audit_single`, `brand_audit_batch_start`, `brand_audit_status`, `brand_audit_get_report`, + the 3 watch tools).

**Why:** Brand audit is a paid feature. Free/unauthenticated callers are already blocked at two independent gates:
1. `FREE_TOOL_DAILY_LIMITS.brand_audit_* = 0` — first-line daily gate every unauthenticated `tools/call` hits (limit 0 → first call denies, per `rate-limiter.ts:423-425`).
2. `BRAND_AUDIT_QUOTAS.free = 0` — in-tool monthly quota (defense-in-depth).

Only gate #2 was CI-locked (`brand-audit-quota.audit.test.ts`). This locks gate #1 so a future `FREE_TOOL_DAILY_LIMITS` edit can't silently re-open free-tier access — which would leave only the monthly quota, and that fails open when the auth tier / KV bindings are absent.

**No behavior change** — asserts the existing config.

### Verified (no bypass path)
`"free"` is only ever the unauthenticated/revoked state (`tier-auth.ts:162` — cached `free` entries carry `revokedAt` → `authenticated: false`). Every authenticated caller carries a real non-free tier; `isAuthenticated` derives from `tierAuthResult.authenticated`, so the two rate-limit branches are mutually exclusive and exhaustive (no "neither fires" hole).

_Note: `discover_brand_domains` intentionally stays at 1/day for free (lighter discovery op; `tools.ts:861`) — out of scope here._

## Test Plan
- [x] `brand-audit-quota.audit.test.ts` 6/6 pass (Node 22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)