### PR TITLE
feat(supply-chain): JP public-suffix gaps + MessageLabs + Campaign Monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.27] - 2026-05-28
+
+### Fixed
+
+- **`map_supply_chain` PUBLIC_SUFFIX_SECOND_LEVEL: missing Japanese 2LDs.** `rakuten.co.jp` reported `ad.jp` as a "DNS hosting provider" — `ad.jp` is a JPRS-managed registry suffix for network-administration entities, not a provider. The original set covered `co/ac/ne/or/go.jp` but missed `ad.jp` / `ed.jp` (primary+secondary education) / `gr.jp` (groups) / `lg.jp` (local government), so any NS at a 3-label JP host collapsed to the registry suffix instead of the operator's registrable domain. Added the four. Surfaced by a second-round 8-domain sweep. (#290)
+
+### Added
+
+- **`map_supply_chain` catalog batch 2: Symantec Email Security.cloud + Campaign Monitor.**
+  - **Symantec Email Security.cloud (MessageLabs)** — enterprise email gateway (same product class as Proofpoint/Mimecast/Trellix). MX `*.messagelabs.com` and SPF `spf.messagelabs.com` now resolve to "Symantec Email Security.cloud" instead of raw critical rows. Observed on bbc.co.uk.
+  - **Campaign Monitor** — newsletter/transactional ESP. SPF `*.createsend.com` now resolves to "Campaign Monitor". Observed on netflix.com. (#290)
+
 ## [3.3.26] - 2026-05-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.26",
+	"version": "3.3.27",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -146,8 +146,13 @@ const PUBLIC_SUFFIX_SECOND_LEVEL: ReadonlySet<string> = new Set([
 	'com.au', 'net.au', 'org.au', 'edu.au', 'gov.au', 'asn.au', 'id.au',
 	// South Africa
 	'co.za', 'org.za', 'web.za',
-	// Japan
-	'co.jp', 'ac.jp', 'ne.jp', 'or.jp', 'go.jp',
+	// Japan — covers JPRS-managed organisational 2LDs. The missing
+	// `ad.jp` (network admin) / `ed.jp` (primary+secondary education) /
+	// `gr.jp` (groups) / `lg.jp` (local government) entries surfaced
+	// `ad.jp` as a "DNS provider" row on rakuten.co.jp scans (its NS lives
+	// under `*.ad.jp`); without these, any NS at a 3-label JP host collapses
+	// to the registry suffix instead of the operator's registrable domain.
+	'co.jp', 'ac.jp', 'ne.jp', 'or.jp', 'go.jp', 'ad.jp', 'ed.jp', 'gr.jp', 'lg.jp',
 	// India
 	'co.in', 'org.in', 'net.in', 'gov.in', 'ac.in',
 	// South Korea

--- a/src/tools/provider-guides.ts
+++ b/src/tools/provider-guides.ts
@@ -452,6 +452,30 @@ const DETECTION_RULES: DetectionRule[] = [
 		patterns: { ns: /\.alibabadns\.com$/i },
 		signal: 'ns:alibabadns.com',
 	},
+	// --- Catalog batch v3.3.27 (raw-hostname → vendor name; sweep 2 2026-05-28) ---
+	{
+		// Symantec Email Security.cloud (formerly MessageLabs; acquired by Symantec
+		// in 2008, transferred to Broadcom in 2019). Enterprise inbound/outbound
+		// email gateway — same product class as Proofpoint / Mimecast / Trellix.
+		// Detected via both MX (`*.messagelabs.com` clusters) and SPF
+		// (`spf.messagelabs.com`). Observed on bbc.co.uk.
+		name: 'Symantec Email Security.cloud',
+		role: 'mail',
+		patterns: {
+			mx: /(^|\.)messagelabs\.com$/i,
+			spf: /(^|\.)messagelabs\.com$/i,
+		},
+		signal: 'mx:messagelabs.com',
+	},
+	{
+		// Campaign Monitor (newsletter / transactional ESP). Customers' SPF
+		// includes resolve under `*.createsend.com` (eg. `_spf.createsend.com`,
+		// `*.spf.createsend.com`). Observed on netflix.com.
+		name: 'Campaign Monitor',
+		role: 'sending',
+		patterns: { spf: /(^|\.)createsend\.com$/i },
+		signal: 'spf:createsend.com',
+	},
 ];
 
 /**

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -1233,3 +1233,45 @@ describe('mapSupplyChain — catalog batch #286 collapse behavior', () => {
 		expect(r.dependencies.some((d) => d.provider.includes('%{'))).toBe(false);
 	});
 });
+
+describe('mapSupplyChain — catalog batch v3.3.27 (G1/G2/G3)', () => {
+	async function run(domain = 'example.com') {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain);
+	}
+
+	describe('G1 — Public Suffix List: Japanese 2LDs (ad/ed/gr/lg .jp)', () => {
+		it.each(['ad.jp', 'ed.jp', 'gr.jp', 'lg.jp'])(
+			'treats *.%s as a registry suffix when computing the parent domain',
+			async (suffix) => {
+				const { getEffectiveParentDomain } = await import('../src/tools/map-supply-chain');
+				expect(getEffectiveParentDomain(`ns1.dnsprovider.${suffix}`)).toBe(`dnsprovider.${suffix}`);
+			},
+		);
+
+		it('does not surface ad.jp as a DNS provider when the NS lives under it (rakuten.co.jp regression)', async () => {
+			mockDnsResponses({ domain: 'rakuten.co.jp', nsHosts: ['ns1.dnsweb.org.ad.jp', 'ns2.dnsweb.org.ad.jp'] });
+			const r = await run('rakuten.co.jp');
+			expect(r.dependencies.some((d) => d.provider === 'ad.jp')).toBe(false);
+			expect(r.dependencies.some((d) => d.provider === 'org.ad.jp')).toBe(true);
+		});
+	});
+
+	describe('G2 — Symantec Email Security.cloud (MessageLabs)', () => {
+		it('maps spf.messagelabs.com SPF to Symantec Email Security.cloud', async () => {
+			const { matchProviderForSpfInclude } = await import('../src/tools/provider-guides');
+			expect(matchProviderForSpfInclude('spf.messagelabs.com')).toBe('Symantec Email Security.cloud');
+		});
+		it('maps cluster*.eu.messagelabs.com MX to Symantec Email Security.cloud', async () => {
+			const { matchProviderForMxHost } = await import('../src/tools/provider-guides');
+			expect(matchProviderForMxHost('cluster1.eu.messagelabs.com')).toBe('Symantec Email Security.cloud');
+		});
+	});
+
+	describe('G3 — Campaign Monitor (createsend.com)', () => {
+		it('maps _spf.createsend.com SPF to Campaign Monitor', async () => {
+			const { matchProviderForSpfInclude } = await import('../src/tools/provider-guides');
+			expect(matchProviderForSpfInclude('_spf.createsend.com')).toBe('Campaign Monitor');
+		});
+	});
+});


### PR DESCRIPTION
Three gaps found in a second-round 8-domain sweep (netflix, bbc.co.uk, gov.uk, deutsche-bank.de, rakuten.co.jp, yandex.ru, anthropic, resend).

## G1 — Public Suffix List gap (correctness bug, mine)

`rakuten.co.jp` reported **`ad.jp` as a "DNS hosting provider"** — but `ad.jp` is a JPRS-managed registry suffix for network-administration entities, **not a provider**. The original `PUBLIC_SUFFIX_SECOND_LEVEL` set covered `co/ac/ne/or/go.jp` but missed:

| Suffix | Use |
|---|---|
| `ad.jp` | Network administration |
| `ed.jp` | Primary + secondary education |
| `gr.jp` | Groups/organisations |
| `lg.jp` | Local government |

Any NS at a 3-label JP host (e.g. `ns1.dnsweb.org.ad.jp`) collapsed to the registry suffix instead of the operator's registrable domain. Fix: add the four. Same bug class as the original PSL set design — just incomplete coverage for Japan.

## G2 — Symantec Email Security.cloud (MessageLabs)
Enterprise email gateway in the same product class as Proofpoint/Mimecast/Trellix. MX `*.messagelabs.com` + SPF `spf.messagelabs.com` now resolve to `Symantec Email Security.cloud`. Observed on bbc.co.uk (raw critical rows pre-fix).

## G3 — Campaign Monitor
Newsletter/transactional ESP. SPF `*.createsend.com` → `Campaign Monitor`. Observed on netflix.com.

## TDD
8 RED tests, all GREEN (4 PSL `it.each` suffixes + 1 rakuten regression integration test asserting `ad.jp` never surfaces and `org.ad.jp` does + 2 MessageLabs match-helper + 1 Campaign Monitor). Full suite **4794 passed, 0 failed**; typecheck + lint + repo-safety clean.

## Not addressed in this PR (intentional)
- bbc.co.uk `bbc.com` NS / deutsche-bank.de `db-dns.{com,de}` / `db.com` MX — these are cross-registrable-domain self-hosted cases (same org, different registrable parents). The fix is the deferred cert-`O=`/DKIM same-entity signal from #263.
- netflix.com hosting tier on AWS without a CDN row — Netflix Open Connect (AS2906) is streaming-only; the apex genuinely is on plain AWS, surfacing as low-trust `cloud-hosting` is correct behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)