### PR TITLE
feat: provider catalog gaps from 2026-05-28 fact-check round (NS1/Dyn collapse + Oracle Cloud Email + NS+IP CF CDN heuristic)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -69,6 +69,7 @@ paths = [
   '''src/tools/.*-analysis\.ts$''',    # Analysis modules contain IP examples in JSDoc
   '''src/lib/ip-utils\.ts$''',         # IP utility module contains example IPs in JSDoc
   '''src/lib/authoritative-dns-infra/root-hints\.ts$''', # Public IANA root-server addresses
+  '''src/lib/cdn-fallback-detection\.ts$''', # Public Cloudflare edge CIDR snapshot from cloudflare.com/ips/
   '''docs/.*\.md$''',                  # IPv4 examples in RFC / explanation context (per-rule, not global)
   '''CHANGELOG\.md$''',                # IPs that appear in incident write-ups
   '''scripts/tranco-deep-.*\.json$''', # Captured scan artifacts (resolved IPs from public Tranco list)

--- a/scripts/repo-safety/policy.json
+++ b/scripts/repo-safety/policy.json
@@ -97,7 +97,8 @@
 		"test/audits/repo-safety-scanner.audit.test.ts",
 		"test/audits/no-tracked-secrets.audit.test.ts",
 		"scripts/repo-safety/policy.json",
-		"src/lib/authoritative-dns-infra/root-hints.ts"
+		"src/lib/authoritative-dns-infra/root-hints.ts",
+		"src/lib/cdn-fallback-detection.ts"
 	],
 	"allowedPathPrefixes": [".github/", "test/", "packages/dns-checks/src/__tests__/"]
 }

--- a/src/lib/cdn-fallback-detection.ts
+++ b/src/lib/cdn-fallback-detection.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Heuristic Cloudflare CDN attribution fallback.
+ *
+ * Header-based CDN detection (see check-http-security.ts) cannot identify
+ * Cloudflare from inside a Cloudflare Worker: CF's outbound `fetch()` layer
+ * rewrites `server: cloudflare` on every response and injects `cf-ray` for
+ * tracing, regardless of the origin. v3.3.11 removed CF detection entirely
+ * to fix the resulting 100% false-positive rate.
+ *
+ * This module restores attribution by combining two corroborating signals
+ * that the scanner CAN observe authentically:
+ *
+ *   1. NS records — all nameservers under `*.ns.cloudflare.com`
+ *   2. A records — at least one IP in Cloudflare's published edge ranges
+ *
+ * BOTH must match to attribute. The combined check rules out the two
+ * common false positives: DNS-only customers (NS on CF, origin elsewhere)
+ * and transit-only paths (origin on CF IPs but NS elsewhere — eg. a
+ * partial migration). When matched, the attribution is flagged
+ * `confidence: 'heuristic'` so consumers can distinguish it from
+ * header-based hits (`confidence` absent → high-confidence vendor signal).
+ *
+ * The published IPv4 ranges are snapshotted from cloudflare.com/ips/.
+ * If Cloudflare publishes a new range, the `CLOUDFLARE_IPV4_RANGES`
+ * snapshot test in `test/cdn-fallback-detection.spec.ts` will force a
+ * deliberate update.
+ */
+
+/**
+ * Cloudflare's published IPv4 edge ranges (snapshot from `cloudflare.com/ips/`).
+ * Sorted to match the order in the published list to make diffs reviewable.
+ */
+export const CLOUDFLARE_IPV4_RANGES: readonly string[] = [
+	'103.21.244.0/22',
+	'103.22.200.0/22',
+	'103.31.4.0/22',
+	'104.16.0.0/13',
+	'104.24.0.0/14',
+	'108.162.192.0/18',
+	'131.0.72.0/22',
+	'141.101.64.0/18',
+	'162.158.0.0/15',
+	'172.64.0.0/13',
+	'173.245.48.0/20',
+	'188.114.96.0/20',
+	'190.93.240.0/20',
+	'197.234.240.0/22',
+	'198.41.128.0/17',
+];
+
+/** Convert a dotted-quad IPv4 string to its uint32 value, or null on malformed input. */
+function ipToUint32(ip: string): number | null {
+	const parts = ip.split('.');
+	if (parts.length !== 4) return null;
+	const nums: number[] = [];
+	for (const p of parts) {
+		if (p.length === 0 || p.length > 3) return null;
+		if (!/^\d+$/.test(p)) return null;
+		const n = Number(p);
+		if (!Number.isInteger(n) || n < 0 || n > 255) return null;
+		nums.push(n);
+	}
+	return ((nums[0] << 24) | (nums[1] << 16) | (nums[2] << 8) | nums[3]) >>> 0;
+}
+
+/** Whether a given IPv4 string falls inside a CIDR block. False on malformed input. */
+function cidrContains(cidr: string, ip: string): boolean {
+	const [base, bits] = cidr.split('/');
+	const baseInt = ipToUint32(base);
+	const ipInt = ipToUint32(ip);
+	if (baseInt === null || ipInt === null) return false;
+	const bitsNum = Number(bits);
+	if (!Number.isInteger(bitsNum) || bitsNum < 0 || bitsNum > 32) return false;
+	const mask = bitsNum === 0 ? 0 : (~0 << (32 - bitsNum)) >>> 0;
+	return (baseInt & mask) === (ipInt & mask);
+}
+
+/** Whether an IPv4 string falls in any published Cloudflare edge range. */
+export function isIpInCloudflareRange(ip: string): boolean {
+	for (const cidr of CLOUDFLARE_IPV4_RANGES) {
+		if (cidrContains(cidr, ip)) return true;
+	}
+	return false;
+}
+
+const CF_NS_PATTERN = /\.ns\.cloudflare\.com\.?$/i;
+
+export interface CloudflareHeuristicResult {
+	provider: 'Cloudflare';
+	confidence: 'heuristic';
+}
+
+/**
+ * Returns a Cloudflare attribution iff BOTH signals match:
+ *   - every NS host is under `*.ns.cloudflare.com`
+ *   - at least one A record is in a published Cloudflare edge range
+ *
+ * Returns null otherwise. Empty NS or empty A list always returns null.
+ */
+export function detectCloudflareViaNsAndIp(opts: {
+	nsHosts: string[];
+	aRecords: string[];
+}): CloudflareHeuristicResult | null {
+	const { nsHosts, aRecords } = opts;
+	if (nsHosts.length === 0 || aRecords.length === 0) return null;
+
+	const allNsOnCloudflare = nsHosts.every((host) => CF_NS_PATTERN.test(host));
+	if (!allNsOnCloudflare) return null;
+
+	const anyARecordInRange = aRecords.some((ip) => isIpInCloudflareRange(ip));
+	if (!anyARecordInRange) return null;
+
+	return { provider: 'Cloudflare', confidence: 'heuristic' };
+}

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -11,7 +11,7 @@ import type { OutputFormat } from '../handlers/tool-args';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { queryTxtRecords, queryDnsRecords, querySrvRecords } from '../lib/dns';
 import { sanitizeOutputText } from '../lib/output-sanitize';
