### PR TITLE
docs: correct v3.4.1 changelog date to 2026-05-30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-## [3.4.1] - 2026-05-31
+## [3.4.1] - 2026-05-30
 
 ### Fixed
 


### PR DESCRIPTION
The `[3.4.1]` CHANGELOG heading was dated `2026-05-31` (local NZST at authoring time), but the tag, GitHub Release, and production deploy all landed **2026-05-30 UTC** — consistent with the `[3.4.0]` entry. This aligns the heading to the actual release date.

Docs-only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)