### PR TITLE
fix(scoring): gate enterprise_mail on enforcing DMARC, not provider + auto-DKIM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Changed
+
+- **`enterprise_mail` profile now requires enforcing DMARC, not provider + any auto-provisioned control.** The detected profile selects the per-profile scoring weight table, and `enterprise_mail` applies a stricter lens (heavier DMARC/DNSSEC/DKIM weighting). The gate was `enterprise provider + any one of {DKIM, MTA-STS, BIMI} present` — but Google Workspace and M365 auto-provision DKIM, so `provider + DKIM` was nearly automatic and over-classified ordinary managed-mail domains as enterprise. The gate is now `enterprise provider + enforcing DMARC (p=quarantine|reject)` — enforcement is a deliberate maturity choice, never auto-provisioned. `check-dmarc` sets the structured `controlPresent` signal to mean "DMARC is an active anti-spoofing control" (enforcing; `p=none` is monitoring-only → `false`; DNS failure → `undefined`), and `detectDomainContext` reads it (no finding-prose matching). **Measured** on a 379-domain portfolio sample: `enterprise_mail` classification dropped from 248 (65%) to 106 (28%); all reclassified domains move to `mail_enabled` (a slightly more lenient lens) with a **per-domain score impact ≤2 pts (same-config, local measurement)** — the two weight tables are close, and on prod (which overrides core weights via `SCORING_CONFIG`) the profile delta reduces to the protective/hardening weights, so local ≤2 is a conservative upper bound. `SCORING_MODEL_VERSION` → `1.2.0`.
+
 ## [3.8.0] - 2026-06-03
 
 Scoring-honesty release: profile detection now keys on observed controls rather than a `passed` flag or finding prose, and a SERVFAIL apex is reported as a distinct "DNS resolution broken" state instead of a fabricated low score. These **do** shift some per-domain scores (bounded ~±2 pts via profile reselection), so `SCORING_MODEL_VERSION` advances to `1.1.0`.

