### PR TITLE
feat(cdn): ASN-based CDN attribution fallback (closes Akamai false-negative) + AutoSPF

### DIFF
--- a/src/lib/cdn-asn-detection.ts
+++ b/src/lib/cdn-asn-detection.ts
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * ASN-based CDN attribution fallback.
+ *
+ * Header-based CDN detection (see check-http-security.ts) can miss CDNs that
+ * don't emit a vendor-specific header — eg. Akamai serving with `Server:
+ * AkamaiGHost` but no `x-akamai-transformed` / `x-check-cacheable` header. The
+ * `server` header is also unusable from inside a Cloudflare Worker, whose
+ * outbound fetch() rewrites it to `cloudflare`. The CF NS+IP+cert heuristic
+ * (cdn-fallback-detection.ts) closes the Cloudflare case, but Akamai has
+ * thousands of dynamic prefixes — a hardcoded CIDR list would be unmaintainable.
+ *
+ * This module attributes a CDN by resolving each A-record IP to its origin
+ * ASN via team-cymru's DoH endpoint, then mapping ASN -> CDN provider:
+ *
+ *   <reversed-ip>.origin.asn.cymru.com  TXT  ->  "16625 | <origin-prefix> | SG | apnic | ..."
+ *                                                 ^^^^^ ASN
+ *
+ * Why ASN over per-provider IP-range lists:
+ *   - Origin-set: the ASN derives from the *resolved IP*, not a response header
+ *     — immune to the CF-Worker `server:` rewrite that killed header detection.
+ *   - Generalizes: one ASN_TO_CDN table covers Akamai, Cloudflare, Fastly,
+ *     Imperva, etc. — no per-provider CIDR maintenance.
+ *   - No new dependency: the scanner already does DoH TXT lookups; this is just
+ *     a new query name passed to the same resolver.
+ *
+ * CRITICAL scoping rule — only map ASNs that are CDN-EXCLUSIVE. AS16509 (AWS)
+ * is deliberately EXCLUDED: it covers all EC2/ELB, not just CloudFront, so
+ * mapping it would false-positive every EC2-hosted app. CloudFront is reliably
+ * caught by the existing `x-amz-cf-id` header check.
+ *
+ * Best-effort and fail-soft: bounded to MAX_ASN_LOOKUPS outbound queries,
+ * short-circuits on the first CDN match, and any DoH error falls through to the
+ * next IP (never throws). The DoH resolver already enforces its own per-query
+ * timeout (see dns-transport.ts), so no extra timeout wrapper is needed here.
+ */
+
+/**
+ * CDN-exclusive origin ASNs -> canonical provider name.
+ *
+ * Akamai operates many ASNs (acquisitions + regional registries); the set
+ * below covers the common origin ASNs observed for Akamai edge IPs. AS16509
+ * (AWS) is deliberately absent — see the module docblock.
+ */
+export const ASN_TO_CDN: ReadonlyMap<number, string> = new Map([
+	[13335, 'Cloudflare'],
+	[16625, 'Akamai'],
+	[20940, 'Akamai'],
+	[16702, 'Akamai'],
+	[21342, 'Akamai'],
+	[21357, 'Akamai'],
+	[23454, 'Akamai'],
+	[35994, 'Akamai'],
+	[34164, 'Akamai'],
+	[43639, 'Akamai'],
+	[54113, 'Fastly'],
+	[19551, 'Imperva'],
+	[15133, 'Edgecast'],
+	[60068, 'CDN77'],
+	// AS16509 (AWS) deliberately excluded — not CDN-exclusive; CloudFront caught by x-amz-cf-id header.
+]);
+
+/** Bound on outbound team-cymru queries per detection run. */
+const MAX_ASN_LOOKUPS = 3;
+
+/** team-cymru origin-ASN reverse-DNS zone (queried over DoH TXT). */
+const CYMRU_ORIGIN_ZONE = 'origin.asn.cymru.com';
+
+/**
+ * A minimal DoH-resolver seam: `queryTxt(name)` resolves a TXT query to its
+ * answer strings. Matches the real `queryTxtRecords(name) => Promise<string[]>`
+ * helper (concatenated, unquoted answer strings) so the call site can pass the
+ * production resolver directly.
+ */
+export interface AsnDohResolver {
+	queryTxt: (name: string) => Promise<string[]>;
+}
+
+/** Result of a successful ASN-based CDN attribution. */
+export interface AsnCdnResult {
+	provider: string;
+	confidence: 'heuristic';
+	asn: number;
+}
+
+/**
+ * Parse the origin ASN from a team-cymru origin TXT answer.
+ *
+ * The answer's first `|`-delimited field holds one or more space-separated
+ * ASNs (multi-origin prefixes list several). We take the first ASN token.
+ * Returns null for empty / malformed answers (no leading numeric token).
+ */
+export function parseAsnFromCymru(txt: string): number | null {
+	const firstField = txt.split('|')[0]?.trim() ?? '';
+	if (firstField.length === 0) return null;
+	const firstToken = firstField.split(/\s+/)[0] ?? '';
+	if (!/^\d+$/.test(firstToken)) return null;
+	const asn = Number.parseInt(firstToken, 10);
+	return Number.isSafeInteger(asn) ? asn : null;
+}
+
+/** Map an origin ASN to its canonical CDN provider name, or null if not CDN-exclusive. */
+export function mapAsnToCdn(asn: number): string | null {
+	return ASN_TO_CDN.get(asn) ?? null;
+}
+
+/**
+ * Attribute a CDN provider by resolving up to MAX_ASN_LOOKUPS A-record IPs to
+ * their origin ASN and mapping ASN -> CDN. Short-circuits on the first CDN
+ * match. Fail-soft: any DoH error or unparseable answer falls through to the
+ * next IP; returns null when no IP maps to a known CDN ASN.
+ */
+export async function detectCdnFromAsn(aRecords: string[], doh: AsnDohResolver): Promise<AsnCdnResult | null> {
+	for (const ip of aRecords.slice(0, MAX_ASN_LOOKUPS)) {
+		const reversed = ip.split('.').reverse().join('.');
+		try {
+			const answers = await doh.queryTxt(`${reversed}.${CYMRU_ORIGIN_ZONE}`);
+			const asn = answers.length > 0 ? parseAsnFromCymru(answers[0]) : null;
+			if (asn !== null) {
+				const provider = mapAsnToCdn(asn);
+				if (provider) return { provider, confidence: 'heuristic', asn };
+			}
+		} catch {
+			// Fail-soft — try the next IP.
+		}
+	}
+	return null;
+}

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -189,6 +189,21 @@ const DETECTION_RULES: DetectionRule[] = [
 		signal: 'spf:mtasv.net',
 	},
 	{
+		// AutoSPF. SPF-flattening service — customers replace their nested SPF
+		// includes with a single per-tenant include under `*.autospf.email`
+		// (eg. `_s00430413.autospf.email`). Without this rule the raw per-tenant
+		// selector hostname surfaces as a third-party row instead of the canonical
+		// provider name. SPF-only (no fixed MX hostnames); the SPF-rule dedup path
+		// (matchProviderForSpfInclude) handles it.
+		// Catalog gap surfaced 2026-05-28 (post-v3.3.19 fact-check round).
+		name: 'AutoSPF',
+		role: 'sending',
+		patterns: {
+			spf: /\.autospf\.email$/i,
+		},
+		signal: 'spf:autospf',
+	},
+	{
 		// Trellix Email Security (formerly FireEye Email Security; rebranded after
 		// Trellix was formed in 2022). Enterprise email security gateway that sits
 		// between sender and recipient; SPF includes resolve to AWS-edge senders.

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -5,6 +5,7 @@ import { queryTxtRecords } from '../../lib/dns';
 import { queryDnsRecords } from '../../lib/dns-records';
 import { detectProviderMatches, detectProviderMatchesBySelectors, loadProviderSignatures } from '../../lib/provider-signatures';
 import { detectCloudflareFallback } from '../../lib/cdn-fallback-detection';
+import { type AsnDohResolver, detectCdnFromAsn } from '../../lib/cdn-asn-detection';
 import { parseDmarcTags } from '../check-dmarc';
 
 export interface ScanRuntimeOptions {
@@ -62,7 +63,7 @@ export async function applyScanPostProcessing(
 		results = adjustForNoSendDomain(results);
 	}
 
-	results = await addCloudflareCdnHeuristic(domain, results, {
+	results = await addCdnHeuristics(domain, results, {
 		certstream: runtimeOptions?.certstream,
 		certstreamAuthToken: runtimeOptions?.certstreamAuthToken,
 	});
@@ -71,24 +72,29 @@ export async function applyScanPostProcessing(
 }
 
 /**
- * Heuristic Cloudflare CDN attribution fallback.
+ * Heuristic CDN attribution fallback (tiered).
  *
- * Header-based CDN detection (in `check-http-security`) cannot identify
- * Cloudflare from inside a Cloudflare Worker — see the rationale in
- * `src/lib/cdn-fallback-detection.ts`. This post-processing pass restores
- * attribution when:
+ * Header-based CDN detection (in `check-http-security`) can miss CDNs that
+ * don't emit a vendor-specific header, and cannot identify Cloudflare at all
+ * from inside a Cloudflare Worker — see the rationale in
+ * `src/lib/cdn-fallback-detection.ts`. `addCdnHeuristics` restores attribution
+ * via three tiers, in order, each only running when the prior produced nothing:
  *
- *   1. No header-based CDN was identified for `http_security`, AND
- *   2. All NS records resolve under `*.ns.cloudflare.com`, AND
- *   3. At least one A record falls in a published Cloudflare edge range.
+ *   1. Header vendor-specific — primary; if `http_security` already carries a
+ *      `metadata.cdnProvider`, the fallbacks are skipped entirely.
+ *   2. Cloudflare NS+IP+cert 2-of-3 heuristic (`detectCloudflareFallback`).
+ *   3. ASN-based fallback (`detectCdnFromAsn`) — resolves A-record IPs to their
+ *      origin ASN via team-cymru DoH and maps ASN -> CDN (closes the Akamai and
+ *      other no-header-CDN false-negatives).
  *
  * When matched, emits a new info-level finding on the `http_security` check
- * with `metadata: { cdnProvider: 'Cloudflare', confidence: 'heuristic',
- * source: 'ns-and-ip-range' }`. Format-report already iterates findings
+ * with `metadata.cdnProvider`/`confidence: 'heuristic'`/`source` (`ns-and-ip-range`,
+ * `ns-ip-and-cert`, or `asn-lookup`). Format-report already iterates findings
  * looking for `metadata.cdnProvider`, so it picks this up automatically.
  *
  * Conservative: any DNS error during the fresh NS/A lookups silently skips
- * the heuristic — never poisons a scan result.
+ * the heuristic, and the ASN tier is bounded + fail-soft — never poisons a
+ * scan result.
  */
 /**
  * Sync budget for the cert-meta lookup inside scan_domain post-processing.
@@ -125,15 +131,15 @@ async function fetchCertIssuerFromCertstream(
 	}
 }
 
-async function addCloudflareCdnHeuristic(
+async function addCdnHeuristics(
 	domain: string,
 	results: CheckResult[],
-	options?: { certstream?: { fetch: typeof fetch }; certstreamAuthToken?: string },
+	options?: { certstream?: { fetch: typeof fetch }; certstreamAuthToken?: string; doh?: AsnDohResolver },
 ): Promise<CheckResult[]> {
 	const httpResult = results.find((result) => result.category === 'http_security');
 	if (!httpResult) return results;
 
-	// Don't compete with a header-based CDN hit — those are stronger signal.
+	// Tier 1: don't compete with a header-based CDN hit — those are stronger signal.
 	const alreadyHasCdn = httpResult.findings.some((f) => typeof f.metadata?.cdnProvider === 'string');
 	if (alreadyHasCdn) return results;
 
@@ -167,8 +173,12 @@ async function addCloudflareCdnHeuristic(
 		);
 	}
 
+	// Tier 2: Cloudflare NS+IP+cert heuristic. When it produces nothing, fall
+	// through to the ASN-based tier 3 below.
 	const heuristic = detectCloudflareFallback({ nsHosts: normalisedNs, aRecords, certIssuer });
-	if (!heuristic) return results;
+	if (!heuristic) {
+		return addAsnCdnHeuristic(httpResult, results, aRecords, options?.doh);
+	}
 
 	// Build a detail string that honestly reflects which signals matched, so
 	// users understand whether attribution came from (NS+IP) or (IP+cert) or
@@ -193,8 +203,56 @@ async function addCloudflareCdnHeuristic(
 		},
 	);
 
+	return appendCdnFinding(httpResult, results, cdnFinding);
+}
+
+/**
+ * Tier 3: ASN-based CDN attribution fallback.
+ *
+ * Runs only when tiers 1 (header) and 2 (CF NS+IP+cert) produced no
+ * attribution. Resolves up to MAX_ASN_LOOKUPS A-record IPs to their origin ASN
+ * via team-cymru DoH TXT and maps ASN -> CDN (see cdn-asn-detection.ts). This
+ * closes false-negatives for CDNs that don't emit a vendor-specific header —
+ * notably Akamai (`Server: AkamaiGHost`, no transform header) — without a
+ * hardcoded per-provider CIDR list.
+ *
+ * Best-effort and fail-soft: the resolver enforces its own per-query timeout,
+ * the lookup count is bounded, and any failure yields no attribution.
+ */
+async function addAsnCdnHeuristic(
+	httpResult: CheckResult,
+	results: CheckResult[],
+	aRecords: string[],
+	doh?: AsnDohResolver,
+): Promise<CheckResult[]> {
+	if (aRecords.length === 0) return results;
+
+	const resolver: AsnDohResolver = doh ?? { queryTxt: (name) => queryTxtRecords(name) };
+	const asnResult = await detectCdnFromAsn(aRecords, resolver);
+	if (!asnResult) return results;
+
+	const cdnFinding = createFinding(
+		'http_security',
+		`HTTP origin attributed to ${asnResult.provider} CDN (heuristic)`,
+		'info',
+		`${asnResult.provider} CDN inferred from the origin ASN (AS${asnResult.asn}) of the resolved A-record IP via team-cymru. Header-based CDN detection was inconclusive — this CDN does not emit a vendor-specific response header, and the scanner runs inside a Cloudflare Worker, which rewrites server: cloudflare on every outbound response.`,
+		{
+			cdnProvider: asnResult.provider,
+			confidence: asnResult.confidence,
+			source: 'asn-lookup',
+			asn: asnResult.asn,
+		},
+	);
+
+	return appendCdnFinding(httpResult, results, cdnFinding);
+}
+
+/**
+ * Append a heuristic CDN finding to the http_security check, preserving its
+ * scoring fields (buildCheckResult creates a fresh CheckResult).
+ */
+function appendCdnFinding(httpResult: CheckResult, results: CheckResult[], cdnFinding: Finding): CheckResult[] {
 	const updated = buildCheckResult('http_security', [...httpResult.findings, cdnFinding]);
-	// buildCheckResult creates a fresh CheckResult — preserve scoring fields we care about.
 	const merged: CheckResult = {
 		...updated,
 		score: httpResult.score,

--- a/test/cdn-asn-detection.spec.ts
+++ b/test/cdn-asn-detection.spec.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest';
+import { parseAsnFromCymru, mapAsnToCdn, detectCdnFromAsn } from '../src/lib/cdn-asn-detection';
+
+/**
+ * Build a fake DoH resolver whose `queryTxt(name)` returns the configured
+ * answer for an exact `<reversed-ip>.origin.asn.cymru.com` name, or [] for
+ * any unmapped name. Mirrors the real `queryTxtRecords(name) => Promise<string[]>`
+ * seam (concatenated, unquoted answer strings).
+ */
+function mockDoh(answers: Record<string, string>): { queryTxt: ReturnType<typeof vi.fn> } {
+	return {
+		queryTxt: vi.fn(async (name: string) => {
+			const answer = answers[name];
+			return answer !== undefined ? [answer] : [];
+		}),
+	};
+}
+
+describe('parseAsnFromCymru', () => {
+	it('extracts the ASN from a team-cymru origin TXT answer', () => {
+		expect(parseAsnFromCymru('16625 | 118.215.88.0/21 | SG | apnic | 2007-10-30')).toBe(16625);
+	});
+	it('handles multiple ASNs (returns the first) — multi-origin prefixes', () => {
+		expect(parseAsnFromCymru('13335 14618 | 162.159.128.0/19 | US | arin')).toBe(13335);
+	});
+	it('returns null for malformed / empty answers', () => {
+		expect(parseAsnFromCymru('')).toBeNull();
+		expect(parseAsnFromCymru('NXDOMAIN')).toBeNull();
+		expect(parseAsnFromCymru('| no asn |')).toBeNull();
+	});
+});
+
+describe('mapAsnToCdn', () => {
+	it('maps Akamai ASNs', () => {
+		expect(mapAsnToCdn(16625)).toBe('Akamai');
+		expect(mapAsnToCdn(20940)).toBe('Akamai');
+	});
+	it('maps Cloudflare / Fastly / Imperva ASNs', () => {
+		expect(mapAsnToCdn(13335)).toBe('Cloudflare');
+		expect(mapAsnToCdn(54113)).toBe('Fastly');
+		expect(mapAsnToCdn(19551)).toBe('Imperva');
+	});
+	it('does NOT map AWS AS16509 (ambiguous — EC2/ELB, not CDN-exclusive)', () => {
+		expect(mapAsnToCdn(16509)).toBeNull();
+	});
+	it('returns null for unknown ASNs', () => {
+		expect(mapAsnToCdn(64512)).toBeNull();
+	});
+});
+
+describe('detectCdnFromAsn', () => {
+	it('attributes Akamai when an A-record IP resolves to an Akamai ASN (mit.edu pattern)', async () => {
+		const doh = mockDoh({ '214.90.215.118.origin.asn.cymru.com': '16625 | 118.215.88.0/21 | SG | apnic' });
+		const r = await detectCdnFromAsn(['118.215.90.214'], doh);
+		expect(r).toEqual({ provider: 'Akamai', confidence: 'heuristic', asn: 16625 });
+	});
+	it('returns null when no A-record maps to a known CDN ASN', async () => {
+		const doh = mockDoh({ '8.8.8.8.origin.asn.cymru.com': '15169 | 8.8.8.0/24 | US | arin' }); // Google, not in CDN map
+		expect(await detectCdnFromAsn(['8.8.8.8'], doh)).toBeNull();
+	});
+	it('returns null and never throws on DoH failure (fail-soft)', async () => {
+		const doh = { queryTxt: vi.fn().mockRejectedValue(new Error('timeout')) };
+		expect(await detectCdnFromAsn(['1.2.3.4'], doh)).toBeNull();
+	});
+	it('checks at most N A-records (bounds outbound query count)', async () => {
+		const doh = mockDoh({});
+		await detectCdnFromAsn(['1.1.1.1', '2.2.2.2', '3.3.3.3', '4.4.4.4', '5.5.5.5'], doh);
+		expect(doh.queryTxt).toHaveBeenCalledTimes(3); // MAX_ASN_LOOKUPS = 3
+	});
+	it('short-circuits on first CDN match (does not query remaining IPs)', async () => {
+		const doh = mockDoh({ '1.0.0.1.origin.asn.cymru.com': '13335 | 1.0.0.0/24 | US | arin' });
+		const r = await detectCdnFromAsn(['1.0.0.1', '2.2.2.2'], doh);
+		expect(r?.provider).toBe('Cloudflare');
+		expect(doh.queryTxt).toHaveBeenCalledTimes(1);
+	});
+});

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -136,6 +136,14 @@ describe('mapSupplyChain', () => {
 		expect(digicertDep!.roles).toContain('certificate-authority');
 	});
 
+	it('resolves AutoSPF via *.autospf.email SPF includes (mit.edu pattern)', async () => {
+		mockDnsResponses({ spf: 'v=spf1 include:_s00430413.autospf.email -all', domain: 'mit.edu' });
+		const result = await run('mit.edu');
+		const rows = result.dependencies.filter((d) => d.provider === 'AutoSPF');
+		expect(rows.length).toBe(1);
+		expect(result.dependencies.find((d) => /autospf\.email/i.test(d.provider))).toBeUndefined();
+	});
+
 	it('detects known providers via detectProviders()', async () => {
 		mockDnsResponses({
 			spf: 'v=spf1 include:spf.protection.outlook.com include:sendgrid.net -all',

--- a/test/scan-post-processing.spec.ts
+++ b/test/scan-post-processing.spec.ts
@@ -873,4 +873,93 @@ describe('addOutboundProviderInference — provider detection coverage', () => {
 			expect(certstream.fetch).not.toHaveBeenCalled();
 		});
 	});
+
+	// Tests for the v3.3.20 ASN-based CDN attribution fallback — tier 3, runs
+	// only when header (tier 1) and CF NS+IP+cert (tier 2) produce no attribution.
+	// Resolves A-record IPs to origin ASN via team-cymru DoH TXT, maps ASN -> CDN.
+	describe('CDN attribution: ASN-based fallback (Akamai)', () => {
+		const HTTP_RESULT_NO_CDN: CheckResult = buildCheckResult('http_security', [
+			createFinding('http_security', 'HTTP probe', 'info', 'baseline'),
+		]);
+
+		const findCdn = (results: CheckResult[]) =>
+			results.find((r) => r.category === 'http_security')?.findings.find((f) => typeof f.metadata?.cdnProvider === 'string');
+
+		afterEach(() => {
+			vi.doUnmock('../src/lib/dns');
+			vi.doUnmock('../src/lib/dns-records');
+			vi.resetModules();
+		});
+
+		it('attributes Akamai via ASN when headers and NS+IP+cert all miss (mit.edu pattern)', async () => {
+			// NS on akam.net (not *.ns.cloudflare.com), A NOT in any CF range, no header CDN.
+			vi.doMock('../src/lib/dns-records', () => ({
+				queryDnsRecords: vi.fn(async (_d: string, type: string) => {
+					if (type === 'NS') return ['use5.akam.net', 'use6.akam.net'];
+					if (type === 'A') return ['118.215.90.214'];
+					return [];
+				}),
+			}));
+			vi.doMock('../src/lib/dns', () => ({
+				queryTxtRecords: vi.fn(async (name: string) =>
+					name === '214.90.215.118.origin.asn.cymru.com' ? ['16625 | 118.215.88.0/21 | SG | apnic'] : [],
+				),
+			}));
+			const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+			const updated = await applyScanPostProcessing('mit.edu', [HTTP_RESULT_NO_CDN]);
+			const cdn = findCdn(updated);
+			expect(cdn?.metadata?.cdnProvider).toBe('Akamai');
+			expect(cdn?.metadata?.source).toBe('asn-lookup');
+			expect(cdn?.metadata?.confidence).toBe('heuristic');
+			expect(cdn?.metadata?.asn).toBe(16625);
+		});
+
+		it('does not run ASN fallback when a header-based CDN attribution already exists', async () => {
+			const cymru = vi.fn().mockResolvedValue([]);
+			vi.doMock('../src/lib/dns', () => ({ queryTxtRecords: cymru }));
+			vi.doMock('../src/lib/dns-records', () => ({ queryDnsRecords: vi.fn(async () => []) }));
+			const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+			const httpWithCdn = buildCheckResult('http_security', [
+				createFinding('http_security', 'CDN: Imperva', 'info', 'x-cdn', { cdnProvider: 'Imperva' }),
+			]);
+			await applyScanPostProcessing('example.com', [httpWithCdn]);
+			expect(cymru).not.toHaveBeenCalled();
+		});
+
+		it('does not run ASN fallback when the CF NS+IP heuristic already attributed Cloudflare', async () => {
+			// CF NS + CF IP → NS+IP heuristic wins tier 2; ASN tier 3 is skipped.
+			const cymru = vi.fn().mockResolvedValue([]);
+			vi.doMock('../src/lib/dns', () => ({ queryTxtRecords: cymru }));
+			vi.doMock('../src/lib/dns-records', () => ({
+				queryDnsRecords: vi.fn(async (_d: string, type: string) => {
+					if (type === 'NS') return ['a.ns.cloudflare.com'];
+					if (type === 'A') return ['104.16.45.99'];
+					return [];
+				}),
+			}));
+			const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+			const updated = await applyScanPostProcessing('example.com', [HTTP_RESULT_NO_CDN]);
+			expect(findCdn(updated)?.metadata?.cdnProvider).toBe('Cloudflare');
+			expect(cymru).not.toHaveBeenCalled();
+		});
+
+		it('degrades to no-attribution when ASN lookup fails (fail-soft, no throw)', async () => {
+			vi.doMock('../src/lib/dns-records', () => ({
+				queryDnsRecords: vi.fn(async (_d: string, type: string) => {
+					if (type === 'NS') return ['use5.akam.net'];
+					if (type === 'A') return ['118.215.90.214'];
+					return [];
+				}),
+			}));
+			// Empty cymru answer → parseAsnFromCymru sees nothing → no attribution.
+			vi.doMock('../src/lib/dns', () => ({ queryTxtRecords: vi.fn(async () => []) }));
+			const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+			const updated = await applyScanPostProcessing('mit.edu', [HTTP_RESULT_NO_CDN]);
+			expect(findCdn(updated)).toBeUndefined();
+		});
+	});
 });


### PR DESCRIPTION
Implements docs/plans/2026-05-28-asn-cdn-detection-and-autospf-tdd-plan.md.

## Cluster A — ASN-based CDN attribution (the fix)

detectCdnProvider only catches Akamai via optional x-akamai-transformed/x-check-cacheable headers. mit.edu (Akamai, Server: AkamaiGHost, no transform headers) returned cdnProvider:null. Same root cause as the Cloudflare saga — CF Worker egress rewrites server to cloudflare, so the reliable server header is dead and the vendor headers are optional.

Fix: new tier-3 fallback resolves each A-record IP to its origin ASN via team-cymru DoH and maps ASN to CDN provider. Origin-set (from the resolved IP, not a header), immune to the CF-Worker rewrite, generalizes via one ASN_TO_CDN table.

New src/lib/cdn-asn-detection.ts — Akamai/Cloudflare/Fastly/Imperva/Edgecast/CDN77 ASNs. AS16509 (AWS) deliberately excluded (EC2/ELB, not CDN-exclusive; CloudFront stays on the x-amz-cf-id header). MAX_ASN_LOOKUPS=3, short-circuit, fail-soft.

post-processing 3-tier order: header (skip if present) -> CF NS+IP+cert (v3.3.17) -> ASN lookup. ASN tier runs only when prior tiers miss. Reuses the existing DoH resolver — no new fetch dependency.

## Cluster B — AutoSPF catalog entry

mit.edu SPF include:_s00430413.autospf.email surfaced raw. Added AutoSPF DETECTION_RULE.

## Tests — 17 new
- cdn-asn-detection.spec.ts (12): parse/map/detect incl AS16509-not-mapped + fail-soft + bounded + short-circuit
- scan-post-processing.spec.ts (+4): Akamai via ASN; ASN NOT run when header/CF present; fail-soft
- map-supply-chain.spec.ts (+1): AutoSPF

96/96 affected pass; full suite 4702 passed/0 failed; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)