### PR TITLE
fix(dns-checks): cache-key version threading + workerd body-discipline (1.3.12)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.11",
+	"version": "1.3.12",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/checks/check-bimi.ts
+++ b/packages/dns-checks/src/checks/check-bimi.ts
@@ -41,6 +41,8 @@ async function validateBimiSvg(logoUrl: string, fetchFn: FetchFunction, timeout:
 					`BIMI logo URL "${logoUrl}" returns a redirect (HTTP ${response.status}). The logo should be served directly without redirects.`,
 				),
 			);
+			// Consume the unread body so workerd doesn't cancel a "stalled HTTP response".
+			void response.body?.cancel();
 			return findings;
 		}
 
@@ -53,6 +55,7 @@ async function validateBimiSvg(logoUrl: string, fetchFn: FetchFunction, timeout:
 					`BIMI logo URL "${logoUrl}" returned HTTP ${response.status}. The logo must be publicly accessible over HTTPS.`,
 				),
 			);
+			void response.body?.cancel();
 			return findings;
 		}
 
@@ -80,6 +83,7 @@ async function validateBimiSvg(logoUrl: string, fetchFn: FetchFunction, timeout:
 					`BIMI logo is ${Math.round(contentLength / 1024)} KB. The BIMI specification recommends logos be under 32 KB for reliable display in email clients.`,
 				),
 			);
+			void response.body?.cancel();
 			return findings;
 		}
 

