### PR TITLE
docs(CLAUDE): correct rate-limit response to HTTP 429

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Both publish together from `publish.yml` on version tags.
 
 - `'Missing required'`, `'Invalid'`, `'Domain '`, `'Resource not found'`, `'Rate limit exceeded'`
 
-Anything else → generic fallback. New client-visible errors must start with one of these. Rate limit: HTTP 200 + JSON-RPC `code: -32029` (MCP spec) — not 429. `retry-after` header still set.
+Anything else → generic fallback. New client-visible errors must start with one of these. Rate limit: HTTP **429** + JSON-RPC `code: -32029` carried in the response body (`useErrorEnvelope`); `retry-after` header set. All rate-limit/quota paths in `mcp/execute.ts` return `httpStatus: 429` (per-IP minute/hour/day, per-tool daily, per-tier daily, global cap); asserted by `test/index.spec.ts`.
 
 ## Scoring
 


### PR DESCRIPTION
The `CLAUDE.md` Security → Error-surfacing note claimed rate limits return *"HTTP 200 + JSON-RPC -32029 (MCP spec) — not 429."* That's inaccurate.

**Verified reality** (code + tests + live prod):
- Every rate-limit/quota path in `src/mcp/execute.ts` returns `httpStatus: 429` — per-IP minute (`:503`), per-IP daily (`:466`), per-tool daily (`:550`), force-refresh (`:602`), per-tier daily (`:650`), global cap (`:432`).
- The JSON-RPC `-32029` error is carried in the body via `useErrorEnvelope`; `retry-after` header set.
- `test/index.spec.ts:357` asserts the throttled response is `429` with a `retry-after`.
- Live prod check (free-tier `explain_finding` 50/day) returned **HTTP 429** + `-32029` + `retry-after`.

Doc-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)