### PR TITLE
docs: sync README, CONTRIBUTING, and scoring.md with current source

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,18 +26,21 @@ Run `npx prettier --write 'src/**/*.ts' 'test/**/*.ts'` before committing large 
 ## Adding a New Tool
 
 1. Create `src/tools/check-<name>.ts` → export async fn returning `CheckResult`
-2. Add the `CheckCategory` value to the union type in `packages/dns-checks/src/scoring/model.ts` + `CATEGORY_DISPLAY_WEIGHTS`
+2. Add the `CheckCategory` value to the union type in `packages/dns-checks/src/types.ts` + `CATEGORY_TIERS` (tier classification) + `CATEGORY_DISPLAY_WEIGHTS` (`scoring/model.ts` only re-exports these — edit `types.ts`)
 3. Add to `IMPORTANCE_WEIGHTS` in `packages/dns-checks/src/scoring/engine.ts`
-4. Add to `DEFAULT_SCORING_CONFIG` weights, profileWeights (all 5 profiles), and baselineFailureRates in `packages/dns-checks/src/scoring/config.ts`
-5. Add to all 5 `PROFILE_WEIGHTS` maps in `packages/dns-checks/src/scoring/profiles.ts`
-6. Register in `src/schemas/tool-definitions.ts` (TOOL_DEFS) + `src/handlers/tools.ts` (import + TOOL_REGISTRY)
-7. Add to `FREE_TOOL_DAILY_LIMITS` in `src/lib/config.ts`
-8. Add explanation templates in `src/tools/explain-finding-data.ts`
-9. If the new check is part of `scan_domain`, add it to the parallel orchestration in `src/tools/scan-domain.ts`
-10. Add `test/check-<name>.spec.ts` using the `dns-mock` helper pattern
-11. Update the README tools table
+4. Add to `DEFAULT_SCORING_CONFIG` weights, profileWeights (all 6 profiles), and baselineFailureRates in `packages/dns-checks/src/scoring/config.ts`
+5. Add to all 6 `PROFILE_WEIGHTS` maps in `packages/dns-checks/src/scoring/profiles.ts`
+6. Rebuild the package: `npm -w packages/dns-checks run build` (the Worker and tests import the built `dist/`, not `src/`)
+7. Register in `src/schemas/tool-definitions.ts` (TOOL_DEFS) + `src/handlers/tools.ts` (import + TOOL_REGISTRY)
+8. Add to `FREE_TOOL_DAILY_LIMITS` in `src/lib/config.ts`
+9. Add explanation templates in `src/tools/explain-finding-data.ts`
+10. If the new check is part of `scan_domain`, add it to the `CHECK_DISPATCH` registry in `src/tools/scan-domain.ts` (the single dispatch source — `SCAN_CATEGORIES` and the retry switch both derive from it)
+11. Add `test/check-<name>.spec.ts` using the `dns-mock` helper pattern
+12. Bump the single tool-count tripwire `EXPECTED_TOOL_COUNT` in `test/audits/tool-count-ssot.audit.test.ts` (all other counts derive from the registry) and update the README tools table
 
-Follow the pattern in `src/tools/check-spf.ts` — use `createFinding()` and `buildCheckResult()` from `lib/scoring.ts`, never construct findings manually.
+Follow the pattern in `src/tools/check-spf.ts` — use `createFinding()` and `buildCheckResult()` from `@blackveil/dns-checks/scoring`, never construct findings manually.
+
+> The full SSOT checklist (the additional audits a new tool trips, scoring-snapshot bumps, generated WASM permissions, etc.) lives in the repo's `CLAUDE.md` "Adding a New Tool" section.
 
 ## Testing
 
@@ -45,6 +48,7 @@ Follow the pattern in `src/tools/check-spf.ts` — use `createFinding()` and `bu
 - Each test file calls `restore()` in `afterEach` to reset mocks
 - Tests that call tool handlers should clear scan cache between cases
 - Dynamic imports are used for mock isolation
+- **Scoring specs** (`model`/`profiles`/`config`/`engine`) keep their assertions and expected values once in `packages/dns-checks/src/__tests__/scoring/scoring-<name>.suite.ts`. The eight `scoring-<name>.spec.ts` files (one per name in that dir, one per name in `test/`) are thin wrappers that inject the SOURCE vs the BUILT `@blackveil/dns-checks/scoring` module so source↔build drift is caught — **edit the `.suite.ts`, not the wrappers**.
 
 ## Public Fixtures
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,12 @@ Transport support:
   + osint_investigate_email_start           — async email OSINT (owner/enterprise tier only)
   + osint_investigation_status   — poll status of any running OSINT investigation
   + osint_investigation_report   — retrieve report for a completed OSINT investigation
+
+  Operator-deploy only (m365Proxy binding; Microsoft 365 / Entra identity security ops — degrade to unprovisioned without it):
+  + query_signins                — query Microsoft Entra sign-in logs for a tenant
+  + query_ual                    — query the Microsoft 365 Unified Audit Log for a tenant
+  + get_ca_policies              — retrieve Conditional Access policies for an Entra tenant
+  + assess_coverage              — assess Conditional Access coverage gaps for an Entra tenant
 ```
 
 ### Tool discovery metadata (`_meta`)

