### PR TITLE
feat(dns-checks): batch — DKIM/TLS-RPT/BIMI/DMARC-multi recalibrations (1.3.9)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.8",
+	"version": "1.3.9",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/checks/check-bimi.ts
+++ b/packages/dns-checks/src/checks/check-bimi.ts
@@ -181,9 +181,11 @@ export async function checkBIMI(
 				createFinding(
 					'bimi',
 					'No BIMI record (DMARC not enforcing)',
+					// BIMI is an advisory brand-display control (IETF draft, no RFC/NIST mandate),
+					// so absence is NOT a deficiency → low, no missingControl. Score ~95. (The
+					// DMARC-not-enforcing aspect belongs to the DMARC check, not double-counted here.)
 					'low',
 					`No BIMI record found at ${bimiDomain}. BIMI requires DMARC enforcement (p=quarantine or p=reject) before a BIMI record can be validated by mail clients. Set up DMARC enforcement first.`,
-					{ missingControl: true },
 				),
 			);
 		} else {
@@ -191,9 +193,9 @@ export async function checkBIMI(
 				createFinding(
 					'bimi',
 					'No BIMI record found',
+					// Advisory control — absence is not a deficiency → low, no missingControl (~95).
 					'low',
 					`No BIMI record found at ${bimiDomain}. This domain has DMARC enforcement and is eligible for BIMI. Publishing a BIMI record allows email clients like Gmail and Apple Mail to display your brand logo next to your emails.`,
-					{ missingControl: true },
 				),
 			);
 		}

--- a/packages/dns-checks/src/checks/check-dkim.ts
+++ b/packages/dns-checks/src/checks/check-dkim.ts
@@ -251,8 +251,10 @@ export async function checkDKIM(
 							createFinding(
 								'dkim',
 								`Deprecated hash algorithm (h=sha1): ${result.selector}`,
-								'medium',
-								`DKIM selector "${result.selector}" only accepts SHA-1 signatures (h=sha1). SHA-1 is deprecated for DKIM signing per RFC 8301. Add sha256 to the h= tag or remove the restriction.`,
+								// RFC 8301 §3.1: rsa-sha1 "MUST NOT be used" and signatures with it
+								// "have permanently failed evaluation" → high, not medium.
+								'high',
+								`DKIM selector "${result.selector}" only accepts SHA-1 signatures (h=sha1). RFC 8301 §3.1 states SHA-1 MUST NOT be used and such signatures have permanently failed evaluation. Add sha256 to the h= tag or remove the restriction.`,
 							),
 						);
 					}

