### PR TITLE
fix: address production-gate P2 findings (alerting timeout, CI deploy guard, server.json bump, docs)

### DIFF
--- a/.github/workflows/deploy-hook.yml
+++ b/.github/workflows/deploy-hook.yml
@@ -72,6 +72,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      # CI deploy is intentionally fenced off — see CLAUDE.md "Deployment".
+      # Production deploys are MANUAL via `npm run deploy:prod`, which injects private
+      # bindings from the gitignored `.dev/wrangler.deploy.jsonc`. Those overrides are
+      # unavailable in CI, so a CI deploy of the public config would ship a worker
+      # missing all KV/D1/R2/Analytics/service bindings. Do not remove this guard without
+      # first wiring private-config injection from an encrypted secret.
+      - name: CI deploy is not supported (use npm run deploy:prod)
+        run: |
+          echo "::error::CI deploy is disabled — deploy manually with 'npm run deploy:prod'. Private bindings live in the gitignored .dev/ overrides and are unavailable in CI."
+          exit 1
+
       - name: Check Cloudflare token
         env:
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,13 @@ jobs:
           sed -i "s/export const SERVER_VERSION = '.*'/export const SERVER_VERSION = '$VERSION'/" src/lib/server-version.ts
           grep SERVER_VERSION src/lib/server-version.ts
 
+      - name: Update server.json version
+        env:
+          VERSION: ${{ steps.extract.outputs.version }}
+        run: |
+          node -e "const fs=require('fs');const o=JSON.parse(fs.readFileSync('server.json','utf8'));o.version=process.env.VERSION;if(o.packages&&o.packages[0])o.packages[0].version=process.env.VERSION;fs.writeFileSync('server.json',JSON.stringify(o,null,'\t')+'\n');"
+          grep -n '"version"' server.json
+
       - id: changelog
         name: Extract changelog for this version
         env:
@@ -122,7 +129,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json src/lib/server-version.ts
+          git add package.json package-lock.json src/lib/server-version.ts server.json
           if git diff --cached --quiet; then
             echo "Version already matches tag"
           else
@@ -185,6 +192,17 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      # CI deploy is intentionally fenced off — see CLAUDE.md "Deployment".
+      # Production deploys are MANUAL via `npm run deploy:prod`, which injects private
+      # bindings from the gitignored `.dev/wrangler.deploy.jsonc`. Those overrides are
+      # unavailable in CI, so a CI deploy of the public config would ship a worker
+      # missing all KV/D1/R2/Analytics/service bindings. Do not remove this guard without
+      # first wiring private-config injection from an encrypted secret.
+      - name: CI deploy is not supported (use npm run deploy:prod)
+        run: |
+          echo "::error::CI deploy is disabled — deploy manually with 'npm run deploy:prod'. Private bindings live in the gitignored .dev/ overrides and are unavailable in CI."
+          exit 1
+
       - name: Check Cloudflare token
         env:
           CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,6 +84,8 @@ Both publish together from `publish.yml` on version tags.
 
 **Timeouts**: scan 12s preserves partial results; per-check 8s.
 
