### PR TITLE
fix(m365): repoint identity_secops proxy at bv-web-prod internal route (#403)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -78,16 +78,16 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
-			"version": "0.16.16",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.16.tgz",
-			"integrity": "sha512-Pwh1arsA09wAMPWb7LiPgcnIYHfzcVAmQiv9bF1NYWGaUeY4Ida+wZdBNZo4FdTn/5pOfBqaJOx1RYrCEqdivg==",
+			"version": "0.16.17",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.17.tgz",
+			"integrity": "sha512-DTd1TBNeZPVhE2sYmLJiEi1z7Z8/QM78ggZ9ci7kOfUSGbA9Bt6ui3vN8f//oanlso9EGZ3AqUsObtqVeMY7Cw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cjs-module-lexer": "1.2.3",
-				"esbuild": "0.27.3",
-				"miniflare": "4.20260616.0",
-				"wrangler": "4.101.0",
+				"esbuild": "0.28.1",
+				"miniflare": "4.20260617.0",
+				"wrangler": "4.102.0",
 				"zod": "3.25.76"
 			},
 			"peerDependencies": {
@@ -107,9 +107,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-64": {
-			"version": "1.20260616.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260616.1.tgz",
-			"integrity": "sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A==",
+			"version": "1.20260617.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260617.1.tgz",
+			"integrity": "sha512-jWwmgEVVWbsHNrLSNXzwjJaH90VzRxq1cWkQFUidxyeUPnMxemeNE8I9qFAfrpzGgE11e9sKDcE3ettJW08swQ==",
 			"cpu": [
 				"x64"
 			],
@@ -124,9 +124,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-darwin-arm64": {
-			"version": "1.20260616.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260616.1.tgz",
-			"integrity": "sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag==",
+			"version": "1.20260617.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260617.1.tgz",
+			"integrity": "sha512-LHH7b565g9znfCUOkwbec6FG2rmRbsgCy6aJiU9KN662mNheWl5sw/iKleiFSiljPKQQP3HkjnC/NSkdgi/aSA==",
 			"cpu": [
 				"arm64"
 			],
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-64": {
-			"version": "1.20260616.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260616.1.tgz",
-			"integrity": "sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA==",
+			"version": "1.20260617.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260617.1.tgz",
+			"integrity": "sha512-FMnaAKXe4Cfd8TQurCVd9fs2XQVBFRCsP+Id/SRdUv89MlwYu9zXfoyx6BxM+brPTIUK38SHbo8iaxiwzLi9JQ==",
 			"cpu": [
 				"x64"
 			],
@@ -158,9 +158,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-linux-arm64": {
-			"version": "1.20260616.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260616.1.tgz",
-			"integrity": "sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw==",
+			"version": "1.20260617.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260617.1.tgz",
+			"integrity": "sha512-MRoifFYcqbxxIIQy7PqO5tFY/qPFSnjXzakWl0sO93l+HLyG35jRAgOi6jfqa4kBxc7gKKtH861DcewjxUfkjA==",
 			"cpu": [
 				"arm64"
 			],
@@ -175,9 +175,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workerd-windows-64": {
-			"version": "1.20260616.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260616.1.tgz",
-			"integrity": "sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ==",
+			"version": "1.20260617.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260617.1.tgz",
+			"integrity": "sha512-rgBV9wQrv0OSKgCTTbhFUFY3sLGNANZ88aqaLvtmEn2gmbFVb1J4PDGochVUdB7NSEp4D/ghHva6/8SZmbONpw==",
 			"cpu": [
 				"x64"
 			],
@@ -1500,19 +1500,6 @@
 				"supports-color": "^10.0.0"
 			}
 		},
-		"node_modules/@poppinss/dumper/node_modules/supports-color": {
-			"version": "10.2.2",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
-			"integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/supports-color?sponsor=1"
-			}
-		},
 		"node_modules/@poppinss/exception": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
