### PR TITLE
fix(scoring): detect control presence via structured controlPresent signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Profile detection now keys on an active control, not a bare `passed`/finding prose.** `detectDomainContext` (which selects the per-profile scoring weight table) inferred a control as "present" from `result.passed === true` for MTA-STS/BIMI/SSL/CAA and a brittle text regex for DKIM/MX. But `passed` is `true` for an absent-but-not-penalized control (e.g. MTA-STS on a non-mail domain), so most domains were mis-read as having hardening present. Checks now emit a structured `controlPresent` tri-state on `CheckResult` — `true` (active record observed: real mail MX, non-revoked DKIM key, MTA-STS policy record, DMARC-enforcing BIMI, reachable HTTPS, CAA records), `false` (definitively absent/inactive: no/null MX, all-revoked DKIM, non-enforcing BIMI), `undefined` (lookup failed) — and detection reads that instead. **Measured effect** on a 90-domain portfolio sample: `enterprise_mail` over-classification dropped from **87% → 62%** (24 domains reclassified to the correct `mail_enabled`/`non_mail`), with a **bounded per-domain score impact (~±2 pts, mean +0.69)** since the profile only selects a weight table — scoring math is unchanged. `SCORING_MODEL_VERSION` → `1.1.0`. Sets `controlPresent` in the six checks `detectDomainContext` consumes (`mx`, `dkim`, `mta_sts`, `bimi`, `ssl`, `caa`); `buildCheckResult` gains an optional `controlPresent` argument. (Supersedes the reverted prose-matching attempt.)
+
 ## [3.7.0] - 2026-06-03
 
 Scoring-output transparency and DNS-integrity severity refinement. No domain scores or grades change in this release: the DNSSEC reclassification adjusts a severity *label* only (the −40 score penalty is preserved), and the new scan-output fields are additive.

--- a/packages/dns-checks/src/__tests__/scoring/scoring-profiles.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-profiles.spec.ts
@@ -22,7 +22,10 @@ function makeResult(category: CheckCategory, score: number, title?: string, seve
 	} else {
 		findings.push(createFinding(category, title ?? `${category} issue`, severity ?? 'medium', 'Issue detected'));
 	}
-	return buildCheckResult(category, findings);
+	// Synthetic controlPresent for profile detection: a full-score check expresses an active control;
+	// a zeroed one expresses an absent control. Mid-scores leave it undefined (scoring ignores it).
+	const controlPresent = score === 100 ? true : score === 0 ? false : undefined;
+	return buildCheckResult(category, findings, controlPresent);
 }
 
 function buildFullResults(overrides: Partial<Record<CheckCategory, CheckResult>> = {}): CheckResult[] {

--- a/packages/dns-checks/src/checks/check-bimi.ts
+++ b/packages/dns-checks/src/checks/check-bimi.ts
@@ -203,7 +203,8 @@ export async function checkBIMI(
 				),
 			);
 		}
-		return buildCheckResult('bimi', findings);
+		// No BIMI record observed → control absent.
+		return buildCheckResult('bimi', findings, false);
 	}
 
 	// BIMI record exists but DMARC is not enforcing — record is non-functional
@@ -307,5 +308,7 @@ export async function checkBIMI(
 		}
 	}
 
-	return buildCheckResult('bimi', findings);
+	// controlPresent: a BIMI record exists AND DMARC is enforcing (the record can actually function).
+	// A record published without DMARC enforcement is non-functional → not an active hardening signal.
+	return buildCheckResult('bimi', findings, Boolean(isEnforcing));
 }

--- a/packages/dns-checks/src/checks/check-caa.ts
+++ b/packages/dns-checks/src/checks/check-caa.ts
@@ -53,7 +53,8 @@ export async function checkCAA(
 				`No CAA records found for ${domain}. CAA records restrict which Certificate Authorities can issue certificates for your domain, preventing unauthorized issuance.`,
 			),
 		);