--- a/packages/dns-checks/src/checks/check-dmarc.ts
+++ b/packages/dns-checks/src/checks/check-dmarc.ts
@@ -91,7 +91,9 @@ export async function checkDMARC(
 	const walk = await dmarcTreeWalk(domain, queryDNS, timeout);
 
 	if (!walk.foundAt) {
-		return buildCheckResult('dmarc', classifyDmarc({ recordCount: 0, policy: null, domain }));
+		// No DMARC record at all → not an active control. controlPresent:false (definitively
+		// absent; a DNS *error* throws out of the tree-walk instead, leaving controlPresent undefined).
+		return buildCheckResult('dmarc', classifyDmarc({ recordCount: 0, policy: null, domain }), false);
 	}
 
 	// A record found above the queried domain is inherited via the org domain.
@@ -148,5 +150,11 @@ export async function checkDMARC(
 	// Closing reassurance finding, evaluated over the COMPLETE finding set.
 	appendDmarcCleanInfo(findings, facts.policy);
 
-	return buildCheckResult('dmarc', findings);
+	// controlPresent = DMARC is an ACTIVE anti-spoofing control = enforcing (p=quarantine|reject).
+	// p=none is monitoring-only (not enforcing → false). Consumed by detectDomainContext as the
+	// enterprise_mail maturity gate. pct< 100 is intentionally not de-rated here, matching the
+	// existing scan post-processing enforcement convention.
+	const dmarcEnforcing = policy === 'quarantine' || policy === 'reject';
+
+	return buildCheckResult('dmarc', findings, dmarcEnforcing);
 }

--- a/packages/dns-checks/src/scoring/profiles.ts
+++ b/packages/dns-checks/src/scoring/profiles.ts
@@ -260,6 +260,7 @@ export function detectDomainContext(results: CheckResult[]): DomainContext {
 	const dkimResult = results.find((r) => r.category === 'dkim');
 	const mtaStsResult = results.find((r) => r.category === 'mta_sts');
 	const bimiResult = results.find((r) => r.category === 'bimi');
+	const dmarcResult = results.find((r) => r.category === 'dmarc');
 
 	// Detect MX presence from the structured controlPresent signal (set by check-mx), not finding
 	// prose. true = real mail-routing MX; false = no MX or null MX (RFC 7505 → not a mail domain);
@@ -305,7 +306,13 @@ export function detectDomainContext(results: CheckResult[]): DomainContext {
 	const bimiPresent = bimiResult?.controlPresent === true;
 	if (bimiPresent) signals.push('BIMI present');
 
-	const hasHardeningSignal = dkimPresent || mtaStsPresent || bimiPresent;
+	// Enterprise-maturity gate: DMARC is an ACTIVE anti-spoofing control only when enforcing
+	// (check-dmarc sets controlPresent = p=quarantine|reject). Unlike DKIM — which Google Workspace
+	// and M365 auto-provision, so provider+DKIM was nearly automatic — enforcement is a deliberate
+	// policy choice. This is what gates the stricter enterprise_mail lens (was: any one of
+	// DKIM/MTA-STS/BIMI present, which over-fired enterprise_mail on managed-provider SMB domains).
+	const dmarcEnforcing = dmarcResult?.controlPresent === true;
+	if (dmarcEnforcing) signals.push('DMARC enforcing');
 
 	// Detect web indicators: reachable HTTPS / published CAA, again via controlPresent (a sparse
 	// domain whose CAA is "absent-but-passed" must not read as web_only).
@@ -333,7 +340,7 @@ export function detectDomainContext(results: CheckResult[]): DomainContext {
 	} else if (hasMxUnknown || !hasMx) {
 		// MX lookup failed or no MX result at all → default to mail_enabled (safe fallback)
 		profile = 'mail_enabled';
-	} else if (hasMx && hasEnterpriseProvider && hasHardeningSignal) {
+	} else if (hasMx && hasEnterpriseProvider && dmarcEnforcing) {
 		profile = 'enterprise_mail';
 	} else {
 		profile = 'mail_enabled';

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -29,8 +29,11 @@
  * - 1.1.0 — profile detection now requires an active observed control (`controlPresent`)
  *   instead of bare `passed`/finding prose. Corrects `enterprise_mail` over-fire and
  *   sparse-domain misdetection; per-domain score impact is bounded (~±2 pts).
+ * - 1.2.0 — `enterprise_mail` now requires enforcing DMARC (p=quarantine|reject) behind a
+ *   managed provider, not provider + any one auto-provisioned control (DKIM). Tightens the
+ *   stricter-lens membership; reclassified domains move to `mail_enabled` (slightly more lenient).
  */
-export const SCORING_MODEL_VERSION = '1.1.0';
+export const SCORING_MODEL_VERSION = '1.2.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/test/check-dmarc.spec.ts
+++ b/test/check-dmarc.spec.ts
@@ -73,6 +73,29 @@ describe('checkDmarc', () => {
 		expect(finding!.severity).toBe('low');
 	});
 
+	// controlPresent = "DMARC is an ACTIVE anti-spoofing control" = enforcing (p=quarantine|reject).
+	// Consumed by detectDomainContext for the enterprise_mail bar (a managed-provider domain is only
+	// scored under the stricter enterprise lens when it enforces DMARC). p=none is monitoring-only.
+	it('sets controlPresent=true for enforcing DMARC (p=reject)', async () => {
+		mockTxtRecords(['v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc@example.com']);
+		expect((await run()).controlPresent).toBe(true);
+	});
+
+	it('sets controlPresent=true for enforcing DMARC (p=quarantine)', async () => {
+		mockTxtRecords(['v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com']);
+		expect((await run()).controlPresent).toBe(true);
+	});
+
+	it('sets controlPresent=false for monitoring-only DMARC (p=none)', async () => {
+		mockTxtRecords(['v=DMARC1; p=none; rua=mailto:dmarc@example.com']);
+		expect((await run()).controlPresent).toBe(false);
+	});
+
+	it('sets controlPresent=false when no DMARC record exists', async () => {
+		mockTxtRecords([]);
+		expect((await run()).controlPresent).toBe(false);
+	});
+
 	it('should return info finding for p=reject with rua and sp', async () => {
 		mockTxtRecords(['v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc@example.com; ruf=mailto:forensic@example.com']);
 		const result = await run();

--- a/test/context-profiles.spec.ts
+++ b/test/context-profiles.spec.ts
@@ -31,7 +31,9 @@ function fullPassingResults(overrides?: Partial<Record<CheckCategory, ReturnType
 
 describe('context-profiles', () => {
 	describe('detectDomainContext', () => {
-		it('detects enterprise_mail when MX + Google Workspace provider + DKIM present', () => {
+		it('detects enterprise_mail when MX + Google Workspace provider + enforcing DMARC', () => {
+			// fullPassingResults defaults dmarc to a passing (controlPresent:true = enforcing) result,
+			// so this is provider + enforcing DMARC → enterprise_mail.
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
@@ -40,6 +42,7 @@ describe('context-profiles', () => {
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('enterprise_mail');
 			expect(ctx.signals).toContain('MX present');
+			expect(ctx.signals).toContain('DMARC enforcing');
 			expect(ctx.signals.some((s) => s.includes('google workspace'))).toBe(true);
 		});
 
@@ -156,12 +159,15 @@ describe('context-profiles', () => {
 		// bare passed===true (true for absent-but-not-penalized controls) or finding prose.
 
 		it('does NOT over-fire enterprise_mail when provider MX present but no ACTIVE hardening', () => {
-			// Google Workspace MX, but MTA-STS/BIMI absent (passed:true, controlPresent:false) and
-			// DKIM absent. Old code read mtaStsResult.passed/bimiResult.passed === true → enterprise_mail.
+			// Google Workspace MX, but MTA-STS/BIMI absent (passed:true, controlPresent:false), DKIM
+			// absent, and DMARC monitoring-only (p=none → controlPresent:false). No enterprise gate met.
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
 				], true),
+				dmarc: buildCheckResult('dmarc', [
+					createFinding('dmarc', 'DMARC policy set to none', 'low', 'p=none — monitoring only.'),
+				], false),
 				dkim: buildCheckResult('dkim', [
 					createFinding('dkim', 'No DKIM records found among tested selectors', 'high', 'No DKIM among tested selectors'),
 				], false),
@@ -179,12 +185,15 @@ describe('context-profiles', () => {
 		});
 
 		it('does NOT count a revoked DKIM key as an active hardening signal', () => {
-			// All-revoked DKIM (info finding, passed:true, controlPresent:false) is the only hardening
-			// candidate. Old prose check (severity!=='info') treated revoked as present → enterprise_mail.
+			// All-revoked DKIM (info finding, passed:true, controlPresent:false). With DMARC also
+			// non-enforcing, no enterprise gate is met → mail_enabled (DKIM not counted as present).
 			const results = fullPassingResults({
 				mx: buildCheckResult('mx', [
 					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
 				], true),
+				dmarc: buildCheckResult('dmarc', [
+					createFinding('dmarc', 'DMARC policy set to none', 'low', 'p=none — monitoring only.'),
+				], false),
 				dkim: buildCheckResult('dkim', [
 					createFinding('dkim', 'DKIM selectors revoked', 'info', 'All 1 DKIM selector(s) have revoked keys (empty p= tag).'),
 				], false),
@@ -198,6 +207,48 @@ describe('context-profiles', () => {
 			const ctx = detectDomainContext(results);
 			expect(ctx.profile).toBe('mail_enabled');
 			expect(ctx.signals).not.toContain('DKIM present');
+		});
+
+		// --- enterprise_mail bar: requires enforcing DMARC, not provider + auto-DKIM (Option C) ---
+
+		it('does NOT classify enterprise_mail on provider + auto-DKIM when DMARC is monitoring-only (p=none)', () => {
+			// Google Workspace + DKIM present (auto-provisioned), but DMARC p=none → controlPresent:false.
+			// The enterprise lens is stricter; applying it requires a deliberate maturity signal
+			// (enforcing DMARC), which p=none is not. Should fall back to mail_enabled.
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
+				], true),
+				dmarc: buildCheckResult('dmarc', [
+					createFinding('dmarc', 'DMARC policy set to none', 'low', 'p=none — monitoring only, not enforcing.'),
+				], false),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('mail_enabled');
+		});
+
+		it('classifies enterprise_mail on provider + enforcing DMARC (p=reject) even without DKIM/MTA-STS/BIMI', () => {
+			// Enforcing DMARC behind a managed provider is the enterprise-maturity signal. It qualifies
+			// on its own — auto-provisioned hardening is no longer what gates the stricter lens.
+			const results = fullPassingResults({
+				mx: buildCheckResult('mx', [
+					createFinding('mx', 'MX records found', 'info', 'Mail handled by Google Workspace', { provider: 'Google Workspace' }),
+				], true),
+				dmarc: buildCheckResult('dmarc', [
+					createFinding('dmarc', 'DMARC enforcing', 'info', 'p=reject — enforcing policy.'),
+				], true),
+				dkim: buildCheckResult('dkim', [
+					createFinding('dkim', 'No DKIM records found among tested selectors', 'high', 'No DKIM among tested selectors'),
+				], false),
+				mta_sts: buildCheckResult('mta_sts', [
+					createFinding('mta_sts', 'No MTA-STS or TLS-RPT records found', 'low', 'Neither present.'),
+				], false),
+				bimi: buildCheckResult('bimi', [
+					createFinding('bimi', 'No BIMI record found', 'low', 'No BIMI record found.'),
+				], false),
+			});
+			const ctx = detectDomainContext(results);
+			expect(ctx.profile).toBe('enterprise_mail');
 		});
 
 		it('detects non_mail (not web_only) for a sparse domain whose CAA is absent-but-passed', () => {


### PR DESCRIPTION
## Summary

Tightens the `enterprise_mail` profile gate. The detected profile selects the per-profile scoring weight table, and `enterprise_mail` applies a **stricter lens** (heavier DMARC/DNSSEC/DKIM weighting). The old gate fired too easily:

- **Was:** `enterprise provider + any one of {DKIM, MTA-STS, BIMI} present`
- **Problem:** Google Workspace and M365 **auto-provision DKIM**, so `provider + DKIM` was nearly automatic — ordinary managed-mail SMB domains got the enterprise lens.
- **Now:** `enterprise provider + enforcing DMARC (p=quarantine|reject)`. Enforcement is a deliberate operator maturity choice, never auto-provisioned — a much better proxy for "this org runs mail at enterprise rigor."

Mechanism: `check-dmarc` now sets the structured `controlPresent` tri-state to mean *"DMARC is an active anti-spoofing control"* — `true` when enforcing, `false` for `p=none` (monitoring-only) or no record, `undefined` on DNS failure. `detectDomainContext` reads that signal directly (no finding-prose matching), consistent with the `controlPresent` convention shipped in #348.

## Measured impact

379-domain portfolio sample (local, repo-default config):

- `enterprise_mail` classification: **248 (65%) → 106 (28%)**
- All reclassified domains move to `mail_enabled` (slightly more lenient lens)
- Per-domain score impact **≤2 pts (same-config, local)** — the two weight tables are close. On prod (core weights overridden via `SCORING_CONFIG`) the profile delta reduces to the protective/hardening weights, so local ≤2 is a conservative upper bound.
- Spot-checked the reclassified set via ground-truth `check_dmarc`: all genuinely lack enforcing DMARC (no false reclassification). Domains that **stay** enterprise enforce by construction (`controlPresent===true` requires `p∈{quarantine,reject}`).

`SCORING_MODEL_VERSION` → `1.2.0`.

## Verification

- TDD: RED→GREEN on 4 new `check-dmarc` `controlPresent` tests + 2 new `context-profiles` detection tests
- Full suite green (known pool-teardown WebSocket flake aside), typecheck + lint clean
- Single-gate confirmed: only `detectDomainContext` assigns `enterprise_mail`; `controlPresent` is reader-clean (only `detectDomainContext` branches on it; not in any wire schema)

## Test plan

- [x] `npx vitest run test/check-dmarc.spec.ts test/context-profiles.spec.ts`
- [x] `npm run typecheck && npm run lint`
- [x] Portfolio measurement + ground-truth spot-check

🤖 Generated with [Claude Code](https://claude.com/claude-code)