### PR TITLE
feat(quota): make discover_brand_domains paid-only (free 1→0/day); v3.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.4] - 2026-05-26
+
+### Changed
+
+- **`discover_brand_domains` is now a paid-tier tool — free/unauthenticated daily limit lowered from 1/day to 0/day.** The full brand-discovery surface (`discover_brand_domains` + the async `brand_audit_*` family) now requires an authenticated paid tier. `brand_audit_*` were already 0/day for free; this closes the last free-tier entry point into brand discovery. An audit test (`brand-audit-quota.audit.test.ts`) locks the whole family at 0/day so the gate can't silently re-open. No tool-count or input-schema change.
+
 ## [3.3.3] - 2026-05-26
 
 ### Changed

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -425,7 +425,7 @@ Static API keys (via `?api_key=` or `Authorization: Bearer`) authenticate as a s
 | developer | 500 scans/day, 10 concurrent | OAuth + MCP Developer plan | Stripe subscription (bv-web) |
 | enterprise | 10,000 scans/day, 25 concurrent | OAuth + MCP Enterprise plan | Stripe subscription (bv-web) |
 
-Free hosted usage keeps core DNS and email checks open for trial traffic, while high-cost or private-probe tools have tighter unauthenticated limits: `discover_brand_domains` is limited to 1/day, `check_fast_flux` to 3/day, `check_lookalikes` and `check_shadow_domains` to 5/day, and `check_authoritative_dns_infra`, `check_subdomain_takeover`, and `check_root_server_set` to 25/day. Async `brand_audit_*` tools require an authenticated paid tier.
+Free hosted usage keeps core DNS and email checks open for trial traffic, while high-cost or private-probe tools have tighter unauthenticated limits: `check_fast_flux` to 3/day, `check_lookalikes` and `check_shadow_domains` to 5/day, and `check_authoritative_dns_infra`, `check_subdomain_takeover`, and `check_root_server_set` to 25/day. The full brand-discovery surface — `discover_brand_domains` and the async `brand_audit_*` tools — requires an authenticated paid tier.
 
 **Agent tier** is intended for:
 - **CI/CD pipelines**: Commit-on-push DNS scans as part of security checks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.3",
