### PR TITLE
feat(supply-chain): provider signal attribution — MX, web CDN (#283), cloud-hosting tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.22] - 2026-05-28
+
+### Added
+
+- **`map_supply_chain`: email-RECEIVING providers from MX.** The tool passed `mxHosts: []` to `detectProviders`, so the MX operator that receives all inbound mail — one of the most material third-party dependencies — was invisible. MX is now queried and attributed via a new `matchProviderForMxHost` (mirrors the SPF/NS match helpers, shared `DETECTION_RULES` SSOT); unrecognized exchanges collapse to their registrable parent (skipping self-hosted), via a new `addUnrecognizedHostsByParent` helper that also de-dups the NS path. New source `mx` → role `email-receiving`, trust `critical`. (#283)
+- **`map_supply_chain`: web CDN attributed as a dependency (#283).** The CDN fronting the primary web property (detected elsewhere as `scan.cdnProvider`) was never joined into the dependency map, so a domain's entire web edge — e.g. AWS CloudFront fronting kiwibank.co.nz — was invisible. The tool now attributes it as a `critical` dependency via the shared, bounded, fail-soft `detectCdnFromAsn` (apex A-record → origin ASN; DoH-only, no HTTP probe — keeps the standalone tool probe-light). An optional `precomputedCdn` option lets a future scan-integration caller pass the richer header-derived value and skip the ASN lookup; header-based attribution stays exclusively in the scan path. Closes #283. (#283)
+- **`map_supply_chain`: low-trust cloud-hosting ASN tier (noise-guarded).** New `ASN_TO_HOSTING` map (AWS/GCP/Azure/OVH/DigitalOcean/Hetzner/Vultr) + `mapAsnToHosting` + `detectHostingFromAsn`, kept strictly distinct from the CDN tier (cloud ASNs host arbitrary compute and must never drive CDN attribution — AS16509 stays out of `ASN_TO_CDN`). A cloud-hosting dependency is attributed **only when no CDN fronts the origin** (the CDN is the meaningful edge dependency; the origin host behind it is shared infra), emitted at **`low`** trust with a `shared_hosting` caveat signal so every EC2-hosted site doesn't get a critical AWS row. `detectCdnFromAsn`/`detectHostingFromAsn` now share a private `detectFromAsn(ips, doh, map)` skeleton. (#283)
+
+### Fixed
+
+- **Stale comment in `check-http-security.ts`.** The Cloudflare-detection docblock claimed "True CF customers now go undetected" — outdated since the v3.3.20 ASN tier closes the CF case (apex A-record → AS13335 → "Cloudflare", immune to the `server:` rewrite; verified live on discord.com / 1password.com). Comment corrected to point at the ASN tier; no behavior change. (#283)
+
 ## [3.3.21] - 2026-05-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.21",
+	"version": "3.3.22",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1130,7 +1130,7 @@ export async function handleToolsCall(
 					return buildToolResult(formatValidateFix(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'map_supply_chain': {
-					const result = await mapSupplyChain(validDomain, buildDnsOptions(runtimeOptions));
+					const result = await mapSupplyChain(validDomain, { dnsOptions: buildDnsOptions(runtimeOptions) });
 					logResult = `${result.summary.totalProviders} providers`;
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });

--- a/src/lib/cdn-asn-detection.ts
+++ b/src/lib/cdn-asn-detection.ts
@@ -61,6 +61,30 @@ export const ASN_TO_CDN: ReadonlyMap<number, string> = new Map([
 	// AS16509 (AWS) deliberately excluded — not CDN-exclusive; CloudFront caught by x-amz-cf-id header.
 ]);
 
+/**
+ * Cloud-HOSTING (compute/IaaS) origin ASNs -> canonical provider name.
+ *
+ * Distinct from ASN_TO_CDN on purpose. These ASNs (AWS/GCP/Azure/…) are NOT
+ * CDN-exclusive — they host arbitrary compute — so they must NEVER feed CDN
+ * attribution (that's why AS16509 is absent from ASN_TO_CDN). They are useful
+ * only as a LOW-confidence "where is the origin hosted" supply-chain signal,
+ * and only when no CDN fronts the origin. CDN-exclusive ASNs (Cloudflare,
+ * Akamai, Fastly, …) are intentionally absent here — they belong to the CDN
+ * tier, not the hosting tier.
+ */
+export const ASN_TO_HOSTING: ReadonlyMap<number, string> = new Map([
+	[16509, 'AWS'],
+	[14618, 'AWS'],
+	[15169, 'GCP'],
+	[396982, 'GCP'],
+	[8075, 'Azure'],
+	[8068, 'Azure'],
+	[16276, 'OVH'],
+	[14061, 'DigitalOcean'],
+	[24940, 'Hetzner'],
+	[20473, 'Vultr'],
+]);
+
 /** Bound on outbound team-cymru queries per detection run. */
 const MAX_ASN_LOOKUPS = 3;
 
@@ -105,20 +129,29 @@ export function mapAsnToCdn(asn: number): string | null {
 	return ASN_TO_CDN.get(asn) ?? null;
 }
 
+/** Map an origin ASN to its canonical cloud-hosting provider name, or null if not a known host. */
+export function mapAsnToHosting(asn: number): string | null {
+	return ASN_TO_HOSTING.get(asn) ?? null;
+}
+
 /**
- * Attribute a CDN provider by resolving up to MAX_ASN_LOOKUPS A-record IPs to
- * their origin ASN and mapping ASN -> CDN. Short-circuits on the first CDN
- * match. Fail-soft: any DoH error or unparseable answer falls through to the
- * next IP; returns null when no IP maps to a known CDN ASN.
+ * Resolve up to MAX_ASN_LOOKUPS A-record IPs to their origin ASN and map each
+ * against `asnMap`. Short-circuits on the first match. Fail-soft: any DoH error
+ * or unparseable answer falls through to the next IP; returns null when no IP
+ * maps to an entry in `asnMap`.
  */
-export async function detectCdnFromAsn(aRecords: string[], doh: AsnDohResolver): Promise<AsnCdnResult | null> {
+async function detectFromAsn(
+	aRecords: string[],
+	doh: AsnDohResolver,
+	asnMap: ReadonlyMap<number, string>,
+): Promise<AsnCdnResult | null> {
 	for (const ip of aRecords.slice(0, MAX_ASN_LOOKUPS)) {
 		const reversed = ip.split('.').reverse().join('.');
 		try {
 			const answers = await doh.queryTxt(`${reversed}.${CYMRU_ORIGIN_ZONE}`);
 			const asn = answers.length > 0 ? parseAsnFromCymru(answers[0]) : null;
 			if (asn !== null) {
-				const provider = mapAsnToCdn(asn);
+				const provider = asnMap.get(asn) ?? null;
 				if (provider) return { provider, confidence: 'heuristic', asn };
 			}
 		} catch {
@@ -126,4 +159,23 @@ export async function detectCdnFromAsn(aRecords: string[], doh: AsnDohResolver):
 		}
 	}
 	return null;
+}
+
+/**
+ * Attribute a CDN provider by resolving A-record IPs to their origin ASN and
+ * mapping ASN -> CDN (CDN-exclusive ASNs only). Bounded, short-circuiting,
+ * fail-soft. Returns null when no IP maps to a known CDN ASN.
+ */
+export function detectCdnFromAsn(aRecords: string[], doh: AsnDohResolver): Promise<AsnCdnResult | null> {
+	return detectFromAsn(aRecords, doh, ASN_TO_CDN);
+}
+
+/**
+ * Attribute a cloud-HOSTING provider (AWS/GCP/Azure/…) the same way. Intended
+ * as a LOW-confidence supply-chain signal used only when no CDN fronts the
+ * origin — callers must apply that guard (a CDN is the meaningful edge
+ * dependency; the origin host behind it is shared infrastructure).
+ */
+export function detectHostingFromAsn(aRecords: string[], doh: AsnDohResolver): Promise<AsnCdnResult | null> {
+	return detectFromAsn(aRecords, doh, ASN_TO_HOSTING);
 }

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -144,15 +144,18 @@ function detectCdnProvider(headers: Headers): string | null {
 	// (origin: `server: github.com`). `cf-ray` is added for tracing and
 	// `cf-cache-status: DYNAMIC` is added by CF's edge cache layer. None of
 	// these signals can distinguish "origin is on CF" from "response transited
-	// CF's edge". True CF customers (cloudflare.com, sites behind Cloudflare
-	// CDN/WAF) now go undetected — acceptable, because false-negative is
-	// strictly better than the 100% false-positive rate we had pre-fix. The
+	// CF's edge", so this function returns null for Cloudflare. The
 	// vendor-specific rules above (Imperva, Sucuri, Vercel, CloudFront,
 	// Akamai, Fastly) still work because they use origin-set headers that
-	// CF cannot impersonate. A future revision could add CF detection via
-	// IP-range matching against Cloudflare's published edge ranges (see
-	// cloudflare.com/ips/) — but that's a separate code path requiring DNS
-	// A-record lookups, not header inspection.
+	// CF cannot impersonate.
+	//
+	// NOTE: Cloudflare customers are NOT undetected overall — the header path
+	// just abstains. The scan-level CDN attribution closes the CF case via the
+	// ASN tier (`src/lib/cdn-asn-detection.ts`, v3.3.20): the apex A-record
+	// resolves to AS13335 → "Cloudflare", origin-set and immune to the
+	// `server:` rewrite. Verified live (discord.com, 1password.com →
+	// "Cloudflare"). That is the IP-range/ASN path foreshadowed here; it lives
+	// in the post-processing CDN tier, not in this header function.
 	return null;
 }
 

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -12,6 +12,7 @@ import type { QueryDnsOptions } from '../lib/dns-types';
 import { queryTxtRecords, queryDnsRecords, querySrvRecords, queryMxRecords } from '../lib/dns';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import { detectProviders, matchProviderForNsHost, matchProviderForSpfInclude, matchProviderForMxHost } from './provider-guides';
+import { detectCdnFromAsn } from '../lib/cdn-asn-detection';
 import { VERIFICATION_PATTERNS, SERVICE_SPF_DOMAINS } from './txt-hygiene-analysis';
 import { SRV_PREFIXES } from './srv-analysis';
 import type { SrvProbeResult } from './srv-analysis';
@@ -85,6 +86,8 @@ function determineTrustLevel(sources: string[]): TrustLevel {
 	if (sources.some((s) => s === 'spf')) return 'critical';
 	// MX = critical (they receive all your inbound mail)
 	if (sources.some((s) => s === 'mx')) return 'critical';
+	// CDN = critical (they front and can see/serve all your web traffic)
+	if (sources.some((s) => s === 'cdn')) return 'critical';
 	// NS = high (they control your DNS)
 	if (sources.some((s) => s === 'ns')) return 'high';
 	// SRV = medium (advertised service)
@@ -103,6 +106,8 @@ function sourceToRole(source: string): string {
 			return 'email-sending';
 		case 'mx':
 			return 'email-receiving';
+		case 'cdn':
+			return 'cdn';
 		case 'ns':
 			return 'dns-hosting';
 		case 'caa':
@@ -204,13 +209,14 @@ export async function mapSupplyChain(
 	domain: string,
 	options: MapSupplyChainOptions = {},
 ): Promise<SupplyChainMap> {
-	const { dnsOptions } = options;
+	const { dnsOptions, precomputedCdn } = options;
 	// Query all record types in parallel — allSettled so one failure doesn't block others
-	const [txtSettled, nsSettled, caaSettled, mxSettled, srvBatchSettled] = await Promise.allSettled([
+	const [txtSettled, nsSettled, caaSettled, mxSettled, aSettled, srvBatchSettled] = await Promise.allSettled([
 		queryTxtRecords(domain, dnsOptions),
 		queryDnsRecords(domain, 'NS', dnsOptions),
 		queryDnsRecords(domain, 'CAA', dnsOptions),
 		queryMxRecords(domain, dnsOptions),
+		queryDnsRecords(domain, 'A', dnsOptions),
 		Promise.allSettled(
 			SRV_PREFIXES.map(async (prefix) => {
 				const name = `${prefix}.${domain}`;
@@ -244,6 +250,9 @@ export async function mapSupplyChain(
 	// Extract MX exchange hosts (email-receiving providers)
 	const rawMxRecords = mxSettled.status === 'fulfilled' ? mxSettled.value : [];
 	const mxHosts = rawMxRecords.map((r) => r.exchange.replace(/\.$/, '').toLowerCase());
+
+	// Apex A-records for the ASN-based CDN tier (resolved to origin ASN below)
+	const aRecords = aSettled.status === 'fulfilled' ? aSettled.value : [];
 
 	// Extract CAA issuers (only issue and issuewild tags)
 	const rawCaaRecords = caaSettled.status === 'fulfilled' ? caaSettled.value : [];
@@ -388,6 +397,23 @@ export async function mapSupplyChain(
 		}
 	}
 	addUnrecognizedHostsByParent(mxHosts, detectedMxHosts, 'mx');
+
+	// Attribute the web CDN as a (critical) dependency. The CDN fronting the
+	// primary web property is one of the most material third-party dependencies
+	// a domain has, yet it derives from a different signal than DNS records.
+	// Use the scan's precomputed header-derived value when available; otherwise
+	// resolve the apex A-records to their origin ASN via the shared, fail-soft,
+	// bounded ASN tier (DoH-only — keeps this standalone tool probe-light, no
+	// HTTP fetch). Header-based attribution stays exclusively in the scan path.
+	let cdnProvider: string | null = precomputedCdn ?? null;
+	if (cdnProvider === null && aRecords.length > 0) {
+		const asnResolver = { queryTxt: (name: string) => queryTxtRecords(name, dnsOptions) };
+		const asnResult = await detectCdnFromAsn(aRecords, asnResolver);
+		cdnProvider = asnResult?.provider ?? null;
+	}
+	if (cdnProvider !== null) {
+		addDependency(cdnProvider, 'cdn');
+	}
 
 	// Add CAA issuers
 	for (const issuer of caaIssuers) {

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -12,7 +12,7 @@ import type { QueryDnsOptions } from '../lib/dns-types';
 import { queryTxtRecords, queryDnsRecords, querySrvRecords, queryMxRecords } from '../lib/dns';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import { detectProviders, matchProviderForNsHost, matchProviderForSpfInclude, matchProviderForMxHost } from './provider-guides';
-import { detectCdnFromAsn } from '../lib/cdn-asn-detection';
+import { detectCdnFromAsn, detectHostingFromAsn } from '../lib/cdn-asn-detection';
 import { VERIFICATION_PATTERNS, SERVICE_SPF_DOMAINS } from './txt-hygiene-analysis';
 import { SRV_PREFIXES } from './srv-analysis';
 import type { SrvProbeResult } from './srv-analysis';
@@ -30,7 +30,7 @@ export interface Dependency {
 
 /** A risk signal detected in the supply chain. */
 export interface Signal {
-	type: 'concentration' | 'excessive_includes' | 'single_ns_provider' | 'stale_integration' | 'shadow_service' | 'insecure_service' | 'security_tooling_exposed';
+	type: 'concentration' | 'excessive_includes' | 'single_ns_provider' | 'stale_integration' | 'shadow_service' | 'insecure_service' | 'security_tooling_exposed' | 'shared_hosting';
 	severity: 'low' | 'medium' | 'high';
 	detail: string;
 }
@@ -90,6 +90,8 @@ function determineTrustLevel(sources: string[]): TrustLevel {
 	if (sources.some((s) => s === 'cdn')) return 'critical';
 	// NS = high (they control your DNS)
 	if (sources.some((s) => s === 'ns')) return 'high';
+	// Cloud hosting = low (shared infrastructure, inferred from origin ASN — see caveat signal)
+	if (sources.some((s) => s === 'hosting')) return 'low';
 	// SRV = medium (advertised service)
 	if (sources.some((s) => s === 'srv')) return 'medium';
 	// TXT verification = low (SaaS integration)
@@ -108,6 +110,8 @@ function sourceToRole(source: string): string {
 			return 'email-receiving';
 		case 'cdn':
 			return 'cdn';
+		case 'hosting':
+			return 'cloud-hosting';
 		case 'ns':
 			return 'dns-hosting';
 		case 'caa':
@@ -406,13 +410,26 @@ export async function mapSupplyChain(
 	// bounded ASN tier (DoH-only — keeps this standalone tool probe-light, no
 	// HTTP fetch). Header-based attribution stays exclusively in the scan path.
 	let cdnProvider: string | null = precomputedCdn ?? null;
+	// Cloud-hosting fallback (noise-guarded). Only attributed when NO CDN fronts
+	// the origin — "hosted on AWS/GCP/Azure" is near-ubiquitous and signal-less
+	// without corroboration, and when a CDN is present the CDN is the meaningful
+	// edge dependency, not the shared origin host. Emitted at LOW trust with a
+	// caveat signal (see below).
+	let hostingProvider: string | null = null;
 	if (cdnProvider === null && aRecords.length > 0) {
 		const asnResolver = { queryTxt: (name: string) => queryTxtRecords(name, dnsOptions) };
-		const asnResult = await detectCdnFromAsn(aRecords, asnResolver);
-		cdnProvider = asnResult?.provider ?? null;
+		const cdnResult = await detectCdnFromAsn(aRecords, asnResolver);
+		if (cdnResult !== null) {
+			cdnProvider = cdnResult.provider;
+		} else {
+			const hostingResult = await detectHostingFromAsn(aRecords, asnResolver);
+			hostingProvider = hostingResult?.provider ?? null;
+		}
 	}
 	if (cdnProvider !== null) {
 		addDependency(cdnProvider, 'cdn');
+	} else if (hostingProvider !== null) {
+		addDependency(hostingProvider, 'hosting');
 	}
 
 	// Add CAA issuers
@@ -459,6 +476,15 @@ export async function mapSupplyChain(
 
 	// Detect signals
 	const signals: Signal[] = [];
+
+	// Cloud-hosting caveat — keep the inferred-from-ASN hosting row honest.
+	if (hostingProvider !== null) {
+		signals.push({
+			type: 'shared_hosting',
+			severity: 'low',
+			detail: `Origin appears to be hosted on ${hostingProvider} (shared cloud infrastructure inferred from the origin ASN). Low-confidence signal — corroborate before treating it as a dedicated dependency.`,
+		});
+	}
 
 	// Concentration risk: provider appears in 3+ roles
 	for (const dep of dependencies) {

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -9,9 +9,9 @@
 
 import type { OutputFormat } from '../handlers/tool-args';
 import type { QueryDnsOptions } from '../lib/dns-types';
-import { queryTxtRecords, queryDnsRecords, querySrvRecords } from '../lib/dns';
+import { queryTxtRecords, queryDnsRecords, querySrvRecords, queryMxRecords } from '../lib/dns';
 import { sanitizeOutputText } from '../lib/output-sanitize';
-import { detectProviders, matchProviderForNsHost, matchProviderForSpfInclude } from './provider-guides';
+import { detectProviders, matchProviderForNsHost, matchProviderForSpfInclude, matchProviderForMxHost } from './provider-guides';
 import { VERIFICATION_PATTERNS, SERVICE_SPF_DOMAINS } from './txt-hygiene-analysis';
 import { SRV_PREFIXES } from './srv-analysis';
 import type { SrvProbeResult } from './srv-analysis';
@@ -83,6 +83,8 @@ function parseCaaIssuer(data: string): string | null {
 function determineTrustLevel(sources: string[]): TrustLevel {
 	// SPF includes = critical (they can send email as you)
 	if (sources.some((s) => s === 'spf')) return 'critical';
+	// MX = critical (they receive all your inbound mail)
+	if (sources.some((s) => s === 'mx')) return 'critical';
 	// NS = high (they control your DNS)
 	if (sources.some((s) => s === 'ns')) return 'high';
 	// SRV = medium (advertised service)
@@ -99,6 +101,8 @@ function sourceToRole(source: string): string {
 	switch (source) {
 		case 'spf':
 			return 'email-sending';
+		case 'mx':
+			return 'email-receiving';
 		case 'ns':
 			return 'dns-hosting';
 		case 'caa':
@@ -185,15 +189,28 @@ const SRV_TARGET_PROVIDERS: Array<{ pattern: RegExp; provider: string }> = [
  * @param dnsOptions - Optional DNS query options
  * @returns Supply chain map with dependencies, signals, and summary
  */
+export interface MapSupplyChainOptions {
+	/** DNS query options (timeout, resolver) threaded into every lookup. */
+	dnsOptions?: QueryDnsOptions;
+	/**
+	 * CDN provider already attributed by the scan's HTTP/header path. When set,
+	 * the supply-chain map uses it directly and skips its own ASN lookup. When
+	 * omitted (standalone calls), the ASN tier resolves the apex A-records.
+	 */
+	precomputedCdn?: string;
+}
+
 export async function mapSupplyChain(
 	domain: string,
-	dnsOptions?: QueryDnsOptions,
+	options: MapSupplyChainOptions = {},
 ): Promise<SupplyChainMap> {
+	const { dnsOptions } = options;
 	// Query all record types in parallel — allSettled so one failure doesn't block others
-	const [txtSettled, nsSettled, caaSettled, srvBatchSettled] = await Promise.allSettled([
+	const [txtSettled, nsSettled, caaSettled, mxSettled, srvBatchSettled] = await Promise.allSettled([
 		queryTxtRecords(domain, dnsOptions),
 		queryDnsRecords(domain, 'NS', dnsOptions),
 		queryDnsRecords(domain, 'CAA', dnsOptions),
+		queryMxRecords(domain, dnsOptions),
 		Promise.allSettled(
 			SRV_PREFIXES.map(async (prefix) => {
 				const name = `${prefix}.${domain}`;
@@ -223,6 +240,10 @@ export async function mapSupplyChain(
 	// Extract NS hostnames
 	const rawNsRecords = nsSettled.status === 'fulfilled' ? nsSettled.value : [];
 	const nsHosts = rawNsRecords.map((r) => r.replace(/\.$/, '').toLowerCase());
+
+	// Extract MX exchange hosts (email-receiving providers)
+	const rawMxRecords = mxSettled.status === 'fulfilled' ? mxSettled.value : [];
+	const mxHosts = rawMxRecords.map((r) => r.exchange.replace(/\.$/, '').toLowerCase());
 
 	// Extract CAA issuers (only issue and issuewild tags)
 	const rawCaaRecords = caaSettled.status === 'fulfilled' ? caaSettled.value : [];
@@ -334,18 +355,39 @@ export async function mapSupplyChain(
 		addDependency(`${scanDomainLower} (self-hosted SPF)`, 'spf');
 	}
 
-	// Add unrecognized NS hosts — group by registrable parent domain.
-	// `getEffectiveParentDomain` accounts for ccTLD-2LD suffixes (co.nz, co.uk,
-	// com.au, …) so `ns1.anz.co.nz` collapses to `anz.co.nz`, not `co.nz`.
-	// When the parent matches the scan domain itself, the NS is self-hosted —
-	// skip adding a "third-party" row so the output isn't misleading.
+	// Group unrecognized infra hosts (NS, MX) by registrable parent domain,
+	// skipping detected providers and self-hosted hosts. `getEffectiveParentDomain`
+	// accounts for ccTLD-2LD suffixes (co.nz, co.uk, com.au, …) so `ns1.anz.co.nz`
+	// collapses to `anz.co.nz`, not `co.nz`. When the parent matches the scan
+	// domain itself, the host is self-hosted — skip the "third-party" row.
 	const scanDomain = domain.toLowerCase();
-	for (const host of nsHosts) {
-		if (detectedNsHosts.has(host)) continue;
-		const parentDomain = getEffectiveParentDomain(host);
-		if (parentDomain === scanDomain) continue;
-		addDependency(parentDomain, 'ns');
+	const addUnrecognizedHostsByParent = (hosts: string[], detected: Set<string>, source: string): void => {
+		for (const host of hosts) {
+			if (detected.has(host)) continue;
+			const parentDomain = getEffectiveParentDomain(host);
+			if (parentDomain === scanDomain) continue;
+			addDependency(parentDomain, source);
+		}
+	};
+
+	// Add unrecognized NS hosts.
+	addUnrecognizedHostsByParent(nsHosts, detectedNsHosts, 'ns');
+
+	// Add MX (email-receiving) providers. Independent of the SPF email-sending
+	// path — a domain can receive via one provider (eg. Mimecast/Proofpoint
+	// inbound) and send via another (eg. M365). Match each exchange against
+	// DETECTION_RULES (shared SSOT, via matchProviderForMxHost); unrecognized
+	// hosts collapse to their registrable parent and skip self-hosted MX,
+	// mirroring the NS path so the two can't drift.
+	const detectedMxHosts = new Set<string>();
+	for (const host of mxHosts) {
+		const matched = matchProviderForMxHost(host);
+		if (matched !== null) {
+			addDependency(matched, 'mx');
+			detectedMxHosts.add(host);
+		}
 	}
+	addUnrecognizedHostsByParent(mxHosts, detectedMxHosts, 'mx');
 
 	// Add CAA issuers
 	for (const issuer of caaIssuers) {

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -340,6 +340,25 @@ export function matchProviderForNsHost(nsHost: string): string | null {
 }
 
 /**
+ * Resolve a single MX exchange host to a known provider name, if any.
+ * Uses the same DETECTION_RULES as detectProviders so the two paths can't drift.
+ * Returns null when no rule's mx pattern matches.
+ *
+ * Mirrors matchProviderForSpfInclude / matchProviderForNsHost so map-supply-chain
+ * can attribute an email-RECEIVING provider from MX independently of the SPF
+ * (email-sending) signal — the two are distinct dependencies (a domain can
+ * receive via Mimecast/Proofpoint while sending via M365, or vice versa).
+ */
+export function matchProviderForMxHost(mxHost: string): string | null {
+	for (const rule of DETECTION_RULES) {
+		if (rule.patterns.mx && rule.patterns.mx.test(mxHost)) {
+			return rule.name;
+		}
+	}
+	return null;
+}
+
+/**
  * Detect infrastructure providers from DNS signals.
  * Returns deduplicated list of DetectedProvider (one entry per provider name).
  */

--- a/test/cdn-asn-detection.spec.ts
+++ b/test/cdn-asn-detection.spec.ts
@@ -74,3 +74,38 @@ describe('detectCdnFromAsn', () => {
 		expect(doh.queryTxt).toHaveBeenCalledTimes(1);
 	});
 });
+
+describe('mapAsnToHosting (Task 3 — cloud-hosting tier)', () => {
+	it('maps major cloud-hosting ASNs', async () => {
+		const { mapAsnToHosting } = await import('../src/lib/cdn-asn-detection');
+		expect(mapAsnToHosting(16509)).toBe('AWS');
+		expect(mapAsnToHosting(15169)).toBe('GCP');
+		expect(mapAsnToHosting(8075)).toBe('Azure');
+	});
+	it('does NOT map CDN-exclusive ASNs (those belong to the CDN tier)', async () => {
+		const { mapAsnToHosting } = await import('../src/lib/cdn-asn-detection');
+		expect(mapAsnToHosting(13335)).toBeNull(); // Cloudflare
+		expect(mapAsnToHosting(20940)).toBeNull(); // Akamai
+	});
+	it('returns null for unknown ASNs', async () => {
+		const { mapAsnToHosting } = await import('../src/lib/cdn-asn-detection');
+		expect(mapAsnToHosting(64512)).toBeNull();
+	});
+});
+
+describe('detectHostingFromAsn (Task 3)', () => {
+	function mockDoh2(answers: Record<string, string>): { queryTxt: ReturnType<typeof vi.fn> } {
+		return { queryTxt: vi.fn(async (name: string) => (answers[name] !== undefined ? [answers[name]] : [])) };
+	}
+	it('attributes a cloud host when an A-record resolves to a hosting ASN', async () => {
+		const { detectHostingFromAsn } = await import('../src/lib/cdn-asn-detection');
+		const doh = mockDoh2({ '20.2.0.192.origin.asn.cymru.com': '16509 | 192.0.2.0/24 | US | arin' });
+		const r = await detectHostingFromAsn(['192.0.2.20'], doh);
+		expect(r).toEqual({ provider: 'AWS', confidence: 'heuristic', asn: 16509 });
+	});
+	it('returns null when no A-record maps to a known hosting ASN', async () => {
+		const { detectHostingFromAsn } = await import('../src/lib/cdn-asn-detection');
+		const doh = mockDoh2({ '10.2.0.192.origin.asn.cymru.com': '13335 | 192.0.2.0/24 | US | arin' }); // CF, not hosting
+		expect(await detectHostingFromAsn(['192.0.2.10'], doh)).toBeNull();
+	});
+});

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -16,17 +16,41 @@ function mockDnsResponses(options: {
 	nsHosts?: string[];
 	caaRecords?: string[];
 	srvRecords?: Record<string, Array<{ priority: number; weight: number; port: number; target: string }>>;
+	mxRecords?: Array<{ pref: number; host: string }>;
+	aRecords?: string[];
+	/** Canned team-cymru origin-ASN TXT answers, keyed by the full `<rev-ip>.origin.asn.cymru.com` query name. */
+	asnAnswers?: Record<string, string>;
+	/** Invoked whenever an `*.origin.asn.cymru.com` TXT lookup is made (lets a test assert the ASN tier did / did not run). */
+	onAsnQuery?: () => void;
 	domain?: string;
 }) {
-	const { spf, txtRecords = [], nsHosts = [], caaRecords = [], srvRecords = {}, domain = 'example.com' } = options;
+	const {
+		spf,
+		txtRecords = [],
+		nsHosts = [],
+		caaRecords = [],
+		srvRecords = {},
+		mxRecords = [],
+		aRecords = [],
+		asnAnswers = {},
+		onAsnQuery,
+		domain = 'example.com',
+	} = options;
 
 	globalThis.fetch = vi.fn().mockImplementation((url: string | URL) => {
 		const u = new URL(typeof url === 'string' ? url : url.toString());
 		const name = u.searchParams.get('name') ?? '';
 		const type = u.searchParams.get('type') ?? '';
 
-		// TXT queries (SPF + verification records)
+		// TXT queries (SPF + verification records + team-cymru origin-ASN lookups)
 		if (type === 'TXT') {
+			// ASN tier: `<rev-ip>.origin.asn.cymru.com` TXT lookups (Task 2/3).
+			if (name.endsWith('.origin.asn.cymru.com')) {
+				onAsnQuery?.();
+				const answer = asnAnswers[name];
+				const answers = answer !== undefined ? [{ name, type: 16, TTL: 300, data: `"${answer}"` }] : [];
+				return Promise.resolve(createDohResponse([{ name, type: 16 }], answers));
+			}
 			if (name === domain) {
 				const answers: Array<{ name: string; type: number; TTL: number; data: string }> = [];
 				if (spf !== null && spf !== undefined) {
@@ -66,6 +90,34 @@ function mockDnsResponses(options: {
 				return Promise.resolve(createDohResponse([{ name, type: 257 }], answers));
 			}
 			return Promise.resolve(createDohResponse([{ name, type: 257 }], []));
+		}
+
+		// MX queries
+		if (type === 'MX') {
+			if (name === domain) {
+				const answers = mxRecords.map((mx) => ({
+					name: domain,
+					type: 15,
+					TTL: 300,
+					data: `${mx.pref} ${mx.host}.`,
+				}));
+				return Promise.resolve(createDohResponse([{ name, type: 15 }], answers));
+			}
+			return Promise.resolve(createDohResponse([{ name, type: 15 }], []));
+		}
+
+		// A queries (apex IPs for the ASN-based CDN / hosting tier)
+		if (type === 'A') {
+			if (name === domain) {
+				const answers = aRecords.map((ip) => ({
+					name: domain,
+					type: 1,
+					TTL: 300,
+					data: ip,
+				}));
+				return Promise.resolve(createDohResponse([{ name, type: 1 }], answers));
+			}
+			return Promise.resolve(createDohResponse([{ name, type: 1 }], []));
 		}
 
 		// SRV queries
@@ -946,5 +998,48 @@ describe('formatSupplyChain', () => {
 
 		const text = formatSupplyChain(result, 'full');
 		expect(text).toContain('No third-party dependencies detected');
+	});
+});
+
+describe('mapSupplyChain — MX email-receiving providers (Task 1)', () => {
+	async function run(domain = 'example.com', opts?: { precomputedCdn?: string }) {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain, opts);
+	}
+
+	it('maps a recognized MX host to an email-receiving dependency', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			nsHosts: ['ns1.acme.com'],
+			mxRecords: [{ pref: 10, host: 'acme-com.mail.protection.outlook.com' }],
+		});
+		const r = await run('acme.com');
+		const dep = r.dependencies.find((d) => d.provider === 'Microsoft 365');
+		expect(dep).toBeDefined();
+		expect(dep!.roles).toContain('email-receiving');
+		expect(dep!.sources).toContain('mx');
+		expect(dep!.trustLevel).toBe('critical');
+	});
+
+	it('groups an unrecognized MX host by registrable parent domain', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			mxRecords: [{ pref: 10, host: 'mx1.mailvendor.co.uk' }],
+		});
+		const r = await run('acme.com');
+		expect(r.dependencies.some((d) => d.provider === 'mailvendor.co.uk' && d.sources.includes('mx'))).toBe(true);
+		expect(r.dependencies.some((d) => d.provider === 'co.uk')).toBe(false);
+	});
+
+	it('does not emit a third-party row for self-hosted MX', async () => {
+		mockDnsResponses({ domain: 'acme.com', mxRecords: [{ pref: 10, host: 'mail.acme.com' }] });
+		const r = await run('acme.com');
+		expect(r.dependencies.some((d) => d.provider === 'acme.com' && d.sources.includes('mx'))).toBe(false);
+	});
+
+	it('handles a web-only domain with no MX records', async () => {
+		mockDnsResponses({ domain: 'acme.com', nsHosts: ['ns1.acme.com'] });
+		const r = await run('acme.com');
+		expect(r.dependencies.every((d) => !d.roles.includes('email-receiving'))).toBe(true);
 	});
 });

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -1043,3 +1043,55 @@ describe('mapSupplyChain — MX email-receiving providers (Task 1)', () => {
 		expect(r.dependencies.every((d) => !d.roles.includes('email-receiving'))).toBe(true);
 	});
 });
+
+describe('mapSupplyChain — CDN attribution (Task 2, #283)', () => {
+	async function run(domain = 'example.com', opts?: { precomputedCdn?: string }) {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain, opts);
+	}
+
+	it('attributes a CDN from the apex A-record ASN when called standalone', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			nsHosts: ['ns1.acme.com'],
+			aRecords: ['192.0.2.10'],
+			asnAnswers: { '10.2.0.192.origin.asn.cymru.com': '13335 | 192.0.2.0/24 | US | arin' },
+		});
+		const r = await run('acme.com');
+		const dep = r.dependencies.find((d) => d.provider === 'Cloudflare' && d.sources.includes('cdn'));
+		expect(dep).toBeDefined();
+		expect(dep!.roles).toContain('cdn');
+		expect(dep!.trustLevel).toBe('critical');
+	});
+
+	it('uses a precomputed cdnProvider without performing an ASN lookup', async () => {
+		const asnSpy = vi.fn();
+		mockDnsResponses({ domain: 'acme.com', aRecords: ['192.0.2.10'], onAsnQuery: asnSpy });
+		const r = await run('acme.com', { precomputedCdn: 'CloudFront' });
+		expect(r.dependencies.some((d) => d.provider === 'CloudFront' && d.sources.includes('cdn'))).toBe(true);
+		expect(asnSpy).not.toHaveBeenCalled();
+	});
+
+	it('emits no cdn dependency when the apex ASN is not a known CDN', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			aRecords: ['198.51.100.5'],
+			asnAnswers: { '5.100.51.198.origin.asn.cymru.com': '15169 | 198.51.100.0/24 | US | arin' }, // GCP, not a CDN ASN
+		});
+		const r = await run('acme.com');
+		expect(r.dependencies.some((d) => d.sources.includes('cdn'))).toBe(false);
+	});
+
+	it('merges a provider serving both NS and CDN into one row (2 roles, no concentration at <3)', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			nsHosts: ['ns.cloudflare.com'],
+			aRecords: ['192.0.2.10'],
+			asnAnswers: { '10.2.0.192.origin.asn.cymru.com': '13335 | 192.0.2.0/24 | US | arin' },
+		});
+		const r = await run('acme.com');
+		const cf = r.dependencies.find((d) => d.provider === 'Cloudflare');
+		expect(cf!.roles).toEqual(expect.arrayContaining(['dns-hosting', 'cdn']));
+		expect(r.signals.some((s) => s.type === 'concentration')).toBe(false);
+	});
+});

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -1095,3 +1095,61 @@ describe('mapSupplyChain — CDN attribution (Task 2, #283)', () => {
 		expect(r.signals.some((s) => s.type === 'concentration')).toBe(false);
 	});
 });
+
+describe('mapSupplyChain — cloud-hosting ASN tier (Task 3, noise-guarded)', () => {
+	async function run(domain = 'example.com', opts?: { precomputedCdn?: string }) {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain, opts);
+	}
+
+	it('emits a low-trust cloud-hosting row when origin is on a cloud ASN and no CDN fronts it', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			aRecords: ['192.0.2.20'],
+			asnAnswers: { '20.2.0.192.origin.asn.cymru.com': '16509 | 192.0.2.0/24 | US | arin' }, // AWS
+		});
+		const r = await run('acme.com');
+		const dep = r.dependencies.find((d) => d.provider === 'AWS' && d.sources.includes('hosting'));
+		expect(dep).toBeDefined();
+		expect(dep!.roles).toContain('cloud-hosting');
+		expect(dep!.trustLevel).toBe('low');
+	});
+
+	it('suppresses the cloud-hosting row when a CDN is attributed (precomputed)', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			aRecords: ['192.0.2.20'],
+			asnAnswers: { '20.2.0.192.origin.asn.cymru.com': '16509 | 192.0.2.0/24 | US | arin' },
+		});
+		const r = await run('acme.com', { precomputedCdn: 'CloudFront' });
+		expect(r.dependencies.some((d) => d.sources.includes('hosting'))).toBe(false);
+		expect(r.dependencies.some((d) => d.provider === 'CloudFront' && d.sources.includes('cdn'))).toBe(true);
+	});
+
+	it('never labels a CDN ASN as cloud-hosting (Akamai stays a cdn row)', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			aRecords: ['192.0.2.30'],
+			asnAnswers: { '30.2.0.192.origin.asn.cymru.com': '20940 | 192.0.2.0/24 | US | arin' }, // Akamai
+		});
+		const r = await run('acme.com');
+		expect(r.dependencies.some((d) => d.sources.includes('hosting'))).toBe(false);
+		expect(r.dependencies.some((d) => d.provider === 'Akamai' && d.sources.includes('cdn'))).toBe(true);
+	});
+});
+
+describe('mapSupplyChain — cloud-hosting caveat signal (Task 3)', () => {
+	async function run(domain = 'example.com') {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain);
+	}
+	it('emits a low-severity shared-infrastructure caveat alongside a hosting row', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			aRecords: ['192.0.2.20'],
+			asnAnswers: { '20.2.0.192.origin.asn.cymru.com': '16509 | 192.0.2.0/24 | US | arin' },
+		});
+		const r = await run('acme.com');
+		expect(r.signals.some((s) => s.type === 'shared_hosting' && s.severity === 'low')).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Closes the **provider signal gaps** in `map_supply_chain`: the tool derived dependencies purely from DNS records (SPF/NS/CAA/SRV/TXT) while the *email-receiving* provider and the *web CDN/host* — two of the most material third-party dependencies — were invisible. Three TDD commits, each a clean RED→GREEN→REFACTOR cycle.

| Commit | What | New source → role / trust |
|---|---|---|
| `93a76db` | **MX** email-receiving providers (was `mxHosts: []`) | `mx` → `email-receiving` / `critical` |
| `2305722` | **Web CDN** as a dependency (#283) + stale-comment fix | `cdn` → `cdn` / `critical` |
| `822aba1` | **Cloud-hosting ASN tier**, noise-guarded | `hosting` → `cloud-hosting` / `low` |

## Architecture

`map_supply_chain` stays **DNS/DoH-native** — CDN/hosting attribution uses the shared, bounded, fail-soft ASN tier (`detectCdnFromAsn`/`detectHostingFromAsn`, apex A-record → team-cymru origin ASN), **no HTTP probe**. An optional `precomputedCdn` option lets a future scan-integration caller pass the richer header-derived value; header-based attribution stays exclusively in the scan path.

## Reviewer notes (read these — intentional decisions, not bugs)

1. **`precomputedCdn` is a future hook.** Confirmed via grep that `handlers/tools.ts:1133` is the *only* production caller of `mapSupplyChain` (`scan_domain` doesn't call it today). The param is tested but currently unexercised in prod — it's the wire-up point for eventual scan integration. Nothing claims "joined into the scan path" — it's standalone-only today.
2. **NS+CDN does NOT trigger a concentration signal** (pinned by a test). A Cloudflare customer using CF for both DNS and CDN is a real single-vendor surface, but concentration still requires ≥3 roles — I deliberately **pinned current semantics** rather than silently change them. Lowering the threshold is its own design decision.
3. **Noise guard (Task 3):** cloud-hosting is attributed **only when no CDN fronts the origin**, at `low` trust, with a `shared_hosting` caveat signal — so an EC2-hosted site doesn't get a critical AWS row. `AS16509` (AWS) stays out of `ASN_TO_CDN` (CDN tier) and lives only in `ASN_TO_HOSTING`.
4. **`AS15169` is the entry to watch** — Google's ASN spans Workspace/YouTube/GCP, so it's the hosting entry most likely to misfire; the low-trust + caveat is the mitigation.
5. Pre-existing duplicate `domain.toLowerCase()` (`scanDomainLower`/`scanDomain`) left untouched — flag for future cleanup.

## Testing

- Strict TDD: every behavior written as a failing test first, watched fail for the right reason, then minimal GREEN. Test mock (`mockDnsResponses`) extended for MX/A/ASN-cymru routing using TEST-NET (192.0.2.x) IPs — no real-infra literals.
- **Full suite green: 4745 passed, 13 skipped, 0 failed.** typecheck + lint + repo-safety scanners clean on every commit.

## Post-deploy verification list (cache auto-busts on the v3.3.22 bump)

Scan after deploy to confirm live behavior (~5 min): a CF-only customer, an Akamai-CDN site, a Fastly site, an AWS-CloudFront site (kiwibank.co.nz — the original #283 case), a **pure-AWS-EC2** domain (should hit the hosting tier), and a **Google-Workspace-only** domain (AS15169 noise check — confirm the caveat does its job).

🤖 Generated with [Claude Code](https://claude.com/claude-code)