### PR TITLE
chore: scope CodeQL to deployed surface + map *.msft.net SPF

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,22 @@
+name: bv-mcp CodeQL config
+
+# Scope CodeQL to the deployed attack surface only.
+#
+# The shipped Worker is `src/` + `packages/`. Test fixtures and dev/CI scripts
+# never run in production, so the production-oriented security-extended queries
+# only produce false positives there:
+#   - js/incomplete-url-substring-sanitization on Vitest mock-fetch routers
+#     (`url.includes('host.example.com')`) and on plain assertions
+#     (`provider.includes('%{')`), which are intentional substring checks in
+#     test code — see the bv-cc memory note on this exact FP class;
+#   - js/file-access-to-http on the chaos harness (`scripts/chaos-*.mjs`),
+#     which reads a domain list from disk and scans it by design;
+#   - js/regex/missing-regexp-anchor on test fixtures.
+#
+# Excluding these keeps the code-scanning signal focused on shippable code.
+# (Production URL/regex handling in `src/` + `packages/` is still fully scanned.)
+paths-ignore:
+  - test
+  - scripts
+  - '**/*.spec.ts'
+  - '**/*.test.ts'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -97,6 +97,9 @@ jobs:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
           queries: ${{ matrix.queries }}
+          # Scope analysis to the deployed surface (src/ + packages/); excludes
+          # test fixtures + dev scripts, whose only findings are false positives.
+          config-file: ./.github/codeql/codeql-config.yml
           dependency-caching: true
 
       - name: Perform CodeQL analysis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.25] - 2026-05-28
+
+### Added
+
+- **`map_supply_chain`: Microsoft first-party SPF infra (`*.msft.net`).** `_spf-ssg-a.msft.net` (used by microsoft.com's own SPF) surfaced as a raw critical row; the Microsoft 365 SPF pattern now also matches `*.msft.net` so it resolves to Microsoft 365. Last raw-hostname residual from the catalog sweep.
+
+### Changed
+
+- **CodeQL scoped to the deployed surface (`src/` + `packages/`).** New `.github/codeql/codeql-config.yml` adds `paths-ignore` for `test/`, `scripts/`, and `**/*.{spec,test}.ts`, wired into `security.yml`'s `init`. The `security-extended` suite was flagging ~30 false positives in non-shipping code — `js/incomplete-url-substring-sanitization` on Vitest mock-fetch routers and plain substring assertions, `js/file-access-to-http` on the chaos harness, `js/regex/missing-regexp-anchor` on fixtures — which produced a perpetual red "CodeQL" check on every PR. Production URL/regex handling in `src/`/`packages/` is still fully scanned; the pre-existing test/script alerts auto-resolve on the next main analysis.
+
 ## [3.3.24] - 2026-05-28
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.24",
+	"version": "3.3.25",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -64,7 +64,11 @@ const DETECTION_RULES: DetectionRule[] = [
 		role: 'mail',
 		patterns: {
 			mx: /\.mail\.protection\.outlook\.com$/i,
-			spf: /spf\.protection\.outlook\.com$/i,
+			// `spf.protection.outlook.com` is the M365 tenant SPF; `*.msft.net`
+			// (eg. `_spf-ssg-a.msft.net`) is Microsoft's first-party sending infra
+			// used by microsoft.com itself — both are Microsoft email infrastructure
+			// for supply-chain purposes, so both resolve here instead of a raw row.
+			spf: /(spf\.protection\.outlook\.com|\.msft\.net)$/i,
 		},
 		signal: 'mx:mail.protection.outlook.com',
 	},

--- a/test/provider-guides.spec.ts
+++ b/test/provider-guides.spec.ts
@@ -159,3 +159,12 @@ describe('provider catalog batch (#286)', () => {
 		});
 	});
 });
+
+describe('catalog residual — Microsoft msft.net SPF', () => {
+	it('maps *.msft.net SPF infra to Microsoft 365', () => {
+		expect(matchProviderForSpfInclude('_spf-ssg-a.msft.net')).toBe('Microsoft 365');
+	});
+	it('still maps spf.protection.outlook.com to Microsoft 365', () => {
+		expect(matchProviderForSpfInclude('spf.protection.outlook.com')).toBe('Microsoft 365');
+	});
+});


### PR DESCRIPTION
Cleanup of the last remaining open items from the supply-chain accuracy work.

## 1. CodeQL scoped to the deployed surface (src/ + packages/)

`security.yml` ran `security-extended` against the **whole repo**, flagging **~30 false positives in code that never ships**:
- `js/incomplete-url-substring-sanitization` — Vitest mock-fetch routers (`url.includes('host.example.com')`) and plain assertions (`provider.includes('%{')`)
- `js/file-access-to-http` — the chaos harness (`scripts/chaos-*.mjs`) reading a domain list from disk and scanning it, by design
- `js/regex/missing-regexp-anchor` — test fixtures

These produced a perpetual red `CodeQL` check on every PR (investigated on #285/#287). New `.github/codeql/codeql-config.yml` adds `paths-ignore` for `test/`, `scripts/`, and `**/*.{spec,test}.ts`, wired into the `init` step. **Production URL/regex handling in `src/` + `packages/` is still fully scanned** — only non-shipping test/dev code is excluded. The pre-existing alerts auto-resolve on the next `main` analysis (files no longer analyzed).

> Reviewer note: this intentionally reduces CodeQL scope to test/script paths. The deployed Worker attack surface is unchanged in coverage.

## 2. Catalog residual — `*.msft.net`

`_spf-ssg-a.msft.net` (microsoft.com's own first-party SPF infra) was the last raw-hostname row from the sweep. The Microsoft 365 SPF pattern now also matches `*.msft.net`. TDD (RED-first).

## Not actionable: bv-phish-engine
The background security review flagged `cloudflare/bv-phish-engine/src/*` — that path has **never existed** in this repo (not on disk, not tracked, not in git history, not on origin). Nothing to fix; the review scanned transient state that isn't part of bv-mcp.

## Testing
Full suite green (4786 passed, 0 failed); typecheck + lint + repo-safety clean. The CodeQL job on this PR will exercise the new config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)