### PR TITLE
chore: release 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.6.0] - 2026-06-02
+
 ### Changed
 
 - **Dependency refresh — no runtime or scoring impact.** Semver-compatible npm bumps: `wrangler` 4.96.0, `zod` 4.4.3, `vitest` 4.1.8, `@cloudflare/vitest-pool-workers` 0.16.11, `@cloudflare/workers-types` 4.20260602.1, `tldts` 7.4.2, `tsup` 8.5.1, `typescript-eslint` 8.60.1; plus Cargo patch bumps for `bv-wasm-core` (`wasm-bindgen` 0.2.122, `serde_json` 1.0.150, `memchr` 2.8.1, `bumpalo` 3.20.3). `npm audit` clean. (#335)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.5.1",
+	"version": "3.6.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.5.1",
+			"version": "3.6.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.5.1",
+	"version": "3.6.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.5.1",
+	"version": "3.6.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Version bump **3.5.1 → 3.6.0**. Pre-bump-before-tag per the release runbook (the `publish.yml` version-sync step's auto-push would be rejected by branch protection, so the surfaces are synced here first).

## Version-sync surfaces (all = 3.6.0)
- `package.json` + `package-lock.json`
- `server.json` top-level `version` (remotes-only; no `packages` stanza)
- `CHANGELOG.md` — new `[3.6.0] - 2026-06-02` heading (fresh empty `[Unreleased]` retained)
- `SERVER_VERSION` auto-derives from `package.json` (not hand-edited, by design)

## What's in 3.6.0 (rolled up from `[Unreleased]`)
- **#335** semver-safe dependency refresh (+ Cargo patch bumps); `npm audit` clean
- **#336** TypeScript 6.0 + ESLint 10 (major); **`engines.node` raised to `>=22.13.0`**
- **#338** `@blackveil/dns-checks` declarations via `tsc` (drops tsup `baseUrl` `TS5101`)
- **#340** `scan_domain` degrades gracefully when the scoring path throws (no more whole-scan crash)
- **#341** `check_authoritative_dns_infra`/`check_root_server_set` fail-soft on probe error; `baseline` param disambiguation (`compare_baseline` vs `analyze_drift`)

**Minor** bump: the `engines.node` floor raise is a consumer-facing requirement change; no MCP tool-surface break (still 78 tools). Prod Worker already deployed manually; this formalizes the tag.

Verified: version surfaces in sync; `token-version` + `cache-key-version` + `server-json-tool-count` audits (20 tests) pass; typecheck clean. After merge I'll tag `v3.6.0` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)