### PR TITLE
feat(mcp): observe MCP-Protocol-Version request header, never reject (#363 item 4)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,6 +124,10 @@ Both publish together from `publish.yml` on version tags.
 
 Anything else → generic fallback. New client-visible errors must start with one of these. Rate limit: HTTP **429** + JSON-RPC `code: -32029` carried in the response body (`useErrorEnvelope`); `retry-after` header set. All rate-limit/quota paths in `mcp/execute.ts` return `httpStatus: 429` (per-IP minute/hour/day, per-tool daily, per-tier daily, global cap); asserted by `test/index.spec.ts`.
 
+### Protocol-version handling
+
+Two channels, both deliberately **lenient — never reject**: (1) the `initialize` **params** `protocolVersion` is negotiated via `negotiateProtocolVersion()` (echo if supported, else fall back to `LATEST_PROTOCOL_VERSION`); (2) the `MCP-Protocol-Version` **HTTP header** on post-init requests is `classifyProtocolVersionHeader()`'d in `index.ts` for **observation only** — an `unsupported` value is logged (`category: 'protocol'`, warn) but the request is NOT 400'd. `initialize` is exempt (header legitimately absent pre-negotiation). MCP 2025-06-18 *suggests* a 400 on an unsupported header; we don't, because most clients omit or lag it — strict rejection is intentionally a one-line gate on that classification, not the default. Both `SUPPORTED_PROTOCOL_VERSIONS` and the lenient posture live in `src/mcp/dispatch.ts`.
+
 ## Scoring
 
 Three-tier model (`computeScanScore`). `CATEGORY_DISPLAY_WEIGHTS` is display-only.

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,7 @@ import { scanDomain } from './tools/scan-domain';
 import { gradeBadge, errorBadge } from './lib/badge';
 import { SERVER_VERSION } from './lib/server-version';
 import { executeMcpRequest } from './mcp/execute';
+import { classifyProtocolVersionHeader } from './mcp/dispatch';
 import { parseScoringConfigCached } from './lib/scoring-config';
 import { closeLegacyStream, enqueueLegacyMessage, openLegacySseStream } from './lib/legacy-sse';
 import { resolveClientIpFromHeaders, resolveClientIpFromRequestHeaders } from './lib/client-ip';
@@ -452,6 +453,25 @@ app.post('/mcp', async (c) => {
 	}
 
 	const parsedBodies = parsedRequest.isBatch ? (parsedRequest.body as unknown[]) : [parsedRequest.body as JsonRpcRequest];
+
+	// #363 item 4 — observe (never reject) the MCP-Protocol-Version request header.
+	// Per MCP 2025-06-18 clients SHOULD send it on post-initialize requests; we log an
+	// unsupported value for spec-awareness but deliberately do not 400 (most clients omit
+	// or lag the header — a hard reject would break them). `initialize` is exempt: the
+	// header is legitimately absent before negotiation. Strict rejection, if ever wanted,
+	// is a one-line gate on this classification.
+	const singleMethod = parsedRequest.isBatch ? undefined : (parsedBodies[0] as JsonRpcRequest | undefined)?.method;
+	if (singleMethod !== 'initialize' && classifyProtocolVersionHeader(headersLc['mcp-protocol-version']) === 'unsupported') {
+		logEvent({
+			timestamp: new Date().toISOString(),
+			severity: 'warn',
+			category: 'protocol',
+			result: 'Unsupported MCP-Protocol-Version header (observed, not rejected)',
+			details: { protocolVersionHeader: headersLc['mcp-protocol-version'], method: singleMethod ?? 'batch' },
+			ipHash,
+		});
+	}
+
 	if (parsedRequest.isBatch) {
 		const batch = parsedBodies;
 		if (batch.length > 20) {

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -35,6 +35,30 @@ export function negotiateProtocolVersion(requested: unknown): string {
 		: LATEST_PROTOCOL_VERSION;
 }
 
+/** Classification of the incoming `MCP-Protocol-Version` HTTP header on a post-init request. */
+export type ProtocolVersionHeaderState = 'absent' | 'supported' | 'unsupported';
+
+/**
+ * Classify the `MCP-Protocol-Version` request header for OBSERVATION ONLY (#363 item 4).
+ *
+ * Per MCP 2025-06-18 (Streamable HTTP) a client SHOULD send this header on every
+ * post-`initialize` request, and the spec suggests a `400` on an unsupported value.
+ * bv-mcp deliberately does **not** reject: most existing clients omit the header
+ * or lag the negotiated version, so a hard 400 would break them. The caller logs
+ * the classification and never fails the request on its basis — mirroring the
+ * lenient posture of `negotiateProtocolVersion` and `validateContentType`.
+ *
+ * `absent` covers a missing, empty, whitespace-only, or non-string header. The
+ * value is trimmed before matching so stray header whitespace doesn't misclassify
+ * an otherwise-supported version.
+ */
+export function classifyProtocolVersionHeader(header: string | undefined | null): ProtocolVersionHeaderState {
+	if (typeof header !== 'string') return 'absent';
+	const trimmed = header.trim();
+	if (trimmed === '') return 'absent';
+	return (SUPPORTED_PROTOCOL_VERSIONS as readonly string[]).includes(trimmed) ? 'supported' : 'unsupported';
+}
+
 export interface DispatchMcpMethodOptions {
 	id: string | number | null | undefined;
 	method: string;

--- a/test/protocol-version-negotiation.spec.ts
+++ b/test/protocol-version-negotiation.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import worker from '../src';
 import {
 	negotiateProtocolVersion,
+	classifyProtocolVersionHeader,
 	SUPPORTED_PROTOCOL_VERSIONS,
 	LATEST_PROTOCOL_VERSION,
 } from '../src/mcp/dispatch';
@@ -37,6 +38,30 @@ describe('negotiateProtocolVersion', () => {
 		expect(negotiateProtocolVersion({})).toBe('2025-06-18');
 		expect(negotiateProtocolVersion([])).toBe('2025-06-18');
 		expect(negotiateProtocolVersion('')).toBe('2025-06-18');
+	});
+});
+
+describe('classifyProtocolVersionHeader (#363 item 4 — observe-only, never rejects)', () => {
+	it('classifies a supported header value', () => {
+		expect(classifyProtocolVersionHeader('2025-06-18')).toBe('supported');
+		expect(classifyProtocolVersionHeader('2025-03-26')).toBe('supported');
+	});
+
+	it('treats a missing / empty / whitespace header as absent (most clients omit it)', () => {
+		expect(classifyProtocolVersionHeader(undefined)).toBe('absent');
+		expect(classifyProtocolVersionHeader(null)).toBe('absent');
+		expect(classifyProtocolVersionHeader('')).toBe('absent');
+		expect(classifyProtocolVersionHeader('   ')).toBe('absent');
+	});
+
+	it('classifies an unknown / lagging / future version as unsupported (observed, not rejected)', () => {
+		expect(classifyProtocolVersionHeader('2024-11-05')).toBe('unsupported');
+		expect(classifyProtocolVersionHeader('2099-01-01')).toBe('unsupported');
+		expect(classifyProtocolVersionHeader('garbage')).toBe('unsupported');
+	});
+
+	it('tolerates surrounding whitespace on an otherwise-supported value', () => {
+		expect(classifyProtocolVersionHeader(' 2025-06-18 ')).toBe('supported');
 	});
 });
 
@@ -77,5 +102,56 @@ describe('initialize protocolVersion negotiation (integration)', () => {
 
 	it('returns the latest version when the client requests an unsupported version', async () => {
 		expect(await initialize({ protocolVersion: '2024-11-05' })).toBe('2025-06-18');
+	});
+});
+
+describe('MCP-Protocol-Version request header (#363 item 4 — never rejects)', () => {
+	beforeEach(async () => {
+		resetAllRateLimits();
+		resetSessions();
+		resetLegacySseState();
+		await resetQuotaCoordinatorState(env.QUOTA_COORDINATOR);
+		await resetAllRateLimitsKv(env.RATE_LIMIT);
+	});
+
+	async function initSession(): Promise<string> {
+		const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: { protocolVersion: '2025-06-18' } }),
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+		const sessionId = response.headers.get('mcp-session-id');
+		expect(sessionId).toBeTruthy();
+		return sessionId!;
+	}
+
+	async function toolsList(sessionId: string, protocolHeader?: string): Promise<number> {
+		const headers: Record<string, string> = { 'Content-Type': 'application/json', 'Mcp-Session-Id': sessionId };
+		if (protocolHeader !== undefined) headers['MCP-Protocol-Version'] = protocolHeader;
+		const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({ jsonrpc: '2.0', id: 2, method: 'tools/list' }),
+		});
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, env, ctx);
+		await waitOnExecutionContext(ctx);
+		return response.status;
+	}
+
+	it('accepts a post-init request with a supported version header', async () => {
+		expect(await toolsList(await initSession(), '2025-06-18')).toBe(200);
+	});
+
+	it('accepts a post-init request with NO version header (most clients omit it)', async () => {
+		expect(await toolsList(await initSession(), undefined)).toBe(200);
+	});
+
+	it('accepts (does NOT reject) a post-init request with an unsupported / future version header', async () => {
+		expect(await toolsList(await initSession(), '2099-01-01')).toBe(200);
+		expect(await toolsList(await initSession(), 'garbage')).toBe(200);
 	});
 });


