### PR TITLE
docs(readme): fix stale badges + add missing tool to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 [![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![MCP tools](https://img.shields.io/badge/MCP%20tools-75-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
-[![MCP](https://img.shields.io/badge/MCP-2025--03--26-blue)](https://modelcontextprotocol.io/)
+[![MCP](https://img.shields.io/badge/MCP-2025--06--18-blue)](https://modelcontextprotocol.io/)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com/)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-6.0-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 
 ![DNS Security](https://dns-mcp.blackveilsecurity.com/badge/blackveilsecurity.com)
 
@@ -106,7 +106,7 @@ Transport support:
   discover_subdomains   check_nsec_             brand_audit_status
   map_compliance          walkability           brand_audit_get_
   simulate_attack_paths check_dnssec_chain        report
-                        check_fast_flux         list_brand_audit_watches
+  check_agent_discovery check_fast_flux         list_brand_audit_watches
                         check_dnskey_strength
                         check_authoritative_dns_infra
                         check_root_server_set   register_brand_audit_watch


### PR DESCRIPTION
Found while reviewing the README for accuracy against the codebase. Three concrete inaccuracies, all docs-only.

## Fixes
- **MCP protocol badge** `2025-03-26` → `2025-06-18` — matches `LATEST_PROTOCOL_VERSION` / `SUPPORTED_PROTOCOL_VERSIONS` in `src/mcp/dispatch.ts`. 2025-03-26 is retained only for back-compat.
- **TypeScript badge** `5.9` → `6.0` — `package.json` pins `typescript: 6.0.3`.
- **`check_agent_discovery`** added to the Intelligence column of the tool table — the registry has 75 tools but the ASCII table was listing only 74 (`group: 'intelligence'`, an IETF BANDAID agent-discovery scanner).

## Verified accurate (no change needed)
Tool count (75), 7 prompts / 6 resources, the 9 `_meta` groups, the `recommended` starter set, `generate` artifacts, `BV_INFRA_PROBE` + `m365Proxy` bindings, free-tier 25 scans/day, rate limits, and the paid-gating model all match the code.

No count-bearing prose strings were touched, so the `readme-tool-surface` audit is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)