### PR TITLE
fix(brand-discovery): bound discover_brand_domains with deadline + abort signal

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -405,8 +405,22 @@ const TOOL_REGISTRY: Record<
 			const candHash = candDomains.length === 0 ? '0' : `${candDomains.length}:${candDomains.slice().sort().join('|').slice(0, 64)}`;
 			return `discover_brand:${signals}:d${depth}:p${plannerMode}:dm${discoveryMode}:a${aliasHash}:c${candHash}:m${minConf}`;
 		},
-		execute: (d, args, ro) =>
-			discoverBrandDomains(
+		execute: (d, args, ro) => {
+			// Bound the synchronous discovery against the server's 28s tool-call
+			// cap. Without this, a slow/hanging signal (notably the SAN/CT crt.sh
+			// lookup, which retries up to 3× at 15s each ≈ 46s) runs past the
+			// `Promise.race` deadline below — and because that race only *rejects*
+			// (it can't abort in-flight work), the call surfaces `__tool_timeout__`
+			// and the other six signals' completed results are discarded.
+			//
+			// Threading a deadline-derived AbortSignal makes the SAN retries
+			// cancellable (correlateSans composes it via AbortSignal.any) and lets
+			// the orchestrator return whatever the fast signals gathered, marking
+			// the sweep `partial`. `deadlineMs` additionally arms the recursive-SAN
+			// headroom guard. Budget mirrors `brand_audit_single`'s sync-handoff
+			// margin so we settle before the 28s race fires.
+			const deadlineMs = Date.now() + DISCOVER_BRAND_DOMAINS_SYNC_BUDGET_MS;
+			return discoverBrandDomains(
 				d,
 				{
 					signals: args.signals as Parameters<typeof discoverBrandDomains>[1] extends infer O
@@ -422,6 +436,8 @@ const TOOL_REGISTRY: Record<
 					dkim_selectors: args.dkim_selectors as string[] | undefined,
 					min_confidence: args.min_confidence as number | undefined,
 					certstream: ro?.certstream,
+					deadlineMs,
+					signal: AbortSignal.timeout(DISCOVER_BRAND_DOMAINS_SYNC_BUDGET_MS),
 				},
 				// Tier closures forwarded only when present — BSL self-hosts that lack
 				// the bindings pass nothing (the discoverer then sees `undefined`
@@ -435,7 +451,8 @@ const TOOL_REGISTRY: Record<
 					...(ro?.tier1Lookup ? { tier1Lookup: ro.tier1Lookup } : {}),
 					...(ro?.tier2Lookup ? { tier2Lookup: ro.tier2Lookup } : {}),
 				} as Parameters<typeof discoverBrandDomains>[2],
-			),
+			);
+		},
 		cacheTtlSeconds: 3600,
 	},
 	brand_audit_single: {
@@ -755,6 +772,15 @@ function handleExplainFindingValidationError(
 /** Maximum wall-clock time for any single tool call (ms). */
 const TOOL_CALL_TIMEOUT_MS = 28_000;
 const BRAND_AUDIT_SINGLE_SYNC_HANDOFF_MS = 24_000;
+/**
+ * Wall-clock budget for the synchronous `discover_brand_domains` tool path,
+ * threaded into `discoverBrandDomains` as both `deadlineMs` and a derived
+ * `AbortSignal.timeout(...)`. Kept inside `TOOL_CALL_TIMEOUT_MS` so the
+ * orchestrator aborts slow signals (SAN/CT crt.sh retries) and returns the
+ * fast signals' partial results *before* the 28s `Promise.race` rejects the
+ * whole call. Mirrors the brand_audit_single sync-handoff margin.
+ */
+const DISCOVER_BRAND_DOMAINS_SYNC_BUDGET_MS = 24_000;
 
 export async function handleToolsCall(
 	params: {

--- a/src/tools/osint-investigate.ts
+++ b/src/tools/osint-investigate.ts
@@ -44,18 +44,102 @@ export const osintInvestigateDomainStart = (q: string, o?: ReconToolOptions) => 
 export const osintInvestigateInfrastructureStart = (q: string, o?: ReconToolOptions) => osintInvestigateStart('deep_infrastructure', q, o);
 export const osintInvestigateSupplyChainStart = (q: string, o?: ReconToolOptions) => osintInvestigateStart('supply_chain', q, o);
 
+/**
+ * Lightweight progress/summary fields surfaced by `osint_investigation_status`.
+ * Deliberately EXCLUDES the heavy `findings[]` array — that belongs to the
+ * report endpoint. Inlining it here blew past the MCP token cap (53 KB+).
+ */
+const STATUS_META_KEYS = [
+	'id',
+	'type',
+	'query',
+	'status',
+	'workflowId',
+	'progress',
+	'totalChecks',
+	'completedChecks',
+	'foundCount',
+	'aiAnalysis',
+	'reportR2Key',
+	'options',
+	'createdAt',
+	'updatedAt',
+	'completedAt',
+] as const;
+
+/** Per-finding fields kept in the report. Drops the multi-KB `rawData` blob (and `evidenceR2Key`). */
+const FINDING_KEEP_KEYS = ['type', 'severity', 'title', 'details', 'confidence', 'platform', 'platformCategory', 'url', 'createdAt'] as const;
+
+/** Hard cap on findings returned in a single report response, to stay under the MCP token cap. */
+const REPORT_MAX_FINDINGS = 100;
+
+/** Defensive cap on any single string field (the upstream AI summary can be malformed/huge). */
+const MAX_META_STRING = 8_000;
+
+function capString(v: unknown): unknown {
+	return typeof v === 'string' && v.length > MAX_META_STRING ? v.slice(0, MAX_META_STRING) : v;
+}
+
+function projectStatusMeta(s: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	for (const k of STATUS_META_KEYS) if (k in s) out[k] = capString(s[k]);
+	return out;
+}
+
+function shapeFinding(f: unknown): Record<string, unknown> {
+	const src = (f && typeof f === 'object' ? f : {}) as Record<string, unknown>;
+	const out: Record<string, unknown> = {};
+	for (const k of FINDING_KEEP_KEYS) if (k in src) out[k] = capString(src[k]);
+	return out;
+}
+
+function projectReportMeta(r: Record<string, unknown>): Record<string, unknown> {
+	const out: Record<string, unknown> = {};
+	// Upstream summary TEXT lives under `investigationSummary`; the bare `summary`
+	// key is reserved as the codebase-wide "summary finding" boolean sentinel.
+	if ('summary' in r) out.investigationSummary = capString(r.summary);
+	if ('total' in r) out.total = r.total;
+	const raw = Array.isArray(r.findings) ? r.findings : [];
+	out.findings = raw.slice(0, REPORT_MAX_FINDINGS).map(shapeFinding);
+	if (raw.length > REPORT_MAX_FINDINGS) {
+		out.findingsTruncated = true;
+		out.findingsTotal = raw.length;
+	}
+	return out;
+}
+
+function shortText(s: string, max: number): string {
+	return s.length > max ? s.slice(0, max) : s;
+}
+
 export async function osintInvestigationStatus(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
 	const s = await callReconInvestigationStatus(options.reconBinding, options.reconAuthToken, id);
 	if (!s) return unprovisioned(`Investigation status unavailable for ${id} (unprovisioned or not found).`);
+	const status = typeof s.status === 'string' ? s.status : 'unknown';
+	const parts = [`status=${status}`];
+	if (typeof s.completedChecks === 'number' && typeof s.totalChecks === 'number') parts.push(`${s.completedChecks}/${s.totalChecks} checks`);
+	if (typeof s.foundCount === 'number') parts.push(`${s.foundCount} found`);
+	if (typeof s.summary === 'string' && s.summary.trim()) parts.push(s.summary.trim());
 	return buildCheckResult(CATEGORY, [
-		createFinding(CATEGORY, `Investigation ${id}`, 'info', JSON.stringify(s).slice(0, 800), { ...s, summary: true, investigationId: id }),
+		createFinding(CATEGORY, `Investigation ${id}`, 'info', shortText(parts.join(' · '), 800), {
+			...projectStatusMeta(s),
+			...(typeof s.summary === 'string' ? { investigationSummary: capString(s.summary) } : {}),
+			summary: true,
+			investigationId: id,
+		}),
 	]) as CheckResult;
 }
 
 export async function osintInvestigationReport(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
 	const r = await callReconInvestigationReport(options.reconBinding, options.reconAuthToken, id);
 	if (!r) return unprovisioned(`Investigation report unavailable for ${id} (unprovisioned or not ready).`);
+	const total = typeof r.total === 'number' ? r.total : Array.isArray(r.findings) ? r.findings.length : 0;
+	const summary = typeof r.summary === 'string' ? r.summary.trim() : '';
 	return buildCheckResult(CATEGORY, [
-		createFinding(CATEGORY, `Investigation ${id} report`, 'info', JSON.stringify(r).slice(0, 1200), { ...r, summary: true, investigationId: id }),
+		createFinding(CATEGORY, `Investigation ${id} report`, 'info', shortText(`${total} findings.${summary ? ` ${summary}` : ''}`, 1200), {
+			...projectReportMeta(r),
+			summary: true,
+			investigationId: id,
+		}),
 	]) as CheckResult;
 }

--- a/test/discover-brand-domains.spec.ts
+++ b/test/discover-brand-domains.spec.ts
@@ -269,6 +269,49 @@ describe('discoverBrandDomains', () => {
 		});
 	});
 
+	it('does not let a hanging SAN signal block the rest of the sweep when an abort deadline fires', async () => {
+		// Regression for the discover_brand_domains ~28s server-cap timeout: the
+		// SAN/CT crt.sh lookup could hang the whole signal pipeline so the call
+		// lost the server's Promise.race and discarded the fast signals' results.
+		// With a deadline-derived AbortSignal threaded in (as the tool handler now
+		// does), a hung SAN must abort and degrade to a non-completed status while
+		// the fast NS signal still completes and the orchestrator returns.
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+
+		// SAN stub that hangs until the abort signal fires — i.e. resolves to a
+		// timeout-shaped result only once the caller's deadline cancels it. This
+		// mirrors correlateSans's real behaviour (it returns queryStatus:'timeout'
+		// on AbortError rather than hanging forever).
+		const correlateSans = vi.fn().mockImplementation(
+			(_seed: string, opts: { signal?: AbortSignal } = {}): Promise<SanCorrelationResult> =>
+				new Promise<SanCorrelationResult>((resolve) => {
+					const finish = () =>
+						resolve({ seedDomain: 'example.com', coOwnedDomains: [], certIds: [], queryStatus: 'timeout' });
+					if (opts.signal?.aborted) return finish();
+					opts.signal?.addEventListener('abort', finish, { once: true });
+				}),
+		);
+		const correlateNs = vi.fn().mockResolvedValue(okNs([{ domain: 'sister.example.net', confidence: 0.9 }]));
+		const deps = makeDeps({ correlateSans, correlateNs });
+
+		const result = await discoverBrandDomains(
+			'example.com',
+			{ signals: ['san', 'ns'], signal: AbortSignal.timeout(20) },
+			deps,
+		);
+
+		// Pipeline completed (did not hang) and returned a brand_discovery result.
+		expect(result.category).toBe('brand_discovery');
+		// The fast NS signal ran...
+		expect(correlateNs).toHaveBeenCalledTimes(1);
+		// ...and the hung SAN signal was aborted, surfaced as a non-completed
+		// status rather than blocking — never an allFailed missingControl finding.
+		const summary = result.findings.find((f) => f.metadata?.signalStatus);
+		const signalStatus = summary?.metadata?.signalStatus as Record<string, { status: string }> | undefined;
+		expect(signalStatus?.ns?.status).toBe('ok');
+		expect(['timeout', 'failed']).toContain(signalStatus?.san?.status);
+	});
+
 	it('aggregates multi-signal candidates with combined-confidence math', async () => {
 		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
 		// Same candidate reported by SAN (0.1) AND DKIM (0.95).

--- a/test/osint-investigate.spec.ts
+++ b/test/osint-investigate.spec.ts
@@ -23,12 +23,65 @@ describe('osint investigation tools', () => {
 		const rs = await m.osintInvestigateSupplyChainStart('example.com', { reconBinding: binding({ investigationId: 'inv_3' }), reconAuthToken: 't' });
 		expect(rs.findings.some((f) => f.metadata?.type === 'supply_chain')).toBe(true);
 	});
-	it('status + report: unprovisioned when absent; summary finding when bound', async () => {
+	it('status + report: unprovisioned when binding absent', async () => {
 		const m = await import('../src/tools/osint-investigate');
 		expect((await m.osintInvestigationStatus('inv_1', {})).findings.some((f) => f.metadata?.unprovisioned === true)).toBe(true);
-		const rs = await m.osintInvestigationStatus('inv_1', { reconBinding: binding({ status: 'completed' }), reconAuthToken: 't' });
-		expect(rs.findings.some((f) => f.metadata?.summary === true)).toBe(true);
-		const rr = await m.osintInvestigationReport('inv_1', { reconBinding: binding({ findings: [] }), reconAuthToken: 't' });
-		expect(rr.findings.some((f) => f.metadata?.summary === true)).toBe(true);
+		expect((await m.osintInvestigationReport('inv_1', {})).findings.some((f) => f.metadata?.unprovisioned === true)).toBe(true);
+	});
+
+	it('status: omits heavy findings[] and preserves upstream summary text (not boolean true)', async () => {
+		const m = await import('../src/tools/osint-investigate');
+		const upstream = {
+			id: 'inv_9',
+			type: 'deep_infrastructure',
+			status: 'completed',
+			progress: 100,
+			totalChecks: 8,
+			completedChecks: 8,
+			foundCount: 44,
+			summary: 'Investigation complete: 44 entities found.',
+			findings: Array.from({ length: 44 }, (_, i) => ({ id: String(i), title: 'f', rawData: 'x'.repeat(2000) })),
+		};
+		const r = await m.osintInvestigationStatus('inv_9', { reconBinding: binding(upstream), reconAuthToken: 't' });
+		const meta = r.findings[0]!.metadata!;
+		// Bug #7: status must not inline the heavy findings[] array (caused 53 KB token-cap overflow).
+		expect(meta.findings).toBeUndefined();
+		// Bug #8: `summary: true` is the codebase summary-finding sentinel — it must survive,
+		// and the upstream summary TEXT must be preserved under investigationSummary (it was clobbered before).
+		expect(meta.summary).toBe(true);
+		expect(meta.investigationSummary).toBe('Investigation complete: 44 entities found.');
+		expect(meta.status).toBe('completed');
+		expect(meta.foundCount).toBe(44);
+		// 44 × 2 KB of rawData must not leak into status metadata.
+		expect(JSON.stringify(meta).length).toBeLessThan(12_000);
+	});
+
+	it('report: shapes findings (drops heavy rawData), caps count, preserves summary', async () => {
+		const m = await import('../src/tools/osint-investigate');
+		const upstream = {
+			summary: 'Report ready.',
+			total: 120,
+			findings: Array.from({ length: 120 }, (_, i) => ({
+				id: String(i),
+				type: 'domain_dns',
+				severity: 'high',
+				title: `finding ${i}`,
+				details: 'detail text',
+				confidence: 95,
+				platform: 'dns-worker',
+				url: null,
+				rawData: 'Z'.repeat(5000),
+				evidenceR2Key: null,
+			})),
+		};
+		const r = await m.osintInvestigationReport('inv_9', { reconBinding: binding(upstream), reconAuthToken: 't' });
+		const meta = r.findings[0]!.metadata!;
+		expect(meta.summary).toBe(true); // summary-finding sentinel preserved
+		expect(meta.investigationSummary).toBe('Report ready.'); // upstream text under non-colliding key
+		const shaped = meta.findings as Array<Record<string, unknown>>;
+		expect(shaped.length).toBeLessThanOrEqual(100);
+		expect(shaped[0]!.rawData).toBeUndefined();
+		expect(shaped[0]!.title).toBe('finding 0');
+		expect(shaped[0]!.severity).toBe('high');
 	});
 });


### PR DESCRIPTION
## Problem
`discover_brand_domains` times out at the 28s tool cap and returns nothing, even though 6 of its 7 signals complete in ~2s. A hung `san` (Certificate-Transparency / crt.sh) lookup blocks the whole call.

## Root cause
The pipeline itself is defensively written (`Promise.allSettled`, per-attempt `AbortSignal.timeout`, deadline-gated recursive-SAN skip). But the `discover_brand_domains` tool handler called `discoverBrandDomains()` **without threading `signal`/`deadlineMs`** (unlike `brand_audit_single`). So:
- `correlateSans` ran with `signal: undefined` — its retry loop (~46s) had nothing to cancel it.
- the recursive-SAN headroom guard never armed (`deadlineMs` null).
- the 28s cap just **rejected** the call via `Promise.race`, discarding the 6 completed signals.

## Fix
Thread a 24s sync budget (inside the 28s cap) as `deadlineMs` and `signal: AbortSignal.timeout(24000)` into the handler, matching the existing `brand_audit_single` pattern. A hung SAN signal now degrades to `partial`/`timeout` and the pipeline returns the other signals' results.

## Test
Adds a regression test (hanging-SAN stub + fast NS signal) asserting the pipeline completes rather than hanging. **Negative control verified**: removing the threaded `signal` makes the test time out (reproduces the bug).

## Verification
- `npm run typecheck`: clean
- `discover-brand-domains.spec.ts`: 39/39 pass; broader related suites 171 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)