### PR TITLE
fix: remaining open issues — cache versioning + SPF UDP-truncation (#250) + CloudFront redirect-chain (#262) + lookalike entity-correlation (#263)

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
@@ -2,7 +2,13 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { checkSPF } from '../../checks/check-spf';
+import { estimateTxtRrsetBytes } from '../../checks/spf-analysis';
 import type { DNSQueryFunction } from '../../types';
+
+/** Build a TXT string of an exact byte length (ASCII, so 1 char === 1 byte). */
+function txtOfLength(length: number): string {
+	return 'a'.repeat(length);
+}
 
 function createMockDNS(records: Record<string, string[]>): DNSQueryFunction {
 	return vi.fn(async (domain: string, _type: string) => {
@@ -110,5 +116,73 @@ describe('checkSPF', () => {
 		});
 		const result = await checkSPF('example.com', queryDNS);
 		expect(result.findings.some((f) => f.title === 'Overly broad IP range')).toBe(true);
+	});
+
+	it('does not flag truncation when the TXT RRset is well under 512 bytes', async () => {
+		const queryDNS = createMockDNS({
+			'example.com': ['v=spf1 include:_spf.example.net -all'],
+			'_dmarc.example.com': ['v=DMARC1; p=reject; aspf=s; adkim=s'],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings.some((f) => f.title.toLowerCase().includes('udp'))).toBe(false);
+		expect(result.findings.some((f) => f.metadata?.findingCode === 'SPF_RRSET_LARGE')).toBe(false);
+	});
+
+	it('emits a low SPF_RRSET_LARGE finding when the TXT RRset is 450-512 bytes', async () => {
+		// Two TXT records summing into the 450-512 byte estimate window.
+		const queryDNS = createMockDNS({
+			'example.com': ['v=spf1 ' + txtOfLength(240) + ' -all', txtOfLength(190)],
+			'_dmarc.example.com': ['v=DMARC1; p=reject; aspf=s; adkim=s'],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		const finding = result.findings.find((f) => f.metadata?.findingCode === 'SPF_RRSET_LARGE');
+		expect(finding).toBeDefined();
+		expect(finding?.severity).toBe('low');
+		expect(finding?.detail).toMatch(/512-byte UDP/i);
+	});
+
+	it('emits a medium finding mentioning TCP fallback and RFC 7208 when the TXT RRset exceeds 512 bytes', async () => {
+		const queryDNS = createMockDNS({
+			'example.com': [
+				'v=spf1 ' + txtOfLength(250) + ' -all',
+				txtOfLength(250),
+				txtOfLength(100),
+			],
+			'_dmarc.example.com': ['v=DMARC1; p=reject; aspf=s; adkim=s'],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		const finding = result.findings.find(
+			(f) => f.severity === 'medium' && /512-byte UDP/i.test(f.detail),
+		);
+		expect(finding).toBeDefined();
+		expect(finding?.detail).toMatch(/TCP fallback/i);
+		expect(finding?.detail).toMatch(/RFC 7208/i);
+	});
+});
+
+describe('estimateTxtRrsetBytes', () => {
+	it('returns 0 for an empty RRset', () => {
+		expect(estimateTxtRrsetBytes([])).toBe(0);
+	});
+
+	it('accounts for per-record overhead and the single length octet for a short string', () => {
+		// 1 record, 10-byte string: 12 (RR overhead) + 10 (string) + 1 (length octet) = 23
+		expect(estimateTxtRrsetBytes([txtOfLength(10)])).toBe(23);
+	});
+
+	it('sums multiple records', () => {
+		// two 10-byte strings: 2 * 23 = 46
+		expect(estimateTxtRrsetBytes([txtOfLength(10), txtOfLength(10)])).toBe(46);
+	});
+
+	it('adds an extra length octet for each 255-byte character-string chunk', () => {
+		// 300-byte string spans 2 character-strings → 2 length octets.
+		// 12 (RR overhead) + 300 (string) + 2 (length octets) = 314
+		expect(estimateTxtRrsetBytes([txtOfLength(300)])).toBe(314);
+	});
+
+	it('counts an empty TXT string as one (empty) character-string', () => {
+		// 12 (RR overhead) + 0 (string) + 1 (length octet) = 13
+		expect(estimateTxtRrsetBytes([''])).toBe(13);
 	});
 });

--- a/packages/dns-checks/src/checks/check-spf.ts
+++ b/packages/dns-checks/src/checks/check-spf.ts
@@ -13,9 +13,12 @@ import type { CheckResult, DNSQueryFunction, Finding } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
 import { parseDmarcTags } from './dmarc-utils';
 import {
+	DNS_UDP_LIMIT_BYTES,
+	DNS_UDP_WARN_BYTES,
 	RISKY_MECHANISMS,
 	checkBroadIpRanges,
 	countRecursiveLookups,
+	estimateTxtRrsetBytes,
 	extractSpfSignalDomains,
 	type RecursiveState,
 } from './spf-analysis';
@@ -29,6 +32,34 @@ function isNoSendPolicy(spf: string): boolean {
 	if (qualifier !== '-' && qualifier !== '~') return false;
 	const hasAuthorizing = /\b(include:|a[:/\s]|a$|mx[:/\s]|mx$|ip4:|ip6:|redirect=|exists:)/i.test(spf);
 	return !hasAuthorizing;
+}
+
+/**
+ * Flag a TXT RRset large enough to truncate over UDP (forcing TCP fallback).
+ * DoH always returns the full response, so this wire-size estimate is the only
+ * signal available to a passive scanner (RFC 7208 §3.4).
+ */
+function checkUdpTruncation(domain: string, txtRecords: string[]): Finding | undefined {
+	const rrsetBytes = estimateTxtRrsetBytes(txtRecords);
+	if (rrsetBytes > DNS_UDP_LIMIT_BYTES) {
+		return createFinding(
+			'spf',
+			'TXT RRset exceeds UDP limit',
+			'medium',
+			`The combined TXT RRset for ${domain} is ~${rrsetBytes} bytes, which exceeds the 512-byte UDP limit and requires TCP fallback. Legacy resolvers and restrictive middleboxes that do not retry over TCP may only see the first ~512 bytes, silently breaking SPF for some receiving MTAs. RFC 7208 §3.4 advises keeping the SPF record and surrounding TXT RRset small enough to fit a single UDP packet.`,
+			{ findingCode: 'SPF_RRSET_LARGE', rrsetBytes },
+		);
+	}
+	if (rrsetBytes > DNS_UDP_WARN_BYTES) {
+		return createFinding(
+			'spf',
+			'TXT RRset approaching UDP limit',
+			'low',
+			`The combined TXT RRset for ${domain} is ~${rrsetBytes} bytes, approaching the 512-byte UDP limit. Once it exceeds 512 bytes, responses require TCP fallback and legacy resolvers that do not retry over TCP may silently break SPF. RFC 7208 §3.4 advises keeping the SPF record and surrounding TXT RRset small enough to fit a single UDP packet.`,
+			{ findingCode: 'SPF_RRSET_LARGE', rrsetBytes },
+		);
+	}
+	return undefined;
 }
 
 interface TrustSurfaceDmarcContext {
@@ -126,6 +157,12 @@ export async function checkSPF(
 				`Found ${spfMatches.length} SPF records in TXT data. RFC 7208 requires exactly one SPF record per domain. Multiple records cause unpredictable behavior.`,
 			),
 		);
+	}
+
+	// UDP truncation risk: estimate the full TXT RRset wire size (RFC 7208 §3.4).
+	const truncationFinding = checkUdpTruncation(domain, txtRecords);
+	if (truncationFinding) {
+		findings.push(truncationFinding);
 	}
 
 	const spf = spfRecords[0];

--- a/packages/dns-checks/src/checks/index.ts
+++ b/packages/dns-checks/src/checks/index.ts
@@ -34,3 +34,4 @@ export type { CaaRecord } from './caa-analysis';
 export { parseCaaRecord } from './caa-analysis';
 export type { TlsaRecord } from './dane-analysis';
 export { analyzeSecurityHeaders } from './http-security-analysis';
+export { estimateTxtRrsetBytes } from './spf-analysis';

--- a/packages/dns-checks/src/checks/spf-analysis.ts
+++ b/packages/dns-checks/src/checks/spf-analysis.ts
@@ -15,6 +15,44 @@ import { createFinding } from '../check-utils';
 /** Known risky SPF mechanisms that allow broad sending. */
 export const RISKY_MECHANISMS = ['+all', '?all'];
 
+/**
+ * UDP payload threshold (bytes) above which a DNS response is truncated and
+ * forces TCP fallback (classic 512-byte limit, RFC 1035 §4.2.1 / RFC 7208 §3.4).
+ */
+export const DNS_UDP_LIMIT_BYTES = 512;
+
+/** Warning threshold: TXT RRset approaching the 512-byte UDP limit. */
+export const DNS_UDP_WARN_BYTES = 450;
+
+/** Fixed per-resource-record wire overhead (bytes) assuming answer-section name compression. */
+const TXT_RR_OVERHEAD_BYTES = 12; // 2 (compressed NAME ptr) + 2 TYPE + 2 CLASS + 4 TTL + 2 RDLENGTH
+
+/** Maximum payload of a single DNS character-string (RFC 1035 §3.3.14). */
+const MAX_CHARACTER_STRING_BYTES = 255;
+
+/**
+ * Estimate the answer-section wire size (bytes) of a domain's full TXT RRset.
+ *
+ * A DoH-based scanner always receives the full (TCP-equivalent) response, so it
+ * never observes UDP truncation directly. This estimator reconstructs the size a
+ * legacy resolver would see over UDP, where exceeding 512 bytes forces a TCP
+ * retry that some restrictive middleboxes / legacy resolvers never perform —
+ * silently dropping part of the SPF policy (RFC 7208 §3.4).
+ *
+ * Per TXT record: fixed RR overhead + the string payload + one length octet per
+ * 255-byte character-string chunk (a TXT RDATA is one or more length-prefixed
+ * character-strings; strings longer than 255 bytes are split). String byte length
+ * is measured as UTF-8 to match wire encoding.
+ */
+export function estimateTxtRrsetBytes(records: string[]): number {
+	return records.reduce((total, record) => {
+		const byteLength = new TextEncoder().encode(record).length;
+		// At least one character-string even for an empty record.
+		const chunks = Math.max(1, Math.ceil(byteLength / MAX_CHARACTER_STRING_BYTES));
+		return total + TXT_RR_OVERHEAD_BYTES + byteLength + chunks;
+	}, 0);
+}
+
 /** Maximum recursion depth for SPF include expansion. */
 export const MAX_RECURSION_DEPTH = 10;
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -2,7 +2,7 @@
 
 import type { CheckResult } from '../lib/scoring';
 import type { QueryDnsOptions, SecondaryDohConfig } from '../lib/dns-types';
-import { runWithCacheTracked } from '../lib/cache';
+import { buildCheckCacheKey, buildScanCacheKey, runWithCacheTracked } from '../lib/cache';
 import { sanitizeErrorMessage } from '../lib/json-rpc';
 import { checkSpf } from '../tools/check-spf';
 import { checkSubdomainTakeover } from '../tools/check-subdomain-takeover';
@@ -918,7 +918,8 @@ export async function handleToolsCall(
 			const registeredTool = TOOL_REGISTRY[name];
 			if (registeredTool) {
 				const checkName = registeredTool.cacheKey(validatedArgs, runtimeOptions);
-				const cacheKey = `cache:${validDomain}:check:${checkName}`;
+				// Versioned (cache:v<version>:...) so a deploy auto-invalidates — see buildCheckCacheKey.
+				const cacheKey = buildCheckCacheKey(validDomain, checkName);
 				let cacheStatus: 'hit' | 'miss' = 'miss';
 				let result: CheckResult;
 				if (registeredTool.cacheable === false) {
@@ -1153,7 +1154,9 @@ export async function handleToolsCall(
 
 					let baselineScore: import('@blackveil/dns-checks/scoring').ScanScore;
 					if (baselineStr === 'cached') {
-						const cacheKey = `cache:${validDomain}`;
+						// MUST match scanDomain's default-profile top-level key (buildScanCacheKey)
+						// so the versioned cache written by scan_domain is readable here.
+						const cacheKey = buildScanCacheKey(validDomain);
 						const cached = scanCacheKV
 							? await import('../lib/cache').then((m) => m.cacheGet<import('../tools/scan-domain').ScanDomainResult>(cacheKey, scanCacheKV))
 							: undefined;

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -2,6 +2,7 @@
 
 import { INFLIGHT_CLEANUP_MS } from './config';
 import { logError } from './log';
+import { SERVER_VERSION } from './server-version';
 
 /**
  * TTL cache for DNS scan results.
@@ -116,6 +117,48 @@ export class TTLCache<T = unknown> {
 		}
 		return evicted;
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Versioned cache-key builders
+// ---------------------------------------------------------------------------
+//
+// Every scan/check KV cache key embeds the server version (`cache:v<version>:`).
+// Deliberate trade-off: each deploy bumps SERVER_VERSION, so ALL keys change and
+// the cache cold-starts on the first request after a deploy. That is the correct
+// behaviour — the bug this fixes was the opposite: domain-only keys kept serving
+// stale pre-deploy results until the TTL expired, forcing a "scan a fresh domain
+// to verify the fix is live" workaround. For this scanner's traffic the cold
+// start is acceptable; correctness after deploy beats a few extra cache misses.
+//
+// Both call sites (handlers dispatch + scan-domain orchestrator) MUST use these
+// helpers so the per-check and top-level keys stay version-consistent — the
+// analyze_drift `baseline: "cached"` path reads the top-level scan key directly,
+// so a drift between the two key shapes would silently break cached baselines.
+
+/** Cache key prefix shared by scan and per-check results. */
+export const CACHE_KEY_PREFIX = 'cache:';
+
+/**
+ * Build the versioned cache key for a single check result.
+ * Shape: `cache:v<version>:<domain>:check:<checkName>`.
+ *
+ * @param version - Defaults to the live {@link SERVER_VERSION}; overridable for tests.
+ */
+export function buildCheckCacheKey(domain: string, checkName: string, version: string = SERVER_VERSION): string {
+	return `${CACHE_KEY_PREFIX}v${version}:${domain}:check:${checkName}`;
+}
+
+/**
+ * Build the versioned cache key for a top-level scan result.
+ * Shape: `cache:v<version>:<domain>` (default profile) or
+ * `cache:v<version>:<domain>:profile:<profile>` when an explicit profile is set.
+ *
+ * @param version - Defaults to the live {@link SERVER_VERSION}; overridable for tests.
+ */
+export function buildScanCacheKey(domain: string, profile?: string, version: string = SERVER_VERSION): string {
+	const base = `${CACHE_KEY_PREFIX}v${version}:${domain}`;
+	return profile ? `${base}:profile:${profile}` : base;
 }
 
 /** In-flight promise map for cache stampede (thundering herd) protection */

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -67,7 +67,41 @@ const MERGE_HEADERS = [
 ] as const;
 
 /** Maximum manual redirect hops to follow during dual-fetch probes. */
-const MAX_REDIRECT_HOPS = 3;
+const MAX_REDIRECT_HOPS = 5;
+
+/**
+ * Vendor-specific, origin-set CDN headers worth carrying forward across redirect
+ * hops. These are exactly the tier-1 signals `detectCdnProvider` inspects — they
+ * cannot be injected by a transit edge (unlike `server`, which the Cloudflare
+ * Worker egress rewrites to `cloudflare` on every hop; see v3.3.12 lesson). A CDN
+ * commonly fronts the FINAL hop of a chain (e.g. apex → intermediate → CDN-fronted
+ * target), but the signal can also appear on an intermediate hop; the final
+ * response captured for security analysis would otherwise lose it.
+ *
+ * `server` is deliberately excluded — carrying it forward would resurrect the
+ * 100%-false-positive Cloudflare bug.
+ */
+const CDN_SIGNAL_HEADERS = [
+	'x-cdn',
+	'x-iinfo',
+	'x-sucuri-id',
+	'x-sucuri-cache',
+	'x-vercel-id',
+	'x-vercel-cache',
+	'x-amz-cf-id',
+	'via',
+	'x-akamai-transformed',
+	'x-check-cacheable',
+	'x-served-by',
+] as const;
+
+/** Copy any CDN-signal headers present on `from` into `into` (first writer wins). */
+function accumulateCdnSignals(into: Headers, from: Headers): void {
+	for (const header of CDN_SIGNAL_HEADERS) {
+		const value = from.get(header);
+		if (value !== null && !into.has(header)) into.set(header, value);
+	}
+}
 
 /**
  * Detect CDN provider from HTTP response headers. Returns provider name or null.
@@ -123,11 +157,23 @@ function detectCdnProvider(headers: Headers): string | null {
 }
 
 /**
- * Fetch a URL with HEAD and follow up to 3 HTTPS redirects manually.
- * Mirrors the package's own redirect follow logic — used only for the
- * dual-fetch probe ahead of the package call.
+ * The final response of a redirect chain, plus a union of vendor-specific CDN
+ * signal headers observed across EVERY hop. The chain's intermediate hops are
+ * otherwise discarded — only the final response is the site's; `cdnSignals`
+ * exists so CDN attribution doesn't lose a signal that appeared on an earlier
+ * hop (or on a hop the security analysis path can't see).
  */
-async function fetchWithRedirects(url: string, timeoutMs: number): Promise<Response> {
+type RedirectResult = { response: Response; cdnSignals: Headers };
+
+/**
+ * Fetch a URL with HEAD and follow up to MAX_REDIRECT_HOPS HTTPS redirects
+ * manually. Mirrors the package's own redirect follow logic — used only for the
+ * dual-fetch probe ahead of the package call. Accumulates vendor-specific CDN
+ * headers from every hop so a CDN fronting an intermediate (or final) hop is
+ * still attributable even when the final security response omits the signal.
+ */
+async function fetchWithRedirects(url: string, timeoutMs: number): Promise<RedirectResult> {
+	const cdnSignals = new Headers();
 	// Initial fetch goes to https://<domain> where <domain> is already validated
 	// upstream. Use raw fetch to keep the cost off the validation path. Subsequent
 	// redirect targets ARE attacker-controlled (Location header) and go via
@@ -138,6 +184,7 @@ async function fetchWithRedirects(url: string, timeoutMs: number): Promise<Respo
 		headers: { 'User-Agent': SCANNER_USER_AGENT },
 		signal: AbortSignal.timeout(timeoutMs),
 	});
+	accumulateCdnSignals(cdnSignals, response.headers);
 
 	for (let hop = 0; hop < MAX_REDIRECT_HOPS; hop++) {
 		const status = response.status;
@@ -170,9 +217,10 @@ async function fetchWithRedirects(url: string, timeoutMs: number): Promise<Respo
 			// redirect destination, not a real failure.
 			break;
 		}
+		accumulateCdnSignals(cdnSignals, response.headers);
 	}
 
-	return response;
+	return { response, cdnSignals };
 }
 
 /**
@@ -212,9 +260,19 @@ async function dualFetchHeaders(
 	const url = `https://${domain}`;
 	const results = await Promise.allSettled([fetchWithRedirects(url, timeoutMs), fetchWithRedirects(url, timeoutMs)]);
 
-	const responses = results.filter((r): r is PromiseFulfilledResult<Response> => r.status === 'fulfilled').map((r) => r.value);
+	const settled = results.filter((r): r is PromiseFulfilledResult<RedirectResult> => r.status === 'fulfilled').map((r) => r.value);
 
-	if (responses.length === 0) return null;
+	if (settled.length === 0) return null;
+
+	// Union of vendor-specific CDN signals seen on ANY hop of EITHER probe's chain.
+	// Folded into the analysed headers so `detectCdnProvider` attributes a CDN that
+	// fronted an intermediate (or final) hop even when the final security response
+	// omits the signal. Security-header analysis is unaffected — these headers are
+	// not in MERGE_HEADERS and are not scored by the package.
+	const allCdnSignals = new Headers();
+	for (const s of settled) accumulateCdnSignals(allCdnSignals, s.cdnSignals);
+
+	const responses = settled.map((s) => s.response);
 
 	// Only treat 2xx/3xx as usable headers for analysis.
 	const usable = responses.filter((r) => r.ok || (r.status >= 300 && r.status < 400));
@@ -228,12 +286,26 @@ async function dualFetchHeaders(
 	}
 
 	if (usable.length === 1) {
-		return { headers: usable[0].headers, ok: usable[0].ok, status: usable[0].status, usable: true };
+		const headers = withCdnSignals(usable[0].headers, allCdnSignals);
+		return { headers, ok: usable[0].ok, status: usable[0].status, usable: true };
 	}
 
 	const merged = mergeSecurityHeaders(usable[0].headers, usable[1].headers);
+	const headers = withCdnSignals(merged, allCdnSignals);
 	const primary = usable[0].ok ? usable[0] : usable[1].ok ? usable[1] : usable[0];
-	return { headers: merged, ok: primary.ok, status: primary.status, usable: true };
+	return { headers, ok: primary.ok, status: primary.status, usable: true };
+}
+
+/**
+ * Return a copy of `base` with any cross-hop CDN-signal headers folded in
+ * (without overwriting a same-named header already present on the final
+ * response). Used so `detectCdnProvider` sees signals from intermediate hops.
+ */
+function withCdnSignals(base: Headers, cdnSignals: Headers): Headers {
+	const out = new Headers();
+	base.forEach((value, key) => out.set(key, value));
+	accumulateCdnSignals(out, cdnSignals);
+	return out;
 }
 
 /**

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -14,7 +14,7 @@ import type { ReconBinding } from '../lib/recon-binding';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { generateLookalikes } from './lookalike-analysis';
-import { FALLBACK_RDAP_SERVERS } from './check-rdap-lookup';
+import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg } from './check-rdap-lookup';
 import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSignals } from './lookalike-severity';
 
 /** Default and minimum batch sizes for adaptive batching */
@@ -50,6 +50,18 @@ const WEB_PROBE_TIMEOUT_MS = 2500;
 
 /** Minimum number of NS records that must overlap to consider domains as sharing nameservers. */
 const SHARED_NS_THRESHOLD = 1;
+
+/**
+ * Cap on the number of medium/high-severity lookalikes for which we attempt
+ * the same-entity (shared-registrant) RDAP correlation. RDAP registrant data
+ * is already harvested from the single enrichment fetch per candidate
+ * ({@link probeRdap}), so the cost is bounded by the enrichment set; this cap
+ * is a defensive ceiling so a pathological permutation explosion can't widen
+ * the RDAP fan-out beyond the lookalike check's wall-clock budget. Ordered by
+ * severity (high before medium) so the most damaging false-positives are
+ * corrected first when the cap binds.
+ */
+const SAME_ENTITY_RDAP_CAP = 10;
 
 /**
  * Check whether an MX record represents real mail infrastructure.
@@ -352,6 +364,30 @@ async function checkLookalikesCore(
 	});
 	const enrichment = await enrichLookalikes(candidatesToEnrich);
 
+	// Same-entity correlation (issue #263): a flagged lookalike that shares the
+	// scan domain's RDAP registrant org is almost certainly the org's own
+	// defensive registration / regional subsidiary (e.g. a vendor's regional
+	// presence on a DIFFERENT DNS provider, which the shared-NS pass above
+	// misses). We only fetch the primary's registrant org — and only apply the
+	// correlation — when at least one enriched candidate would surface at
+	// medium/high severity, so a clean scan pays no RDAP cost. The candidates'
+	// own registrant orgs are already in `enrichment` (harvested from the same
+	// fetch as registrationDays), so this adds exactly ONE extra RDAP fetch (the
+	// primary), not one-per-candidate. The eligible set is capped at
+	// SAME_ENTITY_RDAP_CAP, highest-severity first. Fail-soft: if the primary
+	// RDAP org is unknown, NO downgrade happens (a real threat is never
+	// suppressed because RDAP was unavailable).
+	const sameEntityCandidates = computeSameEntityCandidates(results, lookalikeNsMap, primaryNs, enrichment);
+	const primaryRegistrantOrg = sameEntityCandidates.length > 0 ? await probePrimaryRegistrantOrg(domain) : null;
+	const sameEntityMatches = new Map<string, string>();
+	if (primaryRegistrantOrg !== null) {
+		for (const candidateDomain of sameEntityCandidates) {
+			if (enrichment.get(candidateDomain)?.registrantOrg === primaryRegistrantOrg) {
+				sameEntityMatches.set(candidateDomain, primaryRegistrantOrg);
+			}
+		}
+	}
+
 	// Classify results — check for shared nameservers with primary domain to detect defensive registrations
 	let highCount = 0;
 	for (const result of results) {
@@ -378,6 +414,7 @@ async function checkLookalikesCore(
 			registrationDays: null,
 			mxOnDisposable: false,
 			hasWebContent: true,
+			registrantOrg: null,
 		};
 		const signals: LookalikeSignals = {
 			hasA: result.hasA,
@@ -388,6 +425,26 @@ async function checkLookalikesCore(
 		};
 		const severity = calibrateLookalikeSeverity(signals);
 		const corroboratorReasons = describeCorroborators(signals);
+
+		// Same-entity correlation (issue #263): the calibrated severity is a
+		// threat tier (low/medium/high), but if this lookalike's RDAP registrant
+		// org matches the scan domain's, it's the org's own defensive / regional
+		// registration. Downgrade to an info finding instead of a threat. Only
+		// medium/high candidates are eligible (see computeSameEntityCandidates);
+		// LOW web-only matches stay as-is (cheap, low-noise, not worth the fetch).
+		const matchedOrg = sameEntityMatches.get(result.domain);
+		if (matchedOrg !== undefined) {
+			findings.push(
+				createFinding(
+					'lookalikes',
+					`Lookalike domain likely owned by same entity: ${result.domain}`,
+					'info',
+					`The domain ${result.domain} shares the same RDAP registrant organisation as ${domain} ("${matchedOrg}"), indicating it is likely a defensive registration or regional presence by the same owner rather than a third-party lookalike.${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
+					{ lookalikeDomain: result.domain, hasA: result.hasA, hasMX: result.hasMX, sharedRegistrantOrg: matchedOrg },
+				),
+			);
+			continue;
+		}
 
 		if (result.hasMX) {
 			if (severity === 'high') highCount++;
@@ -478,6 +535,52 @@ interface LookalikeCorroborators {
 	registrationDays: number | null;
 	mxOnDisposable: boolean;
 	hasWebContent: boolean;
+	/**
+	 * Normalised RDAP registrant org for this candidate, harvested from the same
+	 * single RDAP fetch as {@link registrationDays}. `null` when RDAP failed,
+	 * returned no registrant entity, or the org field was empty — in which case
+	 * the same-entity correlation fails soft (the calibrated threat severity
+	 * stands; a real threat is never suppressed on missing RDAP).
+	 */
+	registrantOrg: string | null;
+}
+
+/**
+ * Determine which lookalike candidates are eligible for the issue #263
+ * same-entity (shared-registrant) downgrade. Eligibility mirrors the
+ * classification loop's decision so we never fetch the primary's registrant
+ * org speculatively: a candidate qualifies only when it is NOT already a
+ * shared-NS same-owner hit, has mail/web infra, AND its calibrated severity is
+ * medium or high (low web-only matches aren't worth the RDAP cost). The result
+ * is sorted high-before-medium and capped at {@link SAME_ENTITY_RDAP_CAP} so a
+ * permutation explosion can't widen the RDAP fan-out unbounded.
+ */
+function computeSameEntityCandidates(
+	results: LookalikeResult[],
+	lookalikeNsMap: Map<string, Set<string>>,
+	primaryNs: Set<string>,
+	enrichment: Map<string, LookalikeCorroborators>,
+): string[] {
+	const eligible: Array<{ domain: string; severity: 'medium' | 'high' }> = [];
+	for (const result of results) {
+		const lookalikeNs = lookalikeNsMap.get(result.domain);
+		const sameOwner = primaryNs.size > 0 && lookalikeNs !== undefined && sharesNameservers(primaryNs, lookalikeNs);
+		if (sameOwner) continue;
+		if (!result.hasMX && !result.hasA) continue;
+		const corroborators = enrichment.get(result.domain);
+		const severity = calibrateLookalikeSeverity({
+			hasA: result.hasA,
+			hasMX: result.hasMX,
+			registrationDays: corroborators?.registrationDays ?? null,
+			mxOnDisposable: corroborators?.mxOnDisposable ?? false,
+			hasWebContent: corroborators?.hasWebContent ?? true,
+		});
+		if (severity === 'medium' || severity === 'high') {
+			eligible.push({ domain: result.domain, severity });
+		}
+	}
+	eligible.sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'high' ? -1 : 1));
+	return eligible.slice(0, SAME_ENTITY_RDAP_CAP).map((e) => e.domain);
 }
 
 /**
@@ -493,31 +596,49 @@ async function enrichLookalikes(candidates: LookalikeResult[]): Promise<Map<stri
 	if (candidates.length === 0) return map;
 	await Promise.allSettled(
 		candidates.map(async (candidate) => {
-			const [registrationDays, hasWebContent] = await Promise.all([
-				probeRegistrationDays(candidate.domain),
+			const [rdap, hasWebContent] = await Promise.all([
+				probeRdap(candidate.domain),
 				candidate.hasA ? probeHasWebContent(candidate.domain) : Promise.resolve(true),
 			]);
 			const mxOnDisposable = candidate.mxExchanges.some(isDisposableMxHost);
-			map.set(candidate.domain, { registrationDays, mxOnDisposable, hasWebContent });
+			map.set(candidate.domain, {
+				registrationDays: rdap.registrationDays,
+				mxOnDisposable,
+				hasWebContent,
+				registrantOrg: rdap.registrantOrg,
+			});
 		}),
 	);
 	return map;
 }
 
+/** Result of the single lightweight RDAP probe per candidate. */
+interface RdapProbeResult {
+	/** Age in days since the RDAP `registration` event, or `null` on any failure / missing data. */
+	registrationDays: number | null;
+	/** Normalised RDAP registrant org, or `null` on any failure / missing data. */
+	registrantOrg: string | null;
+}
+
+/** Empty probe result — used for early-outs and the catch path (fail-soft). */
+const EMPTY_RDAP_PROBE: RdapProbeResult = { registrationDays: null, registrantOrg: null };
+
 /**
  * Lightweight RDAP lookup constrained for use inside the lookalike check.
  * Hits the hardcoded {@link FALLBACK_RDAP_SERVERS} map only (no IANA bootstrap),
- * single fetch, hard 2.5s timeout, no retries. Returns the age in days since
- * the `registration` event, or `null` on any failure / missing data — which the
- * calibrator treats as "unknown, not recent" so a single absent signal never
- * elevates severity.
+ * single fetch, hard 2.5s timeout, no retries. From that single response it
+ * derives BOTH the registration age (issue #264 corroborator) AND the registrant
+ * org (issue #263 same-entity correlation) — no extra fetch for the org signal.
+ * Any failure / missing data yields `null` for the affected field, which the
+ * calibrator treats as "unknown" (never elevates severity) and the same-entity
+ * check treats as "no match" (never suppresses a real threat).
  */
-async function probeRegistrationDays(domain: string): Promise<number | null> {
+async function probeRdap(domain: string): Promise<RdapProbeResult> {
 	const labels = domain.split('.');
 	const tld = labels[labels.length - 1]?.toLowerCase();
-	if (!tld) return null;
+	if (!tld) return EMPTY_RDAP_PROBE;
 	const serverUrl = FALLBACK_RDAP_SERVERS[tld];
-	if (!serverUrl) return null;
+	if (!serverUrl) return EMPTY_RDAP_PROBE;
 	try {
 		const baseUrl = serverUrl.endsWith('/') ? serverUrl : `${serverUrl}/`;
 		const rdapUrl = `${baseUrl}domain/${domain}`;
@@ -526,16 +647,28 @@ async function probeRegistrationDays(domain: string): Promise<number | null> {
 			signal: AbortSignal.timeout(RDAP_PROBE_TIMEOUT_MS),
 			headers: { Accept: 'application/rdap+json, application/json' },
 		});
-		if (!resp.ok) return null;
+		if (!resp.ok) return EMPTY_RDAP_PROBE;
 		const data = (await resp.json()) as { events?: Array<{ eventAction?: string; eventDate?: string }> };
 		const registration = Array.isArray(data.events) ? data.events.find((e) => e.eventAction === 'registration') : undefined;
-		if (!registration?.eventDate) return null;
-		const creationTime = new Date(registration.eventDate).getTime();
-		if (!Number.isFinite(creationTime)) return null;
-		return Math.floor((Date.now() - creationTime) / (1000 * 60 * 60 * 24));
+		let registrationDays: number | null = null;
+		if (registration?.eventDate) {
+			const creationTime = new Date(registration.eventDate).getTime();
+			if (Number.isFinite(creationTime)) {
+				registrationDays = Math.floor((Date.now() - creationTime) / (1000 * 60 * 60 * 24));
+			}
+		}
+		return { registrationDays, registrantOrg: extractRegistrantOrg(data) };
 	} catch {
-		return null;
+		return EMPTY_RDAP_PROBE;
 	}
+}
+
+/**
+ * Fetch the scan domain's normalised RDAP registrant org for same-entity
+ * correlation (issue #263). Reuses {@link probeRdap}; fail-soft `null`.
+ */
+async function probePrimaryRegistrantOrg(domain: string): Promise<string | null> {
+	return (await probeRdap(domain)).registrantOrg;
 }
 
 /**

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -237,6 +237,38 @@ function extractVcardName(entity: RdapEntity): string | null {
 	return null;
 }
 
+/**
+ * Extract the registrant organisation from a parsed RDAP domain response and
+ * normalise it for cross-domain equality comparison (lowercase, collapsed
+ * whitespace). Returns `null` when there's no registrant entity or no usable
+ * name/org field. Exported so the lookalike check can reuse the exact same
+ * entity-parsing logic for same-entity (shared-registrant) detection without
+ * duplicating the vCard traversal.
+ *
+ * Accepts `unknown` so callers parsing a lightweight RDAP fetch (no shared
+ * type) can pass the raw JSON; non-conforming shapes fall through to `null`.
+ */
+export function extractRegistrantOrg(rdapData: unknown): string | null {
+	if (typeof rdapData !== 'object' || rdapData === null) return null;
+	const entities = (rdapData as { entities?: unknown }).entities;
+	if (!Array.isArray(entities)) return null;
+	const registrant = findEntityByRole(entities as RdapEntity[], 'registrant');
+	if (!registrant) return null;
+	const raw = extractVcardName(registrant);
+	return normalizeRegistrantOrg(raw);
+}
+
+/**
+ * Normalise a registrant org string for equality comparison: trim, lowercase,
+ * and collapse internal whitespace. Returns `null` for empty / whitespace-only
+ * input. Exported for direct unit testing of the comparison contract.
+ */
+export function normalizeRegistrantOrg(value: string | null | undefined): string | null {
+	if (typeof value !== 'string') return null;
+	const normalized = value.trim().toLowerCase().replace(/\s+/g, ' ');
+	return normalized.length > 0 ? normalized : null;
+}
+
 /** Extract country from a vCard adr property. */
 function extractVcardCountry(entity: RdapEntity): string | null {
 	if (!entity.vcardArray || entity.vcardArray[0] !== 'vcard') return null;
@@ -256,7 +288,7 @@ function extractVcardCountry(entity: RdapEntity): string | null {
 }
 
 /** Find an entity with the given role. Searches top-level and nested entities. */
-function findEntityByRole(entities: RdapEntity[] | undefined, role: string): RdapEntity | null {
+export function findEntityByRole(entities: RdapEntity[] | undefined, role: string): RdapEntity | null {
 	if (!Array.isArray(entities)) return null;
 	for (const entity of entities) {
 		if (Array.isArray(entity.roles) && entity.roles.includes(role)) {

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -30,7 +30,7 @@ import {
 	type ScanTelemetry,
 } from '../lib/adaptive-weights';
 import { applyInteractionPenalties, type InteractionEffect } from '../lib/category-interactions';
-import { cacheGet, cacheSet, runWithCache } from '../lib/cache';
+import { buildCheckCacheKey, buildScanCacheKey, cacheGet, cacheSet, runWithCache } from '../lib/cache';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { checkSpf } from './check-spf';
 import { checkDmarc } from './check-dmarc';
@@ -62,9 +62,6 @@ export { formatScanReport, buildStructuredScanResult } from './scan/format-repor
 export type { StructuredScanResult, ScanResultEnrichment } from './scan/format-report';
 export type { MaturityStage } from './scan/maturity-staging';
 export type { ScanRuntimeOptions } from './scan/post-processing';
-
-/** Cache key prefix for scan and per-check results */
-const CACHE_PREFIX = 'cache:';
 
 /** In-memory cache for adaptive weight responses from the ProfileAccumulator DO. */
 const adaptiveWeightCache = new Map<string, { weights: AdaptiveWeightsResponse; expires: number }>();
@@ -213,9 +210,8 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 	const timeoutBudget = resolveScanTimeoutBudget(runtimeOptions);
 	const explicitProfile = runtimeOptions?.profile;
 	const isExplicit = explicitProfile && explicitProfile !== 'auto';
-	const cacheKey = isExplicit
-		? `${CACHE_PREFIX}${domain}:profile:${explicitProfile}`
-		: `${CACHE_PREFIX}${domain}`;
+	// Versioned (cache:v<version>:...) so a deploy auto-invalidates — see buildScanCacheKey.
+	const cacheKey = isExplicit ? buildScanCacheKey(domain, explicitProfile) : buildScanCacheKey(domain);
 
 	// Check cache first (skip when force_refresh is requested)
 	if (!runtimeOptions?.forceRefresh) {
@@ -676,7 +672,7 @@ async function runCachedCheck(
 	ttlSeconds?: number,
 	skipCache?: boolean,
 ): Promise<CheckResult> {
-	return runWithCache(`${CACHE_PREFIX}${domain}:check:${category}`, run, kv, ttlSeconds, skipCache);
+	return runWithCache(buildCheckCacheKey(domain, category), run, kv, ttlSeconds, skipCache);
 }
 
 /**

--- a/test/cache-key-version.spec.ts
+++ b/test/cache-key-version.spec.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// Regression coverage for the "stale-after-deploy" cache bug: scan/check
+// results were keyed by domain only, so a deploy kept serving pre-deploy
+// results until the TTL expired. The fix threads SERVER_VERSION into every
+// scan/check cache key so a version bump auto-invalidates the cache.
+
+import { describe, it, expect } from 'vitest';
+import { buildCheckCacheKey, buildScanCacheKey } from '../src/lib/cache';
+import { SERVER_VERSION } from '../src/lib/server-version';
+
+describe('buildCheckCacheKey', () => {
+	it('includes the server version', () => {
+		const key = buildCheckCacheKey('example.com', 'mx');
+		expect(key).toContain(`v${SERVER_VERSION}`);
+	});
+
+	it('produces the canonical cache:v<version>:<domain>:check:<name> shape', () => {
+		expect(buildCheckCacheKey('example.com', 'mx')).toBe(`cache:v${SERVER_VERSION}:example.com:check:mx`);
+	});
+
+	it('changes when the version changes', () => {
+		const a = buildCheckCacheKey('example.com', 'mx', '1.0.0');
+		const b = buildCheckCacheKey('example.com', 'mx', '1.0.1');
+		expect(a).not.toBe(b);
+		expect(a).toContain('v1.0.0');
+		expect(b).toContain('v1.0.1');
+	});
+});
+
+describe('buildScanCacheKey', () => {
+	it('includes the server version', () => {
+		const key = buildScanCacheKey('example.com');
+		expect(key).toContain(`v${SERVER_VERSION}`);
+	});
+
+	it('produces the canonical cache:v<version>:<domain> shape for the default profile', () => {
+		expect(buildScanCacheKey('example.com')).toBe(`cache:v${SERVER_VERSION}:example.com`);
+	});
+
+	it('appends an explicit profile when provided', () => {
+		expect(buildScanCacheKey('example.com', 'api_heavy')).toBe(`cache:v${SERVER_VERSION}:example.com:profile:api_heavy`);
+	});
+
+	it('changes when the version changes', () => {
+		const a = buildScanCacheKey('example.com', undefined, '1.0.0');
+		const b = buildScanCacheKey('example.com', undefined, '1.0.1');
+		expect(a).not.toBe(b);
+	});
+});

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -622,4 +622,92 @@ describe('checkHttpSecurity — dual-fetch header union', () => {
 			expect(cdnFinding((await run()).findings)).toBe('Akamai');
 		});
 	});
+
+	describe('CDN attribution across a redirect chain (intermediate-hop signals)', () => {
+		// A "well-configured" header set so the CDN annotation finding fires on the
+		// final analyzed response (annotation is suppressed for unanalyzable responses).
+		function wellConfigured(extra: Record<string, string>): Headers {
+			return new Headers({
+				'content-security-policy': "default-src 'self'; frame-ancestors 'none'",
+				'x-frame-options': 'DENY',
+				'x-content-type-options': 'nosniff',
+				'permissions-policy': 'camera=()',
+				'referrer-policy': 'no-referrer',
+				'cross-origin-resource-policy': 'same-origin',
+				'cross-origin-opener-policy': 'same-origin',
+				'cross-origin-embedder-policy': 'require-corp',
+				...extra,
+			});
+		}
+
+		function cdnFinding(findings: Array<{ metadata?: Record<string, unknown> }>): string | null {
+			const f = findings.find((x) => typeof x.metadata?.cdnProvider === 'string');
+			return f ? (f.metadata!.cdnProvider as string) : null;
+		}
+
+		/**
+		 * Route the mock by URL: a 301 redirect from the apex to a sub-host that
+		 * serves the (possibly CDN-fronted) final 200. `hops` maps URL → headers.
+		 * Any URL not in the map gets the final 200.
+		 */
+		function mockChain(intermediateHeaders: Record<string, string>, finalHeaders: Record<string, string>) {
+			globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+				if (url === 'https://example.com') {
+					return Promise.resolve({
+						ok: false,
+						status: 301,
+						type: 'basic',
+						url: 'https://example.com',
+						headers: new Headers({ location: 'https://cdn.example.com/', ...intermediateHeaders }),
+					});
+				}
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					type: 'basic',
+					url: 'https://cdn.example.com/',
+					headers: wellConfigured(finalHeaders),
+				});
+			});
+		}
+
+		it('detects CloudFront when only an INTERMEDIATE hop carries x-amz-cf-id', async () => {
+			// Final hop has no CDN signal; the intermediate redirect carries it.
+			mockChain({ 'x-amz-cf-id': 'abc123==' }, {});
+			const result = await run();
+			expect(cdnFinding(result.findings)).toBe('CloudFront');
+		});
+
+		it('detects CloudFront when only an INTERMEDIATE hop carries via: ...cloudfront.net', async () => {
+			mockChain({ via: '1.1 a1b2c3.cloudfront.net (CloudFront)' }, {});
+			const result = await run();
+			expect(cdnFinding(result.findings)).toBe('CloudFront');
+		});
+
+		it('still detects CloudFront when only the FINAL hop carries the header (no regression)', async () => {
+			mockChain({}, { 'x-amz-cf-id': 'final==' });
+			const result = await run();
+			expect(cdnFinding(result.findings)).toBe('CloudFront');
+		});
+
+		it('returns null when NO hop carries any CDN header (no false positive)', async () => {
+			mockChain({ server: 'AkamaiGHost' }, { server: 'nginx' });
+			const result = await run();
+			expect(cdnFinding(result.findings)).toBeNull();
+		});
+
+		it('does NOT attribute Cloudflare from server: cloudflare on an intermediate hop (v3.3.12 invariant)', async () => {
+			// server is rewritten to `cloudflare` by CF Worker egress on every hop —
+			// it must never be carried forward as a CF detection signal.
+			mockChain({ server: 'cloudflare', 'cf-ray': '8aabcdef1234-AKL' }, { server: 'cloudflare', 'cf-ray': '8aabcdef1234-AKL' });
+			const result = await run();
+			expect(cdnFinding(result.findings)).toBeNull();
+		});
+
+		it('attributes Akamai from x-akamai-transformed on an intermediate hop', async () => {
+			mockChain({ 'x-akamai-transformed': '9 - 0 pmb=mTOE,2' }, {});
+			const result = await run();
+			expect(cdnFinding(result.findings)).toBe('Akamai');
+		});
+	});
 });

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -802,3 +802,184 @@ describe('checkLookalikes - issue #264 severity calibration wiring', () => {
 		expect(tstFinding!.severity).toBe('medium');
 	});
 });
