### PR TITLE
feat(scoring): extract classifyDmarc — shared DMARC scoring SoT (dns-checks 1.2.0)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/checks/check-dmarc.ts
+++ b/packages/dns-checks/src/checks/check-dmarc.ts
@@ -9,7 +9,8 @@
  */
 
 import type { CheckResult, DNSQueryFunction, Finding } from '../types';
-import { buildCheckResult, createFinding } from '../check-utils';
+import { buildCheckResult } from '../check-utils';
+import { classifyDmarc, appendDmarcCleanInfo, type DmarcFacts } from '../scoring/classifiers/dmarc';
 import { checkRuaAuthorization, detectThirdPartyAggregators, isValidDmarcUri, parseDmarcTags } from './dmarc-utils';
 
 export { parseDmarcTags } from './dmarc-utils';
@@ -24,7 +25,6 @@ export async function checkDMARC(
 	options?: { timeout?: number },
 ): Promise<CheckResult> {
 	const timeout = options?.timeout ?? 5000;
-	const findings: Finding[] = [];
 	const txtRecords = await queryDNS(`_dmarc.${domain}`, 'TXT', { timeout });
 
 	// Concatenate all TXT records to handle cases where DMARC data is split across multiple records
@@ -35,345 +35,48 @@ export async function checkDMARC(
 	const dmarcRecords = dmarcMatch ? [dmarcMatch[0]] : [];
 
 	if (dmarcRecords.length === 0) {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'No DMARC record found',
-				'high',
-				`No DMARC record found at _dmarc.${domain}. Without DMARC, receivers cannot verify email authentication and spoofing is easier. (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
-			),
-		);
-		return buildCheckResult('dmarc', findings);
+		return buildCheckResult('dmarc', classifyDmarc({ recordCount: 0, policy: null, domain }));
 	}
 
 	// Check for multiple DMARC records in the concatenated data
 	const dmarcMatches = concatenatedTxt.match(/v=dmarc1/gi);
-	if (dmarcMatches && dmarcMatches.length > 1) {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Multiple DMARC records',
-				'high',
-				`Found ${dmarcMatches.length} DMARC records in TXT data. Only one DMARC record should exist per domain.`,
-			),
-		);
-	}
+	const recordCount = dmarcMatches?.length ?? 1;
 
-	const dmarc = dmarcRecords[0];
-	const tags = parseDmarcTags(dmarc);
-	const validPolicies = new Set(['none', 'quarantine', 'reject']);
-
-	// Check policy (p= tag)
-	const policy = tags.get('p');
-	if (!policy) {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Missing DMARC policy',
-				'critical',
-				`DMARC record is missing the required "p=" tag. Without a policy, DMARC provides no protection.`,
-			),
-		);
-	} else if (!validPolicies.has(policy)) {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Invalid DMARC policy value',
-				'high',
-				`DMARC policy value "${policy}" is invalid. Allowed values are none, quarantine, or reject.`,
-			),
-		);
-	} else if (policy === 'none') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'DMARC policy set to none',
-				'medium',
-				`DMARC policy is "none" which only monitors but does not reject or quarantine spoofed emails. Consider upgrading to "quarantine" or "reject". (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
-			),
-		);
-	} else if (policy === 'quarantine') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'DMARC policy set to quarantine',
-				'low',
-				`DMARC policy is "quarantine". Consider upgrading to "reject" for maximum protection once you've verified legitimate email flows.`,
-			),
-		);
-	}
-	// "reject" is the strongest setting - no finding needed
-
-	// Check subdomain policy (sp= tag)
-	const sp = tags.get('sp');
-	// DMARCbis (RFC 9989) non-existent-subdomain policy. When `np=reject`/`np=quarantine`
-	// is set, non-existent subdomain spoofing is explicitly protected — the practical risk
-	// of `sp=none` is then limited to *existing* subdomains, which is a substantially
-	// smaller surface than the "any unowned subdomain" risk without np=. We downgrade the
-	// "Subdomain policy weaker than parent policy" finding accordingly.
-	const np = tags.get('np');
-	const npProtects = np === 'reject' || np === 'quarantine';
-	if (!sp && policy === 'reject') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'No subdomain policy',
-				'low',
-				`No subdomain policy (sp=) specified. Subdomains inherit the main policy ("${policy}"), but explicitly setting sp= is recommended.`,
-			),
-		);
-	} else if (!sp && policy === 'none') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Subdomains inherit p=none policy',
-				'info',
-				'No subdomain policy (sp=) specified. Subdomains inherit the "none" policy, which provides no protection against spoofing.',
-			),
-		);
-	} else if (sp) {
-		if (!validPolicies.has(sp)) {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Invalid subdomain policy value',
-					'medium',
-					`DMARC subdomain policy value "${sp}" is invalid. Allowed values are none, quarantine, or reject.`,
-				),
-			);
-		} else if (policy === 'reject' && sp === 'none') {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Subdomain policy weaker than parent policy',
-					npProtects ? 'low' : 'high',
-					npProtects
-						? `Subdomain policy is set to "none" while parent policy is "reject". Non-existent subdomains are still protected by DMARCbis np=${np}, so the residual risk is limited to existing subdomains.`
-						: 'Subdomain policy is set to "none" while parent policy is "reject". This leaves subdomains vulnerable to spoofing.',
-				),
-			);
-		} else if (policy === 'reject' && sp === 'quarantine') {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Subdomain policy weaker than parent policy',
-					'low',
-					'Subdomain policy is "quarantine" while parent policy is "reject". Consider using sp=reject for consistent enforcement.',
-				),
-			);
-		} else if (policy === 'quarantine' && sp === 'none') {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Subdomain policy weaker than domain policy',
-					'medium',
-					'Subdomain policy is set to "none" while domain policy is "quarantine". Subdomains are unprotected against spoofing.',
-				),
-			);
-		}
-	}
-
-	// Check percentage (pct= tag)
-	const pct = tags.get('pct');
-	if (pct) {
-		const pctValue = Number.parseInt(pct, 10);
-		if (!Number.isFinite(pctValue) || Number.isNaN(pctValue) || pctValue < 0 || pctValue > 100) {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Invalid DMARC percentage value',
-					'medium',
-					`DMARC pct value "${pct}" is invalid. Allowed range is 0-100.`,
-				),
-			);
-		} else if (pctValue < 100) {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'DMARC not applied to all emails',
-				'medium',
-				`DMARC pct=${pctValue} means the policy only applies to ${pctValue}% of emails. Set pct=100 for full coverage.`,
-			),
-		);
-		}
-	}
-
-	// Check reporting interval (ri= tag) — RFC 7489 §6.3
-	// Value must be a positive integer (> 0). Default is 86400 (24 hours).
-	const ri = tags.get('ri');
-	if (ri !== undefined) {
-		const riValue = parseInt(ri, 10);
-		if (isNaN(riValue) || !Number.isFinite(riValue) || riValue <= 0) {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Invalid DMARC reporting interval',
-					'medium',
-					`DMARC ri value "${ri}" is invalid. RFC 7489 §6.3 requires ri= to be a positive integer greater than zero. The default is 86400 (24 hours).`,
-				),
-			);
-		}
-	}
-
-	// Check forensic failure reporting options (fo=)
-	const fo = tags.get('fo');
-	if (fo) {
-		const allowedFoValues = new Set(['0', '1', 'd', 's']);
-		const foValues = fo
-			.split(':')
-			.map((v) => v.trim())
-			.filter((v) => v.length > 0);
-
-		const invalidFo = foValues.filter((v) => !allowedFoValues.has(v));
-		if (foValues.length === 0 || invalidFo.length > 0) {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Invalid DMARC failure reporting options',
-					'medium',
-					`DMARC fo value "${fo}" contains unsupported option(s): ${invalidFo.join(', ') || 'none'}. Allowed values: 0, 1, d, s.`,
-				),
-			);
-		} else if (foValues.length === 1 && foValues[0] === '0') {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Limited DMARC failure reporting coverage',
-					'low',
-					'DMARC fo=0 only generates forensic reports when both SPF and DKIM fail. Consider fo=1 for broader failure visibility.',
-				),
-			);
-		}
-	}
-
-	// Check for reporting (rua= tag)
+	const tags = parseDmarcTags(dmarcRecords[0]);
 	const rua = tags.get('rua');