--- a/docs/scoring.md
+++ b/docs/scoring.md
@@ -39,11 +39,13 @@ Active defenses against known attack vectors. Findings penalize but cannot trigg
 | Lookalikes | 2 |
 | Shadow Domains | 2 |
 
+> This table is the flat `protectiveWeights` map (sums to 23). `DANE-HTTPS` and `SVCB-HTTPS` are also protective-tier in `CATEGORY_TIERS`, but their weights are carried per-profile in `PROFILE_WEIGHTS` rather than in the flat map.
+
 ### Hardening (10% of score)
 
 Bonus-only defense-in-depth. Each passed category adds ~1.4 points. Never subtracts from the overall score. Uses `result.passed` (not raw score) to determine pass/fail — this means checks with `missingControl: true` metadata or `scoreIndicatesMissingControl()` detection do not contribute hardening bonus even if their numeric score is >= 50.
 
-Categories: DANE, BIMI, TLS-RPT, TXT Hygiene, MX Reputation, SRV, Zone Hygiene, Brand Discovery.
+Categories: DANE, BIMI, TLS-RPT, TXT Hygiene, MX Reputation, SRV, Zone Hygiene, Brand Discovery, Reverse DNS (PTR/FCrDNS), DNSKEY Strength.
 
 **Tool Annotations**: Every tool definition includes `group`, `tier` (`core`, `protective`, or `hardening`), and a `scanIncluded` flag. These annotations align with the category tiers above and are included in `tools/list` responses for structured consumption by MCP clients.
 
@@ -170,7 +172,7 @@ Source: `scoreToGrade()` in `packages/dns-checks/src/scoring/engine.ts` (re-expo
 | `authoritative_dns_infra` | Explicit infrastructure assessment profile | Mail/web controls are non-scoring; authoritative DNS infra, DNSSEC, NS, and zone hygiene dominate |
 
 - **Email bonus**: only for `mail_enabled` and `enterprise_mail`
-- **Critical gap categories**: `mail_enabled`/`enterprise_mail` use core categories; `non_mail`/`web_only` use `['ssl', 'subdomain_takeover', 'http_security']`; `minimal` uses `['ssl', 'subdomain_takeover']`
+- **Critical gap categories**: `mail_enabled`/`enterprise_mail` use core categories; `non_mail`/`web_only` use `['ssl', 'dnssec', 'http_security', 'subdomain_takeover', 'dane_https']`; `minimal` uses `['ssl', 'dnssec', 'subdomain_takeover']`
 - **Authoritative DNS infra profile**: uses `['authoritative_dns_infra', 'dnssec', 'ns', 'zone_hygiene']` as critical gap categories and disables the email bonus.
 
 ### Phase 1 (Current)


### PR DESCRIPTION
Three docs had drifted from the live tool registry + scoring model. No code change; counts unchanged (79 tools, 27 scoring categories, 19 scan categories).

## CONTRIBUTING.md — "Adding a New Tool"
- `CheckCategory` union lives in `packages/dns-checks/src/types.ts` (+ `CATEGORY_TIERS`), not `scoring/model.ts` (which only re-exports)
- `profileWeights` / `PROFILE_WEIGHTS` cover **all 6** profiles, not 5 (`authoritative_dns_infra` was added)
- findings helpers import from `@blackveil/dns-checks/scoring`, not `lib/scoring.ts`
- added the package-rebuild step, pointed scan-wiring at the new `CHECK_DISPATCH` registry, count at the single `EXPECTED_TOOL_COUNT` tripwire; noted the scoring `.suite.ts` pattern in Testing (edit the suite, not the wrappers)

## docs/scoring.md
- hardening categories 8 → **10** (added Reverse DNS PTR/FCrDNS + DNSKEY Strength)
- noted `DANE-HTTPS` / `SVCB-HTTPS` are protective-tier but per-profile weighted (not in the flat `protectiveWeights` map, which sums to 23)
- corrected non_mail/web_only critical-gap set to include `dnssec` + `dane_https`
- **left intact** the prod `SCORING_CONFIG` core-weight table (22/16/10/7/5) — it's intentional and labeled, with code-defaults documented beside it

## README.md
- added the 4 missing `identity_secops` tools (`query_signins`, `query_ual`, `get_ca_policies`, `assess_coverage`) as an operator-deploy-only (`m365Proxy`) block; the table now reconciles to all 79

## Verification
`readme-tool-surface` + `tool-count-ssot` audits pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)