### PR TITLE
feat(dns-checks): DANE-HTTPS parity corpus (1.3.2)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.1",
+	"version": "1.3.2",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
+++ b/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
@@ -11,10 +11,14 @@
  * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { checkDMARC } from '../checks';
+import { checkDMARC, checkDANEHTTPS } from '../checks';
 import { scoreIndicatesMissingControl } from '../scoring';
 import pkg from '../../package.json';
-import { DMARC_PARITY_FIXTURES, PARITY_CORPUS_VERSION } from '../parity-fixtures';
+import {
+	DMARC_PARITY_FIXTURES,
+	DANE_HTTPS_PARITY_FIXTURES,
+	PARITY_CORPUS_VERSION,
+} from '../parity-fixtures';
 
 function missingControl(findings: Parameters<typeof scoreIndicatesMissingControl>[0]): boolean {
 	return (
@@ -33,6 +37,21 @@ describe('DMARC parity corpus — bv-mcp full checkDMARC', () => {
 			const queryDNS = (async (name: string) => fx.records[name] ?? []) as never;
 			const domain = fx.query.replace(/^_dmarc\./, '');
 			const result = await checkDMARC(domain, queryDNS);
+			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
+				score: fx.expectedScore,
+				missing: fx.expectedMissingControl,
+			});
+		});
+	}
+});
+
+describe('DANE-HTTPS parity corpus — bv-mcp full checkDANEHTTPS', () => {
+	for (const fx of DANE_HTTPS_PARITY_FIXTURES) {
+		it(`scores "${fx.name}" → ${fx.expectedScore} (missingControl=${fx.expectedMissingControl})`, async () => {
+			const queryDNS = (async (name: string) =>
+				name === `_443._tcp.${fx.domain}` ? fx.tlsa : []) as never;
+			const rawQueryDNS = (async () => ({ AD: fx.ad })) as never;
+			const result = await checkDANEHTTPS(fx.domain, queryDNS, { rawQueryDNS });
 			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
 				score: fx.expectedScore,
 				missing: fx.expectedMissingControl,

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -67,8 +67,8 @@ export type { DmarcFacts } from './scoring/classifiers/dmarc';
 
 // Cross-repo scoring parity corpus (shared contract; both repos assert their full
 // check matches these). See bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
-export { DMARC_PARITY_FIXTURES, PARITY_CORPUS_VERSION } from './parity-fixtures';
-export type { DmarcParityFixture } from './parity-fixtures';
+export { DMARC_PARITY_FIXTURES, DANE_HTTPS_PARITY_FIXTURES, PARITY_CORPUS_VERSION } from './parity-fixtures';
+export type { DmarcParityFixture, DaneHttpsParityFixture } from './parity-fixtures';
 
 // Zod schemas
 export {

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,24 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.1';
+export const PARITY_CORPUS_VERSION = '1.3.2';
+
+/**
+ * DANE-HTTPS parity fixture. Keyed on the TLSA records at `_443._tcp.<domain>`
+ * plus the DNSSEC AD flag (DANE without DNSSEC is ineffective → RFC 7672).
+ * Both repos run their full checkDANEHTTPS over these + must match.
+ */
+export interface DaneHttpsParityFixture {
+	check: 'dane_https';
+	name: string;
+	domain: string;
+	/** TLSA records returned at `_443._tcp.<domain>`. */
+	tlsa: string[];
+	/** DNSSEC AD flag from the raw query (DANE-TA/EE without DNSSEC is downgraded). */
+	ad: boolean;
+	expectedScore: number;
+	expectedMissingControl: boolean;
+}
 
 export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 	{
@@ -114,5 +131,55 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 		expectedScore: 80,
 		expectedMissingControl: false,
 		treeWalkOnly: true,
+	},
+];
+
+const SHA256_HASH = '0000000000000000000000000000000000000000000000000000000000000001';
+
+export const DANE_HTTPS_PARITY_FIXTURES: DaneHttpsParityFixture[] = [
+	{
+		check: 'dane_https',
+		name: 'no TLSA record',
+		domain: 'example.com',
+		tlsa: [],
+		ad: true,
+		expectedScore: 95,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dane_https',
+		name: 'valid DANE-EE (3 1 1) + DNSSEC',
+		domain: 'example.com',
+		tlsa: [`3 1 1 ${SHA256_HASH}`],
+		ad: true,
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dane_https',
+		name: 'valid DANE-EE (3 1 1) without DNSSEC',
+		domain: 'example.com',
+		tlsa: [`3 1 1 ${SHA256_HASH}`],
+		ad: false,
+		expectedScore: 75,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dane_https',
+		name: 'malformed TLSA (3 fields)',
+		domain: 'example.com',
+		tlsa: ['3 1 1'],
+		ad: true,
+		expectedScore: 85,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dane_https',
+		name: 'PKIX-EE (1 1 1) without DNSSEC',
+		domain: 'example.com',
+		tlsa: [`1 1 1 ${SHA256_HASH}`],
+		ad: false,
+		expectedScore: 100,
+		expectedMissingControl: false,
 	},
 ];


### PR DESCRIPTION
Canonical side of the DANE-HTTPS parity vertical. Records-keyed DANE_HTTPS_PARITY_FIXTURES (TLSA + AD flag) + contract test running the real checkDANEHTTPS; locked values no-TLSA→95 / valid-EE+DNSSEC→100 / no-DNSSEC→75 / malformed→85 / PKIX-EE→100. Bump 1.3.2. 314/314 tests pass. bv-web re-vendors + delegates next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)