### PR TITLE
chore: release 3.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.9.0] - 2026-06-03
+
+Scoring-policy release: the `enterprise_mail` profile gate now requires enforcing DMARC behind a managed provider rather than any auto-provisioned control. This reselects the per-profile weight table for a large share of managed-mail domains (membership shift only — the scoring math is unchanged), so per-domain scores move within a bounded band and `SCORING_MODEL_VERSION` advances to `1.2.0`.
+
 ### Changed
 
 - **`enterprise_mail` profile now requires enforcing DMARC, not provider + any auto-provisioned control.** The detected profile selects the per-profile scoring weight table, and `enterprise_mail` applies a stricter lens (heavier DMARC/DNSSEC/DKIM weighting). The gate was `enterprise provider + any one of {DKIM, MTA-STS, BIMI} present` — but Google Workspace and M365 auto-provision DKIM, so `provider + DKIM` was nearly automatic and over-classified ordinary managed-mail domains as enterprise. The gate is now `enterprise provider + enforcing DMARC (p=quarantine|reject)` — enforcement is a deliberate maturity choice, never auto-provisioned. `check-dmarc` sets the structured `controlPresent` signal to mean "DMARC is an active anti-spoofing control" (enforcing; `p=none` is monitoring-only → `false`; DNS failure → `undefined`), and `detectDomainContext` reads it (no finding-prose matching). **Measured** on a 379-domain portfolio sample: `enterprise_mail` classification dropped from 248 (65%) to 106 (28%); all reclassified domains move to `mail_enabled` (a slightly more lenient lens) with a **per-domain score impact ≤2 pts (same-config, local measurement)** — the two weight tables are close, and on prod (which overrides core weights via `SCORING_CONFIG`) the profile delta reduces to the protective/hardening weights, so local ≤2 is a conservative upper bound. `SCORING_MODEL_VERSION` → `1.2.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.8.0",
+	"version": "3.9.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.8.0",
+			"version": "3.9.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.8.0",
+	"version": "3.9.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.8.0",
+	"version": "3.9.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Summary

Formalizes **3.9.0** — promotes the `enterprise_mail` enforcing-DMARC gate (#351) from `[Unreleased]` to a dated release.

Version-sync surfaces (all → `3.9.0`):
- `package.json` + `package-lock.json`
- `server.json` top-level `version` (remotes-only, single field — no `packages` stanza)
- `CHANGELOG.md` `[3.9.0] - 2026-06-03` heading (+ fresh empty `[Unreleased]`)
- `SERVER_VERSION` auto-derives from `pkg.version` (not hand-edited)

## What's in the release

`enterprise_mail` now requires **enforcing DMARC behind a managed provider** instead of provider + any auto-provisioned control (#351). Membership reselection only — scoring math unchanged. `SCORING_MODEL_VERSION` → `1.2.0`.

## Release sequence

After this merges: tag `v3.9.0` on the squashed commit → `publish.yml` cuts the GH Release (Cloudflare deploy `cancelled` by design, npm/registry `skipped`). **Prod deploy and MCP Registry publish are separate go-live steps** (registry must follow deploy, never lead it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)