### PR DESCRIPTION
## What

Reads the `MCP-Protocol-Version` HTTP header on `/mcp` POST requests (previously never read) and **observes** it — logs an unsupported value for spec-awareness, but **never rejects**. Resolves item 4 of #363.

Per MCP 2025-06-18 (Streamable HTTP) a client SHOULD send `MCP-Protocol-Version` on every post-`initialize` request; the spec *suggests* a `400` on an unsupported value. bv-mcp deliberately does **not** 400 — most existing clients omit the header or lag the negotiated version, and a hard reject would break them. This matches the codebase's existing lenient posture (`negotiateProtocolVersion` falls back to latest on garbage; `validateContentType` allows a missing Content-Type).

## How

- `src/mcp/dispatch.ts` — new pure `classifyProtocolVersionHeader(h) → 'absent' | 'supported' | 'unsupported'` (reuses `SUPPORTED_PROTOCOL_VERSIONS`; trims whitespace; treats missing/empty/non-string as `absent`).
- `src/index.ts` — at the `/mcp` POST boundary, classify the header; on `unsupported` emit a structured warn log (`category: 'protocol'`). `initialize` is **exempt** (the header is legitimately absent before negotiation). No version is threaded into dispatch — nothing downstream consumes a per-request version (`structuredContent` is emitted regardless), so the job is strictly read → classify → observe → never reject.

