### PR TITLE
fix(supply-chain): shadow_service false positives + duplicate signal (B1/B2/B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.23] - 2026-05-28
+
+### Fixed
+
+- **`map_supply_chain` shadow_service signal — three correctness fixes (surfaced by a 16-domain fact-check sweep).**
+  - **MX corroboration (B2):** the shadow_service check considered only TXT-verification + SPF providers, so a service discovered via MX + SRV (e.g. Microsoft 365 SIP, Google Workspace) was falsely flagged "undocumented or unauthorized". It now also corroborates against MX-detected providers. (Observed: nytimes.com flagged "Google Workspace discovered via SRV…" while Google Workspace was its MX provider.)
+  - **Self-hosted SRV (B3):** a SRV record whose target is on the scan's own registrable domain is the org's own service, not a third party — no longer flagged. (Observed: microsoft.com→`sipdog3.microsoft.com`, paypal.com→`xmpp.paypal.com`, oracle.com→`vcse.dtvlb.oracle.com`.)
+  - **Dedup (B1):** the same provider discovered across multiple SRV prefixes now emits a single signal (mirrors the #261 dedup for stale_integration / security_tooling). (Observed: oracle.com emitted the `vcse.dtvlb.oracle.com` shadow_service twice.)
+  - SRV targets are now normalized (trailing dot stripped, lowercased) and the originating target is carried so the self-domain check works. (#285)
+
 ## [3.3.22] - 2026-05-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.22",
+	"version": "3.3.23",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -393,11 +393,13 @@ export async function mapSupplyChain(
 	// hosts collapse to their registrable parent and skip self-hosted MX,
 	// mirroring the NS path so the two can't drift.
 	const detectedMxHosts = new Set<string>();
+	const mxProviderNames = new Set<string>();
 	for (const host of mxHosts) {
 		const matched = matchProviderForMxHost(host);
 		if (matched !== null) {
 			addDependency(matched, 'mx');
 			detectedMxHosts.add(host);
+			mxProviderNames.add(matched);
 		}
 	}
 	addUnrecognizedHostsByParent(mxHosts, detectedMxHosts, 'mx');
@@ -442,10 +444,12 @@ export async function mapSupplyChain(
 		addDependency(vs.service, 'txt-verification');
 	}
 
-	// Add SRV-discovered services — resolve targets to known providers
-	const srvProviderNames: string[] = [];
+	// Add SRV-discovered services — resolve targets to known providers.
+	// Keep each provider's originating SRV target so the shadow_service check can
+	// tell a self-hosted SRV (target on the scan domain) from a real third party.
+	const srvDiscovered: Array<{ name: string; target: string }> = [];
 	for (const srv of srvResults) {
-		const target = srv.records[0].target;
+		const target = srv.records[0].target.replace(/\.$/, '').toLowerCase();
 		let providerName: string | null = null;
 		for (const mapping of SRV_TARGET_PROVIDERS) {
 			if (mapping.pattern.test(target)) {
@@ -455,7 +459,7 @@ export async function mapSupplyChain(
 		}
 		const name = providerName ?? target;
 		addDependency(name, 'srv');
-		srvProviderNames.push(name);
+		srvDiscovered.push({ name, target });
 	}
 
 	// Build final dependency list
@@ -537,22 +541,36 @@ export async function mapSupplyChain(
 		});
 	}
 
-	// Shadow service: SRV-discovered provider not corroborated by TXT verifications or SPF includes
+	// Shadow service: SRV-discovered provider not corroborated by any other signal.
+	// Corroboration now includes MX (email-receiving) providers — without this a
+	// provider found only via MX + SRV (eg. Microsoft 365 SIP) was falsely flagged
+	// "undocumented". A SRV whose target is on the scan domain itself is the org's
+	// own service, not a third party — skip it. Dedup by provider name so the same
+	// service discovered across multiple SRV prefixes emits a single signal.
 	const verifiedServiceNames = new Set(verifiedServices.map((vs) => vs.service));
 	const spfProviderNames = new Set(
 		detectedProviders
 			.filter((p) => p.role === 'mail' || p.role === 'sending')
 			.map((p) => p.name),
 	);
-	for (const srvProvider of srvProviderNames) {
-		if (!verifiedServiceNames.has(srvProvider) && !spfProviderNames.has(srvProvider)) {
+	const shadowFlagged = new Set<string>();
+	for (const { name: srvProvider, target } of srvDiscovered) {
+		if (shadowFlagged.has(srvProvider)) continue;
+		// Self-hosted SRV (target on the scan's own registrable domain) is not a third party.
+		if (getEffectiveParentDomain(target) === scanDomain) continue;
+		if (
+			!verifiedServiceNames.has(srvProvider) &&
+			!spfProviderNames.has(srvProvider) &&
+			!mxProviderNames.has(srvProvider)
+		) {
 			// Also check raw SPF includes for partial matches
 			const inSpfRaw = spfIncludes.some((inc) => inc.toLowerCase().includes(srvProvider.toLowerCase()));
 			if (!inSpfRaw) {
+				shadowFlagged.add(srvProvider);
 				signals.push({
 					type: 'shadow_service',
 					severity: 'medium',
-					detail: `${srvProvider} discovered via SRV but not corroborated by TXT verifications or SPF includes. This service may be undocumented or unauthorized.`,
+					detail: `${srvProvider} discovered via SRV but not corroborated by TXT verifications, SPF includes, or MX records. This service may be undocumented or unauthorized.`,
 				});
 			}
 		}

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -1153,3 +1153,51 @@ describe('mapSupplyChain — cloud-hosting caveat signal (Task 3)', () => {
 		expect(r.signals.some((s) => s.type === 'shared_hosting' && s.severity === 'low')).toBe(true);
 	});
 });
+
+describe('mapSupplyChain — shadow_service signal correctness (B1/B2/B3)', () => {
+	async function run(domain = 'example.com') {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain);
+	}
+
+	it('B1: emits a single shadow_service signal when one SRV provider is found via multiple prefixes', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			srvRecords: {
+				'_sip._tcp': [{ priority: 10, weight: 5, port: 5060, target: 'sip.thirdparty.net' }],
+				'_sip._udp': [{ priority: 10, weight: 5, port: 5060, target: 'sip.thirdparty.net' }],
+			},
+		});
+		const r = await run('acme.com');
+		const shadow = r.signals.filter((s) => s.type === 'shadow_service' && s.detail.includes('sip.thirdparty.net'));
+		expect(shadow.length).toBe(1);
+	});
+
+	it('B2: does not flag an SRV provider that is corroborated by MX', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			mxRecords: [{ pref: 10, host: 'acme-com.mail.protection.outlook.com' }], // Microsoft 365 via MX
+			srvRecords: { '_sip._tcp': [{ priority: 10, weight: 5, port: 443, target: 'sipfed.online.outlook.com' }] }, // -> Microsoft 365
+		});
+		const r = await run('acme.com');
+		expect(r.signals.some((s) => s.type === 'shadow_service')).toBe(false);
+	});
+
+	it('B3: does not flag a SRV target hosted on the scan domain itself', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			srvRecords: { '_sip._tcp': [{ priority: 10, weight: 5, port: 5060, target: 'sipdir.acme.com' }] },
+		});
+		const r = await run('acme.com');
+		expect(r.signals.some((s) => s.type === 'shadow_service')).toBe(false);
+	});
+
+	it('still flags a genuine uncorroborated third-party SRV service', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			srvRecords: { '_sip._tcp': [{ priority: 10, weight: 5, port: 5060, target: 'sip.thirdparty.net' }] },
+		});
+		const r = await run('acme.com');
+		expect(r.signals.some((s) => s.type === 'shadow_service' && s.detail.includes('sip.thirdparty.net'))).toBe(true);
+	});
+});


