### PR TITLE
release 3.21.0: hardening & global-scalability ship-now wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.21.0] - 2026-06-20
+
+Minor release: hardening & global-scalability ship-now wave from a multi-agent audit of the server. Additive observability + security defense-in-depth + a dependency patch bump. No scoring/scan-model change; `SCORING_MODEL_VERSION` unchanged; tool count unchanged (78).
+
+### Added
+
+- **Server-generated request correlation ID.** Each inbound request is stamped with a `correlationId` (prefers `cf-ray` for cross-correlation with Cloudflare logs, else `crypto.randomUUID()`), threaded via `ExecuteMcpRequestOptions` and stamped onto every `logEvent` on the path — kept distinct from the client-chosen JSON-RPC `requestId` so multi-line traces (auth/rate-limit/dispatch/catch) can be stitched.
+- **Owner-gated deep `/health` readiness mode.** `GET /health?deep=1` (owner-gated; non-owner → 403) runs bounded round-trip probes against `SCAN_CACHE` (KV get/put/delete) and `QUOTA_COORDINATOR` (DO reachability), returning per-binding status. The default cheap liveness path is unchanged.
+- **Binding-degradation telemetry for the operator-only fail-soft bindings** (`BV_RECON`, `BV_TLS_PROBE`). Present-but-failing branches (5xx / timeout / network-unavailable) now emit a structured `binding_degradation` warn log and an optional, fail-soft `degradation` analytics sink (members `binding_unavailable` / `binding_5xx` / `binding_timeout`); expected-absence (BSL self-host) and the recon-404 branch stay silent. Adds a `queryBindingDegradation` query + a 15-min cron alert (`ALERT_BINDING_DEGRADATION_THRESHOLD`). NOTE: the analytics sink is not yet threaded to a live client, so runtime emission is currently the warn log; the analytics-event path + its cron alert activate when a follow-up wires the sink.
+
+### Changed
+
+- **Dependency patch bump:** `hono` 4.12.25 → 4.12.26, `wrangler` → 4.103.0, `@cloudflare/vitest-pool-workers` → 0.16.18, `@cloudflare/workers-types` → 4.20260620.1 (the three Cloudflare devDeps moved in lockstep). 0 npm-audit vulnerabilities.
+
+### Security
+
+- **`PROVIDER_SIGNATURES_URL` fetch routed through `validateOutboundUrl`/`safeFetch`** so an operator-configured signature-source URL gets the same Cloudflare-internal-hostname + userinfo SSRF rejection as the BIMI/RDAP paths (defense-in-depth; operator-set, not request-attacker-controlled).
+- **Removed the unreachable length-mismatch branch in `matchesStaticDevKey`'s constant-time compare** (both operands are invariantly 32-byte SHA-256 digests); the compare now iterates the full fixed 32 bytes, matching the canonical helper. No functional change.
+
 ## [3.20.0] - 2026-06-20
 
 Minor release: async `discover_brand_domains` (start → poll → fetch) to fix interactive-client timeouts, plus two brand-discovery correctness fixes. Tool count 75 → **78**. No scoring/scan-model change; `SCORING_MODEL_VERSION` unchanged.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,19 +25,19 @@
 				"blackveil-dns-mcp": "dist/stdio.js"
 			},
 			"devDependencies": {
-				"@cloudflare/vitest-pool-workers": "^0.16.16",
-				"@cloudflare/workers-types": "4.20260617.1",
+				"@cloudflare/vitest-pool-workers": "^0.16.18",
+				"@cloudflare/workers-types": "4.20260620.1",
 				"@types/marked": "^6.0.0",
 				"@types/punycode": "^2.1.4",
 				"drizzle-kit": "^0.31.10",
 				"eslint": "10.5.0",
-				"hono": "4.12.25",
+				"hono": "4.12.26",
 				"playwright": "^1.61.0",
 				"tsup": "8.5.1",
 				"typescript": "6.0.3",
 				"typescript-eslint": "8.61.1",
 				"vitest": "4.1.9",
-				"wrangler": "^4.101.0"
+				"wrangler": "^4.103.0"
 			},
 			"engines": {
 				"node": ">=22.13.0"
@@ -78,16 +78,16 @@
 			}
 		},
 		"node_modules/@cloudflare/vitest-pool-workers": {
-			"version": "0.16.17",
-			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.17.tgz",
-			"integrity": "sha512-DTd1TBNeZPVhE2sYmLJiEi1z7Z8/QM78ggZ9ci7kOfUSGbA9Bt6ui3vN8f//oanlso9EGZ3AqUsObtqVeMY7Cw==",
+			"version": "0.16.18",
+			"resolved": "https://registry.npmjs.org/@cloudflare/vitest-pool-workers/-/vitest-pool-workers-0.16.18.tgz",
+			"integrity": "sha512-TEktXyevK9lkTWouElbIcDPK3YEfV+Szqgnlq5sNk+KYZR3LiDdYDaGNmUYgiT2LiiFeGU2yzCrcgmN8mJhqWQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"cjs-module-lexer": "1.2.3",
 				"esbuild": "0.28.1",
-				"miniflare": "4.20260617.0",
-				"wrangler": "4.102.0",
+				"miniflare": "4.20260617.1",
+				"wrangler": "4.103.0",
 				"zod": "3.25.76"
 			},
 			"peerDependencies": {
@@ -192,9 +192,9 @@
 			}
 		},
 		"node_modules/@cloudflare/workers-types": {
-			"version": "4.20260617.1",
-			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260617.1.tgz",
-			"integrity": "sha512-HdbP3CNcdMZBwegitFDjWvzv+6wPkFXvV9gBXMnf6RjV2Cy3W8TJL3IhSEGul0S6F1DHjnucP7lrpIsvkzNEjA==",
+			"version": "4.20260620.1",
+			"resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260620.1.tgz",
+			"integrity": "sha512-WB81w9u1bAS7KcekpC7/nYhLpIXAEtgybso7XgGJV8CQKNkNPYcyjvICLdghOlDBi/9Ivk+f7NRckV2Bkq1bDg==",
 			"devOptional": true,
 			"license": "MIT OR Apache-2.0"
 		},
@@ -3357,9 +3357,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.25",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
-			"integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+			"version": "4.12.26",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.26.tgz",
+			"integrity": "sha512-uyZtpnYxM9CmQ7QsQknM4zN8EftNqhON1qYeIKM0Se67CCEe2c44xyGURwB0axX2fBDu1dqHrHAc1hmNT8ITkw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -3810,9 +3810,9 @@
 			}
 		},
 		"node_modules/miniflare": {
-			"version": "4.20260617.0",
-			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.0.tgz",
-			"integrity": "sha512-A+H5gcOCQZsKFg7/daZUtx8WHn4gGxwUfH1jnNDAisyAWSvvSZHe+GCeQWs16uthnUDcm72UQIQ1NXDJtnuo9Q==",
+			"version": "4.20260617.1",
+			"resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260617.1.tgz",
+			"integrity": "sha512-Go3/gzStm99QHptsSgU+q1S+xDfLoRgwjJNY80kaTVi0ENhTyqKq+sc4xZiWBSbM7uUcJwmzm8+QFKtcYLJ9nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5029,9 +5029,9 @@
 			}
 		},
 		"node_modules/wrangler": {
-			"version": "4.102.0",
-			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.102.0.tgz",
-			"integrity": "sha512-GPljlQs9a+/Ai2h0TdEUYaaWv9upK4fUteSWTPlruas7tdixiIwr74CZSWHcEPuRgZYkyYKHIBbT1w+BYPkPrw==",
+			"version": "4.103.0",
+			"resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.103.0.tgz",
+			"integrity": "sha512-3Lv1P5t2xcSEkSTKtG+Lz+3JFryuU7YPLkaCUj7gNe+CJsjZJLtUwqsh1x595QBxkIbCE0GAvDx2DCJUU4+oqw==",
 			"dev": true,
 			"license": "MIT OR Apache-2.0",
 			"dependencies": {
@@ -5039,7 +5039,7 @@
 				"@cloudflare/unenv-preset": "2.16.1",
 				"blake3-wasm": "2.1.5",
 				"esbuild": "0.28.1",
-				"miniflare": "4.20260617.0",
+				"miniflare": "4.20260617.1",
 				"path-to-regexp": "6.3.0",
 				"unenv": "2.0.0-rc.24",
 				"workerd": "1.20260617.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.20.0",
+	"version": "3.21.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.20.0",
+			"version": "3.21.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.20.0",
+	"version": "3.21.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/package.json
+++ b/package.json
@@ -62,19 +62,19 @@
 		"zod": "4.4.3"
 	},
 	"devDependencies": {
-		"@cloudflare/vitest-pool-workers": "^0.16.16",
-		"@cloudflare/workers-types": "4.20260617.1",
+		"@cloudflare/vitest-pool-workers": "^0.16.18",
+		"@cloudflare/workers-types": "4.20260620.1",
 		"@types/marked": "^6.0.0",
 		"@types/punycode": "^2.1.4",
 		"drizzle-kit": "^0.31.10",
 		"eslint": "10.5.0",
-		"hono": "4.12.25",
+		"hono": "4.12.26",
 		"playwright": "^1.61.0",
 		"tsup": "8.5.1",
 		"typescript": "6.0.3",
 		"typescript-eslint": "8.61.1",
 		"vitest": "4.1.9",
-		"wrangler": "^4.101.0"
+		"wrangler": "^4.103.0"
 	},
 	"overrides": {
 		"esbuild": "0.28.1",

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.20.0",
+	"version": "3.21.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,20 @@ function certstreamAuthToken(env: BvMcpEnv): string | undefined {
 	return env.BV_CERTSTREAM_ADMIN_KEY || env.BV_INTERNAL_DEV_KEY;
 }
 
+/**
+ * F2 — mint a server-generated correlation id for an inbound request. Prefers
+ * Cloudflare's `cf-ray` (the edge request id) when present so the bv-mcp trace
+ * stitches against CF's own logs, otherwise falls back to a fresh
+ * `crypto.randomUUID()`. This is the single per-request id threaded through
+ * `ExecuteMcpRequestOptions.correlationId` into every `logEvent` on the path —
+ * distinct from the client-chosen JSON-RPC id.
+ */
+export function makeCorrelationId(headers: Headers): string {
+	const cfRay = headers.get('cf-ray');
+	if (cfRay && /^[a-zA-Z0-9-]{1,64}$/.test(cfRay)) return cfRay;
+	return crypto.randomUUID();
+}
+
 function oauthDisabledResponse(): Response {
 	return new Response('Not found', { status: 404 });
 }
@@ -360,12 +374,93 @@ app.use('*', async (c, next) => {
 	}
 });
 