-	if (!rua) {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'No aggregate reporting',
-				'medium',
-				`No aggregate report URI (rua=) specified. Without reporting, you cannot monitor DMARC authentication results.`,
-			),
-		);
-	} else {
-		// Validate rua= URI format
-		const ruaUris = rua.split(',').map((u) => u.trim());
-		const invalidRuaUris = ruaUris.filter((uri) => !isValidDmarcUri(uri));
-		if (invalidRuaUris.length > 0) {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Invalid aggregate report URI format',
-					'medium',
-					`DMARC aggregate report URI(s) invalid: ${invalidRuaUris.join(', ')}. Must use mailto: scheme.`,
-				),
-			);
-		}
-
-		// Check for third-party aggregator services
-		const aggregators = detectThirdPartyAggregators(ruaUris);
-		if (aggregators.length > 0) {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Third-party DMARC aggregator detected',
-					'info',
-					`Using third-party aggregator(s): ${aggregators.join(', ')}. Ensure these services are authorized to receive your DMARC reports.`,
-					{ aggregators },
-				),
-			);
-		}
-
-		// Cross-domain RUA authorization check (RFC 7489 §7.1)
-		const ruaAuthFindings = await checkRuaAuthorization(domain, ruaUris, queryDNS, timeout);
-		findings.push(...ruaAuthFindings);
-	}
-
-	// Check forensic reporting (ruf= tag)
 	const ruf = tags.get('ruf');
