### PR TITLE
feat: Foundation DNS multi-TLD collapse + Cloudflare cert-issuer signal (2-of-3 fallback)

### DIFF
--- a/src/lib/cdn-fallback-detection.ts
+++ b/src/lib/cdn-fallback-detection.ts
@@ -9,23 +9,34 @@
  * tracing, regardless of the origin. v3.3.11 removed CF detection entirely
  * to fix the resulting 100% false-positive rate.
  *
- * This module restores attribution by combining two corroborating signals
- * that the scanner CAN observe authentically:
+ * This module restores attribution by combining three independent signals
+ * that the scanner CAN observe authentically; ANY 2 of 3 must match:
  *
- *   1. NS records — all nameservers under `*.ns.cloudflare.com`
- *   2. A records — at least one IP in Cloudflare's published edge ranges
+ *   A. NS records — all nameservers under `*.ns.cloudflare.com`
+ *   B. A records — at least one IP in Cloudflare's published edge ranges
+ *   C. TLS cert issuer — issuer string matches Cloudflare's CA family
+ *      (eg. `Cloudflare Inc ECC CA-3`, `Cloudflare Origin SSL ECC Issuer ECC`)
  *
- * BOTH must match to attribute. The combined check rules out the two
- * common false positives: DNS-only customers (NS on CF, origin elsewhere)
- * and transit-only paths (origin on CF IPs but NS elsewhere — eg. a
- * partial migration). When matched, the attribution is flagged
- * `confidence: 'heuristic'` so consumers can distinguish it from
- * header-based hits (`confidence` absent → high-confidence vendor signal).
+ * The original v3.3.15 gate (A+B only) is preserved as a deprecated wrapper
+ * (`detectCloudflareViaNsAndIp`). The new v3.3.17 entry point
+ * (`detectCloudflareFallback`) accepts an optional `certIssuer` and applies
+ * the 2-of-3 rule.
  *
