### PR TITLE
chore(dns-checks): 1.3.14 — surface ScanScore.tierBreakdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 				"wrangler": "^4.96.0"
 			},
 			"engines": {
-				"node": ">=22.0.0"
+				"node": ">=22.13.0"
 			}
 		},
 		"node_modules/@blackveil/bv-whois": {
@@ -8079,7 +8079,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.3.13",
+			"version": "1.3.14",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.13",
+	"version": "1.3.14",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/scoring/scoring-engine.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-engine.spec.ts
@@ -18,6 +18,25 @@ describe('scoring-engine', () => {
 		expect(scan.summary).toContain('Excellent');
 	});
 
+	it('surfaces the three-tier breakdown on the scan score', () => {
+		const scan = computeScanScore([
+			buildCheckResult('http_security', [
+				createFinding('http_security', 'No CSP', 'high', 'Missing Content-Security-Policy'),
+			]),
+		]);
+		expect(scan.tierBreakdown).toBeDefined();
+		expect(typeof scan.tierBreakdown?.core).toBe('number');
+		expect(typeof scan.tierBreakdown?.protective).toBe('number');
+		expect(typeof scan.tierBreakdown?.hardening).toBe('number');
+		// core tier is the 70-point budget; all core checks absent → 100% → full core points
+		expect(scan.tierBreakdown?.core).toBeGreaterThan(0);
+	});
+
+	it('omits the tier breakdown for the degenerate no-checks result', () => {
+		// The empty-results early return is intentionally minimal (optional field absent).
+		expect(computeScanScore([]).tierBreakdown).toBeUndefined();
+	});
+
 	it('applies verified critical penalty during aggregate scoring', () => {
 		const scan = computeScanScore([
 			buildCheckResult('subdomain_takeover', [

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.13';
+export const PARITY_CORPUS_VERSION = '1.3.14';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -321,6 +321,7 @@ export function computeScanScore(results: CheckResult[], context?: DomainContext
 		categoryScores,
 		findings: allFindings,
 		summary,
+		tierBreakdown: genericResult.tierBreakdown,
 	};
 }
 

--- a/packages/dns-checks/src/types.ts
+++ b/packages/dns-checks/src/types.ts
@@ -141,6 +141,15 @@ export interface ScanScore {
 	categoryScores: Record<CheckCategory, number>;
 	findings: Finding[];
 	summary: string;
+	/**
+	 * Points earned per scoring tier (core/protective/hardening) for the overall
+	 * score — the tier-weighted composition behind the headline number, as opposed
+	 * to the per-category `categoryScores`. Structurally identical to `TierBreakdown`
+	 * (scoring/generic); kept inline here because `types` is a leaf module that
+	 * `scoring/generic` imports from. Optional: absent only for the degenerate
+	 * no-checks result.
+	 */
+	tierBreakdown?: { core: number; protective: number; hardening: number };
 }
 
 /** Display/UI weight distribution for categories. NOT used in scoring — see IMPORTANCE_WEIGHTS for actual scoring weights. Exists for category registry and display purposes only. */


### PR DESCRIPTION
## Summary
Surfaces the three-tier scoring breakdown (`core`/`protective`/`hardening`) on the `ScanScore` output. `computeScanScore` already computes it via `computeGenericScore` but dropped it when mapping to `ScanScore`; this returns it (optional field; absent only for the degenerate no-checks result).

**Additive only — no scoring or corpus change.** Consumers (incl. bv-web's scan envelope) can now show the tier composition behind the headline score vs the per-category bars.

## Changes
- `packages/dns-checks/src/types.ts` — `ScanScore.tierBreakdown?` (inline shape; `types` is the leaf module `scoring/generic` imports from, so can't import `TierBreakdown` without a cycle).
- `packages/dns-checks/src/scoring/engine.ts` — `computeScanScore` returns `tierBreakdown: genericResult.tierBreakdown`.
- Release **1.3.14**: `package.json` + lock + `PARITY_CORPUS_VERSION` synced (contract test asserts `pkg.version === corpus version`; bv-web's parity audit asserts the same).
- Unit tests: `computeScanScore` surfaces the breakdown / omits it for no-checks.

## Verify
- `packages/dns-checks` scoring + parity-corpus contract tests: 82 passed (version-lock now 1.3.14).
- Consumed by bv-web via re-vendored tarball (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)