-		return buildCheckResult('caa', findings);
+		// No CAA records observed → control absent (a query failure above leaves controlPresent undefined).
+		return buildCheckResult('caa', findings, false);
 	}
 
 	findings.push(...getCaaValidationFindings(summarizeCaaTags(caaRecords)));
@@ -63,5 +64,6 @@ export async function checkCAA(
 		findings.push(getCaaConfiguredFinding());
 	}
 
-	return buildCheckResult('caa', findings);
+	// CAA records present → control present.
+	return buildCheckResult('caa', findings, true);
 }

--- a/packages/dns-checks/src/checks/check-dkim.ts
+++ b/packages/dns-checks/src/checks/check-dkim.ts
@@ -314,7 +314,10 @@ export async function checkDKIM(
 		);
 	}
 
-	const result = buildCheckResult('dkim', findings);
+	// controlPresent: an ACTIVE DKIM key was observed. All-revoked (empty p=) selectors count as
+	// absent for profile detection — a revoked key is not a working hardening signal.
+	const dkimControlPresent = foundSelectors.length > 0 && hasValidKey;
+	const result = buildCheckResult('dkim', findings, dkimControlPresent);
 
 	// Defect E — score floor on probe miss.
 	// A HIGH "No DKIM records found" finding scores 75 by default (100 - 25),

--- a/packages/dns-checks/src/checks/check-mta-sts.ts
+++ b/packages/dns-checks/src/checks/check-mta-sts.ts
@@ -213,7 +213,9 @@ export async function checkMTASTS(
 		);
 	}
 
