### PR TITLE
feat(dns-checks): DMARC parity corpus + contract gate (1.3.1)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.0",
+	"version": "1.3.1",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
+++ b/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+/**
+ * Cross-repo scoring parity — bv-mcp side.
+ *
+ * Runs the REAL checkDMARC (full fact-extraction + classifier) over each corpus
+ * fixture's records and asserts the canonical score + missingControl. bv-web runs
+ * the SAME corpus through its own full check; with the version-lock, agreement is
+ * transitive (bv-web == corpus == bv-mcp). `treeWalkOnly` fixtures are skipped
+ * here — bv-mcp does not tree-walk (documented bounded-non-parity).
+ *
+ * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
+ */
+import { describe, it, expect } from 'vitest';
+import { checkDMARC } from '../checks';
+import { scoreIndicatesMissingControl } from '../scoring';
+import pkg from '../../package.json';
+import { DMARC_PARITY_FIXTURES, PARITY_CORPUS_VERSION } from '../parity-fixtures';
+
+function missingControl(findings: Parameters<typeof scoreIndicatesMissingControl>[0]): boolean {
+	return (
+		scoreIndicatesMissingControl(findings) ||
+		findings.some((f) => f.metadata?.missingControl === true)
+	);
+}
+
+describe('DMARC parity corpus — bv-mcp full checkDMARC', () => {
+	it('version-lock: package version === corpus version', () => {
+		expect(pkg.version).toBe(PARITY_CORPUS_VERSION);
+	});
+
+	for (const fx of DMARC_PARITY_FIXTURES.filter((f) => !f.treeWalkOnly)) {
+		it(`scores "${fx.name}" → ${fx.expectedScore} (missingControl=${fx.expectedMissingControl})`, async () => {
+			const queryDNS = (async (name: string) => fx.records[name] ?? []) as never;
+			const domain = fx.query.replace(/^_dmarc\./, '');
+			const result = await checkDMARC(domain, queryDNS);
+			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
+				score: fx.expectedScore,
+				missing: fx.expectedMissingControl,
+			});
+		});
+	}
+});

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -65,6 +65,11 @@ export type { CaaRecord, TlsaRecord } from './checks';
 export { classifyDmarc, appendDmarcCleanInfo } from './scoring/classifiers/dmarc';
 export type { DmarcFacts } from './scoring/classifiers/dmarc';
 
+// Cross-repo scoring parity corpus (shared contract; both repos assert their full
+// check matches these). See bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
+export { DMARC_PARITY_FIXTURES, PARITY_CORPUS_VERSION } from './parity-fixtures';
+export type { DmarcParityFixture } from './parity-fixtures';
+
 // Zod schemas
 export {
 	CheckCategorySchema,

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+/**
+ * Shared cross-repo scoring parity corpus.
+ *
+ * Both bv-mcp and bv-web run each fixture through their FULL `checkDMARC` (with a
+ * mocked resolver returning `records`) and must produce `expectedScore` +
+ * `expectedMissingControl`. This makes scoring drift between the two scanners a
+ * test failure rather than a silent product divergence.
+ *
+ * Records are keyed on the queried name (e.g. `_dmarc.example.com`) so the corpus
+ * exercises each repo's fact-extraction (tag parsing, DMARCbis tree-walk) — the
+ * UNSHARED layer where drift actually lives — not just the shared classifier.
+ *
+ * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
+ *
+ * Copyright (c) 2023-2026 BlackVeil Security Ltd. Licensed under BSL 1.1.
+ */
+
+export interface DmarcParityFixture {
+	check: 'dmarc';
+	/** Human label for the case. */
+	name: string;
+	/** Primary lookup name, e.g. "_dmarc.example.com". */
+	query: string;
+	/** Lookup name -> TXT records the mock resolver returns (includes parents for tree-walk). */
+	records: Record<string, string[]>;
+	expectedScore: number;
+	expectedMissingControl: boolean;
+	/**
+	 * True when only bv-web can produce this via RFC 9989 tree-walk inheritance.
+	 * bv-mcp's checkDMARC reads `_dmarc.<domain>` directly (no tree-walk) so it
+	 * diverges here — a documented bounded-non-parity until bv-mcp gains tree-walk.
+	 * The bv-mcp contract test skips these; the bv-web tree-walk test asserts them.
+	 */
+	treeWalkOnly?: boolean;
+	/** Wrapper-only async finding bv-web can't compute (e.g. third-party RUA-auth), documented. */
+	asyncDelta?: { finding: string; points: number };
+}
+
+/** Must equal the package version (asserted by both repos' version-lock). */
+export const PARITY_CORPUS_VERSION = '1.3.1';
+
+export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
+	{
+		check: 'dmarc',
+		name: 'no record (missingControl)',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': [] },
+		expectedScore: 0,
+		expectedMissingControl: true,
+	},
+	{
+		check: 'dmarc',
+		name: 'p=none + rua',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': ['v=DMARC1; p=none; rua=mailto:d@example.com'] },
+		expectedScore: 70,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dmarc',
+		name: 'p=quarantine + rua',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': ['v=DMARC1; p=quarantine; rua=mailto:d@example.com'] },
+		expectedScore: 80,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dmarc',
+		name: 'p=reject strict alignment + rua',
+		query: '_dmarc.example.com',
+		records: {
+			'_dmarc.example.com': [
+				'v=DMARC1; p=reject; sp=reject; adkim=s; aspf=s; rua=mailto:d@example.com',
+			],
+		},
+		expectedScore: 95,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dmarc',
+		name: 't=y test mode (1.3.0 superset)',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': ['v=DMARC1; p=reject; t=y; rua=mailto:d@example.com'] },
+		expectedScore: 65,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dmarc',
+		name: 'np=none spoofable (1.3.0 superset)',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': ['v=DMARC1; p=reject; np=none; rua=mailto:d@example.com'] },
+		expectedScore: 65,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dmarc',
+		name: 'multiple records',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': ['v=DMARC1; p=none', 'v=DMARC1; p=reject'] },
+		expectedScore: 45,
+		expectedMissingControl: false,
+	},
+	{
+		// Tree-walk divergence — see the design's Decision Point. bv-web inherits the
+		// parent's sp; bv-mcp reads _dmarc.blog.example.com directly (no record) -> 0.
+		check: 'dmarc',
+		name: 'subdomain inherits parent p=reject (tree-walk)',
+		query: '_dmarc.blog.example.com',
+		records: {
+			'_dmarc.blog.example.com': [],
+			'_dmarc.example.com': ['v=DMARC1; p=reject; sp=quarantine; rua=mailto:d@example.com'],
+		},
+		expectedScore: 80,
+		expectedMissingControl: false,
+		treeWalkOnly: true,
+	},
+];


### PR DESCRIPTION
Canonical side of the cross-repo scoring parity gate (design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md).

- `DMARC_PARITY_FIXTURES` (records-keyed) + `PARITY_CORPUS_VERSION`, exported from the package.
- `parity-corpus.contract.test.ts` runs the REAL `checkDMARC` over each fixture's records (mocked resolver) + version-lock — tests fact-extraction + classifier end-to-end.
- bv-web re-vendors this and runs the same corpus through its own full check; with the version-lock, parity is transitive.
- `treeWalkOnly` subdomain fixture skipped here (bv-mcp doesn't tree-walk — documented bounded-non-parity vs bv-web RFC 9989).
- Bump 1.3.0 → 1.3.1. 309/309 dns-checks tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)