### PR TITLE
feat(dns-checks): DNSSEC recalibration to NIST SP 800-81r3 / RFC 9364 (1.3.5)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.4",
+	"version": "1.3.5",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
@@ -17,11 +17,13 @@ describe('checkDNSSEC', () => {
 		const result = await checkDNSSEC('example.com', queryDNS, { rawQueryDNS });
 		expect(result.category).toBe('dnssec');
 		expect(result.findings.some((f) => f.title === 'DNSSEC not enabled')).toBe(true);
-		// NIST-aligned (SP 800-81r3): DNSSEC absence is a high-severity integrity gap,
-		// NOT a missing-control zero. Category takes the high penalty (100-25=75) and
-		// passes, rather than zeroing — DNSSEC stays a weighted Core control.
+		// NIST SP 800-81r3 / RFC 9364 (BCP 237): an unsigned PUBLIC zone is near-failing
+		// (DNSSEC origin-auth is best current practice). CRITICAL penalty (100-40=60),
+		// but NOT a missing-control zero — DNSSEC stays a weighted Core control the
+		// category still passes (60≥50). Recalibrated DOWN from the prior lenient 75.
+		expect(result.findings.find((f) => f.title === 'DNSSEC not enabled')?.severity).toBe('critical');
 		expect(result.passed).toBe(true);
-		expect(result.score).toBe(75);
+		expect(result.score).toBe(60);
 		expect(result.findings.find((f) => f.title === 'DNSSEC not enabled')?.metadata?.missingControl).toBeUndefined();
 	});
 

--- a/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
+++ b/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
@@ -11,13 +11,14 @@
  * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS } from '../checks';
+import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS, checkDNSSEC } from '../checks';
 import { scoreIndicatesMissingControl } from '../scoring';
 import pkg from '../../package.json';
 import {
 	DMARC_PARITY_FIXTURES,
 	DANE_HTTPS_PARITY_FIXTURES,
 	SVCB_HTTPS_PARITY_FIXTURES,
+	DNSSEC_PARITY_FIXTURES,
 	PARITY_CORPUS_VERSION,
 } from '../parity-fixtures';
 
