### PR TITLE
build: generate dns-checks declarations via tsc, drop ignoreDeprecations hatch

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -26,7 +26,7 @@
 		"README.md"
 	],
 	"scripts": {
-		"build": "tsup",
+		"build": "tsup && tsc -p tsconfig.json --emitDeclarationOnly",
 		"test": "vitest run",
 		"typecheck": "tsc --noEmit"
 	},

--- a/packages/dns-checks/tsconfig.json
+++ b/packages/dns-checks/tsconfig.json
@@ -1,7 +1,5 @@
 {
 	"compilerOptions": {
-		/* tsup injects a deprecated `baseUrl` into its DTS build; TS 6.0 turns that into a hard error (TS5101). Silence until TS 7.0. */
-		"ignoreDeprecations": "6.0",
 		"target": "ES2024",
 		"module": "ES2022",
 		"moduleResolution": "bundler",

--- a/packages/dns-checks/tsup.config.ts
+++ b/packages/dns-checks/tsup.config.ts
@@ -8,7 +8,9 @@ export default defineConfig({
 	},
 	format: ['esm'],
 	target: 'es2022',
-	dts: true,
+	// Declarations are emitted by `tsc --emitDeclarationOnly` (see build script), not tsup:
+	// tsup's rollup-dts path injects a deprecated `baseUrl`, a hard error under TypeScript 6.0 (TS5101).
+	dts: false,
 	sourcemap: true,
 	clean: true,
 	splitting: false,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,9 +2,6 @@
 	"compilerOptions": {
 		/* Visit https://aka.ms/tsconfig.json to read more about this file */
 
-		/* tsup injects a deprecated `baseUrl` into its DTS build; TS 6.0 turns that into a hard error (TS5101). Silence until TS 7.0. */
-		"ignoreDeprecations": "6.0",
-
     /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
 		"target": "es2024",
     /* Specify a set of bundled library declaration files that describe the target runtime environment. */

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,7 +19,10 @@ const shared: Partial<Options> = {
 	format: ['esm'],
 	target: 'es2022',
 	platform: 'neutral',
-	dts: true,
+	// No `.d.ts` emit: the `blackveil-dns` package ships only a `bin` CLI (no `types`/`exports`),
+	// so nothing consumes declarations here. (Also avoids tsup's rollup-dts injecting a deprecated
+	// `baseUrl`, a hard error under TypeScript 6.0 — TS5101.) Type safety is still covered by `npm run typecheck`.
+	dts: false,
 	sourcemap: true,
 	splitting: false,
 	treeshake: true,


### PR DESCRIPTION
Durable replacement for the `ignoreDeprecations: "6.0"` hatch from #336. **Closes #337.**

## Why the hatch wasn't enough
tsup's rollup-dts path **hardcodes** a deprecated `baseUrl` injection:
```js
// node_modules/tsup/dist/rollup.js
baseUrl: compilerOptions.baseUrl || ".",
```
That's a hard error under TS 6.0 (`TS5101`) and `baseUrl` is **removed entirely in TS 7.0**, so the hatch was only a deferral. tsup 8.5.1 (latest) has no flag to disable the injection.

## Fix (per package's type surface)
| Package | Change | Rationale |
|---|---|---|
| `packages/dns-checks` (publishes types) | tsup `dts: false`; declarations via `tsc -p tsconfig.json --emitDeclarationOnly` (`build` = `tsup && tsc`) | Per-file `.d.ts` instead of bundled; the exports-map entries (`dist/{index,scoring/index,whois/index}.d.ts`) still resolve |
| root `blackveil-dns` (ships only a `bin`; no `types`/`exports`/`main`) | tsup `dts: false` | Nothing consumed those declarations; type safety stays covered by `npm run typecheck` |

`ignoreDeprecations: "6.0"` removed from both tsconfigs. No deprecated compiler options remain in any committed tsconfig.

## Verification
- dns-checks build emits all three published entry `.d.ts`; scoring types resolve
- `tsc --noEmit` clean — worker + dns-checks
- `eslint .` clean — 845 files
- worker build clean (no `.d.ts`, as intended)
- dns-checks tests **370 passed**; full worker suite **4985 passed / 0 failed** (trailing pool-teardown errors are the known flake)
- CI builds dns-checks via the changed script (`ci.yml` + `ci-contract.yml`), so the new tsc path is exercised in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)