### PR TITLE
feat(dns-checks): CAA recalibration — no-CAA is a gap, not zeroed (1.3.7)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.6",
+	"version": "1.3.7",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -60,12 +60,15 @@ describe('checkBIMI', () => {
 });
 
 describe('checkCAA', () => {
-	it('returns medium when no CAA records', async () => {
+	it('returns medium (85, not zeroed) when no CAA records', async () => {
+		// RFC 8659: absence is a defense-in-depth gap (any CA may issue), but CAA is
+		// CA/B-Forum hardening, not a NIST-DNS baseline → medium (85), not a zeroed control.
 		const queryDNS = createMockDNS({ 'example.com': [] });
 		const result = await checkCAA('example.com', queryDNS);
 		expect(result.findings[0].title).toBe('No CAA records');
-		expect(result.passed).toBe(false);
-		expect(result.score).toBe(0);
+		expect(result.findings[0].severity).toBe('medium');
+		expect(result.passed).toBe(true);
+		expect(result.score).toBe(85);
 	});
 
 	it('returns info for properly configured CAA', async () => {

--- a/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
+++ b/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
@@ -11,7 +11,7 @@
  * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS, checkDNSSEC } from '../checks';
+import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS, checkDNSSEC, checkCAA } from '../checks';
 import { scoreIndicatesMissingControl } from '../scoring';
 import pkg from '../../package.json';
 import {
@@ -19,6 +19,7 @@ import {
 	DANE_HTTPS_PARITY_FIXTURES,
 	SVCB_HTTPS_PARITY_FIXTURES,
 	DNSSEC_PARITY_FIXTURES,
+	CAA_PARITY_FIXTURES,
 	PARITY_CORPUS_VERSION,
 } from '../parity-fixtures';
 
@@ -85,6 +86,20 @@ describe('DNSSEC parity corpus — bv-mcp full checkDNSSEC', () => {
 				type === 'DNSKEY' ? fx.dnskey : type === 'DS' ? fx.ds : type === 'NSEC3PARAM' ? fx.nsec3param : []) as never;
 			const rawQueryDNS = (async () => ({ AD: fx.ad })) as never;
 			const result = await checkDNSSEC(fx.domain, queryDNS, { rawQueryDNS });
+			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
+				score: fx.expectedScore,
+				missing: fx.expectedMissingControl,
+			});
+		});
+	}
+});
+
+describe('CAA parity corpus — bv-mcp full checkCAA', () => {
+	for (const fx of CAA_PARITY_FIXTURES) {
+		it(`scores "${fx.name}" → ${fx.expectedScore} (missingControl=${fx.expectedMissingControl})`, async () => {
+			const queryDNS = (async (name: string, type: string) =>
+				type === 'CAA' && name === fx.domain ? fx.caa : []) as never;
+			const result = await checkCAA(fx.domain, queryDNS);
 			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
 				score: fx.expectedScore,
 				missing: fx.expectedMissingControl,

--- a/packages/dns-checks/src/checks/check-caa.ts
+++ b/packages/dns-checks/src/checks/check-caa.ts
@@ -40,13 +40,17 @@ export async function checkCAA(
 		.filter((record): record is CaaRecord => record !== null);
 
 	if (caaRecords.length === 0) {
+		// RFC 8659: absence of CAA means ANY CA may issue — a real defense-in-depth gap,
+		// but NOT a zeroed control (CA/B-Forum hardening, not a NIST-DNS baseline). MEDIUM
+		// (→85), no missingControl. Severity MUST stay medium: at high/critical the
+		// "no … record" text would trip scoreIndicatesMissingControl and re-zero it.
+		// (D3: a managed-CDN domain still owes a CAA record listing its CDN's CA.)
 		findings.push(
 			createFinding(
 				'caa',
 				'No CAA records',
 				'medium',
 				`No CAA records found for ${domain}. CAA records restrict which Certificate Authorities can issue certificates for your domain, preventing unauthorized issuance.`,
-				{ missingControl: true },
 			),
 		);
 		return buildCheckResult('caa', findings);

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -72,6 +72,7 @@ export {
 	DANE_HTTPS_PARITY_FIXTURES,
 	SVCB_HTTPS_PARITY_FIXTURES,
 	DNSSEC_PARITY_FIXTURES,
+	CAA_PARITY_FIXTURES,
 	PARITY_CORPUS_VERSION,
 } from './parity-fixtures';
 export type {
@@ -79,6 +80,7 @@ export type {
 	DaneHttpsParityFixture,
 	SvcbParityFixture,
 	DnssecParityFixture,
+	CaaParityFixture,
 } from './parity-fixtures';
 
 // Zod schemas

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,22 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.6';
+export const PARITY_CORPUS_VERSION = '1.3.7';
+
+/**
+ * CAA parity fixture (RFC 8659). Absence of CAA = any CA may issue → a defense-in-depth
+ * gap (medium → 85, NOT zeroed even behind a managed CDN). Tags graded: missing issue
+ * → medium, missing issuewild/iodef → low.
+ */
+export interface CaaParityFixture {
+	check: 'caa';
+	name: string;
+	domain: string;
+	/** CAA records returned for `domain`. */
+	caa: string[];
+	expectedScore: number;
+	expectedMissingControl: boolean;
+}
 
 /**
  * DNSSEC parity fixture. Keyed on the AD flag + DNSKEY/DS/NSEC3PARAM records.
@@ -344,6 +359,41 @@ export const DNSSEC_PARITY_FIXTURES: DnssecParityFixture[] = [
 		ds: ['12345 13 2 abc123'],
 		nsec3param: [],
 		expectedScore: 85,
+		expectedMissingControl: false,
+	},
+];
+
+export const CAA_PARITY_FIXTURES: CaaParityFixture[] = [
+	{
+		check: 'caa',
+		name: 'no CAA (defense-in-depth gap, not zeroed)',
+		domain: 'example.com',
+		caa: [],
+		expectedScore: 85,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'caa',
+		name: 'issue only (missing issuewild + iodef)',
+		domain: 'example.com',
+		caa: ['0 issue "letsencrypt.org"'],
+		expectedScore: 90,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'caa',
+		name: 'all tags (issue + issuewild + iodef)',
+		domain: 'example.com',
+		caa: ['0 issue "letsencrypt.org"', '0 issuewild "letsencrypt.org"', '0 iodef "mailto:sec@example.com"'],
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'caa',
+		name: 'missing issuewild',
+		domain: 'example.com',
+		caa: ['0 issue "letsencrypt.org"', '0 iodef "mailto:sec@example.com"'],
+		expectedScore: 95,
 		expectedMissingControl: false,
 	},
 ];


### PR DESCRIPTION
RFC 8659: no-CAA = any CA may issue → defense-in-depth gap, medium (85), not a zeroed control (D3: a managed-CDN domain still owes a CAA record). Tag grading unchanged. + CAA corpus. Bump 1.3.7. 331 package + 4943 root green. bv-web delegate (drops managed-CDN pass-100) follows. 🤖 Generated with [Claude Code](https://claude.com/claude-code)