### PR TITLE
chore: release v3.4.0 (check_dnskey_strength)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.4.0] - 2026-05-30
+
+### Added
+
+- **`check_dnskey_strength` — DNSKEY signing-algorithm strength audit (RFC 8624).** New scored tool (hardening tier, included in `scan_domain`) that grades each published DNSKEY algorithm — flagging deprecated RSA/SHA-1 and DSA, rewarding ECDSA P-256 / Ed25519 — independent of whether the DNSSEC chain validates. Tool count 77 → 78.
+
 ## [3.3.29] - 2026-05-29
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.29",
+	"version": "3.4.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.3.29",
+			"version": "3.4.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.3.29",
+	"version": "3.4.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.3.4",
+	"version": "3.4.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Version bump to **3.4.0** for the `check_dnskey_strength` release (PR #296, already merged to `main`).

## Surfaces synced
- `package.json` + `package-lock.json` → 3.4.0
- `server.json` `version` → 3.4.0 (description already at "78 MCP tools" from #296)
- `CHANGELOG.md` → `[3.4.0]` entry (new `check_dnskey_strength` tool, count 77 → 78)
- `SERVER_VERSION` derives from `package.json`, so no manual edit

Version-sync audits (view-version, `server-json-tool-count`) pass locally.

This release ships `check_dnskey_strength` plus the undeployed 3.3.13–3.3.29 fixes — including the now-closed resolutions for #262, #283, #250, #263 — to production on the next `deploy:prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)