-	if (ruf) {
-		const rufUris = ruf.split(',').map((u) => u.trim());
-		const invalidRufUris = rufUris.filter((uri) => !isValidDmarcUri(uri));
-		if (invalidRufUris.length > 0) {
-			findings.push(
-				createFinding(
-					'dmarc',
-					'Invalid forensic report URI format',
-					'medium',
-					`DMARC forensic report URI(s) invalid: ${invalidRufUris.join(', ')}. Must use mailto: scheme.`,
-				),
-			);
-		}
-	} else if (rua) {
-		// rua= is present but ruf= is not
-		findings.push(
-			createFinding(
-				'dmarc',
-				'No forensic reporting configured (ruf= absent)',
-				'low',
-				'Aggregate reporting (rua=) is configured but forensic reporting (ruf=) is not. Forensic reports provide detailed failure information useful for troubleshooting.',
-			),
-		);
+	const ruaUris = rua ? rua.split(',').map((u) => u.trim()) : [];
+	const rufUris = ruf ? ruf.split(',').map((u) => u.trim()) : [];
+
+	const facts: DmarcFacts = {
+		recordCount,
+		policy: tags.get('p') ?? null,
+		domain,
+		sp: tags.get('sp'),
+		np: tags.get('np'),
+		pct: tags.get('pct'),
+		ri: tags.get('ri'),
+		fo: tags.get('fo'),
+		rua,
+		ruf,
+		adkim: tags.get('adkim'),
+		aspf: tags.get('aspf'),
+		aggregators: rua ? detectThirdPartyAggregators(ruaUris) : [],
+		invalidRuaUris: ruaUris.filter((uri) => !isValidDmarcUri(uri)),
+		invalidRufUris: rufUris.filter((uri) => !isValidDmarcUri(uri)),
+	};
+
+	const findings: Finding[] = classifyDmarc(facts);
+
+	// DNS-dependent cross-domain RUA authorization (RFC 7489 §7.1) — stays in the
+	// check wrapper, not the pure classifier.
+	if (rua) {
+		findings.push(...(await checkRuaAuthorization(domain, ruaUris, queryDNS, timeout)));
 	}
 
-	// Check DKIM alignment mode (adkim= tag)
-	const adkim = tags.get('adkim');
-	if (adkim && adkim !== 'r' && adkim !== 's') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Invalid DKIM alignment mode',
-				'medium',
-				`DMARC adkim value "${adkim}" is invalid. Allowed values are "r" (relaxed) or "s" (strict).`,
-			),
-		);
-	} else if (!adkim || adkim === 'r') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Relaxed DKIM alignment',
-				'low',
-				`DKIM alignment mode is relaxed (adkim=r or unset). Consider adkim=s (strict) for stronger authentication.`,
-			),
-		);
-	}
-
-	// Check SPF alignment mode (aspf= tag)
-	const aspf = tags.get('aspf');
-	if (aspf && aspf !== 'r' && aspf !== 's') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Invalid SPF alignment mode',
-				'medium',
-				`DMARC aspf value "${aspf}" is invalid. Allowed values are "r" (relaxed) or "s" (strict).`,
-			),
-		);
-	} else if (!aspf || aspf === 'r') {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'Relaxed SPF alignment',
-				'low',
-				`SPF alignment mode is relaxed (aspf=r or unset). Consider aspf=s (strict) for stronger authentication.`,
-			),
-		);
-	}
-
-	// If no critical, high, or medium issues found, add info
-	const hasSignificantIssues = findings.some((f) => f.severity === 'critical' || f.severity === 'high' || f.severity === 'medium');
-	if (!hasSignificantIssues) {
-		findings.push(
-			createFinding(
-				'dmarc',
-				'DMARC properly configured',
-				'info',
-				`DMARC record found with policy "${policy}" and valid core tags.`,
-			),
-		);
-	}
+	// Closing reassurance finding, evaluated over the COMPLETE finding set
+	// (synchronous + RUA-auth), matching the original ordering.
+	appendDmarcCleanInfo(findings, facts.policy);
 
 	return buildCheckResult('dmarc', findings);
 }

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -61,6 +61,10 @@ export {
 } from './checks';
 export type { CaaRecord, TlsaRecord } from './checks';
 
