### PR TITLE
feat(dns-checks): superset registry-managed DNSSEC (1.3.6)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.5",
+	"version": "1.3.6",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -12,6 +12,7 @@
 import type { CheckResult, DNSQueryFunction, Finding, RawDNSQueryFunction } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
 import { auditDnskeyAlgorithms, auditDsDigestTypes, auditNsec3Params } from './dnssec-analysis';
+import { isRegistryManagedDnssec } from './registry-managed-dnssec';
 
 export { parseDnskeyAlgorithm, parseDsRecord } from './dnssec-analysis';
 
@@ -114,6 +115,24 @@ export async function checkDNSSEC(
 				{ missingControl: true },
 			),
 		);
+	}
+
+	// Registry-managed DNSSEC: when the chain validates (AD set + DS + DNSKEY), some
+	// ccTLD registries auto-signed the zone rather than the owner. The zone is still
+	// protected, so this is a MODERATE deduction (medium → ~85), not the punitive 50
+	// bv-web historically used — 50 would rank a validated zone BELOW an unsigned one
+	// (60), which is incoherent. Detection is fail-safe (false when indeterminate).
+	if (adFlag && dnskeyRecords.length > 0 && dsRecords.length > 0) {
+		if (await isRegistryManagedDnssec(domain, queryDNS, timeout)) {
+			findings.push(
+				createFinding(
+					'dnssec',
+					'DNSSEC is registry-managed',
+					'medium',
+					`The DNSSEC chain for ${domain} validates, but the zone is signed by its ccTLD registry rather than independently configured by the domain owner. The zone is cryptographically protected, but the owner has less direct control over key management.`,
+				),
+			);
+		}
 	}
 
 	// Algorithm/digest audits (only when records exist)

--- a/packages/dns-checks/src/checks/registry-managed-dnssec.ts
+++ b/packages/dns-checks/src/checks/registry-managed-dnssec.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Registry-managed DNSSEC detection.
+ *
+ * Some ccTLD registries auto-sign all child zones with DNSSEC. In that case the
+ * chain of trust was established by the registry, not the domain owner — the zone
+ * is still cryptographically protected, but the owner did not independently deploy
+ * DNSSEC. `checkDNSSEC` flags this (a moderate deduction) when the zone validates.
+ *
+ * Two detection paths: a deterministic TLD seed list (no DNS), and an NS-overlap
+ * fallback (domain NS == parent-zone NS ⇒ registry operates the zone).
+ *
+ * Copyright (c) 2023-2026 BlackVeil Security Ltd. Licensed under BSL 1.1.
+ */
+
+import type { DNSQueryFunction } from '../types';
+
+/**
+ * TLD zones known to automatically sign all child domains with DNSSEC.
+ * Format: lowercase, leading dot, most-specific first within each group.
+ */
+export const REGISTRY_MANAGED_DNSSEC_TLDS = [
+	// Tanzania — TZNIC signs all .tz zones
+	'.go.tz', '.ac.tz', '.co.tz', '.ne.tz', '.or.tz', '.tz',
+	// Sri Lanka — LKNIC signs all .lk zones
+	'.gov.lk', '.ac.lk', '.edu.lk', '.net.lk', '.org.lk', '.lk',
+	// Cambodia — MPTC signs .kh zones
+	'.gov.kh', '.edu.kh', '.kh',
+	// Bangladesh — BTCL signs .bd zones
+	'.gov.bd', '.edu.bd', '.ac.bd', '.bd',
+] as const;
+
+/** True if the domain ends with a known registry-managed-DNSSEC TLD (longest match wins by listing order). */
+export function isInRegistryManagedTLD(domain: string): boolean {
+	const lower = domain.toLowerCase();
+	return REGISTRY_MANAGED_DNSSEC_TLDS.some((tld) => lower.endsWith(tld));
+}
+
+/** Parent zone = domain with its left-most label removed; null if already a TLD. */
+function getParentZone(domain: string): string | null {
+	const labels = domain.toLowerCase().replace(/\.$/, '').split('.').filter(Boolean);
+	return labels.length >= 3 ? labels.slice(1).join('.') : null;
+}
+
+/**
+ * Determine whether the validated DNSSEC chain is registry-managed.
+ * Returns false (no deduction) when indeterminate — fail-safe, never over-penalize.
+ */
+export async function isRegistryManagedDnssec(
+	domain: string,
+	queryDNS: DNSQueryFunction,
+	timeout: number,
+): Promise<boolean> {
+	// Fast path: deterministic TLD seed list (no DNS).
+	if (isInRegistryManagedTLD(domain)) return true;
+
+	// Fallback: NS overlap — if the domain's NS set overlaps the parent zone's NS,
+	// the registry operates the zone (and thus signs it).
+	const parentZone = getParentZone(domain);
+	if (!parentZone) return false;
+
+	try {
+		const [domainNS, parentNS] = await Promise.all([
+			queryDNS(domain, 'NS', { timeout }),
+			queryDNS(parentZone, 'NS', { timeout }),
+		]);
+		if (domainNS.length === 0 || parentNS.length === 0) return false;
+		const normalize = (ns: string) => ns.toLowerCase().replace(/\.$/, '');
+		const domainNSSet = new Set(domainNS.map(normalize));
+		return parentNS.some((ns) => domainNSSet.has(normalize(ns)));
+	} catch {
+		return false; // fail-safe: indeterminate → no deduction
+	}
+}

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.5';
+export const PARITY_CORPUS_VERSION = '1.3.6';
 
 /**
  * DNSSEC parity fixture. Keyed on the AD flag + DNSKEY/DS/NSEC3PARAM records.
@@ -330,6 +330,20 @@ export const DNSSEC_PARITY_FIXTURES: DnssecParityFixture[] = [
 		ds: ['12345 13 2 abc123'],
 		nsec3param: ['1 0 150 ab'],
 		expectedScore: 70,
+		expectedMissingControl: false,
+	},
+	{
+		// Registry-managed (ccTLD seed-list path, no NS query): valid chain, but the
+		// registry signed it → medium deduction → 85 (coherently above unsigned-60,
+		// NOT the historic punitive 50 which would rank below no-DNSSEC).
+		check: 'dnssec',
+		name: 'registry-managed valid DNSSEC (.co.tz)',
+		domain: 'example.co.tz',
+		ad: true,
+		dnskey: ['257 3 13 AwEAAabc'],
+		ds: ['12345 13 2 abc123'],
+		nsec3param: [],
+		expectedScore: 85,
 		expectedMissingControl: false,
 	},
 ];


### PR DESCRIPTION
Ports bv-web's registry-managed DNSSEC signal into canonical so bv-web delegates fully. Validated-but-registry-managed → **medium (85)**, not bv-web's historic 50 (which is incoherent post-#322: it'd rank a validated zone below unsigned-60). TLD seed-list + NS-overlap detection, fail-safe. ⚠️ Recalibrated 50→85 for coherence — flag. + corpus fixture. 327 package + 4939 root tests pass. 🤖 Generated with [Claude Code](https://claude.com/claude-code)