### PR TITLE
feat(brand-audit): combosquat detection + generation

### DIFF
--- a/src/lib/brand-classification.ts
+++ b/src/lib/brand-classification.ts
@@ -20,6 +20,7 @@ import { sameRegistrarFamily } from './registrar-identity';
 import { clearsOwnershipGate, clearsTier1GraphEvidence, type BrandEvidenceObservation } from './brand-evidence';
 import type { BrandDiscoveryTier } from './brand-discovery-tiers';
 import { extractBrandName } from './public-suffix';
+import { combosquatMatch } from './domain-similarity';
 
 /**
  * Buckets emitted by the classifier.
@@ -332,6 +333,54 @@ export function isImpersonation(c: CandidateInput, t: TargetContext): string[] {
 	];
 }
 
+/**
+ * Pure combosquat predicate: the candidate's registrable label embeds the
+ * target's brand token as a bounded segment alongside another token
+ * (`paypal-login.com`, `secure-microsoft.net`, `paypallogin.com`). Whole-label
+ * edit distance scores these well below `IMPERSONATION_LOOKALIKE_THRESHOLD`, so
+ * `isImpersonation` cannot see them — this is a distinct check on token
+ * containment (`combosquatMatch`). Gated identically to impersonation: a
+ * registrar-family match signals a defensive registration (not abuse), and any
+ * shared-infrastructure / cross-channel signal should have routed to shadowIt
+ * earlier. Caller must have eliminated the consolidated/shadowIt branches first.
+ */
+export function isCombosquat(c: CandidateInput, t: TargetContext): string[] {
+	const brandToken = extractBrandName(t.domain);
+	const candidateLabel = extractBrandName(c.domain);
+	if (!brandToken || !candidateLabel) return [];
+
+	const match = combosquatMatch(brandToken, candidateLabel);
+	if (!match) return [];
+
+	// FP guard: a brand token beside a *generic* token (`apple-shop`, `apple-cz`)
+	// is as often legitimate/defensive as abusive (cf. the thesis's 20-legit +
+	// 22-defensive of 50 low-distance hits). Only assert impersonation when a
+	// credential-phishing lure keyword corroborates intent; non-lure combos fall
+	// through to the indeterminate / manual-review path. The lure set is the
+	// tunable knob in `domain-similarity.ts`.
+	if (!match.hasLureKeyword) return [];
+
+	// Registrar-family match signals defensive registration, not impersonation.
+	const sameFamily = sameRegistrarFamily(
+		{ name: c.registrar, ianaId: c.registrarIanaId },
+		{ name: t.registrar, ianaId: t.registrarIanaId },
+	);
+	if (sameFamily) return [];
+
+	// Any shared cross-channel signal should have routed to shadowIt already;
+	// belt-and-braces so the predicate is callable in isolation.
+	const sharedTxt = (c.sharedTxtVerifications ?? []).length > 0;
+	const sharedMx = !!c.sharedMxPlatform;
+	if (sharedTxt || sharedMx || hasSharedInfrastructureSignal(c)) return [];
+
+	const extra = match.extraTokens.map((tok) => `'${tok}'`).join(', ');
+	return [
+		`combosquat: label embeds brand token '${match.brandToken}' + ${extra} (${match.matchKind})`,
+		'contains credential-phishing lure keyword',
+		`registrar mismatch (candidate=${normalizeRegistrar(c.registrar) || 'Unknown'}, target=${t.registrarFamily || 'Unknown'})`,
+	];
+}
+
 function signalLabel(s: string): string {
 	switch (s) {
 		case 'san':
@@ -500,6 +549,17 @@ export function classifyCandidate(c: CandidateInput, t: TargetContext): Classifi
 	const impersonationReasons = isImpersonation(c, t);
 	if (impersonationReasons.length > 0) {
 		reasons.push(...impersonationReasons);
+		return classification('impersonation', tier, 'impersonation_risk', reasons);
+	}
+
+	// Rule 4.7: Combosquat — brand token embedded as a segment in a longer label
+	// (`paypal-login.com`). Whole-label edit distance scores these below the
+	// impersonation threshold, so Rule 4.6 misses them; detect via token
+	// containment. Fires before Rule 5 so a combosquat with redacted RDAP still
+	// surfaces as impersonation rather than vanishing into indeterminate.
+	const combosquatReasons = isCombosquat(c, t);
+	if (combosquatReasons.length > 0) {
+		reasons.push(...combosquatReasons);
 		return classification('impersonation', tier, 'impersonation_risk', reasons);
 	}
 

--- a/src/lib/domain-similarity.ts
+++ b/src/lib/domain-similarity.ts
@@ -24,3 +24,132 @@ export function domainLabelSimilarity(target: string, candidate: string): number
 	const maxLen = Math.max(left.length, right.length);
 	return Math.round((1 - levenshtein(left, right) / maxLen) * 100) / 100;
 }
+
+// ---------------------------------------------------------------------------
+// Combosquat detection
+//
+// Whole-label edit distance (`domainLabelSimilarity`) cannot see `paypal` inside
+// `paypal-login` — appending a token inflates the denominator and collapses the
+// score below any useful threshold. Combosquats are instead detected by treating
+// the label as a token sequence and asking whether the brand token appears as a
+// bounded segment alongside ≥1 other token. See `combosquatMatch`.
+// ---------------------------------------------------------------------------
+
+/**
+ * KNOB (yours to tune): lure keywords that signal credential-phishing intent.
+ *
+ * Two jobs: (1) escalate combosquat severity when an extra token is one of these,
+ * and (2) gate the collision-prone undelimited branch (a concatenated match only
+ * counts when the non-brand remainder is exactly one of these words).
+ *
+ * Keep entries lowercase and singular. Adding a generic word here (e.g. `app`,
+ * `web`) widens recall but raises false positives on the undelimited branch.
+ */
+const LURE_KEYWORDS: ReadonlySet<string> = new Set([
+	'login',
+	'signin',
+	'logon',
+	'secure',
+	'security',
+	'verify',
+	'verification',
+	'account',
+	'support',
+	'help',
+	'billing',
+	'pay',
+	'payment',
+	'update',
+	'confirm',
+	'service',
+	'auth',
+	'sso',
+	'mail',
+	'webmail',
+	'portal',
+	'wallet',
+	'recovery',
+	'alert',
+]);
+
+/**
+ * KNOB (yours to tune): minimum brand-token length for a *delimited* segment
+ * match (`brand` is its own hyphen/dot/underscore segment). Below this, short
+ * brand tokens collide with ordinary words too often (`hp`, `ge`, `bp`).
+ */
+const COMBOSQUAT_MIN_DELIMITED_LEN = 4;
+
+/**
+ * KNOB (yours to tune): minimum brand-token length for an *undelimited* match
+ * (`brand` concatenated with a lure keyword, no separator). Stricter than the
+ * delimited case because concatenation is inherently more collision-prone.
+ * Set this to `Infinity` to disable the undelimited branch entirely (i.e. only
+ * ever match clean `brand-keyword` segments — the lowest-false-positive mode).
+ */
+const COMBOSQUAT_MIN_UNDELIMITED_LEN = 6;
+
+export interface CombosquatMatch {
+	/** The brand token that was found within the candidate label. */
+	brandToken: string;
+	/** Every label token that is NOT the brand token. */
+	extraTokens: string[];
+	/** True when at least one extra token is a known lure keyword. */
+	hasLureKeyword: boolean;
+	/** Whether the brand token was found as a delimited segment or concatenated. */
+	matchKind: 'delimited' | 'undelimited';
+}
+
+/** Split a label into tokens on hyphen / underscore / dot runs, dropping empties. */
+function splitLabelTokens(label: string): string[] {
+	return label
+		.split(/[-_.]+/)
+		.map((t) => t.trim())
+		.filter((t) => t.length > 0);
+}
+
+/**
+ * Detect whether `candidateLabel` is a combosquat of `brandToken` — i.e. the
+ * brand token appears as a bounded segment of a longer label alongside at least
+ * one other token (`paypal-login`, `login-paypal`, `paypallogin`).
+ *
+ * Callers pass already-extracted labels (e.g. via `extractBrandName`), not full
+ * domains, so this stays dependency-free. An exact label match (`paypal` ===
+ * `paypal`) returns null — that is an owned portfolio domain, not a combosquat.
+ *
+ * Returns the match detail (for finding reasons + severity) or null.
+ */
+export function combosquatMatch(brandToken: string, candidateLabel: string): CombosquatMatch | null {
+	const brand = brandToken.trim().toLowerCase();
+	const label = candidateLabel.trim().toLowerCase();
+	if (!brand || !label || label === brand) return null;
+
+	// Delimited: brand token is its own segment, with ≥1 sibling token.
+	if (brand.length >= COMBOSQUAT_MIN_DELIMITED_LEN) {
+		const tokens = splitLabelTokens(label);
+		if (tokens.length >= 2 && tokens.includes(brand)) {
+			const extraTokens = tokens.filter((t) => t !== brand);
+			return {
+				brandToken: brand,
+				extraTokens,
+				hasLureKeyword: extraTokens.some((t) => LURE_KEYWORDS.has(t)),
+				matchKind: 'delimited',
+			};
+		}
+	}
+
+	// Undelimited: brand token concatenated with a single lure keyword and no
+	// separator. The exact-keyword test on the remainder is what keeps this from
+	// firing on innocent substrings (`fabricpay`, `pineapple`, `paypalways`).
+	if (brand.length >= COMBOSQUAT_MIN_UNDELIMITED_LEN) {
+		const remainder = label.startsWith(brand)
+			? label.slice(brand.length)
+			: label.endsWith(brand)
+				? label.slice(0, label.length - brand.length)
+				: null;
+		if (remainder && LURE_KEYWORDS.has(remainder)) {
+			return { brandToken: brand, extraTokens: [remainder], hasLureKeyword: true, matchKind: 'undelimited' };
+		}
+	}
+
+	return null;
+}

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -13,7 +13,7 @@ import { callReconScan, isReconHit } from '../lib/recon-binding';
 import type { ReconBinding } from '../lib/recon-binding';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
-import { generateLookalikes } from './lookalike-analysis';
+import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
 import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg } from './check-rdap-lookup';
 import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSignals } from './lookalike-severity';
 