## Design notes (issue was Claude-filed, not a hand-authored mandate)

- **Not a 400.** This is the reversible-safe direction: shipping observe-only now and adding a strict `400` later is trivial; un-breaking clients you started rejecting is the hard direction. **Strict rejection, if you want it, is a one-line gate on the `'unsupported'` classification** — flagged here so it's a deliberate choice, not an oversight.
- **Observation channel: log-only.** Chose a structured log over an analytics-blob dimension to avoid touching the documented analytics blob-layout SSOT (the `double2`-style surface). If operators later want to *quantify* client header adoption before tightening, an analytics dimension is the follow-up.

## Scope

- **In scope:** `POST /mcp` (single + batch).
- **Out of scope:** the deprecated legacy SSE paths (`POST /mcp/messages`, `GET`/`DELETE /mcp`) — not worth wiring a header observer into a deprecated transport.

## Tests

`test/protocol-version-negotiation.spec.ts`:
- Unit: `classifyProtocolVersionHeader` over supported / absent (missing, empty, whitespace) / unsupported (lagging, future, garbage) / whitespace-tolerance.
- Integration ("never reject" regression floor): a post-init `tools/list` with a supported header, **no** header, and an unsupported/future header all return **200**.

Full suite green (5114 passed; the 8 trailing errors are the known pool-teardown WebSocket-disconnect noise). Typecheck + lint clean. No contract change — additive observation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)