### PR TITLE
chore(dns-checks): bump 1.3.13 → 1.3.15 (parity corpus + version)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 				"wrangler": "^4.96.0"
 			},
 			"engines": {
-				"node": ">=22.0.0"
+				"node": ">=22.13.0"
 			}
 		},
 		"node_modules/@blackveil/bv-whois": {
@@ -8079,7 +8079,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.3.13",
+			"version": "1.3.15",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.13",
+	"version": "1.3.15",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.13';
+export const PARITY_CORPUS_VERSION = '1.3.15';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):


### PR DESCRIPTION
## Summary

Bumps `@blackveil/dns-checks` **1.3.13 → 1.3.15** and advances `PARITY_CORPUS_VERSION` in lockstep, so the next tarball vendored into bv-web traces to a real commit.

### Why
Five dns-checks-affecting fixes landed without a sub-package bump (#345/#348/#351 scoring, #353 DKIM truncated-key, #354 SPF anchoring). bv-web ended up vendoring an **orphan `1.3.14`** tarball that traces to no bv-mcp commit (this repo's `package.json` was still `1.3.13`). Bumping to **`1.3.15`** (skipping the orphan `1.3.14`) restores reproducibility.

### Lockstep version-lock
`PARITY_CORPUS_VERSION` (exported from the package) must equal `package.json` version:
- bv-mcp `parity-corpus.contract.test.ts` asserts `pkg.version === PARITY_CORPUS_VERSION`
- bv-web's wrapper tests assert `installed === PARITY_CORPUS_VERSION`

### No fixtures regenerated
The SPF (#354) and DKIM (#353) detection fixes move **no** parity-corpus score — all **379** dns-checks tests + bv-web's **539** parity/version-lock tests pass.

### No deploy
The content is already live in prod via bv-mcp **3.10.0** (`deploy:prod`, Version ID `c902fa14…`). This is a version-label/reproducibility fix only.

Paired with the bv-web re-vendor PR (1.3.14 → 1.3.15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)