@@ -280,7 +280,11 @@ async function checkLookalikesCore(
 	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string } = {},
 ): Promise<CheckResult> {
 	const findings: Finding[] = [];
-	const permutations = generateLookalikes(domain);
+	// Typo/homoglyph permutations PLUS combosquats (brand + lure affix). The two
+	// generators are disjoint by construction — combosquats defeat the edit-distance
+	// mutators — so the union is deduped to a single candidate set that flows through
+	// the same NS-existence → probe → enrich → severity pipeline.
+	const permutations = [...new Set([...generateLookalikes(domain), ...generateCombosquats(domain)])];
 
 	if (permutations.length === 0) {
 		findings.push(

--- a/src/tools/lookalike-analysis.ts
+++ b/src/tools/lookalike-analysis.ts
@@ -174,3 +174,44 @@ export function generateLookalikes(domain: string): string[] {
 
 	return results.slice(0, MAX_PERMUTATIONS);
 }
+
+/**
+ * Credential-phishing affixes used for combosquat *generation*. Deliberately a
+ * focused subset of the highest-signal lure words — generation pays one DNS
+ * probe per candidate, so it has a tighter cost/recall tradeoff than the
+ * free pattern-matching `LURE_KEYWORDS` set used for detection in
+ * `domain-similarity.ts`. Tune for probe budget, not for recall.
+ */
+const COMBOSQUAT_AFFIXES = ['login', 'signin', 'secure', 'verify', 'account', 'support', 'billing', 'update', 'mail', 'pay'] as const;
+
+/** Cap on combosquat permutations returned — bounds the extra DNS-probe cost. */
+const MAX_COMBOSQUATS = 20;
+
+/**
+ * Generate combosquat permutations: the brand label combined with a
+ * credential-phishing affix, hyphen-delimited, in both positions
+ * (`brand-login.com`, `login-brand.com`).
+ *
+ * Combosquats defeat whole-label edit distance (appending a token collapses the
+ * normalized score), so the typo-based {@link generateLookalikes} never produces
+ * them — this is the proactive counterpart to the detection-side
+ * `combosquatMatch`. Returns up to {@link MAX_COMBOSQUATS} unique, valid,
+ * alphabetically sorted permutations. Delimited-only by design: undelimited
+ * concatenations are too collision-prone to probe speculatively.
+ */
+export function generateCombosquats(domain: string): string[] {
+	const normalizedDomain = domain.toLowerCase();
+	const { base, tld } = splitDomainTld(normalizedDomain);
+	if (!base || !tld) return [];
+
+	const candidates = new Set<string>();
+	for (const affix of COMBOSQUAT_AFFIXES) {
+		candidates.add(`${base}-${affix}${tld}`);
+		candidates.add(`${affix}-${base}${tld}`);
+	}
+
+	return Array.from(candidates)
+		.filter((candidate) => candidate !== normalizedDomain && isDomainValid(candidate))
+		.sort()
+		.slice(0, MAX_COMBOSQUATS);
+}

--- a/test/brand-classification-combosquat.test.ts
+++ b/test/brand-classification-combosquat.test.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { classifyCandidate, isCombosquat, type CandidateInput, type TargetContext } from '../src/lib/brand-classification';
+
+const TARGET: TargetContext = {
+	domain: 'paypal.com',
+	registrar: 'MarkMonitor Inc.',
+	registrarFamily: 'MarkMonitor',
+};
+
+function candidate(overrides: Partial<CandidateInput> & { domain: string }): CandidateInput {
+	return {
+		confidence: 0.45,
+		signals: ['markov_gen'],
+		registrar: 'NameCheap, Inc.',
+		registrarSource: 'rdap',
+		...overrides,
+	};
+}
+
+describe('combosquat classification (Rule 4.7)', () => {
+	it('routes a cross-registrar combosquat to the impersonation bucket', () => {
+		const result = classifyCandidate(candidate({ domain: 'paypal-login.com' }), TARGET);
+		expect(result.bucket).toBe('impersonation');
+		expect(result.relationshipType).toBe('impersonation_risk');
+		// Proves it routed via Rule 4.7 (token containment) and not the Rule 8
+		// low-confidence catch-all — the reason names the embedded brand token.
+		expect(result.reasons.join(' ')).toMatch(/combosquat: label embeds brand token 'paypal'/);
+		expect(result.reasons.join(' ')).toMatch(/lure keyword/);
+	});
+
+	it('catches combosquats that whole-label similarity misses (lookalikeScore stays 0)', () => {
+		// No lookalikeScore supplied → isImpersonation (Rule 4.6) cannot fire;
+		// only the token-containment branch can flag this.
+		const result = classifyCandidate(candidate({ domain: 'secure-paypal.net' }), TARGET);
+		expect(result.bucket).toBe('impersonation');
+		expect(result.reasons.join(' ')).toMatch(/combosquat/);
+	});
+
+	it('does NOT fire for a brand+generic-token combo with no lure keyword (manual-review case)', () => {
+		// `paypal-shop` embeds the brand token but `shop` is not a lure keyword —
+		// as often legitimate/defensive as abusive, so it stays indeterminate
+		// rather than being accused of impersonation.
+		const result = classifyCandidate(candidate({ domain: 'paypal-shop.com', confidence: 0.6 }), TARGET);
+		expect(result.bucket).toBe('indeterminate');
+		expect(result.reasons.join(' ')).not.toMatch(/combosquat/);
+	});
+
+	it('does NOT fire for a same-registrar-family combosquat (defensive registration)', () => {
+		// Same family ⇒ brand-owned defensive registration. With confidence in the
+		// indeterminate band, the combosquat guard sends it to indeterminate, NOT
+		// impersonation — proving the guard, not the Rule 8 catch-all, decided it.
+		const result = classifyCandidate(
+			candidate({ domain: 'paypal-business.com', confidence: 0.6, registrar: 'MarkMonitor Inc.' }),
+			TARGET,
+		);
+		expect(result.bucket).toBe('indeterminate');
+		expect(result.reasons.join(' ')).not.toMatch(/combosquat/);
+	});
+});
+
+describe('isCombosquat predicate guards', () => {
+	it('returns reasons for a genuine cross-family combosquat', () => {
+		expect(isCombosquat(candidate({ domain: 'paypal-verify.com' }), TARGET).length).toBeGreaterThan(0);
+	});
+
+	it('returns [] when the registrar family matches the target (defensive)', () => {
+		expect(isCombosquat(candidate({ domain: 'paypal-verify.com', registrar: 'MarkMonitor Inc.' }), TARGET)).toEqual([]);
+	});
+
+	it('returns [] when the candidate shares infrastructure with the target (routes to shadowIt earlier)', () => {
+		expect(isCombosquat(candidate({ domain: 'paypal-verify.com', signals: ['ns', 'san'] }), TARGET)).toEqual([]);
+	});
+
+	it('returns [] for an unrelated domain with no brand-token containment', () => {
+		expect(isCombosquat(candidate({ domain: 'totally-different.com' }), TARGET)).toEqual([]);
+	});
+});

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -88,6 +88,32 @@ describe('checkLookalikes', () => {
 		expect(registeredFinding).toBeDefined();
 	});
 
+	it('surfaces a registered combosquat (brand + lure affix) that edit-distance generation misses', async () => {
+		// `paypal-login.com` is a combosquat of `paypal.com`: generateLookalikes
+		// (edit-distance mutators) never produces it — generateCombosquats does.
+		// Give it mail infrastructure so it surfaces at MEDIUM per the #264 matrix,
+		// proving Part 3 generation feeds the same severity pipeline.
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'paypal-login.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.attacker.com.' }]));
+				}
+				if (type === 'A' || type === '1') {
+					return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('paypal.com');
+		const surfaced = result.findings.filter((f) => f.severity === 'medium' || f.severity === 'high');
+		expect(surfaced.length).toBeGreaterThan(0);
+		expect(JSON.stringify(result.findings)).toContain('paypal-login.com');
+	});
+
 	it('should handle individual query failures gracefully via Promise.allSettled', async () => {
 		let callCount = 0;
 		globalThis.fetch = vi.fn().mockImplementation(() => {

--- a/test/domain-similarity.test.ts
+++ b/test/domain-similarity.test.ts
@@ -1,11 +1,60 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { describe, expect, it } from 'vitest';
-import { domainLabelSimilarity } from '../src/lib/domain-similarity';
+import { combosquatMatch, domainLabelSimilarity } from '../src/lib/domain-similarity';
 
 describe('domainLabelSimilarity', () => {
 	it('scores close typo labels higher than unrelated labels', () => {
 		expect(domainLabelSimilarity('example.com', 'examp1e.com')).toBeGreaterThanOrEqual(0.85);
 		expect(domainLabelSimilarity('example.com', 'totallydifferent.net')).toBeLessThan(0.5);
+	});
+
+	it('cannot see a brand token inside a longer combosquat label (the gap combosquatMatch fills)', () => {
+		// `paypal-login` vs `paypal` scores far below the 0.85 impersonation
+		// threshold — this is exactly why combosquats need a separate detector.
+		expect(domainLabelSimilarity('paypal', 'paypal-login')).toBeLessThan(0.85);
+	});
+});
+
+describe('combosquatMatch', () => {
+	it('flags delimited brand-token segments (brand-keyword, keyword-brand)', () => {
+		expect(combosquatMatch('paypal', 'paypal-login')).toMatchObject({
+			brandToken: 'paypal',
+			extraTokens: ['login'],
+			hasLureKeyword: true,
+			matchKind: 'delimited',
+		});
+		expect(combosquatMatch('paypal', 'secure-paypal')).toMatchObject({ extraTokens: ['secure'], hasLureKeyword: true });
+		expect(combosquatMatch('microsoft', 'login.microsoft.update')).toMatchObject({ matchKind: 'delimited' });
+	});
+
+	it('flags a non-lure extra token but marks hasLureKeyword false (severity hint, still a match)', () => {
+		expect(combosquatMatch('paypal', 'paypal-shop')).toMatchObject({ extraTokens: ['shop'], hasLureKeyword: false });
+	});
+
+	it('flags undelimited concatenation only when the remainder is a known lure keyword', () => {
+		expect(combosquatMatch('paypal', 'paypallogin')).toMatchObject({ matchKind: 'undelimited', extraTokens: ['login'] });
+		expect(combosquatMatch('microsoft', 'verifymicrosoft')).toMatchObject({ matchKind: 'undelimited', extraTokens: ['verify'] });
+		// remainder is not a lure keyword → not a combosquat
+		expect(combosquatMatch('paypal', 'paypalways')).toBeNull();
+	});
+
+	it('does NOT match an exact label (owned portfolio domain, not a combosquat)', () => {
+		expect(combosquatMatch('paypal', 'paypal')).toBeNull();
+	});
+
+	it('does NOT match a short brand token concatenated into an unrelated word (FP guard)', () => {
+		expect(combosquatMatch('pay', 'fabricpay')).toBeNull(); // brand too short for either branch
+		expect(combosquatMatch('hp', 'shop')).toBeNull();
+	});
+
+	it('does NOT match a long brand token that is merely a substring of one bigger word', () => {
+		expect(combosquatMatch('apple', 'pineapple')).toBeNull(); // < undelimited min len AND no lure remainder
+		expect(combosquatMatch('amazon', 'amazonianforest')).toBeNull(); // remainder `ianforest` is not a lure keyword
+	});
+
+	it('handles empty / whitespace input safely', () => {
+		expect(combosquatMatch('', 'paypal-login')).toBeNull();
+		expect(combosquatMatch('paypal', '   ')).toBeNull();
 	});
 });

--- a/test/lookalike-analysis.spec.ts
+++ b/test/lookalike-analysis.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { generateLookalikes } from '../src/tools/lookalike-analysis';
+import { generateCombosquats, generateLookalikes } from '../src/tools/lookalike-analysis';
 
 describe('generateLookalikes', () => {
 	it('generates expected permutation types for a simple domain', () => {
@@ -63,5 +63,48 @@ describe('generateLookalikes', () => {
 		const results = generateLookalikes('pool.com');
 		// o→0 substitution
 		expect(results).toContain('p0ol.com');
+	});
+
+	it('does NOT generate combosquats (those defeat edit-distance mutators)', () => {
+		const results = generateLookalikes('paypal.com');
+		expect(results).not.toContain('paypal-login.com');
+		expect(results).not.toContain('login-paypal.com');
+	});
+});
+
+describe('generateCombosquats', () => {
+	it('generates brand+affix combos in both positions, hyphen-delimited', () => {
+		const results = generateCombosquats('paypal.com');
+		expect(results).toContain('paypal-login.com');
+		expect(results).toContain('login-paypal.com');
+		expect(results).toContain('secure-paypal.com');
+		expect(results).toContain('paypal-verify.com');
+	});
+
+	it('preserves the original TLD (including multi-part TLDs)', () => {
+		expect(generateCombosquats('example.co.uk')).toContain('example-login.co.uk');
+	});
+
+	it('caps output and never includes the original domain', () => {
+		const results = generateCombosquats('paypal.com');
+		expect(results.length).toBeLessThanOrEqual(20);
+		expect(results).not.toContain('paypal.com');
+	});
+
+	it('produces only structurally valid, alphabetically sorted domains', () => {
+		const results = generateCombosquats('my-brand.com');
+		expect(results).toEqual([...results].sort());
+		for (const domain of results) {
+			const labels = domain.split('.');
+			expect(labels.length).toBeGreaterThanOrEqual(2);
+			for (const label of labels) {
+				expect(label.length).toBeGreaterThan(0);
+				expect(label.length).toBeLessThanOrEqual(63);
+			}
+		}
+	});
+
+	it('returns [] for input with no resolvable TLD', () => {
+		expect(generateCombosquats('localhost')).toEqual([]);
 	});
 });


### PR DESCRIPTION
> [!IMPORTANT]
> **HELD — do not merge until the 3.10.0 release lands.** This branched off `0579a9c` while a concurrent 3.10.0 release was in flight on `main`. Keep as draft until that release is deployed + tagged, then rebase/merge.

## Problem

Whole-label edit distance can't see a brand token embedded in a longer label — `paypal-login.com` scores ~0.45 against `paypal`, below the 0.85 impersonation threshold — so **combosquats** (brand token + another word) were missed on both sides: never *generated* by `check_lookalikes`, and never *classified* when surfaced via brand-audit discovery.

## What's in this PR

**Part 1+2 — detection/classification** (`92d95c5`)
- `combosquatMatch()` (`domain-similarity.ts`) — pure token-containment helper: delimited (`paypal-login`) + gated undelimited (`paypallogin`) matching, with FP guards (min brand-token length, exact-segment match, lure-keyword gate).
- **Rule 4.7** in `classifyCandidate` — wires it in after the impersonation rule, reusing the existing `impersonation` / `impersonation_risk` bucket. **No new enum** → zero churn in the report renderer, API contract, or bucket-coverage audit.

**Part 3 — proactive generation** (`dae16a1`)
- `generateCombosquats()` (`lookalike-analysis.ts`) — brand + curated lure affix, hyphen-delimited, both positions, capped at 20 to bound DNS-probe cost. Merged (deduped) into `check_lookalikes`'s candidate set; flows through the same NS → probe → enrich → severity pipeline. `calibrateLookalikeSeverity` rates on infrastructure (MX/A/age/disposable-MX/web-content), not similarity, so low-similarity combosquats are rated correctly and the existing shared-NS / same-registrant defensive downgrades apply unchanged.

## Key design decision — lure-keyword gate

The full suite caught an ungated classifier over-firing on `apple-shop` / `apple-cz` (brand + generic/geographic token). Rule 4.7 now requires a credential-phishing **lure keyword** to assert impersonation; non-lure combos fall through to `indeterminate` (manual review). This matches the existing calibrated fixtures and the source thesis's empirical finding (of 50 low-distance hits: 20 legitimate, 22 defensive, ~5 abused).

## Tunable knobs

- `LURE_KEYWORDS` (detection) + `COMBOSQUAT_AFFIXES` (generation) — separate sets by design (detection is free pattern-matching; generation pays one probe per candidate).
- `COMBOSQUAT_MIN_DELIMITED_LEN = 4`, `COMBOSQUAT_MIN_UNDELIMITED_LEN = 6` (set the latter to `Infinity` for exact-segment-only), `MAX_COMBOSQUATS = 20`.

## Tests
- `domain-similarity.test.ts` (+8), `brand-classification-combosquat.test.ts` (+8), `lookalike-analysis.spec.ts` (+6 generation), `check-lookalikes.spec.ts` (+1 integration: registered combosquat with mail infra surfaces at MEDIUM).

**Full suite green in isolation: 5053 passed, 0 failed** (run in a dedicated worktree to avoid the concurrent release's churn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)