### PR TITLE
chore: release 3.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.18.1] - 2026-06-18
+
+Maintenance release: dependency bumps only. No scoring/scan change; `SCORING_MODEL_VERSION` unchanged; tool count unchanged (75).
+
+### Changed
+
+- **Dependencies:** bump `tldts` 7.4.2 → 7.4.3 (runtime — public-suffix data refresh used by `src/lib/public-suffix.ts`). Dev tooling: Cloudflare group (`wrangler` 4.99 → 4.101, `miniflare`/`workerd` to `20260616`), `vitest` 4.1.8 → 4.1.9, `eslint` 10.4.1 → 10.5.0, `typescript-eslint` 8.61.0 → 8.61.1, `playwright` 1.60.0 → 1.61.0 (#406–#411).
+
 ## [3.18.0] - 2026-06-11
 
 ### Security

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.18.0",
+	"version": "3.18.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.18.0",
+			"version": "3.18.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.18.0",
+	"version": "3.18.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.18.0",
+	"version": "3.18.1",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Maintenance release — dependency bumps only (#406–#411).

Bumps the version-sync surfaces (package.json + lock, server.json top-level, CHANGELOG `[3.18.1]`) so the prod deploy advertises a distinct `serverInfo.version`. `SERVER_VERSION` auto-derives from `package.json`.

**Runtime delta vs 3.18.0:** only `tldts` 7.4.2 → 7.4.3 (public-suffix data refresh, `src/lib/public-suffix.ts`). The other five bumps are dev tooling and don't ship in the Worker bundle. No scoring/scan change; tool count unchanged (75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)