-	return buildCheckResult('mta_sts', findings);
+	// controlPresent: an MTA-STS policy record (_mta-sts TXT) was observed. TLS-RPT alone does not
+	// count as MTA-STS, and a failed lookup leaves hasTxtRecord false (conservative: not credited).
+	return buildCheckResult('mta_sts', findings, hasTxtRecord);
 }
 
 /**

--- a/packages/dns-checks/src/checks/check-mx.ts
+++ b/packages/dns-checks/src/checks/check-mx.ts
@@ -71,7 +71,8 @@ export async function checkMX(
 				{ missingControl: true },
 			);
 		}
-		return buildCheckResult('mx', [finding]);
+		// No MX records → mail control definitively absent (controlPresent: false).
+		return buildCheckResult('mx', [finding], false);
 	}
 
 	const findings: Finding[] = [];
@@ -82,7 +83,8 @@ export async function checkMX(
 	const nullMx = mxRecords.find(isNullMxRecord);
 	if (nullMx) {
 		findings.push(getNullMxFinding());
-		return buildCheckResult('mx', findings);
+		// Null MX is an explicit "does not accept mail" declaration → not a mail control.
+		return buildCheckResult('mx', findings, false);
 	}
 
 	findings.push(getPresenceFinding(mxRecords));
@@ -124,5 +126,6 @@ export async function checkMX(
 		findings.push(singleMxFinding);
 	}
 
-	return buildCheckResult('mx', findings);
+	// Real mail-routing MX records present → mail control present.
+	return buildCheckResult('mx', findings, true);
 }

--- a/packages/dns-checks/src/checks/check-ssl.ts
+++ b/packages/dns-checks/src/checks/check-ssl.ts
@@ -30,8 +30,8 @@ export async function checkSSL(
 	const timeoutMs = options?.timeout ?? HTTPS_TIMEOUT_MS;
 	const findings: Finding[] = [];
 
-	const httpsResult = await checkHttps(domain, fetchFn, timeoutMs);
-	findings.push(...httpsResult);
+	const { findings: httpsFindings, reachable } = await checkHttps(domain, fetchFn, timeoutMs);
+	findings.push(...httpsFindings);
 
 	// Only check HTTP redirect if HTTPS is working (no critical findings)
 	const hasCritical = findings.some((f) => f.severity === 'critical');
@@ -44,12 +44,19 @@ export async function checkSSL(
 		findings.push(createFinding('ssl', 'HTTPS and HSTS properly configured', 'info', `HTTPS connection succeeded and HSTS header is properly configured for ${domain}. Note: This check verifies HTTPS reachability and HSTS policy. Certificate expiry, TLS version, and cipher suite analysis require a dedicated TLS scanner.`));
 	}
 
-	return buildCheckResult('ssl', findings);
+	// controlPresent: HTTPS was reachable (the TLS handshake completed). A connection failure/timeout
+	// means no working web TLS endpoint → web control absent for profile detection.
+	return buildCheckResult('ssl', findings, reachable);
 }
 
-/** Check HTTPS connectivity by attempting a fetch */
-async function checkHttps(domain: string, fetchFn: FetchFunction, timeoutMs: number): Promise<Finding[]> {
+/**
+ * Check HTTPS connectivity by attempting a fetch.
+ * `reachable` is true when the TLS handshake completed (any HTTP response was received, including
+ * redirects/errors); false when the connection failed or timed out.
+ */
+async function checkHttps(domain: string, fetchFn: FetchFunction, timeoutMs: number): Promise<{ findings: Finding[]; reachable: boolean }> {
 	const findings: Finding[] = [];
+	let reachable = false;
 
 	try {
 		const response = await fetchFn(`https://${domain}`, {
@@ -57,6 +64,7 @@ async function checkHttps(domain: string, fetchFn: FetchFunction, timeoutMs: num
 			redirect: 'manual',
 			signal: AbortSignal.timeout(timeoutMs),
 		});
+		reachable = true;
 
 		const isRedirect = response.status >= 300 && response.status < 400;
 		const location = isRedirect ? response.headers.get('location') : null;
@@ -75,7 +83,7 @@ async function checkHttps(domain: string, fetchFn: FetchFunction, timeoutMs: num
 		findings.push(getHttpsErrorFinding(domain, message));
 	}
 
-	return findings;
+	return { findings, reachable };
 }
 
 /** Check if HTTP redirects to HTTPS */

--- a/packages/dns-checks/src/scoring/model.ts
+++ b/packages/dns-checks/src/scoring/model.ts
@@ -128,7 +128,7 @@ export function scoreIndicatesMissingControl(findings: Finding[]): boolean {
  * a fundamentally missing security control (e.g., no SPF/DMARC record), or if
  * any finding carries explicit `missingControl: true` metadata.
  */
-export function buildCheckResult(category: CheckCategory, findings: Finding[]): CheckResult {
+export function buildCheckResult(category: CheckCategory, findings: Finding[], controlPresent?: boolean): CheckResult {
 	const normalizedFindings = findings.map(withConfidenceMetadata);
 	const score = computeCategoryScore(normalizedFindings, category);
 	const hasMissingControl =
@@ -139,6 +139,9 @@ export function buildCheckResult(category: CheckCategory, findings: Finding[]): 
 		passed,
 		score: hasMissingControl ? 0 : score,
 		findings: normalizedFindings,
+		// Only set when the caller provides a determination; left absent (undefined) otherwise so
+		// consumers can distinguish "definitively absent" (false) from "not determined" (undefined).
+		...(controlPresent === undefined ? {} : { controlPresent }),
 	};
 }
 

--- a/packages/dns-checks/src/scoring/profiles.ts
+++ b/packages/dns-checks/src/scoring/profiles.ts
@@ -261,24 +261,12 @@ export function detectDomainContext(results: CheckResult[]): DomainContext {
 	const mtaStsResult = results.find((r) => r.category === 'mta_sts');
 	const bimiResult = results.find((r) => r.category === 'bimi');
 
-	// Detect MX presence
-	const hasNoMx = mxResult
-		? mxResult.findings.some((f) => {
-				const text = `${f.title} ${f.detail}`.toLowerCase();
-				return (
-					text.includes('no mx records') ||
-					text.includes('null mx') ||
-					text.includes('no mx and no spf') ||
-					text.includes('no mail exchange records') ||
-					text.includes('correctly-configured non-mail domain') ||
-					text.includes('does not accept email')
-				);
-			})
-		: false;
-	const hasMxUnknown = mxResult
-		? mxResult.findings.some((f) => f.title.toLowerCase().includes('dns query failed'))
-		: false;
-	const hasMx = mxResult && !hasNoMx && !hasMxUnknown;
+	// Detect MX presence from the structured controlPresent signal (set by check-mx), not finding
+	// prose. true = real mail-routing MX; false = no MX or null MX (RFC 7505 → not a mail domain);
+	// undefined = the MX lookup failed (status unknown → safe mail_enabled fallback below).
+	const hasMx = mxResult?.controlPresent === true;
+	const hasNoMx = mxResult?.controlPresent === false;
+	const hasMxUnknown = mxResult ? mxResult.controlPresent === undefined : false;
 
 	if (hasMx) signals.push('MX present');
 	if (hasNoMx) signals.push('No MX records');
@@ -304,26 +292,25 @@ export function detectDomainContext(results: CheckResult[]): DomainContext {
 		}
 	}
 
-	// Detect hardening signals (DKIM present, MTA-STS present, BIMI present)
-	const dkimPresent = dkimResult
-		? !dkimResult.findings.some((f) => {
-				const text = `${f.title} ${f.detail}`.toLowerCase();
-				return /(no\s+dkim|not\s+found|missing)/.test(text) && f.severity !== 'info';
-			})
-		: false;
+	// Detect hardening signals from controlPresent (an active record was observed), not passed/prose.
+	// A bare passed===true is true for absent-but-not-penalized controls (MTA-STS/BIMI on a non-mail
+	// domain) and the old DKIM prose check counted revoked keys as present — both inflated
+	// enterprise_mail. controlPresent is false for absent OR inactive (revoked DKIM, non-enforcing BIMI).
+	const dkimPresent = dkimResult?.controlPresent === true;
 	if (dkimPresent && hasMx) signals.push('DKIM present');
 
-	const mtaStsPresent = mtaStsResult ? mtaStsResult.passed : false;
+	const mtaStsPresent = mtaStsResult?.controlPresent === true;
 	if (mtaStsPresent) signals.push('MTA-STS present');
 
-	const bimiPresent = bimiResult ? bimiResult.passed : false;
+	const bimiPresent = bimiResult?.controlPresent === true;
 	if (bimiPresent) signals.push('BIMI present');
 
 	const hasHardeningSignal = dkimPresent || mtaStsPresent || bimiPresent;
 
-	// Detect web indicators
-	const sslPass = sslResult ? sslResult.passed : false;
-	const caaPass = caaResult ? caaResult.passed : false;
+	// Detect web indicators: reachable HTTPS / published CAA, again via controlPresent (a sparse
+	// domain whose CAA is "absent-but-passed" must not read as web_only).
+	const sslPass = sslResult?.controlPresent === true;
+	const caaPass = caaResult?.controlPresent === true;
 	if (sslPass) signals.push('SSL valid');
 	if (caaPass) signals.push('CAA present');
 

--- a/packages/dns-checks/src/types.ts
+++ b/packages/dns-checks/src/types.ts
@@ -119,6 +119,18 @@ export interface CheckResult {
 	checkStatus?: CheckStatus;
 	/** When true, the result is incomplete (e.g. timeout) and should not be cached long-term. */
 	partial?: boolean;
+	/**
+	 * Whether the checked control is *meaningfully present and active* — distinct from `passed`.
+	 * `true` = an active record/response was observed (real mail MX, non-revoked DKIM key, MTA-STS
+	 * policy record, DMARC-enforcing BIMI, reachable HTTPS, CAA records). `false` = definitively
+	 * absent or inactive (no MX / null MX, all-revoked DKIM, no record, non-enforcing BIMI,
+	 * unreachable HTTPS). `undefined` = could not be determined (e.g. the DNS query failed).
+	 *
+	 * `passed` is unsafe as a presence proxy: an absent-but-not-penalized control (e.g. MTA-STS on a
+	 * non-mail domain) still yields `passed === true`. Profile detection (`detectDomainContext`) reads
+	 * this instead of `passed`/finding prose. Only the checks `detectDomainContext` consumes set it.
+	 */
+	controlPresent?: boolean;
 	/** Optional structured metadata attached to the result by the check wrapper (not the core package). */
 	metadata?: Record<string, unknown>;
 }

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -17,13 +17,20 @@
  *
  * BUMP THIS whenever scoring policy changes in a way that alters scores or grades:
  * category weights, profile weights, grade thresholds, severity penalties, the
- * `passed`/missing-control rule, or a severity reclassification (e.g. the recent
- * DNSSEC severity decouple — `critical`→`high` with the penalty preserved via
- * `penaltyOverride` — would have bumped this). Bumping it
- * lets a report consumer detect that two scans of the same domain ran under
- * different scoring policies.
+ * `passed`/missing-control rule, a severity reclassification (e.g. the DNSSEC
+ * severity decouple — `critical`→`high` with the penalty preserved via
+ * `penaltyOverride`), or a change to how the scoring **profile** is detected (the
+ * detected profile selects the per-profile weight table via `getProfileWeights`).
+ * Bumping it lets a report consumer detect that two scans of the same domain ran
+ * under different scoring policies.
+ *
+ * History:
+ * - 1.0.0 — baseline policy as of v3.7.0 (DNSSEC decouple, profile-aware auto scoring).
+ * - 1.1.0 — profile detection now requires an active observed control (`controlPresent`)
+ *   instead of bare `passed`/finding prose. Corrects `enterprise_mail` over-fire and
+ *   sparse-domain misdetection; per-domain score impact is bounded (~±2 pts).
  */
-export const SCORING_MODEL_VERSION = '1.0.0';
+export const SCORING_MODEL_VERSION = '1.1.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/src/lib/tls-probe-binding.ts
+++ b/src/lib/tls-probe-binding.ts
@@ -109,5 +109,7 @@ export function mergeTlsFinding(result: CheckResult, probe: TlsProbeResult): Che
 		`The HTTPS endpoint for ${probe.host ?? 'this domain'} still negotiates a legacy TLS version (minimum observed: ${probe.minVersion}). TLS 1.0/1.1 are deprecated (RFC 8996) and forbidden by PCI-DSS; offer TLS 1.2 as the minimum. This signal comes from the operator-only BV_TLS_PROBE service; self-hosted deploys without the probe will not see this finding.`,
 		{ tlsProbeEnriched: true, minVersion: probe.minVersion, maxVersion: probe.maxVersion, supportedVersions: probe.supportedVersions },
 	);
-	return buildCheckResult('ssl', [...result.findings, finding]);
+	// Preserve controlPresent — detectDomainContext reads it for profile detection,
+	// so dropping it here would flip sslPass to false for legacy-TLS-but-reachable hosts.
+	return buildCheckResult('ssl', [...result.findings, finding], result.controlPresent);
 }

--- a/src/tools/check-dkim.ts
+++ b/src/tools/check-dkim.ts
@@ -94,5 +94,7 @@ export function applyProviderDkimContext(dkimResult: CheckResult, provider: stri
 		);
 	}
 
-	return buildCheckResult('dkim', newFindings) as CheckResult;
+	// Preserve controlPresent — this branch only runs when DKIM was not found
+	// (controlPresent already false); detectDomainContext reads it, not finding prose.
+	return buildCheckResult('dkim', newFindings, dkimResult.controlPresent) as CheckResult;
 }