+// Scoring classifiers
+export { classifyDmarc, appendDmarcCleanInfo } from './scoring/classifiers/dmarc';
+export type { DmarcFacts } from './scoring/classifiers/dmarc';
+
 // Zod schemas
 export {
 	CheckCategorySchema,

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+import { describe, expect, it } from 'vitest';
+import { classifyDmarc } from './dmarc';
+
+const base = { recordCount: 1 } as const;
+
+describe('classifyDmarc', () => {
+	it('flags absent DMARC as high (NIST v3.5.0)', () => {
+		const f = classifyDmarc({ recordCount: 0, policy: null });
+		expect(f).toHaveLength(1);
+		expect(f[0].title).toBe('No DMARC record found');
+		expect(f[0].severity).toBe('high');
+	});
+
+	it('scores p=none as a medium finding (NIST v3.5.0)', () => {
+		const f = classifyDmarc({ ...base, policy: 'none' });
+		expect(f.find((x) => x.title === 'DMARC policy set to none')?.severity).toBe('medium');
+	});
+
+	it('flags p=quarantine as low', () => {
+		const f = classifyDmarc({ ...base, policy: 'quarantine', rua: 'mailto:dmarc@example.com' });
+		expect(f.find((x) => x.title === 'DMARC policy set to quarantine')?.severity).toBe('low');
+	});
+
+	it('emits no significant finding for a clean p=reject record', () => {
+		const f = classifyDmarc({ ...base, policy: 'reject', sp: 'reject', rua: 'mailto:dmarc@example.com', adkim: 's', aspf: 's' });
+		const significant = f.filter((x) => ['critical', 'high', 'medium'].includes(x.severity));
+		expect(significant).toHaveLength(0);
+	});
+
+	it('flags multiple records as high', () => {
+		const f = classifyDmarc({ ...base, recordCount: 2, policy: 'reject', rua: 'mailto:dmarc@example.com', adkim: 's', aspf: 's' });
+		expect(f.some((x) => x.title === 'Multiple DMARC records' && x.severity === 'high')).toBe(true);
+	});
+
+	it('flags missing p= tag as critical', () => {
+		const f = classifyDmarc({ ...base, policy: null });
+		expect(f.some((x) => x.title === 'Missing DMARC policy' && x.severity === 'critical')).toBe(true);
+	});
+
+	it('downgrades weak subdomain policy when np protects (DMARCbis)', () => {
+		const f = classifyDmarc({ ...base, policy: 'reject', sp: 'none', np: 'reject', rua: 'mailto:dmarc@example.com' });
+		expect(f.find((x) => x.title === 'Subdomain policy weaker than parent policy')?.severity).toBe('low');
+	});
+});

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 import { describe, expect, it } from 'vitest';
-import { classifyDmarc } from './dmarc';
+import { appendDmarcCleanInfo, classifyDmarc } from './dmarc';
 
 const base = { recordCount: 1 } as const;
 
@@ -41,5 +41,27 @@ describe('classifyDmarc', () => {
 	it('downgrades weak subdomain policy when np protects (DMARCbis)', () => {
 		const f = classifyDmarc({ ...base, policy: 'reject', sp: 'none', np: 'reject', rua: 'mailto:dmarc@example.com' });
 		expect(f.find((x) => x.title === 'Subdomain policy weaker than parent policy')?.severity).toBe('low');
+	});
+
+	it('flags weak subdomain policy as high when np is absent (DMARCbis)', () => {
+		const f = classifyDmarc({ recordCount: 1, policy: 'reject', sp: 'none', rua: 'mailto:dmarc@example.com' });
+		expect(f.find((x) => x.title === 'Subdomain policy weaker than parent policy')?.severity).toBe('high');
+	});
+
+	it('flags invalid policy value as high', () => {
+		const f = classifyDmarc({ recordCount: 1, policy: 'discard' });
+		expect(f.find((x) => x.title === 'Invalid DMARC policy value')?.severity).toBe('high');
+	});
+
+	it('flags pct<100 as medium', () => {
+		const f = classifyDmarc({ recordCount: 1, policy: 'reject', sp: 'reject', pct: '50', rua: 'mailto:dmarc@example.com', adkim: 's', aspf: 's' });
+		expect(f.find((x) => x.title === 'DMARC not applied to all emails')?.severity).toBe('medium');
+	});
+
+	it('appendDmarcCleanInfo adds the info note only when no significant finding exists', () => {
+		const clean = appendDmarcCleanInfo([], 'reject');
+		expect(clean.some((x) => x.title === 'DMARC properly configured')).toBe(true);
+		const dirty = appendDmarcCleanInfo([{ category: 'dmarc', title: 'x', severity: 'medium', detail: 'y' } as never], 'reject');
+		expect(dirty.some((x) => x.title === 'DMARC properly configured')).toBe(false);
 	});
 });

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -13,6 +13,8 @@ export interface DmarcFacts {
 	recordCount: number;
 	/** Raw policy token from `p=` (may be invalid/unset). `null` when absent. */
 	policy: string | null;
+	/** The domain being checked, for interpolating into finding messages. Optional; falls back to a literal placeholder when absent. */
+	domain?: string;
 	/** Raw subdomain policy token from `sp=`. `undefined` when absent. */
 	sp?: string;
 	/** Raw non-existent-subdomain policy token from `np=` (DMARCbis). */
@@ -53,7 +55,7 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 				'dmarc',
 				'No DMARC record found',
 				'high',
-				`No DMARC record found at _dmarc.<domain>. Without DMARC, receivers cannot verify email authentication and spoofing is easier. (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
+				`No DMARC record found at _dmarc.${facts.domain ?? '<domain>'}. Without DMARC, receivers cannot verify email authentication and spoofing is easier. (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
 			),
 		);
 		return findings;
@@ -369,8 +371,20 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 		);
 	}
 
