### PR TITLE
docs(threat-model): incremental STRIDE-A update vs 2026-05-24 baseline

### DIFF
--- a/docs/threat-model/threat-model-20260611-112908/0-assessment.md
+++ b/docs/threat-model/threat-model-20260611-112908/0-assessment.md
@@ -1,0 +1,219 @@
+# Security Assessment
+
+---
+
+## Report Files
+
+| File | Description |
+|------|-------------|
+| [0-assessment.md](0-assessment.md) | This document — executive summary, risk rating, action plan, metadata |
+| [0.1-architecture.md](0.1-architecture.md) | Architecture overview, components, scenarios, tech stack |
+| [1-threatmodel.md](1-threatmodel.md) | Threat model DFD diagram with element, flow, and boundary tables |
+| [1.1-threatmodel.mmd](1.1-threatmodel.mmd) | Pure Mermaid DFD source file |
+| [1.2-threatmodel-summary.mmd](1.2-threatmodel-summary.mmd) | Summary DFD for large systems |
+| [2-stride-analysis.md](2-stride-analysis.md) | Full STRIDE-A analysis for all components |
+| [3-findings.md](3-findings.md) | Prioritized security findings with remediation |
+| [incremental-comparison.html](incremental-comparison.html) | Visual comparison report |
+
+---
+
+## Executive Summary
+
+Blackveil DNS (`bv-mcp`) is a publicly-exposed Cloudflare Worker exposing 75 DNS/email-security tools via an MCP server (JSON-RPC over Streamable HTTP), an OAuth 2.1 issuer for paid tiers, a multi-tenant subsystem, and internal service-binding routes. This is an **incremental** threat model: it inherits the component inventory of baseline `threat-model-20260524-114907` (commit `7e23243`) and the interim remediation overlay at `f75ca7d`, and verifies the full posture against commit `7a1c6b3` (v3.18.0) — a window of 230 commits / ~159 PRs.
+
+The window is strongly net-defensive. Twelve baseline threats are now code-verified **fixed** — among them the distributed free-tier abuse vector (per-IP distinct-domain cap), the scanner-as-recon-proxy vector (paid-only gating with HTTP 403), the insecure-by-default internal bearer gate (now secure-by-default), JWT tier persistence after downgrade (token-version revocation + entitlement TTL clamp), and access-log retention (now enforced by cron). Three new attack surfaces arrived with new features: the **M365Proxy** identity-secops tool family (highly sensitive sign-in/audit data, tenant authorization delegated to bv-web), the **BvRecon** OSINT/bucket-scan binding (cross-principal poll-ID and LLM prompt-injection considerations), and the **BvTlsProbe** enrichment binding. These produce 15 new threats and 4 new findings, all Tier 2 — none are exploitable without a valid credential.
+
+The analysis covers 26 system elements across 5 trust boundaries.
+
+### Risk Rating: Low
+
+All Tier 1 threats except two deploy-config activations are mitigated in code; the four remaining [Partial] items are deploy-config activations (`REJECT_QUERY_API_KEY`, `OAUTH_ISSUER`), a pending DNS-TXT ownership challenge, and trial-key envelope adoption. The new exposure is concentrated in authenticated, paid-tier surfaces whose residual risk depends on cross-service contracts (bv-web tenant scoping, bv-recon ID ownership) — verifiable, bounded, and listed in Needs Verification.
+
+> **Note on threat counts:** This analysis identified 93 threats across 24 analyzed components. This count reflects comprehensive STRIDE-A coverage, not systemic insecurity. Of these, **40 are directly exploitable** without prerequisites (Tier 1) — 38 are mitigated by existing controls and 2 (query-key acceptance, Host-derived issuer) await deploy-config activation of already-merged mechanisms. The remaining 53 represent conditional risks and defense-in-depth considerations.
+
+---
+
+## Action Summary
+
+| Tier | Description | Threats | Findings | Priority |
+|------|-------------|---------|----------|----------|
+| [Tier 1](3-findings.md#tier-1--direct-exposure-no-prerequisites) | Directly exploitable | 40 | 11 | 🔴 Critical Risk |
+| [Tier 2](3-findings.md#tier-2--conditional-risk-authenticated--single-prerequisite) | Requires authenticated access | 34 | 9 | 🟠 Elevated Risk |
+| [Tier 3](3-findings.md#tier-3--defense-in-depth-prior-compromise--host-access) | Requires prior compromise | 19 | 1 | 🟡 Moderate Risk |
+| **Total** | | **93** | **21** | |
+
+### Priority by Tier and CVSS Score (Top 10)
+
+| Finding | Tier | CVSS Score | SDL Severity | Title |
+|---------|------|------------|-------------|-------|
+| [FIND-01](3-findings.md#find-01-api-key-accepted-via-query-parameter) | T1 | 5.3 | Moderate | API key accepted via query parameter |
+| [FIND-02](3-findings.md#find-02-free-tier-abuse-via-distributed-ips) | T1 | 5.3 | Moderate | Free-tier abuse via distributed IPs |
+| [FIND-03](3-findings.md#find-03-scanner-usable-as-reconamplification-proxy) | T1 | 5.1 | Moderate | Scanner usable as recon/amplification proxy |
+| [FIND-04](3-findings.md#find-04-oauth-issuer-from-spoofable-host-header) | T1 | 4.8 | Moderate | OAuth issuer from spoofable Host header |
+| [FIND-05](3-findings.md#find-05-open-oauth-dynamic-client-registration) | T1 | 4.3 | Low | Open OAuth dynamic client registration |
+| [FIND-06](3-findings.md#find-06-force_refresh-cache-busting-amplification) | T1 | 3.7 | Low | force_refresh cache-busting amplification |
+| [FIND-07](3-findings.md#find-07-domain-validation-hardening-for-homoglyphidn) | T1 | 3.1 | Low | Domain validation hardening for homoglyph/IDN |
+| [FIND-08](3-findings.md#find-08-authentication--token-integrity-controls-existing-control) | T1 | 2.3 | Low | Authentication & token-integrity controls (existing control) |
+| [FIND-09](3-findings.md#find-09-ssrf-egress-controls-existing-control) | T1 | 2.3 | Low | SSRF egress controls (existing control) |
+| [FIND-10](3-findings.md#find-10-rate-limiting-quotas--dos-budgets-existing-control) | T1 | 2.3 | Low | Rate limiting, quotas & DoS budgets (existing control) |
+
+### Quick Wins
+
+| Finding | Title | Why Quick |
+|---------|-------|-----------|
+| [FIND-01](3-findings.md#find-01-api-key-accepted-via-query-parameter) | API key accepted via query parameter | Code is merged — set `REJECT_QUERY_API_KEY=true` in the private deploy overrides once Smithery clients are migrated |
+| [FIND-04](3-findings.md#find-04-oauth-issuer-from-spoofable-host-header) | OAuth issuer from spoofable Host header | Code is merged — set `OAUTH_ISSUER` in the private deploy overrides and route discovery through the strict resolver |
+
+---
+
+## Change Summary
+
+### Component Changes
+
+| Status | Count | Components |
+|--------|-------|------------|
+| Unchanged | 11 | BrandAuditPipeline, CertTransparency, DnsResolver, McpClient, Operator, ProfileAccumulator, PublicDoH, QuotaCoordinator, SafeFetch, SessionStoreKV, WhoisRdap |
+| Modified | 12 | BvWeb, DomainSanitizer, HonoWorker, IntelligenceDB, InternalRouter, McpExecutor, OAuthIssuer, RateLimitKV, RateLimiter, ScanCacheKV, TierAuthResolver, ToolsHandler |
+| New | 3 | BvRecon, BvTlsProbe, M365Proxy |
+| Removed | 0 | — |
+
+### Threat Status
+
+| Status | Count |
+|--------|-------|
+| Existing | 66 |
+| Fixed | 12 |
+| New | 15 |
+| Removed | 0 |
+
+### Finding Status
+
+| Status | Count |
+|--------|-------|
+| Existing | 6 |
+| Fixed | 7 |
+| Partial | 4 |
+| New | 4 |
+| Removed | 0 |
+
+### Risk Direction
+
+Improving — every Tier 1 finding from the baseline is fixed or control-locked, and the window added gating/quota/authorization controls faster than it added attack surface; the 4 new findings are all Tier 2, credential-gated, and dominated by cross-service verification work rather than code defects.
+
+---
+
+## Previously Unidentified Issues
+
+No previously unidentified issues found. All four new findings (FIND-18–21) arise from code added after the baseline (`new_code`), not from gaps in the prior analysis. The baseline's one over-report (FIND-05) was already corrected in the interim overlay and re-verified here.
+
+| Finding | Title | Component | Evidence |
+|---------|-------|-----------|----------|
+| — | — | — | — |
+
+---
+
+## Analysis Context & Assumptions
+
+### Analysis Scope
+
+| Constraint | Description |
+|------------|-------------|
+| Scope | Incremental source-level STRIDE-A re-verification of the `bv-mcp` Cloudflare Worker (commit `7a1c6b3`) against the 2026-05-24 baseline: all baseline components re-checked, diff window f75ca7d→7a1c6b3 analyzed, new components fully modeled. |
+| Excluded | Sibling-worker internals (bv-web, bv-recon, bv-tls-probe, bv-dns) — modeled as external trust targets; `threat-model-*` folders, `node_modules`, `dist`. |
+| Focus Areas | New service-binding surfaces (M365/recon/TLS-probe), free-tier gating + distinct-domain cap, internal-route auth defaults + agent-chat allowlist, OAuth revocation/TTL, baseline finding status re-verification. |
+
+### Infrastructure Context
+
+| Category | Discovered from Codebase | Findings Affected |
+|----------|--------------------------|-------------------|
+| Edge platform | Cloudflare Worker, public `/mcp` + `/oauth/*`; `global_fetch_strictly_public` flag ([wrangler.jsonc](../../../wrangler.jsonc)) | FIND-09 |
+| Service bindings | bv-web (validate-key/entitlements/M365), BV_RECON, BV_TLS_PROBE, BV_CERTSTREAM, BV_WHOIS — operator-deploy-only bindings absent on BSL self-hosts ([src/index.ts](../../../src/index.ts)) | FIND-18, FIND-19, FIND-20 |
+| State | KV (RATE_LIMIT/SCAN_CACHE/SESSION_STORE), D1 (INTELLIGENCE_DB/BRAND_AUDIT_DB), 2 Durable Objects | FIND-17 |
+| CI guardrails | Exact-set audits: gated-tools SSOT, agent-tool allowlist, tenant-scope coverage, tool-quota coverage ([test/audits/](../../../test/audits/)) | FIND-03, FIND-16 |
+
+### Needs Verification
+
+| Item | Question | What to Check | Why Uncertain |
+|------|----------|---------------|---------------|
+| bv-web M365 tenant scoping (FIND-19) | Does bv-web reject `keyHash` values not entitled to the requested `ms_tenant_id` (and `keyHash: undefined`)? | bv-web-prod `/api/internal/m365/*` handlers; add a cross-repo contract test | Enforcement lives in a different repo; bv-mcp only forwards the principal |
+| bv-recon poll-ID ownership (FIND-18) | Does bv-recon bind investigation/bucket-scan IDs to the creating caller? | bv-recon route handlers for `/osint/*` status/report and `/buckets/api/*` | bv-mcp forwards IDs with a shared bearer; ownership check not visible here |
+| bv-tls-probe host validation (T89.I) | Does the probe refuse internal/reserved targets? | bv-tls-probe worker source (local-only repo) | Probe is operator-controlled but its validation is outside this repo |
+| Deploy gates (FIND-01, FIND-04) | Are `REJECT_QUERY_API_KEY=true` and `OAUTH_ISSUER` set in production overrides? | `.dev/wrangler.deploy.jsonc` / private overlay + live discovery response | Code defaults remain permissive; fixes are config-activated |
+| KV envelope adoption (FIND-17) | Is `KV_ENVELOPE_KEY` set in prod, and when will trial-key records be wrapped? | Private deploy overrides; `src/lib/trial-keys.ts` | **Disagreement with interim overlay:** it marked FIND-17 fixed; this analysis found trial keys still unwrapped (envelope live on the OAuth path only) — downgraded to [Partial] per code evidence |
+| bv-web revoke call (FIND-13 residual) | Does bv-web call `POST /internal/oauth/revoke-subject` on plan downgrade? | bv-web-prod billing/downgrade flow | TTL clamp bounds the exposure, but the revoke call completes the design |
+| M365 per-principal metering (FIND-20) | Should identity_secops gain a per-principal daily quota? | Product decision + bv-web Graph cost telemetry | Current unlimited status is intentional but cost exposure is unbounded per key |
+
+### Finding Overrides
+
+| Finding ID | Original Severity | Override | Justification | New Status |
+|------------|-------------------|----------|---------------|------------|
+| — | — | — | No overrides applied. Update this section after review. | — |
+
+### Additional Notes
+
+Threat IDs T01–T78 and finding IDs FIND-01–17 are stable against the baseline for cross-report tracing; the interim overlay's per-finding statuses were re-derived from code rather than carried forward (one downgrade: FIND-17). The `tenants/`, `queue/`, and `workers/infra-probe` code remains folded into existing components per the baseline's modeling judgment (tenant routes under InternalRouter, queue consumers under BrandAuditPipeline).
+
+---
+
+## References Consulted
+
+### Security Standards
+
+| Standard | URL | How Used |
+|----------|-----|----------|
+| Microsoft SDL Bug Bar | https://www.microsoft.com/en-us/msrc/sdlbugbar | Severity classification |
+| OWASP Top 10:2025 | https://owasp.org/Top10/2025/ | Threat categorization |
+| CVSS 4.0 | https://www.first.org/cvss/v4.0/specification-document | Risk scoring |
+| CWE | https://cwe.mitre.org/ | Weakness classification |
+| STRIDE | https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool-threats | Threat enumeration |
+| OWASP LLM Top 10 | https://owasp.org/www-project-top-10-for-large-language-model-applications/ | Prompt-injection surface (FIND-21) |
+| NIST SP 800-81r3 | https://csrc.nist.gov/pubs/sp/800/81/r3/final | DNS security control context |
+
+### Component Documentation
+
+| Component | Documentation URL | Relevant Section |
+|-----------|------------------|------------------|
+| Cloudflare Workers | https://developers.cloudflare.com/workers/ | Service bindings, `global_fetch_strictly_public`, KV/D1/DO isolation |
+| Model Context Protocol | https://modelcontextprotocol.io/specification/2025-06-18 | Streamable HTTP transport, protocol-version header, structuredContent |
+| OAuth 2.1 / PKCE | https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1 | Authorization-code flow, dynamic client registration |
+| Microsoft Graph (sign-in/audit logs) | https://learn.microsoft.com/en-us/graph/api/resources/signin | Data sensitivity of identity_secops surface |
+
+---
+
+## Report Metadata
+
+| Field | Value |
+|-------|-------|
+| Source Location | `/Applications/Github/bv-mcp` |
+| Git Repository | `https://github.com/MadaBurns/bv-mcp.git` |
+| Git Branch | `main` |
+| Git Commit | `7a1c6b3` (`2026-06-11 00:41:51 +1200`) |
+| Model | `claude-fable-5` |
+| Machine Name | `Adams-MacBook-Pro.local` |
+| Analysis Started | `2026-06-11 11:29:08 UTC` |
+| Analysis Completed | `2026-06-11 12:34:00 UTC` |
+| Duration | `~65 minutes` |
+| Output Folder | `docs/threat-model/threat-model-20260611-112908` |
+| Prompt | `/threat-model-analyst` (incremental mode selected against the 2026-05-24 baseline) |
+| Baseline Report | `docs/threat-model/threat-model-20260524-114907` |
+| Baseline Commit | `7e23243` (`2026-05-24`) |
+| Target Commit | `7a1c6b3` (`2026-06-11`) |
+| Baseline Worktree | `.worktrees/baseline-f75ca7d` (diff base `f75ca7d`, `2026-05-25`) |
+| Analysis Mode | `Incremental` |
+
+---
+
+## Classification Reference
+
+| Classification | Values |
+|---------------|--------|
+| **Exploitability Tiers** | **T1** Direct Exposure (no prerequisites) · **T2** Conditional Risk (single prerequisite) · **T3** Defense-in-Depth (multiple prerequisites or infrastructure access) |
+| **STRIDE + Abuse** | **S** Spoofing · **T** Tampering · **R** Repudiation · **I** Information Disclosure · **D** Denial of Service · **E** Elevation of Privilege · **A** Abuse (feature misuse) |
+| **SDL Severity** | `Critical` · `Important` · `Moderate` · `Low` |
+| **Remediation Effort** | `Low` · `Medium` · `High` |
+| **Mitigation Type** | `Redesign` · `Standard Mitigation` · `Custom Mitigation` · `Existing Control` · `Accept Risk` · `Transfer Risk` |
+| **Threat Status** | `Open` · `Mitigated` · `Platform` |
+| **Incremental Tags** | `[Existing]` · `[Fixed]` · `[Partial]` · `[New]` · `[Removed]` (incremental reports only) |
+| **CVSS** | CVSS 4.0 vector with `CVSS:4.0/` prefix |
+| **OWASP** | OWASP Top 10:2025 mapping (e.g., A01:2025 – Broken Access Control) |
+| **CWE** | Hyperlinked CWE ID (e.g., [CWE-306](https://cwe.mitre.org/data/definitions/306.html)) |

--- a/docs/threat-model/threat-model-20260611-112908/0.1-architecture.md
+++ b/docs/threat-model/threat-model-20260611-112908/0.1-architecture.md
@@ -1,0 +1,338 @@
+# Architecture Overview
+
+> **Incremental analysis** — baseline `threat-model-20260524-114907` (commit `7e23243`), interim status overlay `threat-model-20260524-184006-incremental` (commit `f75ca7d`), target commit `7a1c6b3` (2026-06-11, v3.18.0). 230 commits / ~159 PRs in the window. Component IDs are inherited from the baseline; three components are new.
+
+## System Purpose
+
+Blackveil DNS (`bv-mcp`) is a source-available DNS & email-security scanner delivered as a Cloudflare Worker. It exposes 75 security tools through a Model Context Protocol (MCP) server over Streamable HTTP (JSON-RPC 2.0) at a public endpoint, plus an OAuth 2.1 issuer for paid tiers, a multi-tenant subsystem, and internal service-binding routes for sibling BlackVeil workers. Users are MCP clients (LLM IDEs, agents, `claude_*` clients) running unauthenticated free-tier scans or authenticated paid scans, BlackVeil operators managing trial keys and OAuth grants, and — new in this window — the bv-web agent-chat feature calling a restricted read-only tool set over the internal binding.
+
+## Key Components
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| McpClient | External Interactor | MCP client (LLM IDE/agent) calling `/mcp` over JSON-RPC; may be unauthenticated (free tier) or bearer/OAuth authenticated |
+| Operator | External Interactor | BlackVeil operator using the static `BV_API_KEY`/`BV_INTERNAL_DEV_KEY` (owner tier) or driving `/internal/*` via the bv-web service binding |
+| HonoWorker | Process | [MODIFIED — security-relevant changes detected] Edge HTTP router (`src/index.ts`); CORS/Origin checks, body-size limits, route gating, error wrapping; now threads BV_RECON/BV_TLS_PROBE/M365 bindings into tool runtime options and classifies the `MCP-Protocol-Version` header (observe-only) |
+| TierAuthResolver | Process | [MODIFIED — security-relevant changes detected] Resolves caller tier (`src/lib/tier-auth.ts`): constant-time static-key compare (now two independent dev-key slots), OAuth JWT verify with stable `keyHash` derivation, trial-key/bv-web lookup with expiry re-check, last-known-good (LKG) tier cache for bv-web 5xx outages, `OWNER_ALLOW_IPS` gate applied on every owner-tier path |
+| OAuthIssuer | Process | [MODIFIED — security-relevant changes detected] OAuth 2.1 issuer (`src/oauth/`): register, authorize, PKCE token exchange, HS256 JWT signing/validation, entitlements; JWT lifetime now clamped to the caller's entitlement window and per-subject token-version (`ver`) revocation is live |
+| McpExecutor | Process | [MODIFIED — security-relevant changes detected] MCP request pipeline (`src/mcp/execute.ts` + `dispatch.ts`): session validation, per-tier rate/quota application, method routing; now enforces `GATED_PAID_ONLY_TOOLS` (HTTP 403/-32003), `AUTH_REQUIRED_TOOLS` (HTTP 401/-32001), the per-IP distinct-domain daily cap, and threads `keyHash` to handlers (3.17.2 P0 fix) |
+| ToolsHandler | Process | [MODIFIED — security-relevant changes detected] Tool registry + execution (`src/handlers/tools.ts`): lists/dispatches 75 `check_*`/scan tools; new registry entries for recon/M365/TLS-probe-backed tools, KV request-dedup for mutating `*_start`/`register_*` tools keyed on `keyHash` only, versioned cache keys embedding the dns-checks version |
+| M365Proxy | Process | [NEW] Identity-secops tool family (`src/tools/m365/proxy.ts` + query-signins/query-ual/get-ca-policies/assess-coverage): authenticated-only proxy that forwards M365 sign-in/UAL/Conditional-Access queries to bv-web's internal `/api/internal/m365/*` endpoints carrying `BV_WEB_INTERNAL_KEY` and the caller's `keyHash` principal |
+| DomainSanitizer | Process | [MODIFIED — security-relevant changes detected] Input validation/SSRF guard (`src/lib/sanitize.ts` + `config.ts` blocklists): `validateDomain`, `sanitizeDomain` (mixed-script/homoglyph rejection), `validateOutboundUrl`; validation helpers extended in the window without posture change |
+| SafeFetch | Process | Egress SSRF guard (`src/lib/safe-fetch.ts`): HTTPS-only, manual redirects, RFC1918/reserved/rebinding rejection for attacker-influenced URLs |
+| DnsResolver | Process | DoH egress (`src/lib/dns-transport.ts`, `dns-multi-resolver.ts`): Cloudflare DoH primary, `BV_DOH_ENDPOINT` secondary, Google fallback |
+| RateLimiter | Process | [MODIFIED — security-relevant changes detected] Limits/quotas + abuse detection (`src/lib/rate-limiter.ts`, `fuzzing-detector.ts`): per-IP min/hr, per-tool daily, global ceiling, fuzzing scoring; new `checkDistinctDomainDailyLimit()` capping unauthenticated callers at 12 distinct domains/day per IP |
+| InternalRouter | Process | [MODIFIED — security-relevant changes detected] Service-binding surface (`src/internal.ts`): `/internal/tools/*`, `/internal/oauth/grants`, `/internal/trial-keys/*`, `/internal/tenants/*`, guarded by `isPublicInternetRequest`; bearer gate (`internalLenientAuthGate`) is now secure-by-default, and the `x-bv-caller: agent-chat` principal is restricted to a 13-tool read-only allowlist |
+| BrandAuditPipeline | Process | Brand-audit orchestration (`src/lib/brand-audit-pipeline.ts`) + cron/queue (`src/scheduled.ts`, queue consumer): tiered discovery, registrar/CT/WHOIS enrichment; ownership attestation remains caller-supplied |
+| QuotaCoordinator | Process | Durable Object (`src/lib/quota-coordinator.ts`): cross-isolate rate-limit/global-quota coordination with circuit-breaker fallback |
+| ProfileAccumulator | Process | Durable Object (`src/lib/profile-accumulator.ts`): adaptive-scoring EMA persistence per profile+provider |
+| SessionStoreKV | Data Store | KV `SESSION_STORE`: session records, OAuth authorization codes, JWT JTI revocation markers, per-subject token-version counters |
+| ScanCacheKV | Data Store | [MODIFIED — security-relevant changes detected] KV `SCAN_CACHE`: cached scan/check results; cache keys now embed both the server version and the dns-checks version (`cache:v<srv>-dc<dns>:<domain>…`) so library bumps invalidate stale scores |
+| RateLimitKV | Data Store | [MODIFIED — security-relevant changes detected] KV `RATE_LIMIT`: rate-limit counters, fuzzing counters, trial keys, distinct-domain markers, request-dedup records; AES-256-GCM KV envelope helper (`kv-envelope.ts`) exists but trial-key records are not yet wrapped |
+| IntelligenceDB | Data Store | [MODIFIED — security-relevant changes detected] D1 `INTELLIGENCE_DB`: MCP access logs with AES-GCM-encrypted IP evidence; a scheduled retention job now deletes rows older than 90 days |
+| BvWeb | External Service | [MODIFIED — security-relevant changes detected] Sibling worker (service binding): `validate-key`, OAuth entitlements resolution, and now the internal M365 proxy endpoints; bv-mcp delegates M365 tenant-scope authorization to bv-web on the forwarded `keyHash` |
+| BvRecon | External Service | [NEW] Operator-deploy-only bv-recon worker (`src/lib/recon-binding.ts`, `BV_RECON` + `BV_RECON_KEY` bearer): powers OSINT investigations, bucket scans, and the realtime threat feed via a start→poll pattern; fail-soft `unprovisioned` when absent; upstream payloads scrubbed by `sanitize-upstream.ts` before entering finding metadata |
+| BvTlsProbe | External Service | [NEW] Operator-deploy-only bv-tls-probe worker (`src/lib/tls-probe-binding.ts`, `BV_TLS_PROBE` + `BV_TLS_PROBE_KEY` bearer): version-aware TLS handshakes enriching `check_ssl` legacy-TLS detection; fail-soft no-op when absent |
+| PublicDoH | External Service | Public DoH resolvers (Cloudflare `cloudflare-dns.com`, Google fallback) for DNS queries |
+| CertTransparency | External Service | `BV_CERTSTREAM` binding + crt.sh fallback for CT-log subdomain/SAN enumeration |
+| WhoisRdap | External Service | `BV_WHOIS` binding + RDAP fallback for registration data; lookalike enrichment also queries a hardcoded allowlist of registry RDAP endpoints |
+
+## Component Diagram
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef service fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+    linkStyle default stroke:#666666,stroke-width:2px
+
+    McpClient(["McpClient"]):::external
+    Operator(["Operator"]):::external
+
+    subgraph Worker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker["HonoWorker"]:::service
+        TierAuthResolver["TierAuthResolver"]:::service
+        OAuthIssuer["OAuthIssuer"]:::service
+        McpExecutor["McpExecutor"]:::service
+        ToolsHandler["ToolsHandler"]:::service
+        M365Proxy["M365Proxy (new)"]:::service
+        DomainSanitizer["DomainSanitizer"]:::service
+        SafeFetch["SafeFetch"]:::service
+        DnsResolver["DnsResolver"]:::service
+        RateLimiter["RateLimiter"]:::service
+        InternalRouter["InternalRouter"]:::service
+        BrandAuditPipeline["BrandAuditPipeline"]:::service
+    end
+
+    subgraph DOs["Durable Objects"]
+        QuotaCoordinator["QuotaCoordinator"]:::service
+        ProfileAccumulator["ProfileAccumulator"]:::service
+    end
+
+    subgraph Storage["Cloudflare Platform Storage"]
+        SessionStoreKV[("SessionStoreKV")]:::datastore
+        ScanCacheKV[("ScanCacheKV")]:::datastore
+        RateLimitKV[("RateLimitKV")]:::datastore
+        IntelligenceDB[("IntelligenceDB")]:::datastore
+    end
+
+    subgraph BvServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::service
+        BvRecon["BvRecon (new)"]:::service
+        BvTlsProbe["BvTlsProbe (new)"]:::service
+    end
+
+    PublicDoH(["PublicDoH"]):::external
+    CertTransparency(["CertTransparency"]):::external
+    WhoisRdap(["WhoisRdap"]):::external
+
+    McpClient -->|"JSON-RPC (HTTPS)"| HonoWorker
+    Operator -->|"Service binding"| InternalRouter
+    HonoWorker -->|"Resolve tier"| TierAuthResolver
+    HonoWorker -->|"OAuth flows"| OAuthIssuer
+    HonoWorker -->|"MCP requests"| McpExecutor
+    TierAuthResolver -->|"Validate key"| BvWeb
+    OAuthIssuer -->|"Entitlements"| BvWeb
+    McpExecutor -->|"Limits/quota"| RateLimiter
+    McpExecutor -->|"Dispatch"| ToolsHandler
+    RateLimiter -->|"Coordinate"| QuotaCoordinator
+    ToolsHandler -->|"Validate domain"| DomainSanitizer
+    ToolsHandler -->|"DNS queries"| DnsResolver
+    ToolsHandler -->|"Fetch (BIMI/redirects)"| SafeFetch
+    ToolsHandler -->|"Brand audits"| BrandAuditPipeline
+    ToolsHandler -->|"Adaptive weights"| ProfileAccumulator
+    ToolsHandler -->|"identity_secops"| M365Proxy
+    ToolsHandler -->|"OSINT/buckets/feed"| BvRecon
+    ToolsHandler -->|"TLS version probe"| BvTlsProbe
+    M365Proxy -->|"M365 queries (bearer)"| BvWeb
+    DnsResolver -->|"DoH"| PublicDoH
+    BrandAuditPipeline -->|"CT logs"| CertTransparency
+    BrandAuditPipeline -->|"WHOIS/RDAP"| WhoisRdap
+    McpExecutor -->|"Sessions/codes"| SessionStoreKV
+    ToolsHandler -->|"Cache"| ScanCacheKV
+    RateLimiter -->|"Counters"| RateLimitKV
+    McpExecutor -->|"Access logs"| IntelligenceDB
+
+    style Worker fill:#f0f4ff,stroke:#2171b5,stroke-width:2px,stroke-dasharray: 5 5
+    style DOs fill:#f0f4ff,stroke:#2171b5,stroke-width:2px,stroke-dasharray: 5 5
+    style Storage fill:#f0fff0,stroke:#238b45,stroke-width:2px,stroke-dasharray: 5 5
+    style BvServices fill:#fff8f0,stroke:#d94701,stroke-width:2px,stroke-dasharray: 5 5
+```
+
+## Top Scenarios
+
+### Scenario 1: Unauthenticated free-tier domain scan
+
+An MCP client calls `tools/call` for `scan_domain` over `/mcp`. The worker checks Origin, resolves tier (free if no token), validates the session, applies per-IP and per-tool rate limits plus the new 12-distinct-domains/day cap, sanitizes the domain, runs DNS checks over DoH, caches the result under a version-stamped key, and returns a graded report. Paid-only tools return HTTP 403 (`-32003`) at this tier.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'background': '#ffffff',
+  'actorBkg': '#6baed6', 'actorBorder': '#2171b5', 'actorTextColor': '#000000',
+  'signalColor': '#666666', 'signalTextColor': '#666666',
+  'noteBkgColor': '#fdae61', 'noteBorderColor': '#d94701', 'noteTextColor': '#000000',
+  'activationBkgColor': '#ddeeff', 'activationBorderColor': '#2171b5'
+}}}%%
+sequenceDiagram
+    actor McpClient
+    participant HonoWorker
+    participant TierAuthResolver
+    participant McpExecutor
+    participant ToolsHandler
+    participant DomainSanitizer
+    participant DnsResolver
+    participant PublicDoH
+
+    McpClient->>HonoWorker: POST /mcp tools/call scan_domain
+    activate HonoWorker
+    Note over HonoWorker: Origin check, 10 KB body limit
+    HonoWorker->>TierAuthResolver: Resolve tier (no token -> free)
+    HonoWorker->>McpExecutor: Validated JSON-RPC
+    activate McpExecutor
+    Note over McpExecutor: Session + rate limits + paid-tool gate + distinct-domain cap
+    McpExecutor->>ToolsHandler: Dispatch scan_domain
+    activate ToolsHandler
+    ToolsHandler->>DomainSanitizer: validateDomain(domain)
+    Note over DomainSanitizer: Reject IP literals, localhost, mixed-script labels
+    ToolsHandler->>DnsResolver: queryDns(records)
+    DnsResolver->>PublicDoH: DoH GET (TLS)
+    PublicDoH-->>DnsResolver: DNS answers
+    DnsResolver-->>ToolsHandler: Records
+    ToolsHandler-->>McpExecutor: Graded CheckResult (cached)
+    deactivate ToolsHandler
+    McpExecutor-->>HonoWorker: JSON-RPC result
+    deactivate McpExecutor
+    HonoWorker-->>McpClient: 200 (sanitized errors)
+    deactivate HonoWorker
+```
+
+### Scenario 2: OAuth 2.1 paid-tier token issuance
+
+A paid MCP client completes the OAuth authorization-code + PKCE flow. The issuer resolves entitlements from bv-web, mints an HS256 JWT carrying a tier claim and a per-subject token-version (`ver`), clamps the JWT lifetime to the remaining entitlement window, and subsequent `/mcp` calls present it as a bearer token that `TierAuthResolver` verifies (deriving a stable `keyHash` for quota/concurrency keying).
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'background': '#ffffff',
+  'actorBkg': '#6baed6', 'actorBorder': '#2171b5', 'actorTextColor': '#000000',
+  'signalColor': '#666666', 'signalTextColor': '#666666',
+  'noteBkgColor': '#fdae61', 'noteBorderColor': '#d94701', 'noteTextColor': '#000000',
+  'activationBkgColor': '#ddeeff', 'activationBorderColor': '#2171b5'
+}}}%%
+sequenceDiagram
+    actor McpClient
+    participant OAuthIssuer
+    participant BvWeb
+    participant SessionStoreKV
+    participant TierAuthResolver
+
+    McpClient->>OAuthIssuer: GET /oauth/authorize (PKCE challenge)
+    activate OAuthIssuer
+    OAuthIssuer->>BvWeb: Resolve plan -> tier entitlement
+    BvWeb-->>OAuthIssuer: Tier (developer/enterprise) + entitlement window
+    OAuthIssuer->>SessionStoreKV: Store auth code + challenge
+    OAuthIssuer-->>McpClient: redirect with code
+    deactivate OAuthIssuer
+    McpClient->>OAuthIssuer: POST /oauth/token (code + verifier)
+    activate OAuthIssuer
+    Note over OAuthIssuer: PKCE S256 verify; HS256 JWT with tier, jti, ver; TTL clamped to entitlement
+    OAuthIssuer-->>McpClient: access_token (JWT)
+    deactivate OAuthIssuer
+    McpClient->>TierAuthResolver: /mcp with Bearer JWT
+    Note over TierAuthResolver: Verify alg, signature, exp/iss/aud, jti, ver >= stored version
+```
+
+### Scenario 3: Authenticated identity-secops M365 query (new)
+
+An authenticated customer calls `query_signins` for their M365 tenant. The executor rejects unauthenticated callers (HTTP 401), the handler re-checks that a `keyHash` principal is present, and `M365Proxy` forwards the query to bv-web's internal M365 endpoints with the internal bearer plus the caller's `keyHash`; bv-web enforces that the principal is entitled to the requested tenant before querying Microsoft Graph.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {
+  'background': '#ffffff',
+  'actorBkg': '#6baed6', 'actorBorder': '#2171b5', 'actorTextColor': '#000000',
+  'signalColor': '#666666', 'signalTextColor': '#666666',
+  'noteBkgColor': '#fdae61', 'noteBorderColor': '#d94701', 'noteTextColor': '#000000',
+  'activationBkgColor': '#ddeeff', 'activationBorderColor': '#2171b5'
+}}}%%
+sequenceDiagram
+    actor McpClient
+    participant McpExecutor
+    participant ToolsHandler
+    participant M365Proxy
+    participant BvWeb
+
+    McpClient->>McpExecutor: tools/call query_signins (Bearer key)
+    activate McpExecutor
+    Note over McpExecutor: AUTH_REQUIRED_TOOLS gate - 401 if unauthenticated
+    McpExecutor->>ToolsHandler: Dispatch with keyHash principal
+    activate ToolsHandler
+    Note over ToolsHandler: Backstop - reject if m365Proxy bound and keyHash absent
+    ToolsHandler->>M365Proxy: query-signins(tenant, filters)
+    activate M365Proxy
+    M365Proxy->>BvWeb: POST /api/internal/m365/query-signins (internal bearer + keyHash)
+    Note over BvWeb: Tenant-scope authorization on keyHash
+    BvWeb-->>M365Proxy: Sign-in events (or m365_proxy_* error)
+    deactivate M365Proxy
+    M365Proxy-->>ToolsHandler: Result
+    deactivate ToolsHandler
+    McpExecutor-->>McpClient: JSON-RPC result
+    deactivate McpExecutor
+```
+
+### Scenario 4: Paid-tier OSINT investigation via bv-recon (new)
+
+A developer-tier client calls `osint_investigate_domain_start`. The paid-only gate admits the caller, request-dedup (keyed on `keyHash` + tool + canonical args) absorbs network retries, and the recon binding starts an investigation on bv-recon returning an opaque investigation ID. The client polls `osint_investigation_status`/`_report`; upstream payloads are scrubbed by `sanitize-upstream` before entering finding metadata.
+
+### Scenario 5: Internal service-binding tool call (agent-chat restricted)
+
+A sibling worker (bv-web) calls `/internal/tools/call` via service binding. `isPublicInternetRequest` rejects any request carrying public proxy headers; the secure-by-default bearer gate requires `Authorization: Bearer ${BV_WEB_INTERNAL_KEY}` (503 if unset, 401 on mismatch) unless explicitly disabled. Requests carrying `x-bv-caller: agent-chat` are additionally restricted to a 13-tool read-only allowlist (403 `agent_tool_not_allowed` otherwise).
+
+### Scenario 6: Scheduled cron (fuzzing alerts, brand reaper, log retention)
+
+Every 15 minutes the cron handler reads fuzzing counters, emits `fuzzing_suspected` alerts to `ALERT_WEBHOOK_URL`, runs analytics anomaly checks, reaps stale brand-audit jobs, and deletes `mcp_access_log` rows older than 90 days via a parameterized D1 query.
+
+## Technology Stack
+
+| Layer | Technologies |
+|-------|--------------|
+| Languages | TypeScript (strict, ES2024) |
+| Frameworks | Hono v4, Model Context Protocol (JSON-RPC 2.0 Streamable HTTP, protocol versions 2025-03-26 / 2025-06-18), Zod v4 |
+| Data Stores | Cloudflare KV (RATE_LIMIT, SCAN_CACHE, SESSION_STORE), D1 (BRAND_AUDIT_DB, INTELLIGENCE_DB), R2 (BRAND_REPORTS), Durable Objects (QuotaCoordinator, ProfileAccumulator), Analytics Engine |
+| Infrastructure | Cloudflare Workers (edge), Wrangler 4.x, service bindings (bv-web, certstream, whois, intel, bv-recon, bv-tls-probe), Queues, cron triggers |
+| Security | Constant-time XOR over SHA-256 (`tier-auth.ts`), HS256 OAuth JWT with `ver` revocation + entitlement TTL clamp (`oauth/jwt.ts`, `token.ts`), PKCE S256, SSRF allow/deny (`safe-fetch.ts`, `config.ts`), domain sanitization incl. mixed-script rejection (`sanitize.ts`), rate limiting + distinct-domain cap + global quota DO, paid-tool gating (`GATED_PAID_ONLY_TOOLS`), auth-required tooling (`AUTH_REQUIRED_TOOLS`), agent-chat tool allowlist (`AGENT_ALLOWED_TOOLS`), request-dedup (`request-dedup.ts`), upstream-payload sanitization (`sanitize-upstream.ts`), AES-256-GCM KV envelope helper (`kv-envelope.ts`), fuzzing detector, AES-GCM access-log IP encryption, error allowlist (`json-rpc.ts`), `global_fetch_strictly_public` Worker flag |
+
+## Deployment Model
+
+`bv-mcp` is a single Cloudflare Worker deployed to the global edge and reachable over HTTPS (TLS terminated by Cloudflare) at a public hostname (`dns-mcp.blackveilsecurity.com`). The public surface is `POST/GET/DELETE /mcp`, the legacy SSE endpoints, `/oauth/*`, `/.well-known/oauth-*`, `/health`, and `/badge/:domain`. The `/internal/*` surface is reachable only via Cloudflare service bindings from sibling workers — public requests are rejected by `isPublicInternetRequest`, and the bearer gate is active by default. State lives in Cloudflare-managed KV, D1, R2, Queues, and two Durable Objects; none of these expose network listeners and are reachable only through in-account bindings. External egress is TLS-only to public DoH resolvers, CT logs, and RDAP/WHOIS, plus service-binding RPC to BlackVeil workers (bv-web, bv-recon, bv-tls-probe — the latter two operator-deploy-only and fail-soft when absent).
+
+**Deployment Classification:** `NETWORK_SERVICE`
+
+### Component Exposure Table
+
+| Component | Listens On | Auth Required | Reachability | Min Prerequisite | Derived Tier |
+|-----------|------------|---------------|--------------|------------------|-------------|
+| McpClient | N/A — no listener | N/A | External | Host/OS Access | T3 |
+| Operator | N/A — no listener | N/A | External | Host/OS Access | T3 |
+| HonoWorker | 0.0.0.0:443 (CF edge) | No (free tier allowed) | External | None | T1 |
+| TierAuthResolver | via HonoWorker (no own listener) | No (it is the auth) | External | None | T1 |
+| OAuthIssuer | 0.0.0.0:443 `/oauth/*` | No (registration/authorize/token public) | External | None | T1 |
+| McpExecutor | via HonoWorker (no own listener) | No (free tier allowed) | External | None | T1 |
+| ToolsHandler | via HonoWorker (no own listener) | No (free tier allowed) | External | None | T1 |
+| M365Proxy | via HonoWorker `tools/call` (no own listener) | Yes (`AUTH_REQUIRED_TOOLS` — valid API key/JWT) | External | Authenticated User | T2 |
+| DomainSanitizer | N/A — invoked in request path | No | External | None | T1 |
+| SafeFetch | N/A — egress library | No | External | None | T1 |
+| DnsResolver | N/A — egress library | No | External | None | T1 |
+| RateLimiter | N/A — invoked in request path | No | External | None | T1 |
+| InternalRouter | service binding only | Yes (secure-by-default bearer; strict for credential-minting) | Internal Only | Internal Network | T2 |
+| BrandAuditPipeline | via tools/call + queue/cron | Yes (paid tier quota) | External | Authenticated User | T2 |
+| QuotaCoordinator | N/A — DO binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| ProfileAccumulator | N/A — DO binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| SessionStoreKV | N/A — KV binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| ScanCacheKV | N/A — KV binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| RateLimitKV | N/A — KV binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| IntelligenceDB | N/A — D1 binding only | No (in-account binding) | No Listener | Host/OS Access | T3 |
+| BvWeb | service binding (sibling worker) | Yes (`BV_WEB_INTERNAL_KEY`) | Internal Only | Internal Network | T2 |
+| BvRecon | service binding (sibling worker) | Yes (`BV_RECON_KEY` bearer) | Internal Only | Authenticated User | T2 |
+| BvTlsProbe | service binding (sibling worker) | Yes (`BV_TLS_PROBE_KEY` bearer) | Internal Only | Internal Network | T2 |
+| PublicDoH | external (TLS egress target) | N/A (TLS) | Internal Only | Internal Network | T2 |
+| CertTransparency | service binding + crt.sh (TLS) | N/A | Internal Only | Internal Network | T2 |
+| WhoisRdap | service binding + RDAP (TLS) | N/A | Internal Only | Internal Network | T2 |
+
+## Security Infrastructure Inventory
+
+| Component | Security Role | Configuration | Notes |
+|-----------|---------------|---------------|-------|
+| TierAuthResolver | Authentication & tiering | Constant-time XOR over SHA-256 for both static dev keys; OAuth JWT verify with `ver` check + `keyHash` derivation; trial-key expiry re-check on cache hit; LKG tier cache (24 h, 5xx-only); `OWNER_ALLOW_IPS` gate on every owner path | `src/lib/tier-auth.ts`; owner downgraded to partner off-allowlist |
+| OAuthIssuer | Token issuance/validation | HS256 with `OAUTH_SIGNING_SECRET` (≥32 bytes); alg pinned; PKCE S256; JTI revocation in KV; per-subject token-version (`bumpTokenVersion`); JWT TTL clamped to entitlement window | `src/oauth/jwt.ts`, `token.ts`, `storage.ts` |
+| DomainSanitizer | Input validation / SSRF | Reject IP literals, localhost/.local/.onion, DNS-rebinding hosts, mixed-script (homoglyph) labels; HTTPS-only outbound | `src/lib/sanitize.ts`, blocklists in `src/lib/config.ts` |
+| SafeFetch | Egress SSRF guard | HTTPS-only, `redirect:'manual'`, RFC1918/reserved/link-local/IPv6-private/rebinding deny | `src/lib/safe-fetch.ts`; verified used by all new attacker-influenced fetch paths (lookalike web probe, brand CSC enrichment) |
+| RateLimiter | Abuse prevention | Per-IP 50/min + 300/hr (tools); per-tool daily quotas; 500K/day global ceiling; 12 distinct domains/day per unauthenticated IP; KV + DO + in-memory fallback | `src/lib/rate-limiter.ts`, `quota-coordinator.ts` |
+| PaidToolGate | Commercial/abuse gating | `GATED_PAID_ONLY_TOOLS` → HTTP 403 `-32003` for free/agent/unauthenticated; pinned to 0 in free/agent quota maps | `src/lib/config.ts:340-378`, `src/mcp/execute.ts` |
+| AuthRequiredGate | Sensitive-tool gating | `AUTH_REQUIRED_TOOLS` (identity_secops) → HTTP 401 `-32001` pre-dispatch; handler backstop rejects when `keyHash` absent | `src/lib/config.ts:444-454`, `src/mcp/execute.ts:601-603`, `src/handlers/tools.ts:909-912` |
+| AgentChatAllowlist | Internal least-privilege | `x-bv-caller: agent-chat` → 13 read-only tools on `/internal/tools/*`; 403 otherwise; exact-set audit test | `src/lib/config.ts:390-410`, `src/internal.ts:217-223,419-422` |
+| RequestDedup | Replay/duplicate control | SHA-256(principal+tool+canonical args), ~90 s KV window, store-on-success only, skipped without `keyHash` | `src/lib/request-dedup.ts`, wired in `src/handlers/tools.ts` |
+| UpstreamSanitizer | LLM-injection control | `sanitizeUpstreamObject/Value` scrub C0/ANSI, clamp depth 6 / 8000 chars on recon/threat-feed payloads | `src/lib/sanitize-upstream.ts` |
+| KvEnvelope | Encryption-at-rest helper | AES-256-GCM, versioned wire format, no-op when `KV_ENVELOPE_KEY` unset | `src/lib/kv-envelope.ts`; trial-key records not yet wrapped |
+| FuzzingDetector | Abuse detection | Sliding-window scoring on unknown_tool/unknown_method/zod_arg/auth_fail; webhook alerts | `src/lib/fuzzing-detector.ts`, thresholds in `config.ts` |
+| SessionStore | Session management | 64-hex IDs (32 random bytes), 2 h idle TTL, KV + in-isolate map, creation rate-limited per IP | `src/lib/session.ts`, `session-memory.ts` |
+| ClientIp | Trust source | Only `cf-connecting-ip` trusted; `x-forwarded-for`/`x-real-ip` never trusted for security | `src/lib/ip-utils.ts` / client-ip |
+| ErrorSanitizer | Information-disclosure control | Allowlist prefixes (`Missing required`, `Invalid`, `Domain `, `Resource not found`, `Rate limit exceeded`) else generic | `src/lib/json-rpc.ts` |
+| AnalyticsClient | Privacy-preserving telemetry | FNV-1a IP hash (`i_` prefix), truncated key hash; no raw IPs in events | `src/lib/analytics.ts`, `log.ts` |
+| AccessLog | Privacy-preserving audit | AES-GCM-encrypted IP evidence in D1, 90-day retention enforced by scheduled delete | `src/mcp/execute.ts`, `src/scheduled.ts:89-100`, `INTELLIGENCE_DB` |
+| InternalGuard | Internal isolation | `isPublicInternetRequest` rejects public proxy headers; secure-by-default bearer gate (`internalLenientAuthGate`); strict gate for credential-minting | `src/internal.ts:123-182` |
+| TenantScopeGuard | Multi-tenant authorization | `X-Tenant-Scope` header ∩ `TENANT_KEY_SCOPE` env map (intersection, credential-anchored); `denyIfOutOfScope` choke point with coverage audit | `src/tenants/routes.ts:107-180` |
+| OriginCheck | CSRF/abuse control | Allowlisted Origins + desktop IDE schemes; MCP-compliant rejection | `src/index.ts` `checkOrigin` |
+
+## Repository Structure
+
+| Directory | Purpose |
+|-----------|---------|
+| `src/mcp/` | MCP protocol: execute, dispatch, request parsing, route gates |
+| `src/schemas/` | Zod schemas: tool-args + TOOL_SCHEMA_MAP, tool-definitions, json-rpc, auth, session, internal |
+| `src/handlers/` | tools/list+call, resources, prompts, tool-args/formatters |
+| `src/tools/` | `check-*`, scan-domain, discover-subdomains, brand-audit, osint/bucket recon, `m365/` identity-secops entrypoints |
+| `src/oauth/` | OAuth 2.1 issuer: discovery, register, authorize, token, JWT, KV storage, entitlements |
+| `src/tenants/` | Multi-tenant subsystem (resolver, routes, per-tenant rate limit, queue consumer, scope guards) |
+| `src/lib/` | Auth, SSRF, DNS, cache, session, rate-limiter, scoring, fuzzing, analytics, brand-audit, recon/tls-probe bindings, request-dedup, kv-envelope, Durable Objects |
+| `src/queue/` | Async brand-audit / PDF queue consumers |
+| `packages/dns-checks/` | Runtime-agnostic core: scoring + checks + schemas (`@blackveil/dns-checks`) |

--- a/docs/threat-model/threat-model-20260611-112908/1-threatmodel.md
+++ b/docs/threat-model/threat-model-20260611-112908/1-threatmodel.md
@@ -1,0 +1,249 @@
+# Threat Model
+
+## Data Flow Diagram
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+    classDef newComponent fill:#d4edda,stroke:#28a745,stroke-width:3px,color:#000000
+    classDef removedComponent fill:#e9ecef,stroke:#6c757d,stroke-width:1px,stroke-dasharray:5,color:#6c757d
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        M365Proxy(("M365Proxy")):::newComponent
+        DomainSanitizer(("DomainSanitizer")):::process
+        SafeFetch(("SafeFetch")):::process
+        DnsResolver(("DnsResolver")):::process
+        RateLimiter(("RateLimiter")):::process
+        InternalRouter(("InternalRouter")):::process
+        BrandAuditPipeline(("BrandAuditPipeline")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        QuotaCoordinator(("QuotaCoordinator")):::process
+        ProfileAccumulator(("ProfileAccumulator")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        SessionStoreKV[("SessionStoreKV")]:::datastore
+        ScanCacheKV[("ScanCacheKV")]:::datastore
+        RateLimitKV[("RateLimitKV")]:::datastore
+        IntelligenceDB[("IntelligenceDB")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+        BvRecon["BvRecon"]:::newComponent
+        BvTlsProbe["BvTlsProbe"]:::newComponent
+    end
+
+    McpClient <-->|"DF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"DF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"DF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"DF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"DF05: MCP request"| McpExecutor
+    McpExecutor <-->|"DF06: Limits/quota"| RateLimiter
+    McpExecutor <-->|"DF07: Dispatch tool"| ToolsHandler
+    ToolsHandler <-->|"DF08: Validate domain"| DomainSanitizer
+    ToolsHandler <-->|"DF09: DNS query"| DnsResolver
+    ToolsHandler <-->|"DF10: Fetch attacker-influenced URL"| SafeFetch
+    ToolsHandler <-->|"DF11: Brand audit"| BrandAuditPipeline
+    McpExecutor <-->|"DF12: Sessions/OAuth codes (KV)"| SessionStoreKV
+    OAuthIssuer <-->|"DF13: Auth codes/JTI/token-version (KV)"| SessionStoreKV
+    ToolsHandler <-->|"DF14: Versioned scan cache (KV)"| ScanCacheKV
+    RateLimiter <-->|"DF15: Counters/trial keys/dedup (KV)"| RateLimitKV
+    RateLimiter <-->|"DF16: Global quota (DO)"| QuotaCoordinator
+    ToolsHandler <-->|"DF17: Adaptive weights (DO)"| ProfileAccumulator
+    McpExecutor <-->|"DF18: Encrypted access logs (D1)"| IntelligenceDB
+    TierAuthResolver <-->|"DF19: validate-key (binding)"| BvWeb
+    OAuthIssuer <-->|"DF20: Entitlements (binding)"| BvWeb
+    DnsResolver <-->|"DF21: DoH (TLS)"| PublicDoH
+    BrandAuditPipeline <-->|"DF22: CT enumeration (TLS)"| CertTransparency
+    BrandAuditPipeline <-->|"DF23: WHOIS/RDAP (TLS)"| WhoisRdap
+    ToolsHandler <-->|"DF24: identity_secops dispatch"| M365Proxy
+    M365Proxy <-->|"DF25: M365 queries (bearer + keyHash)"| BvWeb
+    ToolsHandler <-->|"DF26: OSINT/buckets/threat-feed (bearer)"| BvRecon
+    ToolsHandler <-->|"DF27: TLS version probe (bearer)"| BvTlsProbe
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px
+```
+
+## Element Table
+
+| Element | Type | TMT Category | Description | Trust Boundary | Status |
+|---------|------|--------------|-------------|----------------|--------|
+| McpClient | External Interactor | SE.EI.TMCore.WebApp | MCP client (LLM IDE/agent) calling `/mcp` | Internet | Unchanged |
+| Operator | External Interactor | SE.EI.TMCore.User | BlackVeil operator (owner key / bv-web binding) | Internet | Unchanged |
+| HonoWorker | Process | SE.P.TMCore.WebServer | Edge HTTP router; CORS/Origin, body-limit, routing, binding threading | CloudflareWorker | Modified |
+| TierAuthResolver | Process | SE.P.TMCore.WebSvc | Caller tier resolution & authentication (dual dev keys, LKG cache, JWT keyHash) | CloudflareWorker | Modified |
+| OAuthIssuer | Process | SE.P.TMCore.WebSvc | OAuth 2.1 issuer (JWT, PKCE, entitlements, `ver` revocation, TTL clamp) | CloudflareWorker | Modified |
+| McpExecutor | Process | SE.P.TMCore.WebSvc | MCP pipeline: session, rate/quota, paid/auth tool gates, dispatch | CloudflareWorker | Modified |
+| ToolsHandler | Process | SE.P.TMCore.WebSvc | Tool registry + execution (75 tools, request-dedup, versioned cache) | CloudflareWorker | Modified |
+| M365Proxy | Process | SE.P.TMCore.WebSvc | Identity-secops proxy to bv-web internal M365 endpoints | CloudflareWorker | New |
+| DomainSanitizer | Process | SE.P.TMCore.WebSvc | Domain input validation / SSRF input guard | CloudflareWorker | Modified |
+| SafeFetch | Process | SE.P.TMCore.WebSvc | Egress SSRF guard for attacker-influenced URLs | CloudflareWorker | Unchanged |
+| DnsResolver | Process | SE.P.TMCore.WebSvc | DoH egress (multi-resolver) | CloudflareWorker | Unchanged |
+| RateLimiter | Process | SE.P.TMCore.WebSvc | Rate limits, quotas, distinct-domain cap, fuzzing detection | CloudflareWorker | Modified |
+| InternalRouter | Process | SE.P.TMCore.WebSvc | Service-binding `/internal/*` surface (secure-by-default bearer, agent-chat allowlist) | CloudflareWorker | Modified |
+| BrandAuditPipeline | Process | SE.P.TMCore.WebSvc | Brand-audit orchestration + cron/queue | CloudflareWorker | Unchanged |
+| QuotaCoordinator | Process | SE.P.TMCore.WebSvc | Durable Object: cross-isolate quota coordination | DurableObjects | Unchanged |
+| ProfileAccumulator | Process | SE.P.TMCore.WebSvc | Durable Object: adaptive-scoring persistence | DurableObjects | Unchanged |
+| SessionStoreKV | Data Store | SE.DS.TMCore.NoSQL | KV: sessions, OAuth codes, JTI revocation, token-version counters | PlatformStorage | Unchanged |
+| ScanCacheKV | Data Store | SE.DS.TMCore.Cache | KV: cached scan/check results under version-stamped keys | PlatformStorage | Modified |
+| RateLimitKV | Data Store | SE.DS.TMCore.NoSQL | KV: rate/fuzzing counters, trial keys, distinct-domain markers, dedup records | PlatformStorage | Modified |
+| IntelligenceDB | Data Store | SE.DS.TMCore.SQL | D1: access logs with AES-GCM-encrypted IP evidence, 90-day retention job | PlatformStorage | Modified |
+| BvWeb | External Interactor | SE.EI.TMCore.WebSvc | Sibling worker: validate-key, OAuth entitlements, internal M365 proxy | BlackVeilServices | Modified |
+| BvRecon | External Interactor | SE.EI.TMCore.WebSvc | Operator-only bv-recon worker: OSINT/buckets/threat feed (bearer-authenticated) | BlackVeilServices | New |
+| BvTlsProbe | External Interactor | SE.EI.TMCore.WebSvc | Operator-only bv-tls-probe worker: TLS version handshakes (bearer-authenticated) | BlackVeilServices | New |
+| PublicDoH | External Interactor | SE.EI.TMCore.WebSvc | Public DoH resolvers (Cloudflare/Google) | Internet | Unchanged |
+| CertTransparency | External Interactor | SE.EI.TMCore.WebSvc | CT-log enumeration (certstream/crt.sh) | Internet | Unchanged |
+| WhoisRdap | External Interactor | SE.EI.TMCore.WebSvc | WHOIS/RDAP registration lookups (+ registry RDAP allowlist for lookalike enrichment) | Internet | Unchanged |
+
+## Data Flow Table
+
+| ID | Source | Target | Protocol | Description | Status |
+|----|--------|--------|----------|-------------|--------|
+| DF01 | McpClient | HonoWorker | HTTPS (JSON-RPC) | MCP requests over Streamable HTTP | Unchanged |
+| DF02 | Operator | InternalRouter | Service binding RPC | Internal tool/grant/trial-key/tenant calls | Modified |
+| DF03 | HonoWorker | TierAuthResolver | In-process | Resolve caller tier from token/key | Unchanged |
+| DF04 | HonoWorker | OAuthIssuer | In-process | OAuth register/authorize/token flows | Unchanged |
+| DF05 | HonoWorker | McpExecutor | In-process | Validated JSON-RPC dispatch | Unchanged |
+| DF06 | McpExecutor | RateLimiter | In-process | Apply per-IP/per-tool/global/distinct-domain limits | Modified |
+| DF07 | McpExecutor | ToolsHandler | In-process | Dispatch tools/call (with keyHash principal) | Modified |
+| DF08 | ToolsHandler | DomainSanitizer | In-process | Validate/sanitize domain input | Unchanged |
+| DF09 | ToolsHandler | DnsResolver | In-process | Issue DNS record queries | Unchanged |
+| DF10 | ToolsHandler | SafeFetch | In-process | Fetch attacker-influenced URLs (BIMI/redirects) | Unchanged |
+| DF11 | ToolsHandler | BrandAuditPipeline | In-process | Run brand audit | Unchanged |
+| DF12 | McpExecutor | SessionStoreKV | KV API (TLS) | Read/write sessions and OAuth codes | Unchanged |
+| DF13 | OAuthIssuer | SessionStoreKV | KV API (TLS) | Store auth codes / JTI revocation / token-version counters | Modified |
+| DF14 | ToolsHandler | ScanCacheKV | KV API (TLS) | Read/write cached results under version-stamped keys | Modified |
+| DF15 | RateLimiter | RateLimitKV | KV API (TLS) | Read/write counters, trial keys, distinct-domain markers, dedup records | Modified |
+| DF16 | RateLimiter | QuotaCoordinator | DO RPC | Global daily quota coordination | Unchanged |
+| DF17 | ToolsHandler | ProfileAccumulator | DO RPC | Adaptive scoring weights | Unchanged |
+| DF18 | McpExecutor | IntelligenceDB | D1 (TLS) | Write encrypted access-log evidence (90-day retention) | Modified |
+| DF19 | TierAuthResolver | BvWeb | Service binding RPC | validate-key tier resolution (with LKG fallback) | Modified |
+| DF20 | OAuthIssuer | BvWeb | Service binding RPC | Plan-to-tier entitlement lookup (with entitlement window) | Modified |
+| DF21 | DnsResolver | PublicDoH | HTTPS (DoH) | DNS-over-HTTPS queries | Unchanged |
+| DF22 | BrandAuditPipeline | CertTransparency | HTTPS | CT-log SAN/subdomain enumeration | Unchanged |
+| DF23 | BrandAuditPipeline | WhoisRdap | HTTPS | Registration/ownership lookups | Unchanged |
+| DF24 | ToolsHandler | M365Proxy | In-process | Dispatch identity_secops tools with keyHash principal | New |
+| DF25 | M365Proxy | BvWeb | Service binding RPC | M365 sign-in/UAL/CA queries (internal bearer + keyHash) | New |
+| DF26 | ToolsHandler | BvRecon | Service binding RPC | OSINT investigations, bucket scans, threat feed (bearer) | New |
+| DF27 | ToolsHandler | BvTlsProbe | Service binding RPC | TLS version probe for check_ssl (bearer) | New |
+
+## Trust Boundary Table
+
+| Boundary | Description | Contains |
+|----------|-------------|----------|
+| Internet | Public internet — untrusted external actors and third-party services reachable over TLS | McpClient, Operator, PublicDoH, CertTransparency, WhoisRdap |
+| CloudflareWorker | The bv-mcp Worker isolate at the Cloudflare edge; all request-path logic runs here | HonoWorker, TierAuthResolver, OAuthIssuer, McpExecutor, ToolsHandler, M365Proxy, DomainSanitizer, SafeFetch, DnsResolver, RateLimiter, InternalRouter, BrandAuditPipeline |
+| DurableObjects | Cloudflare Durable Objects — stateful single-instance coordinators reachable only via in-account bindings | QuotaCoordinator, ProfileAccumulator |
+| PlatformStorage | Cloudflare-managed KV/D1 stores reachable only via in-account bindings (no network listeners) | SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB |
+| BlackVeilServices | Sibling BlackVeil workers reachable via authenticated service bindings | BvWeb, BvRecon, BvTlsProbe |
+
+## Summary View
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+    classDef newComponent fill:#d4edda,stroke:#28a745,stroke-width:3px,color:#000000
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        M365Proxy(("M365Proxy")):::newComponent
+        InternalRouter(("InternalRouter")):::process
+        EgressGuards(("Egress Guards<br/>(DomainSanitizer, SafeFetch, DnsResolver)")):::process
+        SupportingServices(("Supporting<br/>(RateLimiter, BrandAuditPipeline)")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        DurableObjectsGroup(("Durable Objects<br/>(QuotaCoordinator, ProfileAccumulator)")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        PlatformStorageGroup[("Platform Storage<br/>(SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB)")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+        ReconProbes["Recon Probes<br/>(BvRecon, BvTlsProbe)"]:::newComponent
+    end
+
+    McpClient <-->|"SDF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"SDF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"SDF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"SDF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"SDF05: MCP request"| McpExecutor
+    McpExecutor <-->|"SDF06: Dispatch tool"| ToolsHandler
+    McpExecutor <-->|"SDF07: Limits/quota"| SupportingServices
+    ToolsHandler <-->|"SDF08: Validate/fetch/DNS"| EgressGuards
+    ToolsHandler <-->|"SDF09: Brand audit"| SupportingServices
+    McpExecutor <-->|"SDF10: Sessions/codes/logs"| PlatformStorageGroup
+    ToolsHandler <-->|"SDF11: Scan cache"| PlatformStorageGroup
+    SupportingServices <-->|"SDF12: Counters/trial keys"| PlatformStorageGroup
+    SupportingServices <-->|"SDF13: Global quota"| DurableObjectsGroup
+    ToolsHandler <-->|"SDF14: Adaptive weights"| DurableObjectsGroup
+    TierAuthResolver <-->|"SDF15: validate-key"| BvWeb
+    OAuthIssuer <-->|"SDF16: Entitlements"| BvWeb
+    EgressGuards <-->|"SDF17: DoH (TLS)"| PublicDoH
+    SupportingServices <-->|"SDF18: CT enumeration"| CertTransparency
+    SupportingServices <-->|"SDF19: WHOIS/RDAP"| WhoisRdap
+    ToolsHandler <-->|"SDF20: identity_secops dispatch"| M365Proxy
+    M365Proxy <-->|"SDF21: M365 queries (bearer + keyHash)"| BvWeb
+    ToolsHandler <-->|"SDF22: OSINT/buckets/TLS probe (bearer)"| ReconProbes
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px
+```
+
+## Summary to Detailed Mapping
+
+| Summary Element | Contains | Summary Flows | Maps to Detailed Flows |
+|-----------------|----------|---------------|------------------------|
+| EgressGuards | DomainSanitizer, SafeFetch, DnsResolver | SDF08, SDF17 | DF08, DF09, DF10, DF21 |
+| SupportingServices | RateLimiter, BrandAuditPipeline | SDF07, SDF09, SDF12, SDF13, SDF18, SDF19 | DF06, DF11, DF15, DF16, DF22, DF23 |
+| DurableObjectsGroup | QuotaCoordinator, ProfileAccumulator | SDF13, SDF14 | DF16, DF17 |
+| PlatformStorageGroup | SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB | SDF10, SDF11, SDF12 | DF12, DF13, DF14, DF15, DF18 |
+| ReconProbes | BvRecon, BvTlsProbe | SDF22 | DF26, DF27 |
+| HonoWorker | HonoWorker | SDF01, SDF03, SDF04, SDF05 | DF01, DF03, DF04, DF05 |
+| McpExecutor | McpExecutor | SDF05, SDF06, SDF07, SDF10 | DF05, DF06, DF07, DF12, DF18 |
+| ToolsHandler | ToolsHandler | SDF06, SDF08, SDF09, SDF11, SDF14, SDF20, SDF22 | DF07, DF08, DF09, DF10, DF11, DF14, DF17, DF24, DF26, DF27 |
+| M365Proxy | M365Proxy | SDF20, SDF21 | DF24, DF25 |
+| TierAuthResolver | TierAuthResolver | SDF03, SDF15 | DF03, DF19 |
+| OAuthIssuer | OAuthIssuer | SDF04, SDF16 | DF04, DF13, DF20 |
+| InternalRouter | InternalRouter | SDF02 | DF02 |

--- a/docs/threat-model/threat-model-20260611-112908/1.1-threatmodel.mmd
+++ b/docs/threat-model/threat-model-20260611-112908/1.1-threatmodel.mmd
@@ -1,0 +1,81 @@
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+    classDef newComponent fill:#d4edda,stroke:#28a745,stroke-width:3px,color:#000000
+    classDef removedComponent fill:#e9ecef,stroke:#6c757d,stroke-width:1px,stroke-dasharray:5,color:#6c757d
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        M365Proxy(("M365Proxy")):::newComponent
+        DomainSanitizer(("DomainSanitizer")):::process
+        SafeFetch(("SafeFetch")):::process
+        DnsResolver(("DnsResolver")):::process
+        RateLimiter(("RateLimiter")):::process
+        InternalRouter(("InternalRouter")):::process
+        BrandAuditPipeline(("BrandAuditPipeline")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        QuotaCoordinator(("QuotaCoordinator")):::process
+        ProfileAccumulator(("ProfileAccumulator")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        SessionStoreKV[("SessionStoreKV")]:::datastore
+        ScanCacheKV[("ScanCacheKV")]:::datastore
+        RateLimitKV[("RateLimitKV")]:::datastore
+        IntelligenceDB[("IntelligenceDB")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+        BvRecon["BvRecon"]:::newComponent
+        BvTlsProbe["BvTlsProbe"]:::newComponent
+    end
+
+    McpClient <-->|"DF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"DF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"DF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"DF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"DF05: MCP request"| McpExecutor
+    McpExecutor <-->|"DF06: Limits/quota"| RateLimiter
+    McpExecutor <-->|"DF07: Dispatch tool"| ToolsHandler
+    ToolsHandler <-->|"DF08: Validate domain"| DomainSanitizer
+    ToolsHandler <-->|"DF09: DNS query"| DnsResolver
+    ToolsHandler <-->|"DF10: Fetch attacker-influenced URL"| SafeFetch
+    ToolsHandler <-->|"DF11: Brand audit"| BrandAuditPipeline
+    McpExecutor <-->|"DF12: Sessions/OAuth codes (KV)"| SessionStoreKV
+    OAuthIssuer <-->|"DF13: Auth codes/JTI/token-version (KV)"| SessionStoreKV
+    ToolsHandler <-->|"DF14: Versioned scan cache (KV)"| ScanCacheKV
+    RateLimiter <-->|"DF15: Counters/trial keys/dedup (KV)"| RateLimitKV
+    RateLimiter <-->|"DF16: Global quota (DO)"| QuotaCoordinator
+    ToolsHandler <-->|"DF17: Adaptive weights (DO)"| ProfileAccumulator
+    McpExecutor <-->|"DF18: Encrypted access logs (D1)"| IntelligenceDB
+    TierAuthResolver <-->|"DF19: validate-key (binding)"| BvWeb
+    OAuthIssuer <-->|"DF20: Entitlements (binding)"| BvWeb
+    DnsResolver <-->|"DF21: DoH (TLS)"| PublicDoH
+    BrandAuditPipeline <-->|"DF22: CT enumeration (TLS)"| CertTransparency
+    BrandAuditPipeline <-->|"DF23: WHOIS/RDAP (TLS)"| WhoisRdap
+    ToolsHandler <-->|"DF24: identity_secops dispatch"| M365Proxy
+    M365Proxy <-->|"DF25: M365 queries (bearer + keyHash)"| BvWeb
+    ToolsHandler <-->|"DF26: OSINT/buckets/threat-feed (bearer)"| BvRecon
+    ToolsHandler <-->|"DF27: TLS version probe (bearer)"| BvTlsProbe
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px

--- a/docs/threat-model/threat-model-20260611-112908/1.2-threatmodel-summary.mmd
+++ b/docs/threat-model/threat-model-20260611-112908/1.2-threatmodel-summary.mmd
@@ -1,0 +1,67 @@
+%%{init: {'theme': 'base', 'themeVariables': { 'background': '#ffffff', 'primaryColor': '#ffffff', 'lineColor': '#666666' }}}%%
+flowchart LR
+    classDef process fill:#6baed6,stroke:#2171b5,stroke-width:2px,color:#000000
+    classDef external fill:#fdae61,stroke:#d94701,stroke-width:2px,color:#000000
+    classDef datastore fill:#74c476,stroke:#238b45,stroke-width:2px,color:#000000
+    classDef newComponent fill:#d4edda,stroke:#28a745,stroke-width:3px,color:#000000
+
+    McpClient["McpClient"]:::external
+    Operator["Operator"]:::external
+    PublicDoH["PublicDoH"]:::external
+    CertTransparency["CertTransparency"]:::external
+    WhoisRdap["WhoisRdap"]:::external
+
+    subgraph CloudflareWorker["Cloudflare Worker (bv-mcp)"]
+        HonoWorker(("HonoWorker")):::process
+        TierAuthResolver(("TierAuthResolver")):::process
+        OAuthIssuer(("OAuthIssuer")):::process
+        McpExecutor(("McpExecutor")):::process
+        ToolsHandler(("ToolsHandler")):::process
+        M365Proxy(("M365Proxy")):::newComponent
+        InternalRouter(("InternalRouter")):::process
+        EgressGuards(("Egress Guards<br/>(DomainSanitizer, SafeFetch, DnsResolver)")):::process
+        SupportingServices(("Supporting<br/>(RateLimiter, BrandAuditPipeline)")):::process
+    end
+
+    subgraph DurableObjects["Durable Objects"]
+        DurableObjectsGroup(("Durable Objects<br/>(QuotaCoordinator, ProfileAccumulator)")):::process
+    end
+
+    subgraph PlatformStorage["Cloudflare Platform Storage"]
+        PlatformStorageGroup[("Platform Storage<br/>(SessionStoreKV, ScanCacheKV, RateLimitKV, IntelligenceDB)")]:::datastore
+    end
+
+    subgraph BlackVeilServices["BlackVeil Services"]
+        BvWeb["BvWeb"]:::external
+        ReconProbes["Recon Probes<br/>(BvRecon, BvTlsProbe)"]:::newComponent
+    end
+
+    McpClient <-->|"SDF01: JSON-RPC over HTTPS"| HonoWorker
+    Operator <-->|"SDF02: Service binding RPC"| InternalRouter
+    HonoWorker <-->|"SDF03: Resolve tier"| TierAuthResolver
+    HonoWorker <-->|"SDF04: OAuth flows"| OAuthIssuer
+    HonoWorker <-->|"SDF05: MCP request"| McpExecutor
+    McpExecutor <-->|"SDF06: Dispatch tool"| ToolsHandler
+    McpExecutor <-->|"SDF07: Limits/quota"| SupportingServices
+    ToolsHandler <-->|"SDF08: Validate/fetch/DNS"| EgressGuards
+    ToolsHandler <-->|"SDF09: Brand audit"| SupportingServices
+    McpExecutor <-->|"SDF10: Sessions/codes/logs"| PlatformStorageGroup
+    ToolsHandler <-->|"SDF11: Scan cache"| PlatformStorageGroup
+    SupportingServices <-->|"SDF12: Counters/trial keys"| PlatformStorageGroup
+    SupportingServices <-->|"SDF13: Global quota"| DurableObjectsGroup
+    ToolsHandler <-->|"SDF14: Adaptive weights"| DurableObjectsGroup
+    TierAuthResolver <-->|"SDF15: validate-key"| BvWeb
+    OAuthIssuer <-->|"SDF16: Entitlements"| BvWeb
+    EgressGuards <-->|"SDF17: DoH (TLS)"| PublicDoH
+    SupportingServices <-->|"SDF18: CT enumeration"| CertTransparency
+    SupportingServices <-->|"SDF19: WHOIS/RDAP"| WhoisRdap
+    ToolsHandler <-->|"SDF20: identity_secops dispatch"| M365Proxy
+    M365Proxy <-->|"SDF21: M365 queries (bearer + keyHash)"| BvWeb
+    ToolsHandler <-->|"SDF22: OSINT/buckets/TLS probe (bearer)"| ReconProbes
+
+    style CloudflareWorker fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style DurableObjects fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style PlatformStorage fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+    style BlackVeilServices fill:none,stroke:#e31a1c,stroke-width:3px,stroke-dasharray: 5 5
+
+    linkStyle default stroke:#666666,stroke-width:2px

--- a/docs/threat-model/threat-model-20260611-112908/2-stride-analysis.md
+++ b/docs/threat-model/threat-model-20260611-112908/2-stride-analysis.md
@@ -1,0 +1,928 @@
+# STRIDE-A Threat Analysis
+
+> This analysis uses the standard **STRIDE** methodology (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege) extended with **Abuse Cases** (business logic abuse, workflow manipulation, feature misuse). The "A" column in tables below represents Abuse — a supplementary category covering threats where legitimate features are misused for unintended purposes. This is distinct from Elevation of Privilege (E), which covers authorization bypass.
+>
+> **Incremental report.** Threat IDs T01–T78 are inherited from baseline `threat-model-20260524-114907`; T79–T93 are new in this window (f75ca7d → 7a1c6b3). Each threat row carries a `Change` column: `Existing` (still present in current code), `Fixed` (remediated — code change cited), `New`, or `Removed`.
+
+## Exploitability Tiers
+
+| Tier | Label | Prerequisites | Assignment Rule |
+|------|-------|---------------|----------------|
+| **Tier 1** | Direct Exposure | `None` | Exploitable by unauthenticated external attacker with NO prior access. The prerequisite field MUST say `None`. |
+| **Tier 2** | Conditional Risk | Single prerequisite: `Authenticated User`, `Privileged User`, `Internal Network`, or single `{Boundary} Access` | Requires exactly ONE form of access. The prerequisite field has ONE item. |
+| **Tier 3** | Defense-in-Depth | `Host/OS Access`, `Admin Credentials`, `{Component} Compromise`, `Physical Access`, or MULTIPLE prerequisites joined with `+` | Requires significant prior breach, infrastructure access, or multiple combined prerequisites. |
+
+## Summary
+
+| Component | Link | S | T | R | I | D | E | A | Total | T1 | T2 | T3 | Risk |
+|-----------|------|---|---|---|---|---|---|---|-------|----|----|----|------|
+| HonoWorker | [Link](#honoworker) | 1 | 1 | 1 | 2 | 1 | 0 | 1 | 7 | 7 | 0 | 0 | Low |
+| TierAuthResolver | [Link](#tierauthresolver) | 2 | 1 | 0 | 1 | 0 | 3 | 1 | 8 | 6 | 1 | 1 | Low |
+| OAuthIssuer | [Link](#oauthissuer) | 1 | 1 | 0 | 1 | 1 | 1 | 1 | 6 | 3 | 1 | 2 | Low |
+| McpExecutor | [Link](#mcpexecutor) | 1 | 1 | 1 | 1 | 1 | 1 | 1 | 7 | 7 | 0 | 0 | Low |
+| ToolsHandler | [Link](#toolshandler) | 0 | 1 | 0 | 1 | 1 | 1 | 2 | 6 | 6 | 0 | 0 | Low |
+| M365Proxy | [Link](#m365proxy) | 1 | 0 | 0 | 2 | 1 | 0 | 1 | 5 | 0 | 5 | 0 | Medium |
+| DomainSanitizer | [Link](#domainsanitizer) | 0 | 1 | 0 | 1 | 0 | 1 | 0 | 3 | 3 | 0 | 0 | Low |
+| SafeFetch | [Link](#safefetch) | 0 | 1 | 0 | 1 | 1 | 0 | 0 | 3 | 3 | 0 | 0 | Low |
+| DnsResolver | [Link](#dnsresolver) | 1 | 1 | 0 | 0 | 1 | 0 | 1 | 4 | 2 | 2 | 0 | Low |
+| RateLimiter | [Link](#ratelimiter) | 0 | 1 | 0 | 0 | 1 | 1 | 1 | 4 | 3 | 0 | 1 | Low |
+| InternalRouter | [Link](#internalrouter) | 1 | 1 | 0 | 0 | 1 | 1 | 2 | 6 | 0 | 6 | 0 | Low |
+| BrandAuditPipeline | [Link](#brandauditpipeline) | 0 | 1 | 0 | 1 | 1 | 0 | 1 | 4 | 0 | 4 | 0 | Medium |
+| QuotaCoordinator | [Link](#quotacoordinator) | 0 | 1 | 0 | 0 | 1 | 0 | 0 | 2 | 0 | 0 | 2 | Low |
+| ProfileAccumulator | [Link](#profileaccumulator) | 0 | 1 | 0 | 0 | 0 | 0 | 1 | 2 | 0 | 0 | 2 | Low |
+| SessionStoreKV | [Link](#sessionstorekv) | 0 | 1 | 0 | 1 | 0 | 0 | 0 | 2 | 0 | 0 | 2 | Low |
+| ScanCacheKV | [Link](#scancachekv) | 0 | 1 | 0 | 0 | 0 | 0 | 0 | 1 | 0 | 0 | 1 | Low |
+| RateLimitKV | [Link](#ratelimitkv) | 0 | 1 | 0 | 1 | 0 | 0 | 0 | 2 | 0 | 0 | 2 | Low |
+| IntelligenceDB | [Link](#intelligencedb) | 0 | 1 | 1 | 1 | 0 | 0 | 0 | 3 | 0 | 0 | 3 | Low |
+| BvWeb | [Link](#bvweb) | 1 | 0 | 0 | 1 | 1 | 0 | 0 | 3 | 0 | 2 | 1 | Low |
+| BvRecon | [Link](#bvrecon) | 1 | 1 | 0 | 1 | 1 | 0 | 1 | 5 | 0 | 4 | 1 | Medium |
+| BvTlsProbe | [Link](#bvtlsprobe) | 0 | 1 | 0 | 1 | 1 | 0 | 0 | 3 | 0 | 2 | 1 | Low |
+| PublicDoH | [Link](#publicdoh) | 1 | 1 | 0 | 0 | 1 | 0 | 0 | 3 | 0 | 3 | 0 | Low |
+| CertTransparency | [Link](#certtransparency) | 0 | 1 | 0 | 0 | 1 | 0 | 0 | 2 | 0 | 2 | 0 | Low |
+| WhoisRdap | [Link](#whoisrdap) | 0 | 0 | 0 | 1 | 1 | 0 | 0 | 2 | 0 | 2 | 0 | Low |
+| **Totals** | | **11** | **21** | **3** | **18** | **17** | **9** | **14** | **93** | **40** | **34** | **19** | |
+
+---
+
+## HonoWorker
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Edge HTTP router — CORS/Origin checks, body-size limits, route gating, error wrapping, binding threading
+**Data Flows:** DF01, DF03, DF04, DF05
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T01.S | Spoofing | Forged `Origin` header to mount cross-site/CSRF requests against `/mcp` | None | DF01 | `checkOrigin` allowlist + MCP-compliant rejection of unauthorized browser origins (`src/index.ts`) | Mitigated | Existing |
+| T02.T | Tampering | Oversized request body to exhaust isolate memory/CPU | None | DF01 | 10 KB body cap (`MAX_REQUEST_BODY_BYTES`) read before parse | Mitigated | Existing |
+| T03.R | Repudiation | Client denies issuing abusive requests; weak attribution | None | DF01 | Encrypted access log (D1) + analytics `keyHash`/`ipHash`; JSON-RPC error codes now emitted to analytics | Mitigated | Existing |
+| T04.I | Information Disclosure | Verbose/stack-trace errors leak internals to clients | None | DF01 | `sanitizeErrorMessage` allowlist; generic fallback (`src/lib/json-rpc.ts`) | Mitigated | Existing |
+| T05.I | Information Disclosure | `Host` header spoofing poisons OAuth issuer URL in discovery responses | None | DF04 | `resolveIssuer` honors `OAUTH_ISSUER` override; `resolveIssuerStrict` host-pinning added (`src/oauth/discovery.ts:18-39`); Host fallback remains the default when unset (deploy-config-gated) | Open | Existing |
+| T06.D | Denial of Service | Unauthenticated request flood against `/mcp` | None | DF01 | Per-IP 50/min + 300/hr limits, global 500K/day ceiling | Mitigated | Existing |
+| T07.A | Abuse | Distributed free-tier abuse consuming the shared global daily budget | None | DF01 | Per-IP distinct-domain daily cap (12/day, `checkDistinctDomainDailyLimit`, `src/lib/rate-limiter.ts:555-593`) + global quota DO + per-IP limits | Mitigated | Fixed |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Elevation of Privilege | The router makes no authorization decisions; tier resolution and gating happen in TierAuthResolver/McpExecutor. |
+
+---
+
+## TierAuthResolver
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Caller tier resolution & authentication — static keys, OAuth JWT, trial keys, bv-web validate-key, LKG fallback
+**Data Flows:** DF03, DF19
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T08.S | Spoofing | API-key brute force / timing side-channel against static keys | None | DF03 | Constant-time XOR over SHA-256 digests for both dev-key slots (`src/lib/tier-auth.ts:50-59,168-171`) | Mitigated | Existing |
+| T09.S | Spoofing | Forged OAuth JWT via `alg=none`/algorithm confusion | None | DF03 | HS256 pinned; algorithm checked before signature verify (`src/oauth/jwt.ts`) | Mitigated | Existing |
+| T10.T | Tampering | Tier-claim tampering to obtain a higher tier | None | DF03 | Signature verified before claims parsed; `JwtIssuableTierSchema` enum (owner/developer/enterprise) | Mitigated | Existing |
+| T11.I | Information Disclosure | Owner key leaks via `?api_key=` query into CDN/edge logs | None | DF03 | Bearer preferred; `REJECT_QUERY_API_KEY` rejection gate merged (`src/index.ts:106`) but defaults to accepting query keys — activation is deploy-config | Open | Existing |
+| T12.E | Elevation of Privilege | Spoofing client IP to satisfy `OWNER_ALLOW_IPS` and gain owner tier | None | DF03 | IP sourced only from `cf-connecting-ip`; `applyOwnerIpGate()` now applied on every owner-tier path including JWT (`src/lib/tier-auth.ts:61-68,136`) | Mitigated | Existing |
+| T14.A | Abuse | Caller supplies a tier hint expecting the server to honor it | None | DF03 | Tier is always server-derived; never read from caller input | Mitigated | Existing |
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T13.E | Elevation of Privilege | Expired/exhausted trial key retains its tier during the 60 s resolution cache window | Authenticated User | DF03 | Fixed: cache hits now re-check `trialExpiresAt` and evict stale entries (`src/lib/tier-auth.ts:190-193`) | Mitigated | Fixed |
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T92.E | Elevation of Privilege | A key revoked while bv-web is unavailable keeps its last-known-good paid tier for up to 24 h (LKG cache consulted on 5xx/network errors) | Authenticated User + BvWeb Compromise | DF19 | LKG never consulted on definitive 4xx rejections — revocation correctness preserved; 24 h TTL bounds the window (`src/lib/tier-auth.ts:302-317`) | Mitigated | New |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Authentication outcomes are attributed via keyHash in analytics and access logs; no repudiation surface beyond T03.R. |
+| Denial of Service | The resolver is a bounded in-process step; flood scenarios are covered at HonoWorker (T06.D) and RateLimiter. |
+
+---
+
+## OAuthIssuer
+
+**Trust Boundary:** CloudflareWorker
+**Role:** OAuth 2.1 issuer — register, authorize, PKCE token exchange, HS256 JWT, entitlements, token-version revocation
+**Data Flows:** DF04, DF13, DF20
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T15.S | Spoofing | Abuse of open dynamic client registration to register rogue clients | None | DF04 | PKCE required; redirect_uri validation; per-IP 10/min + 30/hr registration limits (`src/oauth/register.ts`); reclassified false positive in the interim overlay — controls verified intact at HEAD | Mitigated | Existing |
+| T16.T | Tampering | Authorization-code injection / replay | None | DF04 | PKCE S256 verify; single-use codes with TTL in KV (`src/oauth/token.ts`) | Mitigated | Existing |
+| T18.D | Denial of Service | Token-endpoint flooding | None | DF04 | 30/min per-IP limit on `/oauth/token` | Mitigated | Existing |
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T20.A | Abuse | Issued JWT retains an elevated tier after the customer's plan is downgraded, until `exp` | Authenticated User | DF20 | Fixed: per-subject token-version (`ver`) revocation via `bumpTokenVersion()` (`src/oauth/storage.ts:139-144`, verified in `src/lib/tier-auth.ts:128-135`) + JWT TTL clamped to the entitlement window with expired entitlements rejected (`src/oauth/token.ts:167-181`) | Mitigated | Fixed |
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T17.I | Information Disclosure | Weak/short `OAUTH_SIGNING_SECRET` enabling JWT forgery | Host/OS Access | DF04 | `OAUTH_SIGNING_SECRET_MIN_BYTES` (≥32) enforced; 503 until set | Mitigated | Existing |
+| T19.E | Elevation of Privilege | Spoofed bv-web entitlement response grants an unauthorized tier | BvWeb Compromise | DF20 | Authenticated service binding; tier value validated against enum | Mitigated | Existing |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Token issuance is logged with jti/subject; covered by platform/audit logging rather than a distinct issuer threat. |
+
+---
+
+## McpExecutor
+
+**Trust Boundary:** CloudflareWorker
+**Role:** MCP request pipeline — session validation, rate/quota application, paid/auth tool gates, method routing, keyHash threading
+**Data Flows:** DF05, DF06, DF07, DF12, DF18
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T21.S | Spoofing | Session-ID guessing or fixation to hijack a session | None | DF12 | 64-hex IDs from 32 random bytes; schema-validated; KV-backed | Mitigated | Existing |
+| T22.T | Tampering | Malformed JSON-RPC / parameter tampering | None | DF05 | JSON-RPC validation + Zod `validateToolArgs`; `isJsonRpcNotification()` now correctly treats `id: null` as requiring a response (`src/mcp/execute.ts:906`) | Mitigated | Existing |
+| T23.R | Repudiation | Tool invocation cannot be attributed to a principal | None | DF18 | `tool_call` analytics + encrypted access log (D1); keyHash now threaded through dispatch to handlers (3.17.2 fix) | Mitigated | Existing |
+| T24.I | Information Disclosure | Cross-session/tenant data leakage via predictable cache keys | None | DF12 | Domain-scoped, version-stamped cache keys; no per-user secrets cached | Mitigated | Existing |
+| T25.D | Denial of Service | Amplification via expensive methods (e.g., `scan_domain`) | None | DF07 | Per-tool daily quotas; 15 s scan / 8 s per-check budgets (clamped, env-overridable) | Mitigated | Existing |
+| T26.E | Elevation of Privilege | Invoking a non-allowlisted, scan-only, paid-only, or auth-required tool directly | None | DF07 | `TOOL_REGISTRY` allowlist; `GATED_PAID_ONLY_TOOLS` → 403/-32003 (`src/mcp/execute.ts:604-606`); `AUTH_REQUIRED_TOOLS` → 401/-32001 (`src/mcp/execute.ts:601-603`) | Mitigated | Existing |
+| T27.A | Abuse | Session-creation flooding to exhaust KV / session maps | None | DF12 | Session creation rate-limited per IP; LRU-capped maps | Mitigated | Existing |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+*None — all seven STRIDE-A categories produced concrete threats for this component.*
+
+---
+
+## ToolsHandler
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Tool registry + execution (75 tools), request-dedup, versioned caching, binding dispatch
+**Data Flows:** DF07, DF08, DF09, DF10, DF11, DF14, DF17, DF24, DF26, DF27
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T28.T | Tampering | Tool arguments injected to reach DNS/fetch with unvalidated values | None | DF08 | Zod `validateToolArgs` + `validateDomain`/`sanitizeDomain` after schema | Mitigated | Existing |
+| T29.I | Information Disclosure | `STRUCTURED_RESULT` JSON leaks internal data to clients | None | DF07 | Omitted for interactive LLM clients; findings auto-sanitized via `createFinding()`; redundant comment stripped for structuredContent-capable clients (`src/mcp/dispatch.ts:188-200`) | Mitigated | Existing |
+| T30.D | Denial of Service | `batch_scan` resource exhaustion | None | DF07 | `budgetMs` 25 s, concurrency 3, per-domain `Promise.race`; `batch_scan` now paid-only | Mitigated | Existing |
+| T31.E | Elevation of Privilege | Domain-optional tool bypassing domain validation | None | DF08 | `DOMAIN_OPTIONAL_TOOLS` explicit allowlist; args still Zod-validated; domain-required SSOT audit | Mitigated | Existing |
+| T32.A | Abuse | Using the scanner as a recon/attack proxy against arbitrary third-party domains | None | DF09 | Fixed: offensive/multi-domain tools gated to paid tiers via `GATED_PAID_ONLY_TOOLS` → HTTP 403/-32003 (`src/lib/config.ts:340-378`), pinned to 0 in free/agent quota maps | Mitigated | Fixed |
+| T33.A | Abuse | Repeated `force_refresh` to bust cache and amplify backend load | None | DF14 | Fixed: `FORCE_REFRESH_DAILY_LIMIT = 5` free-tier daily cache-bypass cap (`src/lib/config.ts:338`) in addition to per-tool quotas | Mitigated | Fixed |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | The handler trusts the principal resolved upstream (TierAuthResolver); no identity decisions are made here. |
+| Repudiation | Tool calls are attributed via `tool_call` analytics and access logs (covered at T23.R). |
+
+---
+
+## M365Proxy
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Identity-secops tool family (query_signins, query_ual, get_ca_policies, assess_coverage) proxying to bv-web internal M365 endpoints
+**Data Flows:** DF24, DF25
+**Pod Co-location:** N/A
+
+> **[New]** Component added in this window (identity_secops, v3.17.x; caller-principal hardening in 3.17.2/3.18.0).
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Authenticated User` — `AUTH_REQUIRED_TOOLS` rejects unauthenticated callers pre-dispatch.)
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T79.S | Spoofing | Stolen/leaked API key of any paid tier used to invoke identity-secops tools as that principal | Authenticated User | DF24 | `AUTH_REQUIRED_TOOLS` 401 gate (`src/mcp/execute.ts:601-603`) + handler backstop rejecting dispatch when `keyHash` absent (`src/handlers/tools.ts:909-912`); key hygiene/revocation via `ver` mechanism | Mitigated | New |
+| T80.I | Information Disclosure | Cross-tenant M365 log access: caller supplies an arbitrary `ms_tenant_id`; bv-mcp forwards it with the trusted internal bearer, relying on bv-web to enforce that the `keyHash` principal owns the tenant | Authenticated User | DF25 | `keyHash` forwarded in request body (`src/tools/m365/proxy.ts:38`); enforcement is delegated cross-service — bv-mcp cannot verify it locally | Open | New |
+| T81.I | Information Disclosure | Tenant-ID enumeration via differentiable `m365_proxy_*` error codes (404 vs 403 vs 500) | Authenticated User | DF25 | Error codes map upstream statuses distinctly (`src/tools/m365/proxy.ts:41-49`); no bleaching to a generic error | Open | New |
+| T82.D | Denial of Service | Unmetered M365 queries: tools are in `INTENTIONALLY_UNLIMITED_TOOLS` (no per-tool daily quota), so an authenticated caller can amplify load/cost on bv-web and Microsoft Graph | Authenticated User | DF25 | Global/per-IP caps only (`src/lib/config.ts:457-467`); per-principal metering not implemented | Open | New |
+| T83.A | Abuse | Using identity-secops tools to surveil an organization's sign-in/audit activity beyond the caller's legitimate scope | Authenticated User | DF25 | Read-only tool set; bv-web tenant-scope authorization on `keyHash`; access logged | Mitigated | New |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Tampering | The proxy is read-only — it mutates no state in bv-mcp or M365; request bodies are fixed-shape JSON to an internal binding. |
+| Repudiation | Every call carries the `keyHash` principal and is recorded in `tool_call` analytics and access logs. |
+| Elevation of Privilege | Authorization decisions are delegated to bv-web; the bypass scenario is captured as T80.I (information disclosure via missing scope check). |
+
+---
+
+## DomainSanitizer
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Domain input validation / SSRF input guard
+**Data Flows:** DF08
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T34.T | Tampering | Unicode/punycode homoglyph or encoding tricks bypassing domain validation | None | DF08 | Fixed: mixed-script (confusable) label rejection in `hasMixedScripts()`/`sanitizeDomain` (`src/lib/sanitize.ts`), verified present at HEAD; normalization + public-suffix checks | Mitigated | Fixed |
+| T35.I | Information Disclosure | SSRF — domain input crafted to resolve to internal/metadata IPs | None | DF08 | Reject IP literals, localhost/.local/.onion, RFC1918, rebinding hosts (`src/lib/config.ts`) | Mitigated | Existing |
+| T36.E | Elevation of Privilege | DNS-rebinding TOCTOU: validated hostname resolves to an internal IP at fetch time | None | DF08 | Cloudflare `global_fetch_strictly_public` blocks RFC1918 at runtime; SafeFetch re-validation | Mitigated | Existing |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | The sanitizer processes data, not identities. |
+| Repudiation | Stateless validation library; no audit surface of its own. |
+| Denial of Service | Validation is O(label count) string work; flood scenarios are covered upstream. |
+| Abuse | Feature-misuse scenarios route through ToolsHandler (T32.A). |
+
+---
+
+## SafeFetch
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Egress SSRF guard for attacker-influenced URLs
+**Data Flows:** DF10
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T37.T | Tampering | Redirect-based SSRF — `Location:` header pointing at internal targets | None | DF10 | `redirect:'manual'` + per-hop re-validation through SafeFetch (`src/lib/safe-fetch.ts`) | Mitigated | Existing |
+| T38.I | Information Disclosure | Attacker-influenced URL (BIMI `l=`/`a=`) fetched against internal services | None | DF10 | HTTPS-only, blocklist, userinfo rejection in SafeFetch; new outbound paths (lookalike web probe, brand CSC enrichment) verified to use safeFetch; RDAP enrichment restricted to a hardcoded registry-endpoint allowlist (`src/tools/check-lookalikes.ts:641-668`) | Mitigated | Existing |
+| T39.D | Denial of Service | Slowloris/large-response from an attacker-controlled fetch target | None | DF10 | `AbortSignal.timeout` + total-budget caps (`check_http_security` 10 s) | Mitigated | Existing |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Egress library; no identity surface. |
+| Repudiation | Stateless; outbound requests attributed via the invoking tool's logs. |
+| Elevation of Privilege | No authorization decisions made here. |
+| Abuse | Abuse-of-fetch scenarios are captured at ToolsHandler (T32.A). |
+
+---
+
+## DnsResolver
+
+**Trust Boundary:** CloudflareWorker
+**Role:** DoH egress (multi-resolver chain)
+**Data Flows:** DF09, DF21
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T42.D | Denial of Service | Using the scanner to flood a victim domain/resolver with DNS queries (reflection) | None | DF21 | Fixed: multi-domain/offensive tools paid-gated (`GATED_PAID_ONLY_TOOLS`) + 12 distinct domains/day per unauthenticated IP; queries target public DoH, not arbitrary victims | Mitigated | Fixed |
+| T43.A | Abuse | Driving DNS queries for reconnaissance / resolver cache snooping | None | DF21 | Fixed: distinct-domain daily cap throttles enumeration breadth (`src/lib/rate-limiter.ts:555-593`); rate limits; bounded record types | Mitigated | Fixed |
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T40.S | Spoofing | Malicious/MITM DoH resolver returns forged records | Internal Network | DF21 | TLS to resolvers; secondary resolver uses `X-BV-Token`; multi-resolver chain | Mitigated | Existing |
+| T41.T | Tampering | DNS-response tampering that skews scan grades | Internal Network | DF21 | TLS transport; cross-resolver corroboration; DNSSEC checks where applicable | Mitigated | Existing |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Resolver egress is attributed via tool-call logging; no distinct repudiation surface. |
+| Information Disclosure | The resolver queries public DNS data only; SSRF-style disclosure is covered at DomainSanitizer/SafeFetch. |
+| Elevation of Privilege | No authorization decisions made here. |
+
+---
+
+## RateLimiter
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Rate limits, quotas, distinct-domain cap, fuzzing detection
+**Data Flows:** DF06, DF15, DF16
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T44.T | Tampering | Forging client IP to evade per-IP counters | None | DF06 | IP sourced only from `cf-connecting-ip`; `x-forwarded-for` never trusted | Mitigated | Existing |
+| T46.E | Elevation of Privilege | Distributed IPs (botnet) bypassing per-IP limits | None | DF06 | Fixed: per-IP distinct-domain daily cap (12) narrows per-IP value; global 500K/day ceiling enforced by QuotaCoordinator DO | Mitigated | Fixed |
+| T47.A | Abuse | Low-and-slow fuzzing/enumeration kept under per-IP thresholds | None | DF15 | Fuzzing detector sliding-window scoring + webhook alerts; JSON-RPC error-code analytics added | Mitigated | Existing |
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T45.D | Denial of Service | KV unavailability disabling rate-limit enforcement (fail-open) | RateLimitKV Compromise | DF15 | In-memory fallback + QuotaCoordinator DO with circuit breaker; distinct-domain cap is deliberately fail-open (best-effort) | Mitigated | Existing |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Identity spoofing against limits is captured as T44.T (IP forging). |
+| Repudiation | Counter state is operational, not an audit record. |
+| Information Disclosure | Counters contain hashed principals only. |
+
+---
+
+## InternalRouter
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Service-binding `/internal/*` surface — tools, analytics, tenants, credential-minting routes; agent-chat allowlist
+**Data Flows:** DF02
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Internal Network` — reachable only via in-account service bindings.)
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T48.S | Spoofing | Public attacker reaching `/internal/*` by manipulating proxy headers | Internal Network | DF02 | `isPublicInternetRequest` rejects any public proxy header → 404 (`src/internal.ts:123-125`) | Mitigated | Existing |
+| T49.T | Tampering | Oversized/abusive internal batch payload | Internal Network | DF02 | 256 KB batch limit; tool names `^[a-z_]+$` ≤30 chars; arg-key allowlist | Mitigated | Existing |
+| T50.D | Denial of Service | Batch endpoint resource exhaustion (up to 500 domains) | Internal Network | DF02 | Max 500 domains, concurrency cap, per-domain budget | Mitigated | Existing |
+| T51.E | Elevation of Privilege | Reaching credential-minting routes (`/internal/oauth/grants`, `/internal/trial-keys/*`) without authorization | Internal Network | DF02 | Strict `BV_WEB_INTERNAL_KEY` bearer gate: 503 if unset, 401 on missing/wrong | Mitigated | Existing |
+| T52.A | Abuse | Bearer auth on `/internal/tools/*` and `/internal/analytics/*` left opt-in, exposing them to any in-account binding | Internal Network | DF02 | Fixed: `internalLenientAuthGate` is secure-by-default — active unless `REQUIRE_INTERNAL_AUTH=false`, 503 when `BV_WEB_INTERNAL_KEY` unset, 401 on bad bearer (`src/internal.ts:165-182`) | Mitigated | Fixed |
+| T93.A | Abuse | Internal caller omits or alters the `x-bv-caller: agent-chat` header to escape the 13-tool read-only allowlist | Internal Network | DF02 | Header rides the authenticated binding only; allowlist enforced at both `/internal/tools/call` and `/batch` (`src/internal.ts:217-223,419-422`) with tool-name normalization before the check; bv-web gateway enforces the same allowlist independently; exact-set audit test | Mitigated | New |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Internal calls are attributed to the calling worker via binding identity and logs. |
+| Information Disclosure | Internal responses go only to authenticated sibling workers; public exposure is captured as T48.S. |
+
+---
+
+## BrandAuditPipeline
+
+**Trust Boundary:** CloudflareWorker
+**Role:** Brand-audit orchestration + cron/queue — tiered discovery, registrar/CT/WHOIS enrichment
+**Data Flows:** DF11, DF22, DF23
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Authenticated User` — brand-audit tools are paid-gated.)
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T53.T | Tampering | Auditing a watched domain the caller does not own | Authenticated User | DF11 | Watched-domain validated at register time; ownership attestation remains caller-supplied (no DNS-TXT challenge yet) | Open | Existing |
+| T54.I | Information Disclosure | Tiered discovery reveals competitor/third-party infrastructure | Authenticated User | DF22 | Opt-out enforcement; tier gating of discovery modes; brand tools now developer+ only — ownership attestation residual remains | Open | Existing |
+| T55.D | Denial of Service | Expensive tiered discovery / brand-audit queue flooding | Authenticated User | DF11 | Per-tier quotas, processing budget, reaper for stale jobs; request-dedup absorbs client retries of `*_start` | Mitigated | Existing |
+| T56.A | Abuse | Mass third-party domain enumeration via repeated brand audits | Authenticated User | DF22 | Per-tier daily quotas + opt-out registry; ownership attestation still caller-supplied (residual — see FIND-14) | Open | Existing |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Caller identity is resolved upstream; watched-domain spoofing is captured as T53.T (tampering). |
+| Repudiation | Audit rows record the owning principal (`owner_id`). |
+| Elevation of Privilege | Tier gating decisions happen in McpExecutor. |
+
+---
+
+## QuotaCoordinator
+
+**Trust Boundary:** DurableObjects
+**Role:** Durable Object — cross-isolate quota coordination
+**Data Flows:** DF16
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Host/OS Access` — no listener; in-account binding only.)
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T57.T | Tampering | Manipulating DO state to reset/inflate quota counters | CloudflareWorker Compromise | DF16 | DO reachable only via in-account binding; no external listener | Platform | Existing |
+| T58.D | Denial of Service | Single-instance DO bottleneck or unavailability disabling global quota | Host/OS Access | DF16 | Circuit-breaker fallback to KV/in-memory limiting | Mitigated | Existing |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Reachable only via in-account binding; no caller identity surface. |
+| Repudiation | Counter state is operational, not audit evidence. |
+| Information Disclosure | Holds only aggregate counters keyed by hashed principals. |
+| Elevation of Privilege | Makes no authorization decisions. |
+| Abuse | No business workflow exposed. |
+
+---
+
+## ProfileAccumulator
+
+**Trust Boundary:** DurableObjects
+**Role:** Durable Object — adaptive-scoring EMA persistence
+**Data Flows:** DF17
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Host/OS Access`.)
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T59.T | Tampering | Poisoning adaptive weights via crafted telemetry | CloudflareWorker Compromise | DF17 | Maturity-gated blending (`MATURITY_THRESHOLD`); static fallback if DO unavailable | Mitigated | Existing |
+| T60.A | Abuse | Sustained scans biasing the EMA to skew future scores | CloudflareWorker Compromise | DF17 | Maturity threshold before blending; bounded influence per profile | Mitigated | Existing |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | In-account binding only. |
+| Repudiation | Aggregated statistics, not audit evidence. |
+| Information Disclosure | Holds aggregate scoring statistics only. |
+| Denial of Service | DO unavailability degrades to static weights (fail-soft). |
+| Elevation of Privilege | Makes no authorization decisions. |
+
+---
+
+## SessionStoreKV
+
+**Trust Boundary:** PlatformStorage
+**Role:** KV — sessions, OAuth codes, JTI revocation, token-version counters
+**Data Flows:** DF12, DF13
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Host/OS Access`.)
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T61.T | Tampering | Tampering with session/auth-code records | CloudflareWorker Compromise | DF12 | KV reachable only via in-account binding; session schema validated on read | Platform | Existing |
+| T62.I | Information Disclosure | Disclosure of OAuth codes / JTI if the KV namespace is exposed | Host/OS Access | DF13 | Fixed: AES-256-GCM KV envelope applied on the OAuth grants path (`src/lib/kv-envelope.ts`, wired at `src/internal.ts:299`); short single-use code TTL; platform encryption at rest | Mitigated | Fixed |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | No listener; in-account binding only. |
+| Repudiation | Session records are operational state. |
+| Denial of Service | KV outage degrades to in-isolate session map (fail-soft). |
+| Elevation of Privilege | Storage layer makes no authorization decisions. |
+| Abuse | No business workflow exposed. |
+
+---
+
+## ScanCacheKV
+
+**Trust Boundary:** PlatformStorage
+**Role:** KV — cached scan/check results under version-stamped keys
+**Data Flows:** DF14
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Host/OS Access`.)
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T63.T | Tampering | Cache poisoning — tampered cached results served to clients | CloudflareWorker Compromise | DF14 | KV in-account only; 5 min TTL; version-stamped keys (`buildScanCacheKey`) invalidate stale entries on server/dns-checks bumps | Platform | Existing |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | No listener; in-account binding only. |
+| Repudiation | Cache is operational state. |
+| Information Disclosure | Contains only public DNS scan results keyed by domain. |
+| Denial of Service | Cache outage falls through to live checks. |
+| Elevation of Privilege | No authorization decisions. |
+| Abuse | Cache-busting abuse is captured at T33.A. |
+
+---
+
+## RateLimitKV
+
+**Trust Boundary:** PlatformStorage
+**Role:** KV — rate/fuzzing counters, trial keys, distinct-domain markers, request-dedup records
+**Data Flows:** DF15
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Host/OS Access`.)
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T64.T | Tampering | Tampering with counters or trial keys to evade limits/escalate tier | CloudflareWorker Compromise | DF15 | KV in-account only; DO fallback for quota | Platform | Existing |
+| T65.I | Information Disclosure | Disclosure of trial keys / dedup records if the KV namespace is exposed | Host/OS Access | DF15 | Platform encryption at rest; trial keys bounded-lifetime; AES-256-GCM envelope helper exists (`src/lib/kv-envelope.ts`) but trial-key records are **not yet wrapped** (`src/lib/trial-keys.ts` unchanged in window) | Open | Existing |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | No listener; in-account binding only. |
+| Repudiation | Counters are operational state. |
+| Denial of Service | Fail-open design covered at T45.D. |
+| Elevation of Privilege | No authorization decisions. |
+| Abuse | No business workflow exposed. |
+
+---
+
+## IntelligenceDB
+
+**Trust Boundary:** PlatformStorage
+**Role:** D1 — MCP access logs with AES-GCM-encrypted IP evidence, 90-day retention
+**Data Flows:** DF18
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Host/OS Access`.)
+
+#### Tier 2 — Conditional Risk
+
+*No Tier 2 threats identified.*
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T66.I | Information Disclosure | Disclosure of client IP evidence from access logs | Host/OS Access | DF18 | AES-GCM encryption with versioned key; 90-day retention | Mitigated | Existing |
+| T67.T | Tampering | Tampering with access logs to hide abuse activity | CloudflareWorker Compromise | DF18 | D1 in-account only; append-oriented write pattern | Platform | Existing |
+| T68.R | Repudiation | Insufficient retention undermines forensic attribution | Host/OS Access | DF18 | Fixed: scheduled retention job deletes `mcp_access_log` rows older than 90 days via parameterized D1 query (`src/scheduled.ts:89-100`), making the retention window enforced rather than advisory | Mitigated | Fixed |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | No listener; in-account binding only. |
+| Denial of Service | Log-write failure is fail-soft and does not block requests. |
+| Elevation of Privilege | No authorization decisions. |
+| Abuse | No business workflow exposed. |
+
+---
+
+## BvWeb
+
+**Trust Boundary:** BlackVeilServices
+**Role:** Sibling worker — validate-key, OAuth entitlements, internal M365 proxy endpoints
+**Data Flows:** DF19, DF20, DF25
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Internal Network`.)
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T70.I | Information Disclosure | Entitlement/plan data exposed in transit between workers | Internal Network | DF20 | In-account service binding (not public network); TLS within Cloudflare | Mitigated | Existing |
+| T71.D | Denial of Service | bv-web unavailability blocking paid-tier authentication | Internal Network | DF19 | Static `BV_API_KEY` fallback; free tier unaffected; LKG tier cache now preserves paying customers through transient 5xx (`src/lib/tier-auth.ts:302-317`) | Mitigated | Existing |
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T69.S | Spoofing | A compromised bv-web returns forged entitlements granting an elevated tier | BvWeb Compromise | DF20 | Authenticated binding (`BV_WEB_INTERNAL_KEY`); tier value validated against enum | Mitigated | Existing |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Tampering | Covered by the spoofed-response scenario (T69.S); binding traffic is in-account. |
+| Repudiation | Cross-worker calls logged on both sides. |
+| Elevation of Privilege | Tier validation against enum captured under T69.S/T10.T. |
+| Abuse | bv-web's own business logic is out of scope for this repo's model. |
+
+---
+
+## BvRecon
+
+**Trust Boundary:** BlackVeilServices
+**Role:** Operator-deploy-only bv-recon worker — OSINT investigations, bucket scans, realtime threat feed (start→poll), enrichment
+**Data Flows:** DF26
+**Pod Co-location:** N/A
+
+> **[New]** Component added in this window (`BV_RECON` binding, fail-soft `unprovisioned` when absent).
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: recon tools are paid-gated — `Authenticated User`.)
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T85.T | Tampering | Upstream recon payloads (bucket names, object keys, threat-feed entries) are attacker-controllable and flow into finding metadata / `structuredContent` consumed by LLMs (indirect prompt injection) | Authenticated User | DF26 | `sanitizeUpstreamObject/Value` strips C0/ANSI and clamps depth/length on all recon payloads (`src/lib/sanitize-upstream.ts:49-69`); injection-focused tests for the bucket/threat-feed spread pattern are incomplete | Open | New |
+| T86.I | Information Disclosure | Cross-principal access to investigation/bucket-scan results by polling another caller's operation ID (`osint_investigation_status/report`, `scan_buckets_status/findings`) | Authenticated User | DF26 | IDs are opaque bv-recon UUIDs; bv-mcp forwards them with the shared bearer and no principal binding (`src/tools/osint-investigate.ts:115-145`, `src/lib/recon-binding.ts:141-212`) — ownership enforcement is assumed in bv-recon and unverified from this repo | Open | New |
+| T87.D | Denial of Service | OSINT/bucket job flooding spawning expensive backend work on bv-recon | Authenticated User | DF26 | `*_start` tools are paid-only (403 for free/agent); request-dedup absorbs retries; per-tier daily scan quotas | Mitigated | New |
+| T88.A | Abuse | People-OSINT (username/email investigations) used to investigate arbitrary third parties | Authenticated User | DF26 | People-OSINT restricted to owner/enterprise tiers; all recon tools paid-gated; investigations logged per principal | Mitigated | New |
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T84.S | Spoofing | Compromised bv-recon returns forged intelligence that lands in customer reports | BvRecon Compromise | DF26 | Bearer-authenticated in-account binding; operator-controlled deployment; Zod response validation (lenient) | Mitigated | New |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | Investigation lifecycle is attributed via `tool_call` analytics and per-principal dedup records. |
+| Elevation of Privilege | Tier gating for recon tools is enforced upstream in McpExecutor (T26.E). |
+
+---
+
+## BvTlsProbe
+
+**Trust Boundary:** BlackVeilServices
+**Role:** Operator-deploy-only bv-tls-probe worker — version-aware TLS handshakes enriching `check_ssl`
+**Data Flows:** DF27
+**Pod Co-location:** N/A
+
+> **[New]** Component added in this window (`BV_TLS_PROBE` binding, fail-soft no-op when absent).
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Component floor: `Internal Network` — binding reachable only in-account.)
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T89.I | Information Disclosure | Probe used as an internal-network reachability/timing oracle if bv-tls-probe does not validate target hosts | Internal Network | DF27 | Domain is pre-validated by `check_ssl`'s sanitizer before reaching the binding; host validation inside bv-tls-probe is assumed and unverified from this repo (`src/lib/tls-probe-binding.ts:63-83`) | Open | New |
+| T91.D | Denial of Service | Slow/hanging probe targets consume the `check_ssl` latency budget | Internal Network | DF27 | 8 s probe timeout (`TLS_PROBE_TIMEOUT_MS`); fail-soft merge — absent/failed probe yields no finding | Mitigated | New |
+
+#### Tier 3 — Defense-in-Depth
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T90.T | Tampering | Compromised bv-tls-probe returns forged TLS-version results skewing SSL scores | BvTlsProbe Compromise | DF27 | Bearer-authenticated in-account binding; operator-controlled; hardcoded literal matching in `isWeakTlsVersion()` (`src/lib/tls-probe-binding.ts:52-55`) | Mitigated | New |
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Bearer-authenticated binding with no caller-identity surface beyond the shared token (covered under T90.T). |
+| Repudiation | Probe calls are attributed via the invoking tool's logging. |
+| Elevation of Privilege | No authorization decisions. |
+| Abuse | The probe exposes no business workflow; abuse-of-scanning is captured at ToolsHandler (T32.A). |
+
+---
+
+## PublicDoH
+
+**Trust Boundary:** Internet
+**Role:** Public DoH resolvers (Cloudflare/Google) for DNS queries
+**Data Flows:** DF21
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.* (Threats require on-path/network position relative to resolver egress.)
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T72.S | Spoofing | Resolver spoofing/poisoning returning forged answers | Internal Network | DF21 | TLS to resolvers; multi-resolver chain; secondary `X-BV-Token` | Mitigated | Existing |
+| T73.T | Tampering | DNS response tampering on the wire | Internal Network | DF21 | TLS transport (DoH) | Mitigated | Existing |
+| T74.D | Denial of Service | Resolver outage degrading scan availability | Internal Network | DF21 | Fallback chain (empty → bv-dns → Google) | Mitigated | Existing |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Repudiation | External resolver; no audit surface in this repo. |
+| Information Disclosure | Queries carry only public domain names. |
+| Elevation of Privilege | No authorization relationship. |
+| Abuse | Abuse-of-DNS scenarios captured at DnsResolver (T43.A). |
+
+---
+
+## CertTransparency
+
+**Trust Boundary:** Internet
+**Role:** CT-log enumeration (certstream/crt.sh) for discovery
+**Data Flows:** DF22
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T75.T | Tampering | Malicious CT data inflating brand-audit candidate sets | Internal Network | DF22 | crt.sh fallback + candidate validation; bounded result sizes | Mitigated | Existing |
+| T76.D | Denial of Service | CT source outage degrading discovery | Internal Network | DF22 | Direct crt.sh fallback with jittered backoff | Mitigated | Existing |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | CT data authenticity is covered under T75.T (tampering). |
+| Repudiation | External service; no audit surface here. |
+| Information Disclosure | CT logs are public data. |
+| Elevation of Privilege | No authorization relationship. |
+| Abuse | Discovery abuse captured at BrandAuditPipeline (T56.A). |
+
+---
+
+## WhoisRdap
+
+**Trust Boundary:** Internet
+**Role:** WHOIS/RDAP registration lookups (+ hardcoded registry RDAP allowlist for lookalike enrichment)
+**Data Flows:** DF23
+**Pod Co-location:** N/A
+
+### STRIDE-A Analysis
+
+#### Tier 1 — Direct Exposure (No Prerequisites)
+
+*No Tier 1 threats identified.*
+
+#### Tier 2 — Conditional Risk
+
+| ID | Category | Threat | Prerequisites | Affected Flow | Mitigation | Status | Change |
+|----|----------|--------|---------------|---------------|------------|--------|--------|
+| T77.I | Information Disclosure | Untrusted WHOIS/RDAP data injected into rendered reports (stored content) | Internal Network | DF23 | Output sanitization via `createFinding()` auto-sanitize; lookalike RDAP enrichment restricted to hardcoded registry endpoints | Mitigated | Existing |
+| T78.D | Denial of Service | WHOIS/RDAP source outage degrading enrichment | Internal Network | DF23 | RDAP-only fallback; KV-cached IANA referrals; 2.5 s enrichment timeout, fail-soft (no downgrade suppression of real threats) | Mitigated | Existing |
+
+#### Tier 3 — Defense-in-Depth
+
+*No Tier 3 threats identified.*
+
+#### Categories Not Applicable
+
+| Category | Justification |
+|----------|---------------|
+| Spoofing | Registration-data authenticity is covered under T77.I. |
+| Tampering | On-wire tampering is mitigated by TLS and covered by the same controls as T77.I. |
+| Repudiation | External service; no audit surface here. |
+| Elevation of Privilege | No authorization relationship. |
+| Abuse | Enrichment abuse is bounded by paid gating and caps (T32.A). |

--- a/docs/threat-model/threat-model-20260611-112908/3-findings.md
+++ b/docs/threat-model/threat-model-20260611-112908/3-findings.md
@@ -1,0 +1,850 @@
+# Security Findings
+
+> **Incremental report.** Finding IDs FIND-01–17 are inherited from baseline `threat-model-20260524-114907` and re-verified against commit `7a1c6b3`; FIND-18–21 are new. Each finding body opens with a status tag: **[Existing]** (still present / existing control), **[Fixed]** (remediated — code cited), **[Partial]** (mechanism landed, residual remains), **[New]**. Because old IDs are preserved and findings are ordered by tier/severity, ID numbers are not strictly ascending in document order.
+
+---
+
+## Tier 1 — Direct Exposure (No Prerequisites)
+
+### FIND-01: API key accepted via query parameter
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-598](https://cwe.mitre.org/data/definitions/598.html): Use of GET Request Method With Sensitive Query Strings |
+| OWASP | A04:2025 – Cryptographic Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | TierAuthResolver |
+| Related Threats | [T11.I](2-stride-analysis.md#tierauthresolver) |
+
+#### Description
+
+> **[Partial]**
+
+The `/mcp` endpoint accepts an API key via the `?api_key=` query parameter (Smithery compatibility fallback). Query strings are routinely captured in CDN, proxy, and edge logs, so a high-privilege key passed this way can leak outside the application's control. A rejection gate (`REJECT_QUERY_API_KEY`) was merged in the remediation window, but it defaults to *accepting* query keys — the fix is code-complete and deploy-config-gated.
+
+#### Evidence
+
+**Prerequisite basis:** `/mcp` is externally reachable with no auth required (HonoWorker `Reachability = External`, `Min Prerequisite = None` per the Component Exposure Table).
+
+`src/index.ts:106` — `const queryToken = c.env.REJECT_QUERY_API_KEY === 'true' ? null : bearerToken ? null : (c.req.query('api_key') ?? null);`. Unset/absent env → query keys accepted. Bearer is preferred when present.
+
+#### Remediation
+
+Set `REJECT_QUERY_API_KEY=true` in the production deploy overrides once Smithery-dependent clients are migrated; longer-term, flip the code default to reject and allowlist legacy clients explicitly.
+
+#### Verification
+
+With the gate set, `POST /mcp?api_key=<key>` must be treated as unauthenticated (free tier / 401 for auth-required tools); bearer-header auth must continue to work.
+
+### FIND-02: Free-tier abuse via distributed IPs
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html): Allocation of Resources Without Limits or Throttling |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | RateLimiter |
+| Related Threats | [T07.A](2-stride-analysis.md#honoworker), [T46.E](2-stride-analysis.md#ratelimiter) |
+
+#### Description
+
+> **[Fixed]**
+
+An attacker rotating through many source IPs could keep each IP under the per-IP minute/hour limits while collectively consuming large scan volume from the shared free-tier budget. The remediation adds a per-IP distinct-domains-per-day cap, sharply reducing the per-IP value of a botnet for breadth enumeration, on top of the pre-existing global daily ceiling.
+
+#### Evidence
+
+**Prerequisite basis:** Public `/mcp`, no auth required (Exposure Table: `None`).
+
+Fixed by `checkDistinctDomainDailyLimit()` (`src/lib/rate-limiter.ts:555-593`), `FREE_DISTINCT_DOMAIN_DAILY_LIMIT = 12` (`src/lib/config.ts:433`), enforced pre-dispatch for unauthenticated `tools/call` (`src/mcp/execute.ts:715-756`, HTTP 429 + `x-quota-*` headers). Slot recorded before validation so invalid calls also consume budget. Global 500K/day ceiling via QuotaCoordinator unchanged.
+
+#### Remediation
+
+Tune the provisional cap (12) against production telemetry; consider extending distinct-domain budgets to authenticated free-adjacent tiers if abuse shifts.
+
+#### Verification
+
+From a single IP, scans of 12 distinct domains succeed; the 13th distinct domain returns HTTP 429 with `distinct domains per day` messaging; repeats of already-scanned domains are not blocked.
+
+### FIND-03: Scanner usable as recon/amplification proxy
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.1 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:L) |
+| CWE | [CWE-406](https://cwe.mitre.org/data/definitions/406.html): Insufficient Control of Network Message Volume (Network Amplification) |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | ToolsHandler |
+| Related Threats | [T32.A](2-stride-analysis.md#toolshandler), [T42.D](2-stride-analysis.md#dnsresolver), [T43.A](2-stride-analysis.md#dnsresolver), [T87.D](2-stride-analysis.md#bvrecon), [T88.A](2-stride-analysis.md#bvrecon) |
+
+#### Description
+
+> **[Fixed]**
+
+Anonymous callers could use offensive and multi-domain tools (lookalike/shadow-domain discovery, subdomain enumeration, batch scans) to reconnoiter or amplify traffic against third-party domains. The remediation gates the entire offensive/multi-domain tool set to paid tiers (developer+), returning HTTP 403 with JSON-RPC `-32003` (`UPGRADE_REQUIRED`) for free, agent, and unauthenticated callers, while keeping result-pollers free.
+
+#### Evidence
+
+**Prerequisite basis:** Public `/mcp`, no auth required (Exposure Table: `None`).
+
+Fixed by `GATED_PAID_ONLY_TOOLS` (`src/lib/config.ts:340-378`) enforced at `src/mcp/execute.ts:604-606` (unauthenticated) and `769-771` (authenticated free/agent); tools also pinned to 0 in `FREE_TOOL_DAILY_LIMITS` and `TIER_TOOL_DAILY_LIMITS.free/.agent`. SSOT audited by `test/audits/gated-tools-ssot.audit.test.ts` and the commercial-tier contract audit.
+
+#### Remediation
+
+Maintain the gated set as new offensive tools are added (the SSOT audit trips on drift); keep the distinct-domain cap (FIND-02) as the residual brake on single-domain recon breadth.
+
+#### Verification
+
+Unauthenticated `tools/call check_lookalikes` returns HTTP 403/-32003 "requires a paid plan"; a developer-tier key succeeds; `osint_investigation_status` (poller) remains callable without a paid plan.
+
+### FIND-04: OAuth issuer from spoofable Host header
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 4.8 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-350](https://cwe.mitre.org/data/definitions/350.html): Reliance on Reverse DNS Resolution / Host-Derived Trust |
+| OWASP | A02:2025 – Security Misconfiguration |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | HonoWorker |
+| Related Threats | [T05.I](2-stride-analysis.md#honoworker) |
+
+#### Description
+
+> **[Partial]**
+
+When `OAUTH_ISSUER` is unset, OAuth discovery derives the issuer URL from the request `Host` header, which an attacker can influence in some fronting configurations to poison discovery metadata. The override mechanism and a strict host-pinning variant are implemented; the secure behavior activates only when the env var is set in the production deploy config.
+
+#### Evidence
+
+**Prerequisite basis:** `/oauth/*` discovery endpoints are externally reachable without auth (Exposure Table: `None`).
+
+`src/oauth/discovery.ts:18-22` — `resolveIssuer()` uses `OAUTH_ISSUER` when set (trailing-slash stripped), else falls back to `${url.protocol}//${url.host}`. `resolveIssuerStrict` (lines 29-39) errors when the Host doesn't match the configured issuer.
+
+#### Remediation
+
+Set `OAUTH_ISSUER` in production deploy overrides (already recommended in `wrangler` docs); route discovery through `resolveIssuerStrict` once set.
+
+#### Verification
+
+`GET /.well-known/oauth-authorization-server` with a forged `Host` header must return the configured issuer, not the forged host.
+
+### FIND-05: Open OAuth dynamic client registration
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 4.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-1188](https://cwe.mitre.org/data/definitions/1188.html): Insecure Default Initialization of Resource |
+| OWASP | A02:2025 – Security Misconfiguration |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | OAuthIssuer |
+| Related Threats | [T15.S](2-stride-analysis.md#oauthissuer) |
+
+#### Description
+
+> **[Existing]**
+
+Reclassified as a false positive in the interim overlay: the controls flagged as missing were already present at the baseline commit. Re-verified at HEAD — dynamic client registration is rate-limited per IP and constrained, so open registration is not exploitable for resource exhaustion or rogue-client abuse at meaningful scale.
+
+#### Evidence
+
+**Prerequisite basis:** `/oauth/register` is externally reachable without auth (Exposure Table: `None`).
+
+`src/oauth/register.ts` — per-IP 10/min + 30/hr limits (lines 11-78), 4 KB body cap, strict `application/json` check, redirect-URI validation before any write, UUIDv4 client IDs; `client_id_issued_at` stamped per RFC 7591.
+
+#### Remediation
+
+None required beyond keeping the limits regression-tested; consider client-record TTL/cleanup if registration volume grows.
+
+#### Verification
+
+Eleven registrations in one minute from one IP → the 11th is rate-limited; registered clients require valid redirect URIs.
+
+### FIND-06: force_refresh cache-busting amplification
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.7 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html): Allocation of Resources Without Limits or Throttling |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | ToolsHandler |
+| Related Threats | [T33.A](2-stride-analysis.md#toolshandler) |
+
+#### Description
+
+> **[Fixed]**
+
+Repeated `force_refresh=true` calls bypassed the 5-minute scan cache and amplified backend DoH/fetch load. A dedicated free-tier daily cap on cache bypasses now bounds this independently of per-tool quotas.
+
+#### Evidence
+
+**Prerequisite basis:** Public `/mcp`, no auth required (Exposure Table: `None`).
+
+`FORCE_REFRESH_DAILY_LIMIT = 5` (`src/lib/config.ts:338`) — free-tier daily cache-bypass cap, enforced in the quota path alongside per-tool daily limits.
+
+#### Remediation
+
+Monitor cache-status analytics (`cacheStatus` blob) for bypass-pattern drift; raise/lower the cap from telemetry.
+
+#### Verification
+
+Six `force_refresh` scans in a day from a free caller → the 6th is rejected or served from cache.
+
+### FIND-07: Domain validation hardening for homoglyph/IDN
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.1 (CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-1007](https://cwe.mitre.org/data/definitions/1007.html): Insufficient Visual Distinction of Homoglyphs Presented to User |
+| OWASP | A03:2025 – Software Supply Chain Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Medium |
+| Mitigation Type | Standard Mitigation |
+| Component | DomainSanitizer |
+| Related Threats | [T34.T](2-stride-analysis.md#domainsanitizer) |
+
+#### Description
+
+> **[Fixed]**
+
+Mixed-script (e.g., Latin+Cyrillic) confusable labels could slip through domain validation and skew scan/brand-audit results. Mixed-script detection now rejects labels combining characters from multiple Unicode scripts at the validation gate.
+
+#### Evidence
+
+**Prerequisite basis:** Domain inputs arrive via public `/mcp` tools (Exposure Table: `None`).
+
+`hasMixedScripts()` and its enforcement in `sanitizeDomain()` (`src/lib/sanitize.ts`) — present at HEAD (landed in the PR #208 remediation window; verified unchanged-in-behavior through the current diff window despite surrounding additions).
+
+#### Remediation
+
+Keep the confusable tables current with Unicode updates; extend to whole-script confusables if abuse appears.
+
+#### Verification
+
+`scan_domain` of a label mixing Cyrillic `а` with Latin characters is rejected with a `Domain `-prefixed validation error.
+
+### FIND-08: Authentication & token-integrity controls (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-287](https://cwe.mitre.org/data/definitions/287.html): Improper Authentication |
+| OWASP | A07:2025 – Authentication Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | TierAuthResolver |
+| Related Threats | [T08.S](2-stride-analysis.md#tierauthresolver), [T09.S](2-stride-analysis.md#tierauthresolver), [T10.T](2-stride-analysis.md#tierauthresolver), [T12.E](2-stride-analysis.md#tierauthresolver), [T14.A](2-stride-analysis.md#tierauthresolver), [T16.T](2-stride-analysis.md#oauthissuer), [T17.I](2-stride-analysis.md#oauthissuer), [T21.S](2-stride-analysis.md#mcpexecutor), [T92.E](2-stride-analysis.md#tierauthresolver) |
+
+#### Description
+
+> **[Existing]**
+
+Documents the authentication and token-integrity control set so regressions are caught: constant-time static-key comparison, pinned-algorithm JWT verification with signature-before-claims ordering, enum-validated issuable tiers, PKCE S256, session-ID entropy. Strengthened this window: a second independent dev-key slot (also constant-time compared), `OWNER_ALLOW_IPS` applied on every owner path including JWT, and a last-known-good (LKG) tier cache that preserves paying customers through bv-web 5xx without honoring definitive rejections.
+
+#### Evidence
+
+**Prerequisite basis:** The resolver guards the public, unauthenticated `/mcp` surface (Exposure Table: `None`).
+
+`src/lib/tier-auth.ts:50-59` (`matchesStaticDevKey` constant-time XOR), `:61-68,136` (`applyOwnerIpGate` on JWT path), `:128-135` (token-version check), `:302-317` (LKG on 5xx only, 24 h TTL, never on 4xx); `src/oauth/jwt.ts:104-113` (signature before claims); `JwtIssuableTierSchema` (owner/developer/enterprise only).
+
+#### Remediation
+
+Residual to watch: a key revoked *during* a bv-web outage can retain its LKG tier up to 24 h (T92.E) — acceptable trade-off; consider purging the LKG entry from the revoke path if revocation-during-outage becomes a real scenario.
+
+#### Verification
+
+Timing-difference tests on static-key comparison stay flat; `alg=none` and tampered-tier JWTs are rejected; LKG is not consulted after a 401/403 from bv-web.
+
+### FIND-09: SSRF egress controls (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-918](https://cwe.mitre.org/data/definitions/918.html): Server-Side Request Forgery (SSRF) |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | SafeFetch |
+| Related Threats | [T35.I](2-stride-analysis.md#domainsanitizer), [T36.E](2-stride-analysis.md#domainsanitizer), [T37.T](2-stride-analysis.md#safefetch), [T38.I](2-stride-analysis.md#safefetch), [T39.D](2-stride-analysis.md#safefetch), [T89.I](2-stride-analysis.md#bvtlsprobe) |
+
+#### Description
+
+> **[Existing]**
+
+Documents the SSRF control chain: input-side domain blocklists (IP literals, localhost, rebinding hosts), egress-side `safeFetch` (HTTPS-only, manual redirects, per-hop re-validation), and the platform `global_fetch_strictly_public` flag. All outbound paths added this window were audited: lookalike web probes and brand CSC enrichment use `safeFetch`; RDAP enrichment hits a hardcoded registry-endpoint allowlist; recon/M365/TLS-probe traffic goes to fixed in-account service bindings. One open assumption: the bv-tls-probe worker's own target-host validation is not verifiable from this repo (T89.I).
+
+#### Evidence
+
+**Prerequisite basis:** Attacker-influenced URLs originate from public `/mcp` tool inputs (Exposure Table: `None`).
+
+`src/lib/safe-fetch.ts` (unchanged, intact); `src/tools/check-lookalikes.ts:697` (safeFetch web probe), `:641-668` (RDAP via `FALLBACK_RDAP_SERVERS` allowlist — domain appears only in the URL path); `src/lib/brand-audit-csc-enrichment.ts:70,97` (hardcoded Google DoH + safeFetch); `src/lib/tls-probe-binding.ts:63-83` (host forwarded to operator-controlled probe — validation assumed there).
+
+#### Remediation
+
+Confirm bv-tls-probe validates/blocklists target hosts (internal-network oracle, T89.I); keep the new-outbound-path review as part of tool-addition checklists.
+
+#### Verification
+
+BIMI `l=` URLs pointing at RFC1918/metadata addresses are rejected; redirects to internal targets are dropped at each hop; `check_ssl` of an internal hostname yields no probe result.
+
+### FIND-10: Rate limiting, quotas & DoS budgets (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html): Allocation of Resources Without Limits or Throttling |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | RateLimiter |
+| Related Threats | [T01.S](2-stride-analysis.md#honoworker), [T02.T](2-stride-analysis.md#honoworker), [T06.D](2-stride-analysis.md#honoworker), [T18.D](2-stride-analysis.md#oauthissuer), [T22.T](2-stride-analysis.md#mcpexecutor), [T25.D](2-stride-analysis.md#mcpexecutor), [T26.E](2-stride-analysis.md#mcpexecutor), [T27.A](2-stride-analysis.md#mcpexecutor), [T28.T](2-stride-analysis.md#toolshandler), [T30.D](2-stride-analysis.md#toolshandler), [T31.E](2-stride-analysis.md#toolshandler), [T44.T](2-stride-analysis.md#ratelimiter), [T45.D](2-stride-analysis.md#ratelimiter), [T47.A](2-stride-analysis.md#ratelimiter), [T53.T](2-stride-analysis.md#brandauditpipeline), [T55.D](2-stride-analysis.md#brandauditpipeline), [T58.D](2-stride-analysis.md#quotacoordinator), [T91.D](2-stride-analysis.md#bvtlsprobe) |
+
+#### Description
+
+> **[Existing]**
+
+Documents the layered DoS/abuse budget controls: per-IP minute/hour limits, per-tool daily quotas, per-tier daily quotas, the global 500K/day DO-coordinated ceiling, body-size caps, scan/check/tool time budgets, and fuzzing detection. Extended this window with the distinct-domain cap (FIND-02), force-refresh cap (FIND-06), request-dedup for mutating tools, and runtime-clamped scan/check timeouts.
+
+#### Evidence
+
+**Prerequisite basis:** Public `/mcp`, no auth required (Exposure Table: `None`).
+
+`src/lib/rate-limiter.ts` + `src/lib/quota-coordinator.ts` (per-IP/per-tool/global); `src/lib/config.ts` (`FREE_IP_DAILY_LIMIT = 1000`, `GLOBAL_DAILY_TOOL_LIMIT = 500000`, per-tool maps); `src/lib/request-dedup.ts` (90 s KV window, store-on-success, keyHash-only principal); scan 15 s / per-check 8 s budgets clamped `[5s,30s]`/`[2s,15s]`.
+
+#### Remediation
+
+Keep quota maps SSOT-audited as tools are added (`tool-quota-coverage` audit); see FIND-20 for the intentionally-unlimited M365 family.
+
+#### Verification
+
+51 requests/minute from one IP → 429 with `retry-after`; full-suite quota audits green in CI.
+
+### FIND-11: Information-disclosure controls (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-209](https://cwe.mitre.org/data/definitions/209.html): Generation of Error Message Containing Sensitive Information |
+| OWASP | A09:2025 – Security Logging & Alerting Failures |
+| Exploitation Prerequisites | None |
+| Exploitability Tier | Tier 1 — Direct Exposure |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | HonoWorker |
+| Related Threats | [T03.R](2-stride-analysis.md#honoworker), [T04.I](2-stride-analysis.md#honoworker), [T23.R](2-stride-analysis.md#mcpexecutor), [T24.I](2-stride-analysis.md#mcpexecutor), [T29.I](2-stride-analysis.md#toolshandler), [T66.I](2-stride-analysis.md#intelligencedb), [T68.R](2-stride-analysis.md#intelligencedb), [T77.I](2-stride-analysis.md#whoisrdap) |
+
+#### Description
+
+> **[Existing]**
+
+Documents the information-disclosure control set: the client-visible error-message allowlist, finding auto-sanitization (`createFinding()`), privacy-preserving analytics (FNV-1a IP hash, truncated key hash), AES-GCM-encrypted access-log IP evidence, and structured-output gating per client type. Strengthened this window: the 90-day access-log retention is now enforced by a scheduled delete (T68.R fixed), and JSON-RPC error codes are emitted to analytics for attribution without leaking detail to clients.
+
+#### Evidence
+
+**Prerequisite basis:** Public `/mcp` error and output surfaces (Exposure Table: `None`).
+
+`src/lib/json-rpc.ts` `SAFE_ERROR_PREFIXES` (`Missing required`, `Invalid`, `Domain `, `Resource not found`, `Rate limit exceeded`) — unchanged, intact; `src/scheduled.ts:89-100` parameterized `mcp_access_log` retention delete; `src/mcp/dispatch.ts:188-200` structured-comment stripping gated by client allowlists.
+
+#### Remediation
+
+Any new client-visible error must start with an allowlisted prefix (enforced by convention + review); nothing further required.
+
+#### Verification
+
+Forced internal errors return the generic fallback; access-log rows older than 90 days are absent after the cron runs.
+
+---
+
+## Tier 2 — Conditional Risk (Authenticated / Single Prerequisite)
+
+### FIND-19: M365 tenant authorization is delegated cross-service on a forwarded keyHash
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.5 (CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-862](https://cwe.mitre.org/data/definitions/862.html): Missing Authorization |
+| OWASP | A01:2025 – Broken Access Control |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | M365Proxy |
+| Related Threats | [T79.S](2-stride-analysis.md#m365proxy), [T80.I](2-stride-analysis.md#m365proxy), [T81.I](2-stride-analysis.md#m365proxy), [T83.A](2-stride-analysis.md#m365proxy) |
+
+#### Description
+
+> **[New]**
+
+The identity-secops tools (`query_signins`, `query_ual`, `get_ca_policies`, `assess_coverage`) let an authenticated caller name an arbitrary `ms_tenant_id`. bv-mcp forwards the request to bv-web's internal M365 proxy carrying the *trusted* internal bearer plus the caller's `keyHash`; whether the caller is entitled to that tenant is decided entirely in bv-web. bv-mcp's own guards (401 pre-dispatch, keyHash backstop) ensure a real principal is always forwarded, but a bv-web-side scope-check failure would be a cross-tenant read of highly sensitive sign-in/audit data. The distinguishable `m365_proxy_*` error codes also allow modest tenant-ID enumeration.
+
+#### Evidence
+
+**Prerequisite basis:** `AUTH_REQUIRED_TOOLS` rejects unauthenticated callers with HTTP 401 pre-dispatch (`src/mcp/execute.ts:601-603`) — matches the M365Proxy exposure row (`Authenticated User`).
+
+`src/tools/m365/proxy.ts:32-40` — internal bearer + `keyHash: opts?.keyHash` forwarded; `src/handlers/tools.ts:909-912` — backstop rejects dispatch when `m365Proxy` is bound and `keyHash` absent (the 3.17.2 P0 fix made this path correct for authenticated callers); `src/tools/m365/proxy.ts:41-49` — upstream statuses map to distinct error codes.
+
+#### Remediation
+
+Treat bv-web's tenant-membership check on `keyHash` as a tested cross-repo contract (bv-web-prod#97 lineage): add a contract test or runbook check that `keyHash: undefined` and out-of-scope `keyHash` are rejected upstream. Bleach `m365_proxy_*` errors to a generic "unavailable" for non-owner callers to blunt enumeration.
+
+#### Verification
+
+With a valid developer key entitled to tenant A, `query_signins` for tenant B returns an authorization error (not data); responses for nonexistent vs unauthorized tenants are indistinguishable.
+
+### FIND-12: Internal routes default to no bearer auth
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 5.1 (CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-1188](https://cwe.mitre.org/data/definitions/1188.html): Insecure Default Initialization of Resource |
+| OWASP | A02:2025 – Security Misconfiguration |
+| Exploitation Prerequisites | Internal Network |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | InternalRouter |
+| Related Threats | [T52.A](2-stride-analysis.md#internalrouter) |
+
+#### Description
+
+> **[Fixed]**
+
+`/internal/tools/*` and `/internal/analytics/*` previously relied on the network-origin guard alone unless bearer auth was explicitly enabled. The gate is now secure-by-default: bearer auth is ACTIVE unless `REQUIRE_INTERNAL_AUTH=false` is explicitly set, fails closed (503) when the key is unconfigured, and 401s wrong/missing bearers. The agent-chat caller principal added in #391 further constrains the highest-volume internal caller to a 13-tool read-only allowlist.
+
+#### Evidence
+
+**Prerequisite basis:** `/internal/*` reachable only via in-account service bindings; public requests 404 via `isPublicInternetRequest` (Exposure Table: `Internal Network`).
+
+`src/internal.ts:165-182` — `internalLenientAuthGate`: opt-out only via explicit `REQUIRE_INTERNAL_AUTH === 'false'`; 503 when `BV_WEB_INTERNAL_KEY` unset; 401 on bad bearer. Covers `/tools/*`, `/analytics/*`, `/tenants/*`. Agent-chat allowlist at `src/internal.ts:217-223,419-422`.
+
+#### Remediation
+
+None — keep bv-web sending the bearer (deploy sequencing already validated in production since 3.17.x).
+
+#### Verification
+
+Binding call without bearer → 401; with correct bearer → 200; with `REQUIRE_INTERNAL_AUTH=false` → network guard only (documented escape hatch).
+
+### FIND-13: JWT retains elevated tier after plan downgrade
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 4.6 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-613](https://cwe.mitre.org/data/definitions/613.html): Insufficient Session Expiration |
+| OWASP | A07:2025 – Authentication Failures |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | OAuthIssuer |
+| Related Threats | [T20.A](2-stride-analysis.md#oauthissuer) |
+
+#### Description
+
+> **[Fixed]**
+
+A customer who downgraded (or cancelled) could keep using a previously-issued long-lived JWT at the old tier until `exp`. Two independent mechanisms now close this: per-subject token-version (`ver`) revocation — bumping the stored version invalidates all earlier tokens — and, new this window, JWT lifetime clamped to the remaining Stripe entitlement window at issuance, with expired entitlements rejected outright at token exchange.
+
+#### Evidence
+
+**Prerequisite basis:** Requires a previously-issued valid paid-tier JWT (`Authenticated User`).
+
+`src/oauth/jwt.ts:32` (`ver` claim, default 1); `src/oauth/storage.ts:139-144` (`bumpTokenVersion()`); `src/lib/tier-auth.ts:128-135` (reject `tokenVer < storedVer`); `src/oauth/token.ts:167-181` (TTL clamp to `entitlementExpiresAt`; `invalid_grant` 400 when already lapsed).
+
+#### Remediation
+
+Residual cross-repo step: confirm bv-web calls the revoke endpoint on plan downgrade (pre-existing tokens with `ver=1` stay valid until first bump or `exp` — the TTL clamp bounds this to the entitlement window).
+
+#### Verification
+
+After `bumpTokenVersion(subject)`, a previously-valid JWT is rejected; a token minted 1 day before entitlement end carries ≤1 day TTL.
+
+### FIND-14: Brand-audit discovery enables third-party enumeration
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Moderate |
+| CVSS 4.0 | 4.3 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-799](https://cwe.mitre.org/data/definitions/799.html): Improper Control of Interaction Frequency |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | BrandAuditPipeline |
+| Related Threats | [T53.T](2-stride-analysis.md#brandauditpipeline), [T54.I](2-stride-analysis.md#brandauditpipeline), [T56.A](2-stride-analysis.md#brandauditpipeline) |
+
+#### Description
+
+> **[Partial]**
+
+A paid caller can run brand audits against domains they do not own, harvesting competitor/third-party infrastructure intelligence at scale. Quotas, tier gating (now developer+ via the paid gate), and the opt-out registry bound the volume, and ownership attestation exists — but it remains **caller-supplied**; the planned DNS-TXT challenge that would make ownership cryptographically verifiable has not landed in this window.
+
+#### Evidence
+
+**Prerequisite basis:** Brand tools are paid-gated (`GATED_PAID_ONLY_TOOLS`) — `Authenticated User` per the exposure table.
+
+`src/lib/db/brand-audit-schema.ts` — no `ownership_verified` enforcement field; `owner_id` records the caller's principal only; no DNS-TXT challenge logic in `src/lib/brand-audit-pipeline.ts` / `src/tenants/discovery/` at HEAD.
+
+#### Remediation
+
+Implement the DNS-TXT ownership challenge for third-party watched domains before relying on attestation for any access decision; keep per-tier quotas as the volume bound.
+
+#### Verification
+
+Registering a watch for a domain without the expected TXT record should require (or flag) unverified ownership once the challenge ships.
+
+### FIND-18: Recon operation IDs are not bound to the requesting principal on poll
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 4.1 (CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-639](https://cwe.mitre.org/data/definitions/639.html): Authorization Bypass Through User-Controlled Key |
+| OWASP | A01:2025 – Broken Access Control |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | BvRecon |
+| Related Threats | [T84.S](2-stride-analysis.md#bvrecon), [T86.I](2-stride-analysis.md#bvrecon) |
+
+#### Description
+
+> **[New]**
+
+The OSINT/bucket start→poll pattern returns an opaque operation ID; the pollers (`osint_investigation_status/_report`, `scan_buckets_status/_findings`) forward any caller-supplied ID to bv-recon with the shared service bearer and no principal association. A caller who learns another principal's ID (logs, shared transcripts, support snippets) could retrieve their investigation results. IDs are unguessable UUIDs and the pollers stay free-tier, so practical risk hinges on ID leakage plus whether bv-recon enforces ownership — which this repo cannot verify.
+
+#### Evidence
+
+**Prerequisite basis:** Recon `*_start` tools are paid-gated; pollers require knowledge of a live operation ID (`Authenticated User` floor for the component).
+
+`src/tools/osint-investigate.ts:115-145` — status/report take only `id`; `src/lib/recon-binding.ts:141-212` — ID forwarded in URL with shared `BV_RECON_KEY` bearer; `src/tools/scan-buckets.ts:40-50` — same pattern for bucket scans. Request-dedup is principal-scoped, but that protects creation, not polling.
+
+#### Remediation
+
+Bind operation IDs to the creating `keyHash` (KV map `opId → keyHash` at start, checked on poll), or verify and contract-test that bv-recon enforces per-caller ownership of investigation/scan IDs.
+
+#### Verification
+
+Polling a valid operation ID created by principal A using principal B's key returns not-found/forbidden.
+
+### FIND-15: Trial-key tier persists during cache window
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.5 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-613](https://cwe.mitre.org/data/definitions/613.html): Insufficient Session Expiration |
+| OWASP | A07:2025 – Authentication Failures |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | TierAuthResolver |
+| Related Threats | [T13.E](2-stride-analysis.md#tierauthresolver) |
+
+#### Description
+
+> **[Fixed]**
+
+An expired or exhausted trial key could retain its tier for up to 60 seconds via the resolution cache. Cache hits now re-check the stored `trialExpiresAt` and evict stale entries, falling through to a fresh lookup.
+
+#### Evidence
+
+**Prerequisite basis:** Requires possession of a (recently expired) trial key (`Authenticated User`).
+
+`src/lib/tier-auth.ts:190-193` — on cache hit, expired `trialExpiresAt` → evict + re-resolve.
+
+#### Remediation
+
+None — covered; keep the cache TTL at 60 s.
+
+#### Verification
+
+A trial key one second past expiry resolves to free/unauthenticated on the next call even within the cache window.
+
+### FIND-20: M365 identity tools are intentionally unmetered per-tool
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.5 (CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N) |
+| CWE | [CWE-770](https://cwe.mitre.org/data/definitions/770.html): Allocation of Resources Without Limits or Throttling |
+| OWASP | A06:2025 – Insecure Design |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Custom Mitigation |
+| Component | M365Proxy |
+| Related Threats | [T82.D](2-stride-analysis.md#m365proxy) |
+
+#### Description
+
+> **[New]**
+
+The four identity-secops tools sit in `INTENTIONALLY_UNLIMITED_TOOLS` (no per-tool daily quota) on the rationale that they are never reachable by free/anonymous callers. An authenticated customer (or a stolen key) can therefore drive unbounded M365 query volume through bv-web to Microsoft Graph, bounded only by global/per-IP caps — a cost-amplification and upstream-throttling risk rather than an outage risk.
+
+#### Evidence
+
+**Prerequisite basis:** `AUTH_REQUIRED_TOOLS` gate — `Authenticated User` floor.
+
+`src/lib/config.ts:457-467` — M365 tools listed in `INTENTIONALLY_UNLIMITED_TOOLS` with the never-free rationale; no per-principal metering in `src/handlers/tools.ts` M365 dispatch paths.
+
+#### Remediation
+
+Add a per-principal daily quota for the identity_secops group (modest, e.g. matching the tier's scans/day), or meter on the bv-web side where Graph costs accrue.
+
+#### Verification
+
+A single developer key issuing sustained `query_signins` volume hits a per-principal limit before exhausting bv-web/Graph budgets.
+
+### FIND-21: Recon upstream payloads lack injection-focused test coverage
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 3.0 (CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-1427](https://cwe.mitre.org/data/definitions/1427.html): Improper Neutralization of Input Used for LLM Prompting |
+| OWASP | A05:2025 – Injection |
+| Exploitation Prerequisites | Authenticated User |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Standard Mitigation |
+| Component | BvRecon |
+| Related Threats | [T85.T](2-stride-analysis.md#bvrecon) |
+
+#### Description
+
+> **[New]**
+
+Bucket-scan and threat-feed results contain attacker-controllable strings (bucket names, object keys, feed entries) that are spread into finding `metadata` and reach LLM clients via `structuredContent` — an indirect prompt-injection channel. The shared sanitizer (`sanitize-upstream`) strips control bytes/ANSI and clamps depth/length on these payloads, but the bucket/threat-feed spread pattern lacks dedicated injection tests, so regressions in the sanitization path would ship silently.
+
+#### Evidence
+
+**Prerequisite basis:** Recon tools are paid-gated (`Authenticated User`); the injected content targets downstream LLM consumers.
+
+`src/tools/scan-buckets.ts:31,45,57` and `src/tools/check-realtime-threat-feed.ts:69` — `sanitizeUpstreamObject(...)` spread into metadata; `src/lib/sanitize-upstream.ts:49-69` — `sanitizeDnsData` per string, `MAX_META_DEPTH=6`, `MAX_META_STRING=8000`; OSINT status/report paths apply the same helper with test coverage, bucket/feed paths do not.
+
+#### Remediation
+
+Add injection-shaped fixtures (ANSI, C0, prompt-injection phrases, oversized strings) to the bucket-scan and threat-feed specs asserting post-sanitization metadata; consider an allowlist of expected upstream fields instead of opaque spread.
+
+#### Verification
+
+New specs fail if `sanitizeUpstreamObject` is removed from either spread site.
+
+### FIND-16: Internal isolation & dependency hardening (existing control)
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 2.5 (CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-306](https://cwe.mitre.org/data/definitions/306.html): Missing Authentication for Critical Function |
+| OWASP | A04:2025 – Cryptographic Failures |
+| Exploitation Prerequisites | Internal Network |
+| Exploitability Tier | Tier 2 — Conditional Risk |
+| Remediation Effort | Low |
+| Mitigation Type | Existing Control |
+| Component | InternalRouter |
+| Related Threats | [T19.E](2-stride-analysis.md#oauthissuer), [T40.S](2-stride-analysis.md#dnsresolver), [T41.T](2-stride-analysis.md#dnsresolver), [T48.S](2-stride-analysis.md#internalrouter), [T49.T](2-stride-analysis.md#internalrouter), [T50.D](2-stride-analysis.md#internalrouter), [T51.E](2-stride-analysis.md#internalrouter), [T59.T](2-stride-analysis.md#profileaccumulator), [T60.A](2-stride-analysis.md#profileaccumulator), [T69.S](2-stride-analysis.md#bvweb), [T70.I](2-stride-analysis.md#bvweb), [T71.D](2-stride-analysis.md#bvweb), [T72.S](2-stride-analysis.md#publicdoh), [T73.T](2-stride-analysis.md#publicdoh), [T74.D](2-stride-analysis.md#publicdoh), [T75.T](2-stride-analysis.md#certtransparency), [T76.D](2-stride-analysis.md#certtransparency), [T78.D](2-stride-analysis.md#whoisrdap), [T90.T](2-stride-analysis.md#bvtlsprobe), [T93.A](2-stride-analysis.md#internalrouter) |
+
+#### Description
+
+> **[Existing]**
+
+Documents the internal-surface and dependency hardening controls: the public-request guard, strict bearer gate on credential-minting routes, batch input constraints, authenticated sibling-worker bindings, multi-resolver DoH with fallbacks, and bounded external-data ingestion. Strengthened this window by the secure-by-default lenient gate (FIND-12), the agent-chat 13-tool read-only allowlist with exact-set audit, tenant-scope intersection enforcement (`X-Tenant-Scope` ∩ `TENANT_KEY_SCOPE` with `denyIfOutOfScope` coverage audit), the tenant-resolver active-flag recheck, and a proper domain-suffix MX-platform matcher replacing an unanchored substring regex.
+
+#### Evidence
+
+**Prerequisite basis:** All listed surfaces require in-account binding or on-path network position (`Internal Network`).
+
+`src/internal.ts:123-125` (`isPublicInternetRequest`), `:203-205` + config body caps, `:217-223,419-422` (agent-chat allowlist); `src/tenants/routes.ts:107-180` (`assertTenantScope` intersection + `denyIfOutOfScope`); `src/tenants/tenant-resolver.ts:115-149` (active-flag recheck, fail-open on transient read errors only); `src/tenants/discovery/mx-platform-detector.ts:27-41` (suffix matcher).
+
+#### Remediation
+
+None — keep the exact-set and coverage audits green; extend the allowlist pattern to future internal caller principals.
+
+#### Verification
+
+Public request to `/internal/tools/call` → 404; agent-chat caller invoking a non-allowlisted tool → 403 `agent_tool_not_allowed`; out-of-scope tenant access → denied.
+
+---
+
+## Tier 3 — Defense-in-Depth (Prior Compromise / Host Access)
+
+### FIND-17: Sensitive KV records rely on platform isolation only
+
+| Attribute | Value |
+|-----------|-------|
+| SDL Bugbar Severity | Low |
+| CVSS 4.0 | 4.2 (CVSS:4.0/AV:L/AC:L/AT:N/PR:H/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N) |
+| CWE | [CWE-311](https://cwe.mitre.org/data/definitions/311.html): Missing Encryption of Sensitive Data |
+| OWASP | A04:2025 – Cryptographic Failures |
+| Exploitation Prerequisites | Host/OS Access |
+| Exploitability Tier | Tier 3 — Defense-in-Depth |
+| Remediation Effort | Medium |
+| Mitigation Type | Custom Mitigation |
+| Component | RateLimitKV |
+| Related Threats | [T62.I](2-stride-analysis.md#sessionstorekv), [T65.I](2-stride-analysis.md#ratelimitkv) |
+
+#### Description
+
+> **[Partial]**
+
+Sensitive KV records (trial keys, OAuth artifacts) historically relied on Cloudflare's at-rest encryption and account isolation alone. An AES-256-GCM application-layer envelope (`kv-envelope.ts`, versioned wire format, no-op when `KV_ENVELOPE_KEY` unset) shipped and is wired on the OAuth grants path — but trial-key records are **not yet wrapped** (`src/lib/trial-keys.ts` unchanged in this window), and the envelope is inert anywhere the secret is unset. This contradicts the interim overlay's "fixed" status; the disagreement is logged in Needs Verification.
+
+#### Evidence
+
+**Prerequisite basis:** KV namespaces have no listeners; reading them requires Cloudflare account/host access (Exposure Table: `Host/OS Access`).
+
+`src/lib/kv-envelope.ts` — `sealKv`/`openKv`/`isSealed`/`parseEnvelopeKey` (AES-256-GCM, `v{n}:iv:ct`); `src/internal.ts:299` — envelope parsed on the OAuth path; `src/lib/trial-keys.ts` — no envelope usage (no diff f75ca7d→HEAD). Compensating controls: trial keys are bounded-lifetime (14-day default) and quota-limited.
+
+#### Remediation
+
+Wrap trial-key writes/reads in `sealKv`/`openKv` (with `isSealed` migration handling); confirm `KV_ENVELOPE_KEY` is set in production overrides and plan key-version rotation.
+
+#### Verification
+
+New trial-key KV values start with the `v1:` envelope prefix; reads of legacy plaintext records still succeed during migration.
+
+---
+
+## Threat Coverage Verification
+
+| Threat ID | Finding ID | Status |
+|-----------|------------|--------|
+| T01.S | FIND-10 | ✅ Mitigated (FIND-10) |
+| T02.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T03.R | FIND-11 | ✅ Mitigated (FIND-11) |
+| T04.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T05.I | FIND-04 | ✅ Covered (FIND-04) |
+| T06.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T07.A | FIND-02 | ✅ Mitigated (FIND-02) |
+| T08.S | FIND-08 | ✅ Mitigated (FIND-08) |
+| T09.S | FIND-08 | ✅ Mitigated (FIND-08) |
+| T10.T | FIND-08 | ✅ Mitigated (FIND-08) |
+| T11.I | FIND-01 | ✅ Covered (FIND-01) |
+| T12.E | FIND-08 | ✅ Mitigated (FIND-08) |
+| T13.E | FIND-15 | ✅ Mitigated (FIND-15) |
+| T14.A | FIND-08 | ✅ Mitigated (FIND-08) |
+| T15.S | FIND-05 | ✅ Mitigated (FIND-05) |
+| T16.T | FIND-08 | ✅ Mitigated (FIND-08) |
+| T17.I | FIND-08 | ✅ Mitigated (FIND-08) |
+| T18.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T19.E | FIND-16 | ✅ Mitigated (FIND-16) |
+| T20.A | FIND-13 | ✅ Mitigated (FIND-13) |
+| T21.S | FIND-08 | ✅ Mitigated (FIND-08) |
+| T22.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T23.R | FIND-11 | ✅ Mitigated (FIND-11) |
+| T24.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T25.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T26.E | FIND-10 | ✅ Mitigated (FIND-10) |
+| T27.A | FIND-10 | ✅ Mitigated (FIND-10) |
+| T28.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T29.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T30.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T31.E | FIND-10 | ✅ Mitigated (FIND-10) |
+| T32.A | FIND-03 | ✅ Mitigated (FIND-03) |
+| T33.A | FIND-06 | ✅ Mitigated (FIND-06) |
+| T34.T | FIND-07 | ✅ Mitigated (FIND-07) |
+| T35.I | FIND-09 | ✅ Mitigated (FIND-09) |
+| T36.E | FIND-09 | ✅ Mitigated (FIND-09) |
+| T37.T | FIND-09 | ✅ Mitigated (FIND-09) |
+| T38.I | FIND-09 | ✅ Mitigated (FIND-09) |
+| T39.D | FIND-09 | ✅ Mitigated (FIND-09) |
+| T40.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T41.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T42.D | FIND-03 | ✅ Mitigated (FIND-03) |
+| T43.A | FIND-03 | ✅ Mitigated (FIND-03) |
+| T44.T | FIND-10 | ✅ Mitigated (FIND-10) |
+| T45.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T46.E | FIND-02 | ✅ Mitigated (FIND-02) |
+| T47.A | FIND-10 | ✅ Mitigated (FIND-10) |
+| T48.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T49.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T50.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T51.E | FIND-16 | ✅ Mitigated (FIND-16) |
+| T52.A | FIND-12 | ✅ Mitigated (FIND-12) |
+| T53.T | FIND-14 | ✅ Covered (FIND-14) |
+| T54.I | FIND-14 | ✅ Covered (FIND-14) |
+| T55.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T56.A | FIND-14 | ✅ Covered (FIND-14) |
+| T57.T | — | 🔄 Mitigated by Platform |
+| T58.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T59.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T60.A | FIND-16 | ✅ Mitigated (FIND-16) |
+| T61.T | — | 🔄 Mitigated by Platform |
+| T62.I | FIND-17 | ✅ Mitigated (FIND-17) |
+| T63.T | — | 🔄 Mitigated by Platform |
+| T64.T | — | 🔄 Mitigated by Platform |
+| T65.I | FIND-17 | ✅ Covered (FIND-17) |
+| T66.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T67.T | — | 🔄 Mitigated by Platform |
+| T68.R | FIND-11 | ✅ Mitigated (FIND-11) |
+| T69.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T70.I | FIND-16 | ✅ Mitigated (FIND-16) |
+| T71.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T72.S | FIND-16 | ✅ Mitigated (FIND-16) |
+| T73.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T74.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T75.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T76.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T77.I | FIND-11 | ✅ Mitigated (FIND-11) |
+| T78.D | FIND-16 | ✅ Mitigated (FIND-16) |
+| T79.S | FIND-19 | ✅ Mitigated (FIND-19) |
+| T80.I | FIND-19 | ✅ Covered (FIND-19) |
+| T81.I | FIND-19 | ✅ Covered (FIND-19) |
+| T82.D | FIND-20 | ✅ Covered (FIND-20) |
+| T83.A | FIND-19 | ✅ Mitigated (FIND-19) |
+| T84.S | FIND-18 | ✅ Mitigated (FIND-18) |
+| T85.T | FIND-21 | ✅ Covered (FIND-21) |
+| T86.I | FIND-18 | ✅ Covered (FIND-18) |
+| T87.D | FIND-03 | ✅ Mitigated (FIND-03) |
+| T88.A | FIND-03 | ✅ Mitigated (FIND-03) |
+| T89.I | FIND-09 | ✅ Covered (FIND-09) |
+| T90.T | FIND-16 | ✅ Mitigated (FIND-16) |
+| T91.D | FIND-10 | ✅ Mitigated (FIND-10) |
+| T92.E | FIND-08 | ✅ Mitigated (FIND-08) |
+| T93.A | FIND-16 | ✅ Mitigated (FIND-16) |

--- a/docs/threat-model/threat-model-20260611-112908/incremental-comparison.html
+++ b/docs/threat-model/threat-model-20260611-112908/incremental-comparison.html
@@ -1,0 +1,255 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>bv-mcp &mdash; Incremental Threat Model Comparison</title>
+<style>
+:root { --red:#dc3545; --green:#28a745; --amber:#fd7e14; --gray:#6c757d; --accent:#2171b5; }
+body { font-family: -apple-system, "Segoe UI", Roboto, sans-serif; margin:0; background:#f5f7fa; color:#212529; }
+.header { background:#1a2332; color:#fff; padding:28px 40px; }
+.report-badge { display:inline-block; background:var(--accent); color:#fff; font-size:11px; letter-spacing:2px; padding:4px 10px; border-radius:3px; }
+.header h1 { margin:10px 0 0; font-size:28px; }
+.comparison-cards { display:flex; align-items:center; gap:18px; padding:24px 40px; }
+.compare-card { background:#fff; border-radius:8px; padding:16px 22px; box-shadow:0 1px 4px rgba(0,0,0,.12); min-width:160px; }
+.card-label { font-size:11px; letter-spacing:1.5px; color:var(--gray); }
+.card-hash { font-family:monospace; font-size:20px; margin:4px 0; }
+.card-date { font-size:12px; color:var(--gray); }
+.risk-badge { display:inline-block; margin-top:8px; padding:3px 10px; border-radius:12px; color:#fff; font-size:12px; font-weight:600; }
+.risk-moderate { background:var(--amber); } .risk-low { background:var(--green); }
+.compare-arrow { font-size:30px; color:var(--gray); }
+.trend-direction { font-size:20px; font-weight:700; margin:4px 0; }
+.trend-improving { color:var(--green); }
+.trend-duration { font-size:12px; color:var(--gray); }
+.metrics-bar { display:flex; gap:14px; padding:0 40px 10px; flex-wrap:wrap; }
+.metric { background:#fff; border-radius:8px; padding:12px 18px; box-shadow:0 1px 4px rgba(0,0,0,.1); }
+.metric .label { font-size:11px; letter-spacing:1px; color:var(--gray); }
+.metric .value { font-size:18px; font-weight:700; }
+.delta { font-size:13px; color:var(--accent); }
+.status-cards { display:flex; gap:14px; padding:14px 40px; flex-wrap:wrap; }
+.status-card { flex:1; min-width:190px; border-radius:8px; color:#fff; padding:16px 18px; }
+.status-card .count { font-size:30px; font-weight:800; }
+.status-card .desc { font-size:13px; opacity:.95; }
+.sc-green { background:var(--green); } .sc-red { background:var(--red); } .sc-amber { background:var(--amber); } .sc-gray { background:var(--gray); }
+section { padding:14px 40px; }
+h2 { font-size:18px; margin:18px 0 8px; }
+table { border-collapse:collapse; width:100%; background:#fff; box-shadow:0 1px 4px rgba(0,0,0,.08); font-size:13px; }
+th, td { padding:7px 10px; border-bottom:1px solid #e6e9ed; text-align:left; }
+th { background:#eef2f7; font-size:12px; }
+.badge { padding:2px 8px; border-radius:10px; color:#fff; font-size:11px; font-weight:600; white-space:nowrap; }
+.badge-unchanged { background:var(--gray); }
+.badge-modified { background:var(--accent); }
+.badge-new, .badge-new_code, .badge-new_in_modified { background:var(--red); }
+.badge-fixed { background:var(--green); }
+.badge-partial, .badge-partially_mitigated { background:var(--amber); }
+.files { font-family:monospace; font-size:11px; color:var(--gray); }
+.id { font-family:monospace; }
+.stride-heatmap td, .stride-heatmap th { text-align:center; }
+.stride-heatmap td.comp { text-align:left; font-weight:600; }
+.stride-heatmap .divider { background:#dfe4ea; width:4px; padding:0; }
+.up { color:var(--red); font-size:11px; }
+.down { color:var(--green); font-size:11px; }
+.needs-verification { background:#fff8ec; border-left:4px solid var(--amber); padding:14px 18px; border-radius:0 8px 8px 0; }
+.needs-verification li { margin:6px 0; font-size:13px; }
+.footer { padding:20px 40px 34px; color:var(--gray); font-size:12px; }
+@media print { body { background:#fff; } .status-card, .compare-card, table { box-shadow:none; border:1px solid #ccc; } section { padding:8px 12px; } }
+</style>
+</head>
+<body>
+
+<!-- Section 1: Header + Comparison Cards -->
+<div class="header">
+  <div class="report-badge">INCREMENTAL THREAT MODEL COMPARISON</div>
+  <h1>bv-mcp (Blackveil DNS)</h1>
+</div>
+<div class="comparison-cards">
+  <div class="compare-card baseline">
+    <div class="card-label">BASELINE</div>
+    <div class="card-hash">7e23243</div>
+    <div class="card-date">2026-05-24</div>
+    <div class="risk-badge risk-moderate">Moderate</div>
+  </div>
+  <div class="compare-arrow">&rarr;</div>
+  <div class="compare-card target">
+    <div class="card-label">TARGET</div>
+    <div class="card-hash">7a1c6b3</div>
+    <div class="card-date">2026-06-11</div>
+    <div class="risk-badge risk-low">Low</div>
+  </div>
+  <div class="compare-card trend">
+    <div class="card-label">TREND</div>
+    <div class="trend-direction trend-improving">Improving</div>
+    <div class="trend-duration">~2.5 weeks (diff base f75ca7d, 2026-05-25)</div>
+  </div>
+</div>
+
+<!-- Section 2: Metrics Bar -->
+<div class="metrics-bar">
+  <div class="metric"><div class="label">COMPONENTS</div><div class="value">23 &rarr; 26 <span class="delta">(+3)</span></div></div>
+  <div class="metric"><div class="label">TRUST BOUNDARIES</div><div class="value">5 &rarr; 5 <span class="delta">(&plusmn;0)</span></div></div>
+  <div class="metric"><div class="label">THREATS</div><div class="value">78 &rarr; 93 <span class="delta">(+15)</span></div></div>
+  <div class="metric"><div class="label">FINDINGS</div><div class="value">17 &rarr; 21 <span class="delta">(+4)</span></div></div>
+  <div class="metric"><div class="label">CODE CHANGES</div><div class="value">230 commits, ~159 PRs</div></div>
+</div>
+
+<!-- Section 3: Status Summary Cards -->
+<div class="status-cards">
+  <div class="status-card sc-green"><div class="count">12</div><div class="desc">Baseline threats remediated in code &mdash; gating, revocation, retention, and secure-by-default internal auth</div></div>
+  <div class="status-card sc-red"><div class="count">15</div><div class="desc">New threats from three new service-binding surfaces; all credential-gated (Tier 2/3), five open pending cross-service verification</div></div>
+  <div class="status-card sc-amber"><div class="count">0</div><div class="desc">No previously unidentified issues &mdash; the baseline analysis held up against re-verification</div></div>
+  <div class="status-card sc-gray"><div class="count">66</div><div class="desc">Threats carried forward, overwhelmingly mitigated existing controls re-verified at the target commit</div></div>
+</div>
+
+<!-- Section 4: Component Status Grid -->
+<section>
+<h2>Component Status</h2>
+<table class="component-grid">
+<tr><th>Component</th><th>Type</th><th>Status</th><th>Source Files</th></tr>
+<tr><td>BrandAuditPipeline</td><td>process</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/brand-audit-pipeline.ts, src/scheduled.ts</td></tr>
+<tr><td>BvRecon</td><td>external_service</td><td><span class='badge badge-new'>New</span></td><td class='files'>src/lib/recon-binding.ts, src/tools/osint-investigate.ts, src/tools/scan-buckets.ts</td></tr>
+<tr><td>BvTlsProbe</td><td>external_service</td><td><span class='badge badge-new'>New</span></td><td class='files'>src/lib/tls-probe-binding.ts</td></tr>
+<tr><td>BvWeb</td><td>external_service</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/lib/tier-auth.ts, src/oauth/entitlements.ts</td></tr>
+<tr><td>CertTransparency</td><td>external_service</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/brand-discovery-tiers.ts</td></tr>
+<tr><td>DnsResolver</td><td>process</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/dns-transport.ts, src/lib/dns-multi-resolver.ts</td></tr>
+<tr><td>DomainSanitizer</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/lib/sanitize.ts, src/lib/config.ts</td></tr>
+<tr><td>HonoWorker</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/index.ts</td></tr>
+<tr><td>IntelligenceDB</td><td>data_store</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/mcp/execute.ts, src/lib/db</td></tr>
+<tr><td>InternalRouter</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/internal.ts</td></tr>
+<tr><td>M365Proxy</td><td>process</td><td><span class='badge badge-new'>New</span></td><td class='files'>src/tools/m365/proxy.ts, src/tools/m365/query-signins.ts, src/tools/m365/query-ual.ts</td></tr>
+<tr><td>McpClient</td><td>external_interactor</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>&mdash;</td></tr>
+<tr><td>McpExecutor</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/mcp/execute.ts, src/mcp/dispatch.ts</td></tr>
+<tr><td>OAuthIssuer</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/oauth/jwt.ts, src/oauth/token.ts, src/oauth/authorize.ts</td></tr>
+<tr><td>Operator</td><td>external_interactor</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>&mdash;</td></tr>
+<tr><td>ProfileAccumulator</td><td>process</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/profile-accumulator.ts</td></tr>
+<tr><td>PublicDoH</td><td>external_service</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/dns-transport.ts</td></tr>
+<tr><td>QuotaCoordinator</td><td>process</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/quota-coordinator.ts</td></tr>
+<tr><td>RateLimitKV</td><td>data_store</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/lib/rate-limiter.ts, src/lib/trial-keys.ts</td></tr>
+<tr><td>RateLimiter</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/lib/rate-limiter.ts, src/lib/fuzzing-detector.ts</td></tr>
+<tr><td>SafeFetch</td><td>process</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/safe-fetch.ts</td></tr>
+<tr><td>ScanCacheKV</td><td>data_store</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/lib/cache.ts</td></tr>
+<tr><td>SessionStoreKV</td><td>data_store</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/session.ts, src/oauth/storage.ts</td></tr>
+<tr><td>TierAuthResolver</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/lib/tier-auth.ts, src/lib/auth.ts</td></tr>
+<tr><td>ToolsHandler</td><td>process</td><td><span class='badge badge-modified'>Modified</span></td><td class='files'>src/handlers/tools.ts</td></tr>
+<tr><td>WhoisRdap</td><td>external_service</td><td><span class='badge badge-unchanged'>Unchanged</span></td><td class='files'>src/lib/registrar-identity.ts</td></tr>
+</table>
+</section>
+
+<!-- Section 5: Threat/Finding Status Breakdown -->
+<section class="status-breakdown">
+<h2>Fixed Threats (12)</h2>
+<table><tr><th>ID</th><th>Title</th><th>Component</th><th>Status</th></tr>
+<tr><td class='id'>T07.A</td><td>Distributed free-tier budget abuse</td><td>HonoWorker</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T13.E</td><td>Trial-key cache staleness</td><td>TierAuthResolver</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T20.A</td><td>Stale tier after downgrade</td><td>OAuthIssuer</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T32.A</td><td>Scanner as recon proxy</td><td>ToolsHandler</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T33.A</td><td>force_refresh cache busting</td><td>ToolsHandler</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T34.T</td><td>Homoglyph/IDN bypass</td><td>DomainSanitizer</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T42.D</td><td>DNS reflection/flood</td><td>DnsResolver</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T43.A</td><td>DNS recon / cache snooping</td><td>DnsResolver</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T46.E</td><td>Distributed-IP bypass</td><td>RateLimiter</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T52.A</td><td>Internal tools default-open</td><td>InternalRouter</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T62.I</td><td>OAuth code/JTI disclosure</td><td>SessionStoreKV</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>T68.R</td><td>Insufficient retention</td><td>IntelligenceDB</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+</table>
+<h2>New Threats (15)</h2>
+<table><tr><th>ID</th><th>Title</th><th>Component</th><th>Status</th></tr>
+<tr><td class='id'>T79.S</td><td>Stolen API key invokes identity-secops tools</td><td>M365Proxy</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T80.I</td><td>Cross-tenant M365 log access</td><td>M365Proxy</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T81.I</td><td>Tenant-ID enumeration via error codes</td><td>M365Proxy</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T82.D</td><td>Unmetered M365 query volume</td><td>M365Proxy</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T83.A</td><td>Surveillance via identity tools</td><td>M365Proxy</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T84.S</td><td>Compromised bv-recon forges intelligence</td><td>BvRecon</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T85.T</td><td>Recon payload prompt injection</td><td>BvRecon</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T86.I</td><td>Cross-principal recon result polling</td><td>BvRecon</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T87.D</td><td>Recon job flooding</td><td>BvRecon</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T88.A</td><td>People-OSINT abuse</td><td>BvRecon</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T89.I</td><td>TLS probe as internal reachability oracle</td><td>BvTlsProbe</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T90.T</td><td>Forged TLS-version results</td><td>BvTlsProbe</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T91.D</td><td>Probe latency exhaustion</td><td>BvTlsProbe</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>T92.E</td><td>LKG tier outlives revocation during outage</td><td>TierAuthResolver</td><td><span class='badge badge-new'>new in modified</span></td></tr>
+<tr><td class='id'>T93.A</td><td>Agent-chat allowlist evasion</td><td>InternalRouter</td><td><span class='badge badge-new'>new in modified</span></td></tr>
+</table>
+<h2>Fixed Findings (7)</h2>
+<table><tr><th>ID</th><th>Title</th><th>Component</th><th>Status</th></tr>
+<tr><td class='id'>FIND-02</td><td>Free-tier abuse via distributed IPs</td><td>RateLimiter</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>FIND-03</td><td>Scanner usable as recon/amplification proxy</td><td>ToolsHandler</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>FIND-06</td><td>force_refresh cache-busting amplification</td><td>ToolsHandler</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>FIND-07</td><td>Domain validation hardening for homoglyph/IDN</td><td>DomainSanitizer</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>FIND-12</td><td>Internal routes default to no bearer auth</td><td>InternalRouter</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>FIND-13</td><td>JWT retains elevated tier after plan downgrade</td><td>OAuthIssuer</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+<tr><td class='id'>FIND-15</td><td>Trial-key tier persists during cache window</td><td>TierAuthResolver</td><td><span class='badge badge-fixed'>fixed</span></td></tr>
+</table>
+<h2>Partially Mitigated Findings (4)</h2>
+<table><tr><th>ID</th><th>Title</th><th>Component</th><th>Status</th></tr>
+<tr><td class='id'>FIND-01</td><td>API key accepted via query parameter</td><td>TierAuthResolver</td><td><span class='badge badge-partial'>partially mitigated</span></td></tr>
+<tr><td class='id'>FIND-04</td><td>OAuth issuer from spoofable Host header</td><td>HonoWorker</td><td><span class='badge badge-partial'>partially mitigated</span></td></tr>
+<tr><td class='id'>FIND-14</td><td>Brand-audit discovery enables third-party enumeration</td><td>BrandAuditPipeline</td><td><span class='badge badge-partial'>partially mitigated</span></td></tr>
+<tr><td class='id'>FIND-17</td><td>Sensitive KV records rely on platform isolation only</td><td>RateLimitKV</td><td><span class='badge badge-partial'>partially mitigated</span></td></tr>
+</table>
+<h2>New Findings (4)</h2>
+<table><tr><th>ID</th><th>Title</th><th>Component</th><th>Status</th></tr>
+<tr><td class='id'>FIND-18</td><td>Recon operation IDs are not bound to the requesting principal on poll</td><td>BvRecon</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>FIND-19</td><td>M365 tenant authorization is delegated cross-service on a forwarded keyHash</td><td>M365Proxy</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>FIND-20</td><td>M365 identity tools are intentionally unmetered per-tool</td><td>M365Proxy</td><td><span class='badge badge-new'>new code</span></td></tr>
+<tr><td class='id'>FIND-21</td><td>Recon upstream payloads lack injection-focused test coverage</td><td>BvRecon</td><td><span class='badge badge-new'>new code</span></td></tr>
+</table>
+</section>
+
+<!-- Section 6: STRIDE Heatmap with Deltas -->
+<section>
+<h2>STRIDE-A Heatmap (deltas vs baseline)</h2>
+<table class="stride-heatmap">
+<thead><tr><th>Component</th><th>S</th><th>T</th><th>R</th><th>I</th><th>D</th><th>E</th><th>A</th><th>Total</th><th class="divider"></th><th>T1</th><th>T2</th><th>T3</th></tr></thead>
+<tbody>
+<tr><td class='comp'>HonoWorker</td><td>1</td><td>1</td><td>1</td><td>2</td><td>1</td><td>0</td><td>1</td><td><b>7</b></td><td class='divider'></td><td>7</td><td>0</td><td>0</td></tr>
+<tr><td class='comp'>TierAuthResolver</td><td>2</td><td>1</td><td>0</td><td>1</td><td>0</td><td>3 <span class='up'>&#9650;+1</span></td><td>1</td><td><b>8 <span class='up'>&#9650;+1</span></b></td><td class='divider'></td><td>6</td><td>1</td><td>1</td></tr>
+<tr><td class='comp'>OAuthIssuer</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td><b>6</b></td><td class='divider'></td><td>3</td><td>1</td><td>2</td></tr>
+<tr><td class='comp'>McpExecutor</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td><b>7</b></td><td class='divider'></td><td>7</td><td>0</td><td>0</td></tr>
+<tr><td class='comp'>ToolsHandler</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>2</td><td><b>6</b></td><td class='divider'></td><td>6</td><td>0</td><td>0</td></tr>
+<tr><td class='comp'>M365Proxy</td><td>1 <span class='up'>&#9650;+1</span></td><td>0</td><td>0</td><td>2 <span class='up'>&#9650;+2</span></td><td>1 <span class='up'>&#9650;+1</span></td><td>0</td><td>1 <span class='up'>&#9650;+1</span></td><td><b>5 <span class='up'>&#9650;+5</span></b></td><td class='divider'></td><td>0</td><td>5</td><td>0</td></tr>
+<tr><td class='comp'>DomainSanitizer</td><td>0</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>0</td><td><b>3</b></td><td class='divider'></td><td>3</td><td>0</td><td>0</td></tr>
+<tr><td class='comp'>SafeFetch</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>0</td><td><b>3</b></td><td class='divider'></td><td>3</td><td>0</td><td>0</td></tr>
+<tr><td class='comp'>DnsResolver</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td><b>4</b></td><td class='divider'></td><td>2</td><td>2</td><td>0</td></tr>
+<tr><td class='comp'>RateLimiter</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>1</td><td>1</td><td><b>4</b></td><td class='divider'></td><td>3</td><td>0</td><td>1</td></tr>
+<tr><td class='comp'>InternalRouter</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>1</td><td>2 <span class='up'>&#9650;+1</span></td><td><b>6 <span class='up'>&#9650;+1</span></b></td><td class='divider'></td><td>0</td><td>6</td><td>0</td></tr>
+<tr><td class='comp'>BrandAuditPipeline</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td><b>4</b></td><td class='divider'></td><td>0</td><td>4</td><td>0</td></tr>
+<tr><td class='comp'>QuotaCoordinator</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td><b>2</b></td><td class='divider'></td><td>0</td><td>0</td><td>2</td></tr>
+<tr><td class='comp'>ProfileAccumulator</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td><b>2</b></td><td class='divider'></td><td>0</td><td>0</td><td>2</td></tr>
+<tr><td class='comp'>SessionStoreKV</td><td>0</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td><b>2</b></td><td class='divider'></td><td>0</td><td>0</td><td>2</td></tr>
+<tr><td class='comp'>ScanCacheKV</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>0</td><td><b>1</b></td><td class='divider'></td><td>0</td><td>0</td><td>1</td></tr>
+<tr><td class='comp'>RateLimitKV</td><td>0</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td><b>2</b></td><td class='divider'></td><td>0</td><td>0</td><td>2</td></tr>
+<tr><td class='comp'>IntelligenceDB</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>0</td><td><b>3</b></td><td class='divider'></td><td>0</td><td>0</td><td>3</td></tr>
+<tr><td class='comp'>BvWeb</td><td>1</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>0</td><td><b>3</b></td><td class='divider'></td><td>0</td><td>2</td><td>1</td></tr>
+<tr><td class='comp'>BvRecon</td><td>1 <span class='up'>&#9650;+1</span></td><td>1 <span class='up'>&#9650;+1</span></td><td>0</td><td>1 <span class='up'>&#9650;+1</span></td><td>1 <span class='up'>&#9650;+1</span></td><td>0</td><td>1 <span class='up'>&#9650;+1</span></td><td><b>5 <span class='up'>&#9650;+5</span></b></td><td class='divider'></td><td>0</td><td>4</td><td>1</td></tr>
+<tr><td class='comp'>BvTlsProbe</td><td>0</td><td>1 <span class='up'>&#9650;+1</span></td><td>0</td><td>1 <span class='up'>&#9650;+1</span></td><td>1 <span class='up'>&#9650;+1</span></td><td>0</td><td>0</td><td><b>3 <span class='up'>&#9650;+3</span></b></td><td class='divider'></td><td>0</td><td>2</td><td>1</td></tr>
+<tr><td class='comp'>PublicDoH</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td><b>3</b></td><td class='divider'></td><td>0</td><td>3</td><td>0</td></tr>
+<tr><td class='comp'>CertTransparency</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td><b>2</b></td><td class='divider'></td><td>0</td><td>2</td><td>0</td></tr>
+<tr><td class='comp'>WhoisRdap</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>0</td><td><b>2</b></td><td class='divider'></td><td>0</td><td>2</td><td>0</td></tr>
+</tbody>
+</table>
+</section>
+
+<!-- Section 7: Needs Verification -->
+<section>
+<h2>Needs Verification</h2>
+<div class="needs-verification">
+<ul>
+<li><b>bv-web M365 tenant scoping (FIND-19):</b> confirm bv-web rejects keyHash values not entitled to the requested ms_tenant_id (and keyHash: undefined).</li>
+<li><b>bv-recon poll-ID ownership (FIND-18):</b> confirm investigation/bucket-scan IDs are bound to the creating caller inside bv-recon.</li>
+<li><b>bv-tls-probe host validation (T89.I):</b> confirm the probe refuses internal/reserved targets.</li>
+<li><b>Deploy gates (FIND-01, FIND-04):</b> confirm REJECT_QUERY_API_KEY=true and OAUTH_ISSUER are set in production overrides.</li>
+<li><b>KV envelope (FIND-17):</b> disagreement with the interim overlay &mdash; it recorded FIND-17 as fixed, but trial-key records are still not envelope-wrapped at the target commit; downgraded to Partial per code evidence.</li>
+<li><b>bv-web revoke call (FIND-13 residual):</b> confirm bv-web calls POST /internal/oauth/revoke-subject on plan downgrade.</li>
+<li><b>M365 per-principal metering (FIND-20):</b> product decision on a per-principal daily quota for identity_secops tools.</li>
+</ul>
+</div>
+</section>
+
+<!-- Section 8: Footer -->
+<div class="footer">
+Model: claude-fable-5 | Duration: ~65 minutes<br>
+Baseline: threat-model-20260524-114907 at 7e23243 (interim overlay threat-model-20260524-184006-incremental at f75ca7d)<br>
+Generated: 2026-06-11 12:34:00 UTC
+</div>
+
+</body>
+</html>

--- a/docs/threat-model/threat-model-20260611-112908/threat-inventory.json
+++ b/docs/threat-model/threat-model-20260611-112908/threat-inventory.json
@@ -1,0 +1,3650 @@
+{
+ "schema_version": "1.1",
+ "incremental": true,
+ "baseline_report": "threat-model-20260524-114907",
+ "baseline_commit": "7e23243",
+ "interim_overlay": "threat-model-20260524-184006-incremental",
+ "diff_base_commit": "f75ca7d",
+ "target_commit": "7a1c6b3",
+ "report_folder": "threat-model-20260611-112908",
+ "commit": "7a1c6b3",
+ "commit_date": "2026-06-11",
+ "branch": "main",
+ "repository": "https://github.com/MadaBurns/bv-mcp.git",
+ "analysis_timestamp": "2026-06-11T11:29:08Z",
+ "model": "claude-fable-5",
+ "components": [
+  {
+   "id": "BrandAuditPipeline",
+   "display": "BrandAuditPipeline",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/brand-audit-pipeline.ts",
+    "src/scheduled.ts"
+   ],
+   "source_directories": [
+    "src/lib/",
+    "src/queue/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/brand-audit-pipeline.ts",
+     "src/scheduled.ts"
+    ],
+    "source_directories": [
+     "src/lib/",
+     "src/queue/"
+    ],
+    "class_names": [
+     "runBrandAuditPipeline"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [
+     "CertTransparency",
+     "WhoisRdap"
+    ],
+    "protocols": [
+     "HTTPS",
+     "Queue"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "BvRecon",
+   "display": "BvRecon",
+   "type": "external_service",
+   "tmt_type": "SE.EI.TMCore.WebSvc",
+   "boundary": "BlackVeilServices",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [
+    "BV_RECON"
+   ],
+   "source_files": [
+    "src/lib/recon-binding.ts",
+    "src/tools/osint-investigate.ts",
+    "src/tools/scan-buckets.ts",
+    "src/tools/check-realtime-threat-feed.ts",
+    "src/lib/sanitize-upstream.ts"
+   ],
+   "source_directories": [
+    "src/lib",
+    "src/tools"
+   ],
+   "fingerprint": {
+    "component_type": "external_service",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [
+     "src/lib/recon-binding.ts",
+     "src/tools/osint-investigate.ts",
+     "src/tools/scan-buckets.ts"
+    ],
+    "source_directories": [
+     "src/lib",
+     "src/tools"
+    ],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [
+     "BV_RECON",
+     "BV_RECON_KEY"
+    ],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "Service binding RPC"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "new"
+  },
+  {
+   "id": "BvTlsProbe",
+   "display": "BvTlsProbe",
+   "type": "external_service",
+   "tmt_type": "SE.EI.TMCore.WebSvc",
+   "boundary": "BlackVeilServices",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [
+    "BV_TLS_PROBE"
+   ],
+   "source_files": [
+    "src/lib/tls-probe-binding.ts"
+   ],
+   "source_directories": [
+    "src/lib"
+   ],
+   "fingerprint": {
+    "component_type": "external_service",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [
+     "src/lib/tls-probe-binding.ts"
+    ],
+    "source_directories": [
+     "src/lib"
+    ],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [
+     "BV_TLS_PROBE",
+     "BV_TLS_PROBE_KEY"
+    ],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "Service binding RPC"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "new"
+  },
+  {
+   "id": "BvWeb",
+   "display": "BvWeb",
+   "type": "external_service",
+   "tmt_type": "SE.EI.TMCore.WebSvc",
+   "boundary": "BlackVeilServices",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/tier-auth.ts",
+    "src/oauth/entitlements.ts"
+   ],
+   "source_directories": [
+    "src/lib/",
+    "src/oauth/"
+   ],
+   "fingerprint": {
+    "component_type": "external_service",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [
+     "src/lib/tier-auth.ts",
+     "src/oauth/entitlements.ts"
+    ],
+    "source_directories": [
+     "src/lib/",
+     "src/oauth/"
+    ],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [
+     "BV_WEB_INTERNAL_KEY"
+    ],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "TierAuthResolver"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "ServiceBinding"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "CertTransparency",
+   "display": "CertTransparency",
+   "type": "external_service",
+   "tmt_type": "SE.EI.TMCore.WebSvc",
+   "boundary": "Internet",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/brand-discovery-tiers.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "external_service",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [
+     "src/lib/brand-discovery-tiers.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [
+     "BV_CERTSTREAM"
+    ],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "BrandAuditPipeline"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "HTTPS"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "DnsResolver",
+   "display": "DnsResolver",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/dns-transport.ts",
+    "src/lib/dns-multi-resolver.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/dns-transport.ts",
+     "src/lib/dns-multi-resolver.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "queryDns",
+     "queryDnsRecords"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [
+     "PublicDoH"
+    ],
+    "protocols": [
+     "HTTPS"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "DomainSanitizer",
+   "display": "DomainSanitizer",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/sanitize.ts",
+    "src/lib/config.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/sanitize.ts",
+     "src/lib/config.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "validateDomain",
+     "sanitizeDomain",
+     "validateOutboundUrl"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "in-process"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "HonoWorker",
+   "display": "HonoWorker",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebServer",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/index.ts"
+   ],
+   "source_directories": [
+    "src/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/index.ts"
+    ],
+    "source_directories": [
+     "src/"
+    ],
+    "class_names": [
+     "app (Hono)"
+    ],
+    "namespace": "src",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "McpClient"
+    ],
+    "outbound_to": [
+     "TierAuthResolver",
+     "OAuthIssuer",
+     "McpExecutor"
+    ],
+    "protocols": [
+     "HTTPS"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "IntelligenceDB",
+   "display": "IntelligenceDB",
+   "type": "data_store",
+   "tmt_type": "SE.DS.TMCore.SQL",
+   "boundary": "PlatformStorage",
+   "boundary_kind": "PrivilegeBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/mcp/execute.ts",
+    "src/lib/db"
+   ],
+   "source_directories": [
+    "src/lib/db/"
+   ],
+   "fingerprint": {
+    "component_type": "data_store",
+    "boundary_kind": "PrivilegeBoundary",
+    "source_files": [
+     "src/mcp/execute.ts",
+     "src/lib/db"
+    ],
+    "source_directories": [
+     "src/lib/db/"
+    ],
+    "class_names": [],
+    "namespace": "src.lib.db",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [],
+    "outbound_to": [],
+    "protocols": [
+     "D1"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "InternalRouter",
+   "display": "InternalRouter",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/internal.ts"
+   ],
+   "source_directories": [
+    "src/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/internal.ts"
+    ],
+    "source_directories": [
+     "src/"
+    ],
+    "class_names": [
+     "isPublicInternetRequest",
+     "internalLenientAuthGate"
+    ],
+    "namespace": "src",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "Operator"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "ServiceBinding"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "M365Proxy",
+   "display": "M365Proxy",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [
+    "identity_secops"
+   ],
+   "source_files": [
+    "src/tools/m365/proxy.ts",
+    "src/tools/m365/query-signins.ts",
+    "src/tools/m365/query-ual.ts",
+    "src/tools/m365/get-ca-policies.ts",
+    "src/tools/m365/assess-coverage.ts"
+   ],
+   "source_directories": [
+    "src/tools/m365"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/tools/m365/proxy.ts"
+    ],
+    "source_directories": [
+     "src/tools/m365"
+    ],
+    "class_names": [
+     "queryM365Proxy",
+     "querySignins",
+     "queryUal",
+     "getCaPolicies",
+     "assessCoverage"
+    ],
+    "namespace": "",
+    "config_keys": [
+     "BV_WEB_INTERNAL_KEY"
+    ],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [
+     "BvWeb"
+    ],
+    "protocols": [
+     "Service binding RPC"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "new"
+  },
+  {
+   "id": "McpClient",
+   "display": "McpClient",
+   "type": "external_interactor",
+   "tmt_type": "SE.EI.TMCore.WebApp",
+   "boundary": "Internet",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [],
+   "source_files": [],
+   "source_directories": [],
+   "fingerprint": {
+    "component_type": "external_interactor",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [],
+    "source_directories": [],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [],
+    "outbound_to": [
+     "HonoWorker"
+    ],
+    "protocols": [
+     "HTTPS"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "McpExecutor",
+   "display": "McpExecutor",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/mcp/execute.ts",
+    "src/mcp/dispatch.ts"
+   ],
+   "source_directories": [
+    "src/mcp/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/mcp/execute.ts",
+     "src/mcp/dispatch.ts"
+    ],
+    "source_directories": [
+     "src/mcp/"
+    ],
+    "class_names": [
+     "executeMcpRequest",
+     "dispatchMcpMethod"
+    ],
+    "namespace": "src.mcp",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "HonoWorker"
+    ],
+    "outbound_to": [
+     "RateLimiter",
+     "ToolsHandler",
+     "SessionStoreKV",
+     "IntelligenceDB"
+    ],
+    "protocols": [
+     "HTTPS",
+     "KV",
+     "D1"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "OAuthIssuer",
+   "display": "OAuthIssuer",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/oauth/jwt.ts",
+    "src/oauth/token.ts",
+    "src/oauth/authorize.ts"
+   ],
+   "source_directories": [
+    "src/oauth/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/oauth/jwt.ts",
+     "src/oauth/token.ts",
+     "src/oauth/authorize.ts"
+    ],
+    "source_directories": [
+     "src/oauth/"
+    ],
+    "class_names": [
+     "signJwt",
+     "handleToken"
+    ],
+    "namespace": "src.oauth",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "HonoWorker"
+    ],
+    "outbound_to": [
+     "BvWeb",
+     "SessionStoreKV"
+    ],
+    "protocols": [
+     "HTTPS",
+     "ServiceBinding"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "Operator",
+   "display": "Operator",
+   "type": "external_interactor",
+   "tmt_type": "SE.EI.TMCore.User",
+   "boundary": "Internet",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [],
+   "source_files": [],
+   "source_directories": [],
+   "fingerprint": {
+    "component_type": "external_interactor",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [],
+    "source_directories": [],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [],
+    "outbound_to": [
+     "InternalRouter"
+    ],
+    "protocols": [
+     "ServiceBinding"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "ProfileAccumulator",
+   "display": "ProfileAccumulator",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "DurableObjects",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/profile-accumulator.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/profile-accumulator.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "ProfileAccumulator"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "DO"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "PublicDoH",
+   "display": "PublicDoH",
+   "type": "external_service",
+   "tmt_type": "SE.EI.TMCore.WebSvc",
+   "boundary": "Internet",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/dns-transport.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "external_service",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [
+     "src/lib/dns-transport.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [
+     "BV_DOH_ENDPOINT",
+     "BV_DOH_TOKEN"
+    ],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "DnsResolver"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "HTTPS"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "QuotaCoordinator",
+   "display": "QuotaCoordinator",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "DurableObjects",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/quota-coordinator.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/quota-coordinator.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "QuotaCoordinator"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "RateLimiter"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "DO"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "RateLimitKV",
+   "display": "RateLimitKV",
+   "type": "data_store",
+   "tmt_type": "SE.DS.TMCore.NoSQL",
+   "boundary": "PlatformStorage",
+   "boundary_kind": "PrivilegeBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/rate-limiter.ts",
+    "src/lib/trial-keys.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "data_store",
+    "boundary_kind": "PrivilegeBoundary",
+    "source_files": [
+     "src/lib/rate-limiter.ts",
+     "src/lib/trial-keys.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [],
+    "outbound_to": [],
+    "protocols": [
+     "KV"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "RateLimiter",
+   "display": "RateLimiter",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/rate-limiter.ts",
+    "src/lib/fuzzing-detector.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/rate-limiter.ts",
+     "src/lib/fuzzing-detector.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "checkRateLimit",
+     "scoreWindow"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "McpExecutor"
+    ],
+    "outbound_to": [
+     "RateLimitKV",
+     "QuotaCoordinator"
+    ],
+    "protocols": [
+     "KV",
+     "DO"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "SafeFetch",
+   "display": "SafeFetch",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/safe-fetch.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/safe-fetch.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "safeFetch"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "ToolsHandler"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "HTTPS"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "ScanCacheKV",
+   "display": "ScanCacheKV",
+   "type": "data_store",
+   "tmt_type": "SE.DS.TMCore.Cache",
+   "boundary": "PlatformStorage",
+   "boundary_kind": "PrivilegeBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/cache.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "data_store",
+    "boundary_kind": "PrivilegeBoundary",
+    "source_files": [
+     "src/lib/cache.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "runWithCache"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [],
+    "outbound_to": [],
+    "protocols": [
+     "KV"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "SessionStoreKV",
+   "display": "SessionStoreKV",
+   "type": "data_store",
+   "tmt_type": "SE.DS.TMCore.NoSQL",
+   "boundary": "PlatformStorage",
+   "boundary_kind": "PrivilegeBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/session.ts",
+    "src/oauth/storage.ts"
+   ],
+   "source_directories": [
+    "src/lib/",
+    "src/oauth/"
+   ],
+   "fingerprint": {
+    "component_type": "data_store",
+    "boundary_kind": "PrivilegeBoundary",
+    "source_files": [
+     "src/lib/session.ts",
+     "src/oauth/storage.ts"
+    ],
+    "source_directories": [
+     "src/lib/",
+     "src/oauth/"
+    ],
+    "class_names": [
+     "createSession"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [],
+    "outbound_to": [],
+    "protocols": [
+     "KV"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  },
+  {
+   "id": "TierAuthResolver",
+   "display": "TierAuthResolver",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/tier-auth.ts",
+    "src/lib/auth.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/lib/tier-auth.ts",
+     "src/lib/auth.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [
+     "resolveTier",
+     "isAuthorizedRequest"
+    ],
+    "namespace": "src.lib",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "HonoWorker"
+    ],
+    "outbound_to": [
+     "BvWeb"
+    ],
+    "protocols": [
+     "HTTPS",
+     "ServiceBinding"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "ToolsHandler",
+   "display": "ToolsHandler",
+   "type": "process",
+   "tmt_type": "SE.P.TMCore.WebSvc",
+   "boundary": "CloudflareWorker",
+   "boundary_kind": "ProcessBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/handlers/tools.ts"
+   ],
+   "source_directories": [
+    "src/handlers/",
+    "src/tools/"
+   ],
+   "fingerprint": {
+    "component_type": "process",
+    "boundary_kind": "ProcessBoundary",
+    "source_files": [
+     "src/handlers/tools.ts"
+    ],
+    "source_directories": [
+     "src/handlers/",
+     "src/tools/"
+    ],
+    "class_names": [
+     "handleToolsCall",
+     "TOOL_REGISTRY"
+    ],
+    "namespace": "src.handlers",
+    "config_keys": [],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "McpExecutor"
+    ],
+    "outbound_to": [
+     "DomainSanitizer",
+     "DnsResolver",
+     "SafeFetch",
+     "BrandAuditPipeline",
+     "ScanCacheKV",
+     "ProfileAccumulator"
+    ],
+    "protocols": [
+     "KV",
+     "DO"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "modified"
+  },
+  {
+   "id": "WhoisRdap",
+   "display": "WhoisRdap",
+   "type": "external_service",
+   "tmt_type": "SE.EI.TMCore.WebSvc",
+   "boundary": "Internet",
+   "boundary_kind": "NetworkBoundary",
+   "aliases": [],
+   "source_files": [
+    "src/lib/registrar-identity.ts"
+   ],
+   "source_directories": [
+    "src/lib/"
+   ],
+   "fingerprint": {
+    "component_type": "external_service",
+    "boundary_kind": "NetworkBoundary",
+    "source_files": [
+     "src/lib/registrar-identity.ts"
+    ],
+    "source_directories": [
+     "src/lib/"
+    ],
+    "class_names": [],
+    "namespace": "",
+    "config_keys": [
+     "BV_WHOIS"
+    ],
+    "api_routes": [],
+    "dependencies": [],
+    "inbound_from": [
+     "BrandAuditPipeline"
+    ],
+    "outbound_to": [],
+    "protocols": [
+     "HTTPS"
+    ]
+   },
+   "sidecars": [],
+   "change_status": "unchanged"
+  }
+ ],
+ "boundaries": [
+  {
+   "id": "BlackVeilServices",
+   "display": "BlackVeil Services",
+   "kind": "NetworkBoundary",
+   "aliases": [],
+   "contains": [
+    "BvRecon",
+    "BvTlsProbe",
+    "BvWeb"
+   ],
+   "contains_fingerprint": "BvRecon|BvTlsProbe|BvWeb"
+  },
+  {
+   "id": "CloudflareWorker",
+   "display": "Cloudflare Worker (bv-mcp)",
+   "kind": "ProcessBoundary",
+   "aliases": [],
+   "contains": [
+    "BrandAuditPipeline",
+    "DnsResolver",
+    "DomainSanitizer",
+    "HonoWorker",
+    "InternalRouter",
+    "M365Proxy",
+    "McpExecutor",
+    "OAuthIssuer",
+    "RateLimiter",
+    "SafeFetch",
+    "TierAuthResolver",
+    "ToolsHandler"
+   ],
+   "contains_fingerprint": "BrandAuditPipeline|DnsResolver|DomainSanitizer|HonoWorker|InternalRouter|M365Proxy|McpExecutor|OAuthIssuer|RateLimiter|SafeFetch|TierAuthResolver|ToolsHandler"
+  },
+  {
+   "id": "DurableObjects",
+   "display": "Durable Objects",
+   "kind": "ProcessBoundary",
+   "aliases": [],
+   "contains": [
+    "ProfileAccumulator",
+    "QuotaCoordinator"
+   ],
+   "contains_fingerprint": "ProfileAccumulator|QuotaCoordinator"
+  },
+  {
+   "id": "Internet",
+   "display": "Public Internet",
+   "kind": "NetworkBoundary",
+   "aliases": [],
+   "contains": [
+    "CertTransparency",
+    "McpClient",
+    "Operator",
+    "PublicDoH",
+    "WhoisRdap"
+   ],
+   "contains_fingerprint": "CertTransparency|McpClient|Operator|PublicDoH|WhoisRdap"
+  },
+  {
+   "id": "PlatformStorage",
+   "display": "Cloudflare Platform Storage",
+   "kind": "PrivilegeBoundary",
+   "aliases": [],
+   "contains": [
+    "IntelligenceDB",
+    "RateLimitKV",
+    "ScanCacheKV",
+    "SessionStoreKV"
+   ],
+   "contains_fingerprint": "IntelligenceDB|RateLimitKV|ScanCacheKV|SessionStoreKV"
+  }
+ ],
+ "flows": [
+  {
+   "id": "DF_BrandAuditPipeline_to_CertTransparency",
+   "from": "BrandAuditPipeline",
+   "to": "CertTransparency",
+   "protocol": "HTTPS",
+   "description": "CT-log enumeration"
+  },
+  {
+   "id": "DF_BrandAuditPipeline_to_WhoisRdap",
+   "from": "BrandAuditPipeline",
+   "to": "WhoisRdap",
+   "protocol": "HTTPS",
+   "description": "WHOIS/RDAP lookups"
+  },
+  {
+   "id": "DF_DnsResolver_to_PublicDoH",
+   "from": "DnsResolver",
+   "to": "PublicDoH",
+   "protocol": "HTTPS (DoH)",
+   "description": "DNS-over-HTTPS queries"
+  },
+  {
+   "id": "DF_HonoWorker_to_McpExecutor",
+   "from": "HonoWorker",
+   "to": "McpExecutor",
+   "protocol": "in-process",
+   "description": "Validated JSON-RPC dispatch"
+  },
+  {
+   "id": "DF_HonoWorker_to_OAuthIssuer",
+   "from": "HonoWorker",
+   "to": "OAuthIssuer",
+   "protocol": "in-process",
+   "description": "OAuth register/authorize/token"
+  },
+  {
+   "id": "DF_HonoWorker_to_TierAuthResolver",
+   "from": "HonoWorker",
+   "to": "TierAuthResolver",
+   "protocol": "in-process",
+   "description": "Resolve caller tier"
+  },
+  {
+   "id": "DF_M365Proxy_to_BvWeb",
+   "from": "M365Proxy",
+   "to": "BvWeb",
+   "protocol": "Service binding RPC",
+   "description": "M365 sign-in/UAL/CA queries with internal bearer + keyHash."
+  },
+  {
+   "id": "DF_McpClient_to_HonoWorker",
+   "from": "McpClient",
+   "to": "HonoWorker",
+   "protocol": "HTTPS (JSON-RPC)",
+   "description": "MCP requests over Streamable HTTP"
+  },
+  {
+   "id": "DF_McpExecutor_to_IntelligenceDB",
+   "from": "McpExecutor",
+   "to": "IntelligenceDB",
+   "protocol": "D1 (TLS)",
+   "description": "Encrypted access-log evidence"
+  },
+  {
+   "id": "DF_McpExecutor_to_RateLimiter",
+   "from": "McpExecutor",
+   "to": "RateLimiter",
+   "protocol": "in-process",
+   "description": "Apply limits/quota"
+  },
+  {
+   "id": "DF_McpExecutor_to_SessionStoreKV",
+   "from": "McpExecutor",
+   "to": "SessionStoreKV",
+   "protocol": "KV (TLS)",
+   "description": "Sessions and OAuth codes"
+  },
+  {
+   "id": "DF_McpExecutor_to_ToolsHandler",
+   "from": "McpExecutor",
+   "to": "ToolsHandler",
+   "protocol": "in-process",
+   "description": "Dispatch tools/call"
+  },
+  {
+   "id": "DF_OAuthIssuer_to_BvWeb",
+   "from": "OAuthIssuer",
+   "to": "BvWeb",
+   "protocol": "Service binding RPC",
+   "description": "Plan-to-tier entitlement lookup"
+  },
+  {
+   "id": "DF_OAuthIssuer_to_SessionStoreKV",
+   "from": "OAuthIssuer",
+   "to": "SessionStoreKV",
+   "protocol": "KV (TLS)",
+   "description": "Auth codes / JTI revocation"
+  },
+  {
+   "id": "DF_Operator_to_InternalRouter",
+   "from": "Operator",
+   "to": "InternalRouter",
+   "protocol": "Service binding RPC",
+   "description": "Internal tool/grant/trial-key calls"
+  },
+  {
+   "id": "DF_RateLimiter_to_QuotaCoordinator",
+   "from": "RateLimiter",
+   "to": "QuotaCoordinator",
+   "protocol": "DO RPC",
+   "description": "Global daily quota"
+  },
+  {
+   "id": "DF_RateLimiter_to_RateLimitKV",
+   "from": "RateLimiter",
+   "to": "RateLimitKV",
+   "protocol": "KV (TLS)",
+   "description": "Counters and trial keys"
+  },
+  {
+   "id": "DF_TierAuthResolver_to_BvWeb",
+   "from": "TierAuthResolver",
+   "to": "BvWeb",
+   "protocol": "Service binding RPC",
+   "description": "validate-key tier resolution"
+  },
+  {
+   "id": "DF_ToolsHandler_to_BrandAuditPipeline",
+   "from": "ToolsHandler",
+   "to": "BrandAuditPipeline",
+   "protocol": "in-process",
+   "description": "Run brand audit"
+  },
+  {
+   "id": "DF_ToolsHandler_to_BvRecon",
+   "from": "ToolsHandler",
+   "to": "BvRecon",
+   "protocol": "Service binding RPC",
+   "description": "OSINT investigations, bucket scans, realtime threat feed (bearer)."
+  },
+  {
+   "id": "DF_ToolsHandler_to_BvTlsProbe",
+   "from": "ToolsHandler",
+   "to": "BvTlsProbe",
+   "protocol": "Service binding RPC",
+   "description": "TLS version probe enriching check_ssl (bearer)."
+  },
+  {
+   "id": "DF_ToolsHandler_to_DnsResolver",
+   "from": "ToolsHandler",
+   "to": "DnsResolver",
+   "protocol": "in-process",
+   "description": "DNS record queries"
+  },
+  {
+   "id": "DF_ToolsHandler_to_DomainSanitizer",
+   "from": "ToolsHandler",
+   "to": "DomainSanitizer",
+   "protocol": "in-process",
+   "description": "Validate/sanitize domain"
+  },
+  {
+   "id": "DF_ToolsHandler_to_M365Proxy",
+   "from": "ToolsHandler",
+   "to": "M365Proxy",
+   "protocol": "In-process",
+   "description": "Dispatch identity_secops tools with keyHash principal."
+  },
+  {
+   "id": "DF_ToolsHandler_to_ProfileAccumulator",
+   "from": "ToolsHandler",
+   "to": "ProfileAccumulator",
+   "protocol": "DO RPC",
+   "description": "Adaptive scoring weights"
+  },
+  {
+   "id": "DF_ToolsHandler_to_SafeFetch",
+   "from": "ToolsHandler",
+   "to": "SafeFetch",
+   "protocol": "in-process",
+   "description": "Fetch attacker-influenced URLs"
+  },
+  {
+   "id": "DF_ToolsHandler_to_ScanCacheKV",
+   "from": "ToolsHandler",
+   "to": "ScanCacheKV",
+   "protocol": "KV (TLS)",
+   "description": "Cached results"
+  }
+ ],
+ "threats": [
+  {
+   "id": "T01.S",
+   "title": "Origin spoofing / CSRF on /mcp",
+   "description": "Forged Origin header to mount cross-site requests.",
+   "stride_category": "S",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "checkOrigin allowlist + MCP-compliant rejection.",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "data_flow_id": "DF_McpClient_to_HonoWorker",
+    "stride_category": "S",
+    "attack_surface": "Origin spoofing / CSRF on /mcp"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T02.T",
+   "title": "Oversized request body",
+   "description": "Large body to exhaust isolate memory/CPU.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "10 KB body cap read before parse.",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "data_flow_id": "DF_McpClient_to_HonoWorker",
+    "stride_category": "T",
+    "attack_surface": "Oversized request body"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T03.R",
+   "title": "Weak request attribution",
+   "description": "Client denies abusive requests.",
+   "stride_category": "R",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Encrypted access log + hashed analytics principals.",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "data_flow_id": "DF_McpClient_to_HonoWorker",
+    "stride_category": "R",
+    "attack_surface": "Weak request attribution"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T04.I",
+   "title": "Verbose error disclosure",
+   "description": "Errors leak internals.",
+   "stride_category": "I",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "sanitizeErrorMessage allowlist with generic fallback.",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "data_flow_id": "DF_McpClient_to_HonoWorker",
+    "stride_category": "I",
+    "attack_surface": "Verbose error disclosure"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T05.I",
+   "title": "Host-header OAuth issuer poisoning",
+   "description": "Spoofed Host poisons issuer URL.",
+   "stride_category": "I",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Open",
+   "mitigation": "Set OAUTH_ISSUER; JWT aud validation.",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "data_flow_id": "DF_McpClient_to_HonoWorker",
+    "stride_category": "I",
+    "attack_surface": "Host-header OAuth issuer poisoning"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T06.D",
+   "title": "Unauthenticated request flood",
+   "description": "Flooding /mcp.",
+   "stride_category": "D",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Per-IP and global rate limits.",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "data_flow_id": "DF_McpClient_to_HonoWorker",
+    "stride_category": "D",
+    "attack_surface": "Unauthenticated request flood"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T07.A",
+   "title": "Distributed free-tier budget abuse",
+   "description": "Many IPs drain shared global budget.",
+   "stride_category": "A",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Per-IP distinct-domain daily cap (12/day) added in src/lib/rate-limiter.ts:555-593.",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "data_flow_id": "DF_McpClient_to_HonoWorker",
+    "stride_category": "A",
+    "attack_surface": "Distributed free-tier budget abuse"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T08.S",
+   "title": "API key brute force / timing",
+   "description": "Timing side-channel on key compare.",
+   "stride_category": "S",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Constant-time XOR over SHA-256.",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+    "stride_category": "S",
+    "attack_surface": "API key brute force / timing"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T09.S",
+   "title": "JWT alg confusion / none",
+   "description": "Forged JWT via alg=none.",
+   "stride_category": "S",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "HS256 pinned; alg checked before verify.",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+    "stride_category": "S",
+    "attack_surface": "JWT alg confusion / none"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T10.T",
+   "title": "Tier-claim tampering",
+   "description": "Tamper tier to elevate.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Signature verified before claims; tier enum.",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+    "stride_category": "T",
+    "attack_surface": "Tier-claim tampering"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T11.I",
+   "title": "API key in query string",
+   "description": "?api_key= leaks into edge logs.",
+   "stride_category": "I",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Open",
+   "mitigation": "Bearer preferred; query path deprecated.",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+    "stride_category": "I",
+    "attack_surface": "API key in query string"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T12.E",
+   "title": "Owner-tier IP spoofing",
+   "description": "Spoof IP into OWNER_ALLOW_IPS.",
+   "stride_category": "E",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "cf-connecting-ip only; off-allowlist downgrade.",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+    "stride_category": "E",
+    "attack_surface": "Owner-tier IP spoofing"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T13.E",
+   "title": "Trial-key cache staleness",
+   "description": "Expired key keeps tier 60s.",
+   "stride_category": "E",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Mitigated",
+   "mitigation": "Trial-key cache hits re-check trialExpiresAt and evict stale entries (src/lib/tier-auth.ts:190-193).",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+    "stride_category": "E",
+    "attack_surface": "Trial-key cache staleness"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T14.A",
+   "title": "Caller-supplied tier hint",
+   "description": "Caller asserts a tier.",
+   "stride_category": "A",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Tier always server-derived.",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_HonoWorker_to_TierAuthResolver",
+    "stride_category": "A",
+    "attack_surface": "Caller-supplied tier hint"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T15.S",
+   "title": "Open client registration abuse",
+   "description": "Mass rogue client registration.",
+   "stride_category": "S",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "PKCE + redirect_uri validation; throttle needed.",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+    "stride_category": "S",
+    "attack_surface": "Open client registration abuse"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T16.T",
+   "title": "Auth-code injection/replay",
+   "description": "Replay authorization code.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "PKCE S256; single-use codes with TTL.",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+    "stride_category": "T",
+    "attack_surface": "Auth-code injection/replay"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T17.I",
+   "title": "Weak JWT signing secret",
+   "description": "Short secret enables forgery.",
+   "stride_category": "I",
+   "tier": 3,
+   "prerequisites": "Host/OS Access",
+   "status": "Mitigated",
+   "mitigation": "OAUTH_SIGNING_SECRET >=32 bytes enforced; 503 until set.",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+    "stride_category": "I",
+    "attack_surface": "Weak JWT signing secret"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T18.D",
+   "title": "Token endpoint flooding",
+   "description": "Flood /oauth/token.",
+   "stride_category": "D",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "30/min per IP limit.",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "data_flow_id": "DF_HonoWorker_to_OAuthIssuer",
+    "stride_category": "D",
+    "attack_surface": "Token endpoint flooding"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T19.E",
+   "title": "Entitlement spoofing",
+   "description": "Forged entitlement grants tier.",
+   "stride_category": "E",
+   "tier": 3,
+   "prerequisites": "BvWeb Compromise",
+   "status": "Mitigated",
+   "mitigation": "Authenticated binding; tier enum validation.",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+    "stride_category": "E",
+    "attack_surface": "Entitlement spoofing"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T20.A",
+   "title": "Stale tier after downgrade",
+   "description": "JWT keeps tier until exp.",
+   "stride_category": "A",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Mitigated",
+   "mitigation": "Per-subject token-version (ver) revocation plus JWT TTL clamped to entitlement window (src/oauth/token.ts:167-181).",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+    "stride_category": "A",
+    "attack_surface": "Stale tier after downgrade"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T21.S",
+   "title": "Session guessing/fixation",
+   "description": "Hijack session via guessed ID.",
+   "stride_category": "S",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "64-hex random IDs; schema-validated; KV-backed.",
+   "identity_key": {
+    "component_id": "McpExecutor",
+    "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+    "stride_category": "S",
+    "attack_surface": "Session guessing/fixation"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T22.T",
+   "title": "JSON-RPC param tampering",
+   "description": "Malformed params.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "JSON-RPC validation + Zod validateToolArgs.",
+   "identity_key": {
+    "component_id": "McpExecutor",
+    "data_flow_id": "DF_HonoWorker_to_McpExecutor",
+    "stride_category": "T",
+    "attack_surface": "JSON-RPC param tampering"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T23.R",
+   "title": "Tool-call repudiation",
+   "description": "No attribution of tool calls.",
+   "stride_category": "R",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "tool_call analytics + encrypted access log.",
+   "identity_key": {
+    "component_id": "McpExecutor",
+    "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+    "stride_category": "R",
+    "attack_surface": "Tool-call repudiation"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T24.I",
+   "title": "Cross-session cache leakage",
+   "description": "Predictable cache keys.",
+   "stride_category": "I",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Domain-scoped keys; no secrets cached.",
+   "identity_key": {
+    "component_id": "McpExecutor",
+    "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+    "stride_category": "I",
+    "attack_surface": "Cross-session cache leakage"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T25.D",
+   "title": "Expensive-method amplification",
+   "description": "scan_domain amplification.",
+   "stride_category": "D",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Per-tool quotas; 12s/8s budgets.",
+   "identity_key": {
+    "component_id": "McpExecutor",
+    "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+    "stride_category": "D",
+    "attack_surface": "Expensive-method amplification"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T26.E",
+   "title": "Invoking scan-only tool directly",
+   "description": "Call check_subdomain_takeover directly.",
+   "stride_category": "E",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "TOOL_REGISTRY allowlist; scan-only enforced.",
+   "identity_key": {
+    "component_id": "McpExecutor",
+    "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+    "stride_category": "E",
+    "attack_surface": "Invoking scan-only tool directly"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T27.A",
+   "title": "Session creation flooding",
+   "description": "Exhaust KV/session maps.",
+   "stride_category": "A",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "10/min per IP; LRU caps.",
+   "identity_key": {
+    "component_id": "McpExecutor",
+    "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+    "stride_category": "A",
+    "attack_surface": "Session creation flooding"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T28.T",
+   "title": "Tool argument injection",
+   "description": "Unvalidated args reach DNS/fetch.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Zod validateToolArgs + validateDomain.",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+    "stride_category": "T",
+    "attack_surface": "Tool argument injection"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T29.I",
+   "title": "STRUCTURED_RESULT leakage",
+   "description": "Internal data in structured JSON.",
+   "stride_category": "I",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Omitted for interactive clients; sanitized findings.",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+    "stride_category": "I",
+    "attack_surface": "STRUCTURED_RESULT leakage"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T30.D",
+   "title": "batch_scan exhaustion",
+   "description": "Resource exhaustion via batch.",
+   "stride_category": "D",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "budgetMs 25s, concurrency 3, Promise.race.",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "data_flow_id": "DF_McpExecutor_to_ToolsHandler",
+    "stride_category": "D",
+    "attack_surface": "batch_scan exhaustion"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T31.E",
+   "title": "Domain-optional validation bypass",
+   "description": "Bypass domain validation.",
+   "stride_category": "E",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "DOMAIN_OPTIONAL_TOOLS explicit; args Zod-validated.",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+    "stride_category": "E",
+    "attack_surface": "Domain-optional validation bypass"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T32.A",
+   "title": "Scanner as recon proxy",
+   "description": "Scan arbitrary third-party domains.",
+   "stride_category": "A",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Offensive/multi-domain tools paid-gated via GATED_PAID_ONLY_TOOLS -> HTTP 403/-32003 (src/lib/config.ts:340-378).",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "data_flow_id": "DF_ToolsHandler_to_DnsResolver",
+    "stride_category": "A",
+    "attack_surface": "Scanner as recon proxy"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T33.A",
+   "title": "force_refresh cache busting",
+   "description": "Repeated force_refresh amplifies load.",
+   "stride_category": "A",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "FORCE_REFRESH_DAILY_LIMIT=5 free-tier cache-bypass cap (src/lib/config.ts:338).",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "data_flow_id": "DF_ToolsHandler_to_ScanCacheKV",
+    "stride_category": "A",
+    "attack_surface": "force_refresh cache busting"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T34.T",
+   "title": "Homoglyph/IDN bypass",
+   "description": "Confusable domain inputs.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Mixed-script (homoglyph) label rejection in sanitizeDomain (src/lib/sanitize.ts).",
+   "identity_key": {
+    "component_id": "DomainSanitizer",
+    "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+    "stride_category": "T",
+    "attack_surface": "Homoglyph/IDN bypass"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T35.I",
+   "title": "SSRF via domain input",
+   "description": "Domain resolves to internal IP.",
+   "stride_category": "I",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Reject IP literals/localhost/RFC1918/rebinding.",
+   "identity_key": {
+    "component_id": "DomainSanitizer",
+    "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+    "stride_category": "I",
+    "attack_surface": "SSRF via domain input"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T36.E",
+   "title": "DNS rebinding TOCTOU",
+   "description": "Validated host resolves internal at fetch.",
+   "stride_category": "E",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "global_fetch_strictly_public; safeFetch re-validation.",
+   "identity_key": {
+    "component_id": "DomainSanitizer",
+    "data_flow_id": "DF_ToolsHandler_to_DomainSanitizer",
+    "stride_category": "E",
+    "attack_surface": "DNS rebinding TOCTOU"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T37.T",
+   "title": "Redirect SSRF",
+   "description": "Location header to internal target.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "redirect:manual + per-hop re-validation.",
+   "identity_key": {
+    "component_id": "SafeFetch",
+    "data_flow_id": "DF_ToolsHandler_to_SafeFetch",
+    "stride_category": "T",
+    "attack_surface": "Redirect SSRF"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T38.I",
+   "title": "Attacker URL SSRF",
+   "description": "BIMI l= fetched to internal.",
+   "stride_category": "I",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "safeFetch HTTPS-only, blocklist, userinfo rejection.",
+   "identity_key": {
+    "component_id": "SafeFetch",
+    "data_flow_id": "DF_ToolsHandler_to_SafeFetch",
+    "stride_category": "I",
+    "attack_surface": "Attacker URL SSRF"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T39.D",
+   "title": "Slowloris/large response",
+   "description": "Attacker target stalls fetch.",
+   "stride_category": "D",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "AbortSignal.timeout + total-budget caps.",
+   "identity_key": {
+    "component_id": "SafeFetch",
+    "data_flow_id": "DF_ToolsHandler_to_SafeFetch",
+    "stride_category": "D",
+    "attack_surface": "Slowloris/large response"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T40.S",
+   "title": "Malicious/MITM resolver",
+   "description": "Forged DNS records.",
+   "stride_category": "S",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "TLS; secondary token; multi-resolver.",
+   "identity_key": {
+    "component_id": "DnsResolver",
+    "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+    "stride_category": "S",
+    "attack_surface": "Malicious/MITM resolver"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T41.T",
+   "title": "DNS response tampering",
+   "description": "Skew scan grades.",
+   "stride_category": "T",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "TLS; cross-resolver corroboration.",
+   "identity_key": {
+    "component_id": "DnsResolver",
+    "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+    "stride_category": "T",
+    "attack_surface": "DNS response tampering"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T42.D",
+   "title": "DNS reflection/flood",
+   "description": "Flood victim resolver/domain.",
+   "stride_category": "D",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Paid gating of multi-domain tools + distinct-domain cap bound reflection volume.",
+   "identity_key": {
+    "component_id": "DnsResolver",
+    "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+    "stride_category": "D",
+    "attack_surface": "DNS reflection/flood"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T43.A",
+   "title": "DNS recon / cache snooping",
+   "description": "Recon via DNS queries.",
+   "stride_category": "A",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Distinct-domain daily cap throttles enumeration breadth (src/lib/rate-limiter.ts:555-593).",
+   "identity_key": {
+    "component_id": "DnsResolver",
+    "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+    "stride_category": "A",
+    "attack_surface": "DNS recon / cache snooping"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T44.T",
+   "title": "IP spoofing to evade limits",
+   "description": "Forge client IP.",
+   "stride_category": "T",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "cf-connecting-ip only; XFF never trusted.",
+   "identity_key": {
+    "component_id": "RateLimiter",
+    "data_flow_id": "DF_McpExecutor_to_RateLimiter",
+    "stride_category": "T",
+    "attack_surface": "IP spoofing to evade limits"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T45.D",
+   "title": "KV unavailability fail-open",
+   "description": "Disable rate limits.",
+   "stride_category": "D",
+   "tier": 3,
+   "prerequisites": "RateLimitKV Compromise",
+   "status": "Mitigated",
+   "mitigation": "In-memory + DO circuit-breaker fallback.",
+   "identity_key": {
+    "component_id": "RateLimiter",
+    "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+    "stride_category": "D",
+    "attack_surface": "KV unavailability fail-open"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T46.E",
+   "title": "Distributed-IP bypass",
+   "description": "Botnet bypasses per-IP limits.",
+   "stride_category": "E",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Distinct-domain cap narrows per-IP botnet value; global DO ceiling unchanged.",
+   "identity_key": {
+    "component_id": "RateLimiter",
+    "data_flow_id": "DF_McpExecutor_to_RateLimiter",
+    "stride_category": "E",
+    "attack_surface": "Distributed-IP bypass"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T47.A",
+   "title": "Low-and-slow fuzzing",
+   "description": "Stay under thresholds.",
+   "stride_category": "A",
+   "tier": 1,
+   "prerequisites": "None",
+   "status": "Mitigated",
+   "mitigation": "Fuzzing detector sliding window + alerts.",
+   "identity_key": {
+    "component_id": "RateLimiter",
+    "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+    "stride_category": "A",
+    "attack_surface": "Low-and-slow fuzzing"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T48.S",
+   "title": "Public reaching /internal/*",
+   "description": "Spoof absence of proxy headers.",
+   "stride_category": "S",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "isPublicInternetRequest rejects public headers (404).",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "data_flow_id": "DF_Operator_to_InternalRouter",
+    "stride_category": "S",
+    "attack_surface": "Public reaching /internal/*"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T49.T",
+   "title": "Oversized internal batch",
+   "description": "Abusive batch payload.",
+   "stride_category": "T",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "256 KB limit; tool-name + arg-key allowlist.",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "data_flow_id": "DF_Operator_to_InternalRouter",
+    "stride_category": "T",
+    "attack_surface": "Oversized internal batch"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T50.D",
+   "title": "Batch exhaustion",
+   "description": "500-domain batch exhaustion.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "Max 500, concurrency cap, budget.",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "data_flow_id": "DF_Operator_to_InternalRouter",
+    "stride_category": "D",
+    "attack_surface": "Batch exhaustion"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T51.E",
+   "title": "Credential-minting w/o auth",
+   "description": "Reach grants/trial-keys unauthorized.",
+   "stride_category": "E",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "Strict BV_WEB_INTERNAL_KEY gate (503/401).",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "data_flow_id": "DF_Operator_to_InternalRouter",
+    "stride_category": "E",
+    "attack_surface": "Credential-minting w/o auth"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T52.A",
+   "title": "Internal tools default-open",
+   "description": "REQUIRE_INTERNAL_AUTH off by default.",
+   "stride_category": "A",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "internalLenientAuthGate secure-by-default: 503 if key unset, 401 on bad bearer (src/internal.ts:165-182).",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "data_flow_id": "DF_Operator_to_InternalRouter",
+    "stride_category": "A",
+    "attack_surface": "Internal tools default-open"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T53.T",
+   "title": "Watched-domain spoofing",
+   "description": "Audit a non-owned domain.",
+   "stride_category": "T",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "Watched-domain validated at register time.",
+   "identity_key": {
+    "component_id": "BrandAuditPipeline",
+    "data_flow_id": "DF_ToolsHandler_to_BrandAuditPipeline",
+    "stride_category": "T",
+    "attack_surface": "Watched-domain spoofing"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T54.I",
+   "title": "Third-party infra disclosure",
+   "description": "Tiered discovery reveals competitor infra.",
+   "stride_category": "I",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "Opt-out enforcement; tier gating.",
+   "identity_key": {
+    "component_id": "BrandAuditPipeline",
+    "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+    "stride_category": "I",
+    "attack_surface": "Third-party infra disclosure"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T55.D",
+   "title": "Discovery/queue flooding",
+   "description": "Expensive tiered discovery.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Mitigated",
+   "mitigation": "Per-tier quotas, budget, reaper.",
+   "identity_key": {
+    "component_id": "BrandAuditPipeline",
+    "data_flow_id": "DF_ToolsHandler_to_BrandAuditPipeline",
+    "stride_category": "D",
+    "attack_surface": "Discovery/queue flooding"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T56.A",
+   "title": "Mass third-party enumeration",
+   "description": "Repeated audits enumerate third parties.",
+   "stride_category": "A",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "Quotas + opt-out registry.",
+   "identity_key": {
+    "component_id": "BrandAuditPipeline",
+    "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+    "stride_category": "A",
+    "attack_surface": "Mass third-party enumeration"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T57.T",
+   "title": "DO state manipulation",
+   "description": "Reset/inflate quota counters.",
+   "stride_category": "T",
+   "tier": 3,
+   "prerequisites": "CloudflareWorker Compromise",
+   "status": "Platform",
+   "mitigation": "DO reachable only via in-account binding.",
+   "identity_key": {
+    "component_id": "QuotaCoordinator",
+    "data_flow_id": "DF_RateLimiter_to_QuotaCoordinator",
+    "stride_category": "T",
+    "attack_surface": "DO state manipulation"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T58.D",
+   "title": "DO bottleneck/unavailability",
+   "description": "Single-instance DO outage.",
+   "stride_category": "D",
+   "tier": 3,
+   "prerequisites": "Host/OS Access",
+   "status": "Mitigated",
+   "mitigation": "Circuit-breaker fallback to KV/in-memory.",
+   "identity_key": {
+    "component_id": "QuotaCoordinator",
+    "data_flow_id": "DF_RateLimiter_to_QuotaCoordinator",
+    "stride_category": "D",
+    "attack_surface": "DO bottleneck/unavailability"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T59.T",
+   "title": "Adaptive-weight poisoning",
+   "description": "Crafted telemetry poisons weights.",
+   "stride_category": "T",
+   "tier": 3,
+   "prerequisites": "CloudflareWorker Compromise",
+   "status": "Mitigated",
+   "mitigation": "Maturity-gated blending; static fallback.",
+   "identity_key": {
+    "component_id": "ProfileAccumulator",
+    "data_flow_id": "DF_ToolsHandler_to_ProfileAccumulator",
+    "stride_category": "T",
+    "attack_surface": "Adaptive-weight poisoning"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T60.A",
+   "title": "EMA score skew",
+   "description": "Sustained scans bias EMA.",
+   "stride_category": "A",
+   "tier": 3,
+   "prerequisites": "CloudflareWorker Compromise",
+   "status": "Mitigated",
+   "mitigation": "Maturity threshold; bounded influence.",
+   "identity_key": {
+    "component_id": "ProfileAccumulator",
+    "data_flow_id": "DF_ToolsHandler_to_ProfileAccumulator",
+    "stride_category": "A",
+    "attack_surface": "EMA score skew"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T61.T",
+   "title": "Session/code tampering",
+   "description": "Tamper session/auth records.",
+   "stride_category": "T",
+   "tier": 3,
+   "prerequisites": "CloudflareWorker Compromise",
+   "status": "Platform",
+   "mitigation": "In-account only; schema-validated reads.",
+   "identity_key": {
+    "component_id": "SessionStoreKV",
+    "data_flow_id": "DF_McpExecutor_to_SessionStoreKV",
+    "stride_category": "T",
+    "attack_surface": "Session/code tampering"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T62.I",
+   "title": "OAuth code/JTI disclosure",
+   "description": "Codes exposed if KV compromised.",
+   "stride_category": "I",
+   "tier": 3,
+   "prerequisites": "Host/OS Access",
+   "status": "Mitigated",
+   "mitigation": "AES-256-GCM KV envelope applied on the OAuth grants path (src/lib/kv-envelope.ts; src/internal.ts:299).",
+   "identity_key": {
+    "component_id": "SessionStoreKV",
+    "data_flow_id": "DF_OAuthIssuer_to_SessionStoreKV",
+    "stride_category": "I",
+    "attack_surface": "OAuth code/JTI disclosure"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T63.T",
+   "title": "Cache poisoning",
+   "description": "Tampered cached results served.",
+   "stride_category": "T",
+   "tier": 3,
+   "prerequisites": "CloudflareWorker Compromise",
+   "status": "Platform",
+   "mitigation": "In-account only; 5min TTL; force_refresh bypass.",
+   "identity_key": {
+    "component_id": "ScanCacheKV",
+    "data_flow_id": "DF_ToolsHandler_to_ScanCacheKV",
+    "stride_category": "T",
+    "attack_surface": "Cache poisoning"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T64.T",
+   "title": "Counter/trial-key tampering",
+   "description": "Evade limits / escalate tier.",
+   "stride_category": "T",
+   "tier": 3,
+   "prerequisites": "CloudflareWorker Compromise",
+   "status": "Platform",
+   "mitigation": "In-account only; DO fallback.",
+   "identity_key": {
+    "component_id": "RateLimitKV",
+    "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+    "stride_category": "T",
+    "attack_surface": "Counter/trial-key tampering"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T65.I",
+   "title": "Trial-key disclosure",
+   "description": "Keys exposed if KV compromised.",
+   "stride_category": "I",
+   "tier": 3,
+   "prerequisites": "Host/OS Access",
+   "status": "Open",
+   "mitigation": "Platform encryption at rest; bounded lifetime.",
+   "identity_key": {
+    "component_id": "RateLimitKV",
+    "data_flow_id": "DF_RateLimiter_to_RateLimitKV",
+    "stride_category": "I",
+    "attack_surface": "Trial-key disclosure"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T66.I",
+   "title": "Access-log IP disclosure",
+   "description": "Client IP evidence exposed.",
+   "stride_category": "I",
+   "tier": 3,
+   "prerequisites": "Host/OS Access",
+   "status": "Mitigated",
+   "mitigation": "AES-GCM encryption; versioned key; 90-day retention.",
+   "identity_key": {
+    "component_id": "IntelligenceDB",
+    "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+    "stride_category": "I",
+    "attack_surface": "Access-log IP disclosure"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T67.T",
+   "title": "Access-log tampering",
+   "description": "Hide abuse by editing logs.",
+   "stride_category": "T",
+   "tier": 3,
+   "prerequisites": "CloudflareWorker Compromise",
+   "status": "Platform",
+   "mitigation": "D1 in-account; append-oriented writes.",
+   "identity_key": {
+    "component_id": "IntelligenceDB",
+    "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+    "stride_category": "T",
+    "attack_surface": "Access-log tampering"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T68.R",
+   "title": "Insufficient retention",
+   "description": "Forensic gaps.",
+   "stride_category": "R",
+   "tier": 3,
+   "prerequisites": "Host/OS Access",
+   "status": "Mitigated",
+   "mitigation": "Scheduled 90-day mcp_access_log retention delete (src/scheduled.ts:89-100).",
+   "identity_key": {
+    "component_id": "IntelligenceDB",
+    "data_flow_id": "DF_McpExecutor_to_IntelligenceDB",
+    "stride_category": "R",
+    "attack_surface": "Insufficient retention"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "T69.S",
+   "title": "Forged entitlements",
+   "description": "Compromised bv-web elevates tier.",
+   "stride_category": "S",
+   "tier": 3,
+   "prerequisites": "BvWeb Compromise",
+   "status": "Mitigated",
+   "mitigation": "Authenticated binding; enum validation.",
+   "identity_key": {
+    "component_id": "BvWeb",
+    "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+    "stride_category": "S",
+    "attack_surface": "Forged entitlements"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T70.I",
+   "title": "Entitlement data in transit",
+   "description": "Plan data exposed between workers.",
+   "stride_category": "I",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "In-account binding; intra-CF TLS.",
+   "identity_key": {
+    "component_id": "BvWeb",
+    "data_flow_id": "DF_OAuthIssuer_to_BvWeb",
+    "stride_category": "I",
+    "attack_surface": "Entitlement data in transit"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T71.D",
+   "title": "bv-web unavailability",
+   "description": "Paid auth blocked.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "Static key fallback; free tier unaffected.",
+   "identity_key": {
+    "component_id": "BvWeb",
+    "data_flow_id": "DF_TierAuthResolver_to_BvWeb",
+    "stride_category": "D",
+    "attack_surface": "bv-web unavailability"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T72.S",
+   "title": "Resolver spoofing",
+   "description": "Poisoned answers.",
+   "stride_category": "S",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "TLS; multi-resolver; secondary token.",
+   "identity_key": {
+    "component_id": "PublicDoH",
+    "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+    "stride_category": "S",
+    "attack_surface": "Resolver spoofing"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T73.T",
+   "title": "On-wire DNS tampering",
+   "description": "Tamper responses.",
+   "stride_category": "T",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "TLS (DoH).",
+   "identity_key": {
+    "component_id": "PublicDoH",
+    "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+    "stride_category": "T",
+    "attack_surface": "On-wire DNS tampering"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T74.D",
+   "title": "Resolver outage",
+   "description": "Degrade scan availability.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "Fallback chain (bv-dns -> Google).",
+   "identity_key": {
+    "component_id": "PublicDoH",
+    "data_flow_id": "DF_DnsResolver_to_PublicDoH",
+    "stride_category": "D",
+    "attack_surface": "Resolver outage"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T75.T",
+   "title": "Malicious CT data",
+   "description": "Inflate candidate sets.",
+   "stride_category": "T",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "crt.sh fallback + validation; bounded.",
+   "identity_key": {
+    "component_id": "CertTransparency",
+    "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+    "stride_category": "T",
+    "attack_surface": "Malicious CT data"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T76.D",
+   "title": "CT source outage",
+   "description": "Degrade discovery.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "Direct crt.sh fallback + jittered backoff.",
+   "identity_key": {
+    "component_id": "CertTransparency",
+    "data_flow_id": "DF_BrandAuditPipeline_to_CertTransparency",
+    "stride_category": "D",
+    "attack_surface": "CT source outage"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T77.I",
+   "title": "Untrusted WHOIS data injection",
+   "description": "Injected content in reports.",
+   "stride_category": "I",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "Output sanitization via createFinding().",
+   "identity_key": {
+    "component_id": "WhoisRdap",
+    "data_flow_id": "DF_BrandAuditPipeline_to_WhoisRdap",
+    "stride_category": "I",
+    "attack_surface": "Untrusted WHOIS data injection"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T78.D",
+   "title": "WHOIS/RDAP outage",
+   "description": "Degrade enrichment.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "RDAP-only fallback; KV-cached referrals.",
+   "identity_key": {
+    "component_id": "WhoisRdap",
+    "data_flow_id": "DF_BrandAuditPipeline_to_WhoisRdap",
+    "stride_category": "D",
+    "attack_surface": "WHOIS/RDAP outage"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "T79.S",
+   "title": "Stolen API key invokes identity-secops tools",
+   "description": "A stolen/leaked paid-tier key can query M365 identity tools as that principal.",
+   "stride_category": "S",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Mitigated",
+   "mitigation": "AUTH_REQUIRED_TOOLS 401 gate + keyHash backstop; ver revocation.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "M365Proxy",
+    "data_flow_id": "DF_ToolsHandler_to_M365Proxy",
+    "stride_category": "S",
+    "attack_surface": "tools/call query_signins"
+   }
+  },
+  {
+   "id": "T80.I",
+   "title": "Cross-tenant M365 log access",
+   "description": "Caller-supplied ms_tenant_id forwarded with trusted bearer; tenant entitlement enforced only in bv-web on the forwarded keyHash.",
+   "stride_category": "I",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "keyHash forwarded (src/tools/m365/proxy.ts:38); cross-service enforcement unverified from this repo.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "M365Proxy",
+    "data_flow_id": "DF_M365Proxy_to_BvWeb",
+    "stride_category": "I",
+    "attack_surface": "ms_tenant_id argument"
+   }
+  },
+  {
+   "id": "T81.I",
+   "title": "Tenant-ID enumeration via error codes",
+   "description": "Distinguishable m365_proxy_* error codes reveal tenant existence/authorization state.",
+   "stride_category": "I",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "No error bleaching (src/tools/m365/proxy.ts:41-49).",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "M365Proxy",
+    "data_flow_id": "DF_M365Proxy_to_BvWeb",
+    "stride_category": "I",
+    "attack_surface": "m365_proxy_* errors"
+   }
+  },
+  {
+   "id": "T82.D",
+   "title": "Unmetered M365 query volume",
+   "description": "Identity tools are in INTENTIONALLY_UNLIMITED_TOOLS, allowing cost/load amplification on bv-web and Graph.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "Global/per-IP caps only (src/lib/config.ts:457-467).",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "M365Proxy",
+    "data_flow_id": "DF_M365Proxy_to_BvWeb",
+    "stride_category": "D",
+    "attack_surface": "identity_secops quota"
+   }
+  },
+  {
+   "id": "T83.A",
+   "title": "Surveillance via identity tools",
+   "description": "Authorized-but-overbroad principal monitors an org's sign-in/audit activity.",
+   "stride_category": "A",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Mitigated",
+   "mitigation": "Read-only tool set; bv-web tenant scope; access logged.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "M365Proxy",
+    "data_flow_id": "DF_M365Proxy_to_BvWeb",
+    "stride_category": "A",
+    "attack_surface": "query_signins/query_ual"
+   }
+  },
+  {
+   "id": "T84.S",
+   "title": "Compromised bv-recon forges intelligence",
+   "description": "A compromised bv-recon worker plants forged findings in customer reports.",
+   "stride_category": "S",
+   "tier": 3,
+   "prerequisites": "BvRecon Compromise",
+   "status": "Mitigated",
+   "mitigation": "Bearer-authenticated in-account binding; operator-controlled.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvRecon",
+    "data_flow_id": "DF_ToolsHandler_to_BvRecon",
+    "stride_category": "S",
+    "attack_surface": "recon binding responses"
+   }
+  },
+  {
+   "id": "T85.T",
+   "title": "Recon payload prompt injection",
+   "description": "Attacker-controlled bucket/feed strings flow into finding metadata consumed by LLMs.",
+   "stride_category": "T",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "sanitize-upstream strips C0/ANSI and clamps; injection tests incomplete for bucket/feed spread.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvRecon",
+    "data_flow_id": "DF_ToolsHandler_to_BvRecon",
+    "stride_category": "T",
+    "attack_surface": "scan-buckets/threat-feed metadata"
+   }
+  },
+  {
+   "id": "T86.I",
+   "title": "Cross-principal recon result polling",
+   "description": "Operation IDs are pollable with any valid key; ownership enforcement assumed in bv-recon.",
+   "stride_category": "I",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Open",
+   "mitigation": "Opaque UUIDs; no principal binding on poll (src/tools/osint-investigate.ts:115-145).",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvRecon",
+    "data_flow_id": "DF_ToolsHandler_to_BvRecon",
+    "stride_category": "I",
+    "attack_surface": "osint_investigation_status/report ids"
+   }
+  },
+  {
+   "id": "T87.D",
+   "title": "Recon job flooding",
+   "description": "OSINT/bucket starts spawn expensive backend work on bv-recon.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Mitigated",
+   "mitigation": "Paid-only gating; request-dedup; per-tier daily quotas.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvRecon",
+    "data_flow_id": "DF_ToolsHandler_to_BvRecon",
+    "stride_category": "D",
+    "attack_surface": "*_start tools"
+   }
+  },
+  {
+   "id": "T88.A",
+   "title": "People-OSINT abuse",
+   "description": "Username/email investigations used against arbitrary third parties.",
+   "stride_category": "A",
+   "tier": 2,
+   "prerequisites": "Authenticated User",
+   "status": "Mitigated",
+   "mitigation": "People-OSINT restricted to owner/enterprise; logged per principal.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvRecon",
+    "data_flow_id": "DF_ToolsHandler_to_BvRecon",
+    "stride_category": "A",
+    "attack_surface": "osint_investigate_username/email"
+   }
+  },
+  {
+   "id": "T89.I",
+   "title": "TLS probe as internal reachability oracle",
+   "description": "Probe responses could leak internal-network reachability if bv-tls-probe lacks host validation.",
+   "stride_category": "I",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Open",
+   "mitigation": "Domain pre-validated by check_ssl sanitizer; probe-side validation assumed (src/lib/tls-probe-binding.ts:63-83).",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvTlsProbe",
+    "data_flow_id": "DF_ToolsHandler_to_BvTlsProbe",
+    "stride_category": "I",
+    "attack_surface": "probe?host= parameter"
+   }
+  },
+  {
+   "id": "T90.T",
+   "title": "Forged TLS-version results",
+   "description": "A compromised bv-tls-probe skews SSL scores with fake legacy-TLS findings.",
+   "stride_category": "T",
+   "tier": 3,
+   "prerequisites": "BvTlsProbe Compromise",
+   "status": "Mitigated",
+   "mitigation": "Operator-controlled binding; hardcoded literal version matching.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvTlsProbe",
+    "data_flow_id": "DF_ToolsHandler_to_BvTlsProbe",
+    "stride_category": "T",
+    "attack_surface": "probe response"
+   }
+  },
+  {
+   "id": "T91.D",
+   "title": "Probe latency exhaustion",
+   "description": "Hanging probe targets consume the check_ssl latency budget.",
+   "stride_category": "D",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "8 s probe timeout; fail-soft merge.",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvTlsProbe",
+    "data_flow_id": "DF_ToolsHandler_to_BvTlsProbe",
+    "stride_category": "D",
+    "attack_surface": "TLS_PROBE_TIMEOUT_MS"
+   }
+  },
+  {
+   "id": "T92.E",
+   "title": "LKG tier outlives revocation during outage",
+   "description": "A key revoked while bv-web returns 5xx keeps its last-known-good tier up to 24 h.",
+   "stride_category": "E",
+   "tier": 3,
+   "prerequisites": "Authenticated User + BvWeb Compromise",
+   "status": "Mitigated",
+   "mitigation": "LKG never consulted on 4xx; 24 h TTL (src/lib/tier-auth.ts:302-317).",
+   "change_status": "new_in_modified",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "data_flow_id": "DF_TierAuthResolver_to_BvWeb",
+    "stride_category": "E",
+    "attack_surface": "tier:lkg cache"
+   }
+  },
+  {
+   "id": "T93.A",
+   "title": "Agent-chat allowlist evasion",
+   "description": "Internal caller omits/alters x-bv-caller to escape the 13-tool read-only allowlist.",
+   "stride_category": "A",
+   "tier": 2,
+   "prerequisites": "Internal Network",
+   "status": "Mitigated",
+   "mitigation": "Allowlist enforced at call+batch with name normalization; bv-web gateway enforces independently (src/internal.ts:217-223,419-422).",
+   "change_status": "new_in_modified",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "data_flow_id": "DF_Operator_to_InternalRouter",
+    "stride_category": "A",
+    "attack_surface": "x-bv-caller header"
+   }
+  }
+ ],
+ "findings": [
+  {
+   "id": "FIND-01",
+   "title": "API key accepted via query parameter",
+   "severity": "Moderate",
+   "cvss_score": 5.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-598",
+   "owasp": "A04:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T11.I"
+   ],
+   "evidence_files": [
+    "src/lib/tier-auth.ts",
+    "src/lib/auth.ts"
+   ],
+   "component": "TierAuthResolver",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "vulnerability": "CWE-598",
+    "attack_surface": "src/index.ts ?api_key="
+   },
+   "change_status": "partially_mitigated"
+  },
+  {
+   "id": "FIND-02",
+   "title": "Free-tier abuse via distributed IPs",
+   "severity": "Moderate",
+   "cvss_score": 5.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+   "cwe": "CWE-770",
+   "owasp": "A06:2025",
+   "tier": 1,
+   "effort": "Medium",
+   "related_threats": [
+    "T07.A",
+    "T46.E"
+   ],
+   "evidence_files": [
+    "src/lib/rate-limiter.ts",
+    "src/lib/fuzzing-detector.ts"
+   ],
+   "component": "RateLimiter",
+   "identity_key": {
+    "component_id": "RateLimiter",
+    "vulnerability": "CWE-770",
+    "attack_surface": "src/lib/rate-limiter.ts"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "FIND-03",
+   "title": "Scanner usable as recon/amplification proxy",
+   "severity": "Moderate",
+   "cvss_score": 5.1,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:N/SC:N/SI:N/SA:L",
+   "cwe": "CWE-406",
+   "owasp": "A06:2025",
+   "tier": 1,
+   "effort": "Medium",
+   "related_threats": [
+    "T32.A",
+    "T42.D",
+    "T43.A",
+    "T87.D",
+    "T88.A"
+   ],
+   "evidence_files": [
+    "src/handlers/tools.ts"
+   ],
+   "component": "ToolsHandler",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "vulnerability": "CWE-406",
+    "attack_surface": "src/tools/ scan tools"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "FIND-04",
+   "title": "OAuth issuer from spoofable Host header",
+   "severity": "Moderate",
+   "cvss_score": 4.8,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-350",
+   "owasp": "A02:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T05.I"
+   ],
+   "evidence_files": [
+    "src/index.ts"
+   ],
+   "component": "HonoWorker",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "vulnerability": "CWE-350",
+    "attack_surface": "src/oauth/discovery.ts"
+   },
+   "change_status": "partially_mitigated"
+  },
+  {
+   "id": "FIND-05",
+   "title": "Open OAuth dynamic client registration",
+   "severity": "Low",
+   "cvss_score": 4.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+   "cwe": "CWE-1188",
+   "owasp": "A02:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T15.S"
+   ],
+   "evidence_files": [
+    "src/oauth/jwt.ts",
+    "src/oauth/token.ts",
+    "src/oauth/authorize.ts"
+   ],
+   "component": "OAuthIssuer",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "vulnerability": "CWE-1188",
+    "attack_surface": "src/oauth/register.ts"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "FIND-06",
+   "title": "force_refresh cache-busting amplification",
+   "severity": "Low",
+   "cvss_score": 3.7,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+   "cwe": "CWE-770",
+   "owasp": "A06:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T33.A"
+   ],
+   "evidence_files": [
+    "src/handlers/tools.ts"
+   ],
+   "component": "ToolsHandler",
+   "identity_key": {
+    "component_id": "ToolsHandler",
+    "vulnerability": "CWE-770",
+    "attack_surface": "src/lib/cache.ts force_refresh"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "FIND-07",
+   "title": "Domain validation hardening for homoglyph/IDN",
+   "severity": "Low",
+   "cvss_score": 3.1,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:N/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-1007",
+   "owasp": "A03:2025",
+   "tier": 1,
+   "effort": "Medium",
+   "related_threats": [
+    "T34.T"
+   ],
+   "evidence_files": [
+    "src/lib/sanitize.ts",
+    "src/lib/config.ts"
+   ],
+   "component": "DomainSanitizer",
+   "identity_key": {
+    "component_id": "DomainSanitizer",
+    "vulnerability": "CWE-1007",
+    "attack_surface": "src/lib/sanitize.ts"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "FIND-08",
+   "title": "Authentication & token-integrity controls (existing control)",
+   "severity": "Low",
+   "cvss_score": 2.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-287",
+   "owasp": "A07:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T08.S",
+    "T09.S",
+    "T10.T",
+    "T12.E",
+    "T14.A",
+    "T16.T",
+    "T17.I",
+    "T21.S"
+   ],
+   "evidence_files": [
+    "src/lib/tier-auth.ts",
+    "src/lib/auth.ts"
+   ],
+   "component": "TierAuthResolver",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "vulnerability": "CWE-287",
+    "attack_surface": "src/lib/tier-auth.ts"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "FIND-09",
+   "title": "SSRF egress controls (existing control)",
+   "severity": "Low",
+   "cvss_score": 2.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-918",
+   "owasp": "A06:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T35.I",
+    "T36.E",
+    "T37.T",
+    "T38.I",
+    "T39.D"
+   ],
+   "evidence_files": [
+    "src/lib/safe-fetch.ts"
+   ],
+   "component": "SafeFetch",
+   "identity_key": {
+    "component_id": "SafeFetch",
+    "vulnerability": "CWE-918",
+    "attack_surface": "src/lib/safe-fetch.ts"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "FIND-10",
+   "title": "Rate limiting, quotas & DoS budgets (existing control)",
+   "severity": "Low",
+   "cvss_score": 2.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+   "cwe": "CWE-770",
+   "owasp": "A06:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T01.S",
+    "T02.T",
+    "T06.D",
+    "T18.D",
+    "T22.T",
+    "T25.D",
+    "T26.E",
+    "T27.A",
+    "T28.T",
+    "T30.D",
+    "T31.E",
+    "T44.T",
+    "T45.D",
+    "T47.A"
+   ],
+   "evidence_files": [
+    "src/lib/rate-limiter.ts",
+    "src/lib/fuzzing-detector.ts"
+   ],
+   "component": "RateLimiter",
+   "identity_key": {
+    "component_id": "RateLimiter",
+    "vulnerability": "CWE-770",
+    "attack_surface": "src/lib/rate-limiter.ts"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "FIND-11",
+   "title": "Information-disclosure controls (existing control)",
+   "severity": "Low",
+   "cvss_score": 2.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-209",
+   "owasp": "A09:2025",
+   "tier": 1,
+   "effort": "Low",
+   "related_threats": [
+    "T03.R",
+    "T04.I",
+    "T23.R",
+    "T24.I",
+    "T29.I",
+    "T66.I",
+    "T68.R"
+   ],
+   "evidence_files": [
+    "src/index.ts"
+   ],
+   "component": "HonoWorker",
+   "identity_key": {
+    "component_id": "HonoWorker",
+    "vulnerability": "CWE-209",
+    "attack_surface": "src/lib/json-rpc.ts"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "FIND-12",
+   "title": "Internal routes default to no bearer auth",
+   "severity": "Moderate",
+   "cvss_score": 5.1,
+   "cvss_vector": "CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:L/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-1188",
+   "owasp": "A02:2025",
+   "tier": 2,
+   "effort": "Low",
+   "related_threats": [
+    "T52.A"
+   ],
+   "evidence_files": [
+    "src/internal.ts"
+   ],
+   "component": "InternalRouter",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "vulnerability": "CWE-1188",
+    "attack_surface": "src/internal.ts REQUIRE_INTERNAL_AUTH"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "FIND-13",
+   "title": "JWT retains elevated tier after plan downgrade",
+   "severity": "Moderate",
+   "cvss_score": 4.6,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+   "cwe": "CWE-613",
+   "owasp": "A07:2025",
+   "tier": 2,
+   "effort": "Medium",
+   "related_threats": [
+    "T20.A"
+   ],
+   "evidence_files": [
+    "src/oauth/jwt.ts",
+    "src/oauth/token.ts",
+    "src/oauth/authorize.ts"
+   ],
+   "component": "OAuthIssuer",
+   "identity_key": {
+    "component_id": "OAuthIssuer",
+    "vulnerability": "CWE-613",
+    "attack_surface": "src/oauth/jwt.ts"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "FIND-14",
+   "title": "Brand-audit discovery enables third-party enumeration",
+   "severity": "Moderate",
+   "cvss_score": 4.3,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-799",
+   "owasp": "A06:2025",
+   "tier": 2,
+   "effort": "Medium",
+   "related_threats": [
+    "T54.I",
+    "T56.A"
+   ],
+   "evidence_files": [
+    "src/lib/brand-audit-pipeline.ts",
+    "src/scheduled.ts"
+   ],
+   "component": "BrandAuditPipeline",
+   "identity_key": {
+    "component_id": "BrandAuditPipeline",
+    "vulnerability": "CWE-799",
+    "attack_surface": "src/lib/brand-audit-pipeline.ts"
+   },
+   "change_status": "partially_mitigated"
+  },
+  {
+   "id": "FIND-15",
+   "title": "Trial-key tier persists during cache window",
+   "severity": "Low",
+   "cvss_score": 3.5,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+   "cwe": "CWE-613",
+   "owasp": "A07:2025",
+   "tier": 2,
+   "effort": "Low",
+   "related_threats": [
+    "T13.E"
+   ],
+   "evidence_files": [
+    "src/lib/tier-auth.ts",
+    "src/lib/auth.ts"
+   ],
+   "component": "TierAuthResolver",
+   "identity_key": {
+    "component_id": "TierAuthResolver",
+    "vulnerability": "CWE-613",
+    "attack_surface": "src/lib/tier-auth.ts TRIAL_KEY_CACHE_TTL"
+   },
+   "change_status": "fixed"
+  },
+  {
+   "id": "FIND-16",
+   "title": "Internal isolation & dependency hardening (existing control)",
+   "severity": "Low",
+   "cvss_score": 2.5,
+   "cvss_vector": "CVSS:4.0/AV:A/AC:L/AT:N/PR:N/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-306",
+   "owasp": "A04:2025",
+   "tier": 2,
+   "effort": "Low",
+   "related_threats": [
+    "T19.E",
+    "T40.S",
+    "T41.T",
+    "T48.S",
+    "T49.T",
+    "T50.D",
+    "T51.E",
+    "T53.T",
+    "T55.D",
+    "T58.D",
+    "T59.T",
+    "T60.A",
+    "T69.S",
+    "T70.I",
+    "T71.D",
+    "T72.S",
+    "T73.T",
+    "T74.D",
+    "T75.T",
+    "T76.D",
+    "T77.I",
+    "T78.D"
+   ],
+   "evidence_files": [
+    "src/internal.ts"
+   ],
+   "component": "InternalRouter",
+   "identity_key": {
+    "component_id": "InternalRouter",
+    "vulnerability": "CWE-306",
+    "attack_surface": "src/internal.ts"
+   },
+   "change_status": "still_present"
+  },
+  {
+   "id": "FIND-17",
+   "title": "Sensitive KV records rely on platform isolation only",
+   "severity": "Low",
+   "cvss_score": 4.2,
+   "cvss_vector": "CVSS:4.0/AV:L/AC:L/AT:N/PR:H/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-311",
+   "owasp": "A04:2025",
+   "tier": 3,
+   "effort": "Medium",
+   "related_threats": [
+    "T62.I",
+    "T65.I"
+   ],
+   "evidence_files": [
+    "src/lib/rate-limiter.ts",
+    "src/lib/trial-keys.ts"
+   ],
+   "component": "RateLimitKV",
+   "identity_key": {
+    "component_id": "RateLimitKV",
+    "vulnerability": "CWE-311",
+    "attack_surface": "src/lib/trial-keys.ts, src/oauth/storage.ts"
+   },
+   "change_status": "partially_mitigated"
+  },
+  {
+   "id": "FIND-18",
+   "title": "Recon operation IDs are not bound to the requesting principal on poll",
+   "severity": "Low",
+   "cvss_score": 4.1,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:L/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-639",
+   "owasp": "A01:2025",
+   "tier": 2,
+   "effort": "Medium",
+   "related_threats": [
+    "T84.S",
+    "T86.I"
+   ],
+   "evidence_files": [
+    "src/tools/osint-investigate.ts",
+    "src/lib/recon-binding.ts",
+    "src/tools/scan-buckets.ts"
+   ],
+   "component": "BvRecon",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvRecon",
+    "vulnerability": "CWE-639",
+    "attack_surface": "osint_investigation_status/report scan_buckets_status/findings ids"
+   }
+  },
+  {
+   "id": "FIND-19",
+   "title": "M365 tenant authorization is delegated cross-service on a forwarded keyHash",
+   "severity": "Moderate",
+   "cvss_score": 5.5,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:H/VI:N/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-862",
+   "owasp": "A01:2025",
+   "tier": 2,
+   "effort": "Medium",
+   "related_threats": [
+    "T79.S",
+    "T80.I",
+    "T81.I",
+    "T83.A"
+   ],
+   "evidence_files": [
+    "src/tools/m365/proxy.ts",
+    "src/handlers/tools.ts",
+    "src/mcp/execute.ts"
+   ],
+   "component": "M365Proxy",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "M365Proxy",
+    "vulnerability": "CWE-862",
+    "attack_surface": "ms_tenant_id via /api/internal/m365/*"
+   }
+  },
+  {
+   "id": "FIND-20",
+   "title": "M365 identity tools are intentionally unmetered per-tool",
+   "severity": "Low",
+   "cvss_score": 3.5,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:N/VI:N/VA:L/SC:N/SI:N/SA:N",
+   "cwe": "CWE-770",
+   "owasp": "A06:2025",
+   "tier": 2,
+   "effort": "Low",
+   "related_threats": [
+    "T82.D"
+   ],
+   "evidence_files": [
+    "src/lib/config.ts"
+   ],
+   "component": "M365Proxy",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "M365Proxy",
+    "vulnerability": "CWE-770",
+    "attack_surface": "INTENTIONALLY_UNLIMITED_TOOLS identity_secops"
+   }
+  },
+  {
+   "id": "FIND-21",
+   "title": "Recon upstream payloads lack injection-focused test coverage",
+   "severity": "Low",
+   "cvss_score": 3.0,
+   "cvss_vector": "CVSS:4.0/AV:N/AC:L/AT:P/PR:L/UI:N/VC:N/VI:L/VA:N/SC:N/SI:N/SA:N",
+   "cwe": "CWE-1427",
+   "owasp": "A05:2025",
+   "tier": 2,
+   "effort": "Low",
+   "related_threats": [
+    "T85.T"
+   ],
+   "evidence_files": [
+    "src/tools/scan-buckets.ts",
+    "src/tools/check-realtime-threat-feed.ts",
+    "src/lib/sanitize-upstream.ts"
+   ],
+   "component": "BvRecon",
+   "change_status": "new_code",
+   "identity_key": {
+    "component_id": "BvRecon",
+    "vulnerability": "CWE-1427",
+    "attack_surface": "bucket/threat-feed metadata spread into structuredContent"
+   }
+  }
+ ],
+ "metrics": {
+  "total_components": 26,
+  "total_boundaries": 5,
+  "total_flows": 27,
+  "total_threats": 93,
+  "total_findings": 21,
+  "threats_by_tier": {
+   "T1": 40,
+   "T2": 34,
+   "T3": 19
+  },
+  "findings_by_tier": {
+   "T1": 11,
+   "T2": 9,
+   "T3": 1
+  },
+  "threats_by_stride": {
+   "S": 11,
+   "T": 21,
+   "R": 3,
+   "I": 18,
+   "D": 17,
+   "E": 9,
+   "A": 14
+  },
+  "findings_by_severity": {
+   "Critical": 0,
+   "Important": 0,
+   "Moderate": 8,
+   "Low": 13
+  },
+  "status_summary": {
+   "components": {
+    "unchanged": 11,
+    "modified": 12,
+    "new": 3,
+    "removed": 0,
+    "restructured": 0
+   },
+   "threats": {
+    "still_present": 66,
+    "fixed": 12,
+    "mitigated": 0,
+    "new_code": 13,
+    "new_in_modified": 2,
+    "previously_unidentified": 0,
+    "removed_with_component": 0
+   },
+   "findings": {
+    "still_present": 6,
+    "fixed": 7,
+    "partially_mitigated": 4,
+    "new_code": 4,
+    "new_in_modified": 0,
+    "previously_unidentified": 0,
+    "removed_with_component": 0
+   }
+  }
+ }
+}


### PR DESCRIPTION
## Summary

Incremental threat model of bv-mcp at `7a1c6b3` (v3.18.0) against baseline `docs/threat-model/threat-model-20260524-114907` (commit `7e23243`) and the interim remediation overlay at `f75ca7d` — a 230-commit / ~159-PR window. Docs-only: adds the 9-file report folder `docs/threat-model/threat-model-20260611-112908/`.

## Highlights

- **12 baseline threats code-verified fixed**: distinct-domain cap (FIND-02), paid-only offensive-tool gating (FIND-03), secure-by-default internal bearer gate (FIND-12), JWT `ver` revocation + entitlement TTL clamp (FIND-13), trial-key expiry recheck (FIND-15), force_refresh cap (FIND-06), mixed-script rejection (FIND-07), KV envelope on the OAuth path, 90-day access-log retention.
- **3 new components modeled** (M365Proxy, BvRecon, BvTlsProbe) → 15 new threats (T79–T93), 4 new findings (FIND-18–21), all Tier 2 / credential-gated.
- **One status downgrade vs the interim overlay**: FIND-17 fixed → Partial (trial-key KV records still not envelope-wrapped) — disagreement logged in Needs Verification per the incremental methodology.
- **Risk rating: Low (was Moderate at baseline); direction: Improving.** Residual work is concentrated in cross-service contracts (bv-web M365 tenant scoping, bv-recon poll-ID ownership, bv-tls-probe host validation) and two deploy-config activations (`REJECT_QUERY_API_KEY`, `OAUTH_ISSUER`).

Totals: 93 threats (40/34/19 by tier), 21 findings (11/9/1), 26 components, 5 boundaries, 27 flows. Verified by the threat-model verification checklist (187 checks; 4 consistency fixes applied and re-verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)