--- a/test/check-dkim.spec.ts
+++ b/test/check-dkim.spec.ts
@@ -351,6 +351,22 @@ describe('provider-informed DKIM', () => {
 		expect(adjusted.score).toBe(85); // single medium = -15
 	});
 
+	it('applyProviderDkimContext preserves controlPresent (DKIM not found stays false, not undefined)', async () => {
+		const { applyProviderDkimContext } = await import('../src/tools/check-dkim');
+		const findings = [
+			createFinding('dkim', 'No DKIM records found among tested selectors', 'high', 'No DKIM records found', {
+				confidence: 'heuristic',
+				selectorsChecked: ['default', 'google'],
+			}),
+		];
+		// DKIM not found → controlPresent: false. The provider-context rebuild must
+		// preserve it; detectDomainContext reads controlPresent, not finding prose.
+		const result = buildCheckResult('dkim', findings, false);
+		expect(result.controlPresent).toBe(false);
+		const adjusted = applyProviderDkimContext(result, 'google workspace');
+		expect(adjusted.controlPresent).toBe(false);
+	});
+
 	it('applyProviderDkimContext adds low finding for medium-confidence provider', async () => {
 		const { applyProviderDkimContext } = await import('../src/tools/check-dkim');
 		const findings = [

--- a/test/context-profiles.spec.ts
+++ b/test/context-profiles.spec.ts
@@ -17,7 +17,9 @@ function makeCheckResult(category: CheckCategory, score: number, findings: Retur
 			findings = [createFinding(category, `${category} issue`, 'medium', 'Issue detected')];
 		}
 	}
-	return buildCheckResult(category, findings);
+	// A passing (score 100) synthetic check expresses "control present & active"; a failing one
+	// expresses "absent/inactive". Mirrors how the real checks set controlPresent.
+	return buildCheckResult(category, findings, score === 100);
 }
 
 function fullPassingResults(overrides?: Partial<Record<CheckCategory, ReturnType<typeof buildCheckResult>>>) {
@@ -33,7 +35,7 @@ describe('context-profiles', () => {
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
-				]),
+				], true),
 			});
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('enterprise_mail');
@@ -45,7 +47,7 @@ describe('context-profiles', () => {
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'MX records found', 'info', 'mail.example.com'),
-				]),
+				], true),
 			});
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('mail_enabled');
@@ -56,7 +58,7 @@ describe('context-profiles', () => {
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'No MX records found', 'high', 'No MX records found for domain'),
-				]),
+				], false),
 			});
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('web_only');
@@ -68,15 +70,15 @@ describe('context-profiles', () => {
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'No MX records found', 'high', 'No MX records found for domain'),
-				]),
+				], false),
 				caa: buildCheckResult('caa', [
 					createFinding('caa', 'No CAA records', 'critical', 'No CAA records found'),
 					createFinding('caa', 'CAA missing', 'high', 'CAA is required'),
-				]),
+				], false),
 				ssl: buildCheckResult('ssl', [
 					createFinding('ssl', 'SSL check failed', 'critical', 'No valid certificate found'),
 					createFinding('ssl', 'SSL required', 'high', 'Certificate is required'),
-				]),
+				], false),
 			});
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('non_mail');
@@ -105,15 +107,15 @@ describe('context-profiles', () => {
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'Null MX record (RFC 7505)', 'info', 'Domain explicitly declares it does not accept email via null MX record.'),
-				]),
+				], false),
 				caa: buildCheckResult('caa', [
 					createFinding('caa', 'No CAA records', 'critical', 'No CAA records found'),
 					createFinding('caa', 'CAA missing', 'high', 'CAA is required'),
-				]),
+				], false),
 				ssl: buildCheckResult('ssl', [
 					createFinding('ssl', 'SSL check failed', 'critical', 'No valid certificate found'),
 					createFinding('ssl', 'SSL required', 'high', 'Certificate is required'),
-				]),
+				], false),
 			});
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('non_mail');
@@ -124,7 +126,7 @@ describe('context-profiles', () => {
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'Null MX record (RFC 7505)', 'info', 'Domain explicitly declares it does not accept email via null MX record.'),
-				]),
+				], false),
 			});
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('web_only');
@@ -149,11 +151,81 @@ describe('context-profiles', () => {
 			expect(ctx.profile).toBe('mail_enabled');
 		});
 
