### PR TITLE
fix(osint): trim status/report metadata (token-cap overflow + summary collision)

### DIFF
--- a/src/tools/osint-investigate.ts
+++ b/src/tools/osint-investigate.ts
@@ -44,18 +44,102 @@ export const osintInvestigateDomainStart = (q: string, o?: ReconToolOptions) => 
 export const osintInvestigateInfrastructureStart = (q: string, o?: ReconToolOptions) => osintInvestigateStart('deep_infrastructure', q, o);
 export const osintInvestigateSupplyChainStart = (q: string, o?: ReconToolOptions) => osintInvestigateStart('supply_chain', q, o);
 
+/**
+ * Lightweight progress/summary fields surfaced by `osint_investigation_status`.
+ * Deliberately EXCLUDES the heavy `findings[]` array — that belongs to the
+ * report endpoint. Inlining it here blew past the MCP token cap (53 KB+).
+ */
+const STATUS_META_KEYS = [
+	'id',
+	'type',
+	'query',
+	'status',
+	'workflowId',
+	'progress',
+	'totalChecks',
+	'completedChecks',
+	'foundCount',
+	'aiAnalysis',
+	'reportR2Key',
+	'options',
+	'createdAt',
+	'updatedAt',
+	'completedAt',
+] as const;
+
+/** Per-finding fields kept in the report. Drops the multi-KB `rawData` blob (and `evidenceR2Key`). */
+const FINDING_KEEP_KEYS = ['type', 'severity', 'title', 'details', 'confidence', 'platform', 'platformCategory', 'url', 'createdAt'] as const;
+
+/** Hard cap on findings returned in a single report response, to stay under the MCP token cap. */
+const REPORT_MAX_FINDINGS = 100;
+
+/** Defensive cap on any single string field (the upstream AI summary can be malformed/huge). */
+const MAX_META_STRING = 8_000;
+
+function capString(v: unknown): unknown {
+	return typeof v === 'string' && v.length > MAX_META_STRING ? v.slice(0, MAX_META_STRING) : v;
+}
+
+function projectStatusMeta(s: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const k of STATUS_META_KEYS) if (k in s) out[k] = capString(s[k]);
+	return out;
+}
+
+function shapeFinding(f: unknown): Record<string, unknown> {
+	const src = (f && typeof f === 'object' ? f : {}) as Record<string, unknown>;
+	const out: Record<string, unknown> = {};
+	for (const k of FINDING_KEEP_KEYS) if (k in src) out[k] = capString(src[k]);
+	return out;
+}
+
+function projectReportMeta(r: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	// Upstream summary TEXT lives under `investigationSummary`; the bare `summary`
+	// key is reserved as the codebase-wide "summary finding" boolean sentinel.
+	if ('summary' in r) out.investigationSummary = capString(r.summary);
+	if ('total' in r) out.total = r.total;
+	const raw = Array.isArray(r.findings) ? r.findings : [];
+	out.findings = raw.slice(0, REPORT_MAX_FINDINGS).map(shapeFinding);
+	if (raw.length > REPORT_MAX_FINDINGS) {
+		out.findingsTruncated = true;
+		out.findingsTotal = raw.length;
+	}
+	return out;
+}
+
+function shortText(s: string, max: number): string {
+	return s.length > max ? s.slice(0, max) : s;
+}
+
 export async function osintInvestigationStatus(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
 	const s = await callReconInvestigationStatus(options.reconBinding, options.reconAuthToken, id);
 	if (!s) return unprovisioned(`Investigation status unavailable for ${id} (unprovisioned or not found).`);
+	const status = typeof s.status === 'string' ? s.status : 'unknown';
+	const parts = [`status=${status}`];
+	if (typeof s.completedChecks === 'number' && typeof s.totalChecks === 'number') parts.push(`${s.completedChecks}/${s.totalChecks} checks`);
+	if (typeof s.foundCount === 'number') parts.push(`${s.foundCount} found`);
+	if (typeof s.summary === 'string' && s.summary.trim()) parts.push(s.summary.trim());
 	return buildCheckResult(CATEGORY, [
-		createFinding(CATEGORY, `Investigation ${id}`, 'info', JSON.stringify(s).slice(0, 800), { ...s, summary: true, investigationId: id }),
+		createFinding(CATEGORY, `Investigation ${id}`, 'info', shortText(parts.join(' · '), 800), {
+			...projectStatusMeta(s),
+			...(typeof s.summary === 'string' ? { investigationSummary: capString(s.summary) } : {}),
+			summary: true,
+			investigationId: id,
+		}),
 	]) as CheckResult;
 }
 
 export async function osintInvestigationReport(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
 	const r = await callReconInvestigationReport(options.reconBinding, options.reconAuthToken, id);
 	if (!r) return unprovisioned(`Investigation report unavailable for ${id} (unprovisioned or not ready).`);
+	const total = typeof r.total === 'number' ? r.total : Array.isArray(r.findings) ? r.findings.length : 0;
+	const summary = typeof r.summary === 'string' ? r.summary.trim() : '';
 	return buildCheckResult(CATEGORY, [
-		createFinding(CATEGORY, `Investigation ${id} report`, 'info', JSON.stringify(r).slice(0, 1200), { ...r, summary: true, investigationId: id }),
+		createFinding(CATEGORY, `Investigation ${id} report`, 'info', shortText(`${total} findings.${summary ? ` ${summary}` : ''}`, 1200), {
+			...projectReportMeta(r),
+			summary: true,
+			investigationId: id,
+		}),
 	]) as CheckResult;
 }