--- a/packages/dns-checks/src/checks/check-tlsrpt.ts
+++ b/packages/dns-checks/src/checks/check-tlsrpt.ts
@@ -52,8 +52,11 @@ export async function checkTLSRPT(
 			createFinding(
 				'tlsrpt',
 				'Multiple TLS-RPT records',
-				'medium',
-				`Found ${tlsrptMatches.length} TLS-RPT records at ${tlsrptDomain}. There should be exactly one TLS-RPT record per domain.`,
+				// RFC 8460: senders treat ≠1 record as "no TLSRPT" — functionally absent.
+				// TLS-RPT is hardening (reporting only); a duplicate config shouldn't be
+				// penalized harder than having none, so this is low, not medium.
+				'low',
+				`Found ${tlsrptMatches.length} TLS-RPT records at ${tlsrptDomain}. There should be exactly one TLS-RPT record per domain (RFC 8460 §3 — receivers treat multiple records as no policy).`,
 			),
 		);
 	}

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.8';
+export const PARITY_CORPUS_VERSION = '1.3.9';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):
@@ -179,12 +179,15 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 		expectedMissingControl: false,
 	},
 	{
+		// RFC 9989: multiple DMARC records = no valid policy → unprotected (0,
+		// missingControl), same as no record. Closes the prior bv-web divergence
+		// (dns-worker-v2 used to parse-first → 35; now both score 0 via the classifier).
 		check: 'dmarc',
-		name: 'multiple records',
+		name: 'multiple records (no valid policy)',
 		query: '_dmarc.example.com',
 		records: { '_dmarc.example.com': ['v=DMARC1; p=none', 'v=DMARC1; p=reject'] },
-		expectedScore: 45,
-		expectedMissingControl: false,
+		expectedScore: 0,
+		expectedMissingControl: true,
 	},
 	{
 		// RFC 9989 §4.10 inheritance: the subdomain has no record, so the tree walk

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -28,9 +28,13 @@ describe('classifyDmarc', () => {
 		expect(significant).toHaveLength(0);
 	});
 
-	it('flags multiple records as high', () => {
+	it('flags multiple records as no valid policy (missingControl)', () => {
+		// RFC 9989: more than one DMARC record = no policy at all → unprotected.
 		const f = classifyDmarc({ ...base, recordCount: 2, policy: 'reject', rua: 'mailto:dmarc@example.com', adkim: 's', aspf: 's' });
-		expect(f.some((x) => x.title === 'Multiple DMARC records' && x.severity === 'high')).toBe(true);
+		const finding = f.find((x) => x.title === 'Multiple DMARC records — no valid policy');
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe('high');
+		expect(finding!.metadata?.missingControl).toBe(true);
 	});
 
 	it('flags missing p= tag as critical', () => {

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -65,16 +65,20 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 		return findings;
 	}
 
-	// Check for multiple DMARC records
+	// Multiple DMARC records = NO valid policy (RFC 9989: receivers ignore all and
+	// apply no DMARC policy when more than one record is present). Treat as a missing
+	// control (score 0), the same as no record — do NOT evaluate a "first" policy.
 	if (facts.recordCount > 1) {
 		findings.push(
 			createFinding(
 				'dmarc',
-				'Multiple DMARC records',
+				'Multiple DMARC records — no valid policy',
 				'high',
-				`Found ${facts.recordCount} DMARC records in TXT data. Only one DMARC record should exist per domain.`,
+				`Found ${facts.recordCount} DMARC records at _dmarc.${facts.domain ?? '<domain>'}. Per RFC 9989, receivers treat more than one record as no DMARC policy at all — the domain is unprotected. Publish exactly one DMARC record.`,
+				{ missingControl: true },
 			),
 		);
+		return findings;
 	}
 
 	const validPolicies = new Set(['none', 'quarantine', 'reject']);

--- a/test/check-tlsrpt.spec.ts
+++ b/test/check-tlsrpt.spec.ts
@@ -52,12 +52,14 @@ describe('checkTlsrpt', () => {
 		expect(finding!.severity).toBe('medium');
 	});
 
-	it('should return medium finding for multiple TLS-RPT records', async () => {
+	it('should return low finding for multiple TLS-RPT records', async () => {
+		// RFC 8460: ≠1 record = functionally absent; hardening-tier, so a duplicate
+		// config is dinged no harder than having none → low, not medium.
 		mockTxtRecords(['v=TLSRPTv1; rua=mailto:a@example.com', 'v=TLSRPTv1; rua=mailto:b@example.com']);
 		const result = await run();
 		const finding = result.findings.find((f) => /Multiple TLS-RPT records/i.test(f.title));
 		expect(finding).toBeDefined();
-		expect(finding!.severity).toBe('medium');
+		expect(finding!.severity).toBe('low');
 	});
 
 	it('should return info finding for record with multiple comma-separated valid URIs', async () => {


### PR DESCRIPTION
Four standards-grounded canonical scoring changes in one batch:
- **DKIM** (RFC 8301 §3.1): rsa-sha1 medium→**high** (permanently failed evaluation)
- **TLS-RPT** (RFC 8460): multiple records medium→**low** (≠1 = functionally absent, hardening-tier)
- **BIMI** (advisory): drop missingControl on no-record → absence not a deficiency (~95)
- **DMARC multiple records** (#16, RFC 9989): now no-valid-policy → **missingControl/0** (was 45) — closes the prior bv-web divergence (both score 0 via the shared classifier)

DMARC multi-record corpus fixture 45→0. Bump 1.3.9. 337 package + 4949 root green. DKIM/TLS-RPT/BIMI corpus fixtures land with their bv-web delegates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)