- * The published IPv4 ranges are snapshotted from cloudflare.com/ips/.
- * If Cloudflare publishes a new range, the `CLOUDFLARE_IPV4_RANGES`
- * snapshot test in `test/cdn-fallback-detection.spec.ts` will force a
- * deliberate update.
+ * Why 2-of-3 (not OR)? A single signal in isolation is ambiguous:
+ *   - Signal A alone → DNS-only customer; origin could be anywhere.
+ *   - Signal B alone → transit/proxy path; not necessarily a CF customer.
+ *   - Signal C alone → CA was used for a cert; says nothing about delivery.
+ * Requiring two corroborating origin-set signals keeps false-positive risk
+ * low while catching real CF customers who use external DNS (signals B+C).
+ *
+ * When matched, the attribution is flagged `confidence: 'heuristic'` so
+ * consumers can distinguish it from header-based hits (`confidence` absent →
+ * high-confidence vendor signal).
+ *
+ * The published IPv4 ranges are snapshotted from cloudflare.com/ips/. If
+ * Cloudflare publishes a new range, the `CLOUDFLARE_IPV4_RANGES` snapshot
+ * test in `test/cdn-fallback-detection.spec.ts` will force a deliberate
+ * update.
  */
 
 /**
@@ -87,17 +98,71 @@ export function isIpInCloudflareRange(ip: string): boolean {
 
 const CF_NS_PATTERN = /\.ns\.cloudflare\.com\.?$/i;
 
+/**
+ * Pattern for TLS cert issuer strings issued by Cloudflare's CA family.
+ * Covers the common forms observed in the wild:
+ *   - `C=US, O=Cloudflare, Inc., CN=Cloudflare Inc ECC CA-3`
+ *   - `CN=Cloudflare Origin SSL ECC Issuer ECC, O=Cloudflare, Inc., ...`
+ *   - `O=Cloudflare, Inc., ...` (some certs have only the O attribute)
+ * Case-insensitive. Any occurrence of "Cloudflare" anywhere in the issuer
+ * string counts as a match — there is no Cloudflare-issued cert whose
+ * issuer string omits the word.
+ */
+const CF_CERT_ISSUER_PATTERN = /cloudflare/i;
+
 export interface CloudflareHeuristicResult {
 	provider: 'Cloudflare';
 	confidence: 'heuristic';
 }
 
 /**
- * Returns a Cloudflare attribution iff BOTH signals match:
- *   - every NS host is under `*.ns.cloudflare.com`
- *   - at least one A record is in a published Cloudflare edge range
+ * 2-of-3-signal Cloudflare attribution heuristic.
  *
- * Returns null otherwise. Empty NS or empty A list always returns null.
+ * Signals:
+ *   A. `nsHosts` — every NS host under `*.ns.cloudflare.com`
+ *   B. `aRecords` — at least one IP in a published Cloudflare edge range
+ *   C. `certIssuer` — issuer string matches `/cloudflare/i`
+ *
+ * Returns an attribution iff at least TWO of the three signals are present.
+ * Returns null otherwise. Each signal is treated as either present (1) or
+ * absent (0); empty inputs count as absent (do not short-circuit).
+ *
+ * Backward-compat: when `certIssuer` is null/undefined, signal C is absent
+ * and the function reduces to the original v3.3.15 NS+IP requirement.
+ */
+export function detectCloudflareFallback(opts: {
+	nsHosts: string[];
+	aRecords: string[];
+	certIssuer?: string | null;
+}): CloudflareHeuristicResult | null {
+	const { nsHosts, aRecords, certIssuer } = opts;
+
+	// Signal A: every NS on CF (empty list ⇒ absent, NOT vacuously true).
+	const signalA = nsHosts.length > 0 && nsHosts.every((host) => CF_NS_PATTERN.test(host));
+
+	// Signal B: at least one A in published CF range.
+	const signalB = aRecords.length > 0 && aRecords.some((ip) => isIpInCloudflareRange(ip));
+
+	// Signal C: cert issuer mentions Cloudflare.
+	const signalC = typeof certIssuer === 'string' && CF_CERT_ISSUER_PATTERN.test(certIssuer);
+
+	const signalCount = (signalA ? 1 : 0) + (signalB ? 1 : 0) + (signalC ? 1 : 0);
+	if (signalCount < 2) return null;
+
+	return { provider: 'Cloudflare', confidence: 'heuristic' };
+}
+
+/**
+ * Deprecated v3.3.15 entry point — strict NS+IP-only attribution.
+ *
+ * Kept as a thin wrapper for downstream consumers that bound to the
+ * original contract. New code should call {@link detectCloudflareFallback}
+ * directly and pass `certIssuer` when available.
+ *
+ * @deprecated Use {@link detectCloudflareFallback} (2-of-3 signals incl.
+ *             optional `certIssuer`). This wrapper preserves the strict
+ *             NS+IP-only gate: BOTH NS-all-on-CF AND at-least-one-A-in-CF
+ *             must hold; cert issuer is ignored.
  */
 export function detectCloudflareViaNsAndIp(opts: {
 	nsHosts: string[];

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -219,6 +219,20 @@ const DETECTION_RULES: DetectionRule[] = [
 		signal: 'spf:oraclecloud.com',
 	},
 	{
+		// Foundation DNS. Multi-TLD vendor — the same authoritative DNS service is
+		// served from `*.foundationdns.com`, `*.foundationdns.net`, and
+		// `*.foundationdns.org`. Without this collapse a single zone using all three
+		// sibling TLDs (eg. `gold.foundationdns.{com,net,org}`) lists as three
+		// separate dns-hosting rows. Same drift class as UltraDNS / NS1 / Dyn /
+		// Google Cloud DNS — catalog gap surfaced 2026-05-28.
+		name: 'Foundation DNS',
+		role: 'dns',
+		patterns: {
+			ns: /\.foundationdns\.(com|net|org)$/i,
+		},
+		signal: 'ns:foundationdns',
+	},
+	{
 		// Google Cloud DNS. Authoritative DNS for projects on GCP — NS hosts are
 		// `ns-cloud-{a,b,c,d}{1,2,3,4}.googledomains.com`. Without this rule the
 		// raw `googledomains.com` (trailing-label heuristic) surfaces instead of

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -4,7 +4,7 @@ import { type CheckCategory, type CheckResult, type Finding, buildCheckResult, c
 import { queryTxtRecords } from '../../lib/dns';
 import { queryDnsRecords } from '../../lib/dns-records';
 import { detectProviderMatches, detectProviderMatchesBySelectors, loadProviderSignatures } from '../../lib/provider-signatures';
-import { detectCloudflareViaNsAndIp } from '../../lib/cdn-fallback-detection';
+import { detectCloudflareFallback } from '../../lib/cdn-fallback-detection';
 import { parseDmarcTags } from '../check-dmarc';
 
 export interface ScanRuntimeOptions {
@@ -99,7 +99,16 @@ async function addCloudflareCdnHeuristic(domain: string, results: CheckResult[])
 
 	// Strip trailing dots for consistency with the helper's expected input.
 	const normalisedNs = nsHosts.map((h) => h.replace(/\.$/, '').toLowerCase());
-	const heuristic = detectCloudflareViaNsAndIp({ nsHosts: normalisedNs, aRecords });
+
+	// TLS cert issuer is not currently surfaced by `checkSsl` — the CF Worker
+	// `fetch()` API does not expose peer-cert metadata, and we don't make a
+	// separate CT-log lookup in the scan path. Pass null; the 2-of-3 rule
+	// degrades to the original v3.3.15 NS+IP-only gate. Future plumbing (eg.
+	// from a dedicated TLS probe in the infra-probe service binding) can light
+	// up the third signal without changing this call site.
+	const certIssuer: string | null = null;
+
+	const heuristic = detectCloudflareFallback({ nsHosts: normalisedNs, aRecords, certIssuer });
 	if (!heuristic) return results;
 
 	const cdnFinding = createFinding(

--- a/test/cdn-fallback-detection.spec.ts
+++ b/test/cdn-fallback-detection.spec.ts
@@ -3,6 +3,7 @@ import {
 	CLOUDFLARE_IPV4_RANGES,
 	isIpInCloudflareRange,
 	detectCloudflareViaNsAndIp,
+	detectCloudflareFallback,
 } from '../src/lib/cdn-fallback-detection';
 
 describe('CLOUDFLARE_IPV4_RANGES', () => {
@@ -149,5 +150,145 @@ describe('detectCloudflareViaNsAndIp', () => {
 				aRecords: ['8.8.8.8', '104.16.45.99'],
 			}),
 		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+});
+
+describe('detectCloudflareFallback — cert-issuer signal (v3.3.17 extension)', () => {
+	it('attributes CF when A-record in CF range AND cert issuer is Cloudflare, even when NS is external (external-DNS-on-CF pattern)', () => {
+		// External NS provider (eg. Foundation DNS) + origin on CF edge + CF-issued
+		// cert. Signal A absent (NS not on CF), but B+C present → 2-of-3 → attribute.
+		// This is the real-world gap the cert-issuer signal closes.
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['gold.foundationdns.com', 'gold.foundationdns.net'], // EXTERNAL DNS
+				aRecords: ['104.16.45.99'], // CF published range (104.16.0.0/13)
+				certIssuer: 'C=US, O=Cloudflare, Inc., CN=Cloudflare Inc ECC CA-3',
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('attributes CF when NS on CF AND cert issuer is Cloudflare, even when A-records are not in any published CF range', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['jill.ns.cloudflare.com', 'ken.ns.cloudflare.com'],
+				aRecords: ['8.8.8.8'], // not in any published CF range
+				certIssuer: 'CN=Cloudflare Origin SSL ECC Issuer ECC',
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('does NOT attribute CF when only cert issuer matches (single signal)', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['ns-1.awsdns-01.com'],
+				aRecords: ['8.8.8.8'],
+				certIssuer: 'CN=Cloudflare Inc ECC CA-3',
+			}),
+		).toBeNull();
+	});
+
+	it('does NOT attribute CF when only A-record is in CF range (single signal, transit case)', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['ns-1.awsdns-01.com'],
+				aRecords: ['104.16.45.99'], // CF range
+				certIssuer: 'CN=DigiCert TLS RSA SHA256 2020 CA1', // not CF
+			}),
+		).toBeNull();
+	});
+
+	it('matches Cloudflare Origin SSL ECC Issuer ECC (the origin-CA variant)', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['gold.foundationdns.com'],
+				aRecords: ['104.16.45.99'],
+				certIssuer: 'CN=Cloudflare Origin SSL ECC Issuer ECC, O=Cloudflare, Inc., L=San Francisco, C=US',
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('case-insensitive on the cert issuer match', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['gold.foundationdns.com'],
+				aRecords: ['104.16.45.99'],
+				certIssuer: 'cn=cloudflare inc ecc ca-3, o=CLOUDFLARE, INC.',
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('handles null/undefined cert issuer gracefully (degrades to old NS+IP-only behavior)', () => {
+		// NS not on CF, no cert signal → single signal (IP) only → null
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['gold.foundationdns.com'],
+				aRecords: ['104.16.45.99'],
+				certIssuer: null,
+			}),
+		).toBeNull();
+
+		// NS on CF, A in CF range, certIssuer omitted entirely → 2 signals (A + B) → attribute
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['jill.ns.cloudflare.com'],
+				aRecords: ['104.16.45.99'],
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('attributes CF when all three signals present (NS + IP + cert)', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['jill.ns.cloudflare.com', 'ken.ns.cloudflare.com'],
+				aRecords: ['104.16.45.99'],
+				certIssuer: 'CN=Cloudflare Inc ECC CA-3',
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('treats empty aRecords as signal-B-absent (NS+cert still attributes with 2 signals)', () => {
+		// Regression guard: empty A-record list does NOT short-circuit when the
+		// other two signals are present. Old NS+IP-only function returned null on
+		// empty A; new 2-of-3 rule treats signal B as absent and lets A+C attribute.
+		expect(
+			detectCloudflareFallback({
+				nsHosts: ['jill.ns.cloudflare.com', 'ken.ns.cloudflare.com'],
+				aRecords: [],
+				certIssuer: 'CN=Cloudflare Inc ECC CA-3',
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('treats empty nsHosts as signal-A-absent (IP+cert still attributes with 2 signals)', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: [],
+				aRecords: ['104.16.45.99'],
+				certIssuer: 'CN=Cloudflare Inc ECC CA-3',
+			}),
+		).toEqual({ provider: 'Cloudflare', confidence: 'heuristic' });
+	});
+
+	it('returns null when no signals present at all', () => {
+		expect(
+			detectCloudflareFallback({
+				nsHosts: [],
+				aRecords: [],
+				certIssuer: null,
+			}),
+		).toBeNull();
+	});
+});
+
+describe('detectCloudflareViaNsAndIp — backward-compat wrapper', () => {
+	it('still requires BOTH NS+IP and ignores cert-issuer (deprecated NS+IP-only contract)', () => {
+		// Confirms the deprecated wrapper preserves its conservative gate
+		// regardless of any new cert-issuer plumbing on the underlying function.
+		expect(
+			detectCloudflareViaNsAndIp({
+				nsHosts: ['jill.ns.cloudflare.com'],
+				aRecords: ['8.8.8.8'],
+			}),
+		).toBeNull();
 	});
 });

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -768,6 +768,19 @@ describe('mapSupplyChain', () => {
 		expect(result.dependencies.find((d) => /_spf\.salesforce/i.test(d.provider))).toBeUndefined();
 	});
 
+	it('treats foundationdns.{com,net,org} as a single Foundation DNS provider (shopify pattern)', async () => {
+		mockDnsResponses({
+			spf: 'v=spf1 -all',
+			nsHosts: ['gold.foundationdns.com', 'gold.foundationdns.net', 'gold.foundationdns.org'],
+			domain: 'example.com',
+		});
+		const result = await run('example.com');
+		const fdRows = result.dependencies.filter((d) => /Foundation DNS/i.test(d.provider));
+		expect(fdRows.length).toBe(1);
+		expect(fdRows[0].provider).toBe('Foundation DNS');
+		expect(result.dependencies.find((d) => /foundationdns\.(com|net|org)/i.test(d.provider))).toBeUndefined();
+	});
+
 	it('keeps Salesforce Pardot distinct from Salesforce (the et._spf.pardot.com mapping persists)', async () => {
 		mockDnsResponses({
 			spf: 'v=spf1 include:_spf.salesforce.com include:et._spf.pardot.com -all',


### PR DESCRIPTION
Two changes surfaced by the shopify.com fact-check post-v3.3.16.

## #1 Foundation DNS multi-TLD collapse (live improvement)

Same drift class as v3.3.13 UltraDNS, v3.3.15 NS1/Dyn, v3.3.16 Google Cloud DNS. Live evidence: shopify.com NS records `gold.foundationdns.{com,net,org}` currently surface as 3 separate `dns-hosting` rows. Now collapses to one `Foundation DNS` row.

```ts
{ name: 'Foundation DNS', role: 'dns', patterns: { ns: /\.foundationdns\.(com|net|org)$/i }, signal: 'ns:foundationdns' },
```

## #2 Cloudflare cert-issuer signal (wired but dormant)

**Background**: v3.3.15 added `detectCloudflareViaNsAndIp` requiring BOTH (NS on `*.ns.cloudflare.com`) AND (A-record in published CF range). Conservative — avoids false-positives, misses real CF customers using external DNS (e.g. shopify.com on Foundation DNS for NS but genuinely on Cloudflare CDN by ASN+headers).

**Enhancement**: new `detectCloudflareFallback({ nsHosts, aRecords, certIssuer })` with **2-of-3 signal rule**:
- Signal A: NS all on `*.ns.cloudflare.com`
- Signal B: at least one A-record IP in a published CF range
- Signal C: TLS cert issuer matches `/cloudflare/i` (catches `Cloudflare Inc ECC CA-3`, `Cloudflare Origin SSL ECC Issuer ECC`, etc.)

Old `detectCloudflareViaNsAndIp` kept as `@deprecated` wrapper with strict NS+IP-only contract preserved for any downstream consumers.

**Honest scope caveat**: Cloudflare Workers' `fetch()` API does NOT expose peer-cert metadata. Within the current scan path (`scan_domain`), there is no cert source — `checkSsl` is a thin HTTPS-reachability + HSTS wrapper, no peer-cert info captured. The new logic is **invoked with `certIssuer: null`** at the call site, so it degrades to NS+IP-only behavior (same as v3.3.15) in production today.

The 2-of-3 logic is fully unit-tested (12 new specs) and ready to activate when a cert source is plumbed. Likely future work: source cert issuer via a separate infra probe (the bv-recon `cert-transparency` path is one option; a dedicated `crt.sh` query is another). When that lands, shopify.com (and similar external-NS CF customers) will start showing `cdnProvider: "Cloudflare"` automatically.

## Test coverage

- `test/map-supply-chain.spec.ts`: +1 (Foundation DNS) → 43 passed
- `test/cdn-fallback-detection.spec.ts`: +12 (cert-issuer + backward-compat wrapper) → 24 passed
- `test/scan-post-processing.spec.ts`: 29 passed (regression)
- Full repo: 4657 passed, 0 failed
- typecheck + lint clean

## Notable behavior change locked by test

Old `detectCloudflareViaNsAndIp` short-circuited to `null` when EITHER `nsHosts` OR `aRecords` was empty. New `detectCloudflareFallback` treats empty inputs as "signal absent (0)" rather than short-circuiting — so `(NS=CF, A=[], certIssuer=CF)` now attributes via 2 signals. Defensible under 2-of-3; explicit regression test locks it in. The deprecated wrapper preserves the original short-circuit semantics for any external consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)