+		// --- controlPresent structured-signal discriminators (#1+#2) ---
+		// These encode that profile detection must use an *active record observed* signal, not a
+		// bare passed===true (true for absent-but-not-penalized controls) or finding prose.
+
+		it('does NOT over-fire enterprise_mail when provider MX present but no ACTIVE hardening', () => {
+			// Google Workspace MX, but MTA-STS/BIMI absent (passed:true, controlPresent:false) and
+			// DKIM absent. Old code read mtaStsResult.passed/bimiResult.passed === true → enterprise_mail.
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
+				], true),
+				dkim: buildCheckResult('dkim', [
+					createFinding('dkim', 'No DKIM records found among tested selectors', 'high', 'No DKIM among tested selectors'),
+				], false),
+				mta_sts: buildCheckResult('mta_sts', [
+					createFinding('mta_sts', 'No MTA-STS or TLS-RPT records found', 'low', 'Neither MTA-STS nor TLS-RPT present (non-mail).'),
+				], false),
+				bimi: buildCheckResult('bimi', [
+					createFinding('bimi', 'No BIMI record found', 'low', 'No BIMI record found.'),
+				], false),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('mail_enabled');
+			expect(ctx.signals).not.toContain('MTA-STS present');
+			expect(ctx.signals).not.toContain('BIMI present');
+		});
+
+		it('does NOT count a revoked DKIM key as an active hardening signal', () => {
+			// All-revoked DKIM (info finding, passed:true, controlPresent:false) is the only hardening
+			// candidate. Old prose check (severity!=='info') treated revoked as present → enterprise_mail.
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
+				], true),
+				dkim: buildCheckResult('dkim', [
+					createFinding('dkim', 'DKIM selectors revoked', 'info', 'All 1 DKIM selector(s) have revoked keys (empty p= tag).'),
+				], false),
+				mta_sts: buildCheckResult('mta_sts', [
+					createFinding('mta_sts', 'No MTA-STS or TLS-RPT records found', 'low', 'Neither MTA-STS nor TLS-RPT present (non-mail).'),
+				], false),
+				bimi: buildCheckResult('bimi', [
+					createFinding('bimi', 'No BIMI record found', 'low', 'No BIMI record found.'),
+				], false),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('mail_enabled');
+			expect(ctx.signals).not.toContain('DKIM present');
+		});
+
+		it('detects non_mail (not web_only) for a sparse domain whose CAA is absent-but-passed', () => {
+			// No MX, no HTTPS, and CAA absent (medium "No CAA records" → passed:true, controlPresent:false).
+			// Old code read caaResult.passed === true → web_only. With controlPresent it is non_mail.
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'No MX and no SPF — domain spoofable', 'medium', 'No mail exchange records and no SPF policy.'),
+				], false),
+				ssl: buildCheckResult('ssl', [
+					createFinding('ssl', 'HTTPS connection failed', 'high', 'No valid certificate / unreachable.'),
+				], false),
+				caa: buildCheckResult('caa', [
+					createFinding('caa', 'No CAA records', 'medium', 'No CAA records found for domain.'),
+				], false),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('non_mail');
+			expect(ctx.signals).toContain('No MX records');
+			expect(ctx.signals).not.toContain('CAA present');
+			expect(ctx.signals).not.toContain('SSL valid');
+		});
+
 		it('explicit profile override replaces detected profile in signals', () => {
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'MX records found', 'info', 'mail.example.com'),
-				]),
+				], true),
 			});
 			const ctx = detectDomainContext(results);
 			// Detection should give mail_enabled

