### PR TITLE
fix(dkim): report malformed/truncated keys instead of false ~512-bit critical

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/dkim-key-strength.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dkim-key-strength.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, vi } from 'vitest';
+import { analyzeKeyStrength } from '../../checks/dkim-analysis';
+import { checkDKIM } from '../../checks/check-dkim';
+import type { DNSQueryFunction } from '../../types';
+
+// Real RSA SubjectPublicKeyInfo base64, generated with openssl.
+const REAL_512 =
+	'MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBANtwUuPMzIURXcYu/62Q/q8CNmoqMWL+hJeBnDFjurqU28y02wO6fUMQcBs5oHN/32qa9VGDE6BgnABPd0GWDwECAwEAAQ==';
+const REAL_2048 =
+	'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAscfuKyPiWgOCZZ9swgCi4A96RmZadSQeVBH5UfaRuMs1NNh2Se+wewffsV/2XNNrquxh9eZXW/dVK5wztMX4lFzaSL7XWg5coxxvbe88z2eQT8wkLSFTNSRsc+fFb7xny56IEi2iqfV9BHzL25Eh/prfpqHz8Tm08plQ5UkcNJXNagPXOp2mZBAKyWcdO+0gDVrBRdDZyxjYUxlr6rp0zxGtyotVMCQHWx3JjGxABWkMnkf0+w6oeyWeYyrecZMCR244C/yw1b68POoy5HdaBisbFQwHz8hfBnzkYgjHQiYIRQYxBa3akGFwkwap4dTNfiHj4Q1mWNr7IFFR8iy11wIDAQAB';
+// A 2048-bit key truncated in DNS — the real-world failure mode (zerojet.com: single
+// truncated RR; aryde.io: key split across 3 separate TXT RRs so only a fragment is read).
+// The DER header still declares 2048-bit; only the modulus data is missing.
+const TRUNCATED_2048 = REAL_2048.slice(0, 120);
+
+function createMockDNS(records: Record<string, string[]>): DNSQueryFunction {
+	return vi.fn(async (domain: string, _type: string) => records[domain] ?? []);
+}
+
+describe('analyzeKeyStrength — malformed/truncated RSA keys', () => {
+	it('classifies a truncated 2048-bit-header key as malformed, not a weak ~512-bit key', () => {
+		const result = analyzeKeyStrength(TRUNCATED_2048, 'rsa');
+		expect(result.keyType).toBe('rsa-malformed');
+		expect(result.strength).not.toBe('critical');
+		expect(result.bits).toBe(2048); // declared size from the DER header
+	});
+
+	it('still flags a genuine complete 512-bit RSA key as critical', () => {
+		const result = analyzeKeyStrength(REAL_512, 'rsa');
+		expect(result).toMatchObject({ bits: 512, strength: 'critical', keyType: 'rsa' });
+	});
+
+	it('still treats a genuine complete 2048-bit RSA key as strong', () => {
+		const result = analyzeKeyStrength(REAL_2048, 'rsa');
+		expect(result).toMatchObject({ bits: 2048, strength: 'info', keyType: 'rsa' });
+	});
+});
+
+describe('checkDKIM — truncated key does not produce a false weak-key critical', () => {
+	it('reports a malformed/truncated finding instead of "Weak RSA key (~512 bits)"', async () => {
+		const queryDNS = createMockDNS({
+			'google._domainkey.example.com': [`v=DKIM1; k=rsa; p=${TRUNCATED_2048}`],
+		});
+		const result = await checkDKIM('example.com', queryDNS);
+
+		const weakCritical = result.findings.find((f) => /weak rsa key/i.test(f.title) && f.severity === 'critical');
+		expect(weakCritical).toBeUndefined();
+
+		const malformed = result.findings.find((f) => /malformed/i.test(f.title));
+		expect(malformed).toBeDefined();
+		expect(malformed?.severity).toBe('medium');
+	});
+});

--- a/packages/dns-checks/src/checks/check-dkim.ts
+++ b/packages/dns-checks/src/checks/check-dkim.ts
@@ -165,6 +165,21 @@ export async function checkDKIM(
 								},
 							),
 						);