--- a/packages/dns-checks/src/checks/check-http-security.ts
+++ b/packages/dns-checks/src/checks/check-http-security.ts
@@ -54,6 +54,9 @@ async function followRedirects(
 		if (!nextUrl.startsWith('https://')) break;
 
 		try {
+			// Release the body of the response we're about to abandon (e.g. a GET
+			// fallback that itself redirects) so workerd doesn't cancel a stalled stream.
+			void response.body?.cancel();
 			response = await fetchFn(nextUrl, {
 				method: 'HEAD',
 				redirect: 'manual',
@@ -140,6 +143,10 @@ export async function checkHTTPSecurity(
 			if (getResponse && (getResponse.ok || (getResponse.status >= 300 && getResponse.status < 400))) {
 				const followed = await followRedirects(getResponse, fetchFn, timeoutMs);
 				findings.push(...analyzeSecurityHeaders(followed.headers));
+				// GET fallback returns a real body we never read (followRedirects only
+				// cancels it when it redirects); release it so workerd doesn't cancel a
+				// stalled stream.
+				void followed.body?.cancel();
 			} else {
 				inconclusive = 'error';
 				findings.push(

--- a/packages/dns-checks/src/checks/check-mta-sts.ts
+++ b/packages/dns-checks/src/checks/check-mta-sts.ts
@@ -81,6 +81,8 @@ export async function checkMTASTS(
 						`MTA-STS policy file at ${policyUrl} returned HTTP ${response.status} redirect. The policy must be served directly at the well-known URL without redirects.`,
 					),
 				);
+				// Body unread on this branch — release it so workerd doesn't cancel a stalled response.
+				void response.body?.cancel();
 			} else if (!response.ok) {
 				findings.push(
 					createFinding(
@@ -90,6 +92,7 @@ export async function checkMTASTS(
 						`MTA-STS policy file at ${policyUrl} returned HTTP ${response.status}. The policy file must be accessible over HTTPS.`,
 					),
 				);
+				void response.body?.cancel();
 			} else {
 				const MAX_BODY_BYTES = 65_536; // 64 KB — RFC 8461 max for MTA-STS
 				const contentLength = parseInt(response.headers?.get('content-length') ?? '0', 10);
@@ -102,6 +105,7 @@ export async function checkMTASTS(
 							`MTA-STS policy file at ${policyUrl} exceeds 64 KB (Content-Length: ${contentLength}). This is abnormally large for an MTA-STS policy and was not fetched.`,
 						),
 					);
+					void response.body?.cancel();
 				} else {
 					const body = await response.text();
 					if (body.length > MAX_BODY_BYTES) {

--- a/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
+++ b/packages/dns-checks/src/checks/subdomain-takeover-analysis.ts
@@ -316,11 +316,18 @@ export async function probeHttpFingerprint(fqdn: string, cname: string, fetchFn:
 			signal: AbortSignal.timeout(HTTPS_TIMEOUT_MS),
 		});
 		// Skip fingerprint matching on redirects — redirecting services are not deprovisioned.
-		if (response.status >= 300 && response.status < 400) return null;
+		// Release the unread body so workerd doesn't cancel a stalled response.
+		if (response.status >= 300 && response.status < 400) {
+			void response.body?.cancel();
+			return null;
+		}
 
 		const MAX_BODY_BYTES = 65_536; // 64 KB — no legitimate takeover fingerprint exceeds this
 		const contentLength = parseInt(response.headers?.get('content-length') ?? '0', 10);
-		if (contentLength > MAX_BODY_BYTES) return null;
+		if (contentLength > MAX_BODY_BYTES) {
+			void response.body?.cancel();
+			return null;
+		}
 		const body = await response.text();
 		if (body.length > MAX_BODY_BYTES) return null;
 

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.11';
+export const PARITY_CORPUS_VERSION = '1.3.12';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -3,6 +3,14 @@
 import { INFLIGHT_CLEANUP_MS } from './config';
 import { logError } from './log';
 import { SERVER_VERSION } from './server-version';
+import { PARITY_CORPUS_VERSION } from '@blackveil/dns-checks';
+
+// The scoring logic lives in `@blackveil/dns-checks`; its version (== PARITY_CORPUS_VERSION
+// by the version-lock contract) is folded into every cache key. A `dns-checks`-only deploy
+// (recalibrating scores) does NOT bump SERVER_VERSION, so without this a redeploy would keep
+// serving STALE pre-deploy scores until the TTL expired (observed 2026-06-01: cross-system
+// parity showed dns-mcp serving old CAA/DKIM/DANE scores after the dns-checks bump).
+const DNS_CHECKS_VERSION = PARITY_CORPUS_VERSION;
 
 /**
  * TTL cache for DNS scan results.
@@ -123,13 +131,14 @@ export class TTLCache<T = unknown> {
 // Versioned cache-key builders
 // ---------------------------------------------------------------------------
 //
-// Every scan/check KV cache key embeds the server version (`cache:v<version>:`).
-// Deliberate trade-off: each deploy bumps SERVER_VERSION, so ALL keys change and
-// the cache cold-starts on the first request after a deploy. That is the correct
-// behaviour — the bug this fixes was the opposite: domain-only keys kept serving
-// stale pre-deploy results until the TTL expired, forcing a "scan a fresh domain
-// to verify the fix is live" workaround. For this scanner's traffic the cold
-// start is acceptable; correctness after deploy beats a few extra cache misses.
+// Every scan/check KV cache key embeds BOTH the server version AND the dns-checks
+// (scoring) version: `cache:v<serverVersion>-dc<dnsChecksVersion>:`. The cache must
+// cold-start whenever EITHER changes. SERVER_VERSION alone is insufficient: a
+// dns-checks-only deploy recalibrates scores without moving SERVER_VERSION, so a
+// server-version-only key kept serving stale pre-deploy results until the TTL expired
+// (2026-06-01 parity finding). Including the dns-checks version closes that.
+// For this scanner's traffic the cold start is acceptable; correctness after deploy
+// beats a few extra cache misses.
 //
 // Both call sites (handlers dispatch + scan-domain orchestrator) MUST use these
 // helpers so the per-check and top-level keys stay version-consistent — the
@@ -141,23 +150,35 @@ export const CACHE_KEY_PREFIX = 'cache:';
 
 /**
  * Build the versioned cache key for a single check result.
- * Shape: `cache:v<version>:<domain>:check:<checkName>`.
+ * Shape: `cache:v<serverVersion>-dc<dnsChecksVersion>:<domain>:check:<checkName>`.
  *
  * @param version - Defaults to the live {@link SERVER_VERSION}; overridable for tests.
+ * @param dnsChecksVersion - Scoring (dns-checks) version; defaults to the live value.
  */
-export function buildCheckCacheKey(domain: string, checkName: string, version: string = SERVER_VERSION): string {
-	return `${CACHE_KEY_PREFIX}v${version}:${domain}:check:${checkName}`;
+export function buildCheckCacheKey(
+	domain: string,
+	checkName: string,
+	version: string = SERVER_VERSION,
+	dnsChecksVersion: string = DNS_CHECKS_VERSION
+): string {
+	return `${CACHE_KEY_PREFIX}v${version}-dc${dnsChecksVersion}:${domain}:check:${checkName}`;
 }
 
 /**
  * Build the versioned cache key for a top-level scan result.
- * Shape: `cache:v<version>:<domain>` (default profile) or
- * `cache:v<version>:<domain>:profile:<profile>` when an explicit profile is set.
+ * Shape: `cache:v<serverVersion>-dc<dnsChecksVersion>:<domain>` (default profile) or
+ * `…:<domain>:profile:<profile>` when an explicit profile is set.
  *
  * @param version - Defaults to the live {@link SERVER_VERSION}; overridable for tests.
+ * @param dnsChecksVersion - Scoring (dns-checks) version; defaults to the live value.
  */
-export function buildScanCacheKey(domain: string, profile?: string, version: string = SERVER_VERSION): string {
-	const base = `${CACHE_KEY_PREFIX}v${version}:${domain}`;
+export function buildScanCacheKey(
+	domain: string,
+	profile?: string,
+	version: string = SERVER_VERSION,
+	dnsChecksVersion: string = DNS_CHECKS_VERSION
+): string {
+	const base = `${CACHE_KEY_PREFIX}v${version}-dc${dnsChecksVersion}:${domain}`;
 	return profile ? `${base}:profile:${profile}` : base;
 }
 

--- a/test/cache-key-version.spec.ts
+++ b/test/cache-key-version.spec.ts
@@ -1,50 +1,73 @@
 // SPDX-License-Identifier: BUSL-1.1
 
-// Regression coverage for the "stale-after-deploy" cache bug: scan/check
-// results were keyed by domain only, so a deploy kept serving pre-deploy
-// results until the TTL expired. The fix threads SERVER_VERSION into every
-// scan/check cache key so a version bump auto-invalidates the cache.
+// Regression coverage for the "stale-after-deploy" cache bug: scan/check results
+// were keyed by domain only, so a deploy kept serving pre-deploy results until the
+// TTL expired. The fix threads BOTH the server version AND the dns-checks (scoring)
+// version into every cache key — a bump to EITHER auto-invalidates the cache. The
+// dns-checks version is essential: a scoring-only recalibration deploy does not move
+// SERVER_VERSION, yet must still cold-start the cache (2026-06-01 parity finding).
 
 import { describe, it, expect } from 'vitest';
 import { buildCheckCacheKey, buildScanCacheKey } from '../src/lib/cache';
 import { SERVER_VERSION } from '../src/lib/server-version';
+import { PARITY_CORPUS_VERSION } from '@blackveil/dns-checks';
 
 describe('buildCheckCacheKey', () => {
-	it('includes the server version', () => {
+	it('includes the server version and the dns-checks version', () => {
 		const key = buildCheckCacheKey('example.com', 'mx');
 		expect(key).toContain(`v${SERVER_VERSION}`);
+		expect(key).toContain(`dc${PARITY_CORPUS_VERSION}`);
 	});
 
-	it('produces the canonical cache:v<version>:<domain>:check:<name> shape', () => {
-		expect(buildCheckCacheKey('example.com', 'mx')).toBe(`cache:v${SERVER_VERSION}:example.com:check:mx`);
+	it('produces the canonical cache:v<server>-dc<dnsChecks>:<domain>:check:<name> shape', () => {
+		expect(buildCheckCacheKey('example.com', 'mx')).toBe(
+			`cache:v${SERVER_VERSION}-dc${PARITY_CORPUS_VERSION}:example.com:check:mx`
+		);
 	});
 
-	it('changes when the version changes', () => {
+	it('changes when the server version changes', () => {
 		const a = buildCheckCacheKey('example.com', 'mx', '1.0.0');
 		const b = buildCheckCacheKey('example.com', 'mx', '1.0.1');
 		expect(a).not.toBe(b);
-		expect(a).toContain('v1.0.0');
-		expect(b).toContain('v1.0.1');
+	});
+
+	it('changes when ONLY the dns-checks (scoring) version changes (server version fixed)', () => {
+		const a = buildCheckCacheKey('example.com', 'mx', '3.5.0', '1.3.11');
+		const b = buildCheckCacheKey('example.com', 'mx', '3.5.0', '1.3.12');
+		expect(a).not.toBe(b);
+		expect(a).toContain('dc1.3.11');
+		expect(b).toContain('dc1.3.12');
 	});
 });
 
 describe('buildScanCacheKey', () => {
-	it('includes the server version', () => {
+	it('includes the server version and the dns-checks version', () => {
 		const key = buildScanCacheKey('example.com');
 		expect(key).toContain(`v${SERVER_VERSION}`);
+		expect(key).toContain(`dc${PARITY_CORPUS_VERSION}`);
 	});
 
-	it('produces the canonical cache:v<version>:<domain> shape for the default profile', () => {
-		expect(buildScanCacheKey('example.com')).toBe(`cache:v${SERVER_VERSION}:example.com`);
+	it('produces the canonical cache:v<server>-dc<dnsChecks>:<domain> shape for the default profile', () => {
+		expect(buildScanCacheKey('example.com')).toBe(
+			`cache:v${SERVER_VERSION}-dc${PARITY_CORPUS_VERSION}:example.com`
+		);
 	});
 
 	it('appends an explicit profile when provided', () => {
-		expect(buildScanCacheKey('example.com', 'api_heavy')).toBe(`cache:v${SERVER_VERSION}:example.com:profile:api_heavy`);
+		expect(buildScanCacheKey('example.com', 'api_heavy')).toBe(
+			`cache:v${SERVER_VERSION}-dc${PARITY_CORPUS_VERSION}:example.com:profile:api_heavy`
+		);
 	});
 
-	it('changes when the version changes', () => {
+	it('changes when the server version changes', () => {
 		const a = buildScanCacheKey('example.com', undefined, '1.0.0');
 		const b = buildScanCacheKey('example.com', undefined, '1.0.1');
+		expect(a).not.toBe(b);
+	});
+
+	it('changes when ONLY the dns-checks (scoring) version changes', () => {
+		const a = buildScanCacheKey('example.com', undefined, '3.5.0', '1.3.11');
+		const b = buildScanCacheKey('example.com', undefined, '3.5.0', '1.3.12');
 		expect(a).not.toBe(b);
 	});
 });


### PR DESCRIPTION
## Summary

Two cross-system parity findings from the bv-web ↔ bv-mcp 8-check scan:

1. **Stale-after-deploy cache.** Scan/check results were keyed by `SERVER_VERSION` only. A scoring-only recalibration deploys a new `@blackveil/dns-checks` *without* bumping `SERVER_VERSION`, so prod kept serving pre-deploy scores until the TTL expired — this is what made the parity scan read stale bv-mcp values. Cache keys now thread the dns-checks version: `cache:v<server>-dc<dnsChecks>:...`, so a bump to **either** version cold-starts the cache.
2. **workerd body-discipline.** Four checks read only `.headers` (or fell through on redirect/!ok/oversize) without consuming/cancelling the Response body → workerd "stalled HTTP response was canceled" logs. `response.body?.cancel()` added on every unread path in check-bimi, check-mta-sts, check-http-security (incl. GET fallback), subdomain-takeover-analysis.

Bumps `@blackveil/dns-checks` 1.3.11 → 1.3.12 + `PARITY_CORPUS_VERSION`. bv-web re-vendors the matching tgz (MadaBurns/bv-web#691).

## Test Plan

- [x] dns-checks package suite — 383 passed
- [x] root workerd-pool suite — 4982 passed (0 real failures; known pool-teardown flake only)
- [x] cache-key-version.spec — 9 passed (asserts `-dc<version>` shape + dns-checks-only bump invalidation)
- [ ] deploy:prod + post-deploy parity scan