### PR TITLE
chore(scoring): reconcile DNSSEC weight to live value (10) across tables + docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,7 @@ Anything else → generic fallback. New client-visible errors must start with on
 
 Three-tier model (`computeScanScore`). `CATEGORY_DISPLAY_WEIGHTS` is display-only.
 
-**Core (70%)**: DMARC 16, DKIM 10, SPF 10, DNSSEC 8, SSL 8.
+**Core (70%)**: DMARC 16, DKIM 10, SPF 10, DNSSEC 10, SSL 8 (representative `mail_enabled` profile — every core weight is per-profile; e.g. DNSSEC 5–20, SSL 7–14 across the 6 profiles).
 **Protective (20%)**: Subdomain Takeover 4, HTTP Security 3, MTA-STS 3, MX 2, CAA 2, NS 2, Lookalikes 2, Shadow Domains 2.
 **Hardening (10%)**: DANE, BIMI, TLS-RPT, TXT Hygiene, MX Reputation, SRV, Zone Hygiene (~1.4 pts each, bonus-only).
 

--- a/packages/dns-checks/src/scoring/config.ts
+++ b/packages/dns-checks/src/scoring/config.ts
@@ -70,7 +70,7 @@ export const DEFAULT_SCORING_CONFIG: ScoringConfig = {
 		spf: 10,
 		dmarc: 16,
 		dkim: 10,
-		dnssec: 8,
+		dnssec: 10,
 		ssl: 8,
 		mta_sts: 2,
 		ns: 0,

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -29,7 +29,7 @@ export const IMPORTANCE_WEIGHTS: Record<CheckCategory, ImportanceProfile> = {
 	spf: { importance: 10 },
 	dmarc: { importance: 16 },
 	dkim: { importance: 10 },
-	dnssec: { importance: 8 },
+	dnssec: { importance: 10 },
 	ssl: { importance: 8 },
 	mta_sts: { importance: 2 },
 	ns: { importance: 0 },
@@ -56,7 +56,7 @@ export const IMPORTANCE_WEIGHTS: Record<CheckCategory, ImportanceProfile> = {
 
 /** Core-tier importance weights (SPF, DMARC, DKIM, DNSSEC, SSL). Used by the three-tier scoring formula. */
 export const CORE_WEIGHTS: Record<string, number> = {
-	dmarc: 16, dkim: 10, spf: 10, dnssec: 8, ssl: 8, authoritative_dns_infra: 0,
+	dmarc: 16, dkim: 10, spf: 10, dnssec: 10, ssl: 8, authoritative_dns_infra: 0,
 };
 
 /** Protective-tier importance weights. Used by the three-tier scoring formula. */


### PR DESCRIPTION
## Summary

Reconciles the DNSSEC weight so every table tells the truth about the **live** scoring weight. The live `scan_domain` score uses `PROFILE_WEIGHTS` via `detectDomainContext`, where the default `mail_enabled` profile **and** `config.coreWeights` both weight DNSSEC at **10**. Three non-score-bearing surfaces still said **8**, drifting from the live weight:

- `IMPORTANCE_WEIGHTS` (`engine.ts`) — feeds `generate_fix_plan` finding *ordering* only
- `CORE_WEIGHTS` (`engine.ts`) — `@deprecated`, re-export only
- `DEFAULT_SCORING_CONFIG.weights` (`config.ts`) — legacy flat map, not read by the engine

All three aligned to **10**; CLAUDE.md scoring headline updated and relabeled as the representative `mail_enabled` profile (every core weight is per-profile).

## No behavior change (verified, not assumed)

- `toImportanceRecord` has **no production callers** — neither `config.weights` nor `IMPORTANCE_WEIGHTS` reaches a scoring context.
- Golden score snapshots (`scoring-profiles.spec.ts`, 52 tests) pass unchanged on **both** dist and package paths.
- Full scoring suites pass: 383 (package) + 92 (Worker scoring/config/fix-plan/scan-domain).
- Intentional per-profile DNSSEC values (13/12/14/5/20) left untouched.

The score-bearing tables (`coreWeights`=10, `mail_enabled` profile=10) were already correct and unchanged.

## Companion change

The `bv-mcp-scoring` skill headline + its inaccurate "`IMPORTANCE_WEIGHTS` is the real scoring weight" claim were corrected in the **bv-cc** repo (separate, already pushed) — that doc inaccuracy was the root of the 8-vs-10 drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)