+
+describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation', () => {
+	async function run(domain = 'example.com') {
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		return checkLookalikes(domain);
+	}
+
+	/** Build an RDAP domain response carrying a registrant entity with the given org via a vCard `org` property. */
+	function rdapWithRegistrant(org: string | null, registrationDaysAgo: number | null = 1500) {
+		const events =
+			registrationDaysAgo == null
+				? []
+				: [{ eventAction: 'registration', eventDate: new Date(Date.now() - registrationDaysAgo * 24 * 60 * 60 * 1000).toISOString() }];
+		const entities =
+			org == null
+				? []
+				: [
+						{
+							objectClassName: 'entity',
+							roles: ['registrant'],
+							vcardArray: ['vcard', [['version', {}, 'text', '4.0'], ['org', {}, 'text', org]]],
+						},
+				  ];
+		return { events, entities };
+	}
+
+	/**
+	 * Mock that serves DoH probes for one lookalike (NS/A/MX, DIFFERENT NS from
+	 * the primary so the shared-NS pass does NOT short-circuit), the primary
+	 * domain's NS, and RDAP responses for BOTH the lookalike and the primary.
+	 * Registrant orgs are injected per-domain so the same-entity correlation can
+	 * be exercised. HEAD probes default to ok (hasWebContent=true).
+	 */
+	function mockSameEntity(opts: {
+		lookalike: string;
+		lookalikeRdap: ReturnType<typeof rdapWithRegistrant> | { fail: true };
+		primaryRdap: ReturnType<typeof rdapWithRegistrant>;
+	}) {
+		const { lookalike, lookalikeRdap, primaryRdap } = opts;
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+			// DoH queries
+			if (url.includes('cloudflare-dns.com')) {
+				const { name, type } = parseDohQuery(input);
+				if (name === 'test.com' && (type === 'NS' || type === '2')) {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+				}
+				if (name === lookalike) {
+					if (type === 'NS' || type === '2') {
+						// DIFFERENT NS provider — shared-NS pass must NOT fire (forces the RDAP path).
+						return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.other-dns.com.' }]));
+					}
+					if (type === 'MX' || type === '15') {
+						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.example.com.' }]));
+					}
+					if (type === 'A' || type === '1') {
+						return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
+					}
+				}
+				return Promise.resolve(createDohResponse([], []));
+			}
+
+			// RDAP for the lookalike
+			if (url.includes('rdap') && url.includes(`/domain/${lookalike}`)) {
+				if ('fail' in lookalikeRdap) {
+					return Promise.resolve({ ok: false, status: 503, json: () => Promise.resolve({}) } as unknown as Response);
+				}
+				return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(lookalikeRdap) } as unknown as Response);
+			}
+			// RDAP for the primary domain
+			if (url.includes('rdap') && url.includes('/domain/test.com')) {
+				return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(primaryRdap) } as unknown as Response);
+			}
+
+			// HEAD probe — reachable web content (fail-soft true)
+			if (url.startsWith('https://') || url.startsWith('http://')) {
+				return Promise.resolve({ ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve(''), json: () => Promise.resolve({}) } as unknown as Response);
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+	}
+
+	it('downgrades a mail-infra lookalike to info when its RDAP registrant org matches the scan domain (the xero.co.nz case)', async () => {
+		// Models a vendor whose regional subsidiary uses a different DNS provider
+		// (so shared-NS misses it) but shares the registrant org in RDAP.
+		mockSameEntity({
+			lookalike: 'tst.com',
+			lookalikeRdap: rdapWithRegistrant('<Vendor> Limited'),
+			primaryRdap: rdapWithRegistrant('<Vendor> Limited'),
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeDefined();
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.title).toContain('likely owned by same entity');
+		expect(tstFinding!.detail).toContain('registrant organisation');
+		expect(tstFinding!.metadata?.sharedRegistrantOrg).toBe('<vendor> limited');
+		// And it must NOT contribute to the HIGH summary.
+		const summary = result.findings.find((f) => /mail capability detected/i.test(f.title));
+		expect(summary).toBeUndefined();
+	});
+
+	it('keeps the calibrated threat severity when the registrant org differs (real third-party lookalike preserved)', async () => {
+		mockSameEntity({
+			lookalike: 'tst.com',
+			lookalikeRdap: rdapWithRegistrant('Phishing Co', 30), // recent reg + mail-infra → HIGH
+			primaryRdap: rdapWithRegistrant('<Vendor> Limited'),
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeDefined();
+		expect(tstFinding!.severity).toBe('high');
+		expect(tstFinding!.title).not.toContain('likely owned by same entity');
+		expect(tstFinding!.title).toContain('mail infrastructure');
+	});
+
+	it('falls back to the threat severity when RDAP fails for the lookalike (fail-soft, never suppresses)', async () => {
+		mockSameEntity({
+			lookalike: 'tst.com',
+			lookalikeRdap: { fail: true }, // RDAP unavailable → registrantOrg unknown
+			primaryRdap: rdapWithRegistrant('<Vendor> Limited'),
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeDefined();
+		// Mail-infra, no corroborator, RDAP age unknown → MEDIUM (issue #264 default). NOT downgraded to info.
+		expect(tstFinding!.severity).toBe('medium');
+		expect(tstFinding!.title).not.toContain('likely owned by same entity');
+	});
+
+	it('detects a shared-NS same-entity lookalike WITHOUT issuing any RDAP fetch (cheap path preserved)', async () => {
+		const sharedNs = 'ns1.shared-dns.com.';
+		const rdapCalls: string[] = [];
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('rdap')) rdapCalls.push(url);
+			if (url.includes('cloudflare-dns.com')) {
+				const { name, type } = parseDohQuery(input);
+				if (name === 'test.com' && (type === 'NS' || type === '2')) {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: sharedNs }]));
+				}
+				if (name === 'tst.com') {
+					if (type === 'NS' || type === '2') {
+						return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: sharedNs }]));
+					}
+					if (type === 'MX' || type === '15') {
+						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.tst.com.' }]));
+					}
+					if (type === 'A' || type === '1') {
+						return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
+					}
+				}
+				return Promise.resolve(createDohResponse([], []));
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeDefined();
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.title).toContain('likely owned by same entity');
+		expect(tstFinding!.detail).toContain('shares nameservers');
+		// The cheaper shared-NS path must short-circuit BEFORE any RDAP call.
+		expect(rdapCalls.length).toBe(0);
+	});
+
+	it('matches the registrant org case-insensitively and whitespace-normalized', async () => {
+		mockSameEntity({
+			lookalike: 'tst.com',
+			lookalikeRdap: rdapWithRegistrant('  XERO   LIMITED  '),
+			primaryRdap: rdapWithRegistrant('xero limited'),
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeDefined();
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.title).toContain('likely owned by same entity');
+		expect(tstFinding!.metadata?.sharedRegistrantOrg).toBe('xero limited');
+	});
+});

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { env } from 'cloudflare:test';
 import { setupFetchMock, createDohResponse, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse } from './helpers/dns-mock';
