### PR TITLE
fix(certstream): cancel unread service-binding responses

### DIFF
--- a/src/lib/response-body.ts
+++ b/src/lib/response-body.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export async function disposeUnreadResponseBody(response: Response): Promise<void> {
+	if (!response.body) return;
+	try {
+		await response.body.cancel();
+	} catch {
+		// The body may already be locked or consumed.
+	}
+}

--- a/src/tenants/discovery/san-correlator.ts
+++ b/src/tenants/discovery/san-correlator.ts
@@ -19,6 +19,7 @@
  */
 
 import { JSONParser } from '@streamparser/json-whatwg';
+import { disposeUnreadResponseBody } from '../../lib/response-body';
 import { safeFetch } from '../../lib/safe-fetch';
 import { validateDomain } from '../../lib/sanitize';
 
@@ -181,7 +182,10 @@ async function attemptCertstreamSans(
 	}
 	clearTimeout(timeoutId);
 
-	if (!response.ok) return null;
+	if (!response.ok) {
+		await disposeUnreadResponseBody(response);
+		return null;
+	}
 
 	let data: CertstreamSansResponse;
 	try {

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -9,6 +9,7 @@
 
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
+import { disposeUnreadResponseBody } from '../lib/response-body';
 
 /**
  * Synchronous handler budget for `discover_subdomains` (ms).
@@ -443,7 +444,10 @@ async function queryCertstreamEndpoint<T>(
 			...(certstreamAuthToken ? { headers: { Authorization: `Bearer ${certstreamAuthToken}` } } : {}),
 			signal: composed.signal,
 		});
-		if (!response.ok) return null;
+		if (!response.ok) {
+			await disposeUnreadResponseBody(response);
+			return null;
+		}
 		return (await response.json()) as T;
 	} catch {
 		return null;

--- a/test/discover-subdomains.spec.ts
+++ b/test/discover-subdomains.spec.ts
@@ -118,6 +118,38 @@ describe('discoverSubdomains', () => {
 		expect(result.sourceUnavailable).toBeUndefined();
 	});
 
+	it('cancels unread certstream /enumerate body before falling back to /sans', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const enumerateResponse = new Response(JSON.stringify({ error: 'upstream transient' }), {
+			status: 502,
+			headers: { 'Content-Type': 'application/json' },
+		});
+		const enumerateCancel = vi.spyOn(enumerateResponse.body!, 'cancel');
+		const certstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === 'https://certstream/enumerate?domain=example.com') return enumerateResponse;
+			if (url === 'https://certstream/sans?domain=example.com') {
+				return Response.json({
+					domain: 'example.com',
+					names: ['api.example.com', 'www.example.com'],
+					certificateCount: 2,
+					timedOut: false,
+					truncated: false,
+					cached: false,
+				});
+			}
+			throw new Error(`unexpected certstream URL: ${url}`);
+		});
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('crt.sh fallback should not be used');
+		});
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch }, 'shared-internal-key');
+
+		expect(result.totalSubdomains).toBe(2);
+		expect(enumerateCancel).toHaveBeenCalledTimes(1);
+	});
+
 	it('should parse crt.sh response and extract subdomains', async () => {
 		mockCrtSh(mockCtResponse);
 		const result = await run();

--- a/test/tenants/discovery/san-correlator.test.ts
+++ b/test/tenants/discovery/san-correlator.test.ts
@@ -225,6 +225,25 @@ describe('correlateSans', () => {
 		expect(directFetch).toHaveBeenCalledTimes(1);
 	});
 
+	it('cancels unread certstream /sans body before falling back to direct crt.sh', async () => {
+		const certstreamResponse = new Response('boom', { status: 503 });
+		const certstreamCancel = vi.spyOn(certstreamResponse.body!, 'cancel');
+		const csFetch = vi.fn<typeof fetch>().mockResolvedValue(certstreamResponse);
+		const directFetch = mockFetchOk([{ id: 7, name_value: 'foo.com\nfallback-sibling.com' }]);
+		const sleepFn = vi.fn<(ms: number) => Promise<void>>().mockResolvedValue(undefined);
+
+		const result = await correlateSans('foo.com', {
+			certstream: { fetch: csFetch },
+			fetchFn: directFetch,
+			sleepFn,
+			maxRetries: 0,
+		});
+
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual(['fallback-sibling.com']);
+		expect(certstreamCancel).toHaveBeenCalledTimes(1);
+	});
+
 	it('falls back when certstream response sets error or timedOut', async () => {
 		const csFetch = vi.fn<typeof fetch>().mockResolvedValue(
 			Response.json({ domain: 'foo.com', names: [], certificateCount: 0, timedOut: true, cached: false }),


### PR DESCRIPTION
## Summary

Adds a `disposeUnreadResponseBody()` helper and wires it into the two `!response.ok` early-return paths that previously discarded a service-binding `Response` without reading or cancelling its body, leaking the underlying stream.

- **`src/lib/response-body.ts`** (new) — `disposeUnreadResponseBody(response)`: cancels `response.body` if present, swallowing the already-locked/consumed case.
- **`src/tools/discover-subdomains.ts`** — cancel the body before bailing on a non-OK CertStream `/enumerate` response.
- **`src/tenants/discovery/san-correlator.ts`** — same, for the SAN-sibling lookup path.

On Workers, an un-cancelled `Response` body from a service binding holds the stream open until GC; cancelling on the error path releases it deterministically.

## Provenance

Recovered from a local-only branch (`fix/production-rerun-hardening`, never pushed). Cherry-picked **only** the source fix onto current `main` — the branch's client rerun tooling was intentionally left out because it embeds operator-only client data the repo-safety gate blocks.

## Testing

- `npm run typecheck` — clean
- `npx vitest run test/discover-subdomains.spec.ts test/tenants/discovery/san-correlator.test.ts` — **42 passed** (includes new cases asserting the body is cancelled on the error path)
- Repo-safety hygiene scan — no sensitive surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)