### PR TITLE
fix(commercial): entitlement hardening — fail-safe tier, enterprise+ discovery gate, tier-contract lock

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -849,66 +849,26 @@ export async function handleToolsCall(
 
 			// Tier gate: discovery_mode='tiered' activates the Tier-0/1/2 lookups
 			// against private BV_INFRA_GRAPH, BV_INTEL_GATEWAY, and BV_ENTERPRISE
-			// service bindings (operator-deploy only). Pay-walled at developer
-			// tier or higher to match the premium nature of those data sources.
-			// On BSL self-hosts the bindings are unprovisioned and the pipeline
-			// degrades to classic regardless, so this gate is a no-op there.
+			// service bindings (operator-deploy only). Restricted to enterprise tier
+			// or higher (enterprise, partner, owner). Developer was removed because
+			// the prior self-asserted ownership_verified attestation was not
+			// cryptographically verifiable, opening a cost/abuse vector against
+			// third-party domains. On BSL self-hosts the bindings are unprovisioned
+			// and the pipeline degrades to classic regardless, so this gate is a
+			// no-op there.
 			if (name === 'discover_brand_domains' || name === 'brand_audit_single' || name === 'brand_audit_batch_start') {
 				const requestedMode = (validatedArgs as { discovery_mode?: string }).discovery_mode;
 				if (requestedMode === 'tiered') {
 					const tier = runtimeOptions?.authTier;
-					if (tier !== 'developer' && tier !== 'partner' && tier !== 'enterprise' && tier !== 'owner') {
-						return buildToolErrorResult("Invalid discovery_mode: 'tiered' requires developer tier or higher");
-					}
-				}
-			}
-
-			// FIND-14 — Ownership verification gate for tiered discovery.
-			//
-			// Tiered discovery activates Tier 0/1/2 lookups (infrastructure-graph,
-			// intel-gateway, enterprise portfolio) against data sources that can
-			// enumerate thousands of domains. Without a verification signal, a
-			// developer-tier caller could run deep discovery against third-party
-			// domains they don't own, enabling mass reconnaissance.
-			//
-			// Exemptions:
-			//   enterprise / owner — audit their own declared portfolios (Tier 0).
-			//   partner            — operator-internal tier (BV_API_KEY / OWNER_ALLOW_IPS
-			//                        downgrade path); treated same as enterprise.
-			//
-			// developer-tier callers must supply `ownership_verified: true` to attest
-			// that they own or are authorised to audit the target domain. The field is
-			// a caller attestation, not a cryptographic proof — strengthening this to a
-			// real DNS TXT challenge is a separate, deferred work item.
-			//
-			// Note: the recurring watch path (register_brand_audit_watch + cron in
-			// scheduled.ts) does not carry a per-watch discovery_mode column today; its
-			// tiered behaviour is env-gated (BRAND_AUDIT_DISCOVERY_MODE_DEFAULT) and
-			// restricted to operator deployments where that binding is provisioned.
-			// Per-watch ownership enforcement is deferred until the watch schema gains
-			// a discovery_mode + ownership_verified column.
-			if (name === 'discover_brand_domains' || name === 'brand_audit_single' || name === 'brand_audit_batch_start') {
-				const requestedMode = (validatedArgs as { discovery_mode?: string }).discovery_mode;
-				if (requestedMode === 'tiered') {
-					const tier = runtimeOptions?.authTier;
-					// enterprise / owner / partner are exempt — they audit their own portfolios.
-					const ownershipExempt = tier === 'enterprise' || tier === 'owner' || tier === 'partner';
-					if (!ownershipExempt) {
-						const ownershipVerified = (validatedArgs as { ownership_verified?: boolean }).ownership_verified;
-						if (ownershipVerified !== true) {
-							return buildToolErrorResult(
-								"Invalid discovery_mode: 'tiered' requires ownership_verified=true. " +
-									'Attest that you own or are authorised to audit the target domain before enabling deep tiered discovery. ' +
-									'(error: ownership_unverified)',
-							);
-						}
+					if (tier !== 'partner' && tier !== 'enterprise' && tier !== 'owner') {
+						return buildToolErrorResult("Invalid discovery_mode: 'tiered' requires enterprise tier or higher");
 					}
 				}
 			}
 
 			// Tier gate: depth='deep' expands candidate seeding + enrichment fanout
-			// (roughly 3× the per-call compute cost of 'standard'). Pay-walled at
-			// developer tier or higher — same threshold as discovery_mode='tiered'.
+			// (roughly 3× the per-call compute cost of 'standard'). Restricted to
+			// enterprise tier or higher — same threshold as discovery_mode='tiered'.
 			// Defensive for brand_audit_* (free/agent already get 0 quota there)
 			// and for discover_brand_domains on free (now 0/day too); still
 			// meaningful for agent callers, who get discover_brand_domains at the
@@ -917,8 +877,8 @@ export async function handleToolsCall(
 				const requestedDepth = (validatedArgs as { depth?: string }).depth;
 				if (requestedDepth === 'deep') {
 					const tier = runtimeOptions?.authTier;
-					if (tier !== 'developer' && tier !== 'partner' && tier !== 'enterprise' && tier !== 'owner') {
-						return buildToolErrorResult("Invalid depth: 'deep' requires developer tier or higher");
+					if (tier !== 'partner' && tier !== 'enterprise' && tier !== 'owner') {
+						return buildToolErrorResult("Invalid depth: 'deep' requires enterprise tier or higher");
 					}
 				}
 			}

--- a/src/lib/tier-auth.ts
+++ b/src/lib/tier-auth.ts
@@ -208,6 +208,9 @@ export async function resolveTier(
 
 	// 3. Try service binding to bv-web
 	if (env.BV_WEB && env.BV_WEB_INTERNAL_KEY) {
+		let bvWebThrew = false;
+		let bvWebIsServerError = false;
+
 		try {
 			const response = await env.BV_WEB.fetch(
 				new Request('https://internal/api/internal/mcp/validate-key', {
@@ -226,19 +229,31 @@ export async function resolveTier(
 				if (keyResult.success) {
 					const data = keyResult.data;
 					if (data.tier !== null) {
-						// Cache the valid tier result
+						// Cache the valid tier result (short-lived, 5 min)
 						if (env.RATE_LIMIT) {
 							await env.RATE_LIMIT.put(
 								`tier:${keyHash}`,
 								JSON.stringify({ tier: data.tier, revokedAt: null }),
 								{ expirationTtl: TIER_KV_CACHE_TTL },
 							);
+							// Write long-lived last-known-good entry (24h, best-effort).
+							// Used as a fail-safe if bv-web is unreachable or returns 5xx on
+							// a future request — avoids downgrading paying customers during
+							// transient outages. Apply only to confirmed-valid tiers, never
+							// to null/revoked responses (those must still downgrade correctly).
+							try {
+								await env.RATE_LIMIT.put(`tier:lkg:${keyHash}`, data.tier, { expirationTtl: 86400 });
+							} catch {
+								// Best-effort — a KV write failure must not break auth
+							}
 						}
 						const resolvedTier = applyOwnerIpGate(data.tier, env.OWNER_ALLOW_IPS, clientIp);
 						return { authenticated: true, tier: resolvedTier, keyHash };
 					}
-					// Null tier = revoked or unknown key — cache negative result to avoid
-					// repeated service binding calls within the TTL window
+					// Null tier = definitive revocation or unknown key — cache negative result
+					// to avoid repeated service binding calls within the TTL window.
+					// LKG is NOT consulted or updated here: this is a definitive "no entitlement"
+					// signal from bv-web, not an ambiguous failure.
 					if (env.RATE_LIMIT) {
 						await env.RATE_LIMIT.put(
 							`tier:${keyHash}`,
@@ -247,9 +262,34 @@ export async function resolveTier(
 						);
 					}
 				}
+			} else if (response.status >= 500) {
+				// 5xx response: bv-web is up but returning server errors — treat as ambiguous.
+				// NOTE: fetch() resolves (not throws) on HTTP errors, so this branch handles
+				// the primary outage scenario. 4xx responses are definitive client errors and
+				// fall through without LKG (no entitlement signal is explicit, not ambiguous).
+				bvWebIsServerError = true;
 			}
+			// 4xx: fall through to BV_API_KEY without LKG — definitive rejection
 		} catch {
-			// Service binding failed, fall through to BV_API_KEY
+			// Network error / connection failure / service binding throw — ambiguous.
+			bvWebThrew = true;
+		}
+
+		// LKG fallback: only for ambiguous failures (thrown or 5xx), NOT for definitive
+		// rejections (null tier, 4xx). Preserves revocation correctness.
+		if ((bvWebThrew || bvWebIsServerError) && env.RATE_LIMIT) {
+			try {
+				const lkg = await env.RATE_LIMIT.get(`tier:lkg:${keyHash}`);
+				if (lkg) {
+					const lkgResult = ValidateKeyResponseSchema.shape.tier.safeParse(lkg);
+					if (lkgResult.success && lkgResult.data !== null) {
+						const resolvedTier = applyOwnerIpGate(lkgResult.data, env.OWNER_ALLOW_IPS, clientIp);
+						return { authenticated: true, tier: resolvedTier, keyHash };
+					}
+				}
+			} catch {
+				// LKG read failed — fall through to BV_API_KEY as before
+			}
 		}
 	}
 

--- a/test/audits/commercial-tier-contract.audit.test.ts
+++ b/test/audits/commercial-tier-contract.audit.test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Audit test: commercial tier contract.
+//
+// SSOT for the commercial tier contract. bv-web marketing/pricing MUST match
+// these numbers — see bv-web test/<...> commercial-tier-contract.
+// Changing a number here is a deliberate go-to-market change.
+//
+// Background: three enforcement constants each live in different modules. A
+// pricing change requires co-ordinated edits across all three (plus bv-web
+// marketing copy). Without this file, drift can sit undetected until a
+// customer support ticket surfaces it. This audit collapses all three into
+// one table and verifies the enforced values match it exactly.
+//
+// Per testing-methodology.md principle 4 — audit tests replace review checklists.
+
+import { describe, it, expect } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// The commercial contract table — single source of truth for go-to-market
+// numbers. Update here (and in the matching bv-web test) when pricing changes.
+// ---------------------------------------------------------------------------
+
+type TierKey = 'free' | 'agent' | 'developer' | 'enterprise' | 'partner' | 'owner';
+
+interface TierRow {
+	/** Maximum tool calls per day (flat, per-tool default). */
+	dailyToolCalls: number;
+	/** Maximum concurrent in-flight tool executions (per-isolate, best-effort). */
+	concurrent: number;
+	/** Maximum brand-audit targets per calendar month. */
+	brandAuditsPerMonth: number;
+}
+
+const COMMERCIAL_CONTRACT: Record<TierKey, TierRow> = {
+	free: { dailyToolCalls: 50, concurrent: 3, brandAuditsPerMonth: 0 },
+	agent: { dailyToolCalls: 200, concurrent: 5, brandAuditsPerMonth: 0 },
+	developer: { dailyToolCalls: 500, concurrent: 10, brandAuditsPerMonth: 50 },
+	enterprise: {
+		dailyToolCalls: 10_000, // 10,000/day — UNDER COST REVIEW (Cloudflare unit-economics); update both repos' contract together when the enterprise MCP cap is finalized.
+		concurrent: 25,
+		brandAuditsPerMonth: 500,
+	},
+	partner: { dailyToolCalls: 100_000, concurrent: 50, brandAuditsPerMonth: 200 },
+	owner: {
+		dailyToolCalls: Number.POSITIVE_INFINITY,
+		concurrent: Number.POSITIVE_INFINITY,
+		brandAuditsPerMonth: Number.POSITIVE_INFINITY,
+	},
+};
+
+// All tiers in the TierSchema enum — used by the completeness guards below.
+const ALL_TIERS: TierKey[] = ['free', 'agent', 'developer', 'enterprise', 'partner', 'owner'];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build the daily-calls map from the contract for a deep-equal comparison. */
+function contractDailyMap(): Record<TierKey, number> {
+	return Object.fromEntries(ALL_TIERS.map(t => [t, COMMERCIAL_CONTRACT[t].dailyToolCalls])) as Record<TierKey, number>;
+}
+
+/** Build the concurrent map from the contract for a deep-equal comparison. */
+function contractConcurrentMap(): Record<TierKey, number> {
+	return Object.fromEntries(ALL_TIERS.map(t => [t, COMMERCIAL_CONTRACT[t].concurrent])) as Record<TierKey, number>;
+}
+
+/** Build the brand-audits map from the contract for a deep-equal comparison. */
+function contractBrandAuditMap(): Record<TierKey, number> {
+	return Object.fromEntries(ALL_TIERS.map(t => [t, COMMERCIAL_CONTRACT[t].brandAuditsPerMonth])) as Record<TierKey, number>;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('commercial tier contract audit', () => {
+	describe('tier completeness guard', () => {
+		it('contract table covers every tier in TierSchema (adding a tier forces a pricing decision)', () => {
+			// Dynamically import the schema enum values to stay in sync with the source.
+			// If a new tier is added to TierSchema and not to COMMERCIAL_CONTRACT this
+			// test will fail — that's the point.
+			for (const tier of ALL_TIERS) {
+				expect(
+					COMMERCIAL_CONTRACT,
+					`COMMERCIAL_CONTRACT must have an entry for tier "${tier}"`,
+				).toHaveProperty(tier);
+			}
+		});
+
+		it('every tier in TIER_DAILY_LIMITS is present in the contract table', async () => {
+			const { TIER_DAILY_LIMITS } = await import('../../src/lib/config');
+			const enforcedTiers = Object.keys(TIER_DAILY_LIMITS).sort();
+			const contractTiers = ALL_TIERS.slice().sort();
+			expect(
+				enforcedTiers,
+				'TIER_DAILY_LIMITS must not introduce tiers absent from COMMERCIAL_CONTRACT',
+			).toEqual(contractTiers);
+		});
+
+		it('every tier in TIER_CONCURRENT_LIMITS is present in the contract table', async () => {
+			const { TIER_CONCURRENT_LIMITS } = await import('../../src/lib/config');
+			const enforcedTiers = Object.keys(TIER_CONCURRENT_LIMITS).sort();
+			const contractTiers = ALL_TIERS.slice().sort();
+			expect(
+				enforcedTiers,
+				'TIER_CONCURRENT_LIMITS must not introduce tiers absent from COMMERCIAL_CONTRACT',
+			).toEqual(contractTiers);
+		});
+
+		it('every tier in BRAND_AUDIT_QUOTAS is present in the contract table', async () => {
+			const { BRAND_AUDIT_QUOTAS } = await import('../../src/lib/brand-audit-quota');
+			const enforcedTiers = Object.keys(BRAND_AUDIT_QUOTAS).sort();
+			const contractTiers = ALL_TIERS.slice().sort();
+			expect(
+				enforcedTiers,
+				'BRAND_AUDIT_QUOTAS must not introduce tiers absent from COMMERCIAL_CONTRACT',
+			).toEqual(contractTiers);
+		});
+	});
+
+	describe('TIER_DAILY_LIMITS vs contract', () => {
+		it('enforced daily-tool-call limits deep-equal the commercial contract', async () => {
+			const { TIER_DAILY_LIMITS } = await import('../../src/lib/config');
+			expect(TIER_DAILY_LIMITS).toEqual(contractDailyMap());
+		});
+
+		it('owner tier is exactly Number.POSITIVE_INFINITY', async () => {
+			const { TIER_DAILY_LIMITS } = await import('../../src/lib/config');
+			expect(TIER_DAILY_LIMITS.owner).toBe(Number.POSITIVE_INFINITY);
+		});
+	});
+
+	describe('TIER_CONCURRENT_LIMITS vs contract', () => {
+		it('enforced concurrent limits deep-equal the commercial contract', async () => {
+			const { TIER_CONCURRENT_LIMITS } = await import('../../src/lib/config');
+			expect(TIER_CONCURRENT_LIMITS).toEqual(contractConcurrentMap());
+		});
+
+		it('owner tier is exactly Number.POSITIVE_INFINITY', async () => {
+			const { TIER_CONCURRENT_LIMITS } = await import('../../src/lib/config');
+			expect(TIER_CONCURRENT_LIMITS.owner).toBe(Number.POSITIVE_INFINITY);
+		});
+	});
+
+	describe('BRAND_AUDIT_QUOTAS vs contract', () => {
+		it('enforced brand-audit monthly quotas deep-equal the commercial contract', async () => {
+			const { BRAND_AUDIT_QUOTAS } = await import('../../src/lib/brand-audit-quota');
+			expect(BRAND_AUDIT_QUOTAS).toEqual(contractBrandAuditMap());
+		});
+
+		it('owner tier is exactly Number.POSITIVE_INFINITY', async () => {
+			const { BRAND_AUDIT_QUOTAS } = await import('../../src/lib/brand-audit-quota');
+			expect(BRAND_AUDIT_QUOTAS.owner).toBe(Number.POSITIVE_INFINITY);
+		});
+
+		it('free and agent tiers are 0 (brand-audit is a paid feature)', async () => {
+			const { BRAND_AUDIT_QUOTAS } = await import('../../src/lib/brand-audit-quota');
+			expect(BRAND_AUDIT_QUOTAS.free).toBe(0);
+			expect(BRAND_AUDIT_QUOTAS.agent).toBe(0);
+		});
+	});
+});

--- a/test/brand-audit-depth-gate.spec.ts
+++ b/test/brand-audit-depth-gate.spec.ts
@@ -11,8 +11,9 @@
  * free; it stays meaningful for agent callers, who get `discover_brand_domains`
  * at the tier default and could otherwise request `deep`.
  *
- * Pay-walled at developer tier or higher — same threshold as the
- * `discovery_mode='tiered'` gate landed in PR #188.
+ * Pay-walled at enterprise tier or higher (enterprise, partner, owner).
+ * Developer tier was removed from this gate at the same time as the
+ * `discovery_mode='tiered'` gate — both gates use the same threshold.
  *
  * Mocks underlying tools so "accepts" tests don't hit real DNS/RDAP.
  */
@@ -59,7 +60,7 @@ describe('depth=deep tier gate', () => {
 			expect(result.isError, `${tool}@free with depth=deep must error`).toBe(true);
 			const textContent = result.content[0];
 			const text = textContent && 'text' in textContent ? textContent.text : '';
-			expect(text).toMatch(/^Error: Invalid depth: 'deep' requires developer tier or higher/);
+			expect(text).toMatch(/^Error: Invalid depth: 'deep' requires enterprise tier or higher/);
 		});
 
 		it(`rejects ${tool} depth='deep' when authTier is agent`, async () => {
@@ -69,13 +70,23 @@ describe('depth=deep tier gate', () => {
 			expect(result.isError, `${tool}@agent with depth=deep must error`).toBe(true);
 			const textContent = result.content[0];
 			const text = textContent && 'text' in textContent ? textContent.text : '';
-			expect(text).toMatch(/^Error: Invalid depth: 'deep' requires developer tier or higher/);
+			expect(text).toMatch(/^Error: Invalid depth: 'deep' requires enterprise tier or higher/);
 		});
 
-		it(`accepts ${tool} depth='deep' when authTier is developer`, async () => {
+		it(`rejects ${tool} depth='deep' when authTier is developer`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
 			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'developer' } as never);
+			expect(result.isError, `${tool}@developer with depth=deep must error`).toBe(true);
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).toMatch(/^Error: Invalid depth: 'deep' requires enterprise tier or higher/);
+		});
+
+		it(`accepts ${tool} depth='deep' when authTier is enterprise`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'enterprise' } as never);
 			if (result.isError) {
 				const textContent = result.content[0];
 				const text = textContent && 'text' in textContent ? textContent.text : '';
@@ -83,10 +94,21 @@ describe('depth=deep tier gate', () => {
 			}
 		});
 
-		it(`accepts ${tool} depth='deep' when authTier is enterprise`, async () => {
+		it(`accepts ${tool} depth='deep' when authTier is partner`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
-			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'enterprise' } as never);
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'partner' } as never);
+			if (result.isError) {
+				const textContent = result.content[0];
+				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid depth: 'deep'/);
+			}
+		});
+
+		it(`accepts ${tool} depth='deep' when authTier is owner`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'owner' } as never);
 			if (result.isError) {
 				const textContent = result.content[0];
 				const text = textContent && 'text' in textContent ? textContent.text : '';

--- a/test/brand-audit-discovery-mode-gate.spec.ts
+++ b/test/brand-audit-discovery-mode-gate.spec.ts
@@ -6,11 +6,14 @@
  * Background: `tiered` discovery activates Tier-0/1/2 lookups against the
  * private BV_INFRA_GRAPH, BV_INTEL_GATEWAY, and BV_ENTERPRISE service
  * bindings (operator-deploy only). Premium data sources behind a public
- * tool surface — pay-walling them mirrors the `view='csc_complement'` gate
- * at handlers/tools.ts and brings discover_brand_domains, brand_audit_single,
- * and brand_audit_batch_start into parity. On BSL self-hosts, the bindings
- * aren't provisioned and the pipeline degrades to classic; the gate is a
- * no-op there because the underlying capability never existed.
+ * tool surface — pay-walled at enterprise tier or higher (enterprise, partner,
+ * owner). Developer tier was removed from this gate (decision: self-asserted
+ * ownership_verified attestation was not cryptographically verifiable, enabling
+ * low-cost mass reconnaissance against third-party domains).
+ *
+ * On BSL self-hosts, the bindings aren't provisioned and the pipeline degrades
+ * to classic; the gate is a no-op there because the underlying capability never
+ * existed.
  *
  * Mocks underlying tools so the "accepts" tests don't hit real DNS/RDAP.
  */
@@ -54,11 +57,7 @@ describe('discovery_mode=tiered tier gate', () => {
 	});
 
 	for (const tool of TOOLS_ACCEPTING_DISCOVERY_MODE) {
-		// Used for low-tier rejection tests (free/agent — fail at tier gate before ownership gate).
 		const args = makeArgs(tool, 'tiered');
-		// Used for developer-tier acceptance tests: ownership_verified=true to clear the
-		// FIND-14 ownership gate that fires after the tier gate passes.
-		const argsWithOwnership = makeArgs(tool, 'tiered', { ownership_verified: true });
 
 		it(`rejects ${tool} discovery_mode='tiered' when authTier is free`, async () => {
 			mockUnderlyingTools();
@@ -67,7 +66,7 @@ describe('discovery_mode=tiered tier gate', () => {
 			expect(result.isError, `${tool}@free with discovery_mode=tiered must error`).toBe(true);
 			const textContent = result.content[0];
 			const text = textContent && 'text' in textContent ? textContent.text : '';
-			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires developer tier or higher/);
+			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires enterprise tier or higher/);
 		});
 
 		it(`rejects ${tool} discovery_mode='tiered' when authTier is agent`, async () => {
@@ -77,13 +76,23 @@ describe('discovery_mode=tiered tier gate', () => {
 			expect(result.isError, `${tool}@agent with discovery_mode=tiered must error`).toBe(true);
 			const textContent = result.content[0];
 			const text = textContent && 'text' in textContent ? textContent.text : '';
-			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires developer tier or higher/);
+			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires enterprise tier or higher/);
 		});
 
-		it(`accepts ${tool} discovery_mode='tiered' when authTier is developer (with ownership_verified=true)`, async () => {
+		it(`rejects ${tool} discovery_mode='tiered' when authTier is developer`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
-			const result = await handleToolsCall({ name: tool, arguments: argsWithOwnership }, undefined, { authTier: 'developer' } as never);
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'developer' } as never);
+			expect(result.isError, `${tool}@developer with discovery_mode=tiered must error`).toBe(true);
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires enterprise tier or higher/);
+		});
+
+		it(`accepts ${tool} discovery_mode='tiered' when authTier is enterprise`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'enterprise' } as never);
 			if (result.isError) {
 				const textContent = result.content[0];
 				const text = textContent && 'text' in textContent ? textContent.text : '';
@@ -91,10 +100,21 @@ describe('discovery_mode=tiered tier gate', () => {
 			}
 		});
 
-		it(`accepts ${tool} discovery_mode='tiered' when authTier is enterprise`, async () => {
+		it(`accepts ${tool} discovery_mode='tiered' when authTier is partner`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
-			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'enterprise' } as never);
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'partner' } as never);
+			if (result.isError) {
+				const textContent = result.content[0];
+				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid discovery_mode: 'tiered'/);
+			}
+		});
+
+		it(`accepts ${tool} discovery_mode='tiered' when authTier is owner`, async () => {
+			mockUnderlyingTools();
+			const { handleToolsCall } = await import('../src/handlers/tools');
+			const result = await handleToolsCall({ name: tool, arguments: args }, undefined, { authTier: 'owner' } as never);
 			if (result.isError) {
 				const textContent = result.content[0];
 				const text = textContent && 'text' in textContent ? textContent.text : '';

--- a/test/brand-audit-ownership.integration.test.ts
+++ b/test/brand-audit-ownership.integration.test.ts
@@ -1,18 +1,28 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 /**
- * FIND-14 — Domain-ownership verification before tiered brand-audit discovery.
+ * Post-FIND-14 ownership gate tests.
  *
- * A developer-tier caller can run brand-audit "tiered" discovery against
- * third-party domains they don't own, enabling mass reconnaissance. The guard
- * requires `ownership_verified: true` on the tool call when `discovery_mode`
- * is `'tiered'` and the caller is not an enterprise/owner/partner principal
- * (those tiers audit their own portfolios and are exempt from the attestation).
+ * The self-asserted `ownership_verified` attestation path has been removed.
+ * Developer-tier callers no longer qualify for `discovery_mode='tiered'`
+ * (they hit the tier gate in src/handlers/tools.ts before any ownership
+ * logic fires), so the FIND-14 gate block is gone.
  *
- * Insertion point: `src/handlers/tools.ts`, inline with the existing
- * `discovery_mode='tiered'` tier gate.
+ * Enterprise, owner, and partner callers were already exempt from the
+ * ownership attestation under the old model. Under the new model they
+ * remain exempt — and are now the only tiers that can request tiered
+ * discovery at all.
  *
- * Mirrors the test structure in `test/brand-audit-discovery-mode-gate.spec.ts`.
+ * This file:
+ *  - Confirms developer-tier is rejected by the TIER gate (not ownership gate).
+ *  - Confirms enterprise / owner / partner are accepted by the tier gate.
+ *  - Confirms classic discovery is never gated for any tier.
+ *  - Confirms omitting discovery_mode is never gated for any tier.
+ *
+ * The `ownership_verified` field remains accepted by the Zod schema (no
+ * source change needed) but is ignored — enterprise/partner/owner callers
+ * may pass it without error; developer callers never reach the point where
+ * it would be read.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -45,7 +55,7 @@ function mockUnderlyingTools() {
 	}));
 }
 
-describe('FIND-14: ownership_verified gate for tiered discovery', () => {
+describe('Tiered-discovery tier gate — post ownership-attestation removal', () => {
 	afterEach(() => {
 		vi.resetModules();
 		vi.doUnmock('../src/tools/discover-brand-domains');
@@ -54,7 +64,9 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 	});
 
 	for (const tool of TOOLS_ACCEPTING_DISCOVERY_MODE) {
-		it(`rejects ${tool} with discovery_mode='tiered' when developer tier omits ownership_verified`, async () => {
+		// --- Developer is now rejected by the TIER gate ---
+
+		it(`rejects ${tool} with discovery_mode='tiered' for developer tier (tier gate, not ownership gate)`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
 			const result = await handleToolsCall(
@@ -62,27 +74,15 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 				undefined,
 				{ authTier: 'developer' } as never,
 			);
-			expect(result.isError, `${tool}@developer with tiered and no ownership_verified must error`).toBe(true);
+			expect(result.isError, `${tool}@developer with tiered must be rejected by tier gate`).toBe(true);
 			const textContent = result.content[0];
 			const text = textContent && 'text' in textContent ? textContent.text : '';
-			expect(text).toMatch(/ownership_unverified/);
+			// Must hit the TIER gate — not the (removed) ownership gate.
+			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires enterprise tier or higher/);
+			expect(text).not.toMatch(/ownership_unverified/);
 		});
 
-		it(`rejects ${tool} with discovery_mode='tiered' when developer tier sends ownership_verified=false`, async () => {
-			mockUnderlyingTools();
-			const { handleToolsCall } = await import('../src/handlers/tools');
-			const result = await handleToolsCall(
-				{ name: tool, arguments: makeArgs(tool, { ownership_verified: false }) },
-				undefined,
-				{ authTier: 'developer' } as never,
-			);
-			expect(result.isError, `${tool}@developer with tiered and ownership_verified=false must error`).toBe(true);
-			const textContent = result.content[0];
-			const text = textContent && 'text' in textContent ? textContent.text : '';
-			expect(text).toMatch(/ownership_unverified/);
-		});
-
-		it(`allows ${tool} with discovery_mode='tiered' when developer tier sends ownership_verified=true`, async () => {
+		it(`rejects ${tool} with discovery_mode='tiered' for developer even when ownership_verified=true (tier gate wins)`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
 			const result = await handleToolsCall(
@@ -90,15 +90,16 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 				undefined,
 				{ authTier: 'developer' } as never,
 			);
-			// Must not be the ownership_unverified error
-			if (result.isError) {
-				const textContent = result.content[0];
-				const text = textContent && 'text' in textContent ? textContent.text : '';
-				expect(text).not.toMatch(/ownership_unverified/);
-			}
+			// Ownership attestation no longer unlocks tiered discovery for developer.
+			expect(result.isError, `${tool}@developer with tiered+ownership_verified=true must still be rejected`).toBe(true);
+			const textContent = result.content[0];
+			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).toMatch(/^Error: Invalid discovery_mode: 'tiered' requires enterprise tier or higher/);
 		});
 
-		it(`allows ${tool} with discovery_mode='tiered' when enterprise tier omits ownership_verified (exempt)`, async () => {
+		// --- Enterprise / partner / owner pass the tier gate ---
+
+		it(`allows ${tool} with discovery_mode='tiered' when enterprise tier (no ownership_verified needed)`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
 			const result = await handleToolsCall(
@@ -106,15 +107,15 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 				undefined,
 				{ authTier: 'enterprise' } as never,
 			);
-			// Enterprise is exempt — must not be the ownership_unverified error
 			if (result.isError) {
 				const textContent = result.content[0];
 				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid discovery_mode: 'tiered'/);
 				expect(text).not.toMatch(/ownership_unverified/);
 			}
 		});
 
-		it(`allows ${tool} with discovery_mode='tiered' when owner tier omits ownership_verified (exempt)`, async () => {
+		it(`allows ${tool} with discovery_mode='tiered' when owner tier (no ownership_verified needed)`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
 			const result = await handleToolsCall(
@@ -125,11 +126,12 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 			if (result.isError) {
 				const textContent = result.content[0];
 				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid discovery_mode: 'tiered'/);
 				expect(text).not.toMatch(/ownership_unverified/);
 			}
 		});
 
-		it(`allows ${tool} with discovery_mode='tiered' when partner tier omits ownership_verified (exempt — operator-internal)`, async () => {
+		it(`allows ${tool} with discovery_mode='tiered' when partner tier (operator-internal, no ownership_verified needed)`, async () => {
 			mockUnderlyingTools();
 			const { handleToolsCall } = await import('../src/handlers/tools');
 			const result = await handleToolsCall(
@@ -140,12 +142,13 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 			if (result.isError) {
 				const textContent = result.content[0];
 				const text = textContent && 'text' in textContent ? textContent.text : '';
+				expect(text).not.toMatch(/^Error: Invalid discovery_mode: 'tiered'/);
 				expect(text).not.toMatch(/ownership_unverified/);
 			}
 		});
 	}
 
-	it("classic discovery_mode does not trigger the ownership gate (developer tier, no ownership_verified)", async () => {
+	it("classic discovery_mode is never gated (developer tier, no ownership_verified)", async () => {
 		mockUnderlyingTools();
 		const { handleToolsCall } = await import('../src/handlers/tools');
 		const result = await handleToolsCall(
@@ -156,11 +159,12 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 		if (result.isError) {
 			const textContent = result.content[0];
 			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).not.toMatch(/^Error: Invalid discovery_mode/);
 			expect(text).not.toMatch(/ownership_unverified/);
 		}
 	});
 
-	it("omitting discovery_mode does not trigger the ownership gate (developer tier)", async () => {
+	it("omitting discovery_mode is never gated (developer tier)", async () => {
 		mockUnderlyingTools();
 		const { handleToolsCall } = await import('../src/handlers/tools');
 		const result = await handleToolsCall(
@@ -171,6 +175,7 @@ describe('FIND-14: ownership_verified gate for tiered discovery', () => {
 		if (result.isError) {
 			const textContent = result.content[0];
 			const text = textContent && 'text' in textContent ? textContent.text : '';
+			expect(text).not.toMatch(/^Error: Invalid discovery_mode/);
 			expect(text).not.toMatch(/ownership_unverified/);
 		}
 	});

--- a/test/tier-auth.spec.ts
+++ b/test/tier-auth.spec.ts
@@ -353,3 +353,293 @@ describe('tier-auth KV cache validation', () => {
 		expect(kv.put).not.toHaveBeenCalled();
 	});
 });
+
+describe('tier-auth LKG (last-known-good) fallback', () => {
+	// ─── LKG WRITE on success ──────────────────────────────────────────────────
+
+	it('writes tier:lkg:{keyHash} with expirationTtl 86400 on successful bv-web resolution', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const kv = {
+			get: vi.fn().mockResolvedValue(null),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockResolvedValue(Response.json({ tier: 'enterprise' })),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'lkg-success-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		expect(result.authenticated).toBe(true);
+		expect(result.tier).toBe('enterprise');
+
+		// Must write the short-lived cache entry AND the long-lived LKG entry
+		const putCalls = vi.mocked(kv.put).mock.calls;
+		const lkgCall = putCalls.find((c) => c[0] === `tier:lkg:${result.keyHash}`);
+		expect(lkgCall).toBeDefined();
+		expect(lkgCall![1]).toBe('enterprise');
+		expect(lkgCall![2]).toEqual({ expirationTtl: 86400 });
+	});
+
+	it('does not write LKG for null tier (definitive revocation) from bv-web', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const kv = {
+			get: vi.fn().mockResolvedValue(null),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockResolvedValue(Response.json({ tier: null })),
+		} as unknown as Fetcher;
+
+		await resolveTier(
+			'revoked-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		const putCalls = vi.mocked(kv.put).mock.calls;
+		const lkgCall = putCalls.find((c) => String(c[0]).startsWith('tier:lkg:'));
+		expect(lkgCall).toBeUndefined();
+	});
+
+	// ─── LKG READ when bv-web throws (network/connection failure) ─────────────
+
+	it('returns LKG tier when bv-web throws (network error) and LKG entry exists', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const keyHash = await (async () => {
+			// Pre-compute keyHash for 'lkg-throw-key' to build the correct KV mock
+			const raw = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode('lkg-throw-key')));
+			return Array.from(raw)
+				.map((b) => b.toString(16).padStart(2, '0'))
+				.join('');
+		})();
+
+		const kv = {
+			get: vi.fn((key: string) => {
+				if (key === `tier:lkg:${keyHash}`) return Promise.resolve('developer');
+				return Promise.resolve(null); // no short-lived cache
+			}),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockRejectedValue(new Error('network error')),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'lkg-throw-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		expect(result.authenticated).toBe(true);
+		expect(result.tier).toBe('developer');
+		expect(result.keyHash).toBe(keyHash);
+	});
+
+	it('falls through to BV_API_KEY when bv-web throws and no LKG entry exists', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const kv = {
+			get: vi.fn().mockResolvedValue(null), // no cache, no LKG
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockRejectedValue(new Error('network error')),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'no-lkg-throw-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		// No LKG, no BV_API_KEY match → falls through to unauthenticated
+		expect(result.authenticated).toBe(false);
+	});
+
+	// ─── LKG READ when bv-web returns a 5xx (server error / outage) ──────────
+	// NOTE: fetch() resolves on HTTP errors — 5xx does NOT throw, it returns a
+	// Response with response.ok === false. A catch-only implementation misses this
+	// case. Both ambiguous-failure branches must consult LKG.
+
+	it('returns LKG tier when bv-web returns 503 and LKG entry exists', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const keyHash = await (async () => {
+			const raw = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode('lkg-503-key')));
+			return Array.from(raw)
+				.map((b) => b.toString(16).padStart(2, '0'))
+				.join('');
+		})();
+
+		const kv = {
+			get: vi.fn((key: string) => {
+				if (key === `tier:lkg:${keyHash}`) return Promise.resolve('enterprise');
+				return Promise.resolve(null);
+			}),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockResolvedValue(new Response('Service Unavailable', { status: 503 })),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'lkg-503-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		expect(result.authenticated).toBe(true);
+		expect(result.tier).toBe('enterprise');
+		expect(result.keyHash).toBe(keyHash);
+	});
+
+	it('falls through to unauthenticated when bv-web returns 503 and no LKG entry exists', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const kv = {
+			get: vi.fn().mockResolvedValue(null),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockResolvedValue(new Response('Service Unavailable', { status: 503 })),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'no-lkg-503-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		expect(result.authenticated).toBe(false);
+	});
+
+	// ─── 4xx is definitive — LKG must NOT be consulted ────────────────────────
+
+	it('does not serve LKG when bv-web returns 401 (definitive rejection)', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const keyHash = await (async () => {
+			const raw = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode('lkg-401-key')));
+			return Array.from(raw)
+				.map((b) => b.toString(16).padStart(2, '0'))
+				.join('');
+		})();
+
+		const kv = {
+			get: vi.fn((key: string) => {
+				// LKG entry exists — but should NOT be used for a 4xx response
+				if (key === `tier:lkg:${keyHash}`) return Promise.resolve('enterprise');
+				return Promise.resolve(null);
+			}),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockResolvedValue(new Response('Unauthorized', { status: 401 })),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'lkg-401-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		expect(result.authenticated).toBe(false);
+	});
+
+	// ─── OWNER_ALLOW_IPS gate applied to LKG tier ─────────────────────────────
+
+	it('applies OWNER_ALLOW_IPS gate to the tier returned from LKG on bv-web throw', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const keyHash = await (async () => {
+			const raw = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode('lkg-owner-gate-key')));
+			return Array.from(raw)
+				.map((b) => b.toString(16).padStart(2, '0'))
+				.join('');
+		})();
+
+		const kv = {
+			get: vi.fn((key: string) => {
+				if (key === `tier:lkg:${keyHash}`) return Promise.resolve('owner');
+				return Promise.resolve(null);
+			}),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockRejectedValue(new Error('unreachable')),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'lkg-owner-gate-key',
+			{
+				RATE_LIMIT: kv,
+				BV_WEB: bvWeb,
+				BV_WEB_INTERNAL_KEY: 'internal-key',
+				OWNER_ALLOW_IPS: '203.0.113.10',
+			},
+			'198.51.100.10', // NOT in allowlist
+			'https://example.com/mcp',
+		);
+
+		expect(result.authenticated).toBe(true);
+		expect(result.tier).toBe('partner'); // downgraded from owner
+	});
+
+	// ─── Definitive "no entitlement" — LKG must NOT be consulted ─────────────
+
+	it('does not consult LKG when bv-web returns definitive null tier (revocation)', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+
+		const keyHash = await (async () => {
+			const raw = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode('revoked-lkg-key')));
+			return Array.from(raw)
+				.map((b) => b.toString(16).padStart(2, '0'))
+				.join('');
+		})();
+
+		const kv = {
+			get: vi.fn((key: string) => {
+				// LKG entry exists — should NOT be consulted on a definitive null response
+				if (key === `tier:lkg:${keyHash}`) return Promise.resolve('enterprise');
+				return Promise.resolve(null);
+			}),
+			put: vi.fn(),
+			delete: vi.fn(),
+		} as unknown as KVNamespace;
+		const bvWeb = {
+			fetch: vi.fn().mockResolvedValue(Response.json({ tier: null })),
+		} as unknown as Fetcher;
+
+		const result = await resolveTier(
+			'revoked-lkg-key',
+			{ RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' },
+			undefined,
+			'https://example.com/mcp',
+		);
+
+		// Definitive revocation must still downgrade, even if LKG says 'enterprise'
+		expect(result.authenticated).toBe(false);
+	});
+});


### PR DESCRIPTION
**Billing/entitlement change — do not merge without sign-off.** Three reviewed fixes from the commercialization-architecture review, all TDD (93 tests across 5 specs, `tsc` clean).

## P1 — fail-safe tier resolution (`src/lib/tier-auth.ts`)
A paying customer was **silently downgraded to free** when bv-web had an *ambiguous* failure (network error / 5xx / timeout) and the 5-min tier cache expired. Now:
- every successful bv-web resolution writes a 24h **last-known-good** entry (`tier:lkg:<keyHash>`);
- on an ambiguous failure (catch **or** `status >= 5xx` — 5xx resolves, doesn't throw) we serve the LKG tier, preserving paid access during a bv-web outage;
- a **definitive** no-entitlement (revocation / 401 / 404) still downgrades — revocation correctness is unaffected (covered by a regression test).

## P3 — restrict tiered/deep brand-discovery to enterprise+ (`src/handlers/tools.ts`)
`discovery_mode='tiered'` and `depth='deep'` dropped `developer` → now **partner/enterprise/owner**, and the self-asserted `ownership_verified` developer attestation path was **removed** (it was a non-cryptographic cost/abuse hole on the expensive bv-infra-graph / bv-intel-gateway lookups). `view='registrar_complement'` gate unchanged.

## P5 — commercial tier-contract lock (`test/audits/commercial-tier-contract.audit.test.ts`)
Pins `TIER_DAILY_LIMITS` / `TIER_CONCURRENT_LIMITS` / `BRAND_AUDIT_QUOTAS` to an explicit SSOT table so enforcement changes are deliberate and bv-web marketing drift is catchable. (A sibling test will land in bv-web.) Enterprise daily (10k) flagged "under cost review."

## Enterprise-cap cost research (informs the 10k flag)
Cloudflare unit-economics: **10,000/day ≈ 72–77% gross margin** ($45–56/mo cost vs $199 revenue). "Unlimited" inverts economics (100k/day ≈ $579/mo cost). **Recommendation: keep 10k/day; fix bv-web copy to state it** (currently markets "unlimited"). Dominant cost = KV writes from 18 separate per-check cache keys; batching to one key cuts KV ~18× and could fund a higher cap later.

## Out of scope (per your direction)
- The partner tier is **untouched** (unsigned-off; no Stripe plan).
- bv-web fixes (graceful Starter 403, `agent` schema alignment, the sibling contract test) come in a separate PR — bv-web's working tree is mid-work, so I'll isolate those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)