### PR TITLE
chore(release): v3.3.7 — dev-tooling chore #234, no worker behaviour change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.7] - 2026-05-28
+
+### Changed
+
+- **Dev-tooling-only:** removed an inert pre-commit regex layer that scanned for `.dev/blocked-patterns` (a file that never existed in the repo, so the gate was always a no-op). Real PII / secrets protection remains carried by Gitleaks, `scan-sensitive-surface.mjs`, and the `File hygiene check` CI gate. No worker / tool / schema change; deployed bundle is byte-identical to v3.3.6. (#234)
+
 ## [3.3.6] - 2026-05-27
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.6",
+	"version": "3.3.7",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
Bumps 3.3.6 → 3.3.7 + CHANGELOG. Only main commit since v3.3.6 is #234 (removed inert pre-commit IP-leakage regex layer — the gate read a file that never existed in git history; substance carried by Gitleaks + `scan-sensitive-surface.mjs` + `File hygiene check` CI gate). **Worker bundle byte-identical to v3.3.6 — deploy is a no-op rebuild.** Following the established release+deploy cycle for tag-vs-package-version monotonicity.