### PR TITLE
refactor(oauth): type handlers against AppEnv + correct stale CLAUDE.md facts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Guidance for Claude Code working in this repo.
 ## What is this?
 
 Blackveil DNS — source-available DNS & email security scanner, built as a Cloudflare Worker.
-79 tools exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` runs only inside `scan_domain`. Listed on the MCP Registry as `com.blackveilsecurity/dns`.
+80 tools exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` runs only inside `scan_domain`. Listed on the MCP Registry as `com.blackveilsecurity/dns`.
 
 **Version sync** when bumping: `version` in `package.json` + `package-lock.json` (the source of truth — `SERVER_VERSION` in `src/lib/server-version.ts` auto-derives via `pkg.version`, do **not** hand-edit it), top-level `version` in `server.json` (currently **remotes-only — single `version` field**; the `packages[0].version` foot-gun only applies if an npm `packages` stanza is re-added), and the `[X.Y.Z]` heading in `CHANGELOG.md`.
 
@@ -78,13 +78,13 @@ Both publish together from `publish.yml` on version tags.
 
 ### scan_domain orchestration
 
-18 scan categories run in parallel via `Promise.allSettled`: 17 registered scan-included tools plus internal `subdomain_takeover`. Cache keys: `cache:<domain>:check:<name>` + top-level `cache:<domain>`. 5 min TTL (overridable via `cacheTtlSeconds`). `force_refresh` → `skipCache` in `runWithCache()`.
+19 scan categories run in parallel via `Promise.allSettled`: 18 registered scan-included tools plus internal `subdomain_takeover`. Cache keys: `cache:<domain>:check:<name>` + top-level `cache:<domain>`. 5 min TTL (overridable via `cacheTtlSeconds`). `force_refresh` → `skipCache` in `runWithCache()`.
 
 **Maturity staging**: `computeMaturityStage()` 0–4 (Unprotected → Hardened). Stage 3 doesn't require DKIM; Stage 4 hardening: CAA, DKIM-discovered, BIMI, DANE, MTA-STS strict. Score caps stage: F → ≤2, D/D+ → ≤3.
 
-**Timeouts**: scan 12s preserves partial results; per-check 8s.
+**Timeouts**: scan 15s preserves partial results; per-check 8s. (`SCAN_TIMEOUT_MS`, env-overridable, clamped [5s, 30s].)
 
