### PR TITLE
fix(map-supply-chain): dedup providers when SPF include resolves to same provider as TXT verification

### DIFF
--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -11,7 +11,7 @@ import type { OutputFormat } from '../handlers/tool-args';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { queryTxtRecords, queryDnsRecords, querySrvRecords } from '../lib/dns';
 import { sanitizeOutputText } from '../lib/output-sanitize';
-import { detectProviders } from './provider-guides';
+import { detectProviders, matchProviderForSpfInclude } from './provider-guides';
 import { VERIFICATION_PATTERNS, SERVICE_SPF_DOMAINS } from './txt-hygiene-analysis';
 import { SRV_PREFIXES } from './srv-analysis';
 import type { SrvProbeResult } from './srv-analysis';
@@ -220,20 +220,30 @@ export async function mapSupplyChain(
 	const detectedSpfDomains = new Set<string>();
 	const detectedNsHosts = new Set<string>();
 
+	const detectedMailSendingNames = new Set(
+		detectedProviders
+			.filter((p) => p.role === 'mail' || p.role === 'sending')
+			.map((p) => p.name),
+	);
+
+	// Resolve each raw SPF include against DETECTION_RULES (shared SSOT with
+	// detectProviders) so dedup can't drift from the detection patterns. This
+	// also closes the gap where a provider rule's static `signal` referenced
+	// MX (e.g. Microsoft 365 — `mx:mail.protection.outlook.com`) but the rule
+	// actually matched via its `spf` pattern (`spf.protection.outlook.com`),
+	// causing the substring-based dedup to miss and emit a duplicate raw row.
+	for (const inc of spfIncludes) {
+		const matchedName = matchProviderForSpfInclude(inc);
+		if (matchedName && detectedMailSendingNames.has(matchedName)) {
+			detectedSpfDomains.add(inc);
+		}
+	}
+
 	for (const provider of detectedProviders) {
 		const source = provider.role === 'mail' || provider.role === 'sending' ? 'spf' : 'ns';
 		addDependency(provider.name, source);
 
-		if (source === 'spf') {
-			for (const inc of spfIncludes) {
-				if (provider.signal.startsWith('spf:') || provider.signal.startsWith('mx:')) {
-					const signalDomain = provider.signal.split(':').slice(1).join(':');
-					if (inc.includes(signalDomain)) {
-						detectedSpfDomains.add(inc);
-					}
-				}
-			}
-		} else {
+		if (source === 'ns') {
 			for (const host of nsHosts) {
 				if (provider.signal.startsWith('ns:')) {
 					const signalDomain = provider.signal.split(':').slice(1).join(':');

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -151,6 +151,20 @@ const DETECTION_RULES: DetectionRule[] = [
 ];
 
 /**
+ * Resolve a single SPF include hostname to a known provider name, if any.
+ * Uses the same DETECTION_RULES as detectProviders so the two paths can't drift.
+ * Returns null when no rule's spf pattern matches.
+ */
+export function matchProviderForSpfInclude(spfInclude: string): string | null {
+	for (const rule of DETECTION_RULES) {
+		if (rule.patterns.spf && rule.patterns.spf.test(spfInclude)) {
+			return rule.name;
+		}
+	}
+	return null;
+}
+
+/**
  * Detect infrastructure providers from DNS signals.
  * Returns deduplicated list of DetectedProvider (one entry per provider name).
  */

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -459,6 +459,39 @@ describe('mapSupplyChain', () => {
 		expect(m365Deps[0].sources).toContain('srv');
 	});
 
+	it('deduplicates Microsoft 365 across SPF include + TXT verification (spark.co.nz pattern)', async () => {
+		// Regression: prior to this fix, the Microsoft 365 detection rule's static
+		// `signal: 'mx:mail.protection.outlook.com'` did NOT substring-match the
+		// SPF include `spf.protection.outlook.com`, so the include slipped through
+		// the dedup and produced a second standalone `spf.protection.outlook.com`
+		// row alongside the Microsoft 365 TXT-verification row.
+		mockDnsResponses({
+			spf: 'v=spf1 include:spf.protection.outlook.com include:_spf-c.spark.co.nz -all',
+			txtRecords: ['MS=ms12345'],
+			nsHosts: ['ns1.cloudflare.com', 'ns2.cloudflare.com'],
+		});
+
+		const result = await run();
+
+		// Microsoft 365 should collapse to a single dependency carrying both sources.
+		const m365Deps = result.dependencies.filter((d) => d.provider === 'Microsoft 365');
+		expect(m365Deps.length).toBe(1);
+		expect(m365Deps[0].sources).toContain('spf');
+		expect(m365Deps[0].sources).toContain('txt-verification');
+		// SPF sources promote trust to critical.
+		expect(m365Deps[0].trustLevel).toBe('critical');
+
+		// No standalone raw SPF include row for the Microsoft 365 host.
+		expect(
+			result.dependencies.find((d) => d.provider === 'spf.protection.outlook.com'),
+		).toBeUndefined();
+
+		// Unrelated SPF include (Spark's own host) is still surfaced as a raw entry.
+		expect(
+			result.dependencies.find((d) => d.provider === '_spf-c.spark.co.nz'),
+		).toBeDefined();
+	});
+
 	it('tolerates SRV probe failures gracefully', async () => {
 		// Mock that throws for SRV queries but succeeds for everything else
 		globalThis.fetch = vi.fn().mockImplementation((url: string | URL) => {


### PR DESCRIPTION
## Bug

`map_supply_chain` double-counts the same provider when it's discovered via both a TXT verification record AND an SPF include. Live evidence on `spark.co.nz`:

- `provider: "Microsoft 365"` from `sources: ["txt-verification"]` (via `MS=ms…` TXT)
- `provider: "spf.protection.outlook.com"` from `sources: ["spf"]` (via SPF include)

Same authorization (Microsoft 365), split into two rows.

## Root cause

The Microsoft 365 rule in `DETECTION_RULES` (`src/tools/provider-guides.ts`) has both `mx` and `spf` patterns but a single static `signal: 'mx:mail.protection.outlook.com'`. When `mapSupplyChain` calls `detectProviders` with `mxHosts: []`, the rule still matches via its `spf` pattern, but the returned `signal` still claims `mx:…`.

The dedup loop at `map-supply-chain.ts:228–235` then substring-checks the signal-domain against each SPF include — `'spf.protection.outlook.com'.includes('mail.protection.outlook.com')` is **false**, so the include slips through to the unrecognized-SPF-include path at lines 248–253 and is emitted as a second, raw row.

Google Workspace only avoided the same fate by coincidence (`_spf.google.com` substring-contains `google.com`). Pure-SPF providers (AWS SES, SendGrid, Mailgun, Postmark) already have `signal: 'spf:…'`, so they were correct.

## Fix

- Add `matchProviderForSpfInclude(include: string): string | null` in `src/tools/provider-guides.ts` — reuses `DETECTION_RULES`' `spf` patterns directly (single source of truth, no parallel list).
- Replace the brittle signal-substring SPF dedup with: iterate `spfIncludes`, resolve each via `matchProviderForSpfInclude`, mark as covered when the resolved provider name appears in the detected mail/sending providers.
- NS branch unchanged.

## Test

New regression in `test/map-supply-chain.spec.ts`: "deduplicates Microsoft 365 across SPF include + TXT verification (spark.co.nz pattern)". Asserts a single Microsoft 365 dependency with both `spf` and `txt-verification` sources at `trustLevel: 'critical'`, no standalone `spf.protection.outlook.com` row, unrelated `_spf-c.spark.co.nz` include still surfaces as a raw entry.

22/22 spec tests pass. typecheck + lint clean.

## How surfaced

Live fact-check of MCP scan output against multiple resolvers on 2026-05-28. Companion finding (SPF UDP-truncation flag) filed separately as #250.

🤖 Generated with [Claude Code](https://claude.com/claude-code)