-app.get('/health', (c) => {
-	return c.json({
-		status: 'ok',
-		service: 'bv-dns-security-mcp',
-		timestamp: new Date().toISOString(),
+/**
+ * F5 — bounded round-trip probe of a single binding for the deep-readiness mode.
+ * Each probe is wrapped in `Promise.race` against a hard 1.5s ceiling so a wedged
+ * binding can't hang the health endpoint (which uptime monitors poll). Any thrown
+ * error or timeout → `'error'`; a successful round-trip → `'ok'`; an absent
+ * binding → `'absent'` (BSL self-hosts legitimately omit these).
+ */
+const DEEP_HEALTH_PROBE_TIMEOUT_MS = 1500;
+
+async function probeWithTimeout(work: () => Promise<void>): Promise<'ok' | 'error'> {
+	try {
+		await Promise.race([
+			work(),
+			new Promise<never>((_, reject) => setTimeout(() => reject(new Error('probe_timeout')), DEEP_HEALTH_PROBE_TIMEOUT_MS)),
+		]);
+		return 'ok';
+	} catch {
+		return 'error';
+	}
+}
+
+async function probeScanCacheKv(kv: KVNamespace | undefined): Promise<'ok' | 'error' | 'absent'> {
+	if (!kv) return 'absent';
+	return probeWithTimeout(async () => {
+		// Best-effort round-trip on a dedicated, short-lived health key. A get/put
+		// pair exercises both read and write paths without touching live data.
+		const key = `health:probe:${crypto.randomUUID()}`;
+		await kv.put(key, '1', { expirationTtl: 60 });
+		await kv.get(key);
+		await kv.delete(key);
 	});
+}
+
+async function probeQuotaCoordinator(ns: DurableObjectNamespace | undefined): Promise<'ok' | 'error' | 'absent'> {
+	if (!ns) return 'absent';
+	return probeWithTimeout(async () => {
+		// A GET to the DO returns 405 (it only accepts POST) — that non-error
+		// HTTP response still proves the DO is reachable and responding. Any
+		// transport-level throw (DO unreachable) is caught and reported as error.
+		const stub = ns.get(ns.idFromName('health-probe'));
+		await stub.fetch('https://do/health');
+	});
+}
+
+app.get('/health', async (c) => {
+	const deep = c.req.query('deep');
+	if (deep !== '1' && deep !== 'true') {
+		// Cheap default liveness path — UNCHANGED. No binding I/O, no auth.
+		return c.json({
+			status: 'ok',
+			service: 'bv-dns-security-mcp',
+			timestamp: new Date().toISOString(),
+		});
+	}
+
+	// Deep readiness mode is owner-gated: it does binding I/O (load-amplification
+	// surface for an unauthenticated poller) so we require an owner-tier credential.
+	// The `/health` route has no auth middleware (it isn't an mcpPath), so resolve
+	// the bearer here directly. OWNER_ALLOW_IPS still applies via resolveTier.
+	const authHeader = c.req.header('authorization');
+	const token = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null;
+	const resolvedClientIp = resolveClientIpFromRequestHeaders(c.req.raw.headers);
+	const clientIp = resolvedClientIp === 'unknown' ? undefined : resolvedClientIp;
+	const tier = await resolveTier(token, c.env, clientIp, c.req.url);
+	if (!tier.authenticated || tier.tier !== 'owner') {
+		return c.json({ error: 'forbidden', error_description: 'Deep health checks require an owner-tier credential' }, 403);
+	}
+
+	const [scanCache, quotaCoordinator] = await Promise.all([
+		probeScanCacheKv(c.env.SCAN_CACHE),
+		probeQuotaCoordinator(c.env.QUOTA_COORDINATOR),
+	]);
+
+	const bindings = { scanCache, quotaCoordinator };
+	// Overall status degrades only on an actual probe error; an 'absent' binding
+	// (BSL self-host) is not a failure of a provisioned dependency.
+	const degraded = Object.values(bindings).some((status) => status === 'error');
+
+	return c.json(
+		{
+			status: degraded ? 'degraded' : 'ok',
+			service: 'bv-dns-security-mcp',
+			timestamp: new Date().toISOString(),
+			bindings,
+		},
+		degraded ? 503 : 200,
+	);
 });
 
 app.get('/badge/:domain', async (c) => {
@@ -419,6 +514,11 @@ app.get('/badge/:domain', async (c) => {
 
 app.post('/mcp', async (c) => {
 	const startTime = Date.now();
+	// F2 — one server-generated correlation id per inbound request, threaded into
+	// every executeMcpRequest below (and onward into every logEvent on the path)
+	// so multi-line traces can be stitched. cf-ray (Cloudflare's edge request id)
+	// is folded in when present for cross-correlation with CF logs.
+	const correlationId = makeCorrelationId(c.req.raw.headers);
 	const analytics = createAnalyticsClient(c.env.MCP_ANALYTICS);
 	logAnalyticsBindingStatus(analytics.enabled);
 	const headersLc = normalizeHeaders(c.req.raw.headers);
@@ -504,6 +604,7 @@ app.post('/mcp', async (c) => {
 					responseTransport: acceptsSSE(accept) ? 'sse' : 'json',
 					accept,
 					startTime,
+					correlationId,
 					ip,
 					isAuthenticated,
 					tierAuthResult,
@@ -589,6 +690,7 @@ app.post('/mcp', async (c) => {
 		responseTransport: acceptsSSE(accept) ? 'sse' : 'json',
 		accept,
 		startTime,
+		correlationId,
 		ip,
 		isAuthenticated,
 		tierAuthResult,
@@ -681,6 +783,8 @@ app.post('/mcp', async (c) => {
 
 app.post('/mcp/messages', async (c) => {
 	const startTime = Date.now();
+	// F2 — per-request correlation id for the legacy SSE message path.
+	const correlationId = makeCorrelationId(c.req.raw.headers);
 	const analytics = createAnalyticsClient(c.env.MCP_ANALYTICS);
 	logAnalyticsBindingStatus(analytics.enabled);
 	const headersLc = normalizeHeaders(c.req.raw.headers);
@@ -751,6 +855,7 @@ app.post('/mcp/messages', async (c) => {
 				batchSize: parsedBodies.length,
 				responseTransport: 'sse',
 				startTime,
+				correlationId,
 				ip,
 				isAuthenticated,
 				tierAuthResult,

--- a/src/lib/analytics-queries.ts
+++ b/src/lib/analytics-queries.ts
@@ -169,6 +169,28 @@ WHERE index1 = 'rate_limit'
   AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE`;
 }
 
+/**
+ * Binding-degradation detection for alerting. Counts `degradation` events from
+ * the operator-only service bindings (BV_RECON / BV_TLS_PROBE), grouped by
+ * component + kind, over the last N minutes. Excludes the `kv_fallback` member
+ * (that's a session-store concern, alerted separately if at all).
+ *
+ * Blob positions (degradation): blob1=degradationType, blob2=component.
+ */
+export function queryBindingDegradation(minutes: string): string {
+	minutes = safeInterval(minutes);
+	return `SELECT
+  blob2 AS component,
+  blob1 AS degradation_type,
+  SUM(_sample_interval) AS event_count
+FROM ${DS}
+WHERE index1 = 'degradation'
+  AND blob1 != 'kv_fallback'
+  AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE
+GROUP BY component, degradation_type
+ORDER BY event_count DESC`;
+}
+
 // ---------------------------------------------------------------------------
 // Per-Tier Analytics Queries
 // ---------------------------------------------------------------------------
@@ -178,7 +200,11 @@ WHERE index1 = 'rate_limit'
 /** Sanitize tier value: lowercase, alphanumeric/underscore only, max 20 chars. */
 function safeTier(value: string | undefined): string | undefined {
 	if (!value) return undefined;
-	const cleaned = value.trim().toLowerCase().replace(/[^a-z0-9_]/g, '').slice(0, 20);
+	const cleaned = value
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9_]/g, '')
+		.slice(0, 20);
 	return cleaned || undefined;
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -15,11 +15,7 @@ import type { McpClientType } from './client-detection';
 
 /** Minimal shape used by Cloudflare Analytics Engine dataset bindings. */
 interface AnalyticsDatasetLike {
-	writeDataPoint: (point: {
-		indexes?: string[];
-		blobs?: string[];
-		doubles?: number[];
-	}) => void;
+	writeDataPoint: (point: { indexes?: string[]; blobs?: string[]; doubles?: number[] }) => void;
 }
 
 /** Enriched context dimensions threaded from the request handler. */
@@ -43,44 +39,59 @@ export interface AnalyticsContext {
 
 export interface AnalyticsClient {
 	enabled: boolean;
-	emitRequestEvent(event: {
-		method: string;
-		status: 'ok' | 'error';
-		durationMs: number;
-		isAuthenticated: boolean;
-		hasJsonRpcError: boolean;
-		/** JSON-RPC error code (negative per spec); stored as abs() in double2, 0 when absent. */
-		jsonRpcErrorCode?: number;
-		transport: 'json' | 'sse';
-	} & AnalyticsContext): void;
-	emitToolEvent(event: {
-		toolName: string;
-		status: 'pass' | 'fail' | 'error' | 'unknown';
-		durationMs: number;
-		domain?: string;
-		isError: boolean;
-		score?: number;
-		cacheStatus?: 'hit' | 'miss' | 'n/a';
-	} & AnalyticsContext): void;
-	emitRateLimitEvent(event: {
-		limitType: 'minute' | 'hour' | 'daily_tool' | 'daily_global' | 'daily_ip' | 'distinct_domain' | 'gated_tool';
-		toolName: string;
-		limit: number;
-		remaining: number;
-	} & AnalyticsContext): void;
-	emitSessionEvent(event: {
-		action: 'created' | 'terminated' | 'revived';
-		method?: string;
-	} & AnalyticsContext): void;
-	emitDegradationEvent(event: {
-		/**
-		 * Only `kv_fallback` is emitted (from session.ts when a KV write throws).
-		 * The scan-level degradation members were never wired and were removed.
-		 */
-		degradationType: 'kv_fallback';
-		component: string;
-		domain?: string;
-	} & AnalyticsContext): void;
+	emitRequestEvent(
+		event: {
+			method: string;
+			status: 'ok' | 'error';
+			durationMs: number;
+			isAuthenticated: boolean;
+			hasJsonRpcError: boolean;
+			/** JSON-RPC error code (negative per spec); stored as abs() in double2, 0 when absent. */
+			jsonRpcErrorCode?: number;
+			transport: 'json' | 'sse';
+		} & AnalyticsContext,
+	): void;
+	emitToolEvent(
+		event: {
+			toolName: string;
+			status: 'pass' | 'fail' | 'error' | 'unknown';
+			durationMs: number;
+			domain?: string;
+			isError: boolean;
+			score?: number;
+			cacheStatus?: 'hit' | 'miss' | 'n/a';
+		} & AnalyticsContext,
+	): void;
+	emitRateLimitEvent(
+		event: {
+			limitType: 'minute' | 'hour' | 'daily_tool' | 'daily_global' | 'daily_ip' | 'distinct_domain' | 'gated_tool';
+			toolName: string;
+			limit: number;
+			remaining: number;
+		} & AnalyticsContext,
+	): void;
+	emitSessionEvent(
+		event: {
+			action: 'created' | 'terminated' | 'revived';
+			method?: string;
+		} & AnalyticsContext,
+	): void;
+	emitDegradationEvent(
+		event: {
+			/**
+			 * Degradation members:
+			 *  - `kv_fallback` — a KV write threw (emitted from session.ts).
+			 *  - `binding_unavailable` / `binding_5xx` / `binding_timeout` — a PRESENT
+			 *    operator-only service binding (BV_RECON / BV_TLS_PROBE) failed at call
+			 *    time. Absent-on-self-host and the benign recon 404 are deliberately NOT
+			 *    emitted (those are expected, not alertable). `component` carries which
+			 *    binding (`recon` | `tls_probe`).
+			 */
+			degradationType: 'kv_fallback' | 'binding_unavailable' | 'binding_5xx' | 'binding_timeout';
+			component: string;
+			domain?: string;
+		} & AnalyticsContext,
+	): void;
 }
 
 /**
@@ -93,7 +104,14 @@ export function createAnalyticsClient(dataset?: AnalyticsDatasetLike): Analytics
 	};
 
 	if (!dataset) {
-		return { enabled: false, emitRequestEvent: noop, emitToolEvent: noop, emitRateLimitEvent: noop, emitSessionEvent: noop, emitDegradationEvent: noop };
+		return {
+			enabled: false,
+			emitRequestEvent: noop,
+			emitToolEvent: noop,
+			emitRateLimitEvent: noop,
+			emitSessionEvent: noop,
+			emitDegradationEvent: noop,
+		};
 	}
 
 	return {
@@ -140,12 +158,7 @@ export function createAnalyticsClient(dataset?: AnalyticsDatasetLike): Analytics
 		emitRateLimitEvent: (event) => {
 			safeWrite(dataset, {
 				indexes: ['rate_limit'],
-				blobs: [
-					event.limitType,
-					normalizeIndex(event.toolName),
-					event.country ?? 'unknown',
-					event.authTier ?? 'anon',
-				],
+				blobs: [event.limitType, normalizeIndex(event.toolName), event.country ?? 'unknown', event.authTier ?? 'anon'],
 				doubles: [sanitizeNumber(event.limit), sanitizeNumber(event.remaining)],
 			});
 		},

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -8,6 +8,14 @@
 
 export type LogEvent = {
 	timestamp: string;
+	/**
+	 * Server-generated per-request correlation id (`crypto.randomUUID()`),
+	 * minted once at the Worker entry point and stamped onto EVERY log line on
+	 * the request path so multi-line traces (auth, rate-limit, parse-error,
+	 * session, dispatch, error) can be stitched together. Distinct from
+	 * {@link LogEvent.requestId}, which is the client-chosen JSON-RPC id.
+	 */
+	correlationId?: string;
 	requestId?: string;
 	/**
 	 * FNV-1a hash of the client IP (`i_` prefix), aligned with the analytics

--- a/src/lib/provider-signature-source.ts
+++ b/src/lib/provider-signature-source.ts
@@ -1,5 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import { validateOutboundUrl } from './sanitize';
+
 export interface ProviderSignature {
 	name: string;
 	domains: string[];
@@ -70,6 +72,15 @@ export function validateRuntimeSourceUrl(sourceUrl: string, allowedHosts: string
 
 	if (allowedHosts.length > 0 && !allowedHosts.includes(url.hostname.toLowerCase())) {
 		throw new Error('Invalid provider signature source URL: host is not allowlisted');
+	}
+
+	// Defense-in-depth SSRF guard (F4): even an operator-set source URL must pass the
+	// same outbound-URL validation the BIMI/RDAP paths get — rejects RFC1918 / loopback /
+	// Cloudflare-internal hostnames + userinfo-spoofed targets that the host allowlist
+	// (which is empty by default) would otherwise let through.
+	const outbound = validateOutboundUrl(url.toString());
+	if (!outbound.valid) {
+		throw new Error(`Invalid provider signature source URL: ${outbound.error ?? 'blocked by outbound policy'}`);
 	}
 
 	return url;

--- a/src/lib/recon-binding.ts
+++ b/src/lib/recon-binding.ts
@@ -8,9 +8,63 @@
  */
 import { z } from 'zod';
 
+import { logEvent } from './log';
+
 /** Minimal Fetcher shape — matches a Cloudflare service binding. */
 export interface ReconBinding {
 	fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+/**
+ * Binding-degradation kinds for a PRESENT-but-failing operator service binding.
+ * Deliberately excludes absent-binding and the benign recon 404 (both expected,
+ * not alertable). Mirrors the matching members on the analytics `degradation`
+ * event (`binding_unavailable` | `binding_5xx` | `binding_timeout`).
+ */
+export type BindingDegradationKind = 'binding_unavailable' | 'binding_5xx' | 'binding_timeout';
+
+/**
+ * Optional telemetry callback invoked ONLY when a present binding fails. The
+ * caller forwards a sink that emits the analytics `degradation` event; the
+ * binding additionally emits a structured warn log on its own (see
+ * `recordReconDegradation`). Fail-soft: the binding never throws if the sink does.
+ */
+export type BindingDegradationSink = (event: { degradationType: BindingDegradationKind; component: string; domain?: string }) => void;
+
+const RECON_COMPONENT = 'recon';
+
+/** Map a thrown fetch error to a degradation kind. AbortSignal.timeout → timeout. */
+function errorToKind(err: unknown): BindingDegradationKind {
+	const name = err instanceof Error ? err.name : '';
+	return name === 'TimeoutError' || name === 'AbortError' ? 'binding_timeout' : 'binding_unavailable';
+}
+
+/**
+ * Emit a structured warn log AND invoke the optional sink for a present-but-failing
+ * binding. Fail-soft: a throwing sink can never break the fail-soft contract.
+ */
+function recordReconDegradation(
+	kind: BindingDegradationKind,
+	telemetry: BindingDegradationSink | undefined,
+	context: { route: string; status?: number; domain?: string; errorName?: string },
+): void {
+	logEvent({
+		timestamp: new Date().toISOString(),
+		severity: 'warn',
+		category: 'binding_degradation',
+		result: kind,
+		details: {
+			component: RECON_COMPONENT,
+			route: context.route,
+			...(context.status !== undefined ? { status: context.status } : {}),
+			...(context.errorName ? { errorName: context.errorName } : {}),
+		},
+	});
+	try {
+		telemetry?.({ degradationType: kind, component: RECON_COMPONENT, domain: context.domain });
+	} catch {
+		// Telemetry must never break the fail-soft binding contract.
+	}
 }
 
 const RECON_TIMEOUT_MS = 8_000;
@@ -50,7 +104,9 @@ export async function callReconScan(
 	type: ReconScanType,
 	target: { domain?: string; ip?: string; asn?: number },
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<ReconScanResult | null> {
+	// Absent binding (BSL self-host) is expected, NOT a degradation — stay silent.
 	if (!binding) return null;
 	try {
 		const qs = new URLSearchParams({ type });
@@ -66,14 +122,23 @@ export async function callReconScan(
 		// this target — i.e. no adverse intel (benign), NOT a provisioning failure.
 		// Return a benign result so callers render "no hits" instead of "unavailable".
 		// (The route 404 is fixed + regression-tested in bv-recon, so a 404 here is a
-		// data miss, not a misroute.) Other non-2xx (5xx/auth) stay null → unavailable.
+		// data miss, not a misroute.) Stays SILENT — not a degradation.
 		if (resp.status === 404) {
 			return { status: 'info', details: 'No threat-intelligence match for this target.' };
 		}
-		if (!resp.ok) return null;
+		// Other non-2xx (5xx / auth) are a present-binding failure: record + null.
+		if (!resp.ok) {
+			recordReconDegradation('binding_5xx', telemetry, { route: '/osint/check', status: resp.status, domain: target.domain });
+			return null;
+		}
 		const parsed = ReconScanResponseSchema.safeParse(await resp.json().catch(() => null));
 		return parsed.success ? parsed.data : null;
-	} catch {
+	} catch (err) {
+		recordReconDegradation(errorToKind(err), telemetry, {
+			route: '/osint/check',
+			domain: target.domain,
+			errorName: err instanceof Error ? err.name : undefined,
+		});
 		return null;
 	}
 }
@@ -104,7 +169,9 @@ async function reconJson(
 	init: RequestInit,
 	schema: z.ZodType,
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<unknown | null> {
+	// Absent binding (BSL self-host) is expected, NOT a degradation — stay silent.
 	if (!binding) return null;
 	try {
 		const resp = await binding.fetch(`https://bv-recon${path}`, {
@@ -112,10 +179,14 @@ async function reconJson(
 			headers: { ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}), ...(init.headers ?? {}) },
 			signal: composeSignal(signal),
 		});
-		if (!resp.ok) return null;
+		if (!resp.ok) {
+			recordReconDegradation('binding_5xx', telemetry, { route: path, status: resp.status });
+			return null;
+		}
 		const parsed = schema.safeParse(await resp.json());
 		return parsed.success ? parsed.data : null;
-	} catch {
+	} catch (err) {
+		recordReconDegradation(errorToKind(err), telemetry, { route: path, errorName: err instanceof Error ? err.name : undefined });
 		return null;
 	}
 }
@@ -127,6 +198,7 @@ export function callReconInvestigateStart(
 	query: string,
 	options?: Record<string, unknown>,
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<InvestigationStart | null> {
 	return reconJson(
 		binding,
@@ -135,6 +207,7 @@ export function callReconInvestigateStart(
 		{ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ query, options: options ?? {} }) },
 		InvestigationStartSchema,
 		signal,
+		telemetry,
 	) as Promise<InvestigationStart | null>;
 }
 
@@ -143,6 +216,7 @@ export function callReconInvestigationStatus(
 	authToken: string | undefined,
 	id: string,
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<ReconOpaque | null> {
 	return reconJson(
 		binding,
@@ -151,6 +225,7 @@ export function callReconInvestigationStatus(
 		{ method: 'GET' },
 		OpaqueObjectSchema,
 		signal,
+		telemetry,
 	) as Promise<ReconOpaque | null>;
 }
 
@@ -159,6 +234,7 @@ export function callReconInvestigationReport(
 	authToken: string | undefined,
 	id: string,
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<ReconOpaque | null> {
 	return reconJson(
 		binding,
@@ -167,6 +243,7 @@ export function callReconInvestigationReport(
 		{ method: 'GET' },
 		OpaqueObjectSchema,
 		signal,
+		telemetry,
 	) as Promise<ReconOpaque | null>;
 }
 
@@ -175,6 +252,7 @@ export function callReconBucketScanStart(
 	authToken: string | undefined,
 	body: Record<string, unknown>,
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<BucketScanStart | null> {
 	return reconJson(
 		binding,
@@ -183,6 +261,7 @@ export function callReconBucketScanStart(
 		{ method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) },
 		BucketScanStartSchema,
 		signal,
+		telemetry,
 	) as Promise<BucketScanStart | null>;
 }
 
@@ -191,6 +270,7 @@ export function callReconBucketScanStatus(
 	authToken: string | undefined,
 	scanId: string,
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<ReconOpaque | null> {
 	return reconJson(
 		binding,
@@ -199,6 +279,7 @@ export function callReconBucketScanStatus(
 		{ method: 'GET' },
 		OpaqueObjectSchema,
 		signal,
+		telemetry,
 	) as Promise<ReconOpaque | null>;
 }
 
@@ -207,8 +288,16 @@ export function callReconBucketFindings(
 	authToken: string | undefined,
 	scanId: string | undefined,
 	signal?: AbortSignal,
+	telemetry?: BindingDegradationSink,
 ): Promise<ReconOpaque | null> {
 	const qs = scanId ? `?scanId=${encodeURIComponent(scanId)}` : '';
-	return reconJson(binding, authToken, `/buckets/api/findings${qs}`, { method: 'GET' }, OpaqueObjectSchema, signal) as Promise<ReconOpaque | null>;
+	return reconJson(
+		binding,
+		authToken,
+		`/buckets/api/findings${qs}`,
+		{ method: 'GET' },
+		OpaqueObjectSchema,
+		signal,
+		telemetry,
+	) as Promise<ReconOpaque | null>;
 }
-

--- a/src/lib/tier-auth.ts
+++ b/src/lib/tier-auth.ts
@@ -50,9 +50,11 @@ async function hashTokenRaw(token: string): Promise<Uint8Array> {
 async function matchesStaticDevKey(tokenRaw: Uint8Array, candidate: string | undefined): Promise<boolean> {
 	if (!candidate) return false;
 	const b = await hashTokenRaw(candidate);
-	let mismatch = tokenRaw.byteLength ^ b.byteLength;
-	const len = Math.min(tokenRaw.byteLength, b.byteLength);
-	for (let i = 0; i < len; i++) {
+	// Both operands are fixed-length 32-byte SHA-256 digests, so iterate the
+	// full digest with no length term (matches auth.ts and the step-4 fallback
+	// compare below). Never short-circuits on first mismatch → no timing leak.
+	let mismatch = 0;
+	for (let i = 0; i < tokenRaw.byteLength; i++) {
 		mismatch |= tokenRaw[i] ^ b[i];
 	}
 	return mismatch === 0;

--- a/src/lib/tls-probe-binding.ts
+++ b/src/lib/tls-probe-binding.ts
@@ -10,10 +10,61 @@ import { z } from 'zod';
 
 import type { CheckResult, Finding } from './scoring';
 import { buildCheckResult, createFinding } from './scoring';
+import { logEvent } from './log';
 
 /** Minimal Fetcher shape — matches a Cloudflare service binding. */
 export interface TlsProbeBinding {
 	fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+/**
+ * Binding-degradation kinds for a PRESENT-but-failing operator service binding.
+ * Mirrors the matching members on the analytics `degradation` event. Absent
+ * binding (BSL self-host) is excluded — that's expected, not alertable.
+ */
+export type BindingDegradationKind = 'binding_unavailable' | 'binding_5xx' | 'binding_timeout';
+
+/**
+ * Optional telemetry callback invoked ONLY when a present binding fails. The
+ * binding additionally emits a structured warn log on its own. Fail-soft: the
+ * binding never throws if the sink does.
+ */
+export type BindingDegradationSink = (event: { degradationType: BindingDegradationKind; component: string; domain?: string }) => void;
+
+const TLS_PROBE_COMPONENT = 'tls_probe';
+
+/** Map a thrown fetch error to a degradation kind. AbortSignal.timeout → timeout. */
+function errorToKind(err: unknown): BindingDegradationKind {
+	const name = err instanceof Error ? err.name : '';
+	return name === 'TimeoutError' || name === 'AbortError' ? 'binding_timeout' : 'binding_unavailable';
+}
+
+/**
+ * Emit a structured warn log AND invoke the optional sink for a present-but-failing
+ * probe binding. Fail-soft: a throwing sink can never break the fail-soft contract.
+ */
+function recordTlsProbeDegradation(
+	kind: BindingDegradationKind,
+	telemetry: BindingDegradationSink | undefined,
+	context: { status?: number; host?: string; errorName?: string },
+): void {
+	logEvent({
+		timestamp: new Date().toISOString(),
+		severity: 'warn',
+		category: 'binding_degradation',
+		result: kind,
+		details: {
+			component: TLS_PROBE_COMPONENT,
+			route: '/probe',
+			...(context.status !== undefined ? { status: context.status } : {}),
+			...(context.errorName ? { errorName: context.errorName } : {}),
+		},
+	});
+	try {
+		telemetry?.({ degradationType: kind, component: TLS_PROBE_COMPONENT, domain: context.host });
+	} catch {
+		// Telemetry must never break the fail-soft binding contract.
+	}
 }
 
 const TLS_PROBE_TIMEOUT_MS = 8_000;
@@ -29,10 +80,7 @@ const TlsProbeResponseSchema = z
 		minVersion: z.string().optional(),
 		maxVersion: z.string().optional(),
 		supportedVersions: z.array(z.string()).optional(),
-		cipher: z
-			.object({ name: z.string().optional(), bits: z.number().optional() })
-			.passthrough()
-			.optional(),
+		cipher: z.object({ name: z.string().optional(), bits: z.number().optional() }).passthrough().optional(),
 		error: z.string().optional(),
 		probedAt: z.string().optional(),
 	})
@@ -64,8 +112,9 @@ export async function callTlsProbe(
 	binding: TlsProbeBinding | undefined,
 	authToken: string | undefined,
 	host: string,
-	opts?: { port?: number; signal?: AbortSignal },
+	opts?: { port?: number; signal?: AbortSignal; telemetry?: BindingDegradationSink },
 ): Promise<TlsProbeResult | null> {
+	// Absent binding (BSL self-host) is expected, NOT a degradation — stay silent.
 	if (!binding) return null;
 	try {
 		const qs = new URLSearchParams({ host, port: String(opts?.port ?? DEFAULT_PROBE_PORT) });
@@ -74,10 +123,15 @@ export async function callTlsProbe(
 			headers: authToken ? { Authorization: `Bearer ${authToken}` } : {},
 			signal: composeSignal(opts?.signal),
 		});
-		if (!resp.ok) return null;
+		// Any non-ok (incl. 404 — unlike recon, NOT benign here) is a present-binding failure.
+		if (!resp.ok) {
+			recordTlsProbeDegradation('binding_5xx', opts?.telemetry, { status: resp.status, host });
+			return null;
+		}
 		const parsed = TlsProbeResponseSchema.safeParse(await resp.json().catch(() => null));
 		return parsed.success ? parsed.data : null;
-	} catch {
+	} catch (err) {
+		recordTlsProbeDegradation(errorToKind(err), opts?.telemetry, { host, errorName: err instanceof Error ? err.name : undefined });
 		return null;
 	}
 }

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -58,6 +58,14 @@ export interface ExecuteMcpRequestOptions {
 	batchSize: number;
 	responseTransport: 'json' | 'sse';
 	startTime: number;
+	/**
+	 * F2 — server-generated per-request correlation id (`crypto.randomUUID()`),
+	 * minted at the Worker entry point in `src/index.ts` and threaded here so
+	 * every `logEvent`/`logError` on the request path carries the same id,
+	 * letting multi-line traces be stitched. Optional: undefined on legacy/test
+	 * call sites that do not mint one. Distinct from the client JSON-RPC id.
+	 */
+	correlationId?: string;
 	ip: string;
 	isAuthenticated: boolean;
 	tierAuthResult?: import('../lib/tier-auth').TierAuthResult;
@@ -871,6 +879,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 						});
 						logEvent({
 							timestamp: new Date().toISOString(),
+							correlationId: options.correlationId,
 							category: 'session',
 							result: 'recovered',
 							ipHash: options.ipHash,
@@ -1017,6 +1026,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 
 				logEvent({
 					timestamp: new Date().toISOString(),
+					correlationId: options.correlationId,
 					requestId: typeof id === 'string' ? id : undefined,
 					ipHash: options.ipHash,
 					tool: dispatchResult.logTool,
@@ -1132,6 +1142,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 
 		logEvent({
 			timestamp: new Date().toISOString(),
+			correlationId: options.correlationId,
 			requestId: typeof id === 'string' ? id : undefined,
 			ipHash: options.ipHash,
 			tool: dispatchResult.logTool,
@@ -1165,6 +1176,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 		emitRequestAnalytics(options, method, 'error', true);
 		logError(err instanceof Error ? err : String(err), {
 			severity: 'error',
+			correlationId: options.correlationId,
 			ipHash: options.ipHash,
 			requestId: typeof options.body?.id === 'string' ? options.body.id : undefined,
 			tool: typeof options.body?.method === 'string' ? options.body.method : undefined,

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -11,7 +11,7 @@
  *   ALERT_RATE_LIMIT_THRESHOLD (default 50 hits), ALERT_LOOKBACK_MINUTES (default 15)
  */
 
-import { queryRecentAnomalies, queryRateLimitSurge, queryTierDigest } from './lib/analytics-queries';
+import { queryRecentAnomalies, queryRateLimitSurge, queryTierDigest, queryBindingDegradation } from './lib/analytics-queries';
 import { buildAlertPayload, buildDigestPayload, sendAlert } from './lib/alerting';
 import { queryAnalyticsEngine } from './lib/analytics-engine';
 import { logEvent, logError } from './lib/log';
@@ -33,6 +33,12 @@ interface RateLimitRow {
 	total_hits?: number;
 }
 
+interface BindingDegradationRow {
+	component?: string;
+	degradation_type?: string;
+	event_count?: number;
+}
+
 export interface ScheduledEnv {
 	CF_ACCOUNT_ID?: string;
 	CF_ANALYTICS_TOKEN?: string;
@@ -42,6 +48,8 @@ export interface ScheduledEnv {
 	ALERT_RATE_LIMIT_THRESHOLD?: string;
 	ALERT_LOOKBACK_MINUTES?: string;
 	ALERT_SPF_NULL_RATE_THRESHOLD?: string;
+	/** Min present-binding-degradation events in the lookback window to alert (default 1). */
+	ALERT_BINDING_DEGRADATION_THRESHOLD?: string;
 	RATE_LIMIT?: KVNamespace;
 	BRAND_AUDIT_DB?: D1Database;
 	INTELLIGENCE_DB?: D1Database;
@@ -51,6 +59,8 @@ const DEFAULT_ERROR_THRESHOLD = 5;
 const DEFAULT_P95_THRESHOLD = 10_000;
 const DEFAULT_RATE_LIMIT_THRESHOLD = 50;
 const DEFAULT_LOOKBACK_MINUTES = 15;
+/** A single present-binding failure (mis-rotated key, bv-recon 5xx) is worth surfacing. */
+const DEFAULT_BINDING_DEGRADATION_THRESHOLD = 1;
 
 /** Main scheduled handler — called by Cron Trigger. */
 export async function handleScheduled(env: ScheduledEnv): Promise<void> {
@@ -87,8 +97,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 	}
 
 	if (env.INTELLIGENCE_DB) {
-		await env.INTELLIGENCE_DB
-			.prepare("DELETE FROM mcp_access_log WHERE created_at < (strftime('%s', 'now') - ?)")
+		await env.INTELLIGENCE_DB.prepare("DELETE FROM mcp_access_log WHERE created_at < (strftime('%s', 'now') - ?)")
 			.bind(90 * 24 * 3600)
 			.run()
 			.catch((err) => {
@@ -108,10 +117,18 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 	const p95Threshold = Number.isFinite(parsedP95) ? parsedP95 : DEFAULT_P95_THRESHOLD;
 	const parsedRateLimit = parseFloat(env.ALERT_RATE_LIMIT_THRESHOLD ?? '');
 	const rateLimitThreshold = Number.isFinite(parsedRateLimit) ? parsedRateLimit : DEFAULT_RATE_LIMIT_THRESHOLD;
+	const parsedBindingDegradation = parseFloat(env.ALERT_BINDING_DEGRADATION_THRESHOLD ?? '');
+	const bindingDegradationThreshold = Number.isFinite(parsedBindingDegradation)
+		? parsedBindingDegradation
+		: DEFAULT_BINDING_DEGRADATION_THRESHOLD;
 	const lookback = env.ALERT_LOOKBACK_MINUTES ?? String(DEFAULT_LOOKBACK_MINUTES);
 
 	try {
-		const anomalyRows = await queryAnalyticsEngine(env.CF_ACCOUNT_ID, env.CF_ANALYTICS_TOKEN, queryRecentAnomalies(lookback)) as AnomalyRow[];
+		const anomalyRows = (await queryAnalyticsEngine(
+			env.CF_ACCOUNT_ID,
+			env.CF_ANALYTICS_TOKEN,
+			queryRecentAnomalies(lookback),
+		)) as AnomalyRow[];
 		const anomaly = anomalyRows[0];
 
 		if (anomaly && anomaly.total_calls && anomaly.total_calls > 0) {
@@ -152,11 +169,11 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 			}
 		}
 
-		const rateLimitRows = await queryAnalyticsEngine(
+		const rateLimitRows = (await queryAnalyticsEngine(
 			env.CF_ACCOUNT_ID,
 			env.CF_ANALYTICS_TOKEN,
 			queryRateLimitSurge(lookback),
-		) as RateLimitRow[];
+		)) as RateLimitRow[];
 		const rateLimitData = rateLimitRows[0];
 
 		if (rateLimitData && (rateLimitData.total_hits ?? 0) > rateLimitThreshold) {
@@ -171,6 +188,34 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 			);
 		}
 
+		// Present-binding degradation (BV_RECON / BV_TLS_PROBE 5xx / timeout). A
+		// mis-rotated key or upstream outage is invisible without this — the
+		// fail-soft bindings null out silently otherwise. Absent bindings and the
+		// benign recon 404 never reach the `degradation` dataset, so any row here
+		// is a real, present-binding failure worth surfacing.
+		const degradationRows = (await queryAnalyticsEngine(
+			env.CF_ACCOUNT_ID,
+			env.CF_ANALYTICS_TOKEN,
+			queryBindingDegradation(lookback),
+		)) as BindingDegradationRow[];
+		const totalDegradations = degradationRows.reduce((sum, r) => sum + (r.event_count ?? 0), 0);
+
+		if (totalDegradations >= bindingDegradationThreshold) {
+			const components = [...new Set(degradationRows.map((r) => r.component ?? 'unknown'))].join(', ');
+			const breakdown = degradationRows
+				.map((r) => `${r.component ?? 'unknown'}:${r.degradation_type ?? 'unknown'}=${r.event_count ?? 0}`)
+				.join(' · ');
+			await sendAlert(
+				env.ALERT_WEBHOOK_URL,
+				buildAlertPayload({
+					title: `Service-binding degradation: ${totalDegradations} event(s) (${components}, last ${lookback}m)`,
+					severity: totalDegradations > bindingDegradationThreshold * 5 ? 'critical' : 'warning',
+					metrics: { total_events: totalDegradations, breakdown: breakdown || '(none)' },
+					threshold: `binding_degradation_events >= ${bindingDegradationThreshold}`,
+				}),
+			);
+		}
+
 		logEvent({
 			timestamp: new Date().toISOString(),
 			category: 'scheduled',
@@ -181,6 +226,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 				errorPct: anomaly?.error_pct ?? 0,
 				p95Ms: anomaly?.p95_ms ?? 0,
 				rateLimitHits: rateLimitData?.total_hits ?? 0,
+				bindingDegradations: totalDegradations,
 			},
 		});
 	} catch (err) {
@@ -382,9 +428,8 @@ export async function handleSpfCanary(env: ScheduledEnv): Promise<void> {
 	try {
 		const result = await runSpfCanary();
 		const rawThreshold = env.ALERT_SPF_NULL_RATE_THRESHOLD ? Number(env.ALERT_SPF_NULL_RATE_THRESHOLD) : NaN;
-		const threshold = Number.isFinite(rawThreshold) && rawThreshold > 0 && rawThreshold <= 1
-			? rawThreshold
-			: DEFAULT_SPF_NULL_RATE_THRESHOLD;
+		const threshold =
+			Number.isFinite(rawThreshold) && rawThreshold > 0 && rawThreshold <= 1 ? rawThreshold : DEFAULT_SPF_NULL_RATE_THRESHOLD;
 
 		logEvent({
 			timestamp: new Date().toISOString(),
@@ -474,20 +519,16 @@ interface BrandAuditWatchEnv {
  * enqueue side; the diff-and-webhook delivery side is the next slice on the
  * Phase-4 work-list.
  */
-export async function handleBrandAuditWatches(
-	env: Record<string, unknown>,
-	_ctx: ExecutionContext,
-): Promise<void> {
+export async function handleBrandAuditWatches(env: Record<string, unknown>, _ctx: ExecutionContext): Promise<void> {
 	const e = env as BrandAuditWatchEnv;
 	if (!e.BRAND_AUDIT_DB || !e.BRAND_AUDIT_QUEUE) return;
 	const now = Date.now();
 
 	let rows: DueWatchRow[] = [];
 	try {
-		const result = await e.BRAND_AUDIT_DB
-			.prepare(
-				'SELECT id, owner_id, domain, interval, webhook_url, last_run_at, last_classification_hash FROM brand_audit_watches WHERE active = 1 ORDER BY last_run_at ASC NULLS FIRST LIMIT ?',
-			)
+		const result = await e.BRAND_AUDIT_DB.prepare(
+			'SELECT id, owner_id, domain, interval, webhook_url, last_run_at, last_classification_hash FROM brand_audit_watches WHERE active = 1 ORDER BY last_run_at ASC NULLS FIRST LIMIT ?',
+		)
 			.bind(MAX_WATCHES_PER_TICK)
 			.all<DueWatchRow>();
 		rows = result.results ?? [];
@@ -512,10 +553,7 @@ export async function handleBrandAuditWatches(
 				{ auditId, target: row.domain, format: 'json', watchId: row.id, ownerId: row.owner_id },
 				{ contentType: 'json' },
 			);
-			await e.BRAND_AUDIT_DB
-				.prepare('UPDATE brand_audit_watches SET last_run_at = ? WHERE id = ?')
-				.bind(now, row.id)
-				.run();
+			await e.BRAND_AUDIT_DB.prepare('UPDATE brand_audit_watches SET last_run_at = ? WHERE id = ?').bind(now, row.id).run();
 		} catch (err) {
 			logError(err instanceof Error ? err : String(err), {
 				severity: 'warn',

--- a/src/tools/check-cymru-asn.ts
+++ b/src/tools/check-cymru-asn.ts
@@ -10,7 +10,7 @@ import { queryDnsRecords, queryTxtRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { isValidIPv4, reverseIPv4 } from '../lib/ip-utils';
 import { callReconScan, isReconHit } from '../lib/recon-binding';
-import type { ReconBinding } from '../lib/recon-binding';
+import type { ReconBinding, BindingDegradationSink } from '../lib/recon-binding';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory } from '../lib/scoring';
 
@@ -75,7 +75,7 @@ function parseOrgTxt(txt: string): string | null {
 export async function checkCymruAsn(
 	domain: string,
 	dnsOptions?: QueryDnsOptions,
-	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string } = {},
+	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
 ): Promise<CheckResult> {
 	const findings: ReturnType<typeof createFinding>[] = [];
 
@@ -89,9 +89,15 @@ export async function checkCymruAsn(
 
 	if (ips.length === 0) {
 		findings.push(
-			createFinding(CATEGORY, 'No A records found', 'info', `Could not resolve any A records for ${domain}. ASN lookup requires IPv4 addresses.`, {
-				domain,
-			}),
+			createFinding(
+				CATEGORY,
+				'No A records found',
+				'info',
+				`Could not resolve any A records for ${domain}. ASN lookup requires IPv4 addresses.`,
+				{
+					domain,
+				},
+			),
 		);
 		return buildCheckResult(CATEGORY, findings) as CheckResult;
 	}
@@ -202,7 +208,14 @@ export async function checkCymruAsn(
 
 	// Recon enrichment: additive-only, fail-soft
 	if (reconOptions.reconBinding) {
-		const reconResult = await callReconScan(reconOptions.reconBinding, reconOptions.reconAuthToken, 'MALICIOUS_ASN', { domain });
+		const reconResult = await callReconScan(
+			reconOptions.reconBinding,
+			reconOptions.reconAuthToken,
+			'MALICIOUS_ASN',
+			{ domain },
+			undefined,
+			reconOptions.onBindingDegradation,
+		);
 		const hit = reconResult && isReconHit(reconResult.status);
 		if (hit) {
 			findings.push(

--- a/src/tools/check-fast-flux.ts
+++ b/src/tools/check-fast-flux.ts
@@ -14,7 +14,7 @@
 import { queryDns } from '../lib/dns';
 import type { DnsAnswer, QueryDnsOptions } from '../lib/dns-types';
 import { callReconScan, isReconHit } from '../lib/recon-binding';
-import type { ReconBinding } from '../lib/recon-binding';
+import type { ReconBinding, BindingDegradationSink } from '../lib/recon-binding';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory, Finding } from '../lib/scoring';
 
@@ -44,7 +44,7 @@ export async function checkFastFlux(
 	rounds?: number,
 	dnsOptions?: QueryDnsOptions,
 	delayMs = 2000,
-	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string } = {},
+	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
 ): Promise<CheckResult> {
 	const effectiveRounds = Math.max(3, Math.min(5, rounds ?? 3));
 	const roundResults: RoundResult[] = [];
@@ -169,7 +169,14 @@ export async function checkFastFlux(
 
 	// Recon enrichment: additive-only, fail-soft
 	if (reconOptions.reconBinding) {
-		const reconResult = await callReconScan(reconOptions.reconBinding, reconOptions.reconAuthToken, 'ATTACKER_INFRASTRUCTURE', { domain });
+		const reconResult = await callReconScan(
+			reconOptions.reconBinding,
+			reconOptions.reconAuthToken,
+			'ATTACKER_INFRASTRUCTURE',
+			{ domain },
+			undefined,
+			reconOptions.onBindingDegradation,
+		);
 		const hit = reconResult && isReconHit(reconResult.status);
 		if (hit) {
 			findings.push(

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -11,7 +11,7 @@ import { queryDnsRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { callReconScan, isReconHit } from '../lib/recon-binding';
 import { safeFetch } from '../lib/safe-fetch';
-import type { ReconBinding } from '../lib/recon-binding';
+import type { ReconBinding, BindingDegradationSink } from '../lib/recon-binding';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
@@ -107,9 +107,7 @@ async function probeLookalike(domain: string): Promise<LookalikeResult> {
 	const [aRecords, mxRecords] = await Promise.allSettled([queryDnsRecords(domain, 'A'), queryDnsRecords(domain, 'MX')]);
 
 	const realMxRecords = mxRecords.status === 'fulfilled' ? mxRecords.value.filter(isRealMxRecord) : [];
-	const mxExchanges = realMxRecords
-		.map(extractMxExchange)
-		.filter((host): host is string => host !== null);
+	const mxExchanges = realMxRecords.map(extractMxExchange).filter((host): host is string => host !== null);
 
 	return {
 		domain,
@@ -256,7 +254,7 @@ async function probeWithAdaptiveBatching(permutations: string[]): Promise<Promis
  */
 export async function checkLookalikes(
 	domain: string,
-	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string } = {},
+	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
 ): Promise<CheckResult> {
 	return Promise.race([
 		checkLookalikesCore(domain, reconOptions),
@@ -278,7 +276,7 @@ export async function checkLookalikes(
 
 async function checkLookalikesCore(
 	domain: string,
-	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string } = {},
+	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
 ): Promise<CheckResult> {
 	const findings: Finding[] = [];
 	// Typo/homoglyph permutations PLUS combosquats (brand + lure affix). The two
@@ -518,7 +516,14 @@ async function checkLookalikesCore(
 
 	// Recon enrichment: additive-only, fail-soft
 	if (reconOptions.reconBinding) {
-		const reconResult = await callReconScan(reconOptions.reconBinding, reconOptions.reconAuthToken, 'CT_LOOKALIKE', { domain });
+		const reconResult = await callReconScan(
+			reconOptions.reconBinding,
+			reconOptions.reconAuthToken,
+			'CT_LOOKALIKE',
+			{ domain },
+			undefined,
+			reconOptions.onBindingDegradation,
+		);
 		const hit = reconResult && isReconHit(reconResult.status);
 		if (hit) {
 			findings.push(

--- a/src/tools/check-realtime-threat-feed.ts
+++ b/src/tools/check-realtime-threat-feed.ts
@@ -8,7 +8,7 @@
  */
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory } from '../lib/scoring';
-import { callReconScan, isReconHit, type ReconBinding } from '../lib/recon-binding';
+import { callReconScan, isReconHit, type ReconBinding, type BindingDegradationSink } from '../lib/recon-binding';
 
 // F7 (OWASP LLM01): attacker-influenceable upstream metadata/status spread into
 // finding metadata below is sanitized at the `createFinding` chokepoint
@@ -20,6 +20,7 @@ const CATEGORY = 'realtime_threat_feed' as CheckCategory;
 export interface RealtimeThreatFeedOptions {
 	reconBinding?: ReconBinding;
 	reconAuthToken?: string;
+	onBindingDegradation?: BindingDegradationSink;
 }
 
 /** Map a DNSCheckResult status to a finding severity for threat-feed hits. */
@@ -44,7 +45,14 @@ function hitSeverity(status: string | undefined): 'critical' | 'high' | 'medium'
  */
 export async function checkRealtimeThreatFeed(domain: string, options: RealtimeThreatFeedOptions = {}): Promise<CheckResult> {
 	const findings: ReturnType<typeof createFinding>[] = [];
-	const scan = await callReconScan(options.reconBinding, options.reconAuthToken, 'REALTIME_THREAT_FEED', { domain });
+	const scan = await callReconScan(
+		options.reconBinding,
+		options.reconAuthToken,
+		'REALTIME_THREAT_FEED',
+		{ domain },
+		undefined,
+		options.onBindingDegradation,
+	);
 
 	if (!scan) {
 		findings.push(
@@ -75,13 +83,7 @@ export async function checkRealtimeThreatFeed(domain: string, options: RealtimeT
 		);
 	} else {
 		findings.push(
-			createFinding(
-				CATEGORY,
-				'No realtime threat-feed hits',
-				'info',
-				scan.details ?? 'No active threat-feed matches.',
-				{ domain },
-			),
+			createFinding(CATEGORY, 'No realtime threat-feed hits', 'info', scan.details ?? 'No active threat-feed matches.', { domain }),
 		);
 	}
 

--- a/src/tools/check-ssl.ts
+++ b/src/tools/check-ssl.ts
@@ -13,7 +13,7 @@ import { checkSSL } from '@blackveil/dns-checks';
 import type { CheckResult } from '../lib/scoring';
 import { HTTPS_TIMEOUT_MS } from '../lib/config';
 import { callTlsProbe, mergeTlsFinding } from '../lib/tls-probe-binding';
-import type { TlsProbeBinding } from '../lib/tls-probe-binding';
+import type { TlsProbeBinding, BindingDegradationSink } from '../lib/tls-probe-binding';
 
 /**
  * Check SSL/TLS configuration for a domain.
@@ -27,7 +27,7 @@ import type { TlsProbeBinding } from '../lib/tls-probe-binding';
  */
 export async function checkSsl(
 	domain: string,
-	tlsProbeOptions: { tlsProbeBinding?: TlsProbeBinding; tlsProbeAuthToken?: string } = {},
+	tlsProbeOptions: { tlsProbeBinding?: TlsProbeBinding; tlsProbeAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
 ): Promise<CheckResult> {
 	const result = (await checkSSL(domain, fetch, { timeout: HTTPS_TIMEOUT_MS })) as CheckResult;
 	// Operator-only TLS-version enrichment via the BV_TLS_PROBE service binding.
@@ -35,6 +35,8 @@ export async function checkSsl(
 	// callTlsProbe returns null on any failure; mergeTlsFinding only ever appends a
 	// High finding when the probe actively reports legacy TLS (≤1.1), never penalizes 1.2/1.3.
 	if (!tlsProbeOptions.tlsProbeBinding) return result;
-	const probe = await callTlsProbe(tlsProbeOptions.tlsProbeBinding, tlsProbeOptions.tlsProbeAuthToken, domain);
+	const probe = await callTlsProbe(tlsProbeOptions.tlsProbeBinding, tlsProbeOptions.tlsProbeAuthToken, domain, {
+		telemetry: tlsProbeOptions.onBindingDegradation,
+	});
 	return probe ? mergeTlsFinding(result, probe) : result;
 }

--- a/src/tools/osint-investigate.ts
+++ b/src/tools/osint-investigate.ts
@@ -8,6 +8,7 @@ import {
 	callReconInvestigationReport,
 	type ReconBinding,
 	type ReconInvestigationType,
+	type BindingDegradationSink,
 } from '../lib/recon-binding';
 
 const CATEGORY = 'osint_investigation' as CheckCategory;
@@ -15,14 +16,29 @@ const CATEGORY = 'osint_investigation' as CheckCategory;
 export interface ReconToolOptions {
 	reconBinding?: ReconBinding;
 	reconAuthToken?: string;
+	onBindingDegradation?: BindingDegradationSink;
 }
 
 function unprovisioned(detail: string): CheckResult {
-	return buildCheckResult(CATEGORY, [createFinding(CATEGORY, 'OSINT investigation unavailable', 'info', detail, { unprovisioned: true })]) as CheckResult;
+	return buildCheckResult(CATEGORY, [
+		createFinding(CATEGORY, 'OSINT investigation unavailable', 'info', detail, { unprovisioned: true }),
+	]) as CheckResult;
 }
 
-export async function osintInvestigateStart(type: ReconInvestigationType, query: string, options: ReconToolOptions = {}): Promise<CheckResult> {
-	const started = await callReconInvestigateStart(options.reconBinding, options.reconAuthToken, type, query);
+export async function osintInvestigateStart(
+	type: ReconInvestigationType,
+	query: string,
+	options: ReconToolOptions = {},
+): Promise<CheckResult> {
+	const started = await callReconInvestigateStart(
+		options.reconBinding,
+		options.reconAuthToken,
+		type,
+		query,
+		undefined,
+		undefined,
+		options.onBindingDegradation,
+	);
 	if (!started) return unprovisioned(`OSINT ${type} investigation is not provisioned in this deployment for ${query}.`);
 	return buildCheckResult(CATEGORY, [
 		createFinding(
@@ -68,7 +84,17 @@ const STATUS_META_KEYS = [
 ] as const;
 
 /** Per-finding fields kept in the report. Drops the multi-KB `rawData` blob (and `evidenceR2Key`). */
-const FINDING_KEEP_KEYS = ['type', 'severity', 'title', 'details', 'confidence', 'platform', 'platformCategory', 'url', 'createdAt'] as const;
+const FINDING_KEEP_KEYS = [
+	'type',
+	'severity',
+	'title',
+	'details',
+	'confidence',
+	'platform',
+	'platformCategory',
+	'url',
+	'createdAt',
+] as const;
 
 /** Hard cap on findings returned in a single report response, to stay under the MCP token cap. */
 const REPORT_MAX_FINDINGS = 100;
@@ -113,11 +139,12 @@ function shortText(s: string, max: number): string {
 }
 
 export async function osintInvestigationStatus(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
-	const s = await callReconInvestigationStatus(options.reconBinding, options.reconAuthToken, id);
+	const s = await callReconInvestigationStatus(options.reconBinding, options.reconAuthToken, id, undefined, options.onBindingDegradation);
 	if (!s) return unprovisioned(`Investigation status unavailable for ${id} (unprovisioned or not found).`);
 	const status = typeof s.status === 'string' ? s.status : 'unknown';
 	const parts = [`status=${status}`];
-	if (typeof s.completedChecks === 'number' && typeof s.totalChecks === 'number') parts.push(`${s.completedChecks}/${s.totalChecks} checks`);
+	if (typeof s.completedChecks === 'number' && typeof s.totalChecks === 'number')
+		parts.push(`${s.completedChecks}/${s.totalChecks} checks`);
 	if (typeof s.foundCount === 'number') parts.push(`${s.foundCount} found`);
 	if (typeof s.summary === 'string' && s.summary.trim()) parts.push(s.summary.trim());
 	return buildCheckResult(CATEGORY, [
@@ -131,7 +158,7 @@ export async function osintInvestigationStatus(id: string, options: ReconToolOpt
 }
 
 export async function osintInvestigationReport(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
-	const r = await callReconInvestigationReport(options.reconBinding, options.reconAuthToken, id);
+	const r = await callReconInvestigationReport(options.reconBinding, options.reconAuthToken, id, undefined, options.onBindingDegradation);
 	if (!r) return unprovisioned(`Investigation report unavailable for ${id} (unprovisioned or not ready).`);
 	const total = typeof r.total === 'number' ? r.total : Array.isArray(r.findings) ? r.findings.length : 0;
 	const summary = typeof r.summary === 'string' ? r.summary.trim() : '';

--- a/src/tools/scan-buckets.ts
+++ b/src/tools/scan-buckets.ts
@@ -2,7 +2,13 @@
 /** Cloud-bucket discovery tools — thin fail-soft proxies over bv-recon's bucket-scanner. */
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory } from '../lib/scoring';
-import { callReconBucketScanStart, callReconBucketScanStatus, callReconBucketFindings, type ReconBinding } from '../lib/recon-binding';
+import {
+	callReconBucketScanStart,
+	callReconBucketScanStatus,
+	callReconBucketFindings,
+	type ReconBinding,
+	type BindingDegradationSink,
+} from '../lib/recon-binding';
 import { extractBrandName, getRegistrableDomain } from '../lib/public-suffix';
 
 // F7 (OWASP LLM01): upstream bv-recon strings spread into finding metadata below
@@ -17,10 +23,13 @@ export interface ReconToolOptions {
 	reconBinding?: ReconBinding;
 	reconAuthToken?: string;
 	bucketScanKv?: KVNamespace;
+	onBindingDegradation?: BindingDegradationSink;
 }
 
 function unprovisioned(detail: string): CheckResult {
-	return buildCheckResult(CATEGORY, [createFinding(CATEGORY, 'Bucket scanning unavailable', 'info', detail, { unprovisioned: true })]) as CheckResult;
+	return buildCheckResult(CATEGORY, [
+		createFinding(CATEGORY, 'Bucket scanning unavailable', 'info', detail, { unprovisioned: true }),
+	]) as CheckResult;
 }
 
 interface BucketScanScope {
@@ -114,7 +123,13 @@ function hasTargetScope(tokens: TargetScopeTokens): boolean {
 
 function normalizeProvider(provider: string | undefined): string | undefined {
 	if (!provider) return undefined;
-	return provider.toLowerCase().trim().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '') || undefined;
+	return (
+		provider
+			.toLowerCase()
+			.trim()
+			.replace(/[^a-z0-9]+/g, '_')
+			.replace(/^_+|_+$/g, '') || undefined
+	);
 }
 
 function providerAllowed(provider: unknown, requestedProviders: string[] | undefined): boolean {
@@ -151,7 +166,9 @@ async function rememberBucketScanScope(scanId: string | undefined, scope: Bucket
 	if (!scanId || !kv || !SAFE_SCAN_ID.test(scanId)) return;
 	const target = normalizeTarget(scope.target);
 	if (!target && !scope.providers?.length) return;
-	await kv.put(scopeKey(scanId), JSON.stringify({ target, providers: scope.providers }), { expirationTtl: BUCKET_SCAN_SCOPE_TTL_SECONDS }).catch(() => undefined);
+	await kv
+		.put(scopeKey(scanId), JSON.stringify({ target, providers: scope.providers }), { expirationTtl: BUCKET_SCAN_SCOPE_TTL_SECONDS })
+		.catch(() => undefined);
 }
 
 async function loadBucketScanScope(scanId: string | undefined, kv: KVNamespace | undefined): Promise<BucketScanScope> {
@@ -209,8 +226,17 @@ function filterBucketPayload(payload: Record<string, unknown>, scope: BucketScan
 	};
 }
 
-export async function scanBucketsStart(args: { target: string; providers?: string[] }, options: ReconToolOptions = {}): Promise<CheckResult> {
-	const started = await callReconBucketScanStart(options.reconBinding, options.reconAuthToken, { target: args.target, providers: args.providers });
+export async function scanBucketsStart(
+	args: { target: string; providers?: string[] },
+	options: ReconToolOptions = {},
+): Promise<CheckResult> {
+	const started = await callReconBucketScanStart(
+		options.reconBinding,
+		options.reconAuthToken,
+		{ target: args.target, providers: args.providers },
+		undefined,
+		options.onBindingDegradation,
+	);
 	if (!started) return unprovisioned(`Bucket discovery is not provisioned in this deployment for ${args.target}.`);
 	await rememberBucketScanScope(started.scanId, args, options.bucketScanKv);
 	return buildCheckResult(CATEGORY, [
@@ -230,7 +256,13 @@ export async function scanBucketsStart(args: { target: string; providers?: strin
 }
 
 export async function scanBucketsStatus(args: { scanId: string }, options: ReconToolOptions = {}): Promise<CheckResult> {
-	const s = await callReconBucketScanStatus(options.reconBinding, options.reconAuthToken, args.scanId);
+	const s = await callReconBucketScanStatus(
+		options.reconBinding,
+		options.reconAuthToken,
+		args.scanId,
+		undefined,
+		options.onBindingDegradation,
+	);
 	if (!s) return unprovisioned(`Bucket scan status is unavailable for ${args.scanId} (unprovisioned or not found).`);
 	const scope = await loadBucketScanScope(args.scanId, options.bucketScanKv);
 	return buildCheckResult(CATEGORY, [
@@ -245,7 +277,13 @@ export async function scanBucketsStatus(args: { scanId: string }, options: Recon
 }
 
 export async function scanBucketsFindings(args: BucketScanFindingArgs, options: ReconToolOptions = {}): Promise<CheckResult> {
-	const f = await callReconBucketFindings(options.reconBinding, options.reconAuthToken, args.scanId);
+	const f = await callReconBucketFindings(
+		options.reconBinding,
+		options.reconAuthToken,
+		args.scanId,
+		undefined,
+		options.onBindingDegradation,
+	);
 	if (!f) return unprovisioned('Bucket findings are unavailable (unprovisioned or no scan).');
 	const rememberedScope = await loadBucketScanScope(args.scanId, options.bucketScanKv);
 	const target = normalizeTarget(args.target) ?? rememberedScope.target;

--- a/test/analytics-queries.spec.ts
+++ b/test/analytics-queries.spec.ts
@@ -20,6 +20,7 @@ import {
 	queryTierTopTools,
 	queryKeyUsage,
 	queryTierDigest,
+	queryBindingDegradation,
 } from '../src/lib/analytics-queries';
 
 describe('analytics query builders', () => {
@@ -103,6 +104,22 @@ describe('analytics query builders', () => {
 	it('queryRateLimitSurge sanitizes minutes parameter', () => {
 		const sql = queryRateLimitSurge('abc');
 		expect(sql).toContain("INTERVAL '1' MINUTE");
+	});
+
+	it('queryBindingDegradation counts present-binding degradation events, excluding kv_fallback', () => {
+		const sql = queryBindingDegradation('15');
+		expect(sql).toContain("index1 = 'degradation'");
+		expect(sql).toContain("blob1 != 'kv_fallback'");
+		expect(sql).toContain('blob2 AS component');
+		expect(sql).toContain('blob1 AS degradation_type');
+		expect(sql).toContain('event_count');
+		expect(sql).toContain("INTERVAL '15' MINUTE");
+	});
+
+	it('queryBindingDegradation sanitizes minutes parameter', () => {
+		const sql = queryBindingDegradation("10'; DROP TABLE --");
+		expect(sql).toContain("INTERVAL '10' MINUTE");
+		expect(sql).not.toContain('DROP TABLE');
 	});
 });
 

--- a/test/analytics.spec.ts
+++ b/test/analytics.spec.ts
@@ -131,7 +131,15 @@ describe('createAnalyticsClient', () => {
 	it('no-ops gracefully when dataset is undefined', () => {
 		const client = createAnalyticsClient();
 		// Should not throw
-		client.emitRequestEvent({ method: 'ping', status: 'ok', durationMs: 1, isAuthenticated: false, hasJsonRpcError: false, transport: 'json', ...ctx });
+		client.emitRequestEvent({
+			method: 'ping',
+			status: 'ok',
+			durationMs: 1,
+			isAuthenticated: false,
+			hasJsonRpcError: false,
+			transport: 'json',
+			...ctx,
+		});
 		client.emitToolEvent({ toolName: 'check_spf', status: 'pass', durationMs: 50, isError: false, ...ctx });
 		client.emitRateLimitEvent({ limitType: 'minute', toolName: 'n/a', limit: 50, remaining: 0, ...ctx });
 		client.emitSessionEvent({ action: 'created', ...ctx });
@@ -182,5 +190,25 @@ describe('createAnalyticsClient', () => {
 		client.emitDegradationEvent({ degradationType: 'kv_fallback', component: 'session' });
 		// Two identical emits → two writes (no module-level dedup state).
 		expect(ds.writeDataPoint).toHaveBeenCalledTimes(2);
+	});
+
+	it('writes the binding-degradation members (recon binding_5xx)', () => {
+		const ds = mockDataset();
+		const client = createAnalyticsClient(ds);
+		client.emitDegradationEvent({ degradationType: 'binding_5xx', component: 'recon', domain: 'example.com', ...ctx });
+		expect(ds.writeDataPoint).toHaveBeenCalledOnce();
+		const point = ds.writeDataPoint.mock.calls[0][0];
+		expect(point.indexes).toEqual(['degradation']);
+		expect(point.blobs[0]).toBe('binding_5xx');
+		expect(point.blobs[1]).toBe('recon');
+	});
+
+	it('writes the tls_probe binding_timeout member', () => {
+		const ds = mockDataset();
+		const client = createAnalyticsClient(ds);
+		client.emitDegradationEvent({ degradationType: 'binding_timeout', component: 'tls_probe' });
+		const point = ds.writeDataPoint.mock.calls[0][0];
+		expect(point.blobs[0]).toBe('binding_timeout');
+		expect(point.blobs[1]).toBe('tls_probe');
 	});
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -281,6 +281,63 @@ describe('DNS Security MCP Server', () => {
 			expect(body.status).toBe('ok');
 			expect(body.service).toBe('bv-dns-security-mcp');
 		});
+
+		// F5 — owner-gated deep readiness mode. The cheap default path stays
+		// untouched (no auth, no binding I/O); ?deep=1 requires an owner credential.
+		it('cheap default path does NOT include a bindings block', async () => {
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/health');
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			const body = (await response.json()) as Record<string, unknown>;
+			expect(body.status).toBe('ok');
+			expect(body.bindings).toBeUndefined();
+		});
+
+		it('deep mode without an owner credential is 403', async () => {
+			const authEnv = { ...env, BV_API_KEY: TEST_API_KEY } as Env;
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/health?deep=1');
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, authEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(403);
+			const body = (await response.json()) as { error: string };
+			expect(body.error).toBe('forbidden');
+		});
+
+		it('deep mode with a wrong bearer is 403', async () => {
+			const authEnv = { ...env, BV_API_KEY: TEST_API_KEY } as Env;
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/health?deep=1', {
+				headers: { Authorization: 'Bearer wrong-token' },
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, authEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(403);
+		});
+
+		it('deep mode with an owner credential returns per-binding status', async () => {
+			const authEnv = { ...env, BV_API_KEY: TEST_API_KEY } as Env;
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/health?deep=1', {
+				headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, authEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			// 200 when probes pass, 503 if a provisioned binding errors — either way
+			// the body must carry a per-binding status map.
+			expect([200, 503]).toContain(response.status);
+			const body = (await response.json()) as {
+				status: string;
+				service: string;
+				bindings: { scanCache: string; quotaCoordinator: string };
+			};
+			expect(body.service).toBe('bv-dns-security-mcp');
+			expect(body.bindings).toBeDefined();
+			expect(['ok', 'error', 'absent']).toContain(body.bindings.scanCache);
+			expect(['ok', 'error', 'absent']).toContain(body.bindings.quotaCoordinator);
+		});
 	});
 
 	describe('POST /mcp - initialize', () => {

--- a/test/provider-signature-source.spec.ts
+++ b/test/provider-signature-source.spec.ts
@@ -30,6 +30,24 @@ describe('provider-signature-source', () => {
 		expect(() => validateRuntimeSourceUrl('https://other.example/signatures.json', ['example.com'])).toThrow('host is not allowlisted');
 	});
 
+	it('rejects internal/SSRF source URLs even when the host allowlist is empty (F4)', () => {
+		// Empty allowlist is the production default — the outbound-policy guard must still
+		// reject RFC1918 / loopback / metadata-style targets an operator could misconfigure.
+		expect(() => validateRuntimeSourceUrl('https://10.0.0.5/signatures.json', [])).toThrow(
+			'Invalid provider signature source URL',
+		);
+		expect(() => validateRuntimeSourceUrl('https://192.168.1.1/signatures.json', [])).toThrow(
+			'Invalid provider signature source URL',
+		);
+		expect(() => validateRuntimeSourceUrl('https://127.0.0.1/signatures.json', [])).toThrow(
+			'Invalid provider signature source URL',
+		);
+		// userinfo-spoofed target
+		expect(() => validateRuntimeSourceUrl('https://user:pass@example.com/signatures.json', [])).toThrow(
+			'Invalid provider signature source URL',
+		);
+	});
+
 	it('normalizes provider payloads when building results', () => {
 		const result = buildResult(
 			{

--- a/test/recon-binding.spec.ts
+++ b/test/recon-binding.spec.ts
@@ -9,9 +9,7 @@ async function fresh() {
 
 function bindingReturning(body: unknown, status = 200) {
 	return {
-		fetch: vi.fn(async () =>
-			new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }),
-		),
+		fetch: vi.fn(async () => new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })),
 	};
 }
 
@@ -50,15 +48,113 @@ describe('callReconScan', () => {
 	it('returns null when the body is not an object (non-parseable shape)', async () => {
 		const { callReconScan } = await fresh();
 		// A JSON array is not an object — Zod .object() rejects it
-		const binding = { fetch: vi.fn(async () => new Response(JSON.stringify([1, 2, 3]), { status: 200, headers: { 'Content-Type': 'application/json' } })) };
+		const binding = {
+			fetch: vi.fn(async () => new Response(JSON.stringify([1, 2, 3]), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+		};
 		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' });
 		expect(out).toBeNull();
 	});
 
 	it('parses a valid DNSCheckResult body', async () => {
 		const { callReconScan } = await fresh();
-		const binding = bindingReturning({ checkType: 'REALTIME_THREAT_FEED', status: 'info', details: 'Threat intelligence lookup returned status 404.', records: [], metadata: { domain: 'wikipedia.org', breachesFound: [] } });
+		const binding = bindingReturning({
+			checkType: 'REALTIME_THREAT_FEED',
+			status: 'info',
+			details: 'Threat intelligence lookup returned status 404.',
+			records: [],
+			metadata: { domain: 'wikipedia.org', breachesFound: [] },
+		});
 		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' });
 		expect(out?.status).toBe('info');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// F1: binding-degradation telemetry (present-but-failing branches only)
+// ---------------------------------------------------------------------------
+describe('callReconScan degradation telemetry', () => {
+	it('emits binding_5xx (sink + warn log) on a present-but-5xx response', async () => {
+		const { callReconScan } = await fresh();
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = bindingReturning({ error: 'nope' }, 503);
+		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' }, undefined, sink);
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith({ degradationType: 'binding_5xx', component: 'recon', domain: 'x.com' });
+		const logged = warn.mock.calls.map((c) => String(c[0])).join('\n');
+		expect(logged).toContain('binding_degradation');
+		expect(logged).toContain('binding_5xx');
+	});
+
+	it('stays SILENT (no sink, no degradation log) when the binding is absent', async () => {
+		const { callReconScan } = await fresh();
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconScan(undefined, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' }, undefined, sink);
+		expect(out).toBeNull();
+		expect(sink).not.toHaveBeenCalled();
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('binding_degradation');
+	});
+
+	it('keeps the 404 benign branch SILENT (no degradation)', async () => {
+		const { callReconScan } = await fresh();
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = bindingReturning({ error: 'not found' }, 404);
+		const out = await callReconScan(binding, 'tok', 'REALTIME_THREAT_FEED', { domain: 'clean.example' }, undefined, sink);
+		expect(out?.status).toBe('info');
+		expect(sink).not.toHaveBeenCalled();
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('binding_degradation');
+	});
+
+	it('emits binding_timeout when the fetch aborts with a TimeoutError', async () => {
+		const { callReconScan } = await fresh();
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = {
+			fetch: vi.fn(async () => {
+				const e = new Error('The operation was aborted due to timeout');
+				e.name = 'TimeoutError';
+				throw e;
+			}),
+		};
+		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' }, undefined, sink);
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith({ degradationType: 'binding_timeout', component: 'recon', domain: 'x.com' });
+	});
+
+	it('emits binding_unavailable on a generic network throw', async () => {
+		const { callReconScan } = await fresh();
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = {
+			fetch: vi.fn(async () => {
+				throw new Error('connection refused');
+			}),
+		};
+		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' }, undefined, sink);
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith({ degradationType: 'binding_unavailable', component: 'recon', domain: 'x.com' });
+	});
+
+	it('does not throw if the sink itself throws (fail-soft contract preserved)', async () => {
+		const { callReconScan } = await fresh();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const sink = vi.fn(() => {
+			throw new Error('sink boom');
+		});
+		const binding = bindingReturning({ error: 'nope' }, 500);
+		const out = await callReconScan(binding, 'tok', 'MALICIOUS_ASN', { domain: 'x.com' }, undefined, sink);
+		expect(out).toBeNull();
+	});
+
+	it('forwards the sink through reconJson-backed bucket calls on 5xx', async () => {
+		const { callReconBucketScanStatus } = await fresh();
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = bindingReturning({ error: 'boom' }, 502);
+		const out = await callReconBucketScanStatus(binding, 'tok', 'scan-123', undefined, sink);
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith(expect.objectContaining({ degradationType: 'binding_5xx', component: 'recon' }));
 	});
 });

--- a/test/request-correlation-id.spec.ts
+++ b/test/request-correlation-id.spec.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetAllRateLimits, resetGlobalDailyLimit, resetConcurrencyLimits } from '../src/lib/rate-limiter';
+import { resetSessions } from '../src/lib/session';
+import { logEvent } from '../src/lib/log';
+import type { ExecuteMcpRequestOptions } from '../src/mcp/execute';
+import type { JsonRpcRequest } from '../src/lib/json-rpc';
+
+/** Build a minimal valid ExecuteMcpRequestOptions for testing. */
+function baseOptions(overrides: Partial<ExecuteMcpRequestOptions> = {}): ExecuteMcpRequestOptions {
+	return {
+		body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} } as JsonRpcRequest,
+		allowStreaming: false,
+		batchMode: false,
+		batchSize: 1,
+		responseTransport: 'json',
+		startTime: Date.now(),
+		ip: '203.0.113.1',
+		isAuthenticated: false,
+		validateSession: false,
+		serverVersion: '2.3.0',
+		...overrides,
+	};
+}
+
+/** Parse every console.log JSON line emitted during the test. */
+function capturedLogEvents(spy: ReturnType<typeof vi.spyOn>): Array<Record<string, unknown>> {
+	const events: Array<Record<string, unknown>> = [];
+	for (const call of spy.mock.calls) {
+		try {
+			events.push(JSON.parse(String(call[0])) as Record<string, unknown>);
+		} catch {
+			// non-JSON console.log line — ignore
+		}
+	}
+	return events;
+}
+
+beforeEach(() => {
+	resetAllRateLimits();
+	resetGlobalDailyLimit();
+	resetConcurrencyLimits();
+	resetSessions();
+});
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.resetModules();
+});
+
+describe('F2 — request correlation id', () => {
+	it('round-trips through a LogEvent into the serialized log line', () => {
+		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		logEvent({ timestamp: new Date().toISOString(), correlationId: 'corr-abc', category: 'test', result: 'ok' });
+		const events = capturedLogEvents(consoleSpy);
+		expect(events).toHaveLength(1);
+		expect(events[0].correlationId).toBe('corr-abc');
+	});
+
+	it('stamps the threaded correlation id onto the dispatch log line for a request', async () => {
+		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const { executeMcpRequest } = await import('../src/mcp/execute');
+
+		await executeMcpRequest(baseOptions({ correlationId: 'corr-fixed-1', userAgent: 'vitest' }));
+
+		const events = capturedLogEvents(consoleSpy);
+		const stamped = events.filter((e) => e.correlationId === 'corr-fixed-1');
+		// At least the dispatch log line must carry the id.
+		expect(stamped.length).toBeGreaterThanOrEqual(1);
+		// Every log line emitted with a correlationId for this request must carry
+		// THIS request's id — none should be missing/another id.
+		const withCorr = events.filter((e) => typeof e.correlationId === 'string');
+		for (const e of withCorr) {
+			expect(e.correlationId).toBe('corr-fixed-1');
+		}
+	});
+
+	it('keeps correlation ids distinct across two separate requests', async () => {
+		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const { executeMcpRequest } = await import('../src/mcp/execute');
+
+		await executeMcpRequest(baseOptions({ correlationId: 'corr-A' }));
+		await executeMcpRequest(baseOptions({ correlationId: 'corr-B' }));
+
+		const events = capturedLogEvents(consoleSpy);
+		const ids = new Set(events.filter((e) => typeof e.correlationId === 'string').map((e) => e.correlationId));
+		expect(ids.has('corr-A')).toBe(true);
+		expect(ids.has('corr-B')).toBe(true);
+	});
+});

--- a/test/scheduled.spec.ts
+++ b/test/scheduled.spec.ts
@@ -68,6 +68,61 @@ describe('handleScheduled', () => {
 		expect(webhookCall!.body).toContain('error');
 	});
 
+	it('sends a service-binding degradation alert when present-binding events appear', async () => {
+		const fetchCalls: Array<{ url: string; body: string }> = [];
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			fetchCalls.push({ url, body: init?.body as string });
+
+			if (url.includes('analytics_engine/sql')) {
+				const query = init?.body as string;
+				// Healthy tool_call + rate_limit so only the degradation branch fires.
+				if (query.includes("index1 = 'degradation'")) {
+					return new Response(JSON.stringify({ data: [{ component: 'recon', degradation_type: 'binding_5xx', event_count: 4 }] }));
+				}
+				if (query.includes('tool_call')) {
+					return new Response(JSON.stringify({ data: [{ total_calls: 100, error_count: 1, error_pct: 1.0, p95_ms: 500 }] }));
+				}
+				if (query.includes('rate_limit')) {
+					return new Response(JSON.stringify({ data: [{ total_hits: 2 }] }));
+				}
+			}
+			return new Response('ok');
+		}) as typeof fetch;
+
+		const { handleScheduled } = await import('../src/scheduled');
+		await handleScheduled({
+			CF_ACCOUNT_ID: 'test-account',
+			CF_ANALYTICS_TOKEN: 'test-token',
+			ALERT_WEBHOOK_URL: 'https://hooks.slack.com/test',
+		});
+
+		const webhookCall = fetchCalls.find((c) => c.url.includes('hooks.slack.com'));
+		expect(webhookCall).toBeDefined();
+		expect(webhookCall!.body).toContain('binding');
+	});
+
+	it('does NOT send a degradation alert when only kv_fallback occurs (query excludes it → 0 rows)', async () => {
+		const fetchCalls: string[] = [];
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			fetchCalls.push(url);
+			if (url.includes('analytics_engine/sql')) {
+				const query = init?.body as string;
+				// The SQL itself filters kv_fallback, so the engine returns no rows here.
+				if (query.includes("index1 = 'degradation'")) return new Response(JSON.stringify({ data: [] }));
+				if (query.includes('tool_call'))
+					return new Response(JSON.stringify({ data: [{ total_calls: 100, error_count: 1, error_pct: 1.0, p95_ms: 500 }] }));
+				if (query.includes('rate_limit')) return new Response(JSON.stringify({ data: [{ total_hits: 2 }] }));
+			}
+			return new Response('ok');
+		}) as typeof fetch;
+
+		const { handleScheduled } = await import('../src/scheduled');
+		await handleScheduled({ CF_ACCOUNT_ID: 'a', CF_ANALYTICS_TOKEN: 't', ALERT_WEBHOOK_URL: 'https://hooks.slack.com/test' });
+		expect(fetchCalls.filter((u) => u.includes('hooks.slack.com'))).toHaveLength(0);
+	});
+
 	it('does not send alert when metrics are within thresholds', async () => {
 		const fetchCalls: string[] = [];
 		globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {

--- a/test/tls-probe-binding.spec.ts
+++ b/test/tls-probe-binding.spec.ts
@@ -66,8 +66,91 @@ describe('callTlsProbe', () => {
 
 	it('returns null when binding.fetch throws (fail-soft)', async () => {
 		const { callTlsProbe } = await fresh();
-		const binding = { fetch: vi.fn(async () => { throw new Error('network failure'); }) };
+		const binding = {
+			fetch: vi.fn(async () => {
+				throw new Error('network failure');
+			}),
+		};
 		const out = await callTlsProbe(binding, 'tok', 'example.com');
+		expect(out).toBeNull();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// F1: binding-degradation telemetry (present-but-failing branches only)
+// ---------------------------------------------------------------------------
+describe('callTlsProbe degradation telemetry', () => {
+	it('emits binding_5xx (sink + warn log) on a present-but-503 response', async () => {
+		const { callTlsProbe } = await fresh();
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = bindingReturning({ error: 'server error' }, 503);
+		const out = await callTlsProbe(binding, 'tok', 'example.com', { telemetry: sink });
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith({ degradationType: 'binding_5xx', component: 'tls_probe', domain: 'example.com' });
+		const logged = warn.mock.calls.map((c) => String(c[0])).join('\n');
+		expect(logged).toContain('binding_degradation');
+		expect(logged).toContain('tls_probe');
+	});
+
+	it('emits binding_5xx on a 404 (NOT benign for the probe, unlike recon)', async () => {
+		const { callTlsProbe } = await fresh();
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = bindingReturning({ error: 'not found' }, 404);
+		const out = await callTlsProbe(binding, 'tok', 'example.com', { telemetry: sink });
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith({ degradationType: 'binding_5xx', component: 'tls_probe', domain: 'example.com' });
+	});
+
+	it('stays SILENT (no sink, no degradation log) when the binding is absent', async () => {
+		const { callTlsProbe } = await fresh();
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callTlsProbe(undefined, 'tok', 'example.com', { telemetry: sink });
+		expect(out).toBeNull();
+		expect(sink).not.toHaveBeenCalled();
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('binding_degradation');
+	});
+
+	it('emits binding_timeout when the fetch aborts with a TimeoutError', async () => {
+		const { callTlsProbe } = await fresh();
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = {
+			fetch: vi.fn(async () => {
+				const e = new Error('timed out');
+				e.name = 'TimeoutError';
+				throw e;
+			}),
+		};
+		const out = await callTlsProbe(binding, 'tok', 'example.com', { telemetry: sink });
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith({ degradationType: 'binding_timeout', component: 'tls_probe', domain: 'example.com' });
+	});
+
+	it('emits binding_unavailable on a generic network throw', async () => {
+		const { callTlsProbe } = await fresh();
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const binding = {
+			fetch: vi.fn(async () => {
+				throw new Error('network failure');
+			}),
+		};
+		const out = await callTlsProbe(binding, 'tok', 'example.com', { telemetry: sink });
+		expect(out).toBeNull();
+		expect(sink).toHaveBeenCalledWith({ degradationType: 'binding_unavailable', component: 'tls_probe', domain: 'example.com' });
+	});
+
+	it('does not throw if the sink itself throws (fail-soft contract preserved)', async () => {
+		const { callTlsProbe } = await fresh();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const sink = vi.fn(() => {
+			throw new Error('sink boom');
+		});
+		const binding = bindingReturning({ error: 'x' }, 500);
+		const out = await callTlsProbe(binding, 'tok', 'example.com', { telemetry: sink });
 		expect(out).toBeNull();
 	});
 });


### PR DESCRIPTION
## Summary

The **ship-now wave** from a multi-agent audit of the server (hardening + global scalability + dependency currency). 23 findings audited → 17 verified → 7 verified-and-shippable; this PR lands the **5 that passed independent review** as file-disjoint batches. All additive / defense-in-depth — no scoring or scan-model change (`SCORING_MODEL_VERSION` unchanged), tool count unchanged (78).

## What's in it

- **Observability**
  - Server-generated request `correlationId` (prefers `cf-ray`, else `crypto.randomUUID()`) threaded onto every log line, distinct from the JSON-RPC `requestId` — lets multi-line traces be stitched.
  - Owner-gated deep `/health?deep=1` readiness (bounded `SCAN_CACHE` + `QUOTA_COORDINATOR` probes); default liveness path unchanged.
  - Binding-degradation telemetry for the fail-soft operator bindings (`BV_RECON`, `BV_TLS_PROBE`): structured `binding_degradation` warn log on present-but-failing branches + a fail-soft analytics sink + a 15-min cron alert. Expected-absence stays silent. _(Sink is not yet threaded to a live analytics client — runtime emission is currently the warn log; the analytics-event path activates when a follow-up wires the sink.)_
- **Security (defense-in-depth)**
  - `PROVIDER_SIGNATURES_URL` routed through `validateOutboundUrl`/`safeFetch` (same SSRF rejection as BIMI/RDAP).
  - Removed the unreachable length-mismatch branch in `matchesStaticDevKey`'s constant-time compare (operands are invariantly 32-byte digests).
- **Dependencies** — patch bump: `hono` 4.12.26, `wrangler` 4.103.0, `@cloudflare/vitest-pool-workers` 0.16.18, `@cloudflare/workers-types` 4.20260620.1 (CF devDeps in lockstep). 0 npm-audit vulns.

## Verification

- Each batch implemented in an isolated worktree (TDD), then independently reviewed; only `safeToIntegrate` branches merged here.
- Combined branch: `npm run typecheck` clean · 233 changed-spec tests green · audit suite (incl. version-sync) green.

## Deliberately NOT included

- **F7 scan_domain score-recompute dedup** — independent review returned `request-changes` (a scoring-engine refactor; held for a fix-up pass with mandatory score-snapshot gating).
- **Design-level items** (QuotaCoordinator sharding, global-cost-ceiling breaker fallback, subrequest abort-on-timeout, edge-colo telemetry + tail-Worker) — these trade quota correctness / cost and are tracked for a deliberate design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)