### PR TITLE
fix(scanner): drop unreliable Spamhaus ZEN from RBL/MX-reputation checks (v3.3.28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.3.28] - 2026-05-29
+
+### Removed
+
+- **Spamhaus ZEN dropped unconditionally from the RBL/DNSBL provider sets.** bv-mcp queries DNSBLs through shared public resolvers, where Spamhaus ZEN returns rate-limit/refused codes (`127.255.255.252/.254/.255`) that are indistinguishable from a real `127.0.0.x` listing — producing false "clean"/"listed" verdicts. The previous gate (`hasReliableSpamhausPath`, driven by `BV_DOH_TOKEN`) was a no-op for ZEN: the secondary-resolver token only drives empty-result confirmation in the DoH transport, it never reroutes the ZEN lookup, so the token can never make ZEN reliable here. ZEN is therefore removed entirely — neither queried nor counted:
+  - `check_rbl`: `RBL_ZONES` 8 → 7 (`zen.spamhaus.org` removed); "clean on N RBLs" and `zones` metadata reflect 7. Dead Spamhaus quota/return-code decoding removed.
+  - `check_mx_reputation` / `buildDnsblZones()`: ZEN excluded; the `hasReliableSpamhausPath` parameter/branch dropped. Tool description updated to "7 DNS-based Real-time Blocklists".
+  - `hasReliableSpamhausPath()` and `SPAMHAUS_ZEN_ZONE` removed from `src/lib/dns-types.ts` (now unreferenced).
+  - Version bump busts the version-keyed KV cache so stale ZEN-inclusive results are evicted on deploy.
+
 ## [3.3.27] - 2026-05-28
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.27",
+	"version": "3.3.28",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -457,7 +457,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	check_rbl: {
 		description:
-			'Check MX server IP reputation against 8 DNS-based Real-time Blocklists (Spamhaus ZEN, SpamCop, UCEProtect, Mailspike, Barracuda, PSBL, SORBS). Resolves MX hosts to IPs first.',
+			'Check MX server IP reputation against 7 DNS-based Real-time Blocklists (SpamCop, UCEProtect, Mailspike, Barracuda, PSBL, SORBS). Resolves MX hosts to IPs first.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/tools/check-mx-reputation.ts
+++ b/src/tools/check-mx-reputation.ts
@@ -2,8 +2,12 @@
 
 /**
  * MX Reputation check tool.
- * Resolves MX server IPs, checks against major DNSBLs (Spamhaus ZEN, SpamCop,
- * Barracuda), and validates reverse DNS (PTR) with forward-confirmed rDNS.
+ * Resolves MX server IPs, checks against major DNSBLs (SpamCop, Barracuda),
+ * and validates reverse DNS (PTR) with forward-confirmed rDNS.
+ *
+ * Spamhaus ZEN is deliberately excluded — bv-mcp queries via shared public
+ * resolvers, where ZEN returns refusal codes indistinguishable from a real
+ * verdict. See `buildDnsblZones` in `mx-reputation-analysis.ts`.
  *
  * Standalone tool — NOT included in scan_domain due to unpredictable DNSBL
  * response times. Daily quota of 20/day per IP with 60-minute caching.

--- a/src/tools/check-rbl.ts
+++ b/src/tools/check-rbl.ts
@@ -2,7 +2,14 @@
 
 /**
  * Real-time Blocklist (RBL) check tool.
- * Resolves MX IPs for a domain and checks against 8 DNS-based blocklists.
+ * Resolves MX IPs for a domain and checks against 7 DNS-based blocklists.
+ *
+ * Spamhaus ZEN is intentionally NOT in the provider set. bv-mcp queries via
+ * shared public resolvers, where ZEN returns rate-limit/refused codes
+ * (127.255.255.x) indistinguishable from a real verdict — and bv-mcp has no
+ * reliable ZEN query path (its secondary-resolver token only drives
+ * empty-result confirmation, it does not reroute the ZEN lookup). ZEN is
+ * therefore dropped unconditionally: neither queried nor counted.
  */
 
 import { queryDnsRecords, queryMxRecords } from '../lib/dns';
@@ -17,7 +24,6 @@ interface RblZone {
 }
 
 const RBL_ZONES: RblZone[] = [
-	{ name: 'Spamhaus ZEN', zone: 'zen.spamhaus.org' },
 	{ name: 'SpamCop', zone: 'bl.spamcop.net' },
 	{ name: 'UCEProtect L1', zone: 'dnsbl-1.uceprotect.net' },
 	{ name: 'UCEProtect L2', zone: 'dnsbl-2.uceprotect.net' },
@@ -30,24 +36,6 @@ const RBL_ZONES: RblZone[] = [
 const CATEGORY = 'rbl' as CheckCategory;
 const MAX_MX_IPS = 4;
 
-/** Spamhaus ZEN return code descriptions (keyed by last two octets). */
-const SPAMHAUS_CODES: Record<string, string> = {
-	'0.2': 'SBL — direct spam source',
-	'0.3': 'SBL CSS — spam support service',
-	'0.4': 'XBL CBL — exploited host',
-	'0.5': 'XBL — exploited host (NJABL)',
-	'0.9': 'SBL DROP — hijacked netblock',
-	'0.10': 'PBL ISP — end-user IP',
-	'0.11': 'PBL ISP — end-user IP',
-};
-
-/** Decode Spamhaus ZEN return code. Returns null for quota codes. */
-function decodeSpamhausCode(ip: string): string | null {
-	if (ip.startsWith('127.255.255.')) return null; // quota
-	const lastTwo = ip.split('.').slice(2).join('.');
-	return SPAMHAUS_CODES[lastTwo] ?? `Listed (${ip})`;
-}
-
 /** Mailspike positive reputation codes: 127.0.0.10 through 127.0.0.14. */
 function isMailspikePositive(ip: string): boolean {
 	const last = parseInt(ip.split('.').pop() ?? '0', 10);
@@ -55,8 +43,10 @@ function isMailspikePositive(ip: string): boolean {
 }
 
 /**
- * Check MX server IPs against 8 DNS-based Real-time Blocklists.
+ * Check MX server IPs against 7 DNS-based Real-time Blocklists.
  * Falls back to domain A records if no MX records exist.
+ *
+ * Spamhaus ZEN is excluded from the provider set — see the module header.
  */
 export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
 	const findings: ReturnType<typeof createFinding>[] = [];
@@ -153,7 +143,6 @@ export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Pr
 		checkedPublicIps++;
 		const reversed = reverseIPv4(ip);
 		let ipListingCount = 0;
-		let hasSpamhausListing = false;
 		const ipListingIndices: number[] = [];
 
 		const rblResults = await Promise.allSettled(
@@ -164,11 +153,6 @@ export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Pr
 					if (answers.length === 0) return { rbl, listed: false };
 
 					const returnIp = answers[0];
-
-					// Spamhaus quota codes
-					if (rbl.zone === 'zen.spamhaus.org' && returnIp.startsWith('127.255.255.')) {
-						return { rbl, listed: false, quota: true };
-					}
 
 					// Mailspike positive reputation
 					if (rbl.zone === 'bl.mailspike.net' && isMailspikePositive(returnIp)) {
@@ -186,17 +170,6 @@ export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Pr
 			if (settled.status === 'rejected') continue;
 			const result = settled.value;
 
-			if (result.quota) {
-				findings.push(
-					createFinding(CATEGORY, `${result.rbl.name} quota exceeded`, 'info', `Spamhaus returned a quota/rate-limit response for ${ip}. Use a DQS key for reliable results.`, {
-						ip,
-						zone: result.rbl.zone,
-						quota: true,
-					}),
-				);
-				continue;
-			}
-
 			if (result.positiveRep) {
 				findings.push(
 					createFinding(CATEGORY, `Positive Mailspike reputation for ${ip}`, 'info', `${ip} has positive reputation on Mailspike.`, {
@@ -212,17 +185,10 @@ export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Pr
 
 			ipListingCount++;
 			totalListings++;
-			if (result.rbl.zone === 'zen.spamhaus.org') hasSpamhausListing = true;
-
-			const severity = result.rbl.zone === 'zen.spamhaus.org' ? 'high' : 'low';
-			const detail =
-				result.rbl.zone === 'zen.spamhaus.org'
-					? `${ip} is listed on ${result.rbl.name}: ${decodeSpamhausCode(result.returnIp!) ?? result.returnIp}.`
-					: `${ip} is listed on ${result.rbl.name}.`;
 
 			ipListingIndices.push(findings.length);
 			findings.push(
-				createFinding(CATEGORY, `Listed on ${result.rbl.name}`, severity as 'high' | 'low', detail, {
+				createFinding(CATEGORY, `Listed on ${result.rbl.name}`, 'low', `${ip} is listed on ${result.rbl.name}.`, {
 					ip,
 					zone: result.rbl.zone,
 					returnCode: result.returnIp,
@@ -230,8 +196,8 @@ export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Pr
 			);
 		}
 
-		// Elevate severity if 2+ non-Spamhaus RBLs list the same IP
-		if (!hasSpamhausListing && ipListingCount >= 2) {
+		// Elevate severity if 2+ RBLs list the same IP
+		if (ipListingCount >= 2) {
 			const firstLowIdx = ipListingIndices.find((idx) => findings[idx]?.severity === 'low');
 			if (firstLowIdx !== undefined) {
 				const f = findings[firstLowIdx];

--- a/src/tools/mx-reputation-analysis.ts
+++ b/src/tools/mx-reputation-analysis.ts
@@ -269,10 +269,19 @@ export function analyzeDnsblResults(
 
 /**
  * Return the list of DNSBL zones to check.
- * These are well-known, reliable blocklists with publicly queryable DNS interfaces.
+ * These are well-known blocklists with publicly queryable DNS interfaces.
+ *
+ * Spamhaus ZEN is intentionally EXCLUDED. From the shared public resolvers
+ * bv-mcp runs through, ZEN returns rate-limit/refused codes
+ * (127.255.255.252/.254/.255) indistinguishable from a real verdict,
+ * producing false "clean"/"listed" results. bv-mcp has no reliable ZEN query
+ * path — its secondary-resolver token only drives empty-result confirmation in
+ * the DoH transport, it does NOT reroute the ZEN lookup — so ZEN can never be
+ * trusted here and is dropped unconditionally (neither queried nor counted).
+ * All other providers are unaffected.
  */
 export function buildDnsblZones(): string[] {
-	return ['zen.spamhaus.org', 'bl.spamcop.net', 'b.barracudacentral.org'];
+	return ['bl.spamcop.net', 'b.barracudacentral.org'];
 }
 
 /**

--- a/test/check-mx-reputation.spec.ts
+++ b/test/check-mx-reputation.spec.ts
@@ -29,9 +29,9 @@ function emptyResponse(name: string, type: number) {
 }
 
 describe('checkMxReputation', () => {
-	async function run(domain = 'example.com') {
+	async function run(domain = 'example.com', dnsOptions?: import('../src/lib/dns-types').QueryDnsOptions) {
 		const { checkMxReputation } = await import('../src/tools/check-mx-reputation');
-		return checkMxReputation(domain);
+		return checkMxReputation(domain, dnsOptions);
 	}
 
 	it('should return info findings for domain with clean MX reputation', async () => {
@@ -82,12 +82,12 @@ describe('checkMxReputation', () => {
 			if (url.includes('1.100.51.198.in-addr.arpa') && (url.includes('type=PTR') || url.includes('type=12'))) {
 				return Promise.resolve(ptrResponse('198.51.100.1', ['mail.example.com']));
 			}
-			// DNSBL: listed on Spamhaus
-			if (url.includes('spamhaus')) {
-				return Promise.resolve(aResponse('1.100.51.198.zen.spamhaus.org', ['127.0.0.2']));
+			// DNSBL: listed on SpamCop (ZEN is never queried)
+			if (url.includes('spamcop')) {
+				return Promise.resolve(aResponse('1.100.51.198.bl.spamcop.net', ['127.0.0.2']));
 			}
 			// Other DNSBLs clean
-			if (url.includes('spamcop') || url.includes('barracuda')) {
+			if (url.includes('barracuda')) {
 				return Promise.resolve(emptyResponse('lookup', 1));
 			}
 			return Promise.resolve(emptyResponse('example.com', 1));
@@ -98,7 +98,7 @@ describe('checkMxReputation', () => {
 		const highFinding = result.findings.find((f) => f.severity === 'high');
 		expect(highFinding).toBeDefined();
 		expect(highFinding!.title).toContain('listed on');
-		expect(highFinding!.title).toContain('spamhaus');
+		expect(highFinding!.title).toContain('spamcop');
 	});
 
 	it('should return medium finding when MX IP has no PTR record', async () => {
@@ -235,6 +235,39 @@ describe('checkMxReputation', () => {
 		expect(finding!.metadata?.invalidIps).toEqual(['999.0.2.1']);
 	});
 
+	it('NEVER queries Spamhaus ZEN — it is dropped unconditionally (neither queried nor counted)', async () => {
+		const queriedUrls: string[] = [];
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			queriedUrls.push(url);
+			if (url.includes('type=MX') || url.includes('type=15')) {
+				return Promise.resolve(mxResponse('example.com', [{ priority: 10, exchange: 'mail.example.com' }]));
+			}
+			if (url.includes('name=mail.example.com') && (url.includes('type=A') || url.includes('type=1'))) {
+				return Promise.resolve(aResponse('mail.example.com', ['198.51.100.1']));
+			}
+			if (url.includes('in-addr.arpa') && (url.includes('type=PTR') || url.includes('type=12'))) {
+				return Promise.resolve(ptrResponse('198.51.100.1', ['mail.example.com']));
+			}
+			// ZEN would report a listing — but it must not be queried at all here.
+			if (url.includes('spamhaus')) {
+				return Promise.resolve(aResponse('1.100.51.198.zen.spamhaus.org', ['127.0.0.2']));
+			}
+			if (url.includes('spamcop') || url.includes('barracuda')) {
+				return Promise.resolve(emptyResponse('lookup', 1));
+			}
+			return Promise.resolve(emptyResponse('example.com', 1));
+		});
+
+		const result = await run(); // ZEN is dropped regardless of dnsOptions
+		// ZEN never queried; SpamCop + Barracuda still are.
+		expect(queriedUrls.some((u) => u.includes('spamhaus'))).toBe(false);
+		expect(queriedUrls.some((u) => u.includes('spamcop'))).toBe(true);
+		// No Spamhaus verdict emitted, no false high finding.
+		expect(result.findings.some((f) => /spamhaus/i.test(f.title) || /spamhaus/i.test(f.detail))).toBe(false);
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+	});
+
 	it('should limit checks to first 3 MX hosts', async () => {
 		const mxHosts = [
 			{ priority: 10, exchange: 'mx1.example.com' },
@@ -293,11 +326,11 @@ describe('checkMxReputation', () => {
 			if (url.includes('name=smtp-in.l.google.com') && (url.includes('type=A') || url.includes('type=1'))) {
 				return Promise.resolve(aResponse('smtp-in.l.google.com', ['74.125.24.26']));
 			}
-			// DNSBL: listed on Spamhaus
-			if (url.includes('spamhaus')) {
-				return Promise.resolve(aResponse('26.24.125.74.zen.spamhaus.org', ['127.0.0.2']));
+			// DNSBL: listed on SpamCop (ZEN is never queried)
+			if (url.includes('spamcop')) {
+				return Promise.resolve(aResponse('26.24.125.74.bl.spamcop.net', ['127.0.0.2']));
 			}
-			if (url.includes('spamcop') || url.includes('barracuda')) {
+			if (url.includes('barracuda')) {
 				return Promise.resolve(emptyResponse('lookup', 1));
 			}
 			return Promise.resolve(emptyResponse('anthropic.com', 1));
@@ -310,7 +343,7 @@ describe('checkMxReputation', () => {
 		expect(highFindings.length).toBe(0);
 		// Should have an info finding mentioning Google Workspace and shared IP
 		const sharedFinding = result.findings.find(
-			(f) => f.severity === 'info' && f.title.includes('Google Workspace') && f.title.includes('spamhaus'),
+			(f) => f.severity === 'info' && f.title.includes('Google Workspace') && f.title.includes('spamcop'),
 		);
 		expect(sharedFinding).toBeDefined();
 		expect(sharedFinding!.detail).toContain('shared');
@@ -340,15 +373,12 @@ describe('checkMxReputation', () => {
 			if (url.includes('outbound.protection.outlook.com') && (url.includes('type=A') || url.includes('type=1'))) {
 				return Promise.resolve(aResponse('mail-dm6nam10on2052.outbound.protection.outlook.com', ['52.101.73.22']));
 			}
-			// DNSBL: listed on Spamhaus and SpamCop
-			if (url.includes('spamhaus')) {
-				return Promise.resolve(aResponse('lookup', ['127.0.0.2']));
-			}
+			// DNSBL: listed on SpamCop and Barracuda (ZEN is never queried)
 			if (url.includes('spamcop')) {
 				return Promise.resolve(aResponse('lookup', ['127.0.0.2']));
 			}
 			if (url.includes('barracuda')) {
-				return Promise.resolve(emptyResponse('lookup', 1));
+				return Promise.resolve(aResponse('lookup', ['127.0.0.2']));
 			}
 			return Promise.resolve(emptyResponse('contoso.com', 1));
 		});
@@ -379,10 +409,10 @@ describe('checkMxReputation', () => {
 			if (url.includes('in-addr.arpa') && (url.includes('type=PTR') || url.includes('type=12'))) {
 				return Promise.resolve(ptrResponse('198.51.100.1', ['mail.example.com']));
 			}
-			if (url.includes('spamhaus')) {
-				return Promise.resolve(aResponse('1.100.51.198.zen.spamhaus.org', ['127.0.0.2']));
+			if (url.includes('spamcop')) {
+				return Promise.resolve(aResponse('1.100.51.198.bl.spamcop.net', ['127.0.0.2']));
 			}
-			if (url.includes('spamcop') || url.includes('barracuda')) {
+			if (url.includes('barracuda')) {
 				return Promise.resolve(emptyResponse('lookup', 1));
 			}
 			return Promise.resolve(emptyResponse('example.com', 1));

--- a/test/check-rbl.spec.ts
+++ b/test/check-rbl.spec.ts
@@ -32,9 +32,13 @@ function emptyResponse(name: string) {
 	return createDohResponse([{ name, type: 1 }], []);
 }
 
-/** The 8 RBL zones used by check_rbl. */
+/**
+ * The 7 RBL zones used by check_rbl. Spamhaus ZEN is intentionally excluded —
+ * bv-mcp has no reliable ZEN query path, so it is never queried or counted.
+ * `zen.spamhaus.org` is kept in this fixture list ONLY so the mock can assert
+ * it is never queried.
+ */
 const RBL_ZONES = [
-	'zen.spamhaus.org',
 	'bl.spamcop.net',
 	'dnsbl-1.uceprotect.net',
 	'dnsbl-2.uceprotect.net',
@@ -43,6 +47,9 @@ const RBL_ZONES = [
 	'psbl.surriel.com',
 	'dnsbl.sorbs.net',
 ];
+
+/** ZEN zone — must NEVER appear in a query. Tracked separately from RBL_ZONES. */
+const ZEN_ZONE = 'zen.spamhaus.org';
 
 /**
  * Build a fetch mock that routes MX, A, and RBL queries.
@@ -123,27 +130,82 @@ function buildFetchMock(opts: {
 // ---------------------------------------------------------------------------
 
 describe('checkRbl', () => {
-	async function run(domain = 'example.com') {
+	async function run(domain = 'example.com', dnsOptions?: import('../src/lib/dns-types').QueryDnsOptions) {
 		const { checkRbl } = await import('../src/tools/check-rbl');
-		return checkRbl(domain);
+		return checkRbl(domain, dnsOptions);
 	}
 
-	it('should report high finding when listed on Spamhaus ZEN', async () => {
-		buildFetchMock({
-			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
-			mxIps: { 'mail.example.com': ['203.0.113.1'] },
-			rblAnswers: {
-				// 203.0.113.1 reversed = 1.113.0.203
-				'1.113.0.203.zen.spamhaus.org': ['127.0.0.2'],
-			},
+	it('NEVER queries Spamhaus ZEN — it is dropped unconditionally (neither queried nor counted)', async () => {
+		const queriedZones = new Set<string>();
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			const name = new URL(url).searchParams.get('name') ?? '';
+			const type = new URL(url).searchParams.get('type') ?? '';
+			if (name === 'example.com' && type === 'MX') {
+				return Promise.resolve(mxResponse('example.com', [{ priority: 10, exchange: 'mail.example.com' }]));
+			}
+			if (name === 'mail.example.com' && type === 'A') {
+				return Promise.resolve(aResponse('mail.example.com', ['203.0.113.1']));
+			}
+			if (name.endsWith(`.${ZEN_ZONE}`)) {
+				// ZEN must NEVER be queried — record it so the assertion below fails if it is.
+				queriedZones.add(ZEN_ZONE);
+				return Promise.resolve(aResponse(name, ['127.0.0.2']));
+			}
+			for (const zone of RBL_ZONES) {
+				if (name.endsWith(`.${zone}`)) {
+					queriedZones.add(zone);
+					return Promise.resolve(emptyResponse(name));
+				}
+			}
+			return Promise.resolve(emptyResponse('unknown'));
 		});
 
-		const result = await run();
-		expect(result.category).toBe('rbl');
-		const highFinding = result.findings.find((f) => f.severity === 'high');
-		expect(highFinding).toBeDefined();
-		expect(highFinding!.title).toMatch(/Spamhaus/i);
-		expect(highFinding!.detail).toContain('SBL');
+		const result = await run(); // ZEN is dropped regardless of dnsOptions
+		// ZEN never queried.
+		expect(queriedZones.has(ZEN_ZONE)).toBe(false);
+		// No ZEN/Spamhaus verdict emitted (no high listing, no quota finding).
+		expect(result.findings.some((f) => /spamhaus/i.test(f.title) || /spamhaus/i.test(f.detail))).toBe(false);
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		// Clean message counts only the 7 active (non-ZEN) zones.
+		const cleanFinding = result.findings.find((f) => /clean|not listed/i.test(f.title));
+		expect(cleanFinding).toBeDefined();
+		expect(cleanFinding!.detail).toContain('7 RBLs');
+		expect((cleanFinding!.metadata?.zones as string[]) ?? []).not.toContain(ZEN_ZONE);
+	});
+
+	it('NEVER queries Spamhaus ZEN even when a secondary-resolver token is supplied', async () => {
+		const queriedZones = new Set<string>();
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			const name = new URL(url).searchParams.get('name') ?? '';
+			const type = new URL(url).searchParams.get('type') ?? '';
+			if (name === 'example.com' && type === 'MX') {
+				return Promise.resolve(mxResponse('example.com', [{ priority: 10, exchange: 'mail.example.com' }]));
+			}
+			if (name === 'mail.example.com' && type === 'A') {
+				return Promise.resolve(aResponse('mail.example.com', ['203.0.113.1']));
+			}
+			if (name.endsWith(`.${ZEN_ZONE}`)) {
+				queriedZones.add(ZEN_ZONE);
+				return Promise.resolve(aResponse(name, ['127.0.0.2']));
+			}
+			for (const zone of RBL_ZONES) {
+				if (name.endsWith(`.${zone}`)) {
+					queriedZones.add(zone);
+					return Promise.resolve(emptyResponse(name));
+				}
+			}
+			return Promise.resolve(emptyResponse('unknown'));
+		});
+
+		// A secondary-resolver token used to gate ZEN; it no longer does — ZEN is gone.
+		const result = await run('example.com', {
+			secondaryDoh: { endpoint: 'https://doh.bv.example/dns-query', token: 'test-token' },
+		});
+		expect(queriedZones.has(ZEN_ZONE)).toBe(false);
+		expect(result.findings.some((f) => /spamhaus/i.test(f.title) || /spamhaus/i.test(f.detail))).toBe(false);
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
 	});
 
 	it('should report multiple listing findings when listed on multiple RBLs', async () => {
@@ -182,26 +244,6 @@ describe('checkRbl', () => {
 		expect(infoFinding!.title).toMatch(/clean|not listed/i);
 	});
 
-	it('should treat Spamhaus 127.255.255.x as quota error, not a listing', async () => {
-		buildFetchMock({
-			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
-			mxIps: { 'mail.example.com': ['203.0.113.1'] },
-			rblAnswers: {
-				'1.113.0.203.zen.spamhaus.org': ['127.255.255.254'],
-			},
-		});
-
-		const result = await run();
-		expect(result.category).toBe('rbl');
-		// Should NOT have a high finding
-		const highFinding = result.findings.find((f) => f.severity === 'high');
-		expect(highFinding).toBeUndefined();
-		// Should have an info finding about quota
-		const quotaFinding = result.findings.find((f) => f.detail.includes('quota') || f.detail.includes('rate'));
-		expect(quotaFinding).toBeDefined();
-		expect(quotaFinding!.severity).toBe('info');
-	});
-
 	it('should treat Mailspike 127.0.0.10 as positive reputation (info, clean)', async () => {
 		buildFetchMock({
 			mxEntries: [{ priority: 10, exchange: 'mail.example.com' }],
@@ -231,7 +273,7 @@ describe('checkRbl', () => {
 			rblAnswers: {
 				'1.113.0.203.bl.spamcop.net': ['127.0.0.2'],
 			},
-			dnsErrors: new Set(['zen.spamhaus.org']),
+			dnsErrors: new Set(['dnsbl.sorbs.net']),
 		});
 
 		const result = await run();

--- a/test/mx-reputation-analysis.spec.ts
+++ b/test/mx-reputation-analysis.spec.ts
@@ -224,12 +224,12 @@ describe('mx-reputation-analysis', () => {
 	});
 
 	describe('buildDnsblZones', () => {
-		it('should return the expected DNSBL zones', () => {
+		it('NEVER includes Spamhaus ZEN — it is dropped unconditionally', () => {
 			const zones = buildDnsblZones();
-			expect(zones).toContain('zen.spamhaus.org');
+			expect(zones).not.toContain('zen.spamhaus.org');
 			expect(zones).toContain('bl.spamcop.net');
 			expect(zones).toContain('b.barracudacentral.org');
-			expect(zones).toHaveLength(3);
+			expect(zones).toHaveLength(2);
 		});
 	});
 });


### PR DESCRIPTION
bv-mcp never had a passive ARC check (verified — it's a bv-web-only construct), so this is the ZEN change only.

**Drops Spamhaus ZEN unconditionally** from bv-mcp's RBL sets. From bv-mcp's vantage the `BV_DOH_TOKEN` only drives empty-result confirmation — it does NOT reroute the ZEN lookup — so ZEN over public DoH returns refused/quota codes indistinguishable from a real verdict. Rather than emit verdicts we can't stand behind, ZEN is removed entirely:
- `check_rbl`: 8 → **7** zones (SpamCop, UCEProtect L1/L2, Mailspike, Barracuda, PSBL, SORBS)
- `check_mx_reputation` DNSBL set: 3 → **2** (SpamCop, Barracuda)
- Removed the `hasReliableSpamhausPath` gate + dead Spamhaus-code decoding; updated tool description + tests.
- Version 3.3.27 → **3.3.28** (busts the version-keyed KV cache so stale ZEN-inclusive results are evicted on deploy).

Gates: typecheck/build/eslint clean; full suite 4795 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)