--- a/test/tls-probe-binding.spec.ts
+++ b/test/tls-probe-binding.spec.ts
@@ -153,4 +153,15 @@ describe('mergeTlsFinding', () => {
 		expect(merged.findings.length).toBe(base.findings.length + 1);
 		expect(merged.findings.some((f) => f.severity === 'high')).toBe(true);
 	});
+
+	it('preserves controlPresent when adding a weak-TLS finding (profile detection depends on it)', async () => {
+		const { mergeTlsFinding } = await fresh();
+		const { buildCheckResult, createFinding } = await import('../src/lib/scoring');
+		// HTTPS-reachable → controlPresent: true. The weak-TLS rebuild must NOT drop it,
+		// or detectDomainContext sees sslPass=false and can misclassify the profile.
+		const base = buildCheckResult('ssl', [createFinding('ssl', 'HTTPS ok', 'info', 'ok')], true);
+		expect(base.controlPresent).toBe(true);
+		const merged = mergeTlsFinding(base, { reachable: true, minVersion: 'TLS1.0' });
+		expect(merged.controlPresent).toBe(true);
+	});
 });


### PR DESCRIPTION
## What

Profile detection (`detectDomainContext`) selects which per-profile weight table `getProfileWeights` uses on the `auto` scan path — a **score-bearing** input. It previously inferred control presence from a check's `passed` flag and **regex-matched finding prose**, which over-fired `enterprise_mail` and misdetected sparse-but-resolving domains as hardened (the same class of brittleness that sank the reverted P2 prose-detection in #346).