### PR DESCRIPTION
## Summary

Three `map_supply_chain` shadow_service correctness fixes, surfaced by a 16-domain fact-check sweep. TDD (4 new tests, RED→GREEN); full suite green (4749 passed).

| # | Fix | Observed false output |
|---|---|---|
| **B2** | shadow_service now corroborates against **MX** providers (was SPF + TXT only) | nytimes.com: "Google Workspace discovered via SRV but not corroborated" — it was the **MX** provider |
| **B3** | a SRV target on the **scan's own registrable domain** is no longer flagged as a third party | microsoft→`sipdog3.microsoft.com`, paypal→`xmpp.paypal.com`, oracle→`vcse.dtvlb.oracle.com` |
| **B1** | **dedup** — one provider found across multiple SRV prefixes emits a single signal (mirrors #261) | oracle.com emitted `vcse.dtvlb.oracle.com` shadow_service **twice** |

B2 is partly an interaction exposed by the MX work (#284): now that MX is a first-class provider source, it belongs in the corroboration set.

## Implementation
- SRV collection now carries `{ name, target }` (target normalized: trailing dot stripped, lowercased) so the self-domain check has the original target.
- shadow_service loop: `shadowFlagged` Set (dedup) + `getEffectiveParentDomain(target) === scanDomain` skip + `mxProviderNames` added to the corroboration check.
- A guard test confirms a genuine uncorroborated third-party SRV **still** fires.

## Testing
- 4 new tests (B1/B2/B3 + genuine-third-party guard), all RED-first. typecheck + lint + repo-safety clean. Full suite: 4749 passed, 0 failed.

## Follow-up
Catalog/macro gaps from the same sweep (raw-hostname providers: Zendesk, Marketo, Statuspage, Azure DNS ×4, `googlemail.com` MX, Trellix MX, SPF-macro normalization, etc.) are tracked separately — not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)