-	// If no critical, high, or medium issues found, add info
-	const hasSignificantIssues = findings.some((f) => f.severity === 'critical' || f.severity === 'high' || f.severity === 'medium');
+	return findings;
+}
+
+/**
+ * Append the "DMARC properly configured" reassurance finding when no
+ * critical/high/medium finding is present. Apply this AFTER assembling the
+ * complete finding set (synchronous classifier findings + any DNS-dependent
+ * findings the caller adds), so it reflects the full picture. Mutates and
+ * returns `findings`. `policy` is the resolved `p=` value (for the message).
+ */
+export function appendDmarcCleanInfo(findings: Finding[], policy: string | null): Finding[] {
+	const hasSignificantIssues = findings.some(
+		(f) => f.severity === 'critical' || f.severity === 'high' || f.severity === 'medium',
+	);
 	if (!hasSignificantIssues) {
 		findings.push(
 			createFinding(
@@ -381,6 +395,5 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 			),
 		);
 	}
-
 	return findings;
 }

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -1,0 +1,386 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Pure DMARC scoring classifier — the single source of truth for DMARC findings,
+// shared between bv-mcp's checkDMARC and bv-web's local DMARC check.
+// Takes record-derived facts (no DNS I/O) and returns severity-tagged findings.
+
+import type { Finding } from '../../types';
+import { createFinding } from '../../check-utils';
+
+/** Normalized, DNS-resolved facts about a domain's DMARC record. */
+export interface DmarcFacts {
+	/** Number of distinct `v=DMARC1` records found in the TXT RRset. */
+	recordCount: number;
+	/** Raw policy token from `p=` (may be invalid/unset). `null` when absent. */
+	policy: string | null;
+	/** Raw subdomain policy token from `sp=`. `undefined` when absent. */
+	sp?: string;
+	/** Raw non-existent-subdomain policy token from `np=` (DMARCbis). */
+	np?: string;
+	/** Raw `pct=` token (validated inside the classifier). `undefined` when absent. */
+	pct?: string;
+	/** Raw `ri=` token. `undefined` when absent. */
+	ri?: string;
+	/** Raw `fo=` token. `undefined` when absent. */
+	fo?: string;
+	/** Raw `rua=` token. `undefined` when absent. */
+	rua?: string;
+	/** Raw `ruf=` token. `undefined` when absent. */
+	ruf?: string;
+	/** Raw `adkim=` token. `undefined` when absent. */
+	adkim?: string;
+	/** Raw `aspf=` token. `undefined` when absent. */
+	aspf?: string;
+	/** Third-party aggregators in `rua=` (resolved by the caller). Empty when none. */
+	aggregators?: string[];
+	/** Invalid `rua=` URIs (resolved by the caller). Empty when none. */
+	invalidRuaUris?: string[];
+	/** Invalid `ruf=` URIs (resolved by the caller). Empty when none. */
+	invalidRufUris?: string[];
+}
+
+/**
+ * Produce the synchronous, record-derived DMARC findings. Pure — no DNS.
+ * Cross-domain RUA-authorization findings (DNS-dependent) are appended by the
+ * caller, not here.
+ */
+export function classifyDmarc(facts: DmarcFacts): Finding[] {
+	const findings: Finding[] = [];
+
+	if (facts.recordCount === 0) {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'No DMARC record found',
+				'high',
+				`No DMARC record found at _dmarc.<domain>. Without DMARC, receivers cannot verify email authentication and spoofing is easier. (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
+			),
+		);
+		return findings;
+	}
+
+	// Check for multiple DMARC records
+	if (facts.recordCount > 1) {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Multiple DMARC records',
+				'high',
+				`Found ${facts.recordCount} DMARC records in TXT data. Only one DMARC record should exist per domain.`,
+			),
+		);
+	}
+
+	const validPolicies = new Set(['none', 'quarantine', 'reject']);
+
+	// Check policy (p= tag)
+	const policy = facts.policy ?? undefined;
+	if (!policy) {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Missing DMARC policy',
+				'critical',
+				`DMARC record is missing the required "p=" tag. Without a policy, DMARC provides no protection.`,
+			),
+		);
+	} else if (!validPolicies.has(policy)) {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Invalid DMARC policy value',
+				'high',
+				`DMARC policy value "${policy}" is invalid. Allowed values are none, quarantine, or reject.`,
+			),
+		);
+	} else if (policy === 'none') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'DMARC policy set to none',
+				'medium',
+				`DMARC policy is "none" which only monitors but does not reject or quarantine spoofed emails. Consider upgrading to "quarantine" or "reject". (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
+			),
+		);
+	} else if (policy === 'quarantine') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'DMARC policy set to quarantine',
+				'low',
+				`DMARC policy is "quarantine". Consider upgrading to "reject" for maximum protection once you've verified legitimate email flows.`,
+			),
+		);
+	}
+	// "reject" is the strongest setting - no finding needed
+
+	// Check subdomain policy (sp= tag)
+	const sp = facts.sp;
+	// DMARCbis (RFC 9989) non-existent-subdomain policy. When `np=reject`/`np=quarantine`
+	// is set, non-existent subdomain spoofing is explicitly protected — the practical risk
+	// of `sp=none` is then limited to *existing* subdomains, which is a substantially
+	// smaller surface than the "any unowned subdomain" risk without np=. We downgrade the
+	// "Subdomain policy weaker than parent policy" finding accordingly.
+	const np = facts.np;
+	const npProtects = np === 'reject' || np === 'quarantine';
+	if (!sp && policy === 'reject') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'No subdomain policy',
+				'low',
+				`No subdomain policy (sp=) specified. Subdomains inherit the main policy ("${policy}"), but explicitly setting sp= is recommended.`,
+			),
+		);
+	} else if (!sp && policy === 'none') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Subdomains inherit p=none policy',
+				'info',
+				'No subdomain policy (sp=) specified. Subdomains inherit the "none" policy, which provides no protection against spoofing.',
+			),
+		);
+	} else if (sp) {
+		if (!validPolicies.has(sp)) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Invalid subdomain policy value',
+					'medium',
+					`DMARC subdomain policy value "${sp}" is invalid. Allowed values are none, quarantine, or reject.`,
+				),
+			);
+		} else if (policy === 'reject' && sp === 'none') {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Subdomain policy weaker than parent policy',
+					npProtects ? 'low' : 'high',
+					npProtects
+						? `Subdomain policy is set to "none" while parent policy is "reject". Non-existent subdomains are still protected by DMARCbis np=${np}, so the residual risk is limited to existing subdomains.`
+						: 'Subdomain policy is set to "none" while parent policy is "reject". This leaves subdomains vulnerable to spoofing.',
+				),
+			);
+		} else if (policy === 'reject' && sp === 'quarantine') {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Subdomain policy weaker than parent policy',
+					'low',
+					'Subdomain policy is "quarantine" while parent policy is "reject". Consider using sp=reject for consistent enforcement.',
+				),
+			);
+		} else if (policy === 'quarantine' && sp === 'none') {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Subdomain policy weaker than domain policy',
+					'medium',
+					'Subdomain policy is set to "none" while domain policy is "quarantine". Subdomains are unprotected against spoofing.',
+				),
+			);
+		}
+	}
+
+	// Check percentage (pct= tag)
+	const pct = facts.pct;
+	if (pct) {
+		const pctValue = Number.parseInt(pct, 10);
+		if (!Number.isFinite(pctValue) || Number.isNaN(pctValue) || pctValue < 0 || pctValue > 100) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Invalid DMARC percentage value',
+					'medium',
+					`DMARC pct value "${pct}" is invalid. Allowed range is 0-100.`,
+				),
+			);
+		} else if (pctValue < 100) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'DMARC not applied to all emails',
+					'medium',
+					`DMARC pct=${pctValue} means the policy only applies to ${pctValue}% of emails. Set pct=100 for full coverage.`,
+				),
+			);
+		}
+	}
+
+	// Check reporting interval (ri= tag) — RFC 7489 §6.3
+	// Value must be a positive integer (> 0). Default is 86400 (24 hours).
+	const ri = facts.ri;
+	if (ri !== undefined) {
+		const riValue = parseInt(ri, 10);
+		if (isNaN(riValue) || !Number.isFinite(riValue) || riValue <= 0) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Invalid DMARC reporting interval',
+					'medium',
+					`DMARC ri value "${ri}" is invalid. RFC 7489 §6.3 requires ri= to be a positive integer greater than zero. The default is 86400 (24 hours).`,
+				),
+			);
+		}
+	}
+
+	// Check forensic failure reporting options (fo=)
+	const fo = facts.fo;
+	if (fo) {
+		const allowedFoValues = new Set(['0', '1', 'd', 's']);
+		const foValues = fo
+			.split(':')
+			.map((v) => v.trim())
+			.filter((v) => v.length > 0);
+
+		const invalidFo = foValues.filter((v) => !allowedFoValues.has(v));
+		if (foValues.length === 0 || invalidFo.length > 0) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Invalid DMARC failure reporting options',
+					'medium',
+					`DMARC fo value "${fo}" contains unsupported option(s): ${invalidFo.join(', ') || 'none'}. Allowed values: 0, 1, d, s.`,
+				),
+			);
+		} else if (foValues.length === 1 && foValues[0] === '0') {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Limited DMARC failure reporting coverage',
+					'low',
+					'DMARC fo=0 only generates forensic reports when both SPF and DKIM fail. Consider fo=1 for broader failure visibility.',
+				),
+			);
+		}
+	}
+
+	// Check for reporting (rua= tag)
+	const rua = facts.rua;
+	if (!rua) {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'No aggregate reporting',
+				'medium',
+				`No aggregate report URI (rua=) specified. Without reporting, you cannot monitor DMARC authentication results.`,
+			),
+		);
+	} else {
+		// Validate rua= URI format (pre-resolved by caller)
+		const invalidRuaUris = facts.invalidRuaUris ?? [];
+		if (invalidRuaUris.length > 0) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Invalid aggregate report URI format',
+					'medium',
+					`DMARC aggregate report URI(s) invalid: ${invalidRuaUris.join(', ')}. Must use mailto: scheme.`,
+				),
+			);
+		}
+
+		// Check for third-party aggregator services (pre-resolved by caller)
+		const aggregators = facts.aggregators ?? [];
+		if (aggregators.length > 0) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Third-party DMARC aggregator detected',
+					'info',
+					`Using third-party aggregator(s): ${aggregators.join(', ')}. Ensure these services are authorized to receive your DMARC reports.`,
+					{ aggregators },
+				),
+			);
+		}
+
+		// Cross-domain RUA authorization findings (DNS-dependent) are appended by the
+		// caller, not here.
+	}
+
+	// Check forensic reporting (ruf= tag)
+	const ruf = facts.ruf;
+	if (ruf) {
+		const invalidRufUris = facts.invalidRufUris ?? [];
+		if (invalidRufUris.length > 0) {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Invalid forensic report URI format',
+					'medium',
+					`DMARC forensic report URI(s) invalid: ${invalidRufUris.join(', ')}. Must use mailto: scheme.`,
+				),
+			);
+		}
+	} else if (rua) {
+		// rua= is present but ruf= is not
+		findings.push(
+			createFinding(
+				'dmarc',
+				'No forensic reporting configured (ruf= absent)',
+				'low',
+				'Aggregate reporting (rua=) is configured but forensic reporting (ruf=) is not. Forensic reports provide detailed failure information useful for troubleshooting.',
+			),
+		);
+	}
+
+	// Check DKIM alignment mode (adkim= tag)
+	const adkim = facts.adkim;
+	if (adkim && adkim !== 'r' && adkim !== 's') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Invalid DKIM alignment mode',
+				'medium',
+				`DMARC adkim value "${adkim}" is invalid. Allowed values are "r" (relaxed) or "s" (strict).`,
+			),
+		);
+	} else if (!adkim || adkim === 'r') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Relaxed DKIM alignment',
+				'low',
+				`DKIM alignment mode is relaxed (adkim=r or unset). Consider adkim=s (strict) for stronger authentication.`,
+			),
+		);
+	}
+
+	// Check SPF alignment mode (aspf= tag)
+	const aspf = facts.aspf;
+	if (aspf && aspf !== 'r' && aspf !== 's') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Invalid SPF alignment mode',
+				'medium',
+				`DMARC aspf value "${aspf}" is invalid. Allowed values are "r" (relaxed) or "s" (strict).`,
+			),
+		);
+	} else if (!aspf || aspf === 'r') {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'Relaxed SPF alignment',
+				'low',
+				`SPF alignment mode is relaxed (aspf=r or unset). Consider aspf=s (strict) for stronger authentication.`,
+			),
+		);
+	}
+
+	// If no critical, high, or medium issues found, add info
+	const hasSignificantIssues = findings.some((f) => f.severity === 'critical' || f.severity === 'high' || f.severity === 'medium');
+	if (!hasSignificantIssues) {
+		findings.push(
+			createFinding(
+				'dmarc',
+				'DMARC properly configured',
+				'info',
+				`DMARC record found with policy "${policy}" and valid core tags.`,
+			),
+		);
+	}
+
+	return findings;
+}

