### PR TITLE
chore: release 3.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.7.0] - 2026-06-03
+
+Scoring-output transparency and DNS-integrity severity refinement. No domain scores or grades change in this release: the DNSSEC reclassification adjusts a severity *label* only (the −40 score penalty is preserved), and the new scan-output fields are additive.
+
 ### Added
 
 - **Scan output now carries a scoring-model version + config fingerprint.** Every structured scan result includes `scoringModelVersion` (a semver for the scoring *policy*, distinct from the package/server version — bump it whenever weights, thresholds, severities, or the `passed` rule change) and `scoringConfigHash` (a deterministic FNV-1a fingerprint of the effective `SCORING_CONFIG`, so an override is captured). The full human-readable report gains a `Scoring model: v<X>` footer. This makes "the numbers moved between two scans" explainable by design — a dated report records exactly which scoring policy produced it. Inaugural version: `1.0.0`. (`src/lib/scoring-version.ts`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.6.0",
+	"version": "3.7.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.6.0",
+			"version": "3.7.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.6.0",
+	"version": "3.7.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.6.0",
+	"version": "3.7.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Formalizes the 3.7.0 release. Pre-bump-before-tag per the release runbook (so `publish.yml`'s version-sync step is a no-op and doesn't try to push to protected `main`).

Rolls up all `[Unreleased]` entries into `## [3.7.0] - 2026-06-03`:
- Scoring-model version + config-hash stamp on scan output (#346)
- Honest adaptive `scoringNote` (#346)
- `resolves` exposed on the structured wire output (#346)
- NXDOMAIN non-resolving short-circuit + DNSSEC severity decouple (#345)
- CLAUDE.md rate-limit 429 doc correction (#343)

**No domain scores or grades change** — the DNSSEC reclassification is severity-label only (the −40 penalty is preserved via `penaltyOverride`), and the new scan-output fields are additive.

Version surfaces synced: `package.json` + `package-lock.json`, `server.json` (remotes-only top-level `version`), CHANGELOG heading. `SERVER_VERSION` auto-derives from `package.json` (not hand-edited). Tag `v3.7.0` will be pushed after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)