### PR TITLE
fix: structured transient-DNS results for direct check_* calls + sharper tool descriptions

### DIFF
--- a/src/lib/dns-error-result.ts
+++ b/src/lib/dns-error-result.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared helper for the DNS-failure-resilience convention (see CLAUDE.md):
+ * a tool called directly (not just via scan_domain's safeCheck) should convert
+ * a top-level DNS failure into a structured CheckResult instead of throwing, so
+ * a direct tools/call returns an actionable finding rather than a generic
+ * transport error.
+ *
+ * The returned shape is byte-for-byte equivalent to what scan-domain's
+ * safeCheck() produces when a check throws — `checkStatus: 'error'` + score 0 +
+ * a high-severity finding. This matters for the scan path: scan_domain's
+ * transient-zero retry (shouldRetry) keys off `checkStatus === 'error'`, and the
+ * scoring engine EXCLUDES `checkStatus`-tagged categories as transient failures
+ * (renormalised, shown n/a) rather than zeroing them. Using `missingControl`
+ * here instead would silently disable the retry and change the display, so do
+ * not switch shapes without re-running test/scan-domain.spec.ts retry cases.
+ *
+ * `partial: true` keeps the transient error OUT of the cache on the direct
+ * registry path (handlers/tools.ts uses `(r) => !r.partial` as its shouldCache
+ * predicate), so a one-off DNS hiccup on a direct check_* call self-heals on the
+ * next call instead of sticking for the 5-minute TTL. (The scan path caches
+ * regardless — unchanged from the prior throw→safeCheck behaviour.)
+ */
+
+import { buildCheckResult, createFinding, type CheckCategory, type CheckResult } from './scoring';
+
+// Mirrors safeCheck()'s allowlist so the surfaced detail stays bounded/safe.
+const SAFE_PREFIXES = ['DNS query', 'Check timed out', 'Check failed', 'Connection', 'timeout'];
+
+/**
+ * Build a transient-failure CheckResult for a caught DNS error. `label` is the
+ * human-readable control name used in the finding text (e.g. 'DMARC', 'TLS-RPT').
+ */
+export function buildDnsErrorResult(category: CheckCategory, label: string, err: unknown): CheckResult {
+	const rawMessage = err instanceof Error ? err.message : 'Check failed';
+	const safeMessage = SAFE_PREFIXES.some((p) => rawMessage.startsWith(p)) ? rawMessage : 'Check failed';
+	const findings = [createFinding(category, `${label} check error`, 'high', `Check failed: ${safeMessage}`, { errorKind: 'dns_error' })];
+	return { ...buildCheckResult(category, findings), score: 0, checkStatus: 'error' as const, partial: true };
+}

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -199,7 +199,8 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		scanIncluded: true,
 	},
 	check_mta_sts: {
-		description: 'Validate MTA-STS SMTP encryption policy.',
+		description:
+			'Check whether a domain enforces SMTP TLS via MTA-STS. Queries _mta-sts.<domain> for the policy TXT record, fetches the published policy file at mta-sts.<domain>, and reports its mode (enforce/testing/none), MX coverage, and whether MX-accepting domains lack a policy. Use to confirm inbound mail is protected against downgrade/MITM.',
 		schema: BaseDomainArgs,
 		group: 'email_auth',
 		tier: 'protective',
@@ -220,28 +221,32 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		scanIncluded: true,
 	},
 	check_bimi: {
-		description: 'Validate BIMI record and VMC evidence.',
+		description:
+			'Check the BIMI brand-logo record at default._bimi.<domain>. Validates the logo URL (l=) and VMC certificate evidence (a=), and verifies the DMARC enforcement prerequisite (p=quarantine/reject) that mail clients require before displaying a BIMI logo. Returns findings for a missing/malformed record or unmet prerequisites. Use to assess brand-indicator readiness in inboxes.',
 		schema: BaseDomainArgs,
 		group: 'brand_threats',
 		tier: 'hardening',
 		scanIncluded: true,
 	},
 	check_tlsrpt: {
-		description: 'Validate TLS-RPT SMTP failure reporting.',
+		description:
+			'Check whether a domain has SMTP TLS Reporting (TLS-RPT) configured. Queries _smtp._tls.<domain> for the v=TLSRPTv1 record and validates its reporting destination (rua= mailto:/https:), flagging a missing record, duplicate records, or an invalid/absent reporting URI. Complements MTA-STS by giving visibility into TLS delivery failures.',
 		schema: BaseDomainArgs,
 		group: 'brand_threats',
 		tier: 'hardening',
 		scanIncluded: true,
 	},
 	check_http_security: {
-		description: 'Audit HTTP security headers (CSP, COOP, etc.).',
+		description:
+			'Audit a domain\'s browser-facing HTTP security headers over HTTPS. Inspects Content-Security-Policy (flagging unsafe-inline/unsafe-eval/wildcards), X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, and the cross-origin isolation headers (COOP/COEP/CORP), and detects CDN/WAF interception. Returns per-header findings for missing or weak protections against XSS, clickjacking, and cross-origin attacks.',
 		schema: BaseDomainArgs,
 		group: 'infrastructure',
 		tier: 'protective',
 		scanIncluded: true,
 	},
 	check_dane: {
-		description: 'Verify DANE/TLSA certificate pinning.',
+		description:
+			'Check DANE/TLSA certificate pinning for SMTP. Resolves the domain\'s MX hosts and looks up TLSA records at _25._tcp.<mx-host>, verifying whether mail-server certificates are bound in DNS for DNSSEC-backed protection against CA misissuance and MITM on inbound mail. Returns findings for absent or malformed TLSA records (not applicable to no-MX/null-MX domains). For HTTPS DANE at _443._tcp, use check_dane_https.',
 		schema: BaseDomainArgs,
 		group: 'infrastructure',
 		tier: 'hardening',
@@ -329,7 +334,8 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		scanIncluded: false,
 	},
 	check_srv: {
-		description: 'Probe SRV records for service footprint.',
+		description:
+			'Map a domain\'s DNS-visible service footprint by probing ~16 common SRV prefixes (email, calendar, messaging, web, directory) in parallel. Returns the discovered services and flags insecure advertisements such as plaintext IMAP/POP3 offered without an encrypted variant. Standalone reconnaissance; not part of the scored scan.',
 		schema: BaseDomainArgs,
 		group: 'infrastructure',
 		tier: 'hardening',
@@ -385,7 +391,8 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		scanIncluded: false,
 	},
 	assess_spoofability: {
-		description: 'Composite email spoofability score (0-100).',
+		description:
+			'Compute a single composite email-spoofability score (0–100) by combining SPF trust surface, DMARC enforcement, and DKIM coverage with interaction multipliers. Note the scale is inverted versus the scan grade: higher = more spoofable, 0 = fully protected, 100 = any server can send as the domain. Returns the score, a risk level (minimal→critical), per-control sub-scores, and a plain-language summary. Use for a quick spoofing-risk read; use scan_domain for the full graded audit.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/tools/check-bimi.ts
+++ b/src/tools/check-bimi.ts
@@ -8,6 +8,7 @@
 import { checkBIMI } from '@blackveil/dns-checks';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
+import { buildDnsErrorResult } from '../lib/dns-error-result';
 import type { CheckResult } from '../lib/scoring';
 import { safeFetch } from '../lib/safe-fetch';
 
@@ -22,9 +23,9 @@ import { safeFetch } from '../lib/safe-fetch';
  * (H2 fix from the 2026-05-08 security audit).
  */
 export async function checkBimi(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
-	return checkBIMI(
-		domain,
-		makeQueryDNS(dnsOptions),
-		{ timeout: dnsOptions?.timeoutMs ?? 5000, fetchFn: safeFetch },
-	) as Promise<CheckResult>;
+	try {
+		return (await checkBIMI(domain, makeQueryDNS(dnsOptions), { timeout: dnsOptions?.timeoutMs ?? 5000, fetchFn: safeFetch })) as CheckResult;
+	} catch (err) {
+		return buildDnsErrorResult('bimi', 'BIMI', err);
+	}
 }

--- a/src/tools/check-dmarc.ts
+++ b/src/tools/check-dmarc.ts
@@ -8,6 +8,7 @@
 import { checkDMARC } from '@blackveil/dns-checks';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
+import { buildDnsErrorResult } from '../lib/dns-error-result';
 import type { CheckResult } from '../lib/scoring';
 
 export { parseDmarcTags } from '@blackveil/dns-checks';
@@ -15,11 +16,14 @@ export { parseDmarcTags } from '@blackveil/dns-checks';
 /**
  * Check DMARC records for a domain.
  * Queries _dmarc.<domain> TXT records and validates policy configuration.
+ *
+ * Top-level DNS failures (timeout, DoH HTTP error, SERVFAIL) are converted to a
+ * structured CheckResult instead of a thrown error — see buildDnsErrorResult.
  */
 export async function checkDmarc(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
-	return checkDMARC(
-		domain,
-		makeQueryDNS(dnsOptions),
-		{ timeout: dnsOptions?.timeoutMs ?? 5000 },
-	) as Promise<CheckResult>;
+	try {
+		return (await checkDMARC(domain, makeQueryDNS(dnsOptions), { timeout: dnsOptions?.timeoutMs ?? 5000 })) as CheckResult;
+	} catch (err) {
+		return buildDnsErrorResult('dmarc', 'DMARC', err);
+	}
 }

--- a/src/tools/check-tlsrpt.ts
+++ b/src/tools/check-tlsrpt.ts
@@ -8,16 +8,20 @@
 import { checkTLSRPT } from '@blackveil/dns-checks';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
+import { buildDnsErrorResult } from '../lib/dns-error-result';
 import type { CheckResult } from '../lib/scoring';
 
 /**
  * Check TLS-RPT records for a domain.
  * Validates the presence and configuration of SMTP TLS Reporting records.
+ *
+ * Top-level DNS failures are converted to a structured CheckResult instead of a
+ * thrown error — see buildDnsErrorResult.
  */
 export async function checkTlsrpt(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
-	return checkTLSRPT(
-		domain,
-		makeQueryDNS(dnsOptions),
-		{ timeout: dnsOptions?.timeoutMs ?? 5000 },
-	) as Promise<CheckResult>;
+	try {
+		return (await checkTLSRPT(domain, makeQueryDNS(dnsOptions), { timeout: dnsOptions?.timeoutMs ?? 5000 })) as CheckResult;
+	} catch (err) {
+		return buildDnsErrorResult('tlsrpt', 'TLS-RPT', err);
+	}
 }

--- a/test/check-dns-error-result.spec.ts
+++ b/test/check-dns-error-result.spec.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Finding 1: every directly-callable check_* wrapper must convert a transient
+ * top-level DNS failure (timeout / network error / SERVFAIL) into a structured
+ * CheckResult with `missingControl: true` + `errorKind`, instead of throwing —
+ * so a direct `tools/call` returns an actionable finding rather than a generic
+ * "unexpected error". check-spf.ts is the documented reference pattern.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { setupFetchMock, mockFetchError } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+// Every directly-callable check wrapper, called with just a domain.
+const WRAPPERS: { name: string; load: () => Promise<(domain: string) => Promise<{ category: string; findings: { metadata?: Record<string, unknown> }[] }>> }[] = [
+	{ name: 'checkDmarc', load: async () => (await import('../src/tools/check-dmarc')).checkDmarc },
+	{ name: 'checkDkim', load: async () => (await import('../src/tools/check-dkim')).checkDkim },
+	{ name: 'checkCaa', load: async () => (await import('../src/tools/check-caa')).checkCaa },
+	{ name: 'checkNs', load: async () => (await import('../src/tools/check-ns')).checkNs },
+	{ name: 'checkMtaSts', load: async () => (await import('../src/tools/check-mta-sts')).checkMtaSts },
+	{ name: 'checkTlsrpt', load: async () => (await import('../src/tools/check-tlsrpt')).checkTlsrpt },
+	{ name: 'checkBimi', load: async () => (await import('../src/tools/check-bimi')).checkBimi },
+	{ name: 'checkDane', load: async () => (await import('../src/tools/check-dane')).checkDane },
+	{ name: 'checkDaneHttps', load: async () => (await import('../src/tools/check-dane-https')).checkDaneHttps },
+	{ name: 'checkSvcbHttps', load: async () => (await import('../src/tools/check-svcb-https')).checkSvcbHttps },
+	{ name: 'checkSubdomailing', load: async () => (await import('../src/tools/check-subdomailing')).checkSubdomailing },
+	{ name: 'checkSubdomainTakeover', load: async () => (await import('../src/tools/check-subdomain-takeover')).checkSubdomainTakeover },
+	{ name: 'checkResolverConsistency', load: async () => (await import('../src/tools/check-resolver-consistency')).checkResolverConsistency },
+	{ name: 'checkSsl', load: async () => (await import('../src/tools/check-ssl')).checkSsl },
+];
+
+describe('check_* wrappers return a structured CheckResult on transient DNS failure', () => {
+	it.each(WRAPPERS)('$name resolves a CheckResult instead of throwing', async ({ load }) => {
+		mockFetchError(new Error('network timeout'));
+		const fn = await load();
+
+		const result = await fn('example.com');
+
+		expect(result).toBeDefined();
+		expect(result.category).toBeTruthy();
+	});
+
+	it('checkDmarc returns a transient-error result (checkStatus=error, score 0) so the scan retry still fires', async () => {
+		mockFetchError(new Error('DNS query failed: network timeout'));
+		const { checkDmarc } = await import('../src/tools/check-dmarc');
+
+		const result = await checkDmarc('example.com');
+
+		expect(result.category).toBe('dmarc');
+		expect(result.checkStatus).toBe('error'); // shouldRetry() keys off this
+		expect(result.score).toBe(0);
+		expect(result.partial).toBe(true); // keeps the transient error out of the 5-min cache (self-heals)
+		const errFinding = result.findings.find((f) => f.metadata?.errorKind === 'dns_error');
+		expect(errFinding).toBeDefined();
+	});
+});

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -457,6 +457,11 @@ describe('handleToolsCall - input validation & errors', () => {
 // -- handleToolsCall error categorization --
 
 describe('handleToolsCall - error categorization', () => {
+	afterEach(() => {
+		vi.doUnmock('../src/tools/check-dmarc');
+		vi.resetModules();
+	});
+
 	async function call(name: string, args: Record<string, unknown> = {}) {
 		const { handleToolsCall } = await import('../src/handlers/tools');
 		return handleToolsCall({ name, arguments: args });
@@ -469,11 +474,19 @@ describe('handleToolsCall - error categorization', () => {
 	});
 
 	it('unexpected errors return generic error with tool name', async () => {
-		// check_spf has its own DNS-failure catch (see Workstream A, 2026-04-25),
-		// so use check_dmarc — still throws on DNS failure and exercises the
-		// handler's generic-error safety net.
-		globalThis.fetch = vi.fn().mockImplementation(() => {
-			throw new Error('ECONNREFUSED');
+		// All check_* wrappers now convert DNS failures into a structured CheckResult
+		// (buildDnsErrorResult), so a thrown fetch no longer reaches the handler. To
+		// exercise the handler's generic-error safety net we force an *unexpected*
+		// throw from the tool's execute path via a module mock.
+		vi.resetModules();
+		vi.doMock('../src/tools/check-dmarc', async (importOriginal) => {
+			const orig = await importOriginal<typeof import('../src/tools/check-dmarc')>();
+			return {
+				...orig,
+				checkDmarc: () => {
+					throw new Error('ECONNREFUSED');
+				},
+			};
 		});
 		const result = await call('check_dmarc', { domain: 'error-test.example.com' });
 		expect(result.isError).toBe(true);

--- a/test/scan-domain-spf-timeout-scoring.spec.ts
+++ b/test/scan-domain-spf-timeout-scoring.spec.ts
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PROOF TEST (audit Finding 1): a transient SPF DNS failure scores DIFFERENTLY
+ * depending on HOW the failure surfaces, which it should not.
+ *
+ *  - check-spf's wrapper CATCHES the DNS error internally and returns a finding
+ *    with { missingControl: true } and NO checkStatus  → scoring ZEROES spf and
+ *    counts it (missingControls[spf]=true, can trip the critical-gap ceiling).
+ *  - The dmarc-style path RETHROWS, so scan-domain's safeCheck catches it and
+ *    stamps checkStatus='error'             → scoring EXCLUDES spf as a transient
+ *    failure (renormalised denominator, shown n/a), per the documented
+ *    "scoring excludes inconclusive" design.
+ *
+ * Both represent the identical real-world condition ("SPF could not be
+ * measured"), so the overall score MUST be the same. This test asserts the
+ * current divergence; once Finding 1 is fixed (transient catch → checkStatus,
+ * not missingControl) the two runs converge and the `toBeLessThan` flips to
+ * `toBe`.
+ */
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { setupFetchMock, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse, createDohResponse } from './helpers/dns-mock';
+import { IN_MEMORY_CACHE } from '../src/lib/cache';
+import { buildCheckResult, createFinding } from '../src/lib/scoring';
+
+const { restore } = setupFetchMock();
+
+beforeEach(() => IN_MEMORY_CACHE.clear());
+afterEach(() => {
+	restore();
+	vi.doUnmock('../src/tools/check-spf');
+	vi.resetModules();
+});
+
+/** Healthy defaults for every check except the one under test. */
+function mockAllChecks() {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		if (url.includes('cloudflare-dns.com')) {
+			if (url.includes('type=TXT') || url.includes('type=16')) {
+				if (url.includes('_dmarc.')) return Promise.resolve(txtResponse('_dmarc.example.com', ['v=DMARC1; p=reject']));
+				if (url.includes('_domainkey.')) return Promise.resolve(txtResponse('default._domainkey.example.com', ['v=DKIM1; k=rsa; p=MIGf']));
+				if (url.includes('_mta-sts.')) return Promise.resolve(txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']));
+				if (url.includes('_smtp._tls.')) return Promise.resolve(txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']));
+				if (url.includes('default._bimi.')) return Promise.resolve(txtResponse('default._bimi.example.com', ['v=BIMI1; l=https://example.com/logo.svg']));
+				return Promise.resolve(txtResponse('example.com', ['v=spf1 include:_spf.google.com -all']));
+			}
+			if (url.includes('type=NS') || url.includes('type=2')) return Promise.resolve(nsResponse('example.com', ['ns1.example.com.', 'ns2.example.com.']));
+			if (url.includes('type=CAA') || url.includes('type=257')) return Promise.resolve(caaResponse('example.com', ['0 issue "letsencrypt.org"']));
+			if (url.includes('type=A') || url.includes('type=1')) return Promise.resolve(dnssecResponse('example.com', true));
+			return Promise.resolve(createDohResponse([], []));
+		}
+		if (url.includes('mta-sts.') && url.includes('.well-known')) return Promise.resolve(httpResponse('version: STSv1\nmode: enforce\nmx: *.example.com\nmax_age: 86400'));
+		if (url.startsWith('https://')) return Promise.resolve(httpResponse('OK'));
+		return Promise.resolve(httpResponse('OK'));
+	});
+}
+
+/** Run a scan where check-spf is mocked to fail in the given way. */
+async function scanWithSpfFailure(mode: 'missingControl' | 'throws') {
+	vi.resetModules();
+	vi.doMock('../src/tools/check-spf', () => ({
+		checkSpf: vi.fn().mockImplementation(async () => {
+			if (mode === 'throws') throw new Error('SPF check timed out');
+			// Mimic check-spf's real internal-catch output.
+			return buildCheckResult('spf', [
+				createFinding('spf', 'SPF check timed out', 'high', 'DNS lookup timed out before the SPF record could be resolved', {
+					errorKind: 'timeout',
+					confidence: 'heuristic',
+					missingControl: true,
+				}),
+			]);
+		}),
+	}));
+	mockAllChecks();
+	IN_MEMORY_CACHE.clear();
+	const { scanDomain } = await import('../src/tools/scan-domain');
+	return scanDomain('example.com');
+}
+
+describe('Finding 1 — a transient check failure scores the same however it surfaces', () => {
+	// SCORING-EQUIVALENCE GUARD (one axis only — see caveat below).
+	//
+	// A transient DNS failure surfaced as a heuristic `missingControl` finding must not
+	// score worse than the same failure surfaced as a `checkStatus`/throw transient.
+	// Verified empirically: both land on the identical overall score because the
+	// `confidence: 'heuristic'` finding never enters the engine's `missingControls` set
+	// (no critical-gap ceiling), so its zeroed category contribution nets out to the
+	// same headline number as transient exclusion.
+	//
+	// CAVEAT: score-equivalent is NOT behaviour-equivalent. The two shapes differ in
+	// scan_domain's transient-zero RETRY: shouldRetry() keys off `checkStatus === 'error'`,
+	// so only the throw/checkStatus shape is retried — a `missingControl` shape is not.
+	// This is why buildDnsErrorResult (the Finding-1 fix) uses `checkStatus`, NOT
+	// `missingControl`. The two corpora are not interchangeable; do not collapse them.
+	it('overall score is identical whether spf fails via internal-catch or via throw', async () => {
+		const viaMissingControl = await scanWithSpfFailure('missingControl');
+		const viaThrow = await scanWithSpfFailure('throws');
+
+		const spfMC = viaMissingControl.checks.find((c) => c.category === 'spf');
+		const spfThrow = viaThrow.checks.find((c) => c.category === 'spf');
+
+		// The two paths produce the asymmetric per-check shape we traced...
+		expect(spfMC?.checkStatus).toBeUndefined(); // internal-catch: no transient marker
+		expect(spfThrow?.checkStatus).toBe('error'); // safeCheck: transient marker → excluded
+		expect(viaMissingControl.score.categoryScores.spf).toBe(0); // present-and-zeroed
+		expect(viaThrow.score.categoryScores.spf).toBeUndefined(); // excluded/n-a
+
+		// ...yet the headline score is the SAME. No regression from the wrapper catch.
+		expect(viaMissingControl.score.overall).toBe(viaThrow.score.overall);
+	});
+});


### PR DESCRIPTION
## Summary

Two independent findings from an MCP best-practices audit of the server. Wrapper-only — **no `@blackveil/dns-checks` change, no version bump, no bv-web re-vendor.**

### Finding 1 — direct `check_*` calls threw on transient DNS failures (`4ea93ea`)
`check_dmarc`, `check_tlsrpt`, and `check_bimi` rethrew DNS errors (timeout / SERVFAIL / network) when called directly via `tools/call`, surfacing a generic *"unexpected error"* to the model instead of an actionable result. Inside `scan_domain` these were masked by `safeCheck`; **direct calls were not.** Empirically, only these **3 of 14** wrappers actually threw — the other 11 already catch internally.

New shared `buildDnsErrorResult` helper mirrors `safeCheck`'s catch output:
- `checkStatus: 'error'` + score 0 → `scan_domain`'s transient-zero **retry keeps firing** (`shouldRetry` keys off `checkStatus === 'error'`) and the scoring engine **excludes** the category as transient rather than zeroing it.
- `partial: true` → the direct registry path (`shouldCache = !r.partial`) **does not cache** the transient error for the 5-min TTL, so a one-off hiccup self-heals on the next call (before, a thrown error was never cached — this preserves that).

### Finding 3 — weak tool descriptions (`fbe540e`)
Rewrote 7 bare verb-phrase descriptions (`check_mta_sts`, `check_bimi`, `check_tlsrpt`, `check_http_security`, `check_dane`, `check_srv`, `assess_spoofability`) into the when/what/returns form, grounded in each tool's actual behavior. No tools added/removed/renamed; counts/metadata unchanged.

## Tests
- New `test/check-dns-error-result.spec.ts` — 14-wrapper `it.each` contract test guarding every directly-callable check against regressing to a throw.
- New `test/scan-domain-spf-timeout-scoring.spec.ts` — documents that the `missingControl` and `checkStatus` shapes score the same overall **but are NOT retry-interchangeable**.
- Verified green: scan retry suite, scoring snapshots, and all aggregator callers (`assess_spoofability`, `validate_fix`, `simulate_attack_paths`, `generate_*`). Typecheck + lint clean.

## Reviewer notes
- **Discovered finding (not fixed here):** `check-spf`/`-ptr`/`-http-security` use the `missingControl` shape (→ *not* retried on transient failure) while this fix uses `checkStatus` (→ retried). CLAUDE.md's "check-spf is the reference" is therefore now inaccurate, and `check_spf` arguably has a latent no-retry-on-transient bug. Left out of scope.
- **Not addressed (held for deliberate decisions):** tool-overload mitigation for the 79-tool surface, idempotency keys on mutating tools, and reading the `MCP-Protocol-Version` request header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)