### PR TITLE
feat(dns-checks): MTA-STS + DANE-email no-inbound-mail forks (canonical 1.3.10)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8442,7 +8442,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.1.3",
+			"version": "1.3.10",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.3.6"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.9",
+	"version": "1.3.10",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -238,14 +238,19 @@ describe('checkSubdomainTakeover', () => {
 });
 
 describe('checkMTASTS', () => {
-	it('reports missing MTA-STS and TLS-RPT records', async () => {
+	it('reports missing MTA-STS and TLS-RPT records (no inbound mail → low, not a zeroing gap)', async () => {
+		// No MX in this mock → the domain does not accept inbound email, so missing
+		// MTA-STS/TLS-RPT is an informational nudge (low, no missingControl → 95),
+		// not a control deficiency. The has-MX path keeps medium + missingControl.
 		const queryDNS = createMockDNS({
 			'_mta-sts.example.com': [],
 			'_smtp._tls.example.com': [],
 		});
 		const result = await checkMTASTS('example.com', queryDNS);
-		expect(result.findings.some((f) => f.title === 'No MTA-STS or TLS-RPT records found')).toBe(true);
-		expect(result.passed).toBe(false);
-		expect(result.score).toBe(0);
+		const finding = result.findings.find((f) => f.title === 'No MTA-STS or TLS-RPT records found');
+		expect(finding).toBeDefined();
+		expect(finding!.severity).toBe('low');
+		expect(result.passed).toBe(true);
+		expect(result.score).toBe(95);
 	});
 });

--- a/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
+++ b/packages/dns-checks/src/__tests__/parity-corpus.contract.test.ts
@@ -11,12 +11,13 @@
  * Design: bv-web docs/superpowers/specs/2026-05-31-cross-repo-scoring-parity-gate-design.md
  */
 import { describe, it, expect } from 'vitest';
-import { checkDMARC, checkDANEHTTPS, checkSVCBHTTPS, checkDNSSEC, checkCAA, checkMX } from '../checks';
+import { checkDMARC, checkDANEHTTPS, checkDANE, checkSVCBHTTPS, checkDNSSEC, checkCAA, checkMX } from '../checks';
 import { scoreIndicatesMissingControl } from '../scoring';
 import pkg from '../../package.json';
 import {
 	DMARC_PARITY_FIXTURES,
 	DANE_HTTPS_PARITY_FIXTURES,
+	DANE_EMAIL_PARITY_FIXTURES,
 	SVCB_HTTPS_PARITY_FIXTURES,
 	DNSSEC_PARITY_FIXTURES,
 	CAA_PARITY_FIXTURES,
@@ -58,6 +59,28 @@ describe('DANE-HTTPS parity corpus — bv-mcp full checkDANEHTTPS', () => {
 				name === `_443._tcp.${fx.domain}` ? fx.tlsa : []) as never;
 			const rawQueryDNS = (async () => ({ AD: fx.ad })) as never;
 			const result = await checkDANEHTTPS(fx.domain, queryDNS, { rawQueryDNS });
+			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
+				score: fx.expectedScore,
+				missing: fx.expectedMissingControl,
+			});
+		});
+	}
+});
+
+describe('DANE-email parity corpus — bv-mcp full checkDANE', () => {
+	for (const fx of DANE_EMAIL_PARITY_FIXTURES) {
+		it(`scores "${fx.name}" → ${fx.expectedScore} (missingControl=${fx.expectedMissingControl})`, async () => {
+			const queryDNS = (async (name: string, type: string) => {
+				if (type === 'MX' && name === fx.domain) return fx.mx;
+				if (type === 'TLSA') {
+					const host = name.replace(/^_25\._tcp\./, '');
+					return fx.tlsaByHost[host] ?? [];
+				}
+				return [];
+			}) as never;
+			// rawQueryDNS(mxHost, 'A', true) → AD flag of that MX host's zone (RFC 7672).
+			const rawQueryDNS = (async (name: string) => ({ AD: fx.adByHost[name] ?? false })) as never;
+			const result = await checkDANE(fx.domain, queryDNS, { rawQueryDNS });
 			expect({ score: result.score, missing: missingControl(result.findings) }).toEqual({
 				score: fx.expectedScore,
 				missing: fx.expectedMissingControl,

--- a/packages/dns-checks/src/checks/check-dane.ts
+++ b/packages/dns-checks/src/checks/check-dane.ts
@@ -36,6 +36,8 @@ export async function checkDANE(
 	const rawQueryDNS = options?.rawQueryDNS;
 	const findings: Finding[] = [];
 	let hasMxTlsa = false;
+	let realMxHosts = 0;
+	let mxLookupFailed = false;
 
 	// Query MX records and check TLSA for each MX host.
 	// Per RFC 7672 §3.1.3, SMTP DANE security requires DNSSEC on the MX host's zone —
@@ -46,7 +48,10 @@ export async function checkDANE(
 
 		for (const mx of mxRecords) {
 			const mxHost = mx.exchange;
+			// Empty exchange or RFC 7505 null MX ("0 .") = the domain explicitly does
+			// not accept inbound mail. Such hosts carry no SMTP endpoint to DANE-pin.
 			if (!mxHost || mxHost === '.') continue;
+			realMxHosts++;
 
 			// Check DNSSEC on the MX host's zone (RFC 7672 §3.1.3)
 			let mxHasDnssec = false;
@@ -72,6 +77,7 @@ export async function checkDANE(
 		}
 	} catch {
 		// MX query failed
+		mxLookupFailed = true;
 		findings.push(
 			createFinding(
 				'dane',
@@ -82,16 +88,32 @@ export async function checkDANE(
 		);
 	}
 
-	// Step 3: If no MX TLSA found, report absence
+	// Step 3: classify absence. Branch on whether the domain actually accepts mail
+	// (DANE-email-1): a domain with no MX (or only a null MX) does not receive email,
+	// so SMTP DANE is not applicable — that is an INFO note (score 100), NOT a medium
+	// deficiency. Only a mail-accepting domain that omits TLSA is a real gap (medium →
+	// 85). This mirrors the MTA-STS no-inbound-mail fork and prevents parked/web-only
+	// domains from being dinged for an email control they don't need.
 	if (!hasMxTlsa && findings.every((f) => f.severity !== 'medium' || !f.title.includes('Malformed'))) {
-		findings.push(
-			createFinding(
-				'dane',
-				'No DANE TLSA for MX servers',
-				'medium',
-				'No TLSA records found for MX server SMTP ports (_25._tcp). DANE pins TLS certificates to DNS, preventing CA misissuance attacks on email delivery.',
-			),
-		);
+		if (realMxHosts === 0 && !mxLookupFailed) {
+			findings.push(
+				createFinding(
+					'dane',
+					'SMTP DANE not applicable (no inbound mail)',
+					'info',
+					`${domain} publishes no usable MX records (none, or an RFC 7505 null MX), so it does not accept inbound email. SMTP DANE (TLSA at _25._tcp) is therefore not applicable.`,
+				),
+			);
+		} else if (realMxHosts > 0) {
+			findings.push(
+				createFinding(
+					'dane',
+					'No DANE TLSA for MX servers',
+					'medium',
+					'No TLSA records found for MX server SMTP ports (_25._tcp). DANE pins TLS certificates to DNS, preventing CA misissuance attacks on email delivery.',
+				),
+			);
+		}
 	}
 
 	// Step 5: Handle case where all DNS queries failed

--- a/packages/dns-checks/src/checks/check-mta-sts.ts
+++ b/packages/dns-checks/src/checks/check-mta-sts.ts
@@ -199,9 +199,12 @@ export async function checkMTASTS(
 				: createFinding(
 						'mta_sts',
 						'No MTA-STS or TLS-RPT records found',
+						// No inbound MX → this domain does not receive mail, so missing MTA-STS
+						// is NOT a deficiency (low, no missingControl → ~95). Penalizing a parked
+						// domain here harder than for a missing optional control would be
+						// inconsistent. The has-MX branch above keeps missingControl (real gap).
 						'low',
 						`Neither MTA-STS nor TLS-RPT records are present for ${domain}. This is normal for domains that do not accept inbound email, but consider adding these records if you operate a mail server.`,
-						{ missingControl: true },
 					),
 		);
 	}

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -70,6 +70,7 @@ export type { DmarcFacts } from './scoring/classifiers/dmarc';
 export {
 	DMARC_PARITY_FIXTURES,
 	DANE_HTTPS_PARITY_FIXTURES,
+	DANE_EMAIL_PARITY_FIXTURES,
 	SVCB_HTTPS_PARITY_FIXTURES,
 	DNSSEC_PARITY_FIXTURES,
 	CAA_PARITY_FIXTURES,
@@ -79,6 +80,7 @@ export {
 export type {
 	DmarcParityFixture,
 	DaneHttpsParityFixture,
+	DaneEmailParityFixture,
 	SvcbParityFixture,
 	DnssecParityFixture,
 	CaaParityFixture,

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.9';
+export const PARITY_CORPUS_VERSION = '1.3.10';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):
@@ -121,6 +121,26 @@ export interface DaneHttpsParityFixture {
 	tlsa: string[];
 	/** DNSSEC AD flag from the raw query (DANE-TA/EE without DNSSEC is downgraded). */
 	ad: boolean;
+	expectedScore: number;
+	expectedMissingControl: boolean;
+}
+
+/**
+ * DANE-email (SMTP) parity fixture. Keyed on the domain's MX records plus, per MX
+ * host, the TLSA records at `_25._tcp.<host>` and the DNSSEC AD flag of that host's
+ * zone (RFC 7672 §3.1.3 requires DNSSEC on the MX host, not the sending domain).
+ * A domain with no usable MX → SMTP DANE not applicable (info, score 100).
+ */
+export interface DaneEmailParityFixture {
+	check: 'dane';
+	name: string;
+	domain: string;
+	/** MX records at `domain` ("priority exchange"). */
+	mx: string[];
+	/** TLSA records keyed by MX host (queried at `_25._tcp.<host>`). */
+	tlsaByHost: Record<string, string[]>;
+	/** DNSSEC AD flag per MX host (raw A query). Absent host ⇒ false. */
+	adByHost: Record<string, boolean>;
 	expectedScore: number;
 	expectedMissingControl: boolean;
 }
@@ -252,6 +272,74 @@ export const DANE_HTTPS_PARITY_FIXTURES: DaneHttpsParityFixture[] = [
 		tlsa: [`1 1 1 ${SHA256_HASH}`],
 		ad: false,
 		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+];
+
+export const DANE_EMAIL_PARITY_FIXTURES: DaneEmailParityFixture[] = [
+	{
+		// DANE-email-1: no MX → domain does not accept inbound mail → not applicable.
+		check: 'dane',
+		name: 'no MX (SMTP DANE not applicable)',
+		domain: 'example.com',
+		mx: [],
+		tlsaByHost: {},
+		adByHost: {},
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		// RFC 7505 null MX is also "no inbound mail" → not applicable, not a gap.
+		check: 'dane',
+		name: 'null MX (RFC 7505) — not applicable',
+		domain: 'example.com',
+		mx: ['0 .'],
+		tlsaByHost: {},
+		adByHost: {},
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		// Mail-accepting domain with no TLSA → real (but non-zeroing) gap → medium.
+		check: 'dane',
+		name: 'MX present, no TLSA (real gap)',
+		domain: 'example.com',
+		mx: ['10 mail.example.com'],
+		tlsaByHost: {},
+		adByHost: { 'mail.example.com': true },
+		expectedScore: 85,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dane',
+		name: 'valid DANE-EE (3 1 1) + DNSSEC on MX',
+		domain: 'example.com',
+		mx: ['10 mail.example.com'],
+		tlsaByHost: { 'mail.example.com': [`3 1 1 ${SHA256_HASH}`] },
+		adByHost: { 'mail.example.com': true },
+		expectedScore: 100,
+		expectedMissingControl: false,
+	},
+	{
+		// DANE-EE without DNSSEC on the MX zone → spoofable → high (−25) → 75.
+		check: 'dane',
+		name: 'DANE-EE without DNSSEC on MX',
+		domain: 'example.com',
+		mx: ['10 mail.example.com'],
+		tlsaByHost: { 'mail.example.com': [`3 1 1 ${SHA256_HASH}`] },
+		adByHost: { 'mail.example.com': false },
+		expectedScore: 75,
+		expectedMissingControl: false,
+	},
+	{
+		// Malformed TLSA (3 fields) → medium (−15) → 85; absence note suppressed.
+		check: 'dane',
+		name: 'malformed TLSA on MX',
+		domain: 'example.com',
+		mx: ['10 mail.example.com'],
+		tlsaByHost: { 'mail.example.com': ['3 1 1'] },
+		adByHost: { 'mail.example.com': true },
+		expectedScore: 85,
 		expectedMissingControl: false,
 	},
 ];


### PR DESCRIPTION
## Summary
Two hardening-tier checks were over-penalizing domains that don't accept inbound email. This branches both on MX presence so an inapplicable mail control is no longer scored as a deficiency.

- **MTA-STS** — no-MX branch drops `missingControl:true`: a non-mail domain emits **low/95** (was **0/passed-false**). The has-MX branch keeps **medium + missingControl** (real gap).
- **DANE-email** — absence classification split on MX presence: no usable MX (none / RFC 7505 null MX) → SMTP DANE **not applicable → info/100**; mail-accepting domain with no TLSA stays **medium/85**. Per-MX bands (valid+DNSSEC 100, DANE-EE-without-DNSSEC 75, malformed 85) unchanged (shared `analyzeTlsaRecords`).

## Parity
- New `DANE_EMAIL_PARITY_FIXTURES` (6 records-keyed cases) + contract block running the full `checkDANE`.
- Corpus + package → **1.3.10** (version-lock asserts they match).
- bv-web delegates + re-vendor land in the follow-up wiring PR.

## Test Plan
- [x] `npx vitest run packages/dns-checks` — 358 pass (incl. new DANE-email + MTA-STS contract)
- [x] Full root suite — 4955 pass / 13 skip (8 errors = known miniflare pool-teardown flake)

🤖 Generated with [Claude Code](https://claude.com/claude-code)