### PR TITLE
feat: provider catalog gaps from spotify fact-check (Google Cloud DNS + HubSpot + Mailchimp Transactional + Salesforce)

### DIFF
--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -218,6 +218,64 @@ const DETECTION_RULES: DetectionRule[] = [
 		},
 		signal: 'spf:oraclecloud.com',
 	},
+	{
+		// Google Cloud DNS. Authoritative DNS for projects on GCP — NS hosts are
+		// `ns-cloud-{a,b,c,d}{1,2,3,4}.googledomains.com`. Without this rule the
+		// raw `googledomains.com` (trailing-label heuristic) surfaces instead of
+		// the canonical provider name. Distinct from Google Workspace (mail) and
+		// Google Domains registrar (now sunset, transferred to Squarespace).
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.15 fact-check round).
+		name: 'Google Cloud DNS',
+		role: 'dns',
+		patterns: {
+			ns: /\.googledomains\.com$/i,
+		},
+		signal: 'ns:googledomains',
+	},
+	{
+		// HubSpot transactional/marketing email. Customer SPF includes a per-tenant
+		// selector under `*.hubspotemail.net` (eg. `21894833.spf06.hubspotemail.net`).
+		// Without this rule the raw selector hostname surfaces as a third-party row.
+		// SPF-only (no fixed MX hostnames); the SPF-rule dedup path
+		// (matchProviderForSpfInclude) handles it. Distinct from the older
+		// self-wrapper pattern `hubspot.spf-records.<customer>.com` which v3.3.13
+		// self-SPF dedup already collapses.
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.15 fact-check round).
+		name: 'HubSpot',
+		role: 'sending',
+		patterns: {
+			spf: /\.hubspotemail\.net$/i,
+		},
+		signal: 'spf:hubspot',
+	},
+	{
+		// Mailchimp Transactional (formerly Mandrill). Customer SPF includes
+		// `servers.mcsv.net` — the `mcsv.net` domain hosts Mailchimp's transactional
+		// email infrastructure. Distinct from Mailchimp marketing (which uses
+		// `mailchimp.com` / `mail.mailchimp.com` and has no rule here yet). Labelled
+		// "Mailchimp Transactional" to disambiguate from the marketing product.
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.15 fact-check round).
+		name: 'Mailchimp Transactional',
+		role: 'sending',
+		patterns: {
+			spf: /\.mcsv\.net$/i,
+		},
+		signal: 'spf:mailchimp-transactional',
+	},
+	{
+		// Salesforce (Sales Cloud / Service Cloud / Marketing Cloud). Customer SPF
+		// includes `_spf.salesforce.com`. Pattern is anchored to a leading `.` or
+		// start-of-string so it cannot accidentally collapse Pardot endpoints
+		// (`et._spf.pardot.com`) — those continue to surface separately. Distinct
+		// from Pardot (no Pardot rule today; raw `et._spf.pardot.com` surfaces).
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.15 fact-check round).
+		name: 'Salesforce',
+		role: 'sending',
+		patterns: {
+			spf: /(^|\.)salesforce\.com$/i,
+		},
+		signal: 'spf:salesforce',
+	},
 ];
 
 /**

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -709,6 +709,78 @@ describe('mapSupplyChain', () => {
 		expect(result.dependencies.find((d) => d.provider === 'spf_c.oraclecloud.com')).toBeUndefined();
 	});
 
+	// --- Catalog gaps surfaced 2026-05-28 (spotify.com fact-check round) ---
+
+	it('resolves Google Cloud DNS via ns-cloud-*.googledomains.com NS hosts (spotify pattern)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 -all',
+			nsHosts: [
+				'ns-cloud-a1.googledomains.com',
+				'ns-cloud-a2.googledomains.com',
+				'ns-cloud-a3.googledomains.com',
+				'ns-cloud-a4.googledomains.com',
+			],
+			domain: 'spotify.com',
+		});
+		const result = await run('spotify.com');
+		const gcdRows = result.dependencies.filter((d) => /Google Cloud DNS/i.test(d.provider));
+		expect(gcdRows.length).toBe(1);
+		expect(gcdRows[0].provider).toBe('Google Cloud DNS');
+		// no raw googledomains.com row
+		expect(result.dependencies.find((d) => d.provider === 'googledomains.com')).toBeUndefined();
+	});
+
+	it('resolves HubSpot via *.hubspotemail.net SPF includes (spotify pattern)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 include:21894833.spf06.hubspotemail.net -all',
+			nsHosts: ['ns1.cloudflare.com', 'ns2.cloudflare.com'],
+			domain: 'spotify.com',
+		});
+		const result = await run('spotify.com');
+		const hubRows = result.dependencies.filter((d) => /HubSpot/i.test(d.provider));
+		expect(hubRows.length).toBe(1);
+		expect(hubRows[0].provider).toBe('HubSpot');
+		expect(result.dependencies.find((d) => /hubspotemail\.net/i.test(d.provider))).toBeUndefined();
+	});
+
+	it('resolves Mailchimp Transactional via *.mcsv.net SPF includes (spotify pattern)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 include:servers.mcsv.net -all',
+			nsHosts: ['ns1.cloudflare.com', 'ns2.cloudflare.com'],
+			domain: 'spotify.com',
+		});
+		const result = await run('spotify.com');
+		const mcRows = result.dependencies.filter((d) => /Mailchimp Transactional/i.test(d.provider));
+		expect(mcRows.length).toBe(1);
+		expect(mcRows[0].provider).toBe('Mailchimp Transactional');
+		expect(result.dependencies.find((d) => /mcsv\.net/i.test(d.provider))).toBeUndefined();
+	});
+
+	it('resolves Salesforce via *.salesforce.com SPF includes (spotify pattern)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 include:_spf.salesforce.com -all',
+			nsHosts: ['ns1.cloudflare.com', 'ns2.cloudflare.com'],
+			domain: 'spotify.com',
+		});
+		const result = await run('spotify.com');
+		const sfRows = result.dependencies.filter((d) => d.provider === 'Salesforce');
+		expect(sfRows.length).toBe(1);
+		expect(result.dependencies.find((d) => /_spf\.salesforce/i.test(d.provider))).toBeUndefined();
+	});
+
+	it('keeps Salesforce Pardot distinct from Salesforce (the et._spf.pardot.com mapping persists)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 include:_spf.salesforce.com include:et._spf.pardot.com -all',
+			nsHosts: ['ns1.cloudflare.com', 'ns2.cloudflare.com'],
+			domain: 'company.example',
+		});
+		const result = await run('company.example');
+		expect(result.dependencies.find((d) => d.provider === 'Salesforce')).toBeDefined();
+		// Pardot endpoint must NOT collapse into the Salesforce row — it stays as
+		// its own provider (raw `et._spf.pardot.com` if no friendly mapping exists).
+		expect(result.dependencies.find((d) => /pardot/i.test(d.provider))).toBeDefined();
+	});
+
 	it('emits a single security_tooling_exposed signal per service even when multiple TXT records exist (OneTrust pattern)', async () => {
 		mockDnsResponses({
 			spf: 'v=spf1 -all',


### PR DESCRIPTION
Four additive `DETECTION_RULES` entries surfaced by the post-v3.3.15 fact-check on spotify.com. Same drift class as v3.3.13 / v3.3.15 catalog work (UltraDNS, NS1, Dyn, Oracle Cloud Email). Zero behavior change for domains that don't match the new patterns.

## What's new

| Provider | Surface | Pattern | Was |
|---|---|---|---|
| **Google Cloud DNS** | NS | `*.googledomains.com` | raw `googledomains.com` |
| **HubSpot** | SPF | `*.hubspotemail.net` | raw include hostname |
| **Mailchimp Transactional** | SPF | `*.mcsv.net` (Mandrill) | raw `servers.mcsv.net` |
| **Salesforce** | SPF | `(^\|\.)salesforce.com$` | raw `_spf.salesforce.com` |

The Salesforce pattern uses an anchored `(^|.)salesforce.com$` to avoid matching Pardot endpoints (`et._spf.pardot.com`). Regression test locks in that Pardot rows surface separately when both includes are present.

## Tests

5 new specs in `test/map-supply-chain.spec.ts` under "Catalog gaps surfaced 2026-05-28 (spotify.com fact-check round)":

1. `resolves Google Cloud DNS via ns-cloud-*.googledomains.com NS hosts (spotify pattern)`
2. `resolves HubSpot via *.hubspotemail.net SPF includes (spotify pattern)`
3. `resolves Mailchimp Transactional via *.mcsv.net SPF includes (spotify pattern)`
4. `resolves Salesforce via *.salesforce.com SPF includes (spotify pattern)`
5. `keeps Salesforce Pardot distinct from Salesforce (the et._spf.pardot.com mapping persists)`

37 → 42 passing in `test/map-supply-chain.spec.ts` (+5). Full repo: 4644 pass. typecheck + lint clean.

## How they wire up automatically

The v3.3.13 `matchProviderForSpfInclude()` + v3.3.15 `matchProviderForNsHost()` helpers consume the `DETECTION_RULES` table directly — adding entries lights up both detection AND multi-record dedup paths without touching `map-supply-chain.ts`. Same shape as the v3.3.15 follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)