-import { IN_MEMORY_CACHE } from '../src/lib/cache';
+import { IN_MEMORY_CACHE, buildScanCacheKey } from '../src/lib/cache';
 import type { ScanDomainResult } from '../src/tools/scan-domain';
 
 const { restore } = setupFetchMock();
@@ -762,7 +762,7 @@ describe('scanDomain force_refresh', () => {
 		expect(first.cached).toBe(false);
 
 		// Clear only the top-level scan cache so we re-enter orchestration
-		IN_MEMORY_CACHE.delete('cache:force-refresh.com');
+		IN_MEMORY_CACHE.delete(buildScanCacheKey('force-refresh.com'));
 
 		// Record how many fetch calls were made so far
 		const fetchCountBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
@@ -774,7 +774,7 @@ describe('scanDomain force_refresh', () => {
 		const normalFetchCount = fetchCountAfterNormal - fetchCountBefore;
 
 		// Clear top-level again for force_refresh test
-		IN_MEMORY_CACHE.delete('cache:force-refresh.com');
+		IN_MEMORY_CACHE.delete(buildScanCacheKey('force-refresh.com'));
 
 		// With force_refresh=true, per-check caches MUST be bypassed — all checks should re-execute
 		const third = await scanDomain('force-refresh.com', undefined, { forceRefresh: true });
@@ -797,7 +797,7 @@ describe('scanDomain force_refresh', () => {
 
 		// Clear only the top-level scan cache key so scanDomain re-enters orchestration,
 		// but per-check caches remain populated
-		IN_MEMORY_CACHE.delete('cache:normal-cache.com');
+		IN_MEMORY_CACHE.delete(buildScanCacheKey('normal-cache.com'));
 
 		// Second scan without forceRefresh should use per-check caches (no DNS queries)
 		const fetchBefore = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.length;
@@ -934,7 +934,7 @@ describe('scanDomain deferred cache write (Fix 3)', () => {
 		expect(result.cached).toBe(false);
 
 		// The in-memory cache should have the result after return
-		const cached = IN_MEMORY_CACHE.get('cache:sync-cache.com');
+		const cached = IN_MEMORY_CACHE.get(buildScanCacheKey('sync-cache.com'));
 		expect(cached).toBeDefined();
 	});
 });


### PR DESCRIPTION
Closes the remaining open issues from the 2026-05-28 fact-check work. Four independent fixes, integrated from parallel agent branches (SPF branch was de-contaminated — see note).

## 1. KV cache versioning (the systemic one)

`check_*` / `scan_domain` results cached by domain only — no version component, so deploys didn't bust stale results (the "scan a fresh domain to verify" workaround recurred all session). Extracted `buildCheckCacheKey` / `buildScanCacheKey` in `src/lib/cache.ts` that prepend `v${SERVER_VERSION}`; wired at all 4 cache-key sites (`handlers/tools.ts` ×2, `scan-domain.ts` ×2). Every deploy now auto-invalidates the check/scan cache. Documented trade-off: deploys cold-start the cache — correct behavior; stale-after-deploy was the bug.

## 2. SPF UDP-truncation flag (#250)

`check_spf` now estimates the full TXT RRset wire size and flags when it risks UDP truncation (TCP-fallback required; legacy resolvers may not retry → silently broken SPF). RFC 7208 §3.4. New `estimateTxtRrsetBytes()` in `spf-analysis.ts`: `sum(12 + utf8Len(rec) + ceil(utf8Len/255)) per record`. >450 bytes → low `SPF_RRSET_LARGE`; >512 → medium. Reuses the already-fetched full TXT array (no new query).

## 3. CloudFront redirect-chain detection (#262)

CDN detection now unions vendor-specific CDN headers across ALL redirect hops (not just the final response), so `x-amz-cf-id` / `via:cloudfront` on an intermediate hop is caught. `MAX_REDIRECT_HOPS` 3→5. **The `server` header is explicitly excluded from the carried set** (v3.3.12 invariant — CF Worker egress rewrites it; a dedicated test asserts an intermediate `server: cloudflare` still yields null).

## 4. Lookalike entity-correlation (#263, focused)

`check_lookalikes` now uses shared RDAP-registrant-org as a second same-entity signal (the first, shared-NS, missed cases like xero.co.nz where the subsidiary uses a different DNS provider). Matching registrant org → downgrade from threat to `info` "likely same-entity defensive registration". Net cost: ONE extra RDAP fetch (the scan domain's), only when ≥1 candidate reaches medium/high; candidate orgs ride the existing enrichment fetch. Fail-soft (RDAP failure → keep threat severity, never suppress a real threat). Cert/DKIM signals deferred.

## Tests — 154 across the 4 affected areas

- cache-key-version: 7 (+ scan-domain updated to use the helper)
- check-spf (package): truncation thresholds + wire-size estimator units
- check-http-security: 6 new (intermediate-hop CDN headers, server-exclusion invariant) — 42 total
- check-lookalikes: 5 new (registrant match → info, different-org preserved, fail-soft, shared-NS no-RDAP, case-insensitive) — 34 total

154/154 affected pass; typecheck + lint clean.

## Note on integration

Four agents ran in parallel in a shared worktree (isolation collided). The SPF branch accidentally swept in a stale copy of cluster 4's lookalike WIP — excluded by cherry-picking only the 4 SPF package files. The clean lookalike work came from its own branch. Final diff verified: exactly the 14 intended files, no contamination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)