### PR TITLE
fix(spf): anchor SPF detection to start of record (RFC 7208 §4.5) + release 3.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.10.0] - 2026-06-03
+
+SPF detection-accuracy release: `check_spf` now identifies an SPF record per RFC 7208 §4.5 — the record must *begin* with the `v=spf1` version token — instead of matching `v=spf1` anywhere in the TXT data. This corrects a class of false negatives where a malformed record caused a genuinely-unprotected domain to be reported as having SPF. The scoring model is **unchanged** (`SCORING_MODEL_VERSION` stays `1.2.0`): this is a check-detection fix, not a scoring-policy change — but because it corrects the SPF category result, per-domain scores move for the (rare) affected domains, in the direction of correctly penalizing the missing control.
+
+### Fixed
+
+- **`check_spf` anchors SPF detection to the start of the record (RFC 7208 §4.5).** Detection used `concatenatedTxt.match(/v=spf1[^]*/i)` over all TXT records joined together, so any record that merely *contained* `v=spf1` was treated as a valid SPF record. Two real-world malformed shapes slipped through as false negatives: a paste artefact (`"Value: v=spf1 include:… ~all"` — does not begin with `v=spf1`, so receivers ignore it) and run-together mechanisms (`"v=spf1include:…"` — the version token must be followed by a space or end-of-record per the ABNF). Both are now correctly reported as **No SPF record found** (critical), since receivers treat each as having no SPF. Detection now filters per-record with `^v=spf1(\s|$)` (each TXT element is one complete RR — multi-string chunks are pre-joined by the DNS layer per RFC 7208 §3.3, so per-record anchoring is safe). This also removes a latent bug where the old greedy join pulled unrelated TXT records (e.g. vendor verification strings) into the parsed SPF string, and makes the "Multiple SPF records" permerror count from actual records rather than substring occurrences.
+
 ## [3.9.0] - 2026-06-03
 
 Scoring-policy release: the `enterprise_mail` profile gate now requires enforcing DMARC behind a managed provider rather than any auto-provisioned control. This reselects the per-profile weight table for a large share of managed-mail domains (membership shift only — the scoring math is unchanged), so per-domain scores move within a bounded band and `SCORING_MODEL_VERSION` advances to `1.2.0`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.9.0",
+	"version": "3.10.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.9.0",
+			"version": "3.10.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.9.0",
+	"version": "3.10.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
@@ -26,6 +26,43 @@ describe('checkSPF', () => {
 		expect(result.findings[0].title).toBe('No SPF record found');
 	});
 
