### PR TITLE
fix(version): auto-sync SERVER_VERSION from package.json

### DIFF
--- a/src/lib/server-version.ts
+++ b/src/lib/server-version.ts
@@ -1,4 +1,15 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-/** Server version — keep in sync with package.json */
-export const SERVER_VERSION = '3.3.4';
+import pkg from '../../package.json';
+
+/**
+ * Server version — auto-synced from package.json at build time.
+ *
+ * Previously a hand-edited literal; the doc comment said "keep in sync with
+ * package.json" but the manual step was forgotten through v3.3.5, v3.3.6, and
+ * v3.3.7 — the MCP server kept advertising `version: "3.3.4"` in the
+ * `initialize` response while the package shipped at 3.3.7. `resolveJsonModule`
+ * is on in tsconfig, and esbuild (wrangler's bundler) inlines the import at
+ * build time, so there's no runtime fs access.
+ */
+export const SERVER_VERSION: string = pkg.version;


### PR DESCRIPTION
Eliminates a drift class found post-v3.3.7 deploy: the MCP server advertises `serverInfo.version` to clients during `initialize`, but the value came from a hand-edited constant at `src/lib/server-version.ts:4` that was last updated for v3.3.4 — clients have been seeing '3.3.4' through v3.3.5/.6/.7 while the package shipped at 3.3.7. The doc comment literally said 'keep in sync with package.json' — the manual step had been forgotten.

Now reads `pkg.version` from `package.json` directly. `resolveJsonModule` is already on in tsconfig and esbuild (wrangler's bundler) inlines the import at build time, so no runtime fs.

Verified runtime: `SERVER_VERSION === '3.3.7'` (matches package.json). Tsc clean.

Cosmetic-only — same code path otherwise — but eliminates the misleading version-in-logs/telemetry going forward.