### PR TITLE
fix(identity-secops): proxy URL path (5-char fix: /m365 → /api/internal/m365)

### DIFF
--- a/src/tools/m365/proxy.ts
+++ b/src/tools/m365/proxy.ts
@@ -13,7 +13,9 @@
  */
 import type { M365ProxyResult } from './types';
 
-const M365_BASE_URL = 'https://bv-web-internal/m365';
+// Routes live at /api/internal/m365/* on the bv-web SSR app — the prior
+// `/m365/*` path returned 405 (SSR has no top-level /m365 route).
+const M365_BASE_URL = 'https://bv-web-internal/api/internal/m365';
 const TIMEOUT_MS = 10_000;
 
 export async function callM365Proxy(


### PR DESCRIPTION
Discovered during end-to-end smoke after PR #238 deployed: proxy was reaching bv-web (no longer `unprovisioned: true`) but hitting the wrong path → 405. Routes are registered at /api/internal/m365/*. One-line fix; existing tests don't assert on URL (mock fetcher returns 200 regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)