Replace that with a structured tri-state `controlPresent?: boolean` on `CheckResult`:
- `true` — active control observed
- `false` — definitively absent / inactive
- `undefined` — lookup failed (can't measure)

Set by the six checks `detectDomainContext` consumes (`mx`, `dkim`, `mta_sts`, `bimi`, `ssl`, `caa`) and read directly — no prose matching.

## Also: two post-processing strip-points fixed

`scan_domain` re-runs `detectDomainContext` *after* two post-processing rebuilds that used 2-arg `buildCheckResult` and silently dropped `controlPresent`:
- **`mergeTlsFinding` (ssl)** — a legacy-TLS-but-reachable host had `controlPresent` flipped `true→undefined`, flipping `sslPass` false and shifting the detected profile **in prod** (operator-only `BV_TLS_PROBE`; absent locally, so the measurement below is unaffected). Real bug.
- **`applyProviderDkimContext` (dkim)** — preserved for correctness; harmless today (only runs on the not-found branch where `controlPresent` is already `false`, and detection reads `=== true`).

Both now thread the original `controlPresent` through, with RED→GREEN tests proving the strip.

## Measurement

90-domain sample, **same-config explicit-profile delta** (isolates score impact from config differences):
- `enterprise_mail` detection: **87% → 62%**. Residual is by design — the enterprise definition is `provider + any one active control`, and Google Workspace / M365 auto-provision DKIM, so most managed-mail domains still land in `enterprise` correctly. This **reduces** the over-fire; it does not "solve" whether `provider + 1 control` is the right bar (separate, still-open lever).
- Per-domain score impact bounded **~±2 pts (mean +0.69)** on the dominant `enterprise_mail ↔ mail_enabled` transition. The 3 `→non_mail` transitions weren't score-measured and can swing more (non_mail zeroes email-category weights).

Bumps `SCORING_MODEL_VERSION` 1.0.0 → 1.1.0 (profile detection is a scoring-policy input).

## Test
- RED→GREEN unit tests for both strip-points + 3 detection discriminator tests in `context-profiles.spec.ts`
- Full suite: 5012 passed (8 errors = known pool-teardown WebSocket flake), typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)