### PR TITLE
fix: 6 verified bugs from adversarial bug-hunt sweep

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-spf.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { checkSPF } from '../../checks/check-spf';
-import { estimateTxtRrsetBytes } from '../../checks/spf-analysis';
+import { analyzeSpfLookupBudget, estimateTxtRrsetBytes } from '../../checks/spf-analysis';
 import type { DNSQueryFunction } from '../../types';
 
 /** Build a TXT string of an exact byte length (ASCII, so 1 char === 1 byte). */
@@ -221,5 +221,21 @@ describe('estimateTxtRrsetBytes', () => {
 	it('counts an empty TXT string as one (empty) character-string', () => {
 		// 12 (RR overhead) + 0 (string) + 1 (length octet) = 13
 		expect(estimateTxtRrsetBytes([''])).toBe(13);
+	});
+});
+
+describe('analyzeSpfLookupBudget — redirect= counts toward the §4.6.4 budget', () => {
+	it('counts a bare redirect= modifier as one DNS lookup', () => {
+		// RFC 7208 §4.6.4: the redirect modifier is a lookup-consuming term.
+		const analysis = analyzeSpfLookupBudget('v=spf1 redirect=_spf.example.com');
+		expect(analysis.count).toBe(1);
+		expect(analysis.mechanisms).toContain('redirect');
+	});
+
+	it('counts redirect= alongside mechanisms so 10 mechanisms + redirect = 11 (crosses the limit)', () => {
+		const tenMechs = Array.from({ length: 10 }, (_, i) => `include:spf${i}.example.com`).join(' ');
+		const analysis = analyzeSpfLookupBudget(`v=spf1 ${tenMechs} redirect=_spf.example.com -all`);
+		expect(analysis.count).toBe(11);
+		expect(analysis.count).toBeGreaterThan(10);
 	});
 });