-**Subrequest ceiling** (operating constraint, not a bug): a cold-cache `scan_domain` fans out ~20 subrequests/domain (18 categories, mostly DoH + 2 HTTPS); `/internal/tools/batch` can fan out to ~50×18. Cloudflare Workers caps subrequests per invocation at 50 (Free) / 1000 (Paid). BlackVeil production runs on a paid plan, so this is not a prod concern. BSL self-hosters on the Free plan should keep batch size / scan concurrency modest (cache hits don't count) or upgrade.
+**Subrequest ceiling** (operating constraint, not a bug): a cold-cache `scan_domain` fans out ~20 subrequests/domain (19 categories, mostly DoH + 2 HTTPS); `/internal/tools/batch` can fan out to ~50×19. Cloudflare Workers caps subrequests per invocation at 50 (Free) / 1000 (Paid). BlackVeil production runs on a paid plan, so this is not a prod concern. BSL self-hosters on the Free plan should keep batch size / scan concurrency modest (cache hits don't count) or upgrade.
 
 **Post-processing**:
 
@@ -132,7 +132,7 @@ Two channels, both deliberately **lenient — never reject**: (1) the `initializ
 
 Three-tier model (`computeScanScore`). `CATEGORY_DISPLAY_WEIGHTS` is display-only.
 
-**Core (70%)**: DMARC 16, DKIM 10, SPF 10, DNSSEC 10, SSL 8 (representative `mail_enabled` profile — every core weight is per-profile; e.g. DNSSEC 5–20, SSL 7–14 across the 6 profiles).
+**Core (70%)**: DMARC 16, DKIM 10, SPF 10, DNSSEC 10, SSL 8 (representative `mail_enabled` profile — every core weight is per-profile; e.g. DNSSEC 5–20, SSL 0–14 across the 6 profiles — the `authoritative_dns_infra` profile zeroes SSL).
 **Protective (20%)**: Subdomain Takeover 4, HTTP Security 3, MTA-STS 3, MX 2, CAA 2, NS 2, Lookalikes 2, Shadow Domains 2.
 **Hardening (10%)**: DANE, BIMI, TLS-RPT, TXT Hygiene, MX Reputation, SRV, Zone Hygiene (~1.4 pts each, bonus-only).
 
@@ -147,12 +147,12 @@ Override via `SCORING_CONFIG` env (JSON; `weights`, `profileWeights`, `threshold
 - **Confidence gate**: `scoreIndicatesMissingControl()` fires only for `deterministic`/`verified`. Heuristic DKIM "not found" doesn't zero category.
 - **Provider-informed DKIM**: provider detected + probing empty → HIGH → MEDIUM.
 - **Severity penalties**: C −40, H −25, M −15, L −5, Info 0.
-- **`passed`**: `score >= 50 && !hasMissingControl`. Missing control → score zeroed. Checks using `missingControl: true`: CAA, HTTP Security, MTA-STS, MX, SVCB-HTTPS, NS, Zone Hygiene, BIMI, DANE, TLS-RPT. **DNSSEC deliberately does NOT** — per NIST SP 800-81r3, DNSSEC is a baseline integrity control in a defense-in-depth model: absence is a `high`-severity Core penalty (category → 60, via a fixed `penaltyOverride: 40` on the finding metadata that decouples the −40 deduction from the `high` severity label — see `computeCategoryScore`), not a category-zeroing missing control.
+- **`passed`**: `score >= 50 && !hasMissingControl`. Missing control → score zeroed. Checks using `missingControl: true`: HTTP Security, MTA-STS, MX, NS, Zone Hygiene, BIMI, DANE. (CAA, SVCB-HTTPS, TLS-RPT deliberately do NOT — absence is a graded finding, not a category-zeroing missing control.) **DNSSEC deliberately does NOT** — per NIST SP 800-81r3, DNSSEC is a baseline integrity control in a defense-in-depth model: absence is a `high`-severity Core penalty (category → 60, via a fixed `penaltyOverride: 40` on the finding metadata that decouples the −40 deduction from the `high` severity label — see `computeCategoryScore`), not a category-zeroing missing control.
 - **Grades**: A+ 92+, A 87–91, B+ 82–86, B 76–81, C+ 70–75, C 63–69, D+ 56–62, D 50–55, F <50.
 
 ### Profiles
 
-Five: `mail_enabled` (default), `enterprise_mail`, `non_mail`, `web_only`, `minimal`. Defined in `packages/dns-checks/src/scoring/profiles.ts`. **Phase 1**: `auto` uses `mail_enabled` weights; explicit `profile` activates different weights + cache keys.
+Six: `mail_enabled` (default), `enterprise_mail`, `non_mail`, `web_only`, `minimal`, `authoritative_dns_infra`. Defined in `packages/dns-checks/src/scoring/profiles.ts`. **Phase 1**: `auto` uses `mail_enabled` weights; explicit `profile` activates different weights + cache keys.
 
 ### Adaptive weights
 
@@ -162,7 +162,7 @@ EMA per profile+provider via `ProfileAccumulator` DO. Maturity-gated blending (`
 
 - **SSRF**: blocked IPs/TLDs in `config.ts`; enforced by `sanitize.ts`. All outbound `redirect: 'manual'`. **Attacker-controlled URLs** (BIMI `l=`/`a=`, redirect `Location:` targets the worker follows) MUST use `safeFetch` (`lib/safe-fetch.ts`). Fetches to URLs whose hostname is already validated (e.g. `https://${validatedDomain}/.well-known/...`) may use raw `fetch` with manual redirects.
 - **Auth**: Static `BV_API_KEY` (constant-time XOR). Token from `Authorization: Bearer` first, then `?api_key=` (Smithery fallback). Six tiers: `free`, `agent`, `developer`, `enterprise`, `partner`, `owner`. Owner-tier IP gate: client IP must be in `OWNER_ALLOW_IPS` else downgrade to `partner` (including OAuth JWT path). OAuth JWT validates `claims.tier` against `JwtIssuableTierSchema = z.enum(['owner','developer','enterprise'])`. The JWT path returns a `keyHash` (`hex(SHA-256(token))`, same as the static path) so per-key daily quota + concurrency key on the credential, not the client IP (3.15.1 — previously the JWT path returned no `keyHash` and quota fell back to `options.ip`).
-- **Rate limits**: 50/min, 300/hr per IP (unauthenticated). Authenticated bypass per-IP; per-tier daily quotas apply. Only `tools/call` counts. `check_lookalikes`/`check_shadow_domains`: 20/day per IP + 60-min cache.
+- **Rate limits**: 50/min, 300/hr per IP (unauthenticated). Authenticated bypass per-IP; per-tier daily quotas apply. Only `tools/call` counts. `check_mx_reputation`: 20/day per IP + 60-min cache. `check_lookalikes`/`check_shadow_domains`: 5/day (free-tier `FREE_TOOL_DAILY_LIMITS`).
 - **Per-tool quotas**: `FREE_TOOL_DAILY_LIMITS` in `config.ts`. Global cap `GLOBAL_DAILY_TOOL_LIMIT` 500k/day via `QuotaCoordinator` DO.
 - **Body**: 10 KB on `/mcp`. **IP source**: `cf-connecting-ip` only (never `x-forwarded-for`).
 - **Origin**: MCP-compliant rejection of unauthorized browser `Origin`; `ALLOWED_ORIGINS` configurable.
@@ -181,7 +181,7 @@ bv-web plan → OAuth tier claim → bv-mcp limits:
 | pro / business / MCP Developer | developer  | 500       | 10         | Business / 48h  |
 | enterprise / MCP Enterprise    | enterprise | 10,000    | 25         | Enterprise / 4h |
 
-Resolution in `src/oauth/entitlements.ts` via bv-web service binding `api/internal/mcp/oauth/authorize`. Mapping defined in bv-web `app/lib/services/mcp/oauth-entitlements.server.ts`. The local static `BV_API_KEY` resolves to `owner` tier (`src/lib/tier-auth.ts:246-253`), with the `OWNER_ALLOW_IPS` IP gate downgrading to `partner` when the client IP isn't allowlisted. The `agent` tier (200/day, 5 concurrent) is reachable only via the bv-web `validate-key` service binding, when bv-web returns that tier for a non-paying key.
+Resolution in `src/oauth/entitlements.ts` via bv-web service binding `api/internal/mcp/oauth/authorize`. Mapping defined in bv-web `app/lib/services/mcp/oauth-entitlements.server.ts`. The local static `BV_API_KEY` resolves to `owner` tier (`src/lib/tier-auth.ts:320-338`, the step-4 fallback), with the `OWNER_ALLOW_IPS` IP gate downgrading to `partner` when the client IP isn't allowlisted. The `agent` tier (200/day, 5 concurrent) is reachable only via the bv-web `validate-key` service binding, when bv-web returns that tier for a non-paying key.
 
 ### Internal routes
 
@@ -190,7 +190,7 @@ Resolution in `src/oauth/entitlements.ts` via bv-web service binding `api/intern
 **Bearer auth (defense-in-depth)**:
 
 - `/internal/trial-keys/*`, `/internal/oauth/grants` (credential-minting) → strict gate: 503 if `BV_WEB_INTERNAL_KEY` unset, 401 on missing/wrong bearer.
-- `/internal/tools/*`, `/internal/analytics/*` → `internalLenientAuthGate`, opt-in via `REQUIRE_INTERNAL_AUTH=true`.
+- `/internal/tools/*`, `/internal/analytics/*`, `/internal/tenants/*` → `internalLenientAuthGate`. Despite the name it is **secure-by-default (FIND-12)**: ACTIVE unless `REQUIRE_INTERNAL_AUTH=false`, requiring `Authorization: Bearer ${BV_WEB_INTERNAL_KEY}` (503 if the key is unset, 401 on missing/wrong bearer). Set `REQUIRE_INTERNAL_AUTH=false` to disable and fall back to the `cf-connecting-ip` network guard alone.
 
 ### Fuzzing detection
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,8 @@ type BvMcpEnv = {
 	PROFILE_ACCUMULATOR?: DurableObjectNamespace;
 	MCP_ANALYTICS?: AnalyticsEngineDataset;
 	BV_API_KEY?: string;
+	/** Comma-separated IP allowlist for owner tier. When set, an owner-tier credential (static `BV_API_KEY` or owner JWT) from a non-listed client IP is downgraded to `partner` (`applyOwnerIpGate` in `lib/tier-auth.ts`). Unset/empty → owner unrestricted (self-hosted/dev). */
+	OWNER_ALLOW_IPS?: string;
 	BV_WEB?: Fetcher;
 	BV_WEB_INTERNAL_KEY?: string;
 	ALLOWED_ORIGINS?: string;
@@ -180,10 +182,12 @@ type BvMcpEnv = {
 import type { TierAuthResult } from './lib/tier-auth';
 import { resolveTier } from './lib/tier-auth';
 
-const app = new Hono<{
+/** Shared Hono app env (bindings + per-request variables). Exported so route handlers in `oauth/` can type `Context<AppEnv>` instead of casting `c.env`. */
+export type AppEnv = {
 	Bindings: BvMcpEnv;
 	Variables: { isAuthenticated: boolean; tierAuthResult: TierAuthResult; apiKeyInQuery: boolean };
-}>();
+};
+const app = new Hono<AppEnv>();
 const mcpPaths = ['/mcp', '/mcp/messages', '/mcp/sse'] as const;
 
 import { buildBrandTierLookups } from './lib/brand-tier-lookups';
@@ -262,9 +266,9 @@ for (const path of mcpPaths) {
 	app.use(
 		path,
 		cors({
-			origin: (origin, c) => {
+			origin: (origin, c: Context<AppEnv>) => {
 				if (!origin) return '';
-				const result = checkOrigin(origin, c.req.url, (c.env as BvMcpEnv).ALLOWED_ORIGINS?.trim());
+				const result = checkOrigin(origin, c.req.url, c.env.ALLOWED_ORIGINS?.trim());
 				return result === 'allowed' ? origin : '';
 			},
 			allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
@@ -530,7 +534,7 @@ app.post('/mcp', async (c) => {
 					secondaryDohEndpoint: c.env.BV_DOH_ENDPOINT,
 					secondaryDohToken: c.env.BV_DOH_TOKEN,
 					certstream: c.env.BV_CERTSTREAM,
-					certstreamAuthToken: certstreamAuthToken(c.env as BvMcpEnv),
+					certstreamAuthToken: certstreamAuthToken(c.env),
 					whoisBinding: c.env.BV_WHOIS,
 					reconBinding: c.env.BV_RECON,
 					reconAuthToken: c.env.BV_RECON_KEY,
@@ -615,7 +619,7 @@ app.post('/mcp', async (c) => {
 		secondaryDohEndpoint: c.env.BV_DOH_ENDPOINT,
 		secondaryDohToken: c.env.BV_DOH_TOKEN,
 		certstream: c.env.BV_CERTSTREAM,
-		certstreamAuthToken: certstreamAuthToken(c.env as BvMcpEnv),
+		certstreamAuthToken: certstreamAuthToken(c.env),
 		whoisBinding: c.env.BV_WHOIS,
 		reconBinding: c.env.BV_RECON,
 		reconAuthToken: c.env.BV_RECON_KEY,
@@ -776,7 +780,7 @@ app.post('/mcp/messages', async (c) => {
 				secondaryDohEndpoint: c.env.BV_DOH_ENDPOINT,
 				secondaryDohToken: c.env.BV_DOH_TOKEN,
 				certstream: c.env.BV_CERTSTREAM,
-				certstreamAuthToken: certstreamAuthToken(c.env as BvMcpEnv),
+				certstreamAuthToken: certstreamAuthToken(c.env),
 				whoisBinding: c.env.BV_WHOIS,
 				reconBinding: c.env.BV_RECON,
 				reconAuthToken: c.env.BV_RECON_KEY,
@@ -945,8 +949,8 @@ app.route('/internal', internalRoutes);
 // boolean. `'disabled'` → 404 (feature off). `'misconfigured'` → 503 (feature
 // on but signing secret missing/short — fail-fast at first RTT instead of
 // after the user completes the consent dance).
-function oauthGuarded<T>(c: Context, ready: () => T | Response): T | Response {
-	const state = oauthAvailability(c.env as Pick<BvMcpEnv, 'ENABLE_OAUTH' | 'OAUTH_SIGNING_SECRET'>);
+function oauthGuarded<T>(c: Context<AppEnv>, ready: () => T | Response): T | Response {
+	const state = oauthAvailability(c.env);
 	if (state === 'disabled') return oauthDisabledResponse();
 	if (state === 'misconfigured') return oauthMisconfiguredResponse();
 	return ready();

--- a/src/oauth/authorize.ts
+++ b/src/oauth/authorize.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 import type { Context } from 'hono';
+import type { AppEnv } from '../index';
 import { AuthorizeQuerySchema } from '../schemas/oauth';
 import { createAuthorizationCode, getClient, putCode } from './storage';
 import { isAuthorizedRequest } from '../lib/auth';
@@ -100,7 +101,7 @@ function redirectToCustomerConsent(
  * deny, no-store). On any validation or lookup failure returns a plain-text 400 — never HTML
  * and never a redirect — to avoid open-redirect risk before `redirect_uri` is trusted.
  */
-export async function handleAuthorizeGet(c: Context): Promise<Response> {
+export async function handleAuthorizeGet(c: Context<AppEnv>): Promise<Response> {
 	const sp = new URL(c.req.url).searchParams;
 	const q: Record<string, string> = {};
 	sp.forEach((value, key) => {
@@ -113,16 +114,16 @@ export async function handleAuthorizeGet(c: Context): Promise<Response> {
 		// Static description — never echo caller-controlled validation text (mirrors token.ts/register.ts).
 		return new Response('Invalid authorization request', { status: 400 });
 	}
-	const kv = (c.env as { SESSION_STORE: KVNamespace }).SESSION_STORE;
-	const kvEnvelopeKey = parseEnvelopeKey((c.env as { KV_ENVELOPE_KEY?: string }).KV_ENVELOPE_KEY) ?? undefined;
+	const kv = c.env.SESSION_STORE!;
+	const kvEnvelopeKey = parseEnvelopeKey(c.env.KV_ENVELOPE_KEY) ?? undefined;
 	const client = await getClient(kv, parsed.client_id, kvEnvelopeKey);
 	if (!client) return new Response('Unknown client_id', { status: 400 });
 	if (!client.redirect_uris.includes(parsed.redirect_uri)) {
 		return new Response('redirect_uri not registered to this client', { status: 400 });
 	}
-	if (!ownerOAuthEnabled(c.env as { ENABLE_OWNER_OAUTH?: string })) {
+	if (!ownerOAuthEnabled(c.env)) {
 		const customerRedirect = redirectToCustomerConsent(
-			(c.env as { BV_WEB_OAUTH_CONSENT_URL?: string }).BV_WEB_OAUTH_CONSENT_URL,
+			c.env.BV_WEB_OAUTH_CONSENT_URL,
 			parsed,
 		);
 		if (customerRedirect) return customerRedirect;
@@ -194,9 +195,9 @@ function redirectWithError(redirectUri: string, error: string, state: string | u
  * with `?error=access_denied&state=`. Validation failures before redirect_uri is trusted
  * return plain-text 4xx — never HTML, never a redirect.
  */
-export async function handleAuthorizePost(c: Context): Promise<Response> {
-	const kv = (c.env as { SESSION_STORE: KVNamespace }).SESSION_STORE;
-	const kvEnvelopeKey = parseEnvelopeKey((c.env as { KV_ENVELOPE_KEY?: string }).KV_ENVELOPE_KEY) ?? undefined;
+export async function handleAuthorizePost(c: Context<AppEnv>): Promise<Response> {
+	const kv = c.env.SESSION_STORE!;
+	const kvEnvelopeKey = parseEnvelopeKey(c.env.KV_ENVELOPE_KEY) ?? undefined;
 	const ip = resolveClientIpFromRequestHeaders(c.req.raw.headers);
 
 	if (await consentRateExceeded(kv, ip)) {
@@ -235,7 +236,7 @@ export async function handleAuthorizePost(c: Context): Promise<Response> {
 	if (!client.redirect_uris.includes(parsed.redirect_uri)) {
 		return new Response('redirect_uri not registered to this client', { status: 400 });
 	}
-	if (!ownerOAuthEnabled(c.env as { ENABLE_OWNER_OAUTH?: string })) {
+	if (!ownerOAuthEnabled(c.env)) {
 		return redirectWithError(parsed.redirect_uri, 'temporarily_unavailable', parsed.state);
 	}
 
@@ -245,12 +246,12 @@ export async function handleAuthorizePost(c: Context): Promise<Response> {
 	// MCP request). If the env var is set, only allowlisted IPs may proceed; anything else
 	// redirects back with `access_denied` before any code is written. When unset we retain the
 	// self-hosted / dev default of no IP gating.
-	const allowed = parseOwnerAllowIps((c.env as { OWNER_ALLOW_IPS?: string }).OWNER_ALLOW_IPS);
+	const allowed = parseOwnerAllowIps(c.env.OWNER_ALLOW_IPS);
 	if (allowed.length > 0 && !allowed.includes(ip)) {
 		return redirectWithError(parsed.redirect_uri, 'access_denied', parsed.state);
 	}
 
-	const expected = (c.env as { BV_API_KEY?: string }).BV_API_KEY ?? '';
+	const expected = c.env.BV_API_KEY ?? '';
 	const ok = await isAuthorizedRequest(`Bearer ${apiKey}`, expected);
 	if (!ok) {
 		return redirectWithError(parsed.redirect_uri, 'access_denied', parsed.state);

--- a/src/oauth/register.ts
+++ b/src/oauth/register.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 import type { Context } from 'hono';
+import type { AppEnv } from '../index';
 import { RegisterRequestSchema } from '../schemas/oauth';
 import { OAUTH_KV_PREFIX, OAUTH_REDIRECT_URI_ALLOWLIST } from '../lib/config';
 import { putClient } from './storage';
@@ -83,9 +84,9 @@ async function registerRateExceeded(kv: KVNamespace, ip: string): Promise<{ exce
  * URI allowlist (`OAUTH_REDIRECT_URI_ALLOWLIST`) before any write. The `client_id` is a
  * UUID v4 generated via Web Crypto (`crypto.randomUUID`) — unguessable and globally unique.
  */
-export async function handleRegister(c: Context): Promise<Response> {
-	const kv = (c.env as { SESSION_STORE: KVNamespace }).SESSION_STORE;
-	const kvEnvelopeKey = parseEnvelopeKey((c.env as { KV_ENVELOPE_KEY?: string }).KV_ENVELOPE_KEY) ?? undefined;
+export async function handleRegister(c: Context<AppEnv>): Promise<Response> {
+	const kv = c.env.SESSION_STORE!;
+	const kvEnvelopeKey = parseEnvelopeKey(c.env.KV_ENVELOPE_KEY) ?? undefined;
 	const ip = c.req.header('cf-connecting-ip') ?? '0.0.0.0';
 	const rl = await registerRateExceeded(kv, ip);
 	if (rl.exceeded) {

--- a/src/oauth/token.ts
+++ b/src/oauth/token.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 import type { Context } from 'hono';
+import type { AppEnv } from '../index';
 import { TokenRequestSchema } from '../schemas/oauth';
 import { consumeCode, getTokenVersion } from './storage';
 import { signJwt, newJti, constantTimeEqual } from './jwt';
@@ -97,14 +98,15 @@ export async function verifyPkce(verifier: string, challenge: string): Promise<b
  * Scope defaults to `mcp` when the original authorize request omitted one — keeps a
  * recognizable scope claim for downstream Bearer-path policy decisions (Phase 8).
  */
-export async function handleToken(c: Context): Promise<Response> {
-	const env = c.env as { SESSION_STORE: KVNamespace; OAUTH_SIGNING_SECRET?: string; OAUTH_ISSUER?: string; KV_ENVELOPE_KEY?: string };
+export async function handleToken(c: Context<AppEnv>): Promise<Response> {
+	const env = c.env;
+	const kv = env.SESSION_STORE!;
 	const kvEnvelopeKey = parseEnvelopeKey(env.KV_ENVELOPE_KEY) ?? undefined;
 
 	// Rate limit runs FIRST — before content-type / grant-type / Zod — so an attacker
 	// flooding the endpoint with invalid payloads still hits the cheap KV gate.
 	const ip = resolveClientIpFromRequestHeaders(c.req.raw.headers);
-	if (await tokenRateExceeded(env.SESSION_STORE, ip)) {
+	if (await tokenRateExceeded(kv, ip)) {
 		return c.json({ error: 'invalid_request', error_description: 'Too many token requests' }, 429);
 	}
 
@@ -137,7 +139,7 @@ export async function handleToken(c: Context): Promise<Response> {
 		return c.json({ error: 'invalid_request', error_description: 'Request body failed validation' }, 400);
 	}
 
-	const codeRec = await consumeCode(env.SESSION_STORE, parsed.code, kvEnvelopeKey);
+	const codeRec = await consumeCode(kv, parsed.code, kvEnvelopeKey);
 	if (!codeRec) {
 		return c.json({ error: 'invalid_grant', error_description: 'Code unknown, expired, or already used' }, 400);
 	}
@@ -163,7 +165,7 @@ export async function handleToken(c: Context): Promise<Response> {
 	const tier = codeRec.tier ?? 'owner';
 	// Read the current token-version for this subject so the minted JWT can be
 	// invalidated before its 90-day natural expiry (FIND-13).
-	const ver = await getTokenVersion(env.SESSION_STORE, subject);
+	const ver = await getTokenVersion(kv, subject);
 	const token = await signJwt(
 		{ sub: subject, jti: newJti(), tier, client_id: parsed.client_id, ver },
 		{ secret, ttlSeconds: OAUTH_JWT_TTL_SECONDS, issuer, audience: `${issuer}/mcp` },


### PR DESCRIPTION
## Summary

Two related cleanups that came out of a CLAUDE.md tuning pass:

1. **docs** — corrected 10 stale facts in `CLAUDE.md`, each verified against source (tool count 79→80, scan categories 18→19, scan timeout 12s→15s, SSL weight range, `missingControl` check list, profiles Five→Six, the 20/day+60min-cache attribution, a moved line ref, and the now-secure-by-default internal auth gate).

2. **refactor (type-only)** — the OAuth route handlers (`authorize`/`token`/`register`) and a few `index.ts` contexts had `c.env` typed as `any`, so every env access was cast (`c.env as { ... }` / `c.env as BvMcpEnv`) just to recover a shape. This exports a shared `AppEnv` type from `index.ts` and types the handlers as `Context<AppEnv>`, removing **all** those casts and restoring real compile-time checking on env access. Also adds `OWNER_ALLOW_IPS` to the env type (previously read only via cast/structural shapes).

### What changed
- `index.ts`: `export type AppEnv`; typed the CORS `origin` callback + `oauthGuarded`; dropped 5 `c.env` casts.
- `oauth/{authorize,token,register}.ts`: `Context<AppEnv>`, dropped all `c.env` casts.
- `SESSION_STORE` keeps its `!` presence assertion where required downstream (matches the existing `env.X!` idiom).

### Out of scope
The `env as ScheduledEnv` / `ScanQueueConsumerEnv` casts in the raw `scheduled`/`queue` exports — those narrow the platform `env` param (no Hono context) and are a separate concern.

### Verification
- `tsc --noEmit` clean · `eslint` clean
- `index.spec.ts` + full OAuth suite: **160/160 passing**
- No behavior change (type-only refactor); no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)