### PR TITLE
feat(tools): additive _meta.recommended starter-set flag (#363 item 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,15 @@ Transport support:
   + osint_investigation_report   — retrieve report for a completed OSINT investigation
 ```
 
+### Tool discovery metadata (`_meta`)
+
+`tools/list` returns every tool with server-specific discovery metadata under each tool's `_meta` (the MCP-sanctioned extension point), so a client can group or filter the surface without hard-coding tool names:
+
+- `group` — functional group (`email_auth`, `infrastructure`, `brand_threats`, `dns_hygiene`, `intelligence`, `remediation`, `discovery`, `identity_secops`, `meta`).
+- `tier` — scoring tier (`core` / `protective` / `hardening`); absent for non-scoring tools.
+- `scanIncluded` — `true` when the tool runs inside `scan_domain`'s parallel audit.
+- `recommended` — present (`true`) only on the curated **starter set** (`scan_domain`, `explain_finding`, `compare_baseline`); omitted otherwise. A client facing the full surface can lead with `tools.filter(t => t._meta.recommended)` to avoid overwhelming an LLM with all tools flat. Every tool is still listed — this is an additive signal, not a filter.
+
 ### Authoritative DNS infrastructure
 
 `check_authoritative_dns_infra` scores authoritative DNS hosting behavior for a hostname. It is designed to consume raw UDP/TCP DNS, authoritative AA/RA behavior, zone-transfer refusal, DNSSEC, abuse-resistance, BGP/RPKI, and multi-vantage evidence from the `BV_INFRA_PROBE` service binding when that worker is provisioned.

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -119,6 +119,8 @@ interface WireTool {
 		group: McpTool['group'];
 		tier?: McpTool['tier'];
 		scanIncluded: boolean;
+		/** Present (true) only for the curated starter set; omitted otherwise (lean, like tier). */
+		recommended?: boolean;
 	};
 }
 
@@ -138,6 +140,7 @@ export function handleToolsList(): { tools: WireTool[] } {
 				group: tool.group,
 				...(tool.tier !== undefined && { tier: tool.tier }),
 				scanIncluded: tool.scanIncluded,
+				...(tool.recommended && { recommended: true }),
 			},
 		})),
 	};

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -7,6 +7,7 @@ import { parseAllowedHosts } from './request';
 import { createSession, checkSessionCreateRateLimit } from '../lib/session';
 import { auditSessionCreated } from '../lib/audit';
 import { jsonRpcError, jsonRpcSuccess, JSON_RPC_ERRORS } from '../lib/json-rpc';
+import { SERVER_INSTRUCTIONS } from './server-instructions';
 import type { AnalyticsClient } from '../lib/analytics';
 
 type JsonRpcPayload = ReturnType<typeof jsonRpcSuccess> | ReturnType<typeof jsonRpcError>;
@@ -165,8 +166,7 @@ export async function dispatchMcpMethod(options: DispatchMcpMethodOptions): Prom
 						description:
 							'Open-source DNS & email security scanner — 80+ checks across 20 categories with scoring, grading, and remediation guidance',
 					},
-					instructions:
-					'DNS and email security scanner. Use scan_domain for comprehensive audits (score, grade, findings). Use individual check_* tools for targeted investigation. Use explain_finding for remediation guidance. Use compare_baseline for policy enforcement. All checks are passive and read-only.',
+					instructions: SERVER_INSTRUCTIONS,
 				}),
 				newSessionId: createSessionOnInitialize ? sessionId : undefined,
 				logCategory: 'session',

--- a/src/mcp/server-instructions.ts
+++ b/src/mcp/server-instructions.ts
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * The MCP `instructions` string returned at `initialize`. This is one of the
+ * few channels that actually reaches the model's tool-selection context (unlike
+ * `_meta`, which a client surfaces only if it implements filtering), so it is
+ * the source of truth for the curated "starter set".
+ *
+ * The tools flagged `recommended: true` in TOOL_DEFS MUST each be named here —
+ * enforced by test/tool-recommended-meta.spec.ts so the `_meta.recommended`
+ * wire flag can never drift from the prose the model is actually shown. If the
+ * starter set grows, expand BOTH this string and the flags together.
+ */
+export const SERVER_INSTRUCTIONS =
+	'DNS and email security scanner. Use scan_domain for comprehensive audits (score, grade, findings). Use individual check_* tools for targeted investigation. Use explain_finding for remediation guidance. Use compare_baseline for policy enforcement. All checks are passive and read-only.';

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -85,6 +85,14 @@ export interface McpTool {
 	tier?: ToolTier;
 	/** True when this tool is included in the scan_domain parallel orchestration. */
 	scanIncluded: boolean;
+	/**
+	 * True for the curated "starter set" — the small, high-value subset a client
+	 * can surface to avoid overwhelming an LLM with all 79 flat tools. Additive
+	 * signal only (every tool is still listed); absent means "not curated", not a
+	 * negative. MUST mirror the tools named in SERVER_INSTRUCTIONS (the channel
+	 * that actually reaches the model) — see src/mcp/server-instructions.ts.
+	 */
+	recommended?: boolean;
 }
 
 interface ToolDef {
@@ -96,6 +104,8 @@ interface ToolDef {
 	mutating?: boolean;
 	/** True when the tool deletes or overwrites data → drives `destructiveHint`. Implies `mutating`. */
 	destructive?: boolean;
+	/** Curated starter-set member (see McpTool.recommended). Mirror SERVER_INSTRUCTIONS. */
+	recommended?: boolean;
 }
 
 /** DNS/security acronyms that should be uppercased in human-readable tool titles. */
@@ -293,6 +303,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		schema: ScanDomainArgs,
 		group: 'meta',
 		scanIncluded: false,
+		recommended: true,
 	},
 	batch_scan: {
 		description: 'Scan up to 10 domains at once. Returns score, grade, and finding counts per domain.',
@@ -311,6 +322,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		schema: CompareBaselineArgs,
 		group: 'meta',
 		scanIncluded: false,
+		recommended: true,
 	},
 	check_shadow_domains: {
 		description: 'Find TLD variants with email auth gaps. Standalone.',
@@ -408,6 +420,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		schema: ExplainFindingArgs,
 		group: 'meta',
 		scanIncluded: false,
+		recommended: true,
 	},
 	map_supply_chain: {
 		description:
@@ -778,6 +791,7 @@ export const TOOLS: McpTool[] = Object.entries(TOOL_DEFS).map(([name, def]) => (
 	group: def.group,
 	...(def.tier !== undefined && { tier: def.tier }),
 	scanIncluded: def.scanIncluded,
+	...(def.recommended && { recommended: true as const }),
 }));
 
 export { TOOL_SCHEMA_MAP };

--- a/test/tool-recommended-meta.spec.ts
+++ b/test/tool-recommended-meta.spec.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// #363 item 2 — tool-overload mitigation for the 79-tool surface.
+//
+// All tools stay in tools/list; a curated "starter set" is tagged with the
+// additive `_meta.recommended: true` flag so a client that implements filtering
+// can render a lean view. This does NOT reduce what a naive client shows the
+// model — it adds the server-side SIGNAL for client-side curation.
+//
+// The flag is coupled to the `initialize` instructions string (the channel that
+// DOES reach the model): every recommended tool must be named there. If the
+// starter set grows, expand BOTH together.
+
+import { describe, it, expect } from 'vitest';
+import { TOOLS } from '../src/schemas/tool-definitions';
+import { handleToolsList } from '../src/handlers/tools';
+import { SERVER_INSTRUCTIONS } from '../src/mcp/server-instructions';
+
+// The curated starter set — mirrors the named tools in SERVER_INSTRUCTIONS.
+const RECOMMENDED = ['scan_domain', 'explain_finding', 'compare_baseline'];
+
+describe('_meta.recommended starter-set flag', () => {
+	it('flags exactly the curated starter set in TOOL_DEFS', () => {
+		const flagged = TOOLS.filter((t) => t.recommended).map((t) => t.name).sort();
+		expect(flagged).toEqual([...RECOMMENDED].sort());
+	});
+
+	it('emits _meta.recommended === true on tools/list for the starter set', () => {
+		const { tools } = handleToolsList();
+		for (const name of RECOMMENDED) {
+			const wire = tools.find((t) => t.name === name);
+			expect(wire, `${name} should be on the wire`).toBeDefined();
+			expect(wire!._meta.recommended, `${name} should be flagged recommended`).toBe(true);
+		}
+	});
+
+	it('omits the recommended field entirely for non-starter tools (lean, like tier)', () => {
+		const { tools } = handleToolsList();
+		const sample = ['check_spf', 'cymru_asn', 'osint_investigate_domain_start', 'check_dmarc'];
+		for (const name of sample) {
+			const wire = tools.find((t) => t.name === name);
+			expect(wire, `${name} should be on the wire`).toBeDefined();
+			expect(wire!._meta.recommended, `${name} must not carry recommended`).toBeUndefined();
+		}
+	});
+
+	it('is purely additive — every tool is still listed', () => {
+		const { tools } = handleToolsList();
+		expect(tools.length).toBe(TOOLS.length);
+	});
+
+	it('keeps the flag coupled to the instructions string — each recommended tool is named there', () => {
+		for (const name of RECOMMENDED) {
+			expect(SERVER_INSTRUCTIONS, `${name} must be named in SERVER_INSTRUCTIONS`).toContain(name);
+		}
+	});
+});


### PR DESCRIPTION
Resolves item 2 of #363 (tool-overload mitigation for the 79-tool surface).

## What this does — and what it deliberately doesn't

`tools/list` returns all 79 tools flat. A naive client gives an LLM no signal about which tools are the high-value front door. This adds an **additive** `_meta.recommended: true` flag to a curated starter set so a client that implements `_meta` filtering can render a lean view:

```js
tools.filter(t => t._meta.recommended)   // scan_domain, explain_finding, compare_baseline
```

**Honest framing:** this **adds the server-side signal for client-side curation** — it does **not** reduce what a naive client shows the model. Most clients present tools to the LLM as name + description + inputSchema and ignore `_meta` unless they implement filtering. The starter set is therefore anchored to the `initialize` **instructions string** (one of the few channels that *does* reach the model), not to `_meta` alone.

## Design

- **Starter set = `scan_domain`, `explain_finding`, `compare_baseline`** — exactly the tools already named in the server's `initialize` instructions string. (The shipped `prompts/get` templates also organically center on these three, corroborating the choice.)
- **Drift guard:** the instructions string is extracted to a shared `SERVER_INSTRUCTIONS` constant (`src/mcp/server-instructions.ts`); a test asserts every `recommended` tool is named there. The wire flag can't silently diverge from the prose the model is actually shown. If the starter set grows, expand **both** together.
- **Lean emit:** `recommended` is omitted (not `false`) for non-starter tools, matching the existing `tier` pattern — the filter behaves identically whether the field is `false` or absent, so leaner wins.

## Contract / safety

- **Purely additive.** No tool count change, no scoring change, no tool removed from `tools/list`. Clients ignoring `_meta` are unaffected.
- Verified no **exclusive** `_meta` key assertion exists in the suite (only the non-exclusive presence check at `handlers-tools.spec.ts:596`), so the new optional field slots in cleanly.
- `_meta` is emitted in exactly one place (`handleToolsList`).

## Tests / verification

- New `test/tool-recommended-meta.spec.ts` (RED→GREEN): exact starter-set membership, `_meta.recommended === true` on the wire for the three, omitted for non-starters, additive (all tools still listed), and the instructions-string drift guard.
- Full suite green (5092 passed, 0 failures); `typecheck` + `lint` clean.
- README documents the `_meta` discovery fields (`group`/`tier`/`scanIncluded`/`recommended`).

## Note on release timing

Unlike item 1 (behavior-internal, merged without a bump), this **adds a wire field** to `tools/list`. It's purely additive (optional; ignoring clients unaffected) so it needs no coordinated release — but it's a user-visible capability that wants a CHANGELOG line whenever the next version is cut. Left to the maintainer to fold into release timing.

Items 3–4 of #363 (idempotency keys, MCP-Protocol-Version header) remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