-import { detectProviders, matchProviderForSpfInclude } from './provider-guides';
+import { detectProviders, matchProviderForNsHost, matchProviderForSpfInclude } from './provider-guides';
 import { VERIFICATION_PATTERNS, SERVICE_SPF_DOMAINS } from './txt-hygiene-analysis';
 import { SRV_PREFIXES } from './srv-analysis';
 import type { SrvProbeResult } from './srv-analysis';
@@ -297,16 +297,18 @@ export async function mapSupplyChain(
 	for (const provider of detectedProviders) {
 		const source = provider.role === 'mail' || provider.role === 'sending' ? 'spf' : 'ns';
 		addDependency(provider.name, source);
+	}
 
-		if (source === 'ns') {
-			for (const host of nsHosts) {
-				if (provider.signal.startsWith('ns:')) {
-					const signalDomain = provider.signal.split(':').slice(1).join(':');
-					if (host.includes(signalDomain)) {
-						detectedNsHosts.add(host);
-					}
-				}
-			}
+	// Mark every NS host that resolves to a known provider as "detected" so the
+	// downstream "unrecognized NS host → parent-domain row" loop skips it.
+	// Uses the shared DETECTION_RULES regex (via matchProviderForNsHost) instead
+	// of a `provider.signal` substring heuristic; the substring approach silently
+	// broke for multi-TLD vendors whose two TLDs share no common substring
+	// (eg. NS1: `*.ns1.com` + `*.nsone.net`). Mirrors the SPF dedup path's use
+	// of matchProviderForSpfInclude so the two paths can't drift.
+	for (const host of nsHosts) {
+		if (matchProviderForNsHost(host) !== null) {
+			detectedNsHosts.add(host);
 		}
 	}
 

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -131,6 +131,32 @@ const DETECTION_RULES: DetectionRule[] = [
 		signal: 'ns:ultradns',
 	},
 	{
+		// NS1 (IBM, since 2024). Multi-TLD vendor — authoritative DNS is served
+		// from both `*.ns1.com` and `*.nsone.net`. Many large customers carry NS
+		// hosts on both sibling TLDs for redundancy; without this collapse the
+		// supply-chain map double-counts. Single-TLD deployments (eg. nsone.net
+		// only) must still resolve to the same canonical provider name.
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.14 fact-check round).
+		name: 'NS1 (IBM)',
+		role: 'dns',
+		patterns: {
+			ns: /\.(nsone\.net|ns1\.com)$/i,
+		},
+		signal: 'ns:ns1',
+	},
+	{
+		// Dyn (Oracle Dyn). Multi-TLD vendor — authoritative DNS is served from
+		// both `*.dyn.com` and `*.dynect.net`. Many pre-Oracle-acquisition
+		// enterprise customers still carry NS hosts on both sibling TLDs.
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.14 fact-check round).
+		name: 'Dyn (Oracle)',
+		role: 'dns',
+		patterns: {
+			ns: /\.(dyn\.com|dynect\.net)$/i,
+		},
+		signal: 'ns:dyn',
+	},
+	{
 		name: 'AWS SES',
 		role: 'sending',
 		patterns: {
@@ -176,6 +202,22 @@ const DETECTION_RULES: DetectionRule[] = [
 		},
 		signal: 'spf:fireeyecloud.com',
 	},
+	{
+		// Oracle Cloud Email (formerly Oracle Cloud Infrastructure Email Delivery).
+		// Detected via SPF selector subdomains under `oraclecloud.com`: the customer
+		// SPF includes `spf_c.oraclecloud.com`, which cascades through
+		// `spf_s1.oraclecloud.com` and `spf_s2.oraclecloud.com`. Without this rule
+		// the raw selector hostname surfaces as a third-party row instead of the
+		// canonical provider name. SPF-only (no fixed MX hostnames); the SPF-rule
+		// dedup path (matchProviderForSpfInclude) handles it.
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.14 fact-check round).
+		name: 'Oracle Cloud Email',
+		role: 'sending',
+		patterns: {
+			spf: /(_c|_s\d+)\.oraclecloud\.com$/i,
+		},
+		signal: 'spf:oraclecloud.com',
+	},
 ];
 
 /**
@@ -186,6 +228,24 @@ const DETECTION_RULES: DetectionRule[] = [
 export function matchProviderForSpfInclude(spfInclude: string): string | null {
 	for (const rule of DETECTION_RULES) {
 		if (rule.patterns.spf && rule.patterns.spf.test(spfInclude)) {
+			return rule.name;
+		}
+	}
+	return null;
+}
+
+/**
+ * Resolve a single NS host to a known provider name, if any.
+ * Uses the same DETECTION_RULES as detectProviders so the two paths can't drift.
+ * Returns null when no rule's ns pattern matches.
+ *
+ * Replaces the previous substring-via-signal heuristic in map-supply-chain,
+ * which silently broke for multi-TLD vendors whose two TLDs share no common
+ * substring (eg. NS1: `*.ns1.com` + `*.nsone.net`).
+ */
+export function matchProviderForNsHost(nsHost: string): string | null {
+	for (const rule of DETECTION_RULES) {
+		if (rule.patterns.ns && rule.patterns.ns.test(nsHost)) {
 			return rule.name;
 		}
 	}

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -2,7 +2,9 @@
 
 import { type CheckCategory, type CheckResult, type Finding, buildCheckResult, createFinding } from '../../lib/scoring';
 import { queryTxtRecords } from '../../lib/dns';
+import { queryDnsRecords } from '../../lib/dns-records';
 import { detectProviderMatches, detectProviderMatchesBySelectors, loadProviderSignatures } from '../../lib/provider-signatures';
+import { detectCloudflareViaNsAndIp } from '../../lib/cdn-fallback-detection';
 import { parseDmarcTags } from '../check-dmarc';
 
 export interface ScanRuntimeOptions {
@@ -51,7 +53,73 @@ export async function applyScanPostProcessing(
 		results = adjustForNoSendDomain(results);
 	}
 
+	results = await addCloudflareCdnHeuristic(domain, results);
+
 	return addOutboundProviderInference(results, runtimeOptions);
+}
+
+/**
+ * Heuristic Cloudflare CDN attribution fallback.
+ *
+ * Header-based CDN detection (in `check-http-security`) cannot identify
+ * Cloudflare from inside a Cloudflare Worker — see the rationale in
+ * `src/lib/cdn-fallback-detection.ts`. This post-processing pass restores
+ * attribution when:
+ *
+ *   1. No header-based CDN was identified for `http_security`, AND
+ *   2. All NS records resolve under `*.ns.cloudflare.com`, AND
+ *   3. At least one A record falls in a published Cloudflare edge range.
+ *
+ * When matched, emits a new info-level finding on the `http_security` check
+ * with `metadata: { cdnProvider: 'Cloudflare', confidence: 'heuristic',
+ * source: 'ns-and-ip-range' }`. Format-report already iterates findings
+ * looking for `metadata.cdnProvider`, so it picks this up automatically.
+ *
+ * Conservative: any DNS error during the fresh NS/A lookups silently skips
+ * the heuristic — never poisons a scan result.
+ */
+async function addCloudflareCdnHeuristic(domain: string, results: CheckResult[]): Promise<CheckResult[]> {
+	const httpResult = results.find((result) => result.category === 'http_security');
+	if (!httpResult) return results;
+
+	// Don't compete with a header-based CDN hit — those are stronger signal.
+	const alreadyHasCdn = httpResult.findings.some((f) => typeof f.metadata?.cdnProvider === 'string');
+	if (alreadyHasCdn) return results;
+
+	let nsHosts: string[];
+	let aRecords: string[];
+	try {
+		[nsHosts, aRecords] = await Promise.all([
+			queryDnsRecords(domain, 'NS'),
+			queryDnsRecords(domain, 'A'),
+		]);
+	} catch {
+		return results;
+	}
+
+	// Strip trailing dots for consistency with the helper's expected input.
+	const normalisedNs = nsHosts.map((h) => h.replace(/\.$/, '').toLowerCase());
+	const heuristic = detectCloudflareViaNsAndIp({ nsHosts: normalisedNs, aRecords });
+	if (!heuristic) return results;
+
+	const cdnFinding = createFinding(
+		'http_security',
+		'HTTP origin attributed to Cloudflare CDN (heuristic)',
+		'info',
+		'Cloudflare CDN inferred from NS records on *.ns.cloudflare.com combined with A records in Cloudflare\'s published edge ranges. Header-based CDN detection was inconclusive (the scanner runs inside a Cloudflare Worker, which rewrites server: cloudflare on every outbound response).',
+		{ cdnProvider: 'Cloudflare', confidence: 'heuristic', source: 'ns-and-ip-range' },
+	);
+
+	const updated = buildCheckResult('http_security', [...httpResult.findings, cdnFinding]);
+	// buildCheckResult creates a fresh CheckResult — preserve scoring fields we care about.
+	const merged: CheckResult = {
+		...updated,
+		score: httpResult.score,
+		passed: httpResult.passed,
+		checkStatus: httpResult.checkStatus,
+		metadata: httpResult.metadata,
+	};
+	return upsertCheckResult(results, merged);
 }
 
 function extractSpfSignalDomains(result: CheckResult | undefined): string[] {

--- a/test/cdn-fallback-detection.spec.ts
+++ b/test/cdn-fallback-detection.spec.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect } from 'vitest';
+import {
+	CLOUDFLARE_IPV4_RANGES,
+	isIpInCloudflareRange,
+	detectCloudflareViaNsAndIp,
+} from '../src/lib/cdn-fallback-detection';
+
+describe('CLOUDFLARE_IPV4_RANGES', () => {
+	it('includes all 15 published Cloudflare IPv4 ranges', () => {
+		// Snapshot the canonical published list; if Cloudflare adds/removes a
+		// range, this assertion forces a deliberate update.
+		expect(CLOUDFLARE_IPV4_RANGES).toEqual([
+			'103.21.244.0/22',
+			'103.22.200.0/22',
+			'103.31.4.0/22',
+			'104.16.0.0/13',
+			'104.24.0.0/14',
+			'108.162.192.0/18',
+			'131.0.72.0/22',
+			'141.101.64.0/18',
+			'162.158.0.0/15',
+			'172.64.0.0/13',
+			'173.245.48.0/20',
+			'188.114.96.0/20',
+			'190.93.240.0/20',
+			'197.234.240.0/22',
+			'198.41.128.0/17',
+		]);
+	});
+});
+
+describe('isIpInCloudflareRange', () => {
+	it('matches across all 15 published CF ranges (one sample per range)', () => {
+		// Sample one IP per range to prove the CIDR table is wired correctly.
+		expect(isIpInCloudflareRange('103.21.244.10')).toBe(true); // 103.21.244.0/22
+		expect(isIpInCloudflareRange('103.22.200.10')).toBe(true); // 103.22.200.0/22
+		expect(isIpInCloudflareRange('103.31.4.10')).toBe(true); // 103.31.4.0/22
+		expect(isIpInCloudflareRange('104.16.45.99')).toBe(true); // 104.16.0.0/13
+		expect(isIpInCloudflareRange('104.24.10.10')).toBe(true); // 104.24.0.0/14
+		expect(isIpInCloudflareRange('108.162.192.10')).toBe(true); // 108.162.192.0/18
+		expect(isIpInCloudflareRange('131.0.72.10')).toBe(true); // 131.0.72.0/22
+		expect(isIpInCloudflareRange('141.101.64.10')).toBe(true); // 141.101.64.0/18
+		expect(isIpInCloudflareRange('162.158.0.10')).toBe(true); // 162.158.0.0/15
+		expect(isIpInCloudflareRange('172.64.149.224')).toBe(true); // 172.64.0.0/13
+		expect(isIpInCloudflareRange('173.245.48.10')).toBe(true); // 173.245.48.0/20
+		expect(isIpInCloudflareRange('188.114.96.10')).toBe(true); // 188.114.96.0/20
+		expect(isIpInCloudflareRange('190.93.240.10')).toBe(true); // 190.93.240.0/20
+		expect(isIpInCloudflareRange('197.234.240.10')).toBe(true); // 197.234.240.0/22
+		expect(isIpInCloudflareRange('198.41.128.10')).toBe(true); // 198.41.128.0/17
+	});
+
+	it('rejects IPs outside Cloudflare ranges', () => {
+		expect(isIpInCloudflareRange('8.8.8.8')).toBe(false);
+		expect(isIpInCloudflareRange('192.168.1.1')).toBe(false);
+		expect(isIpInCloudflareRange('1.1.1.1')).toBe(false);
+		// Edge-adjacent: 104.15.255.255 is just outside 104.16.0.0/13.
+		expect(isIpInCloudflareRange('104.15.255.255')).toBe(false);
+	});
+
+	it('returns false for malformed input rather than throwing', () => {
+		expect(isIpInCloudflareRange('not-an-ip')).toBe(false);
+		expect(isIpInCloudflareRange('')).toBe(false);
+		expect(isIpInCloudflareRange('999.999.999.999')).toBe(false);
+		expect(isIpInCloudflareRange('1.2.3')).toBe(false);
+	});
+});
+
+describe('detectCloudflareViaNsAndIp', () => {
+	it('attributes CF when NS matches *.ns.cloudflare.com AND A record in CF range', () => {
+		// Real-world shape: ietf.org has NS on Cloudflare and serves A records
+		// from Cloudflare's edge — but no header-based detection works because
+		// the scanner runs inside a CF Worker which rewrites server: cloudflare
+		// on every outbound response.
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['jill.ns.cloudflare.com', 'ken.ns.cloudflare.com'],
+				aRecords: ['104.16.45.99', '104.16.44.99'],
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('does NOT attribute CF when NS matches but A records are outside CF ranges', () => {
+		// Customer points NS at Cloudflare for DNS-only management but resolves
+		// to a non-CF origin (eg. self-hosted, AWS, GCP). DNS is on CF, edge is
+		// not — don't claim CDN attribution.
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['jill.ns.cloudflare.com', 'ken.ns.cloudflare.com'],
+				aRecords: ['8.8.8.8'],
+			}),
+		).toBeNull();
+	});
+
+	it('does NOT attribute CF when A records in CF range but NS is elsewhere (transit-only scenario)', () => {
+		// Someone behind a CF transit IP but using a different NS provider.
+		// Not a CF customer — don't claim CDN attribution.
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['ns-1.awsdns-01.com'],
+				aRecords: ['104.16.45.99'],
+			}),
+		).toBeNull();
+	});
+
+	it('does NOT attribute when both signals absent', () => {
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['ns-1.awsdns-01.com'],
+				aRecords: ['8.8.8.8'],
+			}),
+		).toBeNull();
+	});
+
+	it('does NOT attribute when NS list is empty', () => {
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: [],
+				aRecords: ['104.16.45.99'],
+			}),
+		).toBeNull();
+	});
+
+	it('does NOT attribute when A record list is empty', () => {
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['jill.ns.cloudflare.com', 'ken.ns.cloudflare.com'],
+				aRecords: [],
+			}),
+		).toBeNull();
+	});
+
+	it('requires ALL NS hosts on Cloudflare (mixed NS does NOT attribute)', () => {
+		// Mixed NS (CF + non-CF) is an unusual config but doesn't prove the
+		// origin is on CF — could be a partial migration. Stay conservative.
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['jill.ns.cloudflare.com', 'ns-1.awsdns-01.com'],
+				aRecords: ['104.16.45.99'],
+			}),
+		).toBeNull();
+	});
+
+	it('attributes CF when AT LEAST ONE A record is in CF range', () => {
+		// Multi-A zones (CF DNS often returns multiple A records) — one
+		// in-range record is sufficient corroboration.
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['jill.ns.cloudflare.com', 'ken.ns.cloudflare.com'],
+				aRecords: ['8.8.8.8', '104.16.45.99'],
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+});

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -659,6 +659,56 @@ describe('mapSupplyChain', () => {
 		expect(awsRows.length).toBe(1);
 	});
 
