### PR TITLE
perf(scan): tier-gate TLS probe + skip KV sentinel on scan per-check path

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -254,9 +254,14 @@ export async function cacheSet(key: string, value: unknown, kv?: KVNamespace, tt
  *   result, the result is NOT written to KV / in-memory cache. Sentinel cleanup still runs.
  *   Used to suppress caching of partial results (e.g. lookalike timeouts) without the
  *   put-then-delete anti-pattern. See bv-web 2026-05-14 analytics remediation (cluster F5).
+ * @param skipSentinel - When true, skips the cross-isolate KV sentinel (`key:computing`
+ *   get/put/delete) while keeping the main-key cache read, INFLIGHT in-isolate dedup, and
+ *   result write. Cuts 2 KV ops per check on high-volume low-contention paths (e.g. scan
+ *   per-check, ~98% unique domains) where sentinel overhead exceeds the rare stampede it
+ *   prevents. INFLIGHT still dedups concurrent calls within the same isolate.
  * @returns The cached or freshly computed result
  */
-export async function runWithCache<T>(key: string, run: () => Promise<T>, kv?: KVNamespace, ttlSeconds?: number, skipCache?: boolean, shouldCache?: (result: T) => boolean): Promise<T> {
+export async function runWithCache<T>(key: string, run: () => Promise<T>, kv?: KVNamespace, ttlSeconds?: number, skipCache?: boolean, shouldCache?: (result: T) => boolean, skipSentinel?: boolean): Promise<T> {
 	if (!skipCache) {
 		const cached = await cacheGet<T>(key, kv);
 		if (cached !== undefined) return cached;
@@ -267,7 +272,7 @@ export async function runWithCache<T>(key: string, run: () => Promise<T>, kv?: K
 	if (existing) return existing as Promise<T>;
 
 	// Cross-isolate dedup via KV sentinel (best-effort)
-	if (kv && !skipCache) {
+	if (kv && !skipCache && !skipSentinel) {
 		const sentinelKey = `${key}:computing`;
 		try {
 			const sentinel = await kv.get(sentinelKey);
@@ -294,14 +299,14 @@ export async function runWithCache<T>(key: string, run: () => Promise<T>, kv?: K
 				await cacheSet(key, result, kv, ttlSeconds);
 			}
 			// Clean up sentinel regardless — we still claimed the computation slot.
-			if (kv) {
+			if (kv && !skipSentinel) {
 				try { await kv.delete(`${key}:computing`); } catch { /* best-effort */ }
 			}
 			return result;
 		})
 		.catch(async (err) => {
 			// Clean up sentinel on failure
-			if (kv) {
+			if (kv && !skipSentinel) {
 				try { await kv.delete(`${key}:computing`); } catch { /* best-effort */ }
 			}
 			throw err;

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -64,6 +64,12 @@ export type { StructuredScanResult, ScanResultEnrichment } from './scan/format-r
 export type { MaturityStage } from './scan/maturity-staging';
 export type { ScanRuntimeOptions } from './scan/post-processing';
 
+/**
+ * TLS probe (Browser Rendering) is a paid-tier enrichment — skip it for
+ * free/agent/anonymous scans, which are ~98% of volume and the cost driver.
+ */
+const PROBE_ELIGIBLE_TIERS = new Set(['developer', 'enterprise', 'partner', 'owner']);
+
 /** In-memory cache for adaptive weight responses from the ProfileAccumulator DO. */
 const adaptiveWeightCache = new Map<string, { weights: AdaptiveWeightsResponse; expires: number }>();
 
@@ -168,7 +174,7 @@ async function runCheckRetry(
 		case 'dmarc': checkPromise = checkDmarc(domain, retryDns); break;
 		case 'dkim': checkPromise = checkDkim(domain, undefined, retryDns); break;
 		case 'dnssec': checkPromise = checkDnssec(domain, retryDns); break;
-		case 'ssl': checkPromise = checkSsl(domain, { tlsProbeBinding: runtimeOptions?.tlsProbeBinding, tlsProbeAuthToken: runtimeOptions?.tlsProbeAuthToken }); break;
+		case 'ssl': checkPromise = checkSsl(domain, { tlsProbeBinding: PROBE_ELIGIBLE_TIERS.has(runtimeOptions?.authTier ?? '') ? runtimeOptions?.tlsProbeBinding : undefined, tlsProbeAuthToken: runtimeOptions?.tlsProbeAuthToken }); break;
 		case 'mta_sts': checkPromise = checkMtaSts(domain, retryDns); break;
 		case 'ns': checkPromise = checkNs(domain, retryDns); break;
 		case 'caa': checkPromise = checkCaa(domain, retryDns); break;
@@ -262,7 +268,7 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 		runCachedCheck(domain, 'dmarc', () => safeCheck('dmarc', () => checkDmarc(domain, scanDns), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
 		runCachedCheck(domain, 'dkim', () => safeCheck('dkim', () => checkDkim(domain, undefined, scanDns), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
 		runCachedCheck(domain, 'dnssec', () => safeCheck('dnssec', () => checkDnssec(domain, scanDns), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
-		runCachedCheck(domain, 'ssl', () => safeCheck('ssl', () => checkSsl(domain, { tlsProbeBinding: runtimeOptions?.tlsProbeBinding, tlsProbeAuthToken: runtimeOptions?.tlsProbeAuthToken }), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
+		runCachedCheck(domain, 'ssl', () => safeCheck('ssl', () => checkSsl(domain, { tlsProbeBinding: PROBE_ELIGIBLE_TIERS.has(runtimeOptions?.authTier ?? '') ? runtimeOptions?.tlsProbeBinding : undefined, tlsProbeAuthToken: runtimeOptions?.tlsProbeAuthToken }), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
 		runCachedCheck(domain, 'mta_sts', () => safeCheck('mta_sts', () => checkMtaSts(domain, scanDns), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
 		runCachedCheck(domain, 'ns', () => safeCheck('ns', () => checkNs(domain, scanDns), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
 		runCachedCheck(domain, 'caa', () => safeCheck('caa', () => checkCaa(domain, scanDns), timeoutBudget.perCheckTimeoutMs), kv, cacheTtl, forceRefresh),
@@ -675,7 +681,10 @@ async function runCachedCheck(
 	ttlSeconds?: number,
 	skipCache?: boolean,
 ): Promise<CheckResult> {
-	return runWithCache(buildCheckCacheKey(domain, category), run, kv, ttlSeconds, skipCache);
+	// skipSentinel: per-check scan caches are ~98% unique-domain / low-contention;
+	// the cross-isolate sentinel's KV writes+deletes cost more than the rare stampede
+	// they'd prevent (INFLIGHT still dedups in-isolate).
+	return runWithCache(buildCheckCacheKey(domain, category), run, kv, ttlSeconds, skipCache, undefined, true);
 }
 
 /**

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -41,6 +41,11 @@ export interface ScanRuntimeOptions {
 	certstreamAuthToken?: string;
 	/** Bypass cache and run a fresh scan. Useful for troubleshooting after DNS changes. */
 	forceRefresh?: boolean;
+	/**
+	 * Auth tier of the requesting principal. Threaded from ToolRuntimeOptions so
+	 * scan_domain can gate paid-tier enrichments (e.g. TLS probe Browser Rendering).
+	 */
+	authTier?: string;
 }
 
 export async function applyScanPostProcessing(

--- a/test/cache.spec.ts
+++ b/test/cache.spec.ts
@@ -419,3 +419,80 @@ describe('runWithCache sentinel lifecycle', () => {
 		expect(deleteSentinelIdx).toBeGreaterThan(putResultIdx);
 	});
 });
+
+describe('runWithCache — skipSentinel flag', () => {
+	afterEach(() => {
+		IN_MEMORY_CACHE.clear();
+		vi.restoreAllMocks();
+	});
+
+	it('skipSentinel:true, cold miss: result is returned and cached; no sentinel kv.get/put/delete', async () => {
+		const mockKV = {
+			get: vi.fn().mockResolvedValue(null),   // persistent: main-key lookup returns null (miss)
+			put: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+		const { runWithCache } = await import('../src/lib/cache');
+		const run = vi.fn().mockResolvedValue('computed-skip-sentinel');
+		const result = await runWithCache('ss:miss', run, mockKV as unknown as KVNamespace, 300, false, undefined, true);
+
+		// Result is correct
+		expect(result).toBe('computed-skip-sentinel');
+		expect(run).toHaveBeenCalledOnce();
+
+		// Main-key cacheGet still fires (exactly 1 kv.get for the main key, no sentinel read)
+		expect(mockKV.get).toHaveBeenCalledWith('ss:miss', 'json');
+		expect(mockKV.get).toHaveBeenCalledTimes(1);
+
+		// Result is written to KV
+		const resultPut = mockKV.put.mock.calls.find((c: [string, ...unknown[]]) => c[0] === 'ss:miss');
+		expect(resultPut).toBeDefined();
+
+		// NO sentinel kv.put (`:computing` key must not appear)
+		const sentinelPut = mockKV.put.mock.calls.find((c: [string, ...unknown[]]) => (c[0] as string).endsWith(':computing'));
+		expect(sentinelPut).toBeUndefined();
+
+		// NO kv.delete at all
+		expect(mockKV.delete).not.toHaveBeenCalled();
+	});
+
+	it('skipSentinel default (false), cold miss: sentinel IS written and deleted — current behavior preserved', async () => {
+		const mockKV = {
+			get: vi.fn()
+				.mockResolvedValueOnce(null)  // cacheGet — main key miss
+				.mockResolvedValueOnce(null), // sentinel check — nobody else computing
+			put: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+		const { runWithCache } = await import('../src/lib/cache');
+		const run = vi.fn().mockResolvedValue('computed-default');
+		await runWithCache('ss:default', run, mockKV as unknown as KVNamespace, 300, false, undefined);
+
+		// Sentinel was read (2 kv.get calls: main key + sentinel)
+		expect(mockKV.get).toHaveBeenCalledTimes(2);
+		expect(mockKV.get).toHaveBeenCalledWith('ss:default:computing');
+
+		// Sentinel was written
+		const sentinelPut = mockKV.put.mock.calls.find((c: [string, ...unknown[]]) => c[0] === 'ss:default:computing');
+		expect(sentinelPut).toBeDefined();
+
+		// Sentinel was cleaned up
+		expect(mockKV.delete).toHaveBeenCalledWith('ss:default:computing');
+	});
+
+	it('skipSentinel:true, cache HIT: returns cached value; no run(), no puts, no deletes', async () => {
+		const mockKV = {
+			get: vi.fn().mockResolvedValue({ cached: true }),   // main key is a hit
+			put: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+		const { runWithCache } = await import('../src/lib/cache');
+		const run = vi.fn().mockResolvedValue('should-not-run');
+		const result = await runWithCache('ss:hit', run, mockKV as unknown as KVNamespace, 300, false, undefined, true);
+
+		expect(result).toEqual({ cached: true });
+		expect(run).not.toHaveBeenCalled();
+		expect(mockKV.put).not.toHaveBeenCalled();
+		expect(mockKV.delete).not.toHaveBeenCalled();
+	});
+});

--- a/test/scan-domain-tls-probe.integration.test.ts
+++ b/test/scan-domain-tls-probe.integration.test.ts
@@ -105,6 +105,8 @@ describe('scan_domain TLS-probe scoring coherence', () => {
 		mockCleanScan();
 		const weak = await sslScoreFor('tlsweak.com', {
 			tlsProbeBinding: probeBinding({ reachable: true, minVersion: 'TLS1.1', maxVersion: 'TLS1.2' }),
+			// Probe is a paid-tier enrichment — must supply an eligible authTier for the gate to pass.
+			authTier: 'enterprise',
 		});
 		expect(weak.categoryScore).toBeLessThan(baseline.categoryScore);
 		const enriched = weak.sslCheck!.findings.find((f) => f.metadata?.tlsProbeEnriched === true);
@@ -118,6 +120,8 @@ describe('scan_domain TLS-probe scoring coherence', () => {
 		mockCleanScan();
 		const modern = await sslScoreFor('tlsmodern.com', {
 			tlsProbeBinding: probeBinding({ reachable: true, minVersion: 'TLS1.2', maxVersion: 'TLS1.3' }),
+			// Probe is a paid-tier enrichment — must supply an eligible authTier for the gate to pass.
+			authTier: 'enterprise',
 		});
 		expect(modern.categoryScore).toBe(baseline.categoryScore);
 		expect(modern.sslCheck!.findings.some((f) => f.metadata?.tlsProbeEnriched === true)).toBe(false);
@@ -129,6 +133,8 @@ describe('scan_domain TLS-probe scoring coherence', () => {
 		mockCleanScan();
 		const down = await sslScoreFor('tlsdown.com', {
 			tlsProbeBinding: probeBinding({ reachable: false, error: 'connect timeout' }),
+			// Probe is a paid-tier enrichment — must supply an eligible authTier for the gate to pass.
+			authTier: 'enterprise',
 		});
 		expect(down.categoryScore).toBe(baseline.categoryScore);
 		expect(down.sslCheck!.findings.some((f) => f.metadata?.tlsProbeEnriched === true)).toBe(false);

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -1164,3 +1164,196 @@ describe('scanDomain — transient zero retry', () => {
 		expect(recovered.length).toBe(3);
 	});
 });
+
+/**
+ * FIX 1 — TLS probe tier-gating in scan_domain.
+ *
+ * The BV_TLS_PROBE Browser Rendering call is a paid-tier enrichment.
+ * Free / anonymous / agent scans (~98% of volume) must NOT invoke the
+ * probe binding even when it is physically present in runtimeOptions.
+ */
+describe('scanDomain — TLS probe tier-gating (Fix 1)', () => {
+	/** Minimal DNS mock: all checks healthy, no specific assertions on DNS queries. */
+	function mockAllDns() {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				if (url.includes('type=TXT') || url.includes('type=16')) {
+					if (url.includes('_dmarc.')) return Promise.resolve(txtResponse('_dmarc.probe-gate.com', ['v=DMARC1; p=reject']));
+					if (url.includes('_domainkey.'))
+						return Promise.resolve(txtResponse('default._domainkey.probe-gate.com', ['v=DKIM1; k=rsa; p=MIGf']));
+					if (url.includes('_mta-sts.')) return Promise.resolve(txtResponse('_mta-sts.probe-gate.com', ['v=STSv1; id=20240101']));
+					if (url.includes('_smtp._tls.'))
+						return Promise.resolve(txtResponse('_smtp._tls.probe-gate.com', ['v=TLSRPTv1; rua=mailto:tls@probe-gate.com']));
+					if (url.includes('default._bimi.'))
+						return Promise.resolve(txtResponse('default._bimi.probe-gate.com', ['v=BIMI1; l=https://probe-gate.com/logo.svg']));
+					return Promise.resolve(txtResponse('probe-gate.com', ['v=spf1 include:_spf.google.com -all']));
+				}
+				if (url.includes('type=NS') || url.includes('type=2'))
+					return Promise.resolve(nsResponse('probe-gate.com', ['ns1.probe-gate.com.', 'ns2.probe-gate.com.']));
+				if (url.includes('type=CAA') || url.includes('type=257'))
+					return Promise.resolve(caaResponse('probe-gate.com', ['0 issue "letsencrypt.org"']));
+				if (url.includes('type=A') || url.includes('type=1')) return Promise.resolve(dnssecResponse('probe-gate.com', true));
+				return Promise.resolve(createDohResponse([], []));
+			}
+			if (url.includes('mta-sts.') && url.includes('.well-known'))
+				return Promise.resolve(httpResponse('version: STSv1\nmode: enforce\nmx: *.probe-gate.com\nmax_age: 86400'));
+			// Normal HTTPS responses for the domain (SSL check, http_security check)
+			if (url.startsWith('https://')) return Promise.resolve(httpResponse('OK'));
+			return Promise.resolve(httpResponse('OK'));
+		});
+	}
+
+	it('does NOT invoke the probe binding when authTier is "free"', async () => {
+		mockAllDns();
+		const probeFetch = vi.fn().mockResolvedValue(new Response('{"reachable":true,"minVersion":"TLS1.3"}', { status: 200 }));
+		const tlsProbeBinding = { fetch: probeFetch };
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('probe-gate.com', undefined, { tlsProbeBinding, authTier: 'free' });
+
+		expect(probeFetch).not.toHaveBeenCalled();
+	});
+
+	it('does NOT invoke the probe binding when authTier is "agent"', async () => {
+		mockAllDns();
+		const probeFetch = vi.fn().mockResolvedValue(new Response('{"reachable":true,"minVersion":"TLS1.3"}', { status: 200 }));
+		const tlsProbeBinding = { fetch: probeFetch };
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('probe-gate.com', undefined, { tlsProbeBinding, authTier: 'agent' });
+
+		expect(probeFetch).not.toHaveBeenCalled();
+	});
+
+	it('does NOT invoke the probe binding when authTier is undefined (anonymous)', async () => {
+		mockAllDns();
+		const probeFetch = vi.fn().mockResolvedValue(new Response('{"reachable":true,"minVersion":"TLS1.3"}', { status: 200 }));
+		const tlsProbeBinding = { fetch: probeFetch };
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('probe-gate.com', undefined, { tlsProbeBinding });
+
+		expect(probeFetch).not.toHaveBeenCalled();
+	});
+
+	it('DOES invoke the probe binding when authTier is "developer"', async () => {
+		mockAllDns();
+		const probeFetch = vi.fn().mockResolvedValue(new Response('{"reachable":true,"minVersion":"TLS1.3"}', { status: 200 }));
+		const tlsProbeBinding = { fetch: probeFetch };
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('probe-gate.com', undefined, { tlsProbeBinding, authTier: 'developer' });
+
+		expect(probeFetch).toHaveBeenCalled();
+	});
+
+	it('DOES invoke the probe binding when authTier is "enterprise"', async () => {
+		mockAllDns();
+		const probeFetch = vi.fn().mockResolvedValue(new Response('{"reachable":true,"minVersion":"TLS1.3"}', { status: 200 }));
+		const tlsProbeBinding = { fetch: probeFetch };
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('probe-gate.com', undefined, { tlsProbeBinding, authTier: 'enterprise' });
+
+		expect(probeFetch).toHaveBeenCalled();
+	});
+
+	it('DOES invoke the probe binding when authTier is "partner"', async () => {
+		mockAllDns();
+		const probeFetch = vi.fn().mockResolvedValue(new Response('{"reachable":true,"minVersion":"TLS1.3"}', { status: 200 }));
+		const tlsProbeBinding = { fetch: probeFetch };
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('probe-gate.com', undefined, { tlsProbeBinding, authTier: 'partner' });
+
+		expect(probeFetch).toHaveBeenCalled();
+	});
+
+	it('DOES invoke the probe binding when authTier is "owner"', async () => {
+		mockAllDns();
+		const probeFetch = vi.fn().mockResolvedValue(new Response('{"reachable":true,"minVersion":"TLS1.3"}', { status: 200 }));
+		const tlsProbeBinding = { fetch: probeFetch };
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('probe-gate.com', undefined, { tlsProbeBinding, authTier: 'owner' });
+
+		expect(probeFetch).toHaveBeenCalled();
+	});
+});
+
+/**
+ * FIX 2 — Skip KV sentinel on per-check scan path.
+ *
+ * runCachedCheck passes skipSentinel=true to runWithCache, cutting 2 KV
+ * ops (get + put `:computing`) per check on high-volume unique-domain scans.
+ * INFLIGHT still dedups in-isolate concurrent calls.
+ */
+describe('scanDomain — sentinel-skip on per-check path (Fix 2)', () => {
+	function mockAllDns() {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				if (url.includes('type=TXT') || url.includes('type=16')) {
+					if (url.includes('_dmarc.')) return Promise.resolve(txtResponse('_dmarc.sentinel-skip.com', ['v=DMARC1; p=reject']));
+					if (url.includes('_domainkey.'))
+						return Promise.resolve(txtResponse('default._domainkey.sentinel-skip.com', ['v=DKIM1; k=rsa; p=MIGf']));
+					if (url.includes('_mta-sts.')) return Promise.resolve(txtResponse('_mta-sts.sentinel-skip.com', ['v=STSv1; id=20240101']));
+					if (url.includes('_smtp._tls.'))
+						return Promise.resolve(txtResponse('_smtp._tls.sentinel-skip.com', ['v=TLSRPTv1; rua=mailto:tls@sentinel-skip.com']));
+					if (url.includes('default._bimi.'))
+						return Promise.resolve(txtResponse('default._bimi.sentinel-skip.com', ['v=BIMI1; l=https://sentinel-skip.com/logo.svg']));
+					return Promise.resolve(txtResponse('sentinel-skip.com', ['v=spf1 include:_spf.google.com -all']));
+				}
+				if (url.includes('type=NS') || url.includes('type=2'))
+					return Promise.resolve(nsResponse('sentinel-skip.com', ['ns1.sentinel-skip.com.', 'ns2.sentinel-skip.com.']));
+				if (url.includes('type=CAA') || url.includes('type=257'))
+					return Promise.resolve(caaResponse('sentinel-skip.com', ['0 issue "letsencrypt.org"']));
+				if (url.includes('type=A') || url.includes('type=1')) return Promise.resolve(dnssecResponse('sentinel-skip.com', true));
+				return Promise.resolve(createDohResponse([], []));
+			}
+			if (url.includes('mta-sts.') && url.includes('.well-known'))
+				return Promise.resolve(httpResponse('version: STSv1\nmode: enforce\nmx: *.sentinel-skip.com\nmax_age: 86400'));
+			if (url.startsWith('https://')) return Promise.resolve(httpResponse('OK'));
+			return Promise.resolve(httpResponse('OK'));
+		});
+	}
+
+	it('does not write KV sentinel (:computing) keys during a scan', async () => {
+		mockAllDns();
+		const mockKV = {
+			get: vi.fn().mockResolvedValue(null),
+			put: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('sentinel-skip.com', mockKV as unknown as KVNamespace);
+
+		// No per-check KV put should have a key ending in ':computing'.
+		// The top-level scan cache write is still permitted (no sentinel there either,
+		// since the scan key uses cacheSet directly, not runWithCache sentinel).
+		const computingPuts = mockKV.put.mock.calls.filter((call: unknown[]) =>
+			typeof call[0] === 'string' && (call[0] as string).endsWith(':computing'),
+		);
+		expect(computingPuts).toHaveLength(0);
+	});
+
+	it('still writes per-check results to KV (sentinel skip does not suppress caching)', async () => {
+		mockAllDns();
+		const mockKV = {
+			get: vi.fn().mockResolvedValue(null),
+			put: vi.fn().mockResolvedValue(undefined),
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		await scanDomain('sentinel-skip.com', mockKV as unknown as KVNamespace);
+
+		// Per-check cache writes (cache:<domain>:check:<category>) must still happen.
+		const perCheckPuts = mockKV.put.mock.calls.filter(
+			(call: unknown[]) => typeof call[0] === 'string' && (call[0] as string).includes(':check:'),
+		);
+		expect(perCheckPuts.length).toBeGreaterThan(0);
+	});
+});


### PR DESCRIPTION
**Cost/behavior change — do not merge without sign-off.** Two optimizations motivated by the production cost analysis (Analytics Engine + GraphQL billing API): ~98% of scans are free/anonymous + cold, `SCAN_CACHE` ≈ $441/mo, and the TLS probe (Browser Rendering) fired on every cold SSL check. TDD, 83 tests, `tsc` clean.

## 1. Tier-gate the TLS probe in `scan_domain`
The probe is a paid-tier enrichment (Browser Rendering, ~$0.09/browser-hr). It now fires only for **paid tiers** (`developer`/`enterprise`/`partner`/`owner`), not free/agent/anonymous scans — which are ~98% of volume and the entire Browser Rendering cost driver. `authTier` threaded into `ScanRuntimeOptions`; both `checkSsl` call sites gated by `PROBE_ELIGIBLE_TIERS`. Standalone `check_ssl` is unchanged (low volume).
*Projected: removes the Browser Rendering cost (~$90/mo per cold-heavy enterprise, and the bulk of account-wide probe usage) from free traffic.*

## 2. Skip the cross-isolate KV sentinel on the scan per-check path
`runWithCache` gains a `skipSentinel` flag; `runCachedCheck` uses it. Per-check scan caches are ~98% unique-domain / low-contention, so the sentinel's KV write+delete cost more than the rare stampede they prevent (the in-isolate `INFLIGHT` dedup stays). Cuts **~35→18 writes and ~17→0 deletes per cold scan** — roughly halving the ~$441/mo `SCAN_CACHE` bill.

## Rejected: full per-check key-batching
`buildCheckCacheKey` keys are **shared** with the standalone `check_*` tools (`handlers/tools.ts:931`), so collapsing them into one key would break cache reuse between scans and individual checks. The sentinel-skip achieves most of the saving without that blast radius.

## Notes
- Known: the per-check cache has no tier dimension, so a free-tier scan cached first serves the non-probe result to a later paid scan until TTL expiry (5 min). Cost goal still met (no Browser Rendering for free).
- Residual lever (not in this PR): the probe still costs ~$88/mo for a cold-heavy *paid* enterprise; sampling or a longer probe-cache TTL (a `bv-tls-probe` change) could reduce it further.

🤖 Generated with [Claude Code](https://claude.com/claude-code)