### PR TITLE
feat(scoring): v3.5.0 — NIST-aligned severity recalibration + impersonation-aware DMARC escalation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-## [3.4.1] - 2026-05-30
+## [3.5.0] - 2026-05-31
+
+Scoring-contract recalibration aligning email-authentication and DNS-integrity severities with NIST SP 800-81r3, plus a new impersonation-aware DMARC escalation. Scores and finding severities shift for some domains — see notes below.
+
+### Changed
+
+- **DMARC and SPF severities recalibrated down to reflect standalone risk.** "No DMARC record found" is now **high** (was critical) and "DMARC policy set to none" is now **medium** (was high); SPF "Too many DNS lookups" (>10 lookups → `PermError`) is now **high** (was critical). These reflect the true standalone impact of each gap — a missing DMARC record on a domain with no active impersonation is a serious monitoring gap, not an in-progress compromise. The critical rating is now reserved for the corroborated impersonation case (below).
+- **DNSSEC absence no longer zeroes the DNSSEC category.** Per NIST SP 800-81r3, DNSSEC is a baseline DNS-data-**integrity** control within a defense-in-depth model, not a category-defining missing control like an absent SPF on a mail domain. "DNSSEC not enabled" remains a **high**-severity Core finding (the category takes a proportionate penalty → ~75) but no longer sets `missingControl: true`, which previously zeroed the whole DNSSEC category. DNSSEC stays a weighted Core control; absence is now scored as a real-but-proportionate integrity gap rather than a catastrophic zero.
+
+### Added
+
+- **Impersonation-aware DMARC escalation in `scan_domain`.** When a mail-sending domain (has MX, not a no-send policy) has weak or absent DMARC **and** active lookalike/impersonation domains are detected (a medium-or-higher `lookalikes` finding), the demoted DMARC finding is re-escalated to **critical** in post-processing (`escalateDmarcForImpersonation`). This restores the critical rating precisely for the brand-justified case — weak DMARC enforcement plus a real spoofing channel — rather than applying it to every domain with a DMARC gap.
+- **`impersonation_weak_dmarc` category-interaction rule** (`src/lib/category-interactions.ts`): the score-penalty counterpart to the label escalation, firing on the same signal (`lookalikes ≤ 85` + post-escalation `dmarc ≤ 60` → −8 overall). Keeping the label escalation and the score penalty on the same signal ensures a critical DMARC label never ships without a matching score consequence.
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Override via `SCORING_CONFIG` env (JSON; `weights`, `profileWeights`, `threshold
 - **Confidence gate**: `scoreIndicatesMissingControl()` fires only for `deterministic`/`verified`. Heuristic DKIM "not found" doesn't zero category.
 - **Provider-informed DKIM**: provider detected + probing empty → HIGH → MEDIUM.
 - **Severity penalties**: C −40, H −25, M −15, L −5, Info 0.
-- **`passed`**: `score >= 50 && !hasMissingControl`. Missing control → score zeroed. Checks using `missingControl: true`: CAA, DNSSEC, HTTP Security, MTA-STS, MX, SVCB-HTTPS, NS, Zone Hygiene, BIMI, DANE, TLS-RPT.
+- **`passed`**: `score >= 50 && !hasMissingControl`. Missing control → score zeroed. Checks using `missingControl: true`: CAA, HTTP Security, MTA-STS, MX, SVCB-HTTPS, NS, Zone Hygiene, BIMI, DANE, TLS-RPT. **DNSSEC deliberately does NOT** — per NIST SP 800-81r3, DNSSEC is a baseline integrity control in a defense-in-depth model: absence is a `high`-severity Core penalty (category → 75), not a category-zeroing missing control.
 - **Grades**: A+ 92+, A 87–91, B+ 82–86, B 76–81, C+ 70–75, C 63–69, D+ 56–62, D 50–55, F <50.
 
 ### Profiles

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.4.1",
+	"version": "3.5.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.4.1",
+			"version": "3.5.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.4.1",
+	"version": "3.5.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
@@ -11,15 +11,15 @@ function createMockDNS(records: Record<string, string[]>): DNSQueryFunction {
 }
 
 describe('checkDMARC', () => {
-	it('returns critical when no DMARC record found', async () => {
+	it('returns high when no DMARC record found (scan_domain escalates to critical under impersonation)', async () => {
 		const queryDNS = createMockDNS({ '_dmarc.example.com': [] });
 		const result = await checkDMARC('example.com', queryDNS);
 		expect(result.category).toBe('dmarc');
-		expect(result.findings[0].severity).toBe('critical');
+		expect(result.findings[0].severity).toBe('high');
 		expect(result.findings[0].title).toBe('No DMARC record found');
 	});
 
-	it('flags p=none as high', async () => {
+	it('flags p=none (monitoring-only)', async () => {
 		const queryDNS = createMockDNS({
 			'_dmarc.example.com': ['v=DMARC1; p=none; rua=mailto:dmarc@example.com'],
 		});

--- a/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
@@ -17,8 +17,12 @@ describe('checkDNSSEC', () => {
 		const result = await checkDNSSEC('example.com', queryDNS, { rawQueryDNS });
 		expect(result.category).toBe('dnssec');
 		expect(result.findings.some((f) => f.title === 'DNSSEC not enabled')).toBe(true);
-		expect(result.passed).toBe(false);
-		expect(result.score).toBe(0);
+		// NIST-aligned (SP 800-81r3): DNSSEC absence is a high-severity integrity gap,
+		// NOT a missing-control zero. Category takes the high penalty (100-25=75) and
+		// passes, rather than zeroing — DNSSEC stays a weighted Core control.
+		expect(result.passed).toBe(true);
+		expect(result.score).toBe(75);
+		expect(result.findings.find((f) => f.title === 'DNSSEC not enabled')?.metadata?.missingControl).toBeUndefined();
 	});
 
 	it('reports chain of trust incomplete when DNSKEY present but no DS', async () => {

--- a/packages/dns-checks/src/checks/check-dmarc.ts
+++ b/packages/dns-checks/src/checks/check-dmarc.ts
@@ -39,8 +39,8 @@ export async function checkDMARC(
 			createFinding(
 				'dmarc',
 				'No DMARC record found',
-				'critical',
-				`No DMARC record found at _dmarc.${domain}. Without DMARC, receivers cannot verify email authentication and spoofing is easier.`,
+				'high',
+				`No DMARC record found at _dmarc.${domain}. Without DMARC, receivers cannot verify email authentication and spoofing is easier. (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
 			),
 		);
 		return buildCheckResult('dmarc', findings);
