### PR TITLE
feat(supply-chain): provider catalog batch — resolve raw hostnames to vendors (#286)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.24] - 2026-05-28
+
+### Added
+
+- **`map_supply_chain` provider catalog batch (#286) — raw hostnames now resolve to vendor names.** A 16-domain sweep found many well-known SPF/MX/NS hosts surfacing as raw `critical`/`high` rows instead of a vendor. Added/extended `DETECTION_RULES`:
+  - **Google (C1/C2):** MX now also matches `*.googlemail.com`; SPF now also matches Google's `_netblocks{,2,3}.google.com` internal includes — both previously surfaced as raw rows alongside the detected Google Workspace.
+  - **SPF senders (C3):** Zendesk (`mail.zendesk.com`), Marketo (`mktomail.com`), Statuspage (`stspg-customer.com`), Salesforce Marketing Cloud (`*.exacttarget.com`), Salesforce Pardot (`*.pardot.com`), Qualtrics (`*.qualtrics.com`), SparkPost (`*.sparkpost.com`), Alibaba Mail (`*.aliyun.com`); Mailchimp Transactional now also matches `spf.mandrillapp.com` (was `*.mcsv.net` only).
+  - **NS hosts (C4):** Azure DNS (`*.azure-dns.{com,net,org,info}` — collapses 4 rows → 1), Netlify DNS, Vercel DNS, Oracle Cloud DNS (`*.oraclecloud.net`), Salesforce DNS, Alibaba DNS.
+  - **MX hosts (C5):** Trellix Email Security now also matches MX `*.fireeyecloud.com` (was SPF-only); Cloudflare Email Security (`*.cf-emailsecurity.net`).
+  - **SPF macros (M1):** Proofpoint SPF selectors/macros (`*.pphosted.com`, incl. `%{…}.spf.has.pphosted.com`) and Valimail (`*.vali.email`, incl. macro forms) resolve to the vendor instead of the raw macro string — the suffix match handles both static and macro includes. (#286)
+
 ## [3.3.23] - 2026-05-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.23",
+	"version": "3.3.24",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -46,8 +46,16 @@ const DETECTION_RULES: DetectionRule[] = [
 		name: 'Google Workspace',
 		role: 'mail',
 		patterns: {
-			mx: /\.google\.com$/i,
-			spf: /_spf\.google\.com$/i,
+			// MX hosts use both `.google.com` (aspmx.l.google.com) and, in some
+			// regions, `.googlemail.com` (aspmx.l.googlemail.com). Without the
+			// latter, googlemail MX hosts collapse to a raw `googlemail.com` row
+			// alongside the detected Google Workspace (observed widely 2026-05-28).
+			mx: /(\.google\.com|\.googlemail\.com)$/i,
+			// SPF: the apex commonly includes `_spf.google.com`, but some orgs
+			// include Google's internal netblock includes directly
+			// (`_netblocks{,2,3}.google.com`) — each surfaced as a separate raw
+			// critical row before this. Collapse them all to Google Workspace.
+			spf: /(_spf|_netblocks\d*)\.google\.com$/i,
 		},
 		signal: 'mx:google.com',
 	},
@@ -81,6 +89,11 @@ const DETECTION_RULES: DetectionRule[] = [
 		role: 'mail',
 		patterns: {
 			mx: /\.pphosted\.com$/i,
+			// SPF selectors (`spf-00789a01.pphosted.com`) and macro includes
+			// (`%{ir}.%{v}.%{d}.spf.has.pphosted.com`) both end in `.pphosted.com`;
+			// the suffix match catches both forms so they resolve to Proofpoint
+			// instead of a raw critical row.
+			spf: /(^|\.)pphosted\.com$/i,
 		},
 		signal: 'mx:pphosted.com',
 	},
@@ -214,6 +227,10 @@ const DETECTION_RULES: DetectionRule[] = [
 		role: 'sending',
 		patterns: {
 			spf: /(^|\.)fireeyecloud\.com$/i,
+			// Some tenants DO point MX at `*.fireeyecloud.com` (observed: anz.co.nz).
+			// Match it so the inbound gateway resolves to Trellix instead of a raw
+			// `fireeyecloud.com` email-receiving row.
+			mx: /(^|\.)fireeyecloud\.com$/i,
 		},
 		signal: 'spf:fireeyecloud.com',
 	},
@@ -287,7 +304,9 @@ const DETECTION_RULES: DetectionRule[] = [
 		name: 'Mailchimp Transactional',
 		role: 'sending',
 		patterns: {
-			spf: /\.mcsv\.net$/i,
+			// Both the legacy Mandrill domain (`spf.mandrillapp.com`) and the
+			// current `*.mcsv.net` selector resolve to the same product.
+			spf: /(\.mcsv\.net|\.mandrillapp\.com|^mandrillapp\.com)$/i,
 		},
 		signal: 'spf:mailchimp-transactional',
 	},
@@ -304,6 +323,130 @@ const DETECTION_RULES: DetectionRule[] = [
 			spf: /(^|\.)salesforce\.com$/i,
 		},
 		signal: 'spf:salesforce',
+	},
+	// --- Catalog batch #286 (raw-hostname → vendor name; surfaced by 16-domain sweep 2026-05-28) ---
+	{
+		// Salesforce Pardot (marketing automation). SPF includes resolve under
+		// `*.pardot.com` (eg. `aspmx.pardot.com`, `et._spf.pardot.com`). Kept
+		// separate from the Salesforce rule (whose pattern is anchored to
+		// `salesforce.com`) so the two products surface distinctly.
+		name: 'Salesforce Pardot',
+		role: 'sending',
+		patterns: { spf: /(^|\.)pardot\.com$/i },
+		signal: 'spf:pardot.com',
+	},
+	{
+		// Salesforce Marketing Cloud (formerly ExactTarget). SPF includes under
+		// `*.exacttarget.com` (eg. `cust-spf.exacttarget.com`).
+		name: 'Salesforce Marketing Cloud',
+		role: 'sending',
+		patterns: { spf: /(^|\.)exacttarget\.com$/i },
+		signal: 'spf:exacttarget.com',
+	},
+	{
+		// Zendesk outbound email. SPF include `mail.zendesk.com`.
+		name: 'Zendesk',
+		role: 'sending',
+		patterns: { spf: /(^|\.)zendesk\.com$/i },
+		signal: 'spf:zendesk.com',
+	},
+	{
+		// Marketo (Adobe) email. SPF include `mktomail.com`.
+		name: 'Marketo',
+		role: 'sending',
+		patterns: { spf: /(^|\.)mktomail\.com$/i },
+		signal: 'spf:mktomail.com',
+	},
+	{
+		// Statuspage (Atlassian) notification email. SPF include `stspg-customer.com`.
+		name: 'Statuspage',
+		role: 'sending',
+		patterns: { spf: /(^|\.)stspg-customer\.com$/i },
+		signal: 'spf:stspg-customer.com',
+	},
+	{
+		// Qualtrics survey/email platform. SPF include `_spf.qualtrics.com`.
+		name: 'Qualtrics',
+		role: 'sending',
+		patterns: { spf: /(^|\.)qualtrics\.com$/i },
+		signal: 'spf:qualtrics.com',
+	},
+	{
+		// SparkPost (Bird) email. SPF include `_spf.e.sparkpost.com`.
+		name: 'SparkPost',
+		role: 'sending',
+		patterns: { spf: /(^|\.)sparkpost\.com$/i },
+		signal: 'spf:sparkpost.com',
+	},
+	{
+		// Alibaba Mail / Aliyun DirectMail. SPF includes under `*.aliyun.com`
+		// (eg. `spf1.alibaba.mail.aliyun.com`).
+		name: 'Alibaba Mail',
+		role: 'sending',
+		patterns: { spf: /(^|\.)aliyun\.com$/i },
+		signal: 'spf:aliyun.com',
+	},
+	{
+		// Valimail (managed SPF/DMARC). The apex delegates SPF to a per-tenant
+		// host under `*.vali.email` — both static (`<domain>._nspf.vali.email`)
+		// and macro (`%{i}._ip.%{h}._ehlo.%{d}._spf.vali.email`) forms end in
+		// `.vali.email`, so the suffix match resolves both to Valimail.
+		name: 'Valimail',
+		role: 'sending',
+		patterns: { spf: /(^|\.)vali\.email$/i },
+		signal: 'spf:vali.email',
+	},
+	{
+		// Cloudflare Email Security (formerly Area 1). Inbound gateway — MX points
+		// at `*.cf-emailsecurity.net`. Distinct from the Cloudflare DNS rule.
+		name: 'Cloudflare Email Security',
+		role: 'mail',
+		patterns: { mx: /(^|\.)cf-emailsecurity\.net$/i },
+		signal: 'mx:cf-emailsecurity.net',
+	},
+	{
+		// Azure DNS. Multi-TLD vendor — authoritative DNS is served from
+		// `*.azure-dns.{com,net,org,info}`; large zones use all four for
+		// redundancy, listing as four separate rows before this collapse.
+		name: 'Azure DNS',
+		role: 'dns',
+		patterns: { ns: /\.azure-dns\.(com|net|org|info)$/i },
+		signal: 'ns:azure-dns',
+	},
+	{
+		// Netlify DNS. NS hosts under `*.netlifydns.com`.
+		name: 'Netlify DNS',
+		role: 'dns',
+		patterns: { ns: /\.netlifydns\.com$/i },
+		signal: 'ns:netlifydns.com',
+	},
+	{
+		// Vercel DNS. NS hosts under `*.vercel-dns.com`.
+		name: 'Vercel DNS',
+		role: 'dns',
+		patterns: { ns: /\.vercel-dns\.com$/i },
+		signal: 'ns:vercel-dns.com',
+	},
+	{
+		// Oracle Cloud DNS (OCI). NS hosts under `*.oraclecloud.net`.
+		name: 'Oracle Cloud DNS',
+		role: 'dns',
+		patterns: { ns: /\.oraclecloud\.net$/i },
+		signal: 'ns:oraclecloud.net',
+	},
+	{
+		// Salesforce DNS. NS hosts under `*.salesforce-dns.com`.
+		name: 'Salesforce DNS',
+		role: 'dns',
+		patterns: { ns: /\.salesforce-dns\.com$/i },
+		signal: 'ns:salesforce-dns.com',
+	},
+	{
+		// Alibaba Cloud DNS. NS hosts under `*.alibabadns.com`.
+		name: 'Alibaba DNS',
+		role: 'dns',
+		patterns: { ns: /\.alibabadns\.com$/i },
+		signal: 'ns:alibabadns.com',
 	},
 ];
 

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -663,7 +663,7 @@ describe('mapSupplyChain', () => {
 
 	it('collapses Stripe self-wrapper subdomains (spf1.stripe.com, greenhouse-outbound-mail.stripe.com)', async () => {
 		mockDnsResponses({
-			spf: 'v=spf1 include:spf1.stripe.com include:greenhouse-outbound-mail.stripe.com include:_spf.qualtrics.com ~all',
+			spf: 'v=spf1 include:spf1.stripe.com include:greenhouse-outbound-mail.stripe.com include:_spf.thirdparty-unknown.io ~all',
 			nsHosts: ['ns1.cloudflare.com', 'ns2.cloudflare.com'],
 			domain: 'stripe.com',
 		});
@@ -671,8 +671,8 @@ describe('mapSupplyChain', () => {
 		expect(result.dependencies.filter((d) => d.provider.endsWith('.stripe.com')).length).toBe(0);
 		// Self-hosted row present.
 		expect(result.dependencies.find((d) => d.provider === 'stripe.com (self-hosted SPF)')).toBeDefined();
-		// Genuine third-party include preserved as raw entry.
-		expect(result.dependencies.find((d) => d.provider === '_spf.qualtrics.com')).toBeDefined();
+		// Genuine (uncataloged) third-party include preserved as raw entry.
+		expect(result.dependencies.find((d) => d.provider === '_spf.thirdparty-unknown.io')).toBeDefined();
 	});
 
 	it('distinguishes self-delegation from genuine third-party include at the same eTLD+1 level', async () => {
@@ -1199,5 +1199,37 @@ describe('mapSupplyChain — shadow_service signal correctness (B1/B2/B3)', () =
 		});
 		const r = await run('acme.com');
 		expect(r.signals.some((s) => s.type === 'shadow_service' && s.detail.includes('sip.thirdparty.net'))).toBe(true);
+	});
+});
+
+describe('mapSupplyChain — catalog batch #286 collapse behavior', () => {
+	async function run(domain = 'example.com') {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain);
+	}
+
+	it('collapses azure-dns.{com,net,org,info} into a single Azure DNS row', async () => {
+		mockDnsResponses({
+			domain: 'acme.com',
+			nsHosts: ['ns1-01.azure-dns.com', 'ns2-01.azure-dns.net', 'ns3-01.azure-dns.org', 'ns4-01.azure-dns.info'],
+		});
+		const r = await run('acme.com');
+		const azure = r.dependencies.filter((d) => d.provider === 'Azure DNS');
+		expect(azure.length).toBe(1);
+		expect(r.dependencies.some((d) => /azure-dns\.(com|net|org|info)/.test(d.provider))).toBe(false);
+	});
+
+	it('maps a googlemail.com MX to Google Workspace with no raw googlemail.com row', async () => {
+		mockDnsResponses({ domain: 'acme.com', mxRecords: [{ pref: 10, host: 'aspmx.l.googlemail.com' }] });
+		const r = await run('acme.com');
+		expect(r.dependencies.some((d) => d.provider === 'Google Workspace' && d.roles.includes('email-receiving'))).toBe(true);
+		expect(r.dependencies.some((d) => d.provider === 'googlemail.com')).toBe(false);
+	});
+
+	it('resolves a SPF macro include to its vendor (Valimail) with no raw macro row', async () => {
+		mockDnsResponses({ domain: 'acme.com', spf: 'v=spf1 include:%{i}._ip.%{h}._ehlo.%{d}._spf.vali.email -all' });
+		const r = await run('acme.com');
+		expect(r.dependencies.some((d) => d.provider === 'Valimail')).toBe(true);
+		expect(r.dependencies.some((d) => d.provider.includes('%{'))).toBe(false);
 	});
 });

--- a/test/provider-guides.spec.ts
+++ b/test/provider-guides.spec.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { detectProviders, getProviderFixSteps } from '../src/tools/provider-guides';
+import {
+	detectProviders,
+	getProviderFixSteps,
+	matchProviderForSpfInclude,
+	matchProviderForNsHost,
+	matchProviderForMxHost,
+} from '../src/tools/provider-guides';
 
 describe('provider-guides', () => {
 	describe('detectProviders', () => {
@@ -69,6 +75,87 @@ describe('provider-guides', () => {
 		it('returns null for unknown provider', () => {
 			const steps = getProviderFixSteps('UnknownProvider', 'add_txt', {});
 			expect(steps).toBeNull();
+		});
+	});
+});
+
+describe('provider catalog batch (#286)', () => {
+	describe('C1 — Google MX googlemail.com', () => {
+		it('maps *.googlemail.com MX to Google Workspace', () => {
+			expect(matchProviderForMxHost('aspmx.l.googlemail.com')).toBe('Google Workspace');
+		});
+		it('still maps *.google.com MX to Google Workspace', () => {
+			expect(matchProviderForMxHost('aspmx.l.google.com')).toBe('Google Workspace');
+		});
+	});
+
+	describe('C2 — Google SPF _netblocks*', () => {
+		it.each(['_netblocks.google.com', '_netblocks2.google.com', '_netblocks3.google.com'])(
+			'maps %s to Google Workspace',
+			(host) => {
+				expect(matchProviderForSpfInclude(host)).toBe('Google Workspace');
+			},
+		);
+		it('still maps _spf.google.com to Google Workspace', () => {
+			expect(matchProviderForSpfInclude('_spf.google.com')).toBe('Google Workspace');
+		});
+	});
+
+	describe('C3 — SPF include catalog', () => {
+		it.each([
+			['mail.zendesk.com', 'Zendesk'],
+			['mktomail.com', 'Marketo'],
+			['stspg-customer.com', 'Statuspage'],
+			['cust-spf.exacttarget.com', 'Salesforce Marketing Cloud'],
+			['aspmx.pardot.com', 'Salesforce Pardot'],
+			['_spf.qualtrics.com', 'Qualtrics'],
+			['_spf.e.sparkpost.com', 'SparkPost'],
+			['spf1.alibaba.mail.aliyun.com', 'Alibaba Mail'],
+			['spf.mandrillapp.com', 'Mailchimp Transactional'],
+		])('maps SPF %s to %s', (host, provider) => {
+			expect(matchProviderForSpfInclude(host)).toBe(provider);
+		});
+		it('still maps servers.mcsv.net to Mailchimp Transactional', () => {
+			expect(matchProviderForSpfInclude('servers.mcsv.net')).toBe('Mailchimp Transactional');
+		});
+		it('does not collapse Pardot into Salesforce', () => {
+			expect(matchProviderForSpfInclude('aspmx.pardot.com')).not.toBe('Salesforce');
+		});
+	});
+
+	describe('C4 — NS catalog', () => {
+		it.each([
+			['ns1-01.azure-dns.com', 'Azure DNS'],
+			['ns2-01.azure-dns.net', 'Azure DNS'],
+			['ns3-01.azure-dns.org', 'Azure DNS'],
+			['ns4-01.azure-dns.info', 'Azure DNS'],
+			['dns1.netlifydns.com', 'Netlify DNS'],
+			['ns1.vercel-dns.com', 'Vercel DNS'],
+			['ns1.p201.dns.oraclecloud.net', 'Oracle Cloud DNS'],
+			['ns1.salesforce-dns.com', 'Salesforce DNS'],
+			['ns1.alibabadns.com', 'Alibaba DNS'],
+		])('maps NS %s to %s', (host, provider) => {
+			expect(matchProviderForNsHost(host)).toBe(provider);
+		});
+	});
+
+	describe('C5 — MX catalog', () => {
+		it('maps *.fireeyecloud.com MX to Trellix Email Security', () => {
+			expect(matchProviderForMxHost('mx1.fireeyecloud.com')).toBe('Trellix Email Security');
+		});
+		it('maps *.cf-emailsecurity.net MX to Cloudflare Email Security', () => {
+			expect(matchProviderForMxHost('isolated-eu.mx.cf-emailsecurity.net')).toBe('Cloudflare Email Security');
+		});
+	});
+
+	describe('M1 — SPF macro / selector normalization', () => {
+		it.each([
+			['nytimes.com._nspf.vali.email', 'Valimail'],
+			['%{i}._ip.%{h}._ehlo.%{d}._spf.vali.email', 'Valimail'],
+			['spf-00789a01.pphosted.com', 'Proofpoint'],
+			['%{ir}.%{v}.%{d}.spf.has.pphosted.com', 'Proofpoint'],
+		])('maps SPF %s to %s', (host, provider) => {
+			expect(matchProviderForSpfInclude(host)).toBe(provider);
 		});
 	});
 });


### PR DESCRIPTION
Closes #286.

## Summary

The 16-domain fact-check sweep found many well-known SPF/MX/NS hosts surfacing in `map_supply_chain` as **raw `critical`/`high` rows** instead of a vendor name. This batches the catalog additions (all in `DETECTION_RULES`, the shared SSOT). TDD: 28 new catalog assertions + 3 collapse integration tests, RED-first; full suite green (4784).

## Changes

| Group | Additions |
|---|---|
| **Google (C1/C2)** | MX also matches `*.googlemail.com`; SPF also matches `_netblocks{,2,3}.google.com` — both were raw rows alongside the detected Google Workspace |
| **SPF senders (C3)** | Zendesk, Marketo, Statuspage, Salesforce Marketing Cloud (`*.exacttarget.com`), Salesforce Pardot (`*.pardot.com`), Qualtrics, SparkPost, Alibaba Mail; Mailchimp Transactional now also matches `spf.mandrillapp.com` |
| **NS (C4)** | Azure DNS (`*.azure-dns.{com,net,org,info}` — **4 rows → 1**), Netlify DNS, Vercel DNS, Oracle Cloud DNS, Salesforce DNS, Alibaba DNS |
| **MX (C5)** | Trellix also matches MX `*.fireeyecloud.com`; Cloudflare Email Security (`*.cf-emailsecurity.net`) |
| **SPF macros (M1)** | Proofpoint (`*.pphosted.com`, incl. `%{…}.spf.has.pphosted.com`) and Valimail (`*.vali.email`, incl. macro forms) resolve via suffix match — no separate macro-stripping needed since both static selectors and macros share the vendor suffix |

## Notes
- **Pardot kept distinct from Salesforce** — the Salesforce rule's pattern is anchored to `salesforce.com`, and Pardot has its own `*.pardot.com` rule, so the two products surface separately (asserted by a test).
- Updated one **pre-existing** test that used `_spf.qualtrics.com` as a "raw third-party" example (now cataloged) → swapped to an uncataloged host; its intent (uncataloged includes stay raw) is preserved.
- No production-code logic changes — purely catalog/regex additions consumed by the existing `matchProviderFor{Spf,Ns,Mx}` helpers + `detectProviders`.

## Testing
RED-first per `provider-guides.spec.ts` (per-entry match assertions) + `map-supply-chain.spec.ts` (collapse behavior). typecheck + lint + repo-safety clean. Full suite: 4784 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)