### PR TITLE
feat(internal): agent-chat caller principal + 13-tool read-only allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.18.0] - 2026-06-11
+
 ### Security
 
 - **Internal:** add `agent-chat` caller principal (`X-BV-Caller: agent-chat`) with a server-side 13-tool read-only allowlist on `/internal/tools/{call,batch}`. Defense-in-depth for the bv-web agent feature — non-allowlisted tools (mutating/offensive/identity) are rejected with `403 { "error": "agent_tool_not_allowed" }` even if the consuming gateway is bypassed. Alias-normalized before the check; audit-pinned (`agent-tool-allowlist.audit.test.ts`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Security
+
+- **Internal:** add `agent-chat` caller principal (`X-BV-Caller: agent-chat`) with a server-side 13-tool read-only allowlist on `/internal/tools/{call,batch}`. Defense-in-depth for the bv-web agent feature — non-allowlisted tools (mutating/offensive/identity) are rejected with `403 { "error": "agent_tool_not_allowed" }` even if the consuming gateway is bypassed. Alias-normalized before the check; audit-pinned (`agent-tool-allowlist.audit.test.ts`).
+
 ## [3.17.2] - 2026-06-10
 
 Patch release: fixes a P0 regression introduced in 3.17.1 plus follow-up hardening found in a post-merge code review of #387. No scoring/scan change; `SCORING_MODEL_VERSION` stays `1.2.0`; tool count unchanged (75).

--- a/docs/design/agent-chat-tool-allowlist.md
+++ b/docs/design/agent-chat-tool-allowlist.md
@@ -1,6 +1,6 @@
 # Design: Agent-Chat Caller Principal + Tool Allowlist (bv-mcp side)
 
-**Status:** Proposed · **Date:** 2026-06-10 · **Change class:** A (public contract — new internal caller class)
+**Status:** Implemented · **Date:** 2026-06-10 · **Change class:** A (public contract — new internal caller class)
 **Companion spec:** `bv-web-prod` `docs/superpowers/specs/2026-06-10-agentic-chat-integration-design.md` (the consuming side)
 
 ## Why this exists

--- a/docs/design/agent-chat-tool-allowlist.md
+++ b/docs/design/agent-chat-tool-allowlist.md
@@ -1,0 +1,109 @@
+# Design: Agent-Chat Caller Principal + Tool Allowlist (bv-mcp side)
+
+**Status:** Proposed · **Date:** 2026-06-10 · **Change class:** A (public contract — new internal caller class)
+**Companion spec:** `bv-web-prod` `docs/superpowers/specs/2026-06-10-agentic-chat-integration-design.md` (the consuming side)
+
+## Why this exists
+
+bv-web-prod is adding a customer-facing AI chat agent that calls bv-mcp tools as its
+execution backend, over the existing `/internal/tools/*` service-binding path. Today that
+path is reached with `BV_WEB_INTERNAL_KEY`, which grants **ungated access to all tools** —
+including `query_signins` / `query_ual` (M365 identity telemetry), `osint_*`, and
+`scan_buckets_*`. An LLM is choosing the tool name and arguments on the other side.
+
+The bv-web gateway enforces a 13-tool read-only allowlist in-process, but that is a single
+in-process check one typo/routing-bug away from putting LLM-controlled arguments on
+offensive or identity tooling. This design adds a **second, independent gate on the bv-mcp
+side**, keyed to a distinct agent principal, so the trust boundary is enforced in both
+workers (defense-in-depth) and audit-tested here where the tool SSOT already lives.
+
+This is the "build bv-mcp first" half of a two-repo feature: the trust boundary must exist
+before bv-web calls it.
+
+## Scope
+
+In scope (this repo):
+1. A distinct caller principal for the agent path.
+2. A server-side allowlist of exactly the 13 read-only tools the agent may call.
+3. Enforcement that rejects anything else (and any non-read-only tool) with a 403-style error.
+4. An exact-set audit test (reusing the existing allowlist-audit machinery).
+
+Out of scope: the agent loop, prompt, history, domain-scoping, UI — all bv-web-prod.
+
+## The 13 allowlisted tools
+
+All read-only / passive, all present in `TOOL_DEFS`:
+
+```
+scan_domain, check_spf, check_dkim, check_dmarc, check_dnssec, check_ssl,
+check_mx, check_mta_sts, check_caa, check_http_security,
+explain_finding, compare_baseline, get_benchmark
+```
+
+Invariant: every member must have `readOnlyHint === true` (or equivalently not be in the
+mutating set) — the audit asserts this so a future rename/annotation change can't silently
+admit a mutating tool.
+
+## Caller principal
+
+**Decision needed at implementation:** two viable mechanisms —
+
+- **(A) Header assertion** — bv-web sends `X-BV-Caller: agent-chat` on the internal request
+  (alongside the existing bearer). bv-mcp's internal layer reads it and applies the agent
+  allowlist. Simplest; the header is only trustable *because* it rides the authenticated
+  internal binding (no public listener), same trust model the path already relies on.
+- **(B) Separate key** — a dedicated `BV_AGENT_KEY` distinct from `BV_WEB_INTERNAL_KEY`,
+  so rotating/revoking the agent path doesn't touch the general internal credential. Stronger
+  isolation; more secret-management surface.
+
+Recommendation: **(A) for v1** (header assertion), structured so swapping to (B) later is a
+localized change. Rationale: the internal path already trusts the binding; the win we need
+now is the *tool allowlist*, and (A) delivers it without new secret plumbing. Revisit (B) if
+the agent path ever needs independent revocation.
+
+## Enforcement point
+
+In `src/internal.ts`, at the `/internal/tools/call` (and `/internal/tools/batch`) handler:
+after auth + body parse, if the request carries the agent-caller signal, validate the
+requested tool name against `AGENT_ALLOWED_TOOLS` **before** dispatch to `handleToolsCall`.
+Reject with the internal error shape (mirror the existing 4xx pattern in that file) and a
+sanitized message (`Invalid tool for caller`). Non-agent internal callers are unaffected.
+
+`AGENT_ALLOWED_TOOLS` is a new exported `Set<string>` SSOT (co-located with the other
+internal allowlists, e.g. near `ALLOWED_BATCH_ARGS` / the gated-tools sets).
+
+## Result-format note (informs bv-web, documented here for the contract)
+
+`?format=structured` on `/internal/tools/call` returns raw `CheckResult` JSON **only** for
+the `check_*` cohort. The four non-`CheckResult` tools in the allowlist — `scan_domain`,
+`explain_finding`, `compare_baseline`, `get_benchmark` (members of `NON_CHECK_RESULT_TOOLS`)
+— fall through to MCP-framed `content` blocks even with `format=structured` (see
+`test/internal.spec.ts`). bv-web's gateway requests `format=compact` for those four and reads
+the text content. No change required here; recorded so the contract is explicit.
+
+## Quota / analytics note
+
+The internal path bypasses per-tool quotas, paid gating, and the distinct-domain cap by
+design (bv-web owns entitlement). Agent traffic will therefore not be quota-limited by
+bv-mcp, and analytics rows for these calls currently record `authTier: undefined` /
+`keyHash: undefined`. **Optional follow-up (not v1-blocking):** stamp an `authTier:'agent'`
+or a caller dimension on internal-path analytics so agent volume is attributable. Tracked,
+not required for the trust-boundary change.
+
+## Testing
+
+- `test/audits/agent-tool-allowlist.audit.test.ts` (new): assert `AGENT_ALLOWED_TOOLS` is
+  exactly the 13 names, every member exists in `TOOL_DEFS`, and every member is read-only.
+  Exact-set guard (fails CI if anyone adds/removes a tool without a deliberate edit) — same
+  pattern as `gated-tools-ssot.audit.test.ts`.
+- `test/internal.spec.ts` additions: agent-caller request for an allowlisted tool succeeds;
+  agent-caller request for a non-allowlisted tool (e.g. `query_signins`, `scan_buckets_start`)
+  is rejected; non-agent internal caller is unaffected.
+
+## Rollout / coupling
+
+Ship this **before** bv-web-prod starts calling the agent path, so the second gate exists at
+launch. Because it adds a recognized caller class to a public-ish contract, it's Change-class
+A: changelog entry + a note in the companion bv-web spec. No version-bump-only surfaces are
+touched beyond the new audit (which trips the count? no — it's a test, not a tool).
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.17.2",
+	"version": "3.18.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.17.2",
+			"version": "3.18.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.17.2",
+	"version": "3.18.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.17.2",
+	"version": "3.18.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -219,7 +219,7 @@ internalRoutes.post('/tools/call', async (c) => {
 	// (scan → scan_domain) so a legitimate aliased call isn't wrongly rejected.
 	// See docs/design/agent-chat-tool-allowlist.md.
 	if (isAgentCaller(c.req.header(AGENT_CALLER_HEADER)) && !isAgentAllowedTool(normalizeToolName(body.name))) {
-		return c.json({ content: [{ type: 'text', text: 'Invalid tool for caller' }], isError: true }, 403);
+		return c.json({ error: 'agent_tool_not_allowed' }, 403, { 'Cache-Control': 'no-store' });
 	}
 
 	const url = new URL(c.req.url);

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -416,6 +416,11 @@ internalRoutes.post('/tools/batch', async (c) => {
 		return c.json({ error: 'Invalid request body' }, 400);
 	}
 
+	// Agent-chat caller: same read-only allowlist as /tools/call (normalize alias first).
+	if (isAgentCaller(c.req.header(AGENT_CALLER_HEADER)) && !isAgentAllowedTool(normalizeToolName(body.tool))) {
+		return c.json({ error: 'agent_tool_not_allowed' }, 403, { 'Cache-Control': 'no-store' });
+	}
+
 	const toolName = body.tool;
 	const rawArgs = body.arguments ?? {};
 	// ALLOWED_BATCH_ARGS filtering stays (security allowlist, not shape validation)

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -37,7 +37,17 @@ import { isAuthorizedRequest } from './lib/auth';
 import { createAnalyticsClient } from './lib/analytics';
 import { parseScoringConfigCached } from './lib/scoring-config';
 import { buildBrandTierLookups } from './lib/brand-tier-lookups';
-import { MAX_REQUEST_BODY_BYTES, OAUTH_CODE_TTL_SECONDS, parseCacheTtl, parsePerCheckTimeout, parseScanTimeout } from './lib/config';
+import {
+	AGENT_CALLER_HEADER,
+	isAgentAllowedTool,
+	isAgentCaller,
+	MAX_REQUEST_BODY_BYTES,
+	OAUTH_CODE_TTL_SECONDS,
+	parseCacheTtl,
+	parsePerCheckTimeout,
+	parseScanTimeout,
+} from './lib/config';
+import { normalizeToolName } from './handlers/tool-args';
 import { validateDomain, sanitizeDomain } from './lib/sanitize';
 import { InternalToolCallSchema, BatchRequestSchema, CreateTrialKeyRequestSchema } from './schemas/internal';
 import { InternalOAuthGrantRequestSchema } from './schemas/oauth';
@@ -202,6 +212,14 @@ internalRoutes.post('/tools/call', async (c) => {
 			return c.json({ content: [{ type: 'text', text: `Invalid ${err.issues[0].path.join('.')}: ${err.issues[0].message}` }], isError: true }, 400);
 		}
 		return c.json({ content: [{ type: 'text', text: 'Missing required field: name' }], isError: true }, 400);
+	}
+
+	// Agent-chat caller: enforce the read-only allowlist (defense-in-depth; bv-web
+	// also gates, but this is the boundary-side guard). Normalize the alias first
+	// (scan → scan_domain) so a legitimate aliased call isn't wrongly rejected.
+	// See docs/design/agent-chat-tool-allowlist.md.
+	if (isAgentCaller(c.req.header(AGENT_CALLER_HEADER)) && !isAgentAllowedTool(normalizeToolName(body.name))) {
+		return c.json({ content: [{ type: 'text', text: 'Invalid tool for caller' }], isError: true }, 403);
 	}
 
 	const url = new URL(c.req.url);

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -383,6 +383,9 @@ export function isGatedPaidOnlyTool(toolName: string): boolean {
  * (defense-in-depth across the trust boundary). All members are passive/read-only;
  * the agent-tool-allowlist audit pins the exact set and the read-only invariant.
  * See docs/design/agent-chat-tool-allowlist.md.
+ * Names are canonical TOOL_DEFS names. The `scan` → `scan_domain` alias must be
+ * normalized BEFORE calling isAgentAllowedTool() (same ordering as the gated-tool
+ * check relative to normalizeToolName).
  */
 export const AGENT_ALLOWED_TOOLS: ReadonlySet<string> = new Set<string>([
 	'scan_domain',

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -377,6 +377,45 @@ export function isGatedPaidOnlyTool(toolName: string): boolean {
 	return GATED_PAID_ONLY_TOOLS.has(toolName);
 }
 
+/**
+ * Curated read-only tool set the bv-web agent-chat caller may invoke over the
+ * internal path. Second, independent gate behind bv-web's own gateway allowlist
+ * (defense-in-depth across the trust boundary). All members are passive/read-only;
+ * the agent-tool-allowlist audit pins the exact set and the read-only invariant.
+ * See docs/design/agent-chat-tool-allowlist.md.
+ */
+export const AGENT_ALLOWED_TOOLS: ReadonlySet<string> = new Set<string>([
+	'scan_domain',
+	'check_spf',
+	'check_dkim',
+	'check_dmarc',
+	'check_dnssec',
+	'check_ssl',
+	'check_mx',
+	'check_mta_sts',
+	'check_caa',
+	'check_http_security',
+	'explain_finding',
+	'compare_baseline',
+	'get_benchmark',
+]);
+
+/** Lowercase header name carrying the internal caller identity. */
+export const AGENT_CALLER_HEADER = 'x-bv-caller';
+
+/** Value of AGENT_CALLER_HEADER that identifies the bv-web agent-chat path. */
+export const AGENT_CALLER_VALUE = 'agent-chat';
+
+/** True when the request carries the agent-chat caller assertion. */
+export function isAgentCaller(headerValue: string | null | undefined): boolean {
+	return headerValue === AGENT_CALLER_VALUE;
+}
+
+/** True when `toolName` is in the agent-chat allowlist. */
+export function isAgentAllowedTool(toolName: string): boolean {
+	return AGENT_ALLOWED_TOOLS.has(toolName);
+}
+
 /** URL shown in the upgrade-required (HTTP 403) message. */
 export const UPGRADE_URL = 'https://blackveilsecurity.com/pricing';
 

--- a/test/audits/agent-tool-allowlist.audit.test.ts
+++ b/test/audits/agent-tool-allowlist.audit.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { AGENT_ALLOWED_TOOLS, AGENT_CALLER_HEADER, isAgentCaller, isAgentAllowedTool } from '../../src/lib/config';
+import { AGENT_ALLOWED_TOOLS, AGENT_CALLER_HEADER, AGENT_CALLER_VALUE, isAgentCaller, isAgentAllowedTool } from '../../src/lib/config';
 import { TOOLS } from '../../src/schemas/tool-definitions';
 
 const EXPECTED_AGENT_TOOLS = [
@@ -39,9 +39,11 @@ describe('agent-chat tool allowlist SSOT', () => {
 
 	it('header constant and predicates behave', () => {
 		expect(AGENT_CALLER_HEADER).toBe('x-bv-caller');
-		expect(isAgentCaller('agent-chat')).toBe(true);
+		expect(AGENT_CALLER_VALUE).toBe('agent-chat');
+		expect(isAgentCaller(AGENT_CALLER_VALUE)).toBe(true);
 		expect(isAgentCaller('something-else')).toBe(false);
 		expect(isAgentCaller(null)).toBe(false);
+		expect(isAgentCaller(undefined)).toBe(false);
 		expect(isAgentAllowedTool('scan_domain')).toBe(true);
 		expect(isAgentAllowedTool('query_signins')).toBe(false);
 	});

--- a/test/audits/agent-tool-allowlist.audit.test.ts
+++ b/test/audits/agent-tool-allowlist.audit.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { AGENT_ALLOWED_TOOLS, AGENT_CALLER_HEADER, isAgentCaller, isAgentAllowedTool } from '../../src/lib/config';
+import { TOOLS } from '../../src/schemas/tool-definitions';
+
+const EXPECTED_AGENT_TOOLS = [
+	'scan_domain',
+	'check_spf',
+	'check_dkim',
+	'check_dmarc',
+	'check_dnssec',
+	'check_ssl',
+	'check_mx',
+	'check_mta_sts',
+	'check_caa',
+	'check_http_security',
+	'explain_finding',
+	'compare_baseline',
+	'get_benchmark',
+].sort();
+
+describe('agent-chat tool allowlist SSOT', () => {
+	it('contains exactly the 13 curated tools', () => {
+		expect([...AGENT_ALLOWED_TOOLS].sort()).toEqual(EXPECTED_AGENT_TOOLS);
+	});
+
+	it('every allowlisted tool exists in TOOL_DEFS', () => {
+		const known = new Set(TOOLS.map((t) => t.name));
+		for (const name of AGENT_ALLOWED_TOOLS) {
+			expect(known.has(name), `${name} missing from TOOLS`).toBe(true);
+		}
+	});
+
+	it('every allowlisted tool is read-only (no mutating tool can slip in)', () => {
+		const byName = new Map(TOOLS.map((t) => [t.name, t]));
+		for (const name of AGENT_ALLOWED_TOOLS) {
+			expect(byName.get(name)?.annotations?.readOnlyHint, `${name} is not read-only`).toBe(true);
+		}
+	});
+
+	it('header constant and predicates behave', () => {
+		expect(AGENT_CALLER_HEADER).toBe('x-bv-caller');
+		expect(isAgentCaller('agent-chat')).toBe(true);
+		expect(isAgentCaller('something-else')).toBe(false);
+		expect(isAgentCaller(null)).toBe(false);
+		expect(isAgentAllowedTool('scan_domain')).toBe(true);
+		expect(isAgentAllowedTool('query_signins')).toBe(false);
+	});
+});

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -305,6 +305,48 @@ describe('Internal service binding routes', () => {
 		});
 	});
 
+	describe('agent-chat caller allowlist (/internal/tools/batch)', () => {
+		it('rejects a non-allowlisted batch tool for the agent-chat caller', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/batch', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'X-BV-Caller': 'agent-chat' },
+				body: JSON.stringify({ tool: 'discover_subdomains', domains: ['example.com'] }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(403);
+			const json = (await response.json()) as { error?: string };
+			expect(json.error).toBe('agent_tool_not_allowed');
+		});
+
+		it('allows an allowlisted batch tool for the agent-chat caller', async () => {
+			const { mockTxtRecords } = await import('./helpers/dns-mock');
+			mockTxtRecords(['v=spf1 -all']);
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/batch', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'X-BV-Caller': 'agent-chat' },
+				body: JSON.stringify({ tool: 'check_spf', domains: ['example.com'] }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+		});
+
+		it('does not gate non-agent batch callers', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/batch', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ tool: 'discover_subdomains', domains: ['example.com'] }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).not.toBe(403);
+		});
+	});
+
 	describe('POST /internal/tools/batch', () => {
 		beforeEach(() => {
 			IN_MEMORY_CACHE.clear();

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -232,6 +232,64 @@ describe('Internal service binding routes', () => {
 		});
 	});
 
+	describe('agent-chat caller allowlist (/internal/tools/call)', () => {
+		it('rejects a non-allowlisted tool when X-BV-Caller is agent-chat', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'X-BV-Caller': 'agent-chat' },
+				body: JSON.stringify({ name: 'query_signins', arguments: { tenantId: 't1' } }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(403);
+			const json = (await response.json()) as { isError?: boolean };
+			expect(json.isError).toBe(true);
+		});
+
+		it('allows an allowlisted tool for the agent-chat caller', async () => {
+			const { mockTxtRecords } = await import('./helpers/dns-mock');
+			mockTxtRecords(['v=spf1 -all']);
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'X-BV-Caller': 'agent-chat' },
+				body: JSON.stringify({ name: 'check_spf', arguments: { domain: 'example.com' } }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+		});
+
+		it('allows the scan alias for the agent-chat caller (normalized before the check)', async () => {
+			const { mockTxtRecords } = await import('./helpers/dns-mock');
+			mockTxtRecords(['v=spf1 -all']);
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'X-BV-Caller': 'agent-chat' },
+				body: JSON.stringify({ name: 'scan', arguments: { domain: 'example.com' } }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).not.toBe(403);
+		});
+
+		it('does not gate non-agent internal callers', async () => {
+			const { mockTxtRecords } = await import('./helpers/dns-mock');
+			mockTxtRecords(['v=spf1 -all']);
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' }, // no X-BV-Caller
+				body: JSON.stringify({ name: 'check_spf', arguments: { domain: 'example.com' } }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).not.toBe(403);
+		});
+	});
+
 	describe('POST /internal/tools/batch', () => {
 		beforeEach(() => {
 			IN_MEMORY_CACHE.clear();

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -243,8 +243,8 @@ describe('Internal service binding routes', () => {
 			const response = await worker.fetch(request, testEnv, ctx);
 			await waitOnExecutionContext(ctx);
 			expect(response.status).toBe(403);
-			const json = (await response.json()) as { isError?: boolean };
-			expect(json.isError).toBe(true);
+			const json = (await response.json()) as { error?: string };
+			expect(json.error).toBe('agent_tool_not_allowed');
 		});
 
 		it('allows an allowlisted tool for the agent-chat caller', async () => {
@@ -272,6 +272,9 @@ describe('Internal service binding routes', () => {
 			const ctx = createExecutionContext();
 			const response = await worker.fetch(request, testEnv, ctx);
 			await waitOnExecutionContext(ctx);
+			// scan_domain fans out across ~19 checks, only one of which is SPF-mocked here;
+			// the gate passing (not a 403) is what this case proves, so assert that the
+			// normalized alias was NOT rejected rather than a full 200.
 			expect(response.status).not.toBe(403);
 		});
 
@@ -286,7 +289,19 @@ describe('Internal service binding routes', () => {
 			const ctx = createExecutionContext();
 			const response = await worker.fetch(request, testEnv, ctx);
 			await waitOnExecutionContext(ctx);
-			expect(response.status).not.toBe(403);
+			expect(response.status).toBe(200);
+		});
+
+		it('rejects a deprecated alias that resolves to a non-allowlisted tool', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json', 'X-BV-Caller': 'agent-chat' },
+				body: JSON.stringify({ name: 'generate_fix_plan', arguments: {} }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, testEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(403);
 		});
 	});
 


### PR DESCRIPTION
## Summary

Adds a defense-in-depth tool allowlist for an `agent-chat` caller principal on bv-mcp's internal tool routes. bv-web-prod will drive an LLM that calls bv-mcp tools as the backend for a customer dashboard chat agent; this PR ensures that even if bv-web's own gateway allowlist is bypassed, bv-mcp itself rejects any tool outside a curated 13-tool **read-only** set.

- When a request to `/internal/tools/call` or `/internal/tools/batch` carries `X-BV-Caller: agent-chat`, the requested tool (after alias normalization) must be in `AGENT_ALLOWED_TOOLS` — else `403 { "error": "agent_tool_not_allowed" }` (+ `Cache-Control: no-store`).
- The 13 tools are all passive/read-only: `scan_domain`, `check_{spf,dkim,dmarc,dnssec,ssl,mx,mta_sts,caa,http_security}`, `explain_finding`, `compare_baseline`, `get_benchmark`.
- The header **narrows** access, never widens it — it sits behind the existing `cf-connecting-ip` network guard + `BV_WEB_INTERNAL_KEY` bearer gate, so a public caller can't reach it, and even a spoofed header could only *restrict* the tool set.
- Alias-normalized before the check (`scan` → `scan_domain`) so legitimate aliases aren't wrongly blocked.
- Exact-set audit (`agent-tool-allowlist.audit.test.ts`) pins the 13 names + the read-only invariant, so a future mutating tool can't silently join.

This is the **"build bv-mcp first" half** of a two-repo feature — the trust boundary ships before bv-web consumes it. Design: `docs/design/agent-chat-tool-allowlist.md`. Companion spec lives in bv-web-prod.

Change class: **A** (new internal caller class on a cross-worker contract). Changelog updated.

## Test Plan

- [x] `agent-tool-allowlist.audit.test.ts` — exact 13-tool set, all exist in TOOL_DEFS, all read-only (4 tests)
- [x] `internal.spec.ts` — agent caller: non-allowlisted tool → 403 + error code; allowlisted → 200; `scan` alias passes; deprecated alias (`generate_fix_plan`→`generate`) → 403; non-agent caller ungated; both `/tools/call` and `/tools/batch` (28 tests)
- [x] `npm run typecheck` clean · `npm run lint` clean
- [ ] CI: `build-and-test`, `Secret & PII scan`, `Dependency audit`, `File hygiene check`

## Out of scope (tracked follow-ups)

- `authTier: 'agent'` analytics dimension (internal-path rows currently record `authTier: undefined`)
- bv-web-prod consuming side (agent loop + gateway + UI) — separate plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)