@@ -1613,9 +1600,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1633,9 +1617,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1653,9 +1634,6 @@
 				"ppc64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1673,9 +1651,6 @@
 				"s390x"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1693,9 +1668,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -1713,9 +1685,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -2166,9 +2135,9 @@
 			}
 		},
 		"node_modules/@speed-highlight/core": {
-			"version": "1.2.15",
-			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
-			"integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+			"version": "1.2.17",
+			"resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.17.tgz",
+			"integrity": "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -3654,9 +3623,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3678,9 +3644,6 @@
 				"arm64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3702,9 +3665,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"glibc"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3726,9 +3686,6 @@
 				"x64"
 			],
 			"dev": true,
-			"libc": [
-				"musl"
-			],
 			"license": "MPL-2.0",
 			"optional": true,
 			"os": [
@@ -3853,17 +3810,17 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260616.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260616.0.tgz",
-			"integrity": "sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw==",
+			"version": "4.20260617.0",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.0.tgz",
+			"integrity": "sha512-A+H5gcOCQZsKFg7/daZUtx8WHn4gGxwUfH1jnNDAisyAWSvvSZHe+GCeQWs16uthnUDcm72UQIQ1NXDJtnuo9Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@cspotcode/source-map-support": "0.8.1",
 				"sharp": "0.34.5",
-				"undici": "7.24.8",
-				"workerd": "1.20260616.1",
-				"ws": "8.20.1",
+				"undici": "7.28.0",
+				"workerd": "1.20260617.1",
+				"ws": "8.21.0",
 				"youch": "4.1.0-beta.10"
 			},
 			"bin": {
@@ -4535,6 +4492,19 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
+		"node_modules/supports-color": {
+			"version": "10.2.2",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+			"integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/supports-color?sponsor=1"
+			}
+		},
 		"node_modules/thenify": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -4787,9 +4757,9 @@
 			"license": "MIT"
 		},
 		"node_modules/undici": {
-			"version": "7.24.8",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
-			"integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5038,9 +5008,9 @@
 			}
 		},
 		"node_modules/workerd": {
-			"version": "1.20260616.1",
-			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260616.1.tgz",
-			"integrity": "sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg==",
+			"version": "1.20260617.1",
+			"resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260617.1.tgz",
+			"integrity": "sha512-Re5pl6pdowt3ZmWUzGlOuB7jbRIIPetgKalmo4cYmucQnVhpo7/3e4MfpekbhLi2EhZZz5EY9NWRu8zFzuEZew==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "Apache-2.0",
@@ -5051,28 +5021,28 @@
 				"node": ">=16"
 			},
 			"optionalDependencies": {
-				"@cloudflare/workerd-darwin-64": "1.20260616.1",
-				"@cloudflare/workerd-darwin-arm64": "1.20260616.1",
-				"@cloudflare/workerd-linux-64": "1.20260616.1",
-				"@cloudflare/workerd-linux-arm64": "1.20260616.1",
-				"@cloudflare/workerd-windows-64": "1.20260616.1"
+				"@cloudflare/workerd-darwin-64": "1.20260617.1",
+				"@cloudflare/workerd-darwin-arm64": "1.20260617.1",
+				"@cloudflare/workerd-linux-64": "1.20260617.1",
+				"@cloudflare/workerd-linux-arm64": "1.20260617.1",
+				"@cloudflare/workerd-windows-64": "1.20260617.1"
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.101.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.101.0.tgz",
-			"integrity": "sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g==",
+			"version": "4.102.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.102.0.tgz",
+			"integrity": "sha512-GPljlQs9a+/Ai2h0TdEUYaaWv9upK4fUteSWTPlruas7tdixiIwr74CZSWHcEPuRgZYkyYKHIBbT1w+BYPkPrw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
 				"@cloudflare/kv-asset-handler": "0.5.0",
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
-				"esbuild": "0.27.3",
-				"miniflare": "4.20260616.0",
+				"esbuild": "0.28.1",
+				"miniflare": "4.20260617.0",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
-				"workerd": "1.20260616.1"
+				"workerd": "1.20260617.1"
 			},
 			"bin": {
 				"cf-wrangler": "bin/cf-wrangler.js",
@@ -5086,7 +5056,7 @@
 				"fsevents": "2.3.3"
 			},
 			"peerDependencies": {
-				"@cloudflare/workers-types": "^4.20260616.1"
+				"@cloudflare/workers-types": "^4.20260617.1"
 			},
 			"peerDependenciesMeta": {
 				"@cloudflare/workers-types": {

--- a/src/tools/m365/proxy.ts
+++ b/src/tools/m365/proxy.ts
@@ -14,14 +14,25 @@
 import type { M365ProxyResult } from './types';
 
 // Target endpoint for the M365 read tools, reached via the `BV_WEB` service
-// binding. NOTE (issue #403): this `/api/internal/m365/*` path was served by
-// the now-retired `bv-web` SSR app. The active app, `bv-web-prod`, does NOT
-// implement it — M365 there is session-authenticated dashboard reads from D1
-// (`app/lib/dashboard/m365/*`), not an internal proxy. Until/unless that
-// endpoint is built downstream, the four identity_secops tools fail-soft with
-// `m365_proxy_404` in prod (the proxy never throws — see callM365Proxy). Kept
-// in place intentionally as a deferred surface; do not treat as live.
-const M365_BASE_URL = 'https://bv-web-internal/api/internal/m365';
+// binding (repointed at `bv-web-prod` in #414). Over a service binding the host
+// is irrelevant — only the PATH is matched downstream — so the `bv-web-internal`
+// host is a stable placeholder.
+//
+// ISSUE #403 (repoint): this `/api/internal/mcp/m365/*` path is now served by
+// `bv-web-prod` (`app/routes/api/internal/mcp/m365.ts`, registered as
+// `api/internal/mcp/m365/:tool`), mirroring the validate-key internal-route
+// pattern + `BV_WEB_INTERNAL_KEY` bearer auth. The four `<path>` segments map to
+// the four identity_secops tools: `query-signins`, `query-ual`,
+// `get-ca-policies`, `assess-coverage`.
+//
+// HONESTY: bv-web-prod's live M365 posture (Graph fetch / compliance scan) is
+// operator-gated behind its unbound `M365_DB` + Graph token, so today the route
+// returns a clearly-labelled `representative: true` seam (NOT fabricated live
+// data) until that downstream slice is provisioned. bv-mcp passes the response
+// through opaquely as `{ ok: true, data }`. A non-2xx (e.g. 503 when the
+// internal key is unset, 401 on a bad bearer) surfaces as `m365_proxy_<status>`
+// and the tool stays fail-soft — the proxy never throws (see callM365Proxy).
+const M365_BASE_URL = 'https://bv-web-internal/api/internal/mcp/m365';
 const TIMEOUT_MS = 10_000;
 
 export async function callM365Proxy(


### PR DESCRIPTION
Closes #403.

## Problem
bv-mcp's M365 proxy (`src/tools/m365/proxy.ts`) forwarded the 4 `identity_secops` tools (`query_signins`, `query_ual`, `get_ca_policies`, `assess_coverage`) to `…/api/internal/m365/*` — a path with **no route to answer it**. Reached over the `BV_WEB` service binding (already pointed at bv-web-prod by #414), so the defect was the stale **path**, not the host placeholder. Downstream returned `m365_proxy_404`.

## Fix
- Repoint `M365_BASE_URL` path `…/api/internal/m365` → `…/api/internal/mcp/m365` to match the new bv-web-prod internal route (companion PR: MadaBurns/bv-web-prod `fix/403-bv-mcp-m365-internal-route`).
- v3.17.1 hardening (401 pre-dispatch, hard-reject absent `keyHash`, tenant-scope) untouched.

## Note
The bv-web-prod route returns an honest `representative: true` seam (clears the 404 and gives the tools a live target). **Live Microsoft Graph reads remain deferred** — that's new feature design tracked separately.

## Tests
`test/identity-secops-auth-gate.spec.ts` 14✓ · `test/tools/m365.spec.ts` 22✓ · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)