--- a/packages/dns-checks/src/scoring/index.ts
+++ b/packages/dns-checks/src/scoring/index.ts
@@ -54,3 +54,6 @@ export type { DomainProfile, DomainContext } from './profiles';
 
 export { computeGenericScore } from './generic';
 export type { GenericScoringContext, GenericScanScore, FindingSeverityCounts, EmailBonusKeyMap, TierBreakdown } from './generic';
+
+export { classifyDmarc, appendDmarcCleanInfo } from './classifiers/dmarc';
+export type { DmarcFacts } from './classifiers/dmarc';


### PR DESCRIPTION
## What

Extracts bv-mcp's synchronous DMARC finding logic out of `checkDMARC` into a **pure, exported classifier** `classifyDmarc(facts: DmarcFacts): Finding[]` in `@blackveil/dns-checks`, so **bv-web can consume the exact same NIST-aligned DMARC scoring** instead of its own hand-tuned duplicate. First check (1 of 3) in Phase 1 of the scoring SoT-alignment effort.

Behavior-preserving for bv-mcp: `checkDMARC` now builds facts → `classifyDmarc` → appends the async cross-domain RUA-authorization findings → applies the closing clean-info gate over the complete set. All 50 existing DMARC tests pass unchanged.

## Why

bv-web and bv-mcp share the scoring *formula* (`computeGenericScore`) but feed it per-check scores from two unrelated implementations (penalty-based vs hand-assigned), so they diverge widely (e.g. DMARC `p=none`: 85 here vs 25 in bv-web). The fix is a shared classifier as the single source of truth, guarded by a cross-repo parity test (added in the bv-web PR).

