### PR TITLE
feat(dns-checks): MX SPF-context scoring (1.3.8)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.7",
+	"version": "1.3.8",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -85,10 +85,11 @@ describe('checkCAA', () => {
 });
 
 describe('checkMX', () => {
-	it('returns medium when no MX records', async () => {
+	it('no MX and no SPF → spoofable (0, missingControl)', async () => {
+		// SPF-context (NIST SP 800-177r1): no MX with no SPF policy = genuinely spoofable.
 		const queryDNS = createMockDNS({ 'example.com': [] });
 		const result = await checkMX('example.com', queryDNS);
-		expect(result.findings[0].title).toBe('No MX records found');
+		expect(result.findings[0].title).toBe('No MX and no SPF — domain spoofable');
 		expect(result.passed).toBe(false);
 		expect(result.score).toBe(0);
 	});

--- a/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
+++ b/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
@@ -11,7 +11,7 @@
  * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS, checkDNSSEC, checkCAA } from '../checks';
+import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS, checkDNSSEC, checkCAA, checkMX } from '../checks';
 import { scoreIndicatesMissingControl } from '../scoring';
 import pkg from '../../package.json';
 import {
@@ -20,6 +20,7 @@ import {
 	SVCB_HTTPS_PARITY_FIXTURES,
 	DNSSEC_PARITY_FIXTURES,
 	CAA_PARITY_FIXTURES,
+	MX_PARITY_FIXTURES,
 	PARITY_CORPUS_VERSION,
 } from '../parity-fixtures';
 
@@ -100,6 +101,24 @@ describe('CAA parity corpus — bv-mcp full checkCAA', () => {
 			const queryDNS = (async (name: string, type: string) =>
 				type === 'CAA' && name === fx.domain ? fx.caa : []) as never;
 			const result = await checkCAA(fx.domain, queryDNS);
+			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
+				score: fx.expectedScore,
+				missing: fx.expectedMissingControl,
+			});
+		});
+	}
+});
+
+describe('MX parity corpus — bv-mcp full checkMX', () => {
+	for (const fx of MX_PARITY_FIXTURES) {
+		it(`scores "${fx.name}" → ${fx.expectedScore} (missingControl=${fx.expectedMissingControl})`, async () => {
+			const queryDNS = (async (name: string, type: string) => {
+				if (type === 'MX' && name === fx.domain) return fx.mx;
+				if (type === 'TXT' && name === fx.domain) return fx.txt;
+				if (type === 'A') return fx.hostA[name] ?? [];
+				return [];
+			}) as never;
+			const result = await checkMX(fx.domain, queryDNS);
 			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
 				score: fx.expectedScore,
 				missing: fx.expectedMissingControl,

--- a/packages/dns-checks/src/checks/check-mx.ts
+++ b/packages/dns-checks/src/checks/check-mx.ts
@@ -35,45 +35,43 @@ export async function checkMX(
 	}
 
 	if (!answers || answers.length === 0) {
-		const findings: Finding[] = [
-			createFinding(
-				'mx',
-				'No MX records found',
-				'medium',
-				'No mail exchange records present. If this domain does not handle email, consider publishing a null MX record (RFC 7505).',
-				{ missingControl: true },
-			),
-		];
-		// Non-mail domains should publish v=spf1 -all to explicitly reject all mail
+		// No MX: scoring is SPF-CONTEXT-dependent, NOT an unconditional missing control.
+		// NIST SP 800-177r1 §4.4.2 — a non-mail domain SHOULD publish "v=spf1 -all";
+		// when it does, that is the correct posture (reward, do not penalize). Only a
+		// domain with no MX AND no/soft SPF is genuinely spoofable (the real gap).
+		let spf = '';
 		try {
 			const txtRecords = await queryDNS(domain, 'TXT', { timeout });
-			const spfRecords = txtRecords.filter((r) => r.toLowerCase().startsWith('v=spf1'));
-			if (spfRecords.length === 0) {
-				findings.push(
-					createFinding(
-						'mx',
-						'Missing SPF reject-all for non-mail domain',
-						'medium',
-						`No SPF record found. Non-mail domains should publish "v=spf1 -all" to explicitly prevent email spoofing.`,
-					),
-				);
-			} else {
-				const spf = spfRecords[0].toLowerCase();
-				if (!spf.includes('-all')) {
-					findings.push(
-						createFinding(
-							'mx',
-							'SPF not set to reject-all for non-mail domain',
-							'low',
-							`SPF record found but does not use "-all" (hard fail). Non-mail domains should publish "v=spf1 -all" to explicitly reject all email.`,
-						),
-					);
-				}
-			}
+			spf = (txtRecords.find((r) => r.toLowerCase().startsWith('v=spf1')) ?? '').toLowerCase();
 		} catch {
-			// DNS query failed — skip SPF check for non-mail domain
+			// TXT query failed — treat as no SPF.
 		}
-		return buildCheckResult('mx', findings);
+
+		let finding: Finding;
+		if (spf.includes('-all')) {
+			finding = createFinding(
+				'mx',
+				'Correctly-configured non-mail domain',
+				'info',
+				`No MX records, and SPF publishes "-all" (hard fail). Per NIST SP 800-177r1 §4.4.2 this is the recommended posture for a domain that does not handle email.`,
+			);
+		} else if (spf) {
+			finding = createFinding(
+				'mx',
+				'Non-mail domain SPF not hard-fail',
+				'medium',
+				`No MX records and an SPF record that does not use "-all". Non-mail domains should publish "v=spf1 -all" to fully prevent spoofing.`,
+			);
+		} else {
+			finding = createFinding(
+				'mx',
+				'No MX and no SPF — domain spoofable',
+				'medium',
+				`No mail exchange records and no SPF policy. The domain can be spoofed; publish "v=spf1 -all" (and a null MX per RFC 7505) if it does not handle email.`,
+				{ missingControl: true },
+			);
+		}
+		return buildCheckResult('mx', [finding]);
 	}
 
 	const findings: Finding[] = [];

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -73,6 +73,7 @@ export {
 	SVCB_HTTPS_PARITY_FIXTURES,
 	DNSSEC_PARITY_FIXTURES,
 	CAA_PARITY_FIXTURES,
+	MX_PARITY_FIXTURES,
 	PARITY_CORPUS_VERSION,
 } from './parity-fixtures';
 export type {
@@ -81,6 +82,7 @@ export type {
 	SvcbParityFixture,
 	DnssecParityFixture,
 	CaaParityFixture,
+	MxParityFixture,
 } from './parity-fixtures';
 
 // Zod schemas

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,25 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.7';
+export const PARITY_CORPUS_VERSION = '1.3.8';
+
+/**
+ * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):
+ * `-all`+no-MX = correct non-sender (100); SPF-without-`-all`+no-MX = soft (85);
+ * no-MX+no-SPF = spoofable (0, missingControl). `hostA` provides A records for MX
+ * hosts so the dangling-MX check passes.
+ */
+export interface MxParityFixture {
+	check: 'mx';
+	name: string;
+	domain: string;
+	mx: string[];
+	txt: string[];
+	/** MX-host → A records (so the hostname resolves; avoids a dangling-MX finding). */
+	hostA: Record<string, string[]>;
+	expectedScore: number;
+	expectedMissingControl: boolean;
+}
 
 /**
  * CAA parity fixture (RFC 8659). Absence of CAA = any CA may issue → a defense-in-depth
@@ -393,6 +411,69 @@ export const CAA_PARITY_FIXTURES: CaaParityFixture[] = [
 		name: 'missing issuewild',
 		domain: 'example.com',
 		caa: ['0 issue "letsencrypt.org"', '0 iodef "mailto:sec@example.com"'],
+		expectedScore: 95,
+		expectedMissingControl: false,
+	},
+];
+
+export const MX_PARITY_FIXTURES: MxParityFixture[] = [
+	{
+		check: 'mx',
+		name: 'no MX + SPF -all (correct non-sender)',
+		domain: 'example.com',
+		mx: [],
+		txt: ['v=spf1 -all'],
+		hostA: {},
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'mx',
+		name: 'no MX + SPF ~all (soft, should harden)',
+		domain: 'example.com',
+		mx: [],
+		txt: ['v=spf1 ~all'],
+		hostA: {},
+		expectedScore: 85,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'mx',
+		name: 'no MX + no SPF (spoofable — real gap)',
+		domain: 'example.com',
+		mx: [],
+		txt: [],
+		hostA: {},
+		expectedScore: 0,
+		expectedMissingControl: true,
+	},
+	{
+		check: 'mx',
+		name: 'null MX (RFC 7505)',
+		domain: 'example.com',
+		mx: ['0 .'],
+		txt: [],
+		hostA: {},
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'mx',
+		name: 'two MX (redundant)',
+		domain: 'example.com',
+		mx: ['10 mail1.example.com', '20 mail2.example.com'],
+		txt: [],
+		hostA: { 'mail1.example.com': ['10.0.0.1'], 'mail2.example.com': ['10.0.0.2'] },
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'mx',
+		name: 'single MX (no redundancy)',
+		domain: 'example.com',
+		mx: ['10 mail1.example.com'],
+		txt: [],
+		hostA: { 'mail1.example.com': ['10.0.0.1'] },
 		expectedScore: 95,
 		expectedMissingControl: false,
 	},

--- a/test/check-mx.spec.ts
+++ b/test/check-mx.spec.ts
@@ -21,15 +21,14 @@ describe('checkMx', () => {
 		return checkMx(domain);
 	}
 
-	it('should return medium finding if no MX records found and flag missing SPF reject-all', async () => {
+	it('no MX and no SPF → spoofable, recommends v=spf1 -all', async () => {
+		// SPF-context (NIST SP 800-177r1 §4.4.2): no MX + no SPF = spoofable (the real
+		// gap). One finding, medium, recommending the hard-fail SPF.
 		mockMxRecords('nomx.com', []);
 		const result = await run('nomx.com');
 		expect(result.findings[0].severity).toBe('medium');
-		expect(result.findings[0].title).toMatch(/No MX records found/i);
-		// Should also flag missing SPF reject-all for non-mail domain
-		const spfFinding = result.findings.find((f) => f.title.includes('SPF'));
-		expect(spfFinding).toBeDefined();
-		expect(spfFinding!.detail).toContain('v=spf1 -all');
+		expect(result.findings[0].title).toMatch(/No MX and no SPF/i);
+		expect(result.findings[0].detail).toContain('v=spf1 -all');
 	});
 
 	it('should return pass if MX records found', async () => {


### PR DESCRIPTION
NIST SP 800-177r1: drop the flat missingControl on no-MX; score by SPF context — `-all`+no-MX → 100 (correct non-sender), soft-SPF → 85, no-SPF → 0 (spoofable). + MX corpus. Bump 1.3.8. 337 package + 4949 root green. bv-web delegate follows (batched). 🤖 Generated with [Claude Code](https://claude.com/claude-code)