### PR TITLE
fix(cdn-detect): server: cloudflare alone — CF Worker stamps cf-cache-status on outbound fetches too

### DIFF
--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -101,11 +101,22 @@ function detectCdnProvider(headers: Headers): string | null {
 	if (servedBy.includes('cache') || headers.get('via')?.toLowerCase().includes('varnish')) {
 		return 'Fastly';
 	}
-	// 2. Cloudflare — require an origin-set signal. `cf-ray` alone is NOT
-	// sufficient (added by our own Worker egress), but `server: cloudflare`,
-	// `cf-cache-status` (set by the origin's CF zone), or `cf-mitigated` are.
+	// 2. Cloudflare — require `server: cloudflare`. Other CF-prefix headers
+	// (`cf-ray`, `cf-cache-status`, possibly more) are stamped on every
+	// outbound `fetch()` response by the Cloudflare Worker egress — `cf-ray` for
+	// tracing, `cf-cache-status` (typically `DYNAMIC`/`BYPASS` for non-cached
+	// fetches) by the edge's cache layer — so they appear on responses from
+	// google.com / akamai-fronted sites / anywhere, NOT just on origins that
+	// are actually behind Cloudflare. `server: cloudflare` is the only header
+	// the *origin's* CF zone sets that doesn't get attached to transit
+	// responses; CF customers can't override it via Transform Rules. We
+	// previously also gated on `cf-mitigated` (WAF-action signal) but dropped
+	// it for the same belt-and-braces reason — if a domain is truly fronted
+	// by Cloudflare it will also carry `server: cloudflare`. This is the
+	// third tightening of this rule (v3.3.9 → v3.3.10): each previous pass
+	// missed a CF-injected header the regression tests didn't cover.
 	const server = headers.get('server')?.toLowerCase() ?? '';
-	if (server.includes('cloudflare') || headers.get('cf-cache-status') || headers.get('cf-mitigated')) {
+	if (server.includes('cloudflare')) {
 		return 'Cloudflare';
 	}
 	return null;

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -570,10 +570,27 @@ describe('checkHttpSecurity — dual-fetch header union', () => {
 			expect(cdnFinding(result.findings)).toBe('Cloudflare');
 		});
 
-		it('attributes Cloudflare from cf-cache-status (origin-set signal)', async () => {
-			mockWithHeaders({ 'cf-cache-status': 'HIT', 'cf-ray': '8aabcdef1234-AKL' });
+		it('does NOT attribute Cloudflare from cf-cache-status alone (CF Worker egress stamps this too)', async () => {
+			// Empirically observed in v3.3.9: scanning google.com from the live Worker
+			// still returned `cdnProvider: "Cloudflare"` despite tightening to
+			// (cf-cache-status || cf-mitigated || server:cloudflare). Cloudflare's
+			// Worker fetch() infrastructure attaches `cf-cache-status` (typically
+			// `DYNAMIC` or `BYPASS`) to outbound responses regardless of origin.
+			// Only `server: cloudflare` is reliably an origin-set CF signal.
+			mockWithHeaders({ 'cf-cache-status': 'DYNAMIC', 'cf-ray': '8aabcdef1234-AKL', server: 'gws' });
 			const result = await run();
-			expect(cdnFinding(result.findings)).toBe('Cloudflare');
+			expect(cdnFinding(result.findings)).toBeNull();
+		});
+
+		it('does NOT attribute Cloudflare from cf-mitigated alone on a non-CF origin', async () => {
+			// Belt-and-braces: previously also gated on `cf-mitigated`. If a domain
+			// is truly fronted by CF the response will carry `server: cloudflare`
+			// too, so we don't lose any true positives by dropping the secondary
+			// signal — and we close off the small risk that CF Worker egress also
+			// stamps cf-mitigated in some failure modes we haven't observed.
+			mockWithHeaders({ 'cf-mitigated': 'challenge', 'cf-ray': '8aabcdef1234-AKL', server: 'gws' });
+			const result = await run();
+			expect(cdnFinding(result.findings)).toBeNull();
 		});
 
 		it('returns no CDN attribution when no signals are present (no Cloudflare default)', async () => {


### PR DESCRIPTION
Follow-up to #253. The v3.3.9 fix tightened the CF gate to {server:cloudflare || cf-cache-status || cf-mitigated} but live verification on 2026-05-28 showed google.com STILL returned `cdnProvider: "Cloudflare"` post-deploy. Direct curls confirm google.com returns `server: gws` with no CF-prefix headers at all — Cloudflare's Worker `fetch()` infrastructure stamps `cf-cache-status` (typically `DYNAMIC` or `BYPASS` for non-cached fetches) on outbound responses, not just `cf-ray`.

This is the third pass on this rule. `server: cloudflare` is now the sole gate — it's the only header the origin's CF zone reliably sets that doesn't get attached to transit responses (CF customers can't override it via Transform Rules). Any domain truly fronted by CF will carry `server: cloudflare`, so dropping `cf-cache-status` and `cf-mitigated` loses no true positives.

2 regression tests added (cf-cache-status alone → null; cf-mitigated alone → null). The old "cf-cache-status → Cloudflare" assertion is replaced by its inverse — that's the empirical fact v3.3.9 missed.