Design + plan: `bv-web:docs/superpowers/specs/2026-05-31-scoring-sot-alignment-design.md` + `…/plans/2026-05-31-scoring-sot-alignment-dmarc.md`.

## Changes

- **New** `packages/dns-checks/src/scoring/classifiers/dmarc.ts` — `DmarcFacts` + pure `classifyDmarc` + `appendDmarcCleanInfo` helper (clean-info gate, applied by callers over the full finding set so it stays correct after async RUA-auth findings are appended).
- `check-dmarc.ts` refactored to delegate (−332/+35).
- Exported from both `@blackveil/dns-checks` and `@blackveil/dns-checks/scoring`.
- `@blackveil/dns-checks` `1.1.3` → **`1.2.0`** (new public API).

## Tests

- New classifier unit tests: 11 (covers no-record→high, p=none→medium, p=quarantine→low, multiple→high, missing-p→critical, invalid-policy→high, pct<100→medium, weak-sp ±np, clean-info gate).
- Existing DMARC suites: 50 pass unchanged. Full package suite: 312 pass.

## ⚠️ Follow-up gate

After merge, **publish `@blackveil/dns-checks@1.2.0` to npm** (publish.yml may be GH-Actions-billing-blocked → manual `npm publish` from `packages/dns-checks`). The bv-web PR cannot be verified until 1.2.0 is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)