--- a/test/osint-investigate.spec.ts
+++ b/test/osint-investigate.spec.ts
@@ -23,12 +23,65 @@ describe('osint investigation tools', () => {
 		const rs = await m.osintInvestigateSupplyChainStart('example.com', { reconBinding: binding({ investigationId: 'inv_3' }), reconAuthToken: 't' });
 		expect(rs.findings.some((f) => f.metadata?.type === 'supply_chain')).toBe(true);
 	});
-	it('status + report: unprovisioned when absent; summary finding when bound', async () => {
+	it('status + report: unprovisioned when binding absent', async () => {
 		const m = await import('../src/tools/osint-investigate');
 		expect((await m.osintInvestigationStatus('inv_1', {})).findings.some((f) => f.metadata?.unprovisioned === true)).toBe(true);
-		const rs = await m.osintInvestigationStatus('inv_1', { reconBinding: binding({ status: 'completed' }), reconAuthToken: 't' });
-		expect(rs.findings.some((f) => f.metadata?.summary === true)).toBe(true);
-		const rr = await m.osintInvestigationReport('inv_1', { reconBinding: binding({ findings: [] }), reconAuthToken: 't' });
-		expect(rr.findings.some((f) => f.metadata?.summary === true)).toBe(true);
+		expect((await m.osintInvestigationReport('inv_1', {})).findings.some((f) => f.metadata?.unprovisioned === true)).toBe(true);
+	});
+
+	it('status: omits heavy findings[] and preserves upstream summary text (not boolean true)', async () => {
+		const m = await import('../src/tools/osint-investigate');
+		const upstream = {
+			id: 'inv_9',
+			type: 'deep_infrastructure',
+			status: 'completed',
+			progress: 100,
+			totalChecks: 8,
+			completedChecks: 8,
+			foundCount: 44,
+			summary: 'Investigation complete: 44 entities found.',
+			findings: Array.from({ length: 44 }, (_, i) => ({ id: String(i), title: 'f', rawData: 'x'.repeat(2000) })),
+		};
+		const r = await m.osintInvestigationStatus('inv_9', { reconBinding: binding(upstream), reconAuthToken: 't' });
+		const meta = r.findings[0]!.metadata!;
+		// Bug #7: status must not inline the heavy findings[] array (caused 53 KB token-cap overflow).
+		expect(meta.findings).toBeUndefined();
+		// Bug #8: `summary: true` is the codebase summary-finding sentinel — it must survive,
+		// and the upstream summary TEXT must be preserved under investigationSummary (it was clobbered before).
+		expect(meta.summary).toBe(true);
+		expect(meta.investigationSummary).toBe('Investigation complete: 44 entities found.');
+		expect(meta.status).toBe('completed');
+		expect(meta.foundCount).toBe(44);
+		// 44 × 2 KB of rawData must not leak into status metadata.
+		expect(JSON.stringify(meta).length).toBeLessThan(12_000);
+	});
+
+	it('report: shapes findings (drops heavy rawData), caps count, preserves summary', async () => {
+		const m = await import('../src/tools/osint-investigate');
+		const upstream = {
+			summary: 'Report ready.',
+			total: 120,
+			findings: Array.from({ length: 120 }, (_, i) => ({
+				id: String(i),
+				type: 'domain_dns',
+				severity: 'high',
+				title: `finding ${i}`,
+				details: 'detail text',
+				confidence: 95,
+				platform: 'dns-worker',
+				url: null,
+				rawData: 'Z'.repeat(5000),
+				evidenceR2Key: null,
+			})),
+		};
+		const r = await m.osintInvestigationReport('inv_9', { reconBinding: binding(upstream), reconAuthToken: 't' });
+		const meta = r.findings[0]!.metadata!;
+		expect(meta.summary).toBe(true); // summary-finding sentinel preserved
+		expect(meta.investigationSummary).toBe('Report ready.'); // upstream text under non-colliding key
+		const shaped = meta.findings as Array<Record<string, unknown>>;
+		expect(shaped.length).toBeLessThanOrEqual(100);
+		expect(shaped[0]!.rawData).toBeUndefined();
+		expect(shaped[0]!.title).toBe('finding 0');
+		expect(shaped[0]!.severity).toBe('high');
 	});
 });


### PR DESCRIPTION
## What

`osint_investigation_status` / `osint_investigation_report` spread the **entire** upstream bv-recon record into MCP finding metadata. This caused:

- **Token-cap overflow** — the full `findings[]` array (44 findings × multi-KB `rawData` = ~53 KB) was inlined into the status response, blowing past the MCP tool-result token cap.
- **Summary collision** — the codebase-wide `summary: true` summary-finding sentinel clobbered the upstream `summary` *text* string (surfaced as `"summary": true` in output).

## Fix

- **status**: project a lightweight allowlist of progress fields; never inline `findings[]`.
- **report**: shape each finding (drop the heavy `rawData`/`evidenceR2Key`), cap at 100, expose `findingsTruncated`/`findingsTotal`.
- Preserve the `summary: true` sentinel (90+ uses across brand-audit/discovery/buckets); expose the upstream summary text under a new non-colliding `investigationSummary` key.

## Tests

`test/osint-investigate.spec.ts` — TDD: asserts status omits `findings[]`, preserves the sentinel + `investigationSummary`, and report shapes/caps findings. 21 osint/recon tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)