+	// --- Catalog gaps surfaced 2026-05-28 (post-v3.3.14 fact-check) ---
+
+	it('treats nsone.net and ns1.com as a single NS1 (IBM) provider', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 -all',
+			nsHosts: ['dns1.p08.nsone.net', 'dns2.p08.nsone.net', 'a.ns1.com', 'b.ns1.com'],
+			domain: 'example.com',
+		});
+		const result = await run('example.com');
+		const ns1Rows = result.dependencies.filter((d) => /\bNS1\b|NSOne/i.test(d.provider));
+		expect(ns1Rows.length).toBe(1);
+		expect(ns1Rows[0].provider).toBe('NS1 (IBM)');
+	});
+
+	it('treats dyn.com and dynect.net as a single Dyn (Oracle) provider', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 -all',
+			nsHosts: ['ns1.p01.dynect.net', 'ns2.p01.dynect.net', 'ns3.p01.dyn.com', 'ns4.p01.dyn.com'],
+			domain: 'example.com',
+		});
+		const result = await run('example.com');
+		const dynRows = result.dependencies.filter((d) => /\bDyn\b/i.test(d.provider));
+		expect(dynRows.length).toBe(1);
+		expect(dynRows[0].provider).toBe('Dyn (Oracle)');
+	});
+
+	it('preserves single-TLD case (nsone-only deployment — should still detect NS1)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 -all',
+			nsHosts: ['dns1.p08.nsone.net', 'dns2.p08.nsone.net'],
+			domain: 'airbnb.com',
+		});
+		const result = await run('airbnb.com');
+		expect(result.dependencies.find((d) => d.provider === 'NS1 (IBM)')).toBeDefined();
+	});
+
+	it('resolves Oracle Cloud Email via spf_c/spf_s* selectors (ird.govt.nz pattern)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 include:spf.protection.outlook.com include:spf_c.oraclecloud.com -all',
+			nsHosts: ['ns1.cloudflare.com', 'ns2.cloudflare.com'],
+			domain: 'ird.govt.nz',
+		});
+		const result = await run('ird.govt.nz');
+		const oracleRows = result.dependencies.filter((d) => /Oracle Cloud Email/i.test(d.provider));
+		expect(oracleRows.length).toBe(1);
+		expect(oracleRows[0].sources).toContain('spf');
+		// no raw selector row for the matched host
+		expect(result.dependencies.find((d) => d.provider === 'spf_c.oraclecloud.com')).toBeUndefined();
+	});
+
 	it('emits a single security_tooling_exposed signal per service even when multiple TXT records exist (OneTrust pattern)', async () => {
 		mockDnsResponses({
 			spf: 'v=spf1 -all',

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -618,6 +618,108 @@ describe('scanDomain integration - DMARC/DKIM/DNSSEC/CAA with mocked DoH', () =>
 		expect(dmarc).toBeDefined();
 		expect(dmarc!.passed).toBe(true);
 	});
+
+	// -- CDN fallback attribution (heuristic) --
+
+	it('falls back to NS+IP-based Cloudflare attribution when headers do not indicate CDN', async () => {
+		// Real-world shape: a Cloudflare customer (eg. ietf.org-pattern) whose
+		// NS is on `*.ns.cloudflare.com` and whose A records resolve to CF's
+		// edge ranges, but where the scanner cannot rely on response headers
+		// (server: cloudflare is rewritten by the scanner's own CF Worker egress).
+		// The post-processing NS+IP heuristic should attribute CF.
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				if (url.includes('type=NS') || url.includes('type=2')) {
+					return Promise.resolve(nsResponse('example.com', ['jill.ns.cloudflare.com.', 'ken.ns.cloudflare.com.']));
+				}
+				if (url.includes('type=A') || url.includes('type=1')) {
+					// 104.16.45.99 is inside 104.16.0.0/13 (Cloudflare). Carry AD=true
+					// so DNSSEC also passes — keeps the focus on CDN attribution.
+					return Promise.resolve(
+						createDohResponse(
+							[{ name: 'example.com', type: 1 }],
+							[{ name: 'example.com', type: 1, TTL: 300, data: '104.16.45.99' }],
+							{ ad: true },
+						),
+					);
+				}
+				if (url.includes('type=TXT') || url.includes('type=16')) {
+					if (url.includes('_dmarc.')) return Promise.resolve(txtResponse('_dmarc.example.com', ['v=DMARC1; p=reject']));
+					if (url.includes('_domainkey.'))
+						return Promise.resolve(txtResponse('default._domainkey.example.com', ['v=DKIM1; k=rsa; p=MIGf']));
+					if (url.includes('_mta-sts.')) return Promise.resolve(txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']));
+					if (url.includes('_smtp._tls.'))
+						return Promise.resolve(txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']));
+					return Promise.resolve(txtResponse('example.com', ['v=spf1 include:_spf.google.com -all']));
+				}
+				if (url.includes('type=CAA') || url.includes('type=257'))
+					return Promise.resolve(caaResponse('example.com', ['0 issue "letsencrypt.org"']));
+				return Promise.resolve(createDohResponse([], []));
+			}
+			// HTTPS probes: no CDN-vendor headers. detectCdnProvider() returns null.
+			if (url.startsWith('https://')) return Promise.resolve(httpResponse('OK'));
+			return Promise.resolve(httpResponse('OK'));
+		});
+
+		const result = await run();
+		const httpCheck = findCheck(result, 'http_security');
+		expect(httpCheck).toBeDefined();
+		const cdnFinding = httpCheck!.findings.find((f) => f.metadata?.cdnProvider === 'Cloudflare');
+		expect(cdnFinding).toBeDefined();
+		expect(cdnFinding!.metadata?.confidence).toBe('heuristic');
+		expect(cdnFinding!.metadata?.source).toBe('ns-and-ip-range');
+	});
+
+	it('does NOT attribute CF via heuristic when header-based detection already identified a different CDN', async () => {
+		// If header-based detection found Imperva/Akamai/etc., the heuristic
+		// MUST NOT add a competing Cloudflare row. Header signal is stronger.
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				if (url.includes('type=NS') || url.includes('type=2')) {
+					return Promise.resolve(nsResponse('example.com', ['jill.ns.cloudflare.com.', 'ken.ns.cloudflare.com.']));
+				}
+				if (url.includes('type=A') || url.includes('type=1')) {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name: 'example.com', type: 1 }],
+							[{ name: 'example.com', type: 1, TTL: 300, data: '104.16.45.99' }],
+							{ ad: true },
+						),
+					);
+				}
+				if (url.includes('type=TXT') || url.includes('type=16')) {
+					if (url.includes('_dmarc.')) return Promise.resolve(txtResponse('_dmarc.example.com', ['v=DMARC1; p=reject']));
+					if (url.includes('_domainkey.'))
+						return Promise.resolve(txtResponse('default._domainkey.example.com', ['v=DKIM1; k=rsa; p=MIGf']));
+					if (url.includes('_mta-sts.')) return Promise.resolve(txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']));
+					if (url.includes('_smtp._tls.'))
+						return Promise.resolve(txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']));
+					return Promise.resolve(txtResponse('example.com', ['v=spf1 include:_spf.google.com -all']));
+				}
+				if (url.includes('type=CAA') || url.includes('type=257'))
+					return Promise.resolve(caaResponse('example.com', ['0 issue "letsencrypt.org"']));
+				return Promise.resolve(createDohResponse([], []));
+			}
+			// HTTPS probes: return an Imperva-flagged response. The header-based
+			// detectCdnProvider() will set cdnProvider=Imperva BEFORE post-processing.
+			if (url.startsWith('https://')) {
+				const headers = new Headers({ 'x-cdn': 'Imperva' });
+				return Promise.resolve(httpResponse('OK', 200, headers));
+			}
+			return Promise.resolve(httpResponse('OK'));
+		});
+
+		const result = await run();
+		const httpCheck = findCheck(result, 'http_security');
+		expect(httpCheck).toBeDefined();
+		const cdnFindings = httpCheck!.findings.filter((f) => typeof f.metadata?.cdnProvider === 'string');
+		// Only ONE CDN finding (the header-based Imperva one). No heuristic CF row.
+		expect(cdnFindings).toHaveLength(1);
+		expect(cdnFindings[0].metadata?.cdnProvider).toBe('Imperva');
+		expect(cdnFindings[0].metadata?.confidence).toBeUndefined();
+	});
 });
 
 describe('scanDomain force_refresh', () => {


### PR DESCRIPTION
Three small additive enhancements surfaced by the post-v3.3.14 fact-check round on 2026-05-28 (airbnb.com, ird.govt.nz, ietf.org). All `feat` (no defect fix) — extending the known-SaaS catalog and adding a fallback CDN heuristic. Zero behaviour change for domains that don't match the new patterns.

## #1 NS1 / Dyn multi-TLD collapse

Same drift class as the v3.3.13 UltraDNS fix. Two DNS providers use sibling-TLD redundancy:
- **NS1 / NSOne** (IBM): NS hosts on `*.ns1.com` AND `*.nsone.net`
- **Dyn / Oracle Dyn**: NS hosts on `*.dyn.com` AND `*.dynect.net`

Both now collapse to one row in `map_supply_chain` output (`NS1 (IBM)` / `Dyn (Oracle)`).

**Surprise / structural cleanup** (per agent return): the naive add-rules approach exposed a hidden defect in the v3.3.13 NS-host dedup loop — it used a `host.includes(signalDomain)` heuristic that happened to work for UltraDNS (`.com`/`.net` both contain `ultradns`) but silently broke for NS1 because `ns1.com` and `nsone.net` share no substring. Replaced with a new exported helper `matchProviderForNsHost` that delegates to the actual `DETECTION_RULES` regexes — mirrors the existing `matchProviderForSpfInclude` SSOT pattern (so detection and dedup use the same regex source instead of diverging via signal-string parsing). No regression — UltraDNS test stays green.

## #2 Oracle Cloud Email DETECTION_RULES entry

Same drift class as the v3.3.8 M365 fix and v3.3.13 Trellix entry. Live evidence: `ird.govt.nz` SPF includes `spf_c.oraclecloud.com` (cascades through `spf_s1` / `spf_s2.oraclecloud.com`). MCP currently shows raw provider name; now resolves to `Oracle Cloud Email`. The v3.3.13 `matchProviderForSpfInclude()` helper picks up the new rule automatically.

## #3 NS-based Cloudflare CDN attribution (heuristic fallback)

v3.3.12 dropped header-based CF detection because CF Workers' outbound `fetch()` rewrites `server: cloudflare` on every response. This release adds a heuristic FALLBACK that runs only when header-based detection returned null:

- **Signal A**: domain's NS records all on `*.ns.cloudflare.com` (origin-set, can't be transit-spoofed)
- **Signal B**: at least one A record falls within one of Cloudflare's 15 published edge IPv4 ranges (`cloudflare.com/ips/`)

When BOTH match → attribute as Cloudflare with `confidence: 'heuristic'` in finding metadata.

Implementation: new pure-TS helper `src/lib/cdn-fallback-detection.ts` (no external deps, CIDR matching with bit-shift math), invoked from `src/tools/scan/post-processing.ts` AFTER `check_http_security` returns. Existing format-report logic picks up the new finding's `metadata.cdnProvider` automatically — no changes to `detectCdnProvider` (which stays header-only by design).

Live verification (would happen post-deploy): `ietf.org` and `ird.govt.nz` both expected to flip from `cdnProvider: null` → `cdnProvider: 'Cloudflare'`.

## Test coverage

**18 new tests, 184/184 affected tests green:**
- `test/map-supply-chain.spec.ts` — 4 new (NS1, Dyn, single-TLD case, Oracle Cloud Email)
- `test/cdn-fallback-detection.spec.ts` — 12 new (CIDR matching across all 15 published ranges + heuristic logic invariants)
- `test/scan-domain.spec.ts` — 2 new (integration: heuristic kicks in only when no header-based attribution exists)

Typecheck + lint clean. Full repo: 4639 passed, 0 failed.

## Allowlist additions

The new `cdn-fallback-detection.ts` embeds Cloudflare's published edge CIDR snapshot. Allowlisted in BOTH:
- `.gitleaks.toml` (`real-ipv4-address` rule's `paths` array)
- `scripts/repo-safety/policy.json` (`allowedPaths` array)

Both required — they're separate scanners with overlapping concerns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)