+					} else if (keyAnalysis.keyType === 'rsa-malformed') {
+						findings.push(
+							createFinding(
+								'dkim',
+								`Malformed DKIM key: ${result.selector}`,
+								'medium',
+								`DKIM selector "${result.selector}" declares a ~${keyAnalysis.bits}-bit RSA key but the published key material is truncated or incomplete in DNS — commonly caused by splitting the key across multiple TXT records instead of one. DKIM signature verification fails until the full public key is republished as a single TXT record (RFC 6376 §3.6.2).`,
+								{
+									estimatedBits: keyAnalysis.bits,
+									keyType: 'rsa-malformed',
+									selector: result.selector,
+									...(delegatedTo ? { delegatedTo } : {}),
+								},
+							),
+						);
 					} else if (keyAnalysis.keyType === 'rsa') {
 						const severityMsg =
 							keyAnalysis.strength === 'critical'

--- a/packages/dns-checks/src/checks/dkim-analysis.ts
+++ b/packages/dns-checks/src/checks/dkim-analysis.ts
@@ -16,8 +16,22 @@ export type DkimKeyStrength = 'critical' | 'high' | 'medium' | 'info';
 export type DkimKeyAnalysis = {
 	bits: number | null;
 	strength: DkimKeyStrength;
-	keyType: 'rsa' | 'ed25519' | 'unknown';
+	keyType: 'rsa' | 'ed25519' | 'unknown' | 'rsa-malformed';
 };
+
+/**
+ * Canonical SubjectPublicKeyInfo DER prefixes (base64) that identify the declared RSA
+ * modulus size. These bytes precede the modulus, so they survive truncation: a key whose
+ * data is cut short — or split across multiple TXT RRs (RFC 6376 §3.6.2 violation), so the
+ * resolver returns only a fragment — still carries its declared-size header. `fullChars` is
+ * the base64 length of a *complete* key of that size (deterministic for DER).
+ */
+const RSA_SPKI_HEADERS: ReadonlyArray<{ prefix: string; bits: number; fullChars: number }> = [
+	{ prefix: 'MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBA', bits: 512, fullChars: 128 },
+	{ prefix: 'MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB', bits: 1024, fullChars: 216 },
+	{ prefix: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A', bits: 2048, fullChars: 392 },
+	{ prefix: 'MIICIjANBgkqhkiG9w0BAQEFAAOCAg8A', bits: 4096, fullChars: 736 },
+];
 
 export function getDkimTagValue(record: string, tag: string): string | undefined {
 	if (!/^[a-zA-Z0-9]+$/.test(tag)) return undefined;
@@ -41,6 +55,25 @@ export function analyzeKeyStrength(publicKeyBase64: string | undefined, declared
 
 	const cleanKey = publicKeyBase64.replace(/\s/g, '');
 	const charCount = cleanKey.length;
+
+	// Determine the declared modulus size from the DER header when recognizable. This is
+	// authoritative and survives truncation, so it stops a truncated or fragmented key (e.g.
+	// a 2048-bit key split across multiple TXT records, where the resolver returns only a
+	// short fragment) from being mis-measured as a weak short key by the char-count heuristic.
+	const header = RSA_SPKI_HEADERS.find((h) => cleanKey.startsWith(h.prefix));
+	if (header) {
+		// A complete key of this size has ~fullChars base64 chars. Real truncations seen in
+		// the wild are short fragments (≤60% of full); requiring <70% flags those as malformed
+		// — rather than inventing a small bit-count and escalating to a false "weak key"
+		// critical — while leaving near-complete keys to the normal strength mapping.
+		if (charCount < header.fullChars * 0.7) {
+			return { bits: header.bits, strength: 'medium', keyType: 'rsa-malformed' };
+		}
+		if (header.bits <= 512) return { bits: 512, strength: 'critical', keyType: 'rsa' };
+		if (header.bits <= 1024) return { bits: 1024, strength: 'high', keyType: 'rsa' };
+		if (header.bits < 2048) return { bits: header.bits, strength: 'medium', keyType: 'rsa' };
+		return { bits: header.bits, strength: 'info', keyType: 'rsa' };
+	}
 
 	if (declaredKeyType === 'rsa-default' && charCount < 50) {
 		return { bits: null, strength: 'medium', keyType: 'unknown' };


### PR DESCRIPTION
## Problem

`analyzeKeyStrength` estimated the RSA modulus size purely from the **base64 character count**. So a DKIM key that is **truncated in DNS**, or **split across multiple TXT RRs** (RFC 6376 §3.6.2.2 violation — the resolver returns only a short fragment), fell into the `<150 chars → 512-bit → critical` bucket and produced a false **"Weak RSA key (~512 bits)"** critical for keys that are actually 2048-bit but mis-published.

## How it was found

Surfaced while independently `dig`-fact-checking the Icehouse portfolio scan. Two domains carried false ~512-bit criticals:

- **aryde.io** — google selector key published as **3 separate TXT RRs**; reassembled it is a valid, openssl-verified **2048-bit** key.
- **zerojet.com** — single RR whose `p=` is **truncated mid-key**, but the DER header is the exact 2048-bit prefix `MIIBIjAN…`.

Decoding the google + mandrill DKIM keys across all 365 scored domains confirmed the bug is **confined to malformed records**: the genuine "Legacy RSA key" findings — mandrill 1024-bit ×42, google 1024-bit ×42 — are correct (Mailchimp/Mandrill ships 1024-bit DKIM by default). 8 google keys are malformed-publish, **all with 2048-bit headers**; only 2 tripped the false critical.

## Fix

Recognize the RSA SubjectPublicKeyInfo **DER header** (which encodes the declared modulus size and survives truncation, since the header precedes the modulus). When the published key data is well short of a complete key (`< 70%` of the expected base64 length — real-world truncations observed are ≤60%), emit a `medium` **"Malformed DKIM key"** finding explaining the likely cause, instead of inventing a small bit-count and escalating to `critical`.

- Complete 512/1024/2048/4096-bit keys are classified exactly as before.
- Keys with an unrecognized header fall through to the existing char-count heuristic (no behavior change — covers the existing synthetic-key tests).

## Tests

New `packages/dns-checks/src/__tests__/checks/dkim-key-strength.test.ts` (TDD — written failing first), using **real** openssl-generated keys:
- truncated 2048-header key → `rsa-malformed`, not `critical`; `checkDKIM` emits "Malformed DKIM key" (medium), no "Weak RSA key" critical
- genuine complete 512-bit key → still `critical` (regression guard)
- genuine complete 2048-bit key → still strong/`info`

Verification: `dns-checks` suite 376/376, worker `check-dkim`/`dkim-analysis`/`scan-domain` specs green, repo typecheck clean.

## Note

The canonical fix is in `packages/dns-checks`. `src/tools/dkim-analysis.ts` is a stale, unused duplicate (only its own test imports it; the worker wrapper delegates to `@blackveil/dns-checks`) and is left for a separate dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)