+	it('returns critical when the record does not begin with v=spf1 (paste-prefix)', async () => {
+		// RFC 7208 §4.5: a TXT record is only an SPF record if it BEGINS with "v=spf1".
+		// "Value: v=spf1 ..." (a copy-paste artefact) is ignored by receivers → no SPF.
+		const queryDNS = createMockDNS({
+			'example.com': ['Value: v=spf1 include:spf.protection.outlook.com ~all'],
+			'_dmarc.example.com': [],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings).toHaveLength(1);
+		expect(result.findings[0].title).toBe('No SPF record found');
+		expect(result.findings[0].severity).toBe('critical');
+	});
+
+	it('returns critical when v=spf1 is not followed by a space (run-together mechanisms)', async () => {
+		// RFC 7208 §4.5 ABNF: the version token must be followed by SP or end-of-record.
+		// "v=spf1include:..." is malformed → receivers treat the domain as having no SPF.
+		const queryDNS = createMockDNS({
+			'example.com': ['v=spf1include:spf.protection.outlook.com~all'],
+			'_dmarc.example.com': [],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings).toHaveLength(1);
+		expect(result.findings[0].title).toBe('No SPF record found');
+		expect(result.findings[0].severity).toBe('critical');
+	});
+
+	it('does not treat an unrelated TXT record containing v=spf1 as an SPF record', async () => {
+		// A record that merely embeds the substring mid-string must not be picked up.
+		const queryDNS = createMockDNS({
+			'example.com': ['contains v=spf1 mid-string but is not an SPF record'],
+			'_dmarc.example.com': [],
+		});
+		const result = await checkSPF('example.com', queryDNS);
+		expect(result.findings).toHaveLength(1);
+		expect(result.findings[0].title).toBe('No SPF record found');
+	});
+
 	it('returns high when multiple SPF records found', async () => {
 		const queryDNS = createMockDNS({
 			'example.com': ['v=spf1 -all', 'v=spf1 ~all'],

--- a/packages/dns-checks/src/checks/check-spf.ts
+++ b/packages/dns-checks/src/checks/check-spf.ts
@@ -122,12 +122,14 @@ export async function checkSPF(
 	const findings: Finding[] = [];
 	const txtRecords = await queryDNS(domain, 'TXT', { timeout });
 
-	// Concatenate all TXT records to handle cases where SPF data is split across multiple records
-	const concatenatedTxt = txtRecords.join('');
-
-	// Extract SPF record from concatenated TXT data
-	const spfMatch = concatenatedTxt.match(/v=spf1[^]*/i);
-	const spfRecords = spfMatch ? [spfMatch[0]] : [];
+	// A TXT record is an SPF record only if it BEGINS with the version token "v=spf1"
+	// followed by a space or end-of-record (RFC 7208 §4.5 / ABNF: version *( SP terms )).
+	// Records that merely contain "v=spf1" mid-string (e.g. a "Value: v=spf1 ..." paste
+	// artefact) or run it together with mechanisms ("v=spf1include:...") are NOT valid SPF
+	// records — receivers ignore them, so the domain is effectively unprotected.
+	// Each element of txtRecords is one complete RR (multi-string chunks are pre-joined by
+	// the DNS layer per RFC 7208 §3.3), so anchoring per-record is safe.
+	const spfRecords = txtRecords.filter((record) => /^v=spf1(\s|$)/i.test(record.trim()));
 
 	if (spfRecords.length === 0) {
 		findings.push(
@@ -146,15 +148,14 @@ export async function checkSPF(
 	const dmarcPolicyToken = trustSurfaceContext.dmarcPolicy?.split(';')[0].trim();
 	const dmarcEnforcing = dmarcPolicyToken === 'reject' || dmarcPolicyToken === 'quarantine';
 
-	// Check for multiple SPF records in the concatenated data
-	const spfMatches = concatenatedTxt.match(/v=spf1/gi);
-	if (spfMatches && spfMatches.length > 1) {
+	// RFC 7208 §4.5: a domain MUST publish exactly one SPF record. More than one is a permerror.
+	if (spfRecords.length > 1) {
 		findings.push(
 			createFinding(
 				'spf',
 				'Multiple SPF records',
 				'high',
-				`Found ${spfMatches.length} SPF records in TXT data. RFC 7208 requires exactly one SPF record per domain. Multiple records cause unpredictable behavior.`,
+				`Found ${spfRecords.length} SPF records in TXT data. RFC 7208 requires exactly one SPF record per domain. Multiple records cause unpredictable behavior.`,
 			),
 		);
 	}

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.9.0",
+	"version": "3.10.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Summary

`check_spf` identified an SPF record by matching `v=spf1` **anywhere** in the joined TXT data (`concatenatedTxt.match(/v=spf1[^]*/i)`), so malformed records were treated as valid SPF — **false negatives** that reported genuinely-unprotected domains as protected. Detection now anchors per-record to RFC 7208 §4.5.

Surfaced by the independent multi-source verification of the Icehouse portfolio scan, which found two domains the scanner failed to flag:

| Domain | Record | RFC 7208 §4.5 | Before | After |
|---|---|---|---|---|
| woolchemy.com | `"Value: v=spf1 include:… ~all"` | doesn't begin with `v=spf1` → no SPF | treated as valid ❌ | `No SPF record found` (critical) ✅ |
| merlot.aero | `"v=spf1include:…~all"` | version token not followed by SP/end → malformed | treated as valid ❌ | `No SPF record found` (critical) ✅ |

## The fix

```js
// before: matches v=spf1 anywhere in the joined blob
const spfRecords = txtRecords.join('').match(/v=spf1[^]*/i) ? [...] : [];
// after: per-record, start-anchored (RFC 7208 §4.5)
const spfRecords = txtRecords.filter((r) => /^v=spf1(\s|$)/i.test(r.trim()));
```

Each `txtRecords` element is one complete RR (multi-string chunks pre-joined by the DNS layer per RFC 7208 §3.3), so per-record anchoring is safe. This also:
- removes a latent bug where the greedy `join('')` pulled **unrelated** TXT records (e.g. vendor verification strings) into the parsed SPF string, and
- counts the **Multiple SPF records** permerror from real records rather than substring occurrences.

## Tests (TDD)

3 new cases in `check-spf.test.ts` (paste-prefix, run-together, substring-not-SPF) — written RED, then GREEN. Full `dns-checks` suite (379) + bv-mcp SPF/scan specs green.

## Versioning

Release **3.10.0** (minor — score-affecting for the rare malformed-SPF domains). **`SCORING_MODEL_VERSION` stays `1.2.0`**: this corrects check *detection*, not the scoring *policy* (the documented bump triggers are all policy-layer: weights/thresholds/penalties/profile detection).

Surfaces synced: `package.json` + lock, `server.json` (top-level), `CHANGELOG.md`; `SERVER_VERSION` auto-derives.

## Follow-ups (not in this PR)
- Tag `v3.10.0` → `deploy:prod` → `mcp-publisher publish` (in that order).
- bv-web re-vendors the `dns-checks` tarball to pick up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)