### PR TITLE
chore: release v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.4.1] - 2026-05-31
+
+### Fixed
+
+- **Webhook alert delivery is now time-bounded.** `sendAlert()` in `src/lib/alerting.ts` issued its webhook `POST` with no `AbortSignal`, so a stalled alert endpoint could hang the 15-minute cron. Added `signal: AbortSignal.timeout(5000)` (fail-open via the existing try/catch), matching the timeout discipline of every other outbound `fetch`.
+
+### Changed
+
+- **CI deploy jobs are explicitly fenced off.** `publish.yml` and `deploy-hook.yml` deployed the public `wrangler.jsonc` without the private-config injection that `npm run deploy:prod` performs, so an enabled CI deploy would have shipped a worker missing all KV/D1/R2/Analytics/service bindings. Both deploy jobs now fail loudly directing operators to the manual deploy path (private bindings live in the gitignored `.dev/` overrides, unavailable in CI).
+- **`server.json` version is auto-synced on release.** The `publish.yml` version-bump job now updates `server.json` and includes it in the committed file set, closing a manual, forgettable step.
+
+### Docs
+
+- Documented the Cloudflare Workers subrequest ceiling (Free 50 / Paid 1000) in `CLAUDE.md` for BSL self-hosters; noted why `@vitest/coverage-v8` cannot run under the workers-pool runtime.
+
 ## [3.4.0] - 2026-05-30
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.4.0",
+			"version": "3.4.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.4.0",
+	"version": "3.4.1",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Version-sync release for the production-gate P2 fixes merged in #308.

## Surfaces bumped to 3.4.1
- `package.json` + `package-lock.json`
- `server.json` (top-level `version`; remotes-only, no `packages` stanza)
- `CHANGELOG.md` — new `[3.4.1]` section
- `SERVER_VERSION` derives from `package.json` (no separate edit)

## What 3.4.1 ships (already in main via #308)
- **Fix:** webhook alert `fetch` now time-bounded (`AbortSignal.timeout(5000)`)
- **Change:** CI deploy jobs fenced off (would ship binding-less worker); `server.json` auto-synced in `publish.yml`
- **Docs:** Workers subrequest ceiling + coverage-tooling limitation in `CLAUDE.md`

Pre-bumped locally so `publish.yml`'s version-sync step is a no-op (avoids the auto-bump push that branch protection rejects). Tag `v3.4.1` to be pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)