### PR TITLE
chore(config): point BV_WEB binding at bv-web-prod (bv-web retired)

### DIFF
--- a/scripts/maintenance/update_wrangler.cjs
+++ b/scripts/maintenance/update_wrangler.cjs
@@ -11,7 +11,7 @@ function addBinding(filePath) {
     if (!config.services.find(s => s.binding === 'BV_WEB')) {
         config.services.push({
             "binding": "BV_WEB",
-            "service": "blackveil-web"
+            "service": "bv-web-prod"
         });
     }
     

--- a/scripts/maintenance/update_wrangler.js
+++ b/scripts/maintenance/update_wrangler.js
@@ -11,7 +11,7 @@ function addBinding(filePath) {
     if (!config.services.find(s => s.binding === 'BV_WEB')) {
         config.services.push({
             "binding": "BV_WEB",
-            "service": "blackveil-web"
+            "service": "bv-web-prod"
         });
     }
     

--- a/test/audits/oauth-production-config.audit.test.ts
+++ b/test/audits/oauth-production-config.audit.test.ts
@@ -39,7 +39,7 @@ describe('production OAuth configuration audit', () => {
 		expect(config.services).toContainEqual(
 			expect.objectContaining({
 				binding: 'BV_WEB',
-				service: 'blackveil-web',
+				service: 'bv-web-prod',
 			}),
 		);
 	});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -68,7 +68,7 @@
   "services": [
     {
       "binding": "BV_WEB",
-      "service": "blackveil-web"
+      "service": "bv-web-prod"
     },
     {
       "binding": "BV_WHOIS",


### PR DESCRIPTION
Public `wrangler.jsonc` and the one-off `scripts/maintenance/update_wrangler.*` helpers still named the **retired `blackveil-web`** worker for the `BV_WEB` service binding. bv-web was decommissioned → `bv-web-prod`.

BlackVeil prod already overrides this in the private `.dev/wrangler.deploy.jsonc` overlay (repointed + redeployed today), so **no deploy impact** — this just aligns the public default + docs so BSL self-host config is correct and there's no lingering stale reference.

Found while fixing the static MCP-API-key path: the stale binding made bv-mcp's validate-key/OAuth-entitlement/analytics calls hit the dead worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)