@@ -88,8 +88,8 @@ export async function checkDMARC(
 			createFinding(
 				'dmarc',
 				'DMARC policy set to none',
-				'high',
-				`DMARC policy is "none" which only monitors but does not reject or quarantine spoofed emails. Consider upgrading to "quarantine" or "reject".`,
+				'medium',
+				`DMARC policy is "none" which only monitors but does not reject or quarantine spoofed emails. Consider upgrading to "quarantine" or "reject". (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
 			),
 		);
 	} else if (policy === 'quarantine') {

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -72,14 +72,20 @@ export async function checkDNSSEC(
 
 	// Consolidated finding logic
 	if (!adFlag && dnskeyRecords.length === 0 && dsRecords.length === 0) {
-		// Fully absent — single MEDIUM
+		// Fully absent — high-severity finding, but NOT a missing-control zero.
+		// NIST SP 800-81r3 (Mar 2026) positions DNSSEC as a baseline integrity
+		// control ("Deploy DNSSEC to protect the integrity of DNS data" — one of its
+		// four top-level recommendations) within a defense-in-depth model. Absence is
+		// therefore a real integrity GAP (high severity, dents the category) but not a
+		// catastrophic missing baseline like an absent SPF on a mail domain — so we do
+		// NOT set `missingControl: true`, which would zero the whole category. DNSSEC
+		// stays a weighted Core control; the score reflects a proportionate penalty.
 		findings.push(
 			createFinding(
 				'dnssec',
 				'DNSSEC not enabled',
 				'high',
 				`DNSSEC is not configured for ${domain}. Without DNSSEC, DNS responses are not cryptographically verified, leaving SPF, DMARC, and DKIM records vulnerable to DNS-level manipulation.`,
-				{ missingControl: true },
 			),
 		);
 	} else if (dnskeyRecords.length > 0 && dsRecords.length === 0) {

--- a/packages/dns-checks/src/checks/check-spf.ts
+++ b/packages/dns-checks/src/checks/check-spf.ts
@@ -256,7 +256,7 @@ export async function checkSPF(
 			createFinding(
 				'spf',
 				'Too many DNS lookups',
-				'critical',
+				'high',
 				`SPF record requires ${recursiveLookupCount} DNS lookups (limit: 10). Receivers may return PermError and reject legitimate mail.`,
 				{ ...spfMetadata, lookupCount: recursiveLookupCount },
 			),

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.4.1",
+	"version": "3.5.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/lib/category-interactions.ts
+++ b/src/lib/category-interactions.ts
@@ -61,6 +61,35 @@ export const INTERACTION_RULES: InteractionRule[] = [
 		narrative: 'Complete absence of both SPF and DMARC means any server can send as this domain with no detection mechanism.',
 	},
 	{
+		// Score-penalty counterpart to the DMARC label-escalation in
+		// scan/post-processing.ts (`escalateDmarcForImpersonation`). Both fire on the
+		// SAME signal — active `lookalikes` impersonation — so a critical DMARC label
+		// never ships without a matching score consequence (and vice versa).
+		//
+		// Ordering matters: interaction rules run AFTER post-processing + scoring, so
+		// `dmarc` here is the POST-escalation category score. When impersonation is
+		// present the escalation rewrites the weak-DMARC finding to `critical`, which
+		// drops the dmarc category to 0 (no record, missing-control) or ~45 (p=none,
+		// critical penalty) — both <= 60. So `dmarc <= 60` reliably captures exactly
+		// the escalated cases, including p=none (whose UN-escalated score is ~70-80 and
+		// would otherwise slip past this threshold). Without impersonation the lookalikes
+		// gate below fails and neither mechanism fires.
+		id: 'impersonation_weak_dmarc',
+		conditions: [
+			// lookalikes score drops below 100 only when a calibrated medium/high
+			// lookalike is found (defensive registrations / shared-NS matches stay
+			// info-severity and don't move the score). <= 85 == "at least one
+			// medium-or-higher active impersonation domain" — the same predicate
+			// hasActiveImpersonation() uses on the label side.
+			{ category: 'lookalikes', maxScore: 85 },
+			// Weak/absent DMARC, as left by the escalation pass (see above).
+			{ category: 'dmarc', maxScore: 60 },
+		],
+		overallPenalty: 8,
+		narrative:
+			'Active lookalike/impersonation domains were detected while DMARC enforcement is weak or absent — receivers will not reject spoofed mail, turning a monitoring gap into an exploitable impersonation channel.',
+	},
+	{
 		id: 'weak_dnssec_enforcing_dmarc',
 		conditions: [
 			{ category: 'dmarc', minScore: 80 },

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -63,6 +63,15 @@ export async function applyScanPostProcessing(
 		results = adjustForNoSendDomain(results);
 	}
 
+	// Impersonation escalation: a mail-sending domain whose DMARC is weak/absent
+	// AND that has active lookalike/shadow impersonation domains is the brand-
+	// justified critical case. Re-escalate the demoted DMARC finding to critical
+	// so it is distinguishable from a routine mail domain with the same gap. Only
+	// applies when the domain actually sends mail (has MX, not a no-send policy).
+	if (!hasNoMx && !hasNoSendPolicy && hasActiveImpersonation(results) && dmarcIsWeak(results)) {
+		results = escalateDmarcForImpersonation(results);
+	}
+
 	results = await addCdnHeuristics(domain, results, {
 		certstream: runtimeOptions?.certstream,
 		certstreamAuthToken: runtimeOptions?.certstreamAuthToken,
@@ -458,6 +467,52 @@ function adjustBimiForNonMailDomain(results: CheckResult[]): CheckResult[] {
 				return {
 					...finding,
 					detail: `No BIMI record found at ${bimiDomain}. This domain does not appear to send email, so BIMI is not applicable.`,
+				};
+			}
+			return finding;
+		});
+		return buildCheckResult(result.category, adjusted);
+	});
+}
+
+/**
+ * Active brand impersonation is signalled by a medium-or-higher `lookalikes`
+ * finding (a calibrated lookalike/typosquat with real infrastructure). Info-level
+ * findings — defensive registrations, shared-NS matches — are deliberately excluded.
+ *
+ * This keys on `lookalikes` ONLY, deliberately matching the `impersonation_weak_dmarc`
+ * interaction rule in `category-interactions.ts`, which scores `lookalikes <= 85`
+ * (≈ "at least one medium-or-higher finding"). Keeping the label-escalation here and
+ * the score-penalty there on the *same* signal is what prevents a critical label that
+ * carries no score consequence. `shadow_domains` is a valid corroborator but is left
+ * out of BOTH sides for now — adding it would require a parallel interaction rule to
+ * stay coherent (see the note in category-interactions.ts).
+ */
+function hasActiveImpersonation(results: CheckResult[]): boolean {
+	const lookalikes = results.find((result) => result.category === 'lookalikes');
+	if (!lookalikes) return false;
+	return lookalikes.findings.some(
+		(finding: Finding) => finding.severity === 'medium' || finding.severity === 'high' || finding.severity === 'critical',
+	);
+}
+
+/** Weak DMARC = no record at all, or a published p=none policy (the two demoted findings). */
+function dmarcIsWeak(results: CheckResult[]): boolean {
+	const dmarc = results.find((result) => result.category === 'dmarc');
+	if (!dmarc) return false;
+	return dmarc.findings.some((finding: Finding) => finding.title === 'No DMARC record found' || finding.title === 'DMARC policy set to none');
+}
+
+/** Re-escalate the weak-DMARC finding(s) to critical, recording why. */
+function escalateDmarcForImpersonation(results: CheckResult[]): CheckResult[] {
+	return results.map((result) => {
+		if (result.category !== 'dmarc') return result;
+		const adjusted = result.findings.map((finding: Finding) => {
+			if (finding.title === 'No DMARC record found' || finding.title === 'DMARC policy set to none') {
+				return {
+					...finding,
+					severity: 'critical' as const,
+					detail: `${finding.detail} (escalated — active lookalike/impersonation domains were detected for this domain, so weak DMARC enforcement is an exploitable spoofing channel)`,
 				};
 			}
 			return finding;

--- a/test/category-interactions.spec.ts
+++ b/test/category-interactions.spec.ts
@@ -159,6 +159,35 @@ describe('applyInteractionPenalties', () => {
 		expect(rule).toBeUndefined();
 	});
 
+	it('applies impersonation_weak_dmarc when active lookalikes coincide with weak DMARC', () => {
+		// lookalikes=70 (a medium/high impersonation domain detected) + dmarc=0 (no record)
+		const score = buildScore({ lookalikes: 70, dmarc: 0 }, 55);
+		const { adjustedScore, effects } = applyInteractionPenalties(score);
+		const rule = effects.find((e) => e.ruleId === 'impersonation_weak_dmarc');
+		expect(rule).toBeDefined();
+		expect(rule!.penalty).toBe(8);
+		expect(adjustedScore.overall).toBe(47);
+	});
+
+	it('impersonation_weak_dmarc fires for p=none (dmarc=50) with active lookalikes', () => {
+		const score = buildScore({ lookalikes: 80, dmarc: 50 }, 60);
+		const { effects } = applyInteractionPenalties(score);
+		expect(effects.find((e) => e.ruleId === 'impersonation_weak_dmarc')).toBeDefined();
+	});
+
+	it('impersonation_weak_dmarc does NOT fire when no active lookalikes (clean = 100)', () => {
+		// Weak DMARC but no impersonation — the routine-sender case, must not escalate.
+		const score = buildScore({ lookalikes: 100, dmarc: 0 }, 60);
+		const { effects } = applyInteractionPenalties(score);
+		expect(effects.find((e) => e.ruleId === 'impersonation_weak_dmarc')).toBeUndefined();
+	});
+
+	it('impersonation_weak_dmarc does NOT fire when DMARC is strong', () => {
+		const score = buildScore({ lookalikes: 60, dmarc: 85 }, 80);
+		const { effects } = applyInteractionPenalties(score);
+		expect(effects.find((e) => e.ruleId === 'impersonation_weak_dmarc')).toBeUndefined();
+	});
+
 	it('minScore condition works correctly', () => {
 		// weak_dnssec_enforcing_dmarc requires dmarc >= 80 and dnssec <= 40
 		const score1 = buildScore({ dmarc: 79, dnssec: 0 }, 70);

--- a/test/check-dmarc.spec.ts
+++ b/test/check-dmarc.spec.ts
@@ -32,12 +32,12 @@ describe('checkDmarc', () => {
 		return checkDmarc(domain);
 	}
 
-	it('should return critical finding when no DMARC record exists', async () => {
+	it('should return high finding when no DMARC record exists (critical reserved for the impersonation-corroborated case in scan_domain)', async () => {
 		mockTxtRecords([]);
 		const result = await run();
 		expect(result.category).toBe('dmarc');
 		expect(result.findings).toHaveLength(1);
-		expect(result.findings[0].severity).toBe('critical');
+		expect(result.findings[0].severity).toBe('high');
 		expect(result.findings[0].title).toMatch(/No DMARC/i);
 	});
 
@@ -57,12 +57,12 @@ describe('checkDmarc', () => {
 		expect(finding!.severity).toBe('critical');
 	});
 
-	it('should return high finding for p=none', async () => {
+	it('should return medium finding for p=none (monitoring-only, not a hard fail)', async () => {
 		mockTxtRecords(['v=DMARC1; p=none; rua=mailto:dmarc@example.com']);
 		const result = await run();
 		const finding = result.findings.find((f) => /policy set to none/i.test(f.title));
 		expect(finding).toBeDefined();
-		expect(finding!.severity).toBe('high');
+		expect(finding!.severity).toBe('medium');
 	});
 
 	it('should return low finding for p=quarantine', async () => {

--- a/test/check-spf.spec.ts
+++ b/test/check-spf.spec.ts
@@ -161,7 +161,7 @@ describe('checkSpf', () => {
 		const r = await run();
 		const f = r.findings.find((f) => f.title.includes('Too many DNS'));
 		expect(f).toBeDefined();
-		expect(f!.severity).toBe('critical');
+		expect(f!.severity).toBe('high');
 	});
 
 	// ---- New tests for recursive include expansion ----
@@ -187,7 +187,7 @@ describe('checkSpf', () => {
 		const r = await run();
 		const f = r.findings.find((f) => f.title.includes('Too many DNS'));
 		expect(f).toBeDefined();
-		expect(f!.severity).toBe('critical');
+		expect(f!.severity).toBe('high');
 		// Total: 3 (top-level includes) + 3*3 (nested includes) = 12
 		expect(f!.metadata?.lookupCount).toBe(12);
 	});
@@ -273,7 +273,7 @@ describe('checkSpf', () => {
 		const r = await run();
 		const f = r.findings.find((f) => f.title.includes('Too many DNS'));
 		expect(f).toBeDefined();
-		expect(f!.severity).toBe('critical');
+		expect(f!.severity).toBe('high');
 		// example.com: include + a + mx + exists = 4
 		// a.com: include + a + mx = 3
 		// b.com: include + a + mx + ptr = 4

--- a/test/dmarc-impersonation-escalation.spec.ts
+++ b/test/dmarc-impersonation-escalation.spec.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * End-to-end composition test for the DMARC impersonation escalation feature.
+ *
+ * It exercises the REAL pipeline in order —
+ *   applyScanPostProcessing (label escalation)
+ *     -> computeScanScore (category + tier scoring)
+ *       -> applyInteractionPenalties (overall-score penalty)
+ * — to prove the two new mechanisms stay coherent: a `critical` DMARC label never
+ * ships without the matching `impersonation_weak_dmarc` score penalty, and vice
+ * versa. Unit tests in scan-post-processing.spec.ts and category-interactions.spec.ts
+ * cover each mechanism in isolation; this guards their COMPOSITION, where the
+ * label-vs-score divergence the audit set out to kill would otherwise hide —
+ * especially for p=none, whose un-escalated DMARC score (~70-80) slips past the
+ * rule's `dmarc <= 60` threshold until escalation drops it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { type CheckResult, buildCheckResult, createFinding } from '../src/lib/scoring';
+import { computeScanScore } from '@blackveil/dns-checks/scoring';
+import { applyInteractionPenalties } from '../src/lib/category-interactions';
+
+const mailMx = (): CheckResult => buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 MX records configured.')]);
+
+const noDmarc = (): CheckResult =>
+	buildCheckResult('dmarc', [createFinding('dmarc', 'No DMARC record found', 'high', 'No DMARC record found at _dmarc.example.com.')]);
+
+/** A realistic p=none record: monitoring-only policy + the usual relaxed-alignment lows. */
+const pNoneDmarc = (): CheckResult =>
+	buildCheckResult('dmarc', [
+		createFinding('dmarc', 'DMARC policy set to none', 'medium', 'DMARC policy is "none" which only monitors.'),
+		createFinding('dmarc', 'Relaxed DKIM alignment', 'low', 'adkim relaxed.'),
+		createFinding('dmarc', 'Relaxed SPF alignment', 'low', 'aspf relaxed.'),
+	]);
+
+const activeLookalikes = (): CheckResult =>
+	buildCheckResult('lookalikes', [
+		createFinding('lookalikes', 'Active lookalike domain detected', 'medium', 'examp1e.com resolves with mail infrastructure.'),
+	]);
+
+const cleanLookalikes = (): CheckResult =>
+	buildCheckResult('lookalikes', [createFinding('lookalikes', 'No active lookalike domains detected', 'info', 'No active registrations.')]);
+
+async function runPipeline(results: CheckResult[]) {
+	const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+	const post = await applyScanPostProcessing('example.com', results);
+	// No DomainContext → default scoring, where DEFAULT_CRITICAL_CATEGORIES includes
+	// dmarc at full core weight (the mail-domain-equivalent default).
+	const score = computeScanScore(post);
+	const { adjustedScore, effects } = applyInteractionPenalties(score);
+	const dmarc = post.find((r) => r.category === 'dmarc');
+	const ruleFired = effects.some((e) => e.ruleId === 'impersonation_weak_dmarc');
+	return { post, dmarc, overall: adjustedScore.overall, ruleFired, effects };
+}
+
+describe('DMARC impersonation escalation — full pipeline coherence', () => {
+	it('no-DMARC + impersonation (#5): critical label AND the rule fires AND scores below the no-impersonation case (#2)', async () => {
+		const withImpersonation = await runPipeline([mailMx(), noDmarc(), activeLookalikes()]);
+		const without = await runPipeline([mailMx(), noDmarc(), cleanLookalikes()]);
+
+		// #5: label escalated to critical, score penalty applied.
+		expect(withImpersonation.dmarc?.findings[0].severity).toBe('critical');
+		expect(withImpersonation.ruleFired).toBe(true);
+
+		// #2: routine sender — demoted high, rule does NOT fire.
+		expect(without.dmarc?.findings[0].severity).toBe('high');
+		expect(without.ruleFired).toBe(false);
+
+		// The justified-critical case must score strictly worse.
+		expect(withImpersonation.overall).toBeLessThan(without.overall);
+	});
+
+	it('p=none + impersonation: critical label AND the rule fires (escalation drops dmarc score under the <=60 threshold)', async () => {
+		const result = await runPipeline([mailMx(), pNoneDmarc(), activeLookalikes()]);
+		const none = result.dmarc?.findings.find((f) => f.title === 'DMARC policy set to none');
+		expect(none?.severity).toBe('critical');
+		expect(result.ruleFired).toBe(true);
+	});
+
+	it('p=none WITHOUT impersonation: stays medium, rule does not fire, and the un-escalated dmarc score is above the rule threshold', async () => {
+		const result = await runPipeline([mailMx(), pNoneDmarc(), cleanLookalikes()]);
+		const none = result.dmarc?.findings.find((f) => f.title === 'DMARC policy set to none');
+		expect(none?.severity).toBe('medium');
+		expect(result.ruleFired).toBe(false);
+
+		// Documents WHY the escalation-first ordering matters: an un-escalated p=none
+		// scores ABOVE 60, so the score-based rule alone would miss it. Coherence comes
+		// from escalation running first and lowering this score.
+		const dmarcScore = computeScanScore(result.post).categoryScores.dmarc;
+		expect(dmarcScore).toBeGreaterThan(60);
+	});
+});

--- a/test/scan-post-processing.spec.ts
+++ b/test/scan-post-processing.spec.ts
@@ -106,6 +106,92 @@ describe('scan-post-processing helpers', () => {
 		expect(bimi?.findings[0].detail).not.toContain('does not appear to send email');
 	});
 
+	it('escalates a weak DMARC finding to critical when active impersonation is present on a mail domain', async () => {
+		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+		const results: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 MX records configured.')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'No DMARC record found', 'high', 'No DMARC record found at _dmarc.example.com.')]),
+			buildCheckResult('lookalikes', [
+				createFinding('lookalikes', 'Active lookalike domain detected', 'high', 'examp1e.com resolves with mail infrastructure.'),
+			]),
+		];
+
+		const updated = await applyScanPostProcessing('example.com', results);
+		const dmarc = updated.find((r) => r.category === 'dmarc');
+		expect(dmarc?.findings[0].severity).toBe('critical');
+		expect(dmarc?.findings[0].detail).toContain('escalated');
+	});
+
+	it('escalates p=none to critical under active impersonation', async () => {
+		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+		const results: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 MX records configured.')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC policy set to none', 'medium', 'DMARC policy is "none".')]),
+			buildCheckResult('lookalikes', [
+				createFinding('lookalikes', 'Active lookalike domain detected', 'medium', 'examp1e.com resolves with mail infrastructure.'),
+			]),
+		];
+
+		const updated = await applyScanPostProcessing('example.com', results);
+		const none = updated.find((r) => r.category === 'dmarc')?.findings.find((f) => f.title === 'DMARC policy set to none');
+		expect(none?.severity).toBe('critical');
+	});
+
+	it('does NOT escalate on a shadow_domains signal alone (escalation keys on lookalikes only, to stay coherent with the score penalty)', async () => {
+		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+		const results: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 MX records configured.')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'No DMARC record found', 'high', 'No DMARC record found at _dmarc.example.com.')]),
+			buildCheckResult('shadow_domains', [
+				createFinding('shadow_domains', 'Shadow domain variant detected', 'medium', 'example-support.com shares infrastructure.'),
+			]),
+		];
+
+		const updated = await applyScanPostProcessing('example.com', results);
+		const dmarc = updated.find((r) => r.category === 'dmarc');
+		expect(dmarc?.findings[0].severity).toBe('high');
+	});
+
+	it('does NOT escalate when no active impersonation — a routine sender keeps the demoted high severity', async () => {
+		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+		const results: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 MX records configured.')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'No DMARC record found', 'high', 'No DMARC record found at _dmarc.example.com.')]),
+			buildCheckResult('lookalikes', [
+				createFinding('lookalikes', 'No active lookalike domains detected', 'info', 'No active registrations detected.'),
+			]),
+		];
+
+		const updated = await applyScanPostProcessing('example.com', results);
+		const dmarc = updated.find((r) => r.category === 'dmarc');
+		expect(dmarc?.findings[0].severity).toBe('high');
+		expect(dmarc?.findings[0].detail).not.toContain('escalated');
+	});
+
+	it('does NOT escalate for non-mail domains — missing DMARC is downgraded to info, never escalated', async () => {
+		vi.doMock('../src/lib/dns', () => ({
+			queryTxtRecords: vi.fn().mockResolvedValue([]),
+		}));
+		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
+
+		const results: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'No inbound mail is configured.')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'No DMARC record found', 'high', 'No DMARC record found at _dmarc.parked.example.com.')]),
+			buildCheckResult('lookalikes', [
+				createFinding('lookalikes', 'Active lookalike domain detected', 'high', 'examp1e.com resolves with mail infrastructure.'),
+			]),
+		];
+
+		const updated = await applyScanPostProcessing('parked.example.com', results);
+		const dmarc = updated.find((r) => r.category === 'dmarc');
+		expect(dmarc?.findings[0].severity).toBe('info');
+		vi.doUnmock('../src/lib/dns');
+	});
+
 	it('adds outbound provider inference when SPF include domains match provider signatures', async () => {
 		const { applyScanPostProcessing } = await import('../src/tools/scan/post-processing');
 


### PR DESCRIPTION
## Summary

Public-scoring-contract change (repo-fabric **Change class A**). Recalibrates email-authentication and DNS-integrity severities to reflect *standalone* risk, aligns DNSSEC scoring with **NIST SP 800-81r3**, and adds an **impersonation-aware DMARC escalation** that restores the critical rating for the brand-justified case. Some domain scores and finding severities shift — full notes in `CHANGELOG.md [3.5.0]`.

### Severity recalibration (standalone risk)
- DMARC **"No DMARC record found"** `critical → high`
- DMARC **"DMARC policy set to none"** `high → medium`
- SPF **"Too many DNS lookups"** (>10 → `PermError`) `critical → high`

### DNSSEC de-zeroing (NIST SP 800-81r3)
- Removed `missingControl: true` from **"DNSSEC not enabled"**. DNSSEC is a baseline DNS-data-integrity control in a defense-in-depth model, not a category-defining missing control. Absence stays a **high**-severity Core finding (category → ~75) but no longer zeroes the whole category. DNSSEC remains a weighted Core control.

### Impersonation-aware escalation (new)
- `escalateDmarcForImpersonation` (`src/tools/scan/post-processing.ts`) re-escalates weak/absent DMARC to **critical** when a mail-sending domain (MX present, not no-send) has active lookalike/impersonation domains (medium+ `lookalikes` finding).
- New `impersonation_weak_dmarc` interaction rule (`src/lib/category-interactions.ts`) — score-penalty counterpart on the **same signal** (`lookalikes ≤ 85` + post-escalation `dmarc ≤ 60` → −8), so a critical label never ships without a matching score consequence.

## Version sync
`package.json`, `package-lock.json`, `server.json` (remotes-only single `version`), `CHANGELOG [3.5.0]`. `SERVER_VERSION` auto-derives from `pkg.version`. `CLAUDE.md` missing-control list updated.

## Testing
Under Node 22:
- Package: `check-dmarc`, `check-dnssec`, `scoring-profiles`, `scoring-model` ✅
- Root: `check-dmarc`, `check-spf`, `category-interactions`, `scan-post-processing`, **new** `dmarc-impersonation-escalation` (end-to-end pipeline coherence), `scoring-profiles`, `scoring-model`, `scan-domain` ✅
- Audits + contracts: 362 passed (6 errors = documented WebSocket pool-teardown flake)
- `npm run typecheck` clean

## Deploy
Tagging `v3.5.0` (triggers `publish.yml`: MCP Registry publish + GH Release; npm gated, Cloudflare deploy fenced) and `npm run deploy:prod` are **held pending explicit confirmation** — registry/prod skew otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)