+**Subrequest ceiling** (operating constraint, not a bug): a cold-cache `scan_domain` fans out ~20 subrequests/domain (18 categories, mostly DoH + 2 HTTPS); `/internal/tools/batch` can fan out to ~50×18. Cloudflare Workers caps subrequests per invocation at 50 (Free) / 1000 (Paid). BlackVeil production runs on a paid plan, so this is not a prod concern. BSL self-hosters on the Free plan should keep batch size / scan concurrency modest (cache hits don't count) or upgrade.
+
 **Post-processing**:
 
 - Non-mail (no MX): parent DMARC `sp=`/`p=` → downgrade email-auth findings to `info`

--- a/src/lib/alerting.ts
+++ b/src/lib/alerting.ts
@@ -10,6 +10,9 @@
 
 import { logError } from './log';
 
+/** Bounded timeout for webhook alert delivery so a stalled endpoint can't hang the cron. */
+const ALERT_WEBHOOK_TIMEOUT_MS = 5000;
+
 export interface AlertPayloadInput {
 	title: string;
 	severity: 'warning' | 'critical';
@@ -51,6 +54,7 @@ export async function sendAlert(webhookUrl: string, payload: AlertPayload): Prom
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify(payload),
 			redirect: 'manual',
+			signal: AbortSignal.timeout(ALERT_WEBHOOK_TIMEOUT_MS),
 		});
 		if (!response.ok) {
 			logError(`Alert webhook returned HTTP ${response.status}`, {

--- a/test/alerting.spec.ts
+++ b/test/alerting.spec.ts
@@ -69,6 +69,17 @@ describe('sendAlert', () => {
 		expect(calls[0].redirect).toBe('manual');
 	});
 
+	it('passes a bounded AbortSignal to fetch so a stalled webhook cannot hang the cron', async () => {
+		const calls: RequestInit[] = [];
+		globalThis.fetch = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+			calls.push(init!);
+			return new Response('ok', { status: 200 });
+		}) as typeof fetch;
+		await sendAlert('https://hooks.slack.com/test', { text: 'hello' });
+		expect(calls[0].signal).toBeInstanceOf(AbortSignal);
+		expect(calls[0].signal!.aborted).toBe(false);
+	});
+
 	it('logs warning on HTTP error response without throwing', async () => {
 		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 		globalThis.fetch = vi.fn(async () => {

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -59,5 +59,10 @@ export default defineConfig({
 		// this test environment; the npm Vitest wrapper keeps the matching raw
 		// stderr line out of user-visible test output.
 		dangerouslyIgnoreUnhandledErrors: true,
+		// No coverage config: the @vitest/coverage-v8 provider can't run under the
+		// @cloudflare/vitest-pool-workers runtime (workerd lacks `node:inspector`,
+		// so instrumentation throws and reports a false 0%). Quality is gated by the
+		// structural audit suite under test/audits/ (tool-count/scoring/contract
+		// invariants), not by line-coverage numbers.
 	},
 });


### PR DESCRIPTION
## Summary

A whole-repo **Final Production Gate** audit (Speyer methodology, adapted for this headless Cloudflare Worker MCP server) returned **GO with warnings — no blockers**. This PR resolves the five non-blocking **P2** findings. One automated P0 ("CI deploy ships a binding-less worker") was overturned on verification to P2 — the CI deploy path is held behind an `environment: production` approval gate with no `CLOUDFLARE_API_TOKEN` configured and no `.dev/` overrides in CI; prod deploys are manual. This PR fences it off anyway so the latent footgun can't fire.

## Changes

| Finding | Change |
|---|---|
| **Reliability** — webhook alert `fetch` had no timeout (could hang the cron) | `src/lib/alerting.ts`: added `signal: AbortSignal.timeout(5000)` (+ failing-first test, TDD) |
| **Deployment** — CI deploy jobs run the public `wrangler.jsonc` without private-config injection | `publish.yml` & `deploy-hook.yml`: fail-loud guard step + rationale comment, directing to `npm run deploy:prod` |
| **Deployment** — `server.json` version not auto-bumped at release | `publish.yml`: `node`-based bump step (safe `process.env.VERSION` pattern) + added to the committed file set |
| **Testing** — no coverage tooling | Documented in `vitest.config.mts` why `@vitest/coverage-v8` can't run under the Workers pool (`node:inspector` absent → false 0%); quality stays gated by the `test/audits/` SSOT suite |
| **Performance** — Worker subrequest ceiling undocumented | `CLAUDE.md`: noted Free 50 / Paid 1000, `scan_domain` ~20/scan, batch ~50×18; guidance for BSL self-hosters |

## Verification

- `tsc --noEmit` — **clean** (the LSP-flagged `isolatedStorage`/`poolMatchGlobs` warnings are pre-existing in `vitest.config.mts`, untouched here)
- Targeted suite green (20/20): `infra-probe-wrangler`, `workflow-secret-check`, `workflow-safety-gates`, `alerting`
- The CI-deploy guard comment was deliberately scrubbed of the literal `wrangler.jsonc` so it doesn't break the infra-probe deploy-ordering audit (`indexOf` check)

## Notes

- Coverage tooling was attempted, found non-functional under the workers pool, and **reverted** rather than shipped broken — net result is documentation, not config.
- The audit report itself (`PRODUCTION-GATE-REVIEW.md`) is intentionally **not** committed (analysis artifact; blocked by the repo's report-path pre-commit gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)