@@ -69,6 +70,21 @@ describe('SVCB-HTTPS parity corpus — bv-mcp full checkSVCBHTTPS', () => {
 			const queryDNS = (async (name: string, type: string) =>
 				type === 'HTTPS' && name === fx.domain ? fx.https : []) as never;
 			const result = await checkSVCBHTTPS(fx.domain, queryDNS);
+			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
+				score: fx.expectedScore,
+				missing: fx.expectedMissingControl,
+			});
+		});
+	}
+});
+
+describe('DNSSEC parity corpus — bv-mcp full checkDNSSEC', () => {
+	for (const fx of DNSSEC_PARITY_FIXTURES) {
+		it(`scores "${fx.name}" → ${fx.expectedScore} (missingControl=${fx.expectedMissingControl})`, async () => {
+			const queryDNS = (async (_name: string, type: string) =>
+				type === 'DNSKEY' ? fx.dnskey : type === 'DS' ? fx.ds : type === 'NSEC3PARAM' ? fx.nsec3param : []) as never;
+			const rawQueryDNS = (async () => ({ AD: fx.ad })) as never;
+			const result = await checkDNSSEC(fx.domain, queryDNS, { rawQueryDNS });
 			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
 				score: fx.expectedScore,
 				missing: fx.expectedMissingControl,

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -72,40 +72,46 @@ export async function checkDNSSEC(
 
 	// Consolidated finding logic
 	if (!adFlag && dnskeyRecords.length === 0 && dsRecords.length === 0) {
-		// Fully absent — high-severity finding, but NOT a missing-control zero.
-		// NIST SP 800-81r3 (Mar 2026) positions DNSSEC as a baseline integrity
-		// control ("Deploy DNSSEC to protect the integrity of DNS data" — one of its
-		// four top-level recommendations) within a defense-in-depth model. Absence is
-		// therefore a real integrity GAP (high severity, dents the category) but not a
-		// catastrophic missing baseline like an absent SPF on a mail domain — so we do
-		// NOT set `missingControl: true`, which would zero the whole category. DNSSEC
-		// stays a weighted Core control; the score reflects a proportionate penalty.
+		// Fully absent — CRITICAL, but NOT a missing-control zero. NIST SP 800-81r3
+		// (Mar 2026) makes DNSSEC a baseline deployment goal and RFC 9364 (BCP 237)
+		// states origin-authentication via DNSSEC is "the best current practice", so an
+		// unsigned PUBLIC zone is a near-failing deficiency (critical, −40 → ~60) — far
+		// heavier than the previous lenient 75. We do NOT set `missingControl: true`
+		// (which would zero the category): DNSSEC is one of several integrity controls,
+		// not a sole baseline, so a heavy proportionate deduction is the faithful read.
+		// The detail text deliberately avoids "no … record / missing / not found" so
+		// `scoreIndicatesMissingControl` cannot auto-zero a critical finding.
 		findings.push(
 			createFinding(
 				'dnssec',
 				'DNSSEC not enabled',
-				'high',
+				'critical',
 				`DNSSEC is not configured for ${domain}. Without DNSSEC, DNS responses are not cryptographically verified, leaving SPF, DMARC, and DKIM records vulnerable to DNS-level manipulation.`,
 			),
 		);
 	} else if (dnskeyRecords.length > 0 && dsRecords.length === 0) {
-		// DNSKEY published but no DS in parent zone — broken chain
+		// DNSKEY published but no DS in parent zone — broken chain. BOGUS to any
+		// validating resolver (worse than unsigned): explicit missingControl → score 0.
 		findings.push(
 			createFinding(
 				'dnssec',
 				'DNSSEC chain of trust incomplete',
 				'high',
 				`DNSKEY records are published for ${domain} but no DS records exist in the parent zone. The chain of trust is broken — DNSSEC validation will fail.`,
+				{ missingControl: true },
 			),
 		);
 	} else if (dnskeyRecords.length > 0 && dsRecords.length > 0 && !adFlag) {
-		// Deployed but validation failing — worse than not having DNSSEC
+		// Deployed but validation failing (BOGUS) — worse than not having DNSSEC.
+		// DNSSEC-1 decision: explicit missingControl → score 0 (same BOGUS principle as
+		// the broken chain — a validating resolver rejects the zone's data outright).
 		findings.push(
 			createFinding(
 				'dnssec',
 				'DNSSEC validation failing',
 				'high',
 				`DNSKEY and DS records are present for ${domain} but the AD flag is not set. DNSSEC is deployed but validation is failing — this is worse than not having DNSSEC.`,
+				{ missingControl: true },
 			),
 		);
 	}

--- a/packages/dns-checks/src/checks/dnssec-analysis.ts
+++ b/packages/dns-checks/src/checks/dnssec-analysis.ts
@@ -16,13 +16,16 @@ import { createFinding } from '../check-utils';
  * deprecated: RFC 8624 MUST NOT sign/validate — flag as high severity.
  * notRecommended: RFC 8624 NOT RECOMMENDED for signing — flag as low advisory.
  */
-const DNSKEY_ALGORITHMS: Record<number, { name: string; deprecated: boolean; notRecommended?: boolean }> = {
+const DNSKEY_ALGORITHMS: Record<
+	number,
+	{ name: string; deprecated: boolean; notRecommended?: boolean; rsaAcceptable?: boolean }
+> = {
 	1: { name: 'RSAMD5', deprecated: true },           // RFC 8624: MUST NOT sign/validate
 	3: { name: 'DSA', deprecated: true },              // RFC 8624: MUST NOT sign/validate
 	5: { name: 'RSA/SHA-1', deprecated: true },        // RFC 8624: NOT RECOMMENDED (effectively deprecated)
 	6: { name: 'DSA-NSEC3-SHA1', deprecated: true },   // RFC 8624: MUST NOT sign/validate
 	7: { name: 'RSASHA1-NSEC3', deprecated: true },    // RFC 8624: NOT RECOMMENDED (effectively deprecated)
-	8: { name: 'RSA/SHA-256', deprecated: false },     // RFC 8624: MUST sign/validate
+	8: { name: 'RSA/SHA-256', deprecated: false, rsaAcceptable: true }, // RFC 8624: MUST sign/validate — valid but RSA (large keys); ECDSA/Ed preferable
 	10: { name: 'RSA/SHA-512', deprecated: false, notRecommended: true }, // RFC 8624: NOT RECOMMENDED for signing
 	12: { name: 'ECC-GOST', deprecated: true },        // RFC 8624: MUST NOT sign; MAY validate
 	13: { name: 'ECDSA P-256', deprecated: false },    // RFC 8624: MUST sign/validate
@@ -101,6 +104,18 @@ export function auditDnskeyAlgorithms(domain: string, dnskeyRecords: string[]): 
 					`DNSKEY algorithm not recommended for signing (${known.name})`,
 					'low',
 					`${domain} uses DNSKEY algorithm ${algorithm} (${known.name}), which RFC 8624 marks as NOT RECOMMENDED for new DNSSEC deployments. Consider migrating to ECDSA (algorithm 13/14) or Ed25519 (algorithm 15).`,
+				),
+			);
+		} else if (known?.rsaAcceptable) {
+			// RFC 8624 fully permits RSA/SHA-256, but it produces larger keys/signatures
+			// than elliptic-curve algorithms (response-size & DoS pressure). NIST SP
+			// 800-81r3 Table 1 lists ECDSA/EdDSA as "preferable" — a soft, non-failing nudge.
+			findings.push(
+				createFinding(
+					'dnssec',
+					`RSA DNSSEC algorithm in use (${known.name})`,
+					'low',
+					`${domain} signs with DNSKEY algorithm ${algorithm} (${known.name}). This is valid per RFC 8624, but RSA produces larger keys and signatures than elliptic-curve algorithms; ECDSA (13/14) or Ed25519 (15) are preferable for smaller DNS responses and better DoS resistance.`,
 				),
 			);
 		} else if (!known) {

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -71,12 +71,14 @@ export {
 	DMARC_PARITY_FIXTURES,
 	DANE_HTTPS_PARITY_FIXTURES,
 	SVCB_HTTPS_PARITY_FIXTURES,
+	DNSSEC_PARITY_FIXTURES,
 	PARITY_CORPUS_VERSION,
 } from './parity-fixtures';
 export type {
 	DmarcParityFixture,
 	DaneHttpsParityFixture,
 	SvcbParityFixture,
+	DnssecParityFixture,
 } from './parity-fixtures';
 
 // Zod schemas

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,27 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.4';
+export const PARITY_CORPUS_VERSION = '1.3.5';
+
+/**
+ * DNSSEC parity fixture. Keyed on the AD flag + DNSKEY/DS/NSEC3PARAM records.
+ * NIST SP 800-81r3 / RFC 9364 (BCP 237): unsigned public zone is near-failing
+ * (critical → ~60, NOT zeroed); broken-chain / validation-failing are BOGUS
+ * (missingControl → 0); RSA is valid-but-soft-dinged; NSEC3 penalized only on
+ * RFC-9276-violating params.
+ */
+export interface DnssecParityFixture {
+	check: 'dnssec';
+	name: string;
+	domain: string;
+	/** DNSSEC AD flag (authenticated data) from the raw query. */
+	ad: boolean;
+	dnskey: string[];
+	ds: string[];
+	nsec3param: string[];
+	expectedScore: number;
+	expectedMissingControl: boolean;
+}
 
 /**
  * SVCB-HTTPS parity fixture (RFC 9460). Coarse-advisory scoring: a present record
@@ -239,6 +259,77 @@ export const SVCB_HTTPS_PARITY_FIXTURES: SvcbParityFixture[] = [
 		domain: 'example.com',
 		https: ['1 . port=443'],
 		expectedScore: 90,
+		expectedMissingControl: false,
+	},
+];
+
+// Placeholder DNSKEY/DS records (algorithm field is what matters: alg 13 = ECDSA P-256,
+// alg 8 = RSA/SHA-256). DS format "keytag algorithm digesttype hash".
+export const DNSSEC_PARITY_FIXTURES: DnssecParityFixture[] = [
+	{
+		check: 'dnssec',
+		name: 'no DNSSEC (unsigned public — near-failing, not zeroed)',
+		domain: 'example.com',
+		ad: false,
+		dnskey: [],
+		ds: [],
+		nsec3param: [],
+		expectedScore: 60,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dnssec',
+		name: 'valid + DNSSEC (ECDSA P-256)',
+		domain: 'example.com',
+		ad: true,
+		dnskey: ['257 3 13 AwEAAabc'],
+		ds: ['12345 13 2 abc123'],
+		nsec3param: [],
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dnssec',
+		name: 'valid RSA/SHA-256 (acceptable, soft-dinged)',
+		domain: 'example.com',
+		ad: true,
+		dnskey: ['257 3 8 AwEAAabc'],
+		ds: ['12345 8 2 abc123'],
+		nsec3param: [],
+		expectedScore: 95,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dnssec',
+		name: 'broken chain (DNSKEY, no DS — BOGUS)',
+		domain: 'example.com',
+		ad: false,
+		dnskey: ['257 3 13 AwEAAabc'],
+		ds: [],
+		nsec3param: [],
+		expectedScore: 0,
+		expectedMissingControl: true,
+	},
+	{
+		check: 'dnssec',
+		name: 'validation failing (DNSKEY+DS, AD off — BOGUS, DNSSEC-1)',
+		domain: 'example.com',
+		ad: false,
+		dnskey: ['257 3 13 AwEAAabc'],
+		ds: ['12345 13 2 abc123'],
+		nsec3param: [],
+		expectedScore: 0,
+		expectedMissingControl: true,
+	},
+	{
+		check: 'dnssec',
+		name: 'NSEC3 RFC 9276 violations (150 iterations + non-empty salt)',
+		domain: 'example.com',
+		ad: true,
+		dnskey: ['257 3 13 AwEAAabc'],
+		ds: ['12345 13 2 abc123'],
+		nsec3param: ['1 0 150 ab'],
+		expectedScore: 70,
 		expectedMissingControl: false,
 	},
 ];

--- a/test/check-dnssec.spec.ts
+++ b/test/check-dnssec.spec.ts
@@ -80,13 +80,14 @@ describe('DNSSEC finding consolidation', () => {
 		return checkDnssec(domain);
 	}
 
-	it('emits single HIGH finding when DNSSEC is fully absent', async () => {
-		// AD=false, no DNSKEY, no DS
+	it('emits single CRITICAL finding when DNSSEC is fully absent', async () => {
+		// AD=false, no DNSKEY, no DS. NIST SP 800-81r3 / RFC 9364: unsigned public zone
+		// is near-failing → critical (recalibrated down from the prior lenient high/75).
 		mockDnssecResponses(false, false, false);
 		const result = await run();
 		const nonInfoFindings = result.findings.filter((f) => f.severity !== 'info');
 		expect(nonInfoFindings).toHaveLength(1);
-		expect(nonInfoFindings[0].severity).toBe('high');
+		expect(nonInfoFindings[0].severity).toBe('critical');
 		expect(nonInfoFindings[0].title).toBe('DNSSEC not enabled');
 	});
 

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -496,11 +496,12 @@ describe('scanDomain integration - DMARC/DKIM/DNSSEC/CAA with mocked DoH', () =>
 		const result = await run();
 		const dnssec = findCheck(result, 'dnssec');
 		expect(dnssec).toBeDefined();
-		// Fully absent DNSSEC → single HIGH finding
+		// Fully absent DNSSEC → single CRITICAL finding (NIST SP 800-81r3 / RFC 9364:
+		// unsigned public zone is near-failing; recalibrated down from the prior high).
 		const finding = dnssec!.findings.find((f) => f.severity !== 'info');
 		expect(finding).toBeDefined();
 		expect(finding!.title).toBe('DNSSEC not enabled');
-		expect(finding!.severity).toBe('high');
+		expect(finding!.severity).toBe('critical');
 	});
 
 	it('passes DNSSEC when AD flag is set', async () => {


### PR DESCRIPTION
Recalibrates DNSSEC scoring to the framework (NIST SP 800-81r3 makes DNSSEC a baseline goal; RFC 9364/BCP 237: origin-auth via DNSSEC is "best current practice"). The prior unsigned-zone score (75) was too lenient.

| Case | Before | After |
|---|---|---|
| Unsigned public zone | high / **75** (pass) | **critical / 60** (pass, NOT zeroed) |
| Broken chain (DNSKEY, no DS) | high / 0 (coincidental regex) | high + **explicit missingControl / 0** |
| Validation failing (DNSKEY+DS, AD off) | high / 75 | high + **explicit missingControl / 0** ⚠️ |
| RSA/SHA-256 (alg 8) | (no finding) / 100 | **soft low / 95** |
| NSEC vs NSEC3 | unchanged (NSEC preferred; only RFC-9276 violations penalized) | unchanged |

**⚠️ Decision DNSSEC-1 — please confirm/veto:** treating *validation-failing* (DNSKEY+DS present but AD=off → BOGUS) as missingControl→0 extends past the literal decision (which named only the DNSKEY-no-DS broken chain). Rationale: same BOGUS principle — a validating resolver rejects the zone's data either way. One-line revert if you disagree.

+ DNSSEC_PARITY_FIXTURES + contract. Bump 1.3.5. **326 package + 4938 root tests green** (existing DNSSEC expectations updated 75→60/critical). bv-web side (adapter-B4 + delegate, preserving registry-managed/internal-zone) follows after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)