### PR TITLE
feat(schemas): declare force_refresh on cached tools + forward it in scan-delegating tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.12.0] - 2026-06-03
+
+Cache-control discoverability release: `force_refresh` is now declared in the published `inputSchema` of every **cached** tool, so clients can discover the cache-bypass instead of relying on undocumented passthrough. The flag already functioned at runtime on the `check_*` tools (central `skipCache` + `BaseDomainArgs.passthrough()`); this release makes it visible and fixes the scan-delegating tools that silently ignored it. The scoring model is **unchanged** (`SCORING_MODEL_VERSION` stays `1.2.0`).
+
+### Added
+
+- **`force_refresh` declared on cached tools' `inputSchema`.** Added `force_refresh: z.boolean().optional()` to the 9 Zod schemas backing cached tools — `BaseDomainArgs` (covers ~30 `check_*`/DNS tools in one edit), `CheckDkimArgs`, `CheckFastFluxArgs`, `CheckSubdomainTakeoverArgs`, `CompareDomainsArgs`, `CompareBaselineArgs`, `AnalyzeDriftArgs`, `DiscoverBrandDomainsArgs`, `BrandAuditSingleArgs` (`scan_domain`/`batch_scan` already had it). The flag now appears in those tools' published `inputSchema` so MCP clients can discover and send it. Stateless tools (generators, `explain_finding`, M365/OSINT/recon queries, brand-audit pollers) intentionally **omit** it — there it would be a misleading no-op; a `tool-definitions` contract test enforces the split.
+
+### Fixed
+
+- **Scan-delegating tools now honor `force_refresh`.** `compare_domains`, `compare_baseline`, `generate_fix_plan`, `analyze_drift`, and `map_compliance` call `scanDomain` internally but previously did **not** forward the caller's `force_refresh`, silently serving cached scans. They now thread it through (`analyze_drift`'s stored-baseline read is deliberately untouched — refresh applies only to the fresh comparison scan).
+
 ## [3.11.0] - 2026-06-03
 
 Combosquat detection release: the brand-audit and `check_lookalikes` pipelines now catch combosquatting domains (a brand token embedded in a longer label, e.g. `paypal-login.com`) that whole-label edit distance structurally misses — appending a token inflates `maxLen` and collapses normalized similarity below the lookalike threshold. This release also carries the first shipped `ScanScore.tierBreakdown` output field (#355) and advances the `@blackveil/dns-checks` sub-package to 1.3.15. The scoring model is **unchanged** (`SCORING_MODEL_VERSION` stays `1.2.0`): combosquat is detection coverage and `tierBreakdown` is an additive output field — neither alters weights, thresholds, or grade boundaries.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.11.0",
+	"version": "3.12.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.11.0",
+			"version": "3.12.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.11.0",
+	"version": "3.12.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.11.0",
+	"version": "3.12.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -987,6 +987,7 @@ export async function handleToolsCall(
 				}
 				case 'compare_domains': {
 					const domains = validatedArgs.domains as string[];
+					const forceRefresh = extractForceRefresh(validatedArgs);
 					const compareResults = await compareDomains(domains, {
 						kv: scanCacheKV,
 						signal: AbortSignal.timeout(COMPARE_DOMAINS_SYNC_BUDGET_MS),
@@ -1002,6 +1003,7 @@ export async function handleToolsCall(
 							perCheckTimeoutMs: runtimeOptions?.perCheckTimeoutMs,
 							secondaryDoh: runtimeOptions?.secondaryDoh,
 							infraProbe: runtimeOptions?.infraProbe,
+							...(forceRefresh && { forceRefresh }),
 						},
 					});
 					const compareText = formatDomainComparison(compareResults, effectiveFormat);
@@ -1016,7 +1018,9 @@ export async function handleToolsCall(
 				}
 				case 'compare_baseline': {
 					const baseline = extractBaseline(validatedArgs) as PolicyBaseline;
-					const scan = await scanDomain(validDomain, scanCacheKV, runtimeOptions);
+					const forceRefresh = extractForceRefresh(validatedArgs);
+					const scanOptions = { ...runtimeOptions, ...(forceRefresh && { forceRefresh }) };
+					const scan = await scanDomain(validDomain, scanCacheKV, scanOptions);
 					const result = compareBaseline(scan, baseline);
 					logResult = result.passed ? 'pass' : 'fail';
 					logDetails = result;
@@ -1024,7 +1028,9 @@ export async function handleToolsCall(
 					return buildToolResult(formatBaselineResult(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'generate_fix_plan': {
-					const plan = await generateFixPlan(validDomain, scanCacheKV, runtimeOptions);
+					const forceRefresh = extractForceRefresh(validatedArgs);
+					const scanOptions = { ...runtimeOptions, ...(forceRefresh && { forceRefresh }) };
+					const plan = await generateFixPlan(validDomain, scanCacheKV, scanOptions);
 					logResult = plan.grade;
 					logDetails = plan;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
@@ -1157,7 +1163,9 @@ export async function handleToolsCall(
 						}
 					}
 
-					const scanResult = await scanDomain(validDomain, scanCacheKV, runtimeOptions);
+					const forceRefresh = extractForceRefresh(validatedArgs);
+					const scanOptions = { ...runtimeOptions, ...(forceRefresh && { forceRefresh }) };
+					const scanResult = await scanDomain(validDomain, scanCacheKV, scanOptions);
 					const drift = computeDrift(validDomain, baselineScore, scanResult.score);
 					logResult = drift.classification;
 					logDetails = drift;
@@ -1182,7 +1190,9 @@ export async function handleToolsCall(
 					return buildToolResult(formatSubdomainDiscovery(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'map_compliance': {
-					const result = await mapCompliance(validDomain, scanCacheKV, runtimeOptions);
+					const forceRefresh = extractForceRefresh(validatedArgs);
+					const scanOptions = { ...runtimeOptions, ...(forceRefresh && { forceRefresh }) };
+					const result = await mapCompliance(validDomain, scanCacheKV, scanOptions);
 					logResult = 'mapped';
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -18,6 +18,7 @@ import {
 export const BaseDomainArgs = z
 	.object({
 		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 	})
 	.passthrough();
@@ -45,6 +46,7 @@ export const BatchScanArgs = z
 export const CompareDomainsArgs = z
 	.object({
 		domains: z.array(z.string().min(1).max(253)).min(2).max(5).describe('Domains to compare (2–5 domains)'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 	})
 	.passthrough();
@@ -54,6 +56,7 @@ export const CheckDkimArgs = z
 	.object({
 		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
 		selector: DkimSelectorSchema.optional().describe('DKIM selector. Omit to probe common ones.'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 	})
 	.passthrough();
@@ -135,6 +138,7 @@ export const ExplainFindingArgs = z
 export const CompareBaselineArgs = z
 	.object({
 		domain: DomainSchema.describe('Domain to scan and compare.'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 		baseline: z
 			.object(
@@ -228,6 +232,7 @@ export const AnalyzeDriftArgs = z
 			.describe(
 				'Prior scan reference for drift-over-time analysis: a previous ScanScore JSON STRING, or the literal "cached" to reuse the last cached scan. NOT a policy/requirements object — for compliance enforcement against required controls, use compare_baseline instead.',
 			),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 	})
 	.passthrough();
@@ -247,6 +252,7 @@ export const CheckFastFluxArgs = z
 	.object({
 		domain: DomainSchema.describe('Domain to check (e.g., example.com)'),
 		rounds: z.number().int().min(3).max(5).optional().describe('Number of query rounds (3-5, default 3).'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 	})
 	.passthrough();
@@ -266,6 +272,7 @@ export const CheckSubdomainTakeoverArgs = z
 			.describe(
 				'Optional explicit subdomain list (full FQDNs or short labels). When provided (deduped, capped at 1000), this list is swept instead of the 15-name built-in. Source from Certificate-Transparency enumeration or brand-audit discovery.',
 			),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 	})
 	.passthrough();
@@ -354,6 +361,7 @@ export const DiscoverBrandDomainsArgs = z
 					'Required when discovery_mode is "tiered" and the caller is not an enterprise/owner/partner principal. ' +
 					'Prevents unauthorized mass reconnaissance via deep tier lookups.',
 			),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
 	})
 	.passthrough();
@@ -370,6 +378,7 @@ export const BrandAuditViewSchema = z.enum(['standard', 'csc_complement']);
 export const BrandAuditSingleArgs = z
 	.object({
 		domain: DomainSchema.describe('Target domain to audit (e.g., apple.com).'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run a fresh check. Useful after DNS changes.'),
 		format: BrandAuditFormatSchema.optional().describe('Inline output mode. Defaults to "both".'),
 		min_confidence: z
 			.number()

--- a/test/schemas/tool-definitions.spec.ts
+++ b/test/schemas/tool-definitions.spec.ts
@@ -26,6 +26,52 @@ describe('TOOLS', () => {
 		expect(scan.inputSchema.properties).toHaveProperty('format');
 	});
 
+	// force_refresh is declared in inputSchema for CACHED tools (so clients can discover
+	// the cache-bypass), and intentionally ABSENT from stateless tools (generators,
+	// explain_finding, pure pollers/queries) where it would be a misleading no-op.
+	it('cached tools expose force_refresh; stateless tools do not', () => {
+		const hasForceRefresh = (name: string) =>
+			Boolean(TOOLS.find((t) => t.name === name)?.inputSchema.properties?.force_refresh);
+
+		const cachedTools = [
+			'scan_domain',
+			'batch_scan',
+			'check_spf',
+			'check_lookalikes',
+			'check_dkim',
+			'check_fast_flux',
+			'check_subdomain_takeover',
+			'compare_domains',
+			'compare_baseline',
+			'analyze_drift',
+			'generate_fix_plan',
+			'map_compliance',
+			'discover_brand_domains',
+			'brand_audit_single',
+		];
+		for (const name of cachedTools) {
+			expect(hasForceRefresh(name), `${name} should expose force_refresh`).toBe(true);
+		}
+
+		const statelessTools = [
+			'generate_spf_record',
+			'generate_dmarc_record',
+			'generate_dkim_config',
+			'generate_mta_sts_policy',
+			'generate_rollout_plan',
+			'explain_finding',
+			'get_benchmark',
+			'check_resolver_consistency',
+			'check_root_server_set',
+			'query_signins',
+			'osint_investigate_domain_start',
+			'brand_audit_status',
+		];
+		for (const name of statelessTools) {
+			expect(hasForceRefresh(name), `${name} should NOT expose force_refresh`).toBe(false);
+		}
+	});
+
 	it('check_dkim has selector property', () => {
 		const dkim = TOOLS.find((t) => t.name === 'check_dkim')!;
 		expect(dkim.inputSchema.properties).toHaveProperty('selector');


### PR DESCRIPTION
## What
Declares `force_refresh` in the published `inputSchema` of the **cached** MCP tools so clients can discover the cache-bypass, and fixes the scan-delegating tools that silently ignored it.

### Why
`force_refresh` already *functioned* on every cached tool at runtime — the central dispatch (`handlers/tools.ts:913`) passes `extractForceRefresh(args)` as `skipCache`, and `BaseDomainArgs.passthrough()` lets the flag through. But it was **undocumented**: absent from every tool's `inputSchema`, so neither clients nor operators knew to send it. (Discovered while spot-checking the 3.11.0 combosquat detection — `check_lookalikes` served a stale 60-min cache and there was no advertised way to bypass it. `force_refresh:true` worked once we knew to send it, surfacing 7 live combosquats for `ledger.com`.)

### Changes
- **`src/schemas/tool-args.ts`** — declare `force_refresh: z.boolean().optional()` on the 9 schemas backing cached tools: `BaseDomainArgs` (covers ~30 `check_*`/DNS tools), `CheckDkimArgs`, `CheckFastFluxArgs`, `CheckSubdomainTakeoverArgs`, `CompareDomainsArgs`, `CompareBaselineArgs`, `AnalyzeDriftArgs`, `DiscoverBrandDomainsArgs`, `BrandAuditSingleArgs`. (`ScanDomainArgs`/`BatchScanArgs` already had it.)
- **`src/handlers/tools.ts`** — the 5 scan-delegating tools (`compare_domains`, `compare_baseline`, `generate_fix_plan`, `analyze_drift`, `map_compliance`) called `scanDomain` **without** forwarding `force_refresh`, silently ignoring the caller's flag. Now they thread it through via the same `...(forceRefresh && { forceRefresh })` pattern `scan_domain` uses. (`analyze_drift`'s stored-baseline read is deliberately untouched — refresh applies only to the fresh comparison scan.)
- **`test/schemas/tool-definitions.spec.ts`** — new contract test: cached tools expose `force_refresh`; stateless tools (generators, `explain_finding`, pure pollers/queries) do **not** (it'd be a misleading no-op).

### Scope decision
Cached tools only. Generators, `explain_finding`, M365/OSINT/recon queries, and brand-audit pollers intentionally omit `force_refresh`.

### Verification
- `npm run typecheck` clean.
- Full suite green (Node 22): **452 files / 5056 tests, 0 failures** (8 errors = documented pool-teardown noise).
- New scope-contract test passes (14 cached tools have it, 12 stateless don't).

`SCORING_MODEL_VERSION` unchanged. Additive, backward-compatible schema change; the only runtime behavior change is the 5 delegating tools now honoring a flag they previously dropped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)