--- a/packages/dns-checks/src/checks/spf-analysis.ts
+++ b/packages/dns-checks/src/checks/spf-analysis.ts
@@ -86,9 +86,11 @@ export function analyzeSpfLookupBudget(spfRecord: string): SpfLookupAnalysis {
 		else if (normalized === 'mx' || normalized.startsWith('mx:') || normalized.startsWith('mx/')) mechanisms.push('mx');
 		else if (normalized === 'ptr' || normalized.startsWith('ptr:')) mechanisms.push('ptr');
 		else if (normalized.startsWith('exists:')) mechanisms.push('exists');
-		// Note: redirect= is a modifier (RFC 7208 §6.1), not a mechanism.
-		// It does not consume a DNS lookup slot itself — the target record's
-		// mechanisms are counted when countRecursiveLookups recurses into it.
+		else if (normalized.startsWith('redirect=')) mechanisms.push('redirect');
+		// Note: redirect= is counted as a lookup-consuming term per RFC 7208 §4.6.4
+		// (the lookup-limit rule explicitly counts the redirect modifier). This +1 is
+		// the redirect term's own lookup; the target record's mechanisms are added
+		// separately when countRecursiveLookups recurses into it (no double-count).
 	}
 
 	return { count: mechanisms.length, mechanisms };

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -325,7 +325,7 @@ async function brandAuditWatchUnprovisioned(): Promise<CheckResult> {
  * Registry mapping tool names to their cache key and execution function.
  * Replaces repetitive switch cases for individual DNS check tools.
  */
-const TOOL_REGISTRY: Record<
+export const TOOL_REGISTRY: Record<
 	string,
 	{
 		/** cacheKey may consult runtimeOptions to bind principal (defense against owner-scoped IDOR via cache). */
@@ -423,8 +423,13 @@ const TOOL_REGISTRY: Record<
 	check_subdomain_takeover: {
 		cacheKey: (args) => {
 			const subs = Array.isArray(args.subdomains) ? (args.subdomains as string[]) : null;
-			// Cache key folds caller-supplied list size so callers passing CT inventories don't collide with default sweeps.
-			return subs && subs.length > 0 ? `subdomain_takeover:custom:${subs.length}` : 'subdomain_takeover:default';
+			// Cache key folds caller-supplied list CONTENTS (not just size) so two
+			// different same-length lists don't collide on one entry (5-min TTL,
+			// global per domain+checkName) — mirrors the discover_brand_domains
+			// sibling. Sorted + length-prefixed + bounded to keep keys finite.
+			return subs && subs.length > 0
+				? `subdomain_takeover:custom:${subs.length}:${subs.slice().sort().join('|').slice(0, 128)}`
+				: 'subdomain_takeover:default';
 		},
 		execute: (d, args, ro) => {
 			const subs = Array.isArray(args.subdomains) ? (args.subdomains as string[]) : undefined;
@@ -1309,7 +1314,12 @@ export async function handleToolsCall(
 						withRequestDedup(
 							{
 								toolName: name,
-								principal: runtimeOptions?.principalId ?? runtimeOptions?.keyHash,
+								// keyHash ONLY — it is set solely for AUTHENTICATED callers.
+								// principalId = keyHash ?? ipHash (execute.ts), so using it
+								// would make an unauth caller's ipHash a truthy principal and
+								// defeat withRequestDedup's skip, letting two NAT'd unauth
+								// callers share a fingerprint → cross-principal op-ID replay.
+								principal: runtimeOptions?.keyHash,
 								args: validatedArgs as Record<string, unknown>,
 								kv: dedupKv,
 								waitUntil: runtimeOptions?.waitUntil,

--- a/src/lib/tier-auth.ts
+++ b/src/lib/tier-auth.ts
@@ -134,7 +134,15 @@ export async function resolveTier(
 					return { authenticated: false };
 				}
 				const resolvedTier = applyOwnerIpGate(tierResult.data, env.OWNER_ALLOW_IPS, clientIp);
-				return { authenticated: true, tier: resolvedTier };
+				// Derive a stable per-credential keyHash (same hex(SHA-256(rawToken)) the
+				// static/cache/trial paths return) so quota + concurrency principal selection
+				// (`tierAuthResult.keyHash ?? options.ip` in mcp/execute.ts) keys on the JWT,
+				// not the client IP. Without it, a JWT reused across IPs multiplies the daily
+				// quota and NAT users behind one IP share a single quota bucket.
+				const jwtKeyHash = Array.from(await hashTokenRaw(token))
+					.map((b) => b.toString(16).padStart(2, '0'))
+					.join('');
+				return { authenticated: true, tier: resolvedTier, keyHash: jwtKeyHash };
 			}
 			// JWT verified but payload is not a recognized MCP tier — fall through so static key
 			// path still has a chance for legacy operators with unusual three-segment keys.

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -987,6 +987,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			typeof dispatchResult.payload === 'object' && dispatchResult.payload !== null && 'error' in dispatchResult.payload;
 		const errPayload = hasJsonRpcError ? (dispatchResult.payload as { error?: { code?: number; message?: string } }).error : undefined;
 		emitRequestAnalytics(options, method, hasJsonRpcError ? 'error' : 'ok', hasJsonRpcError, errPayload?.code, errPayload?.message);
+		recordMcpToolErrorIfUnknownTool(options, method, dispatchResult.payload);
 		if (accessLogInput) {
 			recordMcpAccessLog(options, { ...accessLogInput, rateLimited: false });
 		}

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -935,7 +935,7 @@ async function runCachedCheck(
 	// skipSentinel: per-check scan caches are ~98% unique-domain / low-contention;
 	// the cross-isolate sentinel's KV writes+deletes cost more than the rare stampede
 	// they'd prevent (INFLIGHT still dedups in-isolate).
-	return runWithCache(buildCheckCacheKey(domain, category), run, kv, ttlSeconds, skipCache, undefined, true);
+	return runWithCache(buildCheckCacheKey(domain, category), run, kv, ttlSeconds, skipCache, (r: CheckResult) => !r.partial, true);
 }
 
 /**
@@ -969,6 +969,9 @@ async function safeCheck(category: CheckCategory, fn: () => Promise<CheckResult>
 
 		const findings = [createFinding(category, title, severity, detail)];
 		const result = buildCheckResult(category, findings);
-		return { ...result, score: 0, checkStatus };
+		// `partial: true` keeps the one-off transient error OUT of the 5-min
+		// per-check cache (see runCachedCheck's shouldCache predicate) so it
+		// self-heals and isn't served to direct check_* calls.
+		return { ...result, score: 0, checkStatus, partial: true };
 	}
 }

--- a/test/fuzzing-e2e.integration.test.ts
+++ b/test/fuzzing-e2e.integration.test.ts
@@ -111,4 +111,56 @@ describe('fuzzing detection — subcutaneous E2E', () => {
 		}
 		expect(fuzzAlerts[0].kind).toBe('unknown_tool');
 	});
+
+	it('JSON-only transport (Accept: application/json) also increments the unknown_tool fuzz counter', async () => {
+		const ip = '203.0.113.77'; // RFC 5737 documentation prefix — safe for tests
+
+		// 1. Initialize a session (JSON-only Accept routes through the non-SSE dispatch path).
+		const initRes = await SELF.fetch('https://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Accept': 'application/json',
+				'cf-connecting-ip': ip,
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 0,
+				method: 'initialize',
+				params: { protocolVersion: '2025-03-26', capabilities: {}, clientInfo: { name: 'fuzz-e2e-json', version: '1' } },
+			}),
+		});
+		expect(initRes.status).toBe(200);
+		const sessionId = initRes.headers.get('mcp-session-id');
+		expect(sessionId).toBeTruthy();
+
+		// 2. Drive a single unknown-tool request through the JSON-only (non-SSE) path.
+		const res = await SELF.fetch('https://example.com/mcp', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				'Accept': 'application/json',
+				'cf-connecting-ip': ip,
+				'mcp-session-id': sessionId!,
+			},
+			body: JSON.stringify({
+				jsonrpc: '2.0',
+				id: 1,
+				method: 'tools/call',
+				params: { name: 'definitely_not_a_tool_json', arguments: { domain: 'example.com' } },
+			}),
+		});
+		expect([200, 400, 401, 404]).toContain(res.status);
+
+		// 3. Assert the fuzz counter for this principal's unknown_tool kind was incremented in KV.
+		// The record is written via ctx.waitUntil; poll briefly to let it flush.
+		let unknownToolKeys: { name: string }[] = [];
+		for (let attempt = 0; attempt < 20; attempt++) {
+			const list = await env.RATE_LIMIT.list({ prefix: 'fuzz:' });
+			unknownToolKeys = list.keys.filter((k) => k.name.includes('unknown_tool'));
+			if (unknownToolKeys.length > 0) break;
+			await new Promise((r) => setTimeout(r, 25));
+		}
+		expect(unknownToolKeys.length).toBeGreaterThan(0);
+	});
 });

--- a/test/request-dedup-wiring.spec.ts
+++ b/test/request-dedup-wiring.spec.ts
@@ -50,7 +50,7 @@ describe('handleToolsCall dedup wiring', () => {
 		await handleToolsCall(
 			{ name: 'scan_buckets_start', arguments: { target: 'acme.example' } },
 			undefined,
-			{ rateLimitKv: kv, principalId: 'key_abc' },
+			{ rateLimitKv: kv, keyHash: 'key_abc' },
 		);
 		const getMock = kv.get as ReturnType<typeof vi.fn>;
 		const sawIdemKey = getMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].startsWith('idem:scan_buckets_start:'));
@@ -65,6 +65,22 @@ describe('handleToolsCall dedup wiring', () => {
 		expect(sawIdemKey).toBe(false);
 	});
 
+	// Cross-principal-leak guard: an UNAUTHENTICATED caller's principalId is the
+	// ipHash (keyHash ?? ipHash, execute.ts) — truthy, so keying dedup on
+	// principalId would let two NAT'd unauth callers share a fingerprint and
+	// replay each other's operation IDs. Dedup must key on keyHash ONLY (set only
+	// for authenticated callers); an ipHash-only principal must be SKIPPED.
+	it('does NOT dedup an unauthenticated caller (ipHash principalId, no keyHash)', async () => {
+		const { kv } = fakeKv();
+		await handleToolsCall({ name: 'scan_buckets_start', arguments: { target: 'acme.example' } }, undefined, {
+			rateLimitKv: kv,
+			principalId: 'i_deadbeef', // ipHash for an unauth caller — keyHash deliberately absent
+		});
+		const getMock = kv.get as ReturnType<typeof vi.fn>;
+		const sawIdemKey = getMock.mock.calls.some((c) => typeof c[0] === 'string' && c[0].startsWith('idem:'));
+		expect(sawIdemKey).toBe(false);
+	});
+
 	// End-to-end seam: a *successful* mutating dispatch (here the deterministic
 	// `unprovisioned` result when BV_RECON is absent — falsy isError) must be
 	// STORED on the first call and REPLAYED on the second. If buildToolResult's
@@ -74,7 +90,7 @@ describe('handleToolsCall dedup wiring', () => {
 	it('stores a successful mutating result and replays it on a duplicate', async () => {
 		const { kv } = fakeKv();
 		const args = { target: 'acme.example' };
-		const opts = { rateLimitKv: kv, principalId: 'key_abc' };
+		const opts = { rateLimitKv: kv, keyHash: 'key_abc' };
 
 		const first = await handleToolsCall({ name: 'scan_buckets_start', arguments: args }, undefined, opts);
 		const second = await handleToolsCall({ name: 'scan_buckets_start', arguments: args }, undefined, opts);

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
 import { env } from 'cloudflare:test';
 import { setupFetchMock, createDohResponse, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse, nxdomainResponse, servfailResponse } from './helpers/dns-mock';
-import { IN_MEMORY_CACHE, buildScanCacheKey } from '../src/lib/cache';
+import { IN_MEMORY_CACHE, buildScanCacheKey, buildCheckCacheKey, cacheGet } from '../src/lib/cache';
+import type { CheckResult } from '../src/lib/scoring';
 import { type ScanDomainResult, SCAN_CATEGORIES } from '../src/tools/scan-domain';
 
 const { restore } = setupFetchMock();
@@ -256,7 +257,71 @@ describe('scanDomain', () => {
 		expect(second.domain).toBe(first.domain);
 		expect(second.score.overall).toBe(first.score.overall);
 	});
+
+	it('does NOT poison the per-check cache with a transient check error (self-heals)', async () => {
+		// No KV is bound in the test pool — caching falls back to IN_MEMORY_CACHE,
+		// which is what the existing "caches results with KV" test relies on too.
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		// The SSL check's HTTPS fetch to https://example.com hangs, so safeCheck's
+		// per-check timeout race fires → checkStatus:'timeout', score:0. That
+		// transient error must NOT be written to the shared per-check cache key,
+		// which the direct check_* path (handlers/tools.ts) also reads.
+		const sslCacheKey = buildCheckCacheKey('example.com', 'ssl');
+
+		// First scan: SSL times out. forceRefresh skips the cache READ only — the
+		// per-check WRITE still happens, which is exactly what we're guarding.
+		mockSslHangs();
+		const first = await scanDomain('example.com', undefined, { forceRefresh: true });
+		const firstSsl = first.checks.find((c) => c.category === 'ssl');
+		expect(firstSsl).toBeDefined();
+		// Precondition: confirm safeCheck actually caught the transient failure.
+		expect(firstSsl!.checkStatus).toBe('timeout');
+
+		// (1) Load-bearing assertion: the transient error must NOT have populated
+		// the per-check cache. On buggy code this key holds the score-0 error.
+		const cached = await cacheGet<CheckResult>(sslCacheKey);
+		expect(cached).toBeUndefined();
+
+		// (2) Self-heal: a subsequent scan (no forceRefresh, so it reads the
+		// per-check cache) must re-execute SSL rather than serve a cached error.
+		// Clear only the top-level scan key so the per-check keys are re-read.
+		IN_MEMORY_CACHE.delete(buildScanCacheKey('example.com'));
+		mockAllChecks();
+		const second = await scanDomain('example.com');
+		const secondSsl = second.checks.find((c) => c.category === 'ssl');
+		expect(secondSsl).toBeDefined();
+		expect(secondSsl!.checkStatus).not.toBe('timeout');
+	}, 20_000);
 });
+
+/** Healthy mock for every check EXCEPT SSL, whose HTTPS fetch hangs forever. */
+function mockSslHangs() {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		if (url.includes('cloudflare-dns.com')) {
+			if (url.includes('type=TXT') || url.includes('type=16')) {
+				if (url.includes('_dmarc.')) return Promise.resolve(txtResponse('_dmarc.example.com', ['v=DMARC1; p=reject']));
+				if (url.includes('_domainkey.')) return Promise.resolve(txtResponse('default._domainkey.example.com', ['v=DKIM1; k=rsa; p=MIGf']));
+				if (url.includes('_mta-sts.')) return Promise.resolve(txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']));
+				if (url.includes('_smtp._tls.')) return Promise.resolve(txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']));
+				if (url.includes('default._bimi.')) return Promise.resolve(txtResponse('default._bimi.example.com', ['v=BIMI1; l=https://example.com/logo.svg']));
+				return Promise.resolve(txtResponse('example.com', ['v=spf1 include:_spf.google.com -all']));
+			}
+			if (url.includes('type=NS') || url.includes('type=2')) return Promise.resolve(nsResponse('example.com', ['ns1.example.com.', 'ns2.example.com.']));
+			if (url.includes('type=CAA') || url.includes('type=257')) return Promise.resolve(caaResponse('example.com', ['0 issue "letsencrypt.org"']));
+			if (url.includes('type=A') || url.includes('type=1')) return Promise.resolve(dnssecResponse('example.com', true));
+			return Promise.resolve(createDohResponse([], []));
+		}
+		if (url.includes('mta-sts.') && url.includes('.well-known')) {
+			return Promise.resolve(httpResponse('version: STSv1\nmode: enforce\nmx: *.example.com\nmax_age: 86400'));
+		}
+		// SSL check hits the domain via HTTPS — hang forever to force a per-check timeout.
+		if (url.startsWith('https://example.com')) {
+			return new Promise(() => {});
+		}
+		return Promise.resolve(httpResponse('OK'));
+	});
+}
 
 describe('formatScanReport', () => {
 	it('returns human-readable string with grade, category scores, and timestamp', async () => {

--- a/test/subdomain-takeover-cachekey.spec.ts
+++ b/test/subdomain-takeover-cachekey.spec.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Bug-hunt: check_subdomain_takeover cacheKey must fold list CONTENTS, not just
+// LENGTH. Two different same-length custom subdomain lists for the same domain
+// must NOT collide on one cache entry (5-min TTL, global per domain+checkName) —
+// otherwise caller B's list silently gets caller A's takeover results.
+
+import { describe, it, expect } from 'vitest';
+
+describe('check_subdomain_takeover cacheKey', () => {
+	it('produces DIFFERENT keys for different same-length custom lists', async () => {
+		const { TOOL_REGISTRY } = await import('../src/handlers/tools');
+		const cacheKey = TOOL_REGISTRY.check_subdomain_takeover.cacheKey;
+
+		const keyA = cacheKey({ subdomains: ['a', 'b', 'c'] });
+		const keyB = cacheKey({ subdomains: ['x', 'y', 'z'] });
+
+		expect(keyA).not.toBe(keyB);
+	});
+
+	it('produces the SAME key for an identical list', async () => {
+		const { TOOL_REGISTRY } = await import('../src/handlers/tools');
+		const cacheKey = TOOL_REGISTRY.check_subdomain_takeover.cacheKey;
+
+		const keyA = cacheKey({ subdomains: ['a', 'b', 'c'] });
+		const keyB = cacheKey({ subdomains: ['a', 'b', 'c'] });
+
+		expect(keyA).toBe(keyB);
+	});
+
+	it('falls back to the :default key when no custom list is supplied', async () => {
+		const { TOOL_REGISTRY } = await import('../src/handlers/tools');
+		const cacheKey = TOOL_REGISTRY.check_subdomain_takeover.cacheKey;
+
+		expect(cacheKey({})).toBe('subdomain_takeover:default');
+	});
+});

--- a/test/tier-auth-owner-jwt-ip.test.ts
+++ b/test/tier-auth-owner-jwt-ip.test.ts
@@ -25,6 +25,21 @@ async function mintOwnerJwt(): Promise<string> {
 	);
 }
 
+async function mintDeveloperJwt(): Promise<string> {
+	return signJwt(
+		{ sub: 'dev-user', jti: newJti(), tier: 'developer' },
+		{ secret: SECRET, ttlSeconds: OAUTH_JWT_TTL_SECONDS, issuer: ISSUER, audience: AUDIENCE },
+	);
+}
+
+/** Mirror tier-auth's keyHash derivation: hex(SHA-256(rawBearerToken)). */
+async function expectedKeyHash(token: string): Promise<string> {
+	const raw = new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token)));
+	return Array.from(raw)
+		.map((b) => b.toString(16).padStart(2, '0'))
+		.join('');
+}
+
 const baseEnv = {
 	OAUTH_SIGNING_SECRET: SECRET,
 	OAUTH_ISSUER: ISSUER,
@@ -76,5 +91,23 @@ describe('resolveTier — owner-tier JWT IP rebind', () => {
 			`${ISSUER}/mcp`,
 		);
 		expect(result.tier).toBe('owner');
+	});
+});
+
+describe('resolveTier — JWT path returns a per-credential keyHash (BUG #5)', () => {
+	// Quota/concurrency principal selection is `tierAuthResult.keyHash ?? options.ip`
+	// (mcp/execute.ts). If the JWT branch omits keyHash, paid (developer/enterprise)
+	// callers fall back to client IP — a JWT reused across IPs multiplies the daily
+	// quota, and NAT users share one bucket. The JWT branch must return a stable
+	// keyHash derived the SAME way as the static path: hex(SHA-256(rawBearerToken)).
+	it('developer JWT → defined 64-hex keyHash matching hex(SHA-256(token))', async () => {
+		const token = await mintDeveloperJwt();
+		const result = await resolveTier(token, { ...baseEnv }, '203.0.113.9', `${ISSUER}/mcp`);
+
+		expect(result.authenticated).toBe(true);
+		expect(result.tier).toBe('developer');
+		expect(result.keyHash).toBeDefined();
+		expect(result.keyHash).toMatch(/^[0-9a-f]{64}$/);
+		expect(result.keyHash).toBe(await expectedKeyHash(token));
 	});
 });


### PR DESCRIPTION
## Summary

Six real bugs found by a multi-agent adversarial bug-hunt (each candidate cleared two independent refutation skeptics, then was re-verified by hand against source). **Every fix is gated behind a failing-before / passing-after test.** A 7th candidate was a false positive and was rejected (details below).

Branch verification: **5180 tests pass** (+9 new regression tests over the `main` baseline of 5171), `typecheck` clean, `lint` clean, `dns-checks` 387 pass. The 8 "errors" in the full run are the documented miniflare pool-teardown flake (no real failures).

## Fixes

| # | Sev | Area | File | Bug → Fix |
|---|-----|------|------|-----------|
| 1 | med | security | `src/mcp/execute.ts` | `unknown_tool` fuzz signal recorded only on the **SSE** path; JSON (`Accept: application/json`) `tools/call` never tripped the abuse counter → unbounded probing. Now recorded on both paths. |
| 2 | high | correctness | `src/handlers/tools.ts` | `check_subdomain_takeover` cache key folded only **list length** → two different same-length lists collided on one 5-min entry; caller B got caller A's results. Now hashes sorted list contents (mirrors `discover_brand_domains`). |
| 3 | med | correctness | `src/tools/scan-domain.ts` | A transient check error/timeout during `scan_domain` was cached unconditionally and served to direct `check_*` calls for 5 min. `safeCheck` now marks `partial:true` and `runCachedCheck` skips caching partial results — restores the documented self-heal invariant. |
| 5 | high | auth | `src/lib/tier-auth.ts` | OAuth **JWT** path returned no `keyHash`, so per-key daily quota + concurrency keyed on **client IP** for paid (developer/enterprise) callers. Now derives the same `hex(SHA-256(token))` keyHash the static path uses. |
| 6 | med | security | `src/handlers/tools.ts` | request-dedup keyed on `principalId` (= `keyHash ?? ipHash`), so an **unauthenticated** caller's ipHash became a truthy principal, defeating `withRequestDedup`'s skip → two NAT'd unauth callers share a fingerprint (cross-principal op-ID replay). Now keys on `keyHash` only, matching the module's documented invariant. |
| 7 | med | scoring | `packages/dns-checks/src/checks/spf-analysis.ts` | SPF `redirect=` excluded from the RFC 7208 **§4.6.4** 10-lookup budget → undercount by 1. Now counted (verified no double-count vs the recursive target). |

### #7 score impact (narrow, RFC-correct)
Only a record with **exactly 8 lookup mechanisms + a `redirect=`** newly crosses the `>=9` near-limit threshold (one new `high` SPF finding). Records already `>=9`, or far below, are unaffected (metadata `+1` only). Cross-consistent with `resolve_spf_chain`, which already counts `redirect` as a lookup.

## Rejected (false positive)
- **dane_https / svcb_https "missing from protectiveWeights"** — they ARE present in `DEFAULT_SCORING_CONFIG.protectiveWeights` (config.ts); the finder misread the deprecated flat `weights` map (where they're 0). No change.

## Follow-up (not a live bug)
- `src/tools/spf-analysis.ts` is a **dead duplicate** of the fixed `dns-checks` copy (imported only by its own spec). Recommend dedupe in a later pass; its stale `count=4` assertion is internally consistent against the unfixed dead copy.

## Notes for the reviewer
- #5 and #6 touch auth/quota; #1/#6 are security-relevant — worth focused attention.
- Two pre-existing `request-dedup-wiring` tests were migrated `principalId`→`keyHash` to model an *authenticated* caller (the assertions are unchanged; only the field representing the authenticated principal moved, per the #6 contract change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)