### PR TITLE
feat(dns-checks): SVCB-HTTPS coarse-advisory scoring (1.3.3)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.2",
+	"version": "1.3.3",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -124,12 +124,15 @@ describe('checkNS', () => {
 });
 
 describe('checkSVCBHTTPS', () => {
-	it('returns low when no HTTPS records', async () => {
+	it('treats absent HTTPS record as advisory (low, not a failure)', async () => {
+		// RFC 9460: HTTPS/SVCB RRs are a performance/privacy optimization, not a
+		// required security control — absence is not a deficiency (no missingControl).
 		const queryDNS = createMockDNS({ 'example.com': [] });
 		const result = await checkSVCBHTTPS('example.com', queryDNS);
 		expect(result.findings[0].title).toBe('No HTTPS record found');
-		expect(result.passed).toBe(false);
-		expect(result.score).toBe(0);
+		expect(result.findings[0].severity).toBe('low');
+		expect(result.passed).toBe(true);
+		expect(result.score).toBe(95);
 	});
 
 	it('detects H3 ALPN', async () => {

--- a/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
+++ b/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
@@ -11,12 +11,13 @@
  * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { checkDMARC, checkDANEHTTPS } from '../checks';
+import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS } from '../checks';
 import { scoreIndicatesMissingControl } from '../scoring';
 import pkg from '../../package.json';
 import {
 	DMARC_PARITY_FIXTURES,
 	DANE_HTTPS_PARITY_FIXTURES,
+	SVCB_HTTPS_PARITY_FIXTURES,
 	PARITY_CORPUS_VERSION,
 } from '../parity-fixtures';
 
@@ -52,6 +53,20 @@ describe('DANE-HTTPS parity corpus — bv-mcp full checkDANEHTTPS', () => {
 				name === `_443._tcp.${fx.domain}` ? fx.tlsa : []) as never;
 			const rawQueryDNS = (async () => ({ AD: fx.ad })) as never;
 			const result = await checkDANEHTTPS(fx.domain, queryDNS, { rawQueryDNS });
+			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
+				score: fx.expectedScore,
+				missing: fx.expectedMissingControl,
+			});
+		});
+	}
+});
+
+describe('SVCB-HTTPS parity corpus — bv-mcp full checkSVCBHTTPS', () => {
+	for (const fx of SVCB_HTTPS_PARITY_FIXTURES) {
+		it(`scores "${fx.name}" → ${fx.expectedScore} (missingControl=${fx.expectedMissingControl})`, async () => {
+			const queryDNS = (async (name: string, type: string) =>
+				type === 'HTTPS' && name === fx.domain ? fx.https : []) as never;
+			const result = await checkSVCBHTTPS(fx.domain, queryDNS);
 			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
 				score: fx.expectedScore,
 				missing: fx.expectedMissingControl,

--- a/packages/dns-checks/src/checks/check-svcb-https.ts
+++ b/packages/dns-checks/src/checks/check-svcb-https.ts
@@ -140,8 +140,7 @@ export async function checkSVCBHTTPS(
 				'svcb_https',
 				'No HTTPS record found',
 				'low',
-				`No HTTPS (type 65) record found at ${domain}. HTTPS records (RFC 9460) advertise modern transport capabilities (ALPN, ECH) and enable clients to connect securely without an initial redirect round-trip. Consider publishing an HTTPS record with h2 and h3 ALPN support.`,
-				{ missingControl: true },
+				`No HTTPS (type 65) record found at ${domain}. HTTPS records (RFC 9460) advertise modern transport capabilities (ALPN, ECH) and enable clients to connect securely without an initial redirect round-trip. Consider publishing an HTTPS record with h2 and h3 ALPN support. Per RFC 9460 these records are an advisory performance/privacy optimization, not a required security control — absence is not a deficiency.`,
 			),
 		);
 		return buildCheckResult('svcb_https', findings);

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -67,8 +67,17 @@ export type { DmarcFacts } from './scoring/classifiers/dmarc';
 
 // Cross-repo scoring parity corpus (shared contract; both repos assert their full
 // check matches these). See bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
-export { DMARC_PARITY_FIXTURES, DANE_HTTPS_PARITY_FIXTURES, PARITY_CORPUS_VERSION } from './parity-fixtures';
-export type { DmarcParityFixture, DaneHttpsParityFixture } from './parity-fixtures';
+export {
+	DMARC_PARITY_FIXTURES,
+	DANE_HTTPS_PARITY_FIXTURES,
+	SVCB_HTTPS_PARITY_FIXTURES,
+	PARITY_CORPUS_VERSION,
+} from './parity-fixtures';
+export type {
+	DmarcParityFixture,
+	DaneHttpsParityFixture,
+	SvcbParityFixture,
+} from './parity-fixtures';
 
 // Zod schemas
 export {

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,22 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.2';
+export const PARITY_CORPUS_VERSION = '1.3.3';
+
+/**
+ * SVCB-HTTPS parity fixture (RFC 9460). Coarse-advisory scoring: a present record
+ * scores ~90-100 (info/low), absence is NOT a deficiency (~95, no missingControl)
+ * — HTTPS/SVCB RRs are a performance/privacy optimization, not a required control.
+ */
+export interface SvcbParityFixture {
+	check: 'svcb_https';
+	name: string;
+	domain: string;
+	/** HTTPS (type 65) records returned for `domain`. */
+	https: string[];
+	expectedScore: number;
+	expectedMissingControl: boolean;
+}
 
 /**
  * DANE-HTTPS parity fixture. Keyed on the TLSA records at `_443._tcp.<domain>`
@@ -180,6 +195,49 @@ export const DANE_HTTPS_PARITY_FIXTURES: DaneHttpsParityFixture[] = [
 		tlsa: [`1 1 1 ${SHA256_HASH}`],
 		ad: false,
 		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+];
+
+export const SVCB_HTTPS_PARITY_FIXTURES: SvcbParityFixture[] = [
+	{
+		check: 'svcb_https',
+		name: 'no HTTPS record (advisory absence)',
+		domain: 'example.com',
+		https: [],
+		expectedScore: 95,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'svcb_https',
+		name: 'ServiceMode + ALPN h2,h3',
+		domain: 'example.com',
+		https: ['1 . alpn="h2,h3"'],
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'svcb_https',
+		name: 'ServiceMode + ALPN + ECH',
+		domain: 'example.com',
+		https: ['1 . alpn="h2,h3" ech="AEX+DQ"'],
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'svcb_https',
+		name: 'AliasMode',
+		domain: 'example.com',
+		https: ['0 cdn.example.com.'],
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'svcb_https',
+		name: 'ServiceMode no ALPN',
+		domain: 'example.com',
+		https: ['1 . port=443'],
+		expectedScore: 90,
 		expectedMissingControl: false,
 	},
 ];

--- a/test/check-svcb-https.spec.ts
+++ b/test/check-svcb-https.spec.ts
@@ -37,8 +37,10 @@ describe('checkSvcbHttps', () => {
 
 		const result = await run();
 		expect(result.category).toBe('svcb_https');
-		expect(result.passed).toBe(false); // missingControl: true forces passed=false
-		expect(result.score).toBe(0);
+		// RFC 9460: HTTPS/SVCB RRs are an advisory performance/privacy optimization,
+		// not a required control — absence is not a deficiency (lone low → 95, passes).
+		expect(result.passed).toBe(true);
+		expect(result.score).toBe(95);
 		const lowFinding = result.findings.find((f) => f.severity === 'low');
 		expect(lowFinding).toBeDefined();
 		expect(lowFinding!.title).toBe('No HTTPS record found');


### PR DESCRIPTION
RFC 9460: HTTPS/SVCB RRs are a performance/privacy optimization, not a required security control. Drop missingControl on no-record (0→95); present stays 100, no-ALPN 90. + SVCB parity corpus + contract. Bump 1.3.3. bv-web delegates next (subsumes #679 wire-fix). 🤖 Generated with [Claude Code](https://claude.com/claude-code)