### PR TITLE
fix(scoring): N/A vs score reconciliation + profile-aware maturity + DMARCbis credit

### DIFF
--- a/packages/dns-checks/src/checks/check-dmarc.ts
+++ b/packages/dns-checks/src/checks/check-dmarc.ts
@@ -106,6 +106,13 @@ export async function checkDMARC(
 
 	// Check subdomain policy (sp= tag)
 	const sp = tags.get('sp');
+	// DMARCbis (RFC 9989) non-existent-subdomain policy. When `np=reject`/`np=quarantine`
+	// is set, non-existent subdomain spoofing is explicitly protected — the practical risk
+	// of `sp=none` is then limited to *existing* subdomains, which is a substantially
+	// smaller surface than the "any unowned subdomain" risk without np=. We downgrade the
+	// "Subdomain policy weaker than parent policy" finding accordingly.
+	const np = tags.get('np');
+	const npProtects = np === 'reject' || np === 'quarantine';
 	if (!sp && policy === 'reject') {
 		findings.push(
 			createFinding(
@@ -139,8 +146,10 @@ export async function checkDMARC(
 				createFinding(
 					'dmarc',
 					'Subdomain policy weaker than parent policy',
-					'high',
-					'Subdomain policy is set to "none" while parent policy is "reject". This leaves subdomains vulnerable to spoofing.',
+					npProtects ? 'low' : 'high',
+					npProtects
+						? `Subdomain policy is set to "none" while parent policy is "reject". Non-existent subdomains are still protected by DMARCbis np=${np}, so the residual risk is limited to existing subdomains.`
+						: 'Subdomain policy is set to "none" while parent policy is "reject". This leaves subdomains vulnerable to spoofing.',
 				),
 			);
 		} else if (policy === 'reject' && sp === 'quarantine') {

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -497,7 +497,7 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 		const { adjustedScore, effects: interactionEffects } = applyInteractionPenalties(score, runtimeOptions?.scoringConfig);
 		score = adjustedScore;
 
-		const rawMaturity = computeMaturityStage(checkResults);
+		const rawMaturity = computeMaturityStage(checkResults, domainContext?.profile);
 		const maturity = capMaturityStage(rawMaturity, score.overall);
 
 		result = {
@@ -565,7 +565,7 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 		}
 		const fallbackScoringContext = isExplicit ? fallbackContext : undefined;
 		const score = computeScanScore(checkResults, fallbackScoringContext, runtimeOptions?.scoringConfig);
-		const rawMaturity = computeMaturityStage(checkResults);
+		const rawMaturity = computeMaturityStage(checkResults, fallbackContext?.profile);
 		const maturity = capMaturityStage(rawMaturity, score.overall);
 		result = {
 			domain,

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { ScanDomainResult } from '../scan-domain';
-import type { Finding } from '../../lib/scoring';
+import type { CheckResult, Finding } from '../../lib/scoring';
 import type { OutputFormat } from '../../handlers/tool-args';
 import { sanitizeOutputText } from '../../lib/output-sanitize';
 import { resolveImpactNarrative } from '../explain-finding';
@@ -14,7 +14,14 @@ export interface StructuredScanResult {
 	passed: boolean;
 	maturityStage: number | null;
 	maturityLabel: string | null;
-	categoryScores: Record<string, number>;
+	/**
+	 * Per-category numeric score, or `null` when the category is not applicable to this
+	 * domain (mirrored in `notApplicableCategories`). Cluster-3 reconciliation invariant:
+	 * for every `cat` in `notApplicableCategories`, `categoryScores[cat] === null`.
+	 * This eliminates the contradictory "spf: 100 AND spf in notApplicableCategories"
+	 * shape the v3.3.12 fact-check surfaced (defect G).
+	 */
+	categoryScores: Record<string, number | null>;
 	findingCounts: { critical: number; high: number; medium: number; low: number };
 	scoringProfile: string;
 	scoringSignals: string[];
@@ -32,10 +39,72 @@ export interface StructuredScanResult {
 	dnssecSource: 'domain_configured' | 'tld_inherited' | null;
 	/** CDN provider detected from HTTP response headers. null when no CDN detected or check did not run. */
 	cdnProvider: string | null;
-	/** Email categories that scored 100 due to web-only/non-mail profile (no MX). Downstream consumers should treat these as N/A rather than perfect. */
+	/**
+	 * Categories that don't apply to this domain (no MX → mail-only categories under
+	 * `web_only`/`non_mail`; check timed-out/errored → inconclusive). These categories
+	 * are always reported as `null` in `categoryScores` to avoid the misleading 100 or 0.
+	 */
 	notApplicableCategories: string[];
 	timestamp: string;
 	cached: boolean;
+}
+
+/**
+ * Categories that are intrinsically mail-only — under `web_only`/`non_mail`
+ * profiles (no MX) they should be reported as N/A regardless of underlying score.
+ * `bimi` requires DMARC enforcement to publish; `mta_sts` and `dkim` are inbound-
+ * /outbound-mail features; `mx` has no meaning when there are no MX records.
+ */
+const MAIL_ONLY_CATEGORIES_FOR_NON_MAIL_PROFILE = new Set<string>(['dkim', 'mta_sts', 'bimi', 'mx']);
+/** Email categories that current behaviour already downgrades to info under non-mail profiles. */
+const EMAIL_CATEGORIES_HEURISTIC_NA = new Set<string>(['spf', 'dmarc', 'dkim', 'mta_sts']);
+
+/**
+ * Decide whether a single check should be reported as N/A given the active scoring profile.
+ * The two rules combined are the single source of truth that `categoryScores` and
+ * `notApplicableCategories` both derive from (defect G — single-source CategoryEvaluation).
+ */
+function isCategoryNonApplicable(
+	check: CheckResult | undefined,
+	category: string,
+	profile: string,
+	score: number | undefined,
+): boolean {
+	// Rule 1: transient/inconclusive checks are always N/A (could not measure).
+	if (check && (check.checkStatus === 'timeout' || check.checkStatus === 'error')) return true;
+
+	const isNonMailProfile = profile === 'non_mail' || profile === 'web_only';
+	if (!isNonMailProfile) return false;
+
+	// Rule 2 (defect H): under web_only/non_mail, intrinsically mail-only categories
+	// are always N/A — even if the check produced a numeric 0 (pre-fix non-mail pattern).
+	if (MAIL_ONLY_CATEGORIES_FOR_NON_MAIL_PROFILE.has(category)) return true;
+
+	// Rule 3 (legacy heuristic — refined): a non-mail profile downgrades missing
+	// email findings to info; when ALL of an email category's findings are info AND
+	// none of them indicate a record was found, treat as N/A. A finding whose title
+	// signals presence of a configured record (e.g. "SPF record found",
+	// "DMARC record found") flips the category back to applicable — fixes the case
+	// where an anti-spoof SPF `-all` is published but findings happen to all be info.
+	if (EMAIL_CATEGORIES_HEURISTIC_NA.has(category)) {
+		if (check) {
+			const allInfo = check.findings.length > 0 && check.findings.every((f: Finding) => f.severity === 'info');
+			const noFindings = check.findings.length === 0 && check.score === 100;
+			const hasPositiveSignal = check.findings.some((f: Finding) => {
+				const t = f.title.toLowerCase();
+				return /record (found|configured)|properly configured|valid|configured/.test(t) &&
+					!/no\s+\S+\s+record/.test(t) &&
+					!/not found/.test(t) &&
+					!/missing/.test(t);
+			});
+			if ((allInfo || noFindings) && !hasPositiveSignal) return true;
+		} else if (score === 100) {
+			// Category absent from checks but seeded to 100 by the engine.
+			return true;
+		}
+	}
+
+	return false;
 }
 
 /** Optional enrichment data for structured scan results. */
@@ -81,27 +150,38 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		}
 	}
 
-	// notApplicableCategories
-	const emailCategories = ['spf', 'dmarc', 'dkim', 'mta_sts'];
-	const isNonMailProfile = ['non_mail', 'web_only'].includes(result.context?.profile ?? '');
-	const notApplicableCategories: string[] = [];
-	if (isNonMailProfile) {
-		for (const check of result.checks) {
-			if (emailCategories.includes(check.category)) {
-				const allInfo = check.findings.length > 0 && check.findings.every((f: Finding) => f.severity === 'info');
-				const noFindings = check.findings.length === 0 && check.score === 100;
-				if (allInfo || noFindings) {
-					notApplicableCategories.push(check.category);
-				}
-			}
-		}
-	}
-	// Transient/inconclusive checks (checkStatus timeout/error) are excluded from the score by the
-	// engine — surface them as n/a (not a misleading 0) so the report reflects "could not measure".
+	// --- Single-source CategoryEvaluation pass (defect G + H) ---
+	// `notApplicableCategories` and `categoryScores` are now derived from the same
+	// per-category applicability decision. This eliminates the "spf: 100 AND spf in
+	// notApplicableCategories" overlap surfaced in the 2026-05-28 fact-check round.
+	const profile = result.context?.profile ?? 'mail_enabled';
+	const sourceCategoryScores: Record<string, number> = result.score.categoryScores ?? {};
+	const checksByCategory = new Map<string, CheckResult>();
 	for (const check of result.checks) {
-		if ((check.checkStatus === 'timeout' || check.checkStatus === 'error') && !notApplicableCategories.includes(check.category)) {
-			notApplicableCategories.push(check.category);
+		checksByCategory.set(check.category, check);
+	}
+
+	// Union of categories present in either the score map or the checks array.
+	const allCategoryKeys = new Set<string>([
+		...Object.keys(sourceCategoryScores),
+		...result.checks.map((c) => c.category),
+	]);
+
+	const notApplicableCategories: string[] = [];
+	const categoryScores: Record<string, number | null> = {};
+	for (const category of allCategoryKeys) {
+		const check = checksByCategory.get(category);
+		const rawScore: number | undefined = Object.prototype.hasOwnProperty.call(sourceCategoryScores, category)
+			? sourceCategoryScores[category]
+			: undefined;
+		if (isCategoryNonApplicable(check, category, profile, rawScore)) {
+			notApplicableCategories.push(category);
+			categoryScores[category] = null;
+		} else if (rawScore !== undefined) {
+			categoryScores[category] = rawScore;
 		}
+		// If neither in sourceCategoryScores nor non-applicable, skip — preserves prior
+		// "only keys with a score appear" behaviour.
 	}
 
 	return {
@@ -111,7 +191,7 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		passed: result.score.overall >= 50,
 		maturityStage: result.maturity?.stage ?? null,
 		maturityLabel: result.maturity?.label ?? null,
-		categoryScores: result.score.categoryScores,
+		categoryScores,
 		findingCounts: {
 			critical: result.score.findings.filter((f: Finding) => f.severity === 'critical').length,
 			high: result.score.findings.filter((f: Finding) => f.severity === 'high').length,

--- a/src/tools/scan/maturity-staging.ts
+++ b/src/tools/scan/maturity-staging.ts
@@ -1,12 +1,24 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * Email Security Maturity Staging.
- * Classifies a domain's email security posture into a maturity stage (0-4)
- * based on the results of individual DNS security checks.
+ * Security Maturity Staging.
+ *
+ * Classifies a domain's security posture into a maturity stage (0-4). The
+ * specific ladder depends on the scoring profile:
+ *
+ * - **mail-enabled** (and legacy default): email-centric ladder (SPF → DMARC
+ *   monitoring → enforcement → hardened with transport/integrity signals).
+ * - **web_only** (no MX): web-centric ladder. Web-only domains with strong
+ *   web posture (SSL + HSTS + DNSSEC) but no email service should not be capped
+ *   at "DNS-Only" just because they lack DKIM/MTA-STS — those don't apply.
+ *
+ * Defect I, cluster 3 (plan §5.3): the profile is now a first-class input.
+ * Backward-compatibility: omitting `profile` yields the legacy mail-enabled
+ * inference (including the historical "no-MX → DNS-Only" shortcut).
  */
 
 import type { CheckResult, Finding } from '../../lib/scoring';
+import type { DomainProfile } from '../../lib/scoring';
 
 export interface MaturityStage {
 	stage: number;
@@ -52,7 +64,90 @@ export function capMaturityStage(maturity: MaturityStage, score: number): Maturi
 	return maturity;
 }
 
-export function computeMaturityStage(checks: CheckResult[]): MaturityStage {
+/**
+ * Web-only maturity ladder (no-MX domains with real web posture).
+ *
+ * Stages credit transport (SSL), DNS integrity (DNSSEC), browser hardening
+ * (HSTS via http_security), and optional add-ons (CAA, anti-spoof SPF/DMARC).
+ * Mail categories (DKIM, MTA-STS, BIMI, MX) are intentionally excluded — they
+ * don't apply to a domain that doesn't accept email.
+ */
+function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
+	const byCategory = new Map(checks.map((c) => [c.category, c]));
+	const sslCheck = byCategory.get('ssl');
+	const dnssecCheck = byCategory.get('dnssec');
+	const httpSecurityCheck = byCategory.get('http_security');
+	const caaCheck = byCategory.get('caa');
+	const spfCheck = byCategory.get('spf');
+	const dmarcCheck = byCategory.get('dmarc');
+
+	const hasSsl = sslCheck?.passed ?? false;
+	const hasDnssec = dnssecCheck?.passed ?? false;
+	const hasHsts =
+		httpSecurityCheck?.findings.some((f: Finding) => /HSTS/i.test(f.title) && !/missing|no HSTS|no\s+HSTS/i.test(f.title)) ?? false;
+	const hasHttpHardening = httpSecurityCheck?.passed ?? false;
+	const hasCaa = caaCheck?.passed ?? false;
+	// Anti-spoof posture: a published SPF -all (or restrictive include) + DMARC reject is
+	// strong evidence even on a non-sending domain (defence against impersonation).
+	const hasSpfRecord = spfCheck != null && !spfCheck.findings.some((f: Finding) => /No SPF record/i.test(f.title));
+	const hasDmarcReject =
+		dmarcCheck != null &&
+		!dmarcCheck.findings.some((f: Finding) => /No DMARC record/i.test(f.title)) &&
+		!dmarcCheck.findings.some((f: Finding) => /policy set to (none|quarantine)/i.test(f.title));
+	const hasAntiSpoof = hasSpfRecord || hasDmarcReject;
+
+	// Stage 4 — Comprehensive: SSL + DNSSEC + HSTS + (CAA OR anti-spoof SPF/DMARC)
+	if (hasSsl && hasDnssec && hasHsts && (hasCaa || hasAntiSpoof)) {
+		return {
+			stage: 4,
+			label: 'Comprehensive',
+			description: 'This web-only domain has full transport (SSL), DNS integrity (DNSSEC), browser hardening (HSTS), and either CAA pinning or anti-spoof email posture.',
+			nextStep: '',
+		};
+	}
+
+	// Stage 3 — Defensive: SSL + DNSSEC + (HSTS or anti-spoof SPF/DMARC)
+	// CAA is NOT required at stage 3 — a domain can have strong defensive posture without it
+	// (DNSSEC + HSTS already provide DNS-integrity + transport-hardening guarantees).
+	if (hasSsl && hasDnssec && (hasHsts || hasAntiSpoof || hasHttpHardening)) {
+		return {
+			stage: 3,
+			label: 'Defensive',
+			description: 'This web-only domain has SSL, DNSSEC, and additional web/anti-spoof hardening. Strong defensive posture.',
+			nextStep: 'Add HSTS preload, CAA pinning, and explicit anti-spoof DMARC reject to reach full hardening.',
+		};
+	}
+
+	// Stage 2 — Hardened-baseline: SSL + DNSSEC OR SSL + HSTS
+	if (hasSsl && (hasDnssec || hasHsts)) {
+		return {
+			stage: 2,
+			label: 'Hardened',
+			description: 'Browser-facing TLS plus one DNS-or-browser hardening control. Resists most passive attacks.',
+			nextStep: 'Add DNSSEC and HSTS for layered protection.',
+		};
+	}
+
+	// Stage 1 — Basic: SSL present, nothing else
+	if (hasSsl) {
+		return {
+			stage: 1,
+			label: 'Basic',
+			description: 'TLS is configured. No additional DNS or browser hardening detected.',
+			nextStep: 'Enable DNSSEC and HSTS to layer protection above plain TLS.',
+		};
+	}
+
+	// Stage 0 — Unprotected
+	return {
+		stage: 0,
+		label: 'Unprotected',
+		description: 'No TLS detected on this web-only domain. Traffic is not authenticated or encrypted.',
+		nextStep: 'Configure HTTPS with a valid certificate before adding hardening layers.',
+	};
+}
+
+export function computeMaturityStage(checks: CheckResult[], profile?: DomainProfile): MaturityStage {
 	const byCategory = new Map(checks.map((c) => [c.category, c]));
 
 	const mxCheck = byCategory.get('mx');
@@ -63,13 +158,23 @@ export function computeMaturityStage(checks: CheckResult[]): MaturityStage {
 	const dnssecCheck = byCategory.get('dnssec');
 	const bimiCheck = byCategory.get('bimi');
 
+	// Profile-aware dispatch: explicit web_only domains use the web-only ladder.
+	// Non_mail also routes through web-only — both share the "no mail service" shape.
+	if (profile === 'web_only' || profile === 'non_mail') {
+		return computeWebOnlyMaturity(checks);
+	}
+
 	// Non-mail domains should not receive email maturity stages.
 	// The numeric stage values here (0 = "Unprotected", 1 = "DNS-Only") intentionally
 	// reuse the same numbers as the mail-domain scale. This is safe because `stage` is
 	// only ever rendered as a display value alongside `label` — it is never used as a
 	// numeric index or compared against mail-domain stages in any downstream logic.
+	//
+	// Legacy fallback: when `profile` is undefined (older callers) and MX records are
+	// missing, classify under the historical "DNS-Only" branch to preserve existing
+	// behaviour and test coverage.
 	const hasNoMx = mxCheck != null && mxCheck.findings.some((f: Finding) => f.title === 'No MX records found');
-	if (hasNoMx) {
+	if (hasNoMx && profile === undefined) {
 		const hasDnssec = dnssecCheck?.passed ?? false;
 		return {
 			stage: hasDnssec ? 1 : 0,
@@ -113,11 +218,20 @@ export function computeMaturityStage(checks: CheckResult[]): MaturityStage {
 		!dkimCheck.findings.some((f: Finding) => f.metadata?.detectionMethod === 'provider-implied');
 
 	// Stage 4 — Hardened: Stage 3 + at least 2 of (MTA-STS, DNSSEC, BIMI, DANE, CAA, DKIM-discovered)
+	// AND at least one TRANSPORT/INTEGRITY signal: DNSSEC, MTA-STS, or DANE.
+	//
+	// Defect I (cluster 3): the 2026-05-28 fact-check showed a payments-platform domain
+	// being labelled "Hardened" with only `CAA + DKIM-discovered = 2` hardening signals,
+	// despite missing DNSSEC, MTA-STS, BIMI, and DANE. Both CAA and DKIM-discovery are
+	// valuable but neither is a transport-encryption or DNS-integrity signal. Requiring
+	// at least one of {DNSSEC, MTA-STS, DANE} keeps full-stack mail providers at stage 4
+	// and drops the bare-DMARC-only stack to 3.
 	// DKIM is no longer required for Stage 3 — enforcement alone (SPF + DMARC p=quarantine/reject) qualifies
 	const isEnforcing = hasSpf && hasDmarc && (dmarcPolicyReject || dmarcPolicyQuarantine);
 	const hardeningCount = [hasMtaSts, hasDnssec, hasBimi, hasDane, hasCaa, hasDkimDiscovered].filter(Boolean).length;
+	const hasTransportOrIntegrityHardening = hasDnssec || hasMtaSts || hasDane;
 
-	if (isEnforcing && hardeningCount >= 2) {
+	if (isEnforcing && hardeningCount >= 2 && hasTransportOrIntegrityHardening) {
 		return {
 			stage: 4,
 			label: 'Hardened',

--- a/test/check-dmarc-scoring.spec.ts
+++ b/test/check-dmarc-scoring.spec.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Cluster 3 — Defect J — DMARC scoring credits DMARCbis + strict alignment
+//
+// Cross-domain evidence (fact-check 2026-05-28):
+//   - gov.uk DMARC = "v=DMARC1;p=reject;sp=none;np=reject;adkim=s;aspf=s;fo=1;rua=..."
+//     → score 70 (WRONG — DMARCbis non-existent-subdomain protection is strict)
+//   - stripe.com DMARC = "v=DMARC1;p=reject;pct=100;fo=1;rua=...;ruf=..." → score 85
+//
+// Required ordering: gov.uk DMARC > stripe.com DMARC. gov.uk floor ≥ 85.
+//
+// Approach (single-mechanism, penalty-based): when DMARCbis `np=reject` or
+// `np=quarantine` is present, downgrade the "Subdomain policy weaker than
+// parent policy" finding from HIGH to LOW. `np` covers non-existent
+// subdomains explicitly, which is the practical risk `sp=none` leaves open.
+//
+// Per plan §10 (testing anti-patterns): use ">=" / "<" ranges and
+// cross-domain ordering — do NOT assert exact scores.
+
+import { describe, it, expect, vi } from 'vitest';
+import { checkDMARC } from '../packages/dns-checks/src/checks/check-dmarc';
+import type { DNSQueryFunction } from '../packages/dns-checks/src/types';
+
+function mockDmarc(domain: string, record: string): DNSQueryFunction {
+	return vi.fn(async (q: string, _type: string) => {
+		if (q === `_dmarc.${domain}`) return [record];
+		// All other lookups (RUA authorization, parent DMARC) return empty.
+		return [];
+	});
+}
+
+describe('Defect J — DMARC scoring credits modern best practices', () => {
+	it('gov.uk-style strict DMARCbis policy scores ≥ 85 (regression — 2026-05-28 baseline was 70)', async () => {
+		const queryDNS = mockDmarc(
+			'gov.uk',
+			'v=DMARC1; p=reject; sp=none; np=reject; adkim=s; aspf=s; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk',
+		);
+		const result = await checkDMARC('gov.uk', queryDNS);
+		expect(result.score).toBeGreaterThanOrEqual(85);
+	});
+
+	it('credits strict alignment (adkim=s, aspf=s) over relaxed', async () => {
+		const baseline = await checkDMARC(
+			'baseline.example',
+			mockDmarc('baseline.example', 'v=DMARC1; p=reject; rua=mailto:r@baseline.example'),
+		);
+		const strict = await checkDMARC(
+			'strict.example',
+			mockDmarc('strict.example', 'v=DMARC1; p=reject; adkim=s; aspf=s; rua=mailto:r@strict.example'),
+		);
+		expect(strict.score).toBeGreaterThan(baseline.score);
+	});
+
+	it('does NOT credit pct=100 (which is the default since DMARC introduction)', async () => {
+		const withPct = await checkDMARC(
+			'with-pct.example',
+			mockDmarc('with-pct.example', 'v=DMARC1; p=reject; pct=100; rua=mailto:r@with-pct.example'),
+		);
+		const withoutPct = await checkDMARC(
+			'without-pct.example',
+			mockDmarc('without-pct.example', 'v=DMARC1; p=reject; rua=mailto:r@without-pct.example'),
+		);
+		expect(withPct.score).toBe(withoutPct.score);
+	});
+
+	it('cross-domain ordering: gov.uk (DMARCbis + strict) > stripe.com (basic + pct=100)', async () => {
+		const govuk = await checkDMARC(
+			'gov.uk',
+			mockDmarc(
+				'gov.uk',
+				'v=DMARC1; p=reject; sp=none; np=reject; adkim=s; aspf=s; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk',
+			),
+		);
+		const stripe = await checkDMARC(
+			'stripe.com',
+			mockDmarc(
+				'stripe.com',
+				'v=DMARC1; p=reject; pct=100; fo=1; rua=mailto:dmarc@stripe.com; ruf=mailto:ruf@stripe.com',
+			),
+		);
+		expect(govuk.score).toBeGreaterThan(stripe.score);
+	});
+
+	it('np=reject downgrades "Subdomain policy weaker than parent" from HIGH to LOW (DMARCbis covers non-existent subdomains)', async () => {
+		// Without np= — sp=none is a HIGH finding (parent reject, subdomain none — full gap).
+		const withoutNp = await checkDMARC(
+			'a.example',
+			mockDmarc('a.example', 'v=DMARC1; p=reject; sp=none; rua=mailto:r@a.example'),
+		);
+		const sevWithoutNp = withoutNp.findings
+			.filter((f) => f.title === 'Subdomain policy weaker than parent policy')
+			.map((f) => f.severity);
+		expect(sevWithoutNp).toEqual(['high']);
+
+		// With np=reject — DMARCbis explicitly protects non-existent subdomains; sp=none
+		// is now only a concern for existing subdomains, downgraded to low.
+		const withNp = await checkDMARC(
+			'b.example',
+			mockDmarc('b.example', 'v=DMARC1; p=reject; sp=none; np=reject; rua=mailto:r@b.example'),
+		);
+		const subdomainFinding = withNp.findings.find((f) => f.title === 'Subdomain policy weaker than parent policy');
+		// Either downgraded to low OR omitted in favour of an "np present" finding — both acceptable as long as severity is not high.
+		if (subdomainFinding) {
+			expect(subdomainFinding.severity).toBe('low');
+		}
+	});
+
+	it('np=quarantine also triggers the subdomain-finding downgrade (DMARCbis non-existent-subdomain protection)', async () => {
+		const withNpQuarantine = await checkDMARC(
+			'c.example',
+			mockDmarc('c.example', 'v=DMARC1; p=reject; sp=none; np=quarantine; rua=mailto:r@c.example'),
+		);
+		const subdomainFinding = withNpQuarantine.findings.find((f) => f.title === 'Subdomain policy weaker than parent policy');
+		if (subdomainFinding) {
+			expect(subdomainFinding.severity).not.toBe('high');
+		}
+	});
+
+	it('np=none does NOT downgrade the subdomain-weaker finding (no DMARCbis protection)', async () => {
+		const withNpNone = await checkDMARC(
+			'd.example',
+			mockDmarc('d.example', 'v=DMARC1; p=reject; sp=none; np=none; rua=mailto:r@d.example'),
+		);
+		const subdomainFinding = withNpNone.findings.find((f) => f.title === 'Subdomain policy weaker than parent policy');
+		expect(subdomainFinding?.severity).toBe('high');
+	});
+});

--- a/test/cluster-3-canary-regression.spec.ts
+++ b/test/cluster-3-canary-regression.spec.ts
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Cluster 3 — Canary regression suite
+//
+// Locks in the v3.3.12 → v3.3.13+ behavioral changes on the 2026-05-28 fact-check
+// canaries. Mocked DNS fixtures (no live network — per plan §10).
+//
+// Coverage:
+//   - gov.uk: web_only profile must yield maturity stage ≥ 3 (was 1)
+//   - stripe.com: mail_enabled profile must NOT be Hardened (was 4) — stage ≤ 3
+//   - proton.me: mail_enabled regression — stays at stage 4 Hardened
+//   - DMARC cross-domain ordering: gov.uk score > stripe.com score
+//   - DMARC floor: gov.uk DMARCbis-strict policy scores ≥ 85 (was 70)
+//
+// Tests are unit-level (call the staging classifier + DMARC check directly with
+// synthetic checks/records). They avoid the full scanDomain pipeline so they're
+// stable and fast.
+
+import { describe, it, expect, vi } from 'vitest';
+import { computeMaturityStage } from '../src/tools/scan/maturity-staging';
+import { checkDMARC } from '../packages/dns-checks/src/checks/check-dmarc';
+import { buildCheckResult, createFinding } from '../src/lib/scoring';
+import type { CheckResult } from '../src/lib/scoring';
+import type { DNSQueryFunction } from '../packages/dns-checks/src/types';
+
+// Canary DNS fixtures captured 2026-05-28. See fact-check plan §0.
+
+const GOV_UK_DMARC = 'v=DMARC1; p=reject; sp=none; np=reject; adkim=s; aspf=s; fo=1; rua=mailto:dmarc-rua@dmarc.service.gov.uk';
+const STRIPE_DMARC = 'v=DMARC1; p=reject; pct=100; fo=1; rua=mailto:dmarc@stripe.com; ruf=mailto:ruf@stripe.com';
+
+function dmarcMock(domain: string, record: string): DNSQueryFunction {
+	return vi.fn(async (q: string, _type: string) => (q === `_dmarc.${domain}` ? [record] : []));
+}
+
+function passingCheck(category: Parameters<typeof buildCheckResult>[0], title: string): CheckResult {
+	return buildCheckResult(category, [createFinding(category, title, 'info', 'ok')]);
+}
+
+function govUkChecks(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only domain')]),
+		buildCheckResult('spf', [createFinding('spf', 'SPF record found', 'info', 'v=spf1 -all (anti-spoof)')]),
+		buildCheckResult('dmarc', [
+			createFinding('dmarc', 'DMARC record found', 'info', 'p=reject; np=reject; adkim=s; aspf=s'),
+		]),
+		passingCheck('dnssec', 'DNSSEC validated'),
+		passingCheck('ssl', 'SSL certificate valid'),
+		buildCheckResult('http_security', [createFinding('http_security', 'HSTS configured (preload)', 'info', 'HSTS preload + max-age >= 1y')]),
+	];
+}
+
+function stripeChecks(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records')]),
+		passingCheck('spf', 'SPF record configured'),
+		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+		buildCheckResult('dkim', [
+			createFinding('dkim', 'DKIM configured', 'info', 'selectors found', { selectorsFound: ['s1', 's2'] }),
+		]),
+		passingCheck('ssl', 'SSL certificate valid'),
+		buildCheckResult('caa', [createFinding('caa', 'CAA records found', 'info', '0 issue "amazon.com"')]),
+		// stripe.com has NO DNSSEC, NO MTA-STS, NO BIMI, NO DANE (per 2026-05-28 fact-check)
+		buildCheckResult('dnssec', [createFinding('dnssec', 'No DNSKEY records found', 'high', 'No DNSSEC')]),
+		buildCheckResult('mta_sts', [createFinding('mta_sts', 'No MTA-STS or TLS-RPT records found', 'high', 'missing')]),
+	];
+}
+
+function protonChecks(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records (Proton)')]),
+		passingCheck('spf', 'SPF record configured'),
+		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject; rua present')]),
+		buildCheckResult('dkim', [
+			createFinding('dkim', 'DKIM configured', 'info', 'selectors found', { selectorsFound: ['protonmail', 'protonmail2'] }),
+		]),
+		passingCheck('mta_sts', 'MTA-STS configured'),
+		passingCheck('dnssec', 'DNSSEC validated'),
+		passingCheck('dane', 'DANE TLSA configured'),
+	];
+}
+
+describe('Cluster 3 canary regression — maturity classifier', () => {
+	it('gov.uk maturityStage ≥ 3 under web_only (regression — 2026-05-28 baseline was 1 "DNS-Only")', () => {
+		const stage = computeMaturityStage(govUkChecks(), 'web_only');
+		expect(stage.stage).toBeGreaterThanOrEqual(3);
+		expect(stage.label).not.toBe('DNS-Only');
+	});
+
+	it('stripe.com maturityStage ≤ 3 under mail_enabled (regression — 2026-05-28 baseline was 4 "Hardened")', () => {
+		const stage = computeMaturityStage(stripeChecks(), 'mail_enabled');
+		expect(stage.stage).toBeLessThanOrEqual(3);
+		expect(stage.label).not.toBe('Hardened');
+	});
+
+	it('proton.me maturityStage = 4 under mail_enabled (negative regression — does NOT change)', () => {
+		const stage = computeMaturityStage(protonChecks(), 'mail_enabled');
+		expect(stage.stage).toBe(4);
+		expect(stage.label).toBe('Hardened');
+	});
+
+	it('cross-domain ordering: proton.me > stripe.com (regression — both classified on mail-enabled ladder)', () => {
+		const proton = computeMaturityStage(protonChecks(), 'mail_enabled');
+		const stripe = computeMaturityStage(stripeChecks(), 'mail_enabled');
+		expect(proton.stage).toBeGreaterThan(stripe.stage);
+	});
+});
+
+describe('Cluster 3 canary regression — DMARC scoring', () => {
+	it('gov.uk DMARCbis-strict policy scores ≥ 85 (regression — 2026-05-28 baseline was 70)', async () => {
+		const result = await checkDMARC('gov.uk', dmarcMock('gov.uk', GOV_UK_DMARC));
+		expect(result.score).toBeGreaterThanOrEqual(85);
+	});
+
+	it('cross-domain ordering: gov.uk DMARC > stripe.com DMARC (regression — was 70 < 85)', async () => {
+		const govuk = await checkDMARC('gov.uk', dmarcMock('gov.uk', GOV_UK_DMARC));
+		const stripe = await checkDMARC('stripe.com', dmarcMock('stripe.com', STRIPE_DMARC));
+		expect(govuk.score).toBeGreaterThan(stripe.score);
+	});
+
+	it('np=reject downgrades subdomain-weaker finding from HIGH to LOW (mechanism that drives gov.uk floor)', async () => {
+		const result = await checkDMARC('gov.uk', dmarcMock('gov.uk', GOV_UK_DMARC));
+		const finding = result.findings.find((f) => f.title === 'Subdomain policy weaker than parent policy');
+		// Plan §5.4: the downgrade keeps the signal visible but no longer drags the score 25 points.
+		if (finding) {
+			expect(finding.severity).toBe('low');
+		}
+	});
+});

--- a/test/format-report-na-reconciliation.spec.ts
+++ b/test/format-report-na-reconciliation.spec.ts
@@ -1,0 +1,226 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Cluster 3 — Defects G & H
+//   G. `notApplicableCategories` and `categoryScores` reconciliation
+//      (single source — N/A categories must have null score, not 100).
+//   H. `web_only` profile suppresses mail-only categories (dkim, mta_sts, bimi, mx)
+//      regardless of the underlying check score.
+//
+// Reference: docs/plans/2026-05-28-fact-check-defect-remediation-tdd-plan.md §5.1, §5.2
+
+import { describe, it, expect } from 'vitest';
+import type { ScanDomainResult, MaturityStage } from '../src/tools/scan-domain';
+import type { CheckCategory, CheckResult, ScanScore, DomainContext } from '../src/lib/scoring';
+import { buildStructuredScanResult } from '../src/tools/scan/format-report';
+
+function makeMockScanResult(overrides: Partial<ScanDomainResult> = {}): ScanDomainResult {
+	return {
+		domain: 'example.com',
+		score: { overall: 80, grade: 'B', categoryScores: {} as Record<CheckCategory, number>, findings: [], summary: 'ok' } as ScanScore,
+		checks: [],
+		maturity: null as unknown as MaturityStage,
+		context: { profile: 'mail_enabled', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+		cached: false,
+		timestamp: '2026-05-28T00:00:00Z',
+		scoringNote: null,
+		adaptiveWeightDeltas: null,
+		interactionEffects: [],
+		...overrides,
+	};
+}
+
+describe('Defect G — categoryScores / notApplicableCategories never overlap (single source)', () => {
+	it('omits SPF from notApplicableCategories when an SPF record exists (gov.uk pattern)', () => {
+		// gov.uk publishes v=spf1 -all (anti-spoof) — SPF IS applicable
+		const result = makeMockScanResult({
+			score: {
+				overall: 85,
+				grade: 'A',
+				categoryScores: { spf: 100, ssl: 90, dnssec: 100 } as Record<CheckCategory, number>,
+				findings: [],
+				summary: 'ok',
+			} as ScanScore,
+			context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			checks: [
+				{
+					category: 'spf',
+					passed: true,
+					score: 100,
+					findings: [{ category: 'spf', title: 'SPF record found', severity: 'info', detail: 'v=spf1 -all (anti-spoof)' }],
+				},
+			] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.notApplicableCategories).not.toContain('spf');
+		expect(s.categoryScores.spf).toBe(100);
+	});
+
+	it('marks SPF as notApplicable AND nulls its categoryScores entry when SPF absent + web_only', () => {
+		const result = makeMockScanResult({
+			score: {
+				overall: 85,
+				grade: 'A',
+				categoryScores: { spf: 100 } as Record<CheckCategory, number>,
+				findings: [],
+				summary: 'ok',
+			} as ScanScore,
+			context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			checks: [
+				{
+					category: 'spf',
+					passed: true,
+					score: 100,
+					findings: [{ category: 'spf', title: 'No SPF record found', severity: 'info', detail: 'expected — no MX records' }],
+				},
+			] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.notApplicableCategories).toContain('spf');
+		expect(s.categoryScores.spf).toBeNull();
+	});
+
+	it('invariant: no category appears in both notApplicableCategories AND has a non-null score', () => {
+		// Synthetic corpus modelling multiple domains.
+		const corpusInputs: Array<{ profile: 'web_only' | 'mail_enabled' | 'non_mail'; checks: CheckResult[] }> = [
+			// gov.uk-shape (web_only, no mail)
+			{
+				profile: 'web_only',
+				checks: [
+					{
+						category: 'spf',
+						passed: true,
+						score: 100,
+						findings: [{ category: 'spf', title: 'SPF record found', severity: 'info', detail: 'v=spf1 -all' }],
+					},
+					{ category: 'dkim', passed: true, score: 100, findings: [] },
+					{ category: 'mta_sts', passed: true, score: 100, findings: [] },
+					{ category: 'bimi', passed: true, score: 100, findings: [] },
+					{ category: 'mx', passed: true, score: 100, findings: [{ category: 'mx', title: 'No MX records found', severity: 'info', detail: 'web-only domain' }] },
+				] as CheckResult[],
+			},
+			// mail_enabled
+			{
+				profile: 'mail_enabled',
+				checks: [
+					{ category: 'spf', passed: true, score: 100, findings: [] },
+					{ category: 'dkim', passed: true, score: 100, findings: [] },
+				] as CheckResult[],
+			},
+			// non_mail
+			{
+				profile: 'non_mail',
+				checks: [
+					{
+						category: 'dkim',
+						passed: true,
+						score: 100,
+						findings: [{ category: 'dkim', title: 'No DKIM records found', severity: 'info', detail: 'no MX' }],
+					},
+					{
+						category: 'mta_sts',
+						passed: true,
+						score: 100,
+						findings: [{ category: 'mta_sts', title: 'No MTA-STS', severity: 'info', detail: 'N/A' }],
+					},
+				] as CheckResult[],
+			},
+		];
+
+		for (const input of corpusInputs) {
+			const result = makeMockScanResult({
+				context: { profile: input.profile, signals: [], weights: {}, detectedProvider: null } as DomainContext,
+				checks: input.checks,
+				score: {
+					overall: 85,
+					grade: 'A',
+					categoryScores: Object.fromEntries(input.checks.map((c) => [c.category, c.score])) as Record<CheckCategory, number>,
+					findings: [],
+					summary: 'ok',
+				} as ScanScore,
+			});
+			const s = buildStructuredScanResult(result);
+			for (const cat of s.notApplicableCategories) {
+				expect(s.categoryScores[cat], `expected ${cat} to be null in categoryScores when listed N/A (profile=${input.profile})`).toBeNull();
+			}
+		}
+	});
+});
+
+describe('Defect H — web_only profile suppresses mail-only categories', () => {
+	const MAIL_ONLY_CATEGORIES = ['dkim', 'mta_sts', 'bimi', 'mx'] as const;
+
+	for (const category of MAIL_ONLY_CATEGORIES) {
+		it(`marks ${category} as notApplicable under web_only profile (gov.uk pattern: ${category}:0 → null)`, () => {
+			// Even when the underlying check produced a numeric score of 0 (pre-fix gov.uk behaviour),
+			// the structured output should report this as N/A, not 0.
+			const result = makeMockScanResult({
+				score: {
+					overall: 85,
+					grade: 'A',
+					categoryScores: { [category]: 0 } as Record<CheckCategory, number>,
+					findings: [],
+					summary: 'ok',
+				} as ScanScore,
+				context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+				checks: [
+					{
+						category,
+						passed: false,
+						score: 0,
+						findings: [{ category, title: `No ${category} record found`, severity: 'info', detail: 'expected — domain has no MX records' }],
+					},
+				] as CheckResult[],
+			});
+			const s = buildStructuredScanResult(result);
+			expect(s.notApplicableCategories).toContain(category);
+			expect(s.categoryScores[category]).toBeNull();
+		});
+	}
+
+	it('still scores web categories normally under web_only profile (ssl, dnssec, http_security)', () => {
+		const result = makeMockScanResult({
+			score: {
+				overall: 80,
+				grade: 'B',
+				categoryScores: { ssl: 90, dnssec: 100, http_security: 85 } as Record<CheckCategory, number>,
+				findings: [],
+				summary: 'ok',
+			} as ScanScore,
+			context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			checks: [
+				{ category: 'ssl', passed: true, score: 90, findings: [] },
+				{ category: 'dnssec', passed: true, score: 100, findings: [] },
+				{ category: 'http_security', passed: true, score: 85, findings: [] },
+			] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.categoryScores.ssl).toBe(90);
+		expect(s.categoryScores.dnssec).toBe(100);
+		expect(s.categoryScores.http_security).toBe(85);
+		expect(s.notApplicableCategories).not.toContain('ssl');
+		expect(s.notApplicableCategories).not.toContain('dnssec');
+		expect(s.notApplicableCategories).not.toContain('http_security');
+	});
+
+	it('does NOT mark mail-only categories N/A under mail_enabled profile', () => {
+		const result = makeMockScanResult({
+			score: {
+				overall: 80,
+				grade: 'B',
+				categoryScores: { dkim: 75, mta_sts: 60 } as Record<CheckCategory, number>,
+				findings: [],
+				summary: 'ok',
+			} as ScanScore,
+			context: { profile: 'mail_enabled', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			checks: [
+				{ category: 'dkim', passed: true, score: 75, findings: [] },
+				{ category: 'mta_sts', passed: false, score: 60, findings: [] },
+			] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.notApplicableCategories).not.toContain('dkim');
+		expect(s.notApplicableCategories).not.toContain('mta_sts');
+		expect(s.categoryScores.dkim).toBe(75);
+		expect(s.categoryScores.mta_sts).toBe(60);
+	});
+});

--- a/test/maturity-staging-profile.spec.ts
+++ b/test/maturity-staging-profile.spec.ts
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Cluster 3 — Defect I
+//   Maturity classifier must respect scoringProfile.
+//   - web_only domains evaluate against a WEB-ONLY ladder (no mail categories
+//     can pull the stage up or down).
+//   - mail_enabled stage 4 ("Hardened") tightened: stripe.com (no DNSSEC,
+//     no MTA-STS, no BIMI, no DANE) is NOT Hardened despite hasCaa +
+//     hasDkimDiscovered = 2.
+//
+// Plan: docs/plans/2026-05-28-fact-check-defect-remediation-tdd-plan.md §5.3
+// Fact-check baseline (2026-05-28):
+//   - gov.uk currently → stage 1 "DNS-Only" (wrong — has DNSSEC + DMARCbis
+//     + HSTS + Fastly + strong web posture).
+//   - stripe.com currently → stage 4 "Hardened" (wrong — missing transport
+//     and integrity hardening).
+
+import { describe, it, expect } from 'vitest';
+import { computeMaturityStage } from '../src/tools/scan/maturity-staging';
+import { buildCheckResult, createFinding } from '../src/lib/scoring';
+import type { CheckResult } from '../src/lib/scoring';
+
+// Helpers -----------------------------------------------------------------
+
+function passingCheck(category: Parameters<typeof buildCheckResult>[0], title: string): CheckResult {
+	return buildCheckResult(category, [createFinding(category, title, 'info', 'ok')]);
+}
+
+// gov.uk-shaped checks (no MX, strong web + DNSSEC + DMARC strict)
+function govUkChecks(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only domain')]),
+		buildCheckResult('spf', [createFinding('spf', 'SPF record found', 'info', 'v=spf1 -all (anti-spoof)')]),
+		// dmarc: p=reject + np=reject + adkim=s + aspf=s + sp=none(downgraded) + no ruf(low)
+		buildCheckResult('dmarc', [
+			createFinding('dmarc', 'DMARC record found', 'info', 'p=reject; np=reject; adkim=s; aspf=s'),
+			createFinding('dmarc', 'No forensic reporting configured (ruf= absent)', 'low', 'no ruf'),
+		]),
+		passingCheck('dnssec', 'DNSSEC validated'),
+		passingCheck('ssl', 'SSL certificate valid'),
+		buildCheckResult('http_security', [createFinding('http_security', 'HSTS configured (preload)', 'info', 'HSTS preload + max-age >= 1y')]),
+	];
+}
+
+// stripe.com-shaped checks (mail_enabled, no DNSSEC, no MTA-STS, no BIMI, no DANE)
+function stripeChecks(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records')]),
+		passingCheck('spf', 'SPF record configured'),
+		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+		buildCheckResult('dkim', [
+			createFinding('dkim', 'DKIM configured', 'info', 'selectors found', { selectorsFound: ['s1', 's2'] }),
+		]),
+		buildCheckResult('caa', [createFinding('caa', 'CAA records found', 'info', '0 issue "amazon.com"')]),
+		buildCheckResult('ssl', [createFinding('ssl', 'SSL certificate valid', 'info', 'ok')]),
+		// No DNSSEC, no MTA-STS, no BIMI, no DANE — stripe.com lacks transport hardening.
+		// Use high-severity findings so `passed=false` and the maturity classifier sees them as absent.
+		buildCheckResult('dnssec', [createFinding('dnssec', 'No DNSKEY records found', 'high', 'No DNSSEC')]),
+		buildCheckResult('mta_sts', [createFinding('mta_sts', 'No MTA-STS or TLS-RPT records found', 'high', 'missing')]),
+	];
+}
+
+// proton.me-shaped (strong mail, full hardening — stays stage 4)
+function protonChecks(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records')]),
+		passingCheck('spf', 'SPF record configured'),
+		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+		buildCheckResult('dkim', [
+			createFinding('dkim', 'DKIM configured', 'info', 'selectors found', { selectorsFound: ['protonmail', 'protonmail2'] }),
+		]),
+		passingCheck('mta_sts', 'MTA-STS configured'),
+		passingCheck('dnssec', 'DNSSEC validated'),
+		passingCheck('dane', 'DANE TLSA configured'),
+		buildCheckResult('tlsrpt', [createFinding('tlsrpt', 'TLS-RPT configured', 'info', 'ok')]),
+		buildCheckResult('bimi', [createFinding('bimi', 'BIMI record configured', 'info', 'ok')]),
+	];
+}
+
+describe('Defect I — computeMaturityStage accepts profile and respects it', () => {
+	it('classifies gov.uk-style web_only domain at stage ≥ 3 (regression — 2026-05-28 baseline was 1)', () => {
+		const stage = computeMaturityStage(govUkChecks(), 'web_only');
+		expect(stage.stage).toBeGreaterThanOrEqual(3);
+		// Label should NOT be "DNS-Only" any more for a domain with this much web posture.
+		expect(stage.label).not.toBe('DNS-Only');
+		// Description should reflect web-only nature.
+		expect(stage.description.toLowerCase()).toMatch(/web|http|tls|browser|dns/);
+	});
+
+	it('classifies mail-enabled proton.me-style domain at stage 4 (Hardened) — regression', () => {
+		const stage = computeMaturityStage(protonChecks(), 'mail_enabled');
+		expect(stage.stage).toBe(4);
+		expect(stage.label).toBe('Hardened');
+	});
+
+	it('classifies stripe.com-style mail-enabled domain at stage ≤ 3 (NOT Hardened) — regression', () => {
+		// stripe.com is missing DNSSEC, MTA-STS, BIMI, DANE — transport/integrity hardening absent.
+		const stage = computeMaturityStage(stripeChecks(), 'mail_enabled');
+		expect(stage.stage).toBeLessThanOrEqual(3);
+		expect(stage.label).not.toBe('Hardened');
+	});
+
+	it('cross-domain ordering: proton.me Hardened > stripe.com (regression)', () => {
+		const proton = computeMaturityStage(protonChecks(), 'mail_enabled');
+		const stripe = computeMaturityStage(stripeChecks(), 'mail_enabled');
+		expect(proton.stage).toBeGreaterThan(stripe.stage);
+	});
+
+	it('cross-domain ordering: gov.uk web_only stage ≥ 3, stripe.com stage ≤ 3 — both are mid-tier in their own ladders', () => {
+		const govuk = computeMaturityStage(govUkChecks(), 'web_only');
+		const stripe = computeMaturityStage(stripeChecks(), 'mail_enabled');
+		// gov.uk: classified on web-only ladder, gets ≥3 ("Defensive" or higher).
+		expect(govuk.stage).toBeGreaterThanOrEqual(3);
+		// stripe: classified on mail-enabled ladder, capped at ≤3 ("Enforcing") without transport hardening.
+		expect(stripe.stage).toBeLessThanOrEqual(3);
+	});
+
+	it('backward-compatible: omitting profile argument still produces a stage (legacy callers)', () => {
+		const stage = computeMaturityStage(protonChecks());
+		// Without explicit profile, falls back to existing mail-enabled inference.
+		expect(stage.stage).toBeGreaterThanOrEqual(3);
+	});
+
+	it('web_only ladder yields stage 0/1 (Basic) when only SSL is present', () => {
+		const checks: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only')]),
+			passingCheck('ssl', 'SSL certificate valid'),
+		];
+		const stage = computeMaturityStage(checks, 'web_only');
+		expect(stage.stage).toBeLessThanOrEqual(1);
+	});
+
+	it('web_only ladder yields stage ≥ 2 when SSL + DNSSEC + HSTS present', () => {
+		const checks: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only')]),
+			passingCheck('ssl', 'SSL certificate valid'),
+			passingCheck('dnssec', 'DNSSEC validated'),
+			buildCheckResult('http_security', [createFinding('http_security', 'HSTS configured', 'info', 'HSTS')]),
+		];
+		const stage = computeMaturityStage(checks, 'web_only');
+		expect(stage.stage).toBeGreaterThanOrEqual(2);
+	});
+});


### PR DESCRIPTION
Cluster 3 of the 2026-05-28 fact-check defect remediation plan (`docs/plans/2026-05-28-fact-check-defect-remediation-tdd-plan.md` §5). 4 defects in scoring/maturity logic, biggest blast radius — shipped separately from clusters 1+2+4 (v3.3.13) for rollback safety.

## Defect G — `notApplicableCategories` vs `categoryScores` reconciliation

`isCategoryNonApplicable()` is the single source of truth in `format-report.ts`. Both fields derived in one pass. Invariant locked by test: for every cat in `notApplicableCategories`, `categoryScores[cat] === null`.

## Defect H — `web_only` profile suppresses mail-only categories

Mail-only categories (dkim, mta_sts, bimi, mx) marked N/A under web_only/non_mail profiles. The legacy 'all-info → N/A' heuristic preserved but refined: a positive 'record found/configured' signal flips back to applicable (fixes the anti-spoof `v=spf1 -all` case).

## Defect I — maturity classifier respects profile

`computeMaturityStage` accepts optional `profile` parameter. New web-only ladder: Basic → Hardened → Defensive → Comprehensive. Mail-enabled stage 4 gate tightened: `hardeningCount >= 2` AND at least one of {DNSSEC, MTA-STS, DANE}. Locks two cross-domain regressions in test:
- web-only domain with strong defensive posture → stage ≥ 3 (was stage 1 'DNS-Only')
- mail-enabled domain with CAA + DKIM-discovered but no transport/integrity → stage ≤ 3 (was stage 4 'Hardened')

## Defect J — DMARC scoring credits DMARCbis

`np=reject` / `np=quarantine` downgrades the 'Subdomain policy weaker than parent' finding from HIGH (-25) to LOW (-5). Penalty-based — no parallel credit system. Locks cross-domain ordering in test (DMARCbis + strict alignment > basic DMARC + reporting).

## Test coverage

31 new specs across 4 files:
- `test/format-report-na-reconciliation.spec.ts` — 9 specs
- `test/maturity-staging-profile.spec.ts` — 8 specs
- `test/check-dmarc-scoring.spec.ts` — 7 specs
- `test/cluster-3-canary-regression.spec.ts` — 7 specs (locks the 2026-05-28 fact-check fixtures with `>=` / `<` ranges per plan §10)

All cluster-3 tests pass. 58 pre-existing scoring-adjacent tests still pass. `typecheck` + `lint` clean.

## Blast radius note

This release changes the observed `maturityStage`, `categoryScores`, and `score` output on EVERY existing scan. Worth a 'before/after on the v3.3.12 test corpus' eyeball before tagging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)