+	"version": "3.3.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.3.3",
+			"version": "3.3.4",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.3",
+	"version": "3.3.4",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.3.3",
+	"version": "3.3.4",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -857,9 +857,10 @@ export async function handleToolsCall(
 			// Tier gate: depth='deep' expands candidate seeding + enrichment fanout
 			// (roughly 3× the per-call compute cost of 'standard'). Pay-walled at
 			// developer tier or higher — same threshold as discovery_mode='tiered'.
-			// Defensive for brand_audit_* (free/agent already get 0 quota there);
-			// meaningful for discover_brand_domains where free callers have 1/day
-			// and could otherwise burn it on deep.
+			// Defensive for brand_audit_* (free/agent already get 0 quota there)
+			// and for discover_brand_domains on free (now 0/day too); still
+			// meaningful for agent callers, who get discover_brand_domains at the
+			// tier default and could otherwise burn it on deep.
 			if (name === 'discover_brand_domains' || name === 'brand_audit_single' || name === 'brand_audit_batch_start') {
 				const requestedDepth = (validatedArgs as { depth?: string }).depth;
 				if (requestedDepth === 'deep') {

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -275,7 +275,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	check_subdomain_takeover: 25,
 	check_authoritative_dns_infra: 25,
 	check_root_server_set: 25,
-	discover_brand_domains: 1,
+	discover_brand_domains: 0,
 	brand_audit_single: 0,
 	brand_audit_batch_start: 0,
 	brand_audit_status: 0,

--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.3.3';
+export const SERVER_VERSION = '3.3.4';

--- a/test/audits/brand-audit-quota.audit.test.ts
+++ b/test/audits/brand-audit-quota.audit.test.ts
@@ -15,14 +15,16 @@ import { describe, it, expect } from 'vitest';
 import { BRAND_AUDIT_QUOTAS } from '../../src/lib/brand-audit-quota';
 import { FREE_TOOL_DAILY_LIMITS, TIER_DAILY_LIMITS } from '../../src/lib/config';
 
-// The brand_audit_* family is a paid feature. Free/unauthenticated callers are
-// blocked at TWO independent gates: the per-tool free daily limit (this set, the
-// first-line gate every unauthenticated tools/call hits) and the monthly
-// BRAND_AUDIT_QUOTAS budget (the in-tool gate). The monthly gate's free=0 is
-// locked below; without these assertions a future FREE_TOOL_DAILY_LIMITS edit
-// could silently re-open the daily gate, leaving only the monthly quota — which
-// itself fails open if the auth tier/KV bindings are absent.
+// The brand-discovery surface (brand_audit_* family + discover_brand_domains)
+// is a paid feature — fully blocked for free/unauthenticated callers via the
+// per-tool free daily limit (0/day, the first-line gate every unauthenticated
+// tools/call hits; limit 0 → first call denies). brand_audit_* carry a second
+// in-tool gate (BRAND_AUDIT_QUOTAS, monthly, free=0, locked below);
+// discover_brand_domains has no monthly quota, so its daily-0 lock is the sole
+// gate and matters most. Without these assertions a future FREE_TOOL_DAILY_LIMITS
+// edit could silently re-open free-tier access.
 const FREE_BLOCKED_BRAND_TOOLS = [
+	'discover_brand_domains',
 	'brand_audit_single',
 	'brand_audit_batch_start',
 	'brand_audit_status',
@@ -44,7 +46,7 @@ describe('brand-audit-quota audit', () => {
 		expect(BRAND_AUDIT_QUOTAS.agent).toBe(0);
 	});
 
-	it('brand_audit_* family is hard-blocked (0/day) in the free-tier daily gate', () => {
+	it('brand-discovery tools (brand_audit_* + discover_brand_domains) are hard-blocked (0/day) in the free-tier daily gate', () => {
 		for (const tool of FREE_BLOCKED_BRAND_TOOLS) {
 			expect(FREE_TOOL_DAILY_LIMITS[tool], `FREE_TOOL_DAILY_LIMITS.${tool} must be 0 (free tier blocked)`).toBe(0);
 		}

--- a/test/brand-audit-depth-gate.spec.ts
+++ b/test/brand-audit-depth-gate.spec.ts
@@ -6,10 +6,10 @@
  * Background: `deep` discovery expands candidate seeding and enrichment fanout,
  * roughly 3× the per-call compute and outbound-fetch cost of `standard`. The
  * surface accepts it on three tools — `discover_brand_domains`,
- * `brand_audit_single`, and `brand_audit_batch_start`. Pre-gate, a free caller
- * could request `deep` at the per-tool quota limit (1/day for
- * `discover_brand_domains`; brand_audit_* are already 0 for free/agent so the
- * gate is redundant-but-defensive for those two).
+ * `brand_audit_single`, and `brand_audit_batch_start`. The whole brand-discovery
+ * surface is now 0/day for free, so this gate is redundant-but-defensive for
+ * free; it stays meaningful for agent callers, who get `discover_brand_domains`
+ * at the tier default and could otherwise request `deep`.
  *
  * Pay-walled at developer tier or higher — same threshold as the
  * `discovery_mode='tiered'` gate landed in PR #188.

--- a/test/config.spec.ts
+++ b/test/config.spec.ts
@@ -102,7 +102,7 @@ describe('partner tier', () => {
 
 describe('free tier tool quota policy', () => {
 	it('keeps high-cost or private-probe tools on tight free anonymous limits', () => {
-		expect(FREE_TOOL_DAILY_LIMITS.discover_brand_domains).toBe(1);
+		expect(FREE_TOOL_DAILY_LIMITS.discover_brand_domains).toBe(0);
 		expect(FREE_TOOL_DAILY_LIMITS.check_authoritative_dns_infra).toBe(25);
 		expect(FREE_TOOL_DAILY_LIMITS.check_fast_flux).toBe(3);
 	});

--- a/test/rate-limit-chaos.spec.ts
+++ b/test/rate-limit-chaos.spec.ts
@@ -361,7 +361,7 @@ describe('rate-limit chaos tests', () => {
 		});
 
 		it('private-probe checks stay tightly bounded on the free tier', () => {
-			expect(FREE_TOOL_DAILY_LIMITS['discover_brand_domains']).toBe(1);
+			expect(FREE_TOOL_DAILY_LIMITS['discover_brand_domains']).toBe(0);
 			expect(FREE_TOOL_DAILY_LIMITS['check_authoritative_dns_infra']).toBe(25);
 			expect(FREE_TOOL_DAILY_LIMITS['check_fast_flux']).toBe(3);
 		});


### PR DESCRIPTION
## Summary
Lowers `FREE_TOOL_DAILY_LIMITS.discover_brand_domains` from **1/day to 0/day**, making the full brand-discovery surface — `discover_brand_domains` + the async `brand_audit_*` family — a paid-tier feature. `brand_audit_*` were already 0/day for free (PR #232 locked that); this closes the last free-tier entry point into brand discovery.

Follow-up to #232 — the user confirmed `discover_brand_domains` should also be locked to 0 for free.

### Changes
- `src/lib/config.ts` — `discover_brand_domains: 1 → 0`
- `brand-audit-quota.audit.test.ts` — adds `discover_brand_domains` to the family that's CI-locked at 0/day (it has **no** monthly quota, so the daily-0 lock is its sole gate — matters most here)
- Depth-gate rationale comments updated (free is now 0/day there; the `depth='deep'` gate stays meaningful for **agent** callers, who get `discover_brand_domains` at the tier default)
- `docs/client-setup.md` + `CHANGELOG.md` updated
- Two existing `FREE_TOOL_DAILY_LIMITS` value assertions flipped 1→0
- Version sync → **3.3.4** (package.json, package-lock.json, SERVER_VERSION, server.json)

**No tool-count or input-schema change.** Restriction-only (tightens free access; no new surface).

### Verified
- Affected specs pass (Node 22): brand-audit-quota, config, rate-limit-chaos, brand-audit-depth-gate, tier-tool-daily-limits, server-json-tool-count (105 + 28 tests)
- No bypass path: `"free"` is only ever the unauthenticated/revoked state; limit `0` → first call denies (`rate-limiter.ts:423-425`)

## Test Plan
- [x] `npx vitest run` on all affected specs — green
- [ ] CI: build-and-test + contract + security + hygiene + CodeQL
- [ ] Deploy to prod (`npm run deploy:prod`) after merge — required for the limit change to take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)