### PR TITLE
docs(m365): correct stale M365 proxy target comment (#403)

### DIFF
--- a/src/tools/m365/proxy.ts
+++ b/src/tools/m365/proxy.ts
@@ -13,8 +13,14 @@
  */
 import type { M365ProxyResult } from './types';
 
-// Routes live at /api/internal/m365/* on the bv-web SSR app — the prior
-// `/m365/*` path returned 405 (SSR has no top-level /m365 route).
+// Target endpoint for the M365 read tools, reached via the `BV_WEB` service
+// binding. NOTE (issue #403): this `/api/internal/m365/*` path was served by
+// the now-retired `bv-web` SSR app. The active app, `bv-web-prod`, does NOT
+// implement it — M365 there is session-authenticated dashboard reads from D1
+// (`app/lib/dashboard/m365/*`), not an internal proxy. Until/unless that
+// endpoint is built downstream, the four identity_secops tools fail-soft with
+// `m365_proxy_404` in prod (the proxy never throws — see callM365Proxy). Kept
+// in place intentionally as a deferred surface; do not treat as live.
 const M365_BASE_URL = 'https://bv-web-internal/api/internal/m365';
 const TIMEOUT_MS = 10_000;
 


### PR DESCRIPTION
Addresses the documentation foot-gun in #403.

## Investigation (bv-mcp + bv-web-prod, both checked out)

| Surface | Live consumer? | Decision |
|---|---|---|
| **M365 proxy** (`src/tools/m365/proxy.ts` → `/api/internal/m365/*`) | **No** — bv-web-prod implements no such route; the target was the retired `bv-web`. The 4 `identity_secops` tools (`query_signins`, `query_ual`, `get_ca_policies`, `assess_coverage`) currently return `m365_proxy_404` in prod (fail-soft, never throw). | **Keep** as a deferred product surface; fix the misleading comment only (this PR). |
| **Tenant routes** (`/internal/tenants/{portfolio,scan,discover,report}`) | No consumer in bv-web-prod, **but a private operator worker consumes them** (operator-confirmed). | **Keep** — out of scope for this PR. |

## Change

Comment-only edit in `proxy.ts`: the old comment asserted `/api/internal/m365/*` is served by "the bv-web SSR app". That endpoint only existed on the retired `bv-web`; `bv-web-prod` serves M365 as session-authenticated D1 dashboard reads (`app/lib/dashboard/m365/*`), not an internal proxy. The comment now documents the real state and that the surface is intentionally deferred. **No behavior change.**

The broader #403 ask (remove/repoint the dead config) was declined per operator review — both surfaces stay — so #403 remains open to track any future bv-web-prod `/api/internal/m365/*` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)