### PR TITLE
fix(scan): distinguish inconclusive (errored/timed-out) categories from genuine N/A

### DIFF
--- a/src/tools/batch-scan.ts
+++ b/src/tools/batch-scan.ts
@@ -58,6 +58,7 @@ function emptyResult(domain: string, error: string): BatchScanResultItem {
 		dnssecSource: null,
 		cdnProvider: null,
 		notApplicableCategories: [],
+		inconclusiveCategories: [],
 		timestamp: new Date().toISOString(),
 		cached: false,
 		// No scan ran for an error placeholder (invalid domain / budget exceeded),

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -44,8 +44,19 @@ export interface StructuredScanResult {
 	 * Categories that don't apply to this domain (no MX → mail-only categories under
 	 * `web_only`/`non_mail`; check timed-out/errored → inconclusive). These categories
 	 * are always reported as `null` in `categoryScores` to avoid the misleading 100 or 0.
+	 * NOTE: this array deliberately conflates two reasons — a deliberate skip and a
+	 * measurement failure. Use `inconclusiveCategories` (a subset) to tell them apart.
 	 */
 	notApplicableCategories: string[];
+	/**
+	 * Subset of `notApplicableCategories` whose `null` score is due to a transient
+	 * measurement FAILURE (the check timed-out or errored, `checkStatuses[cat]` is
+	 * `'timeout'`/`'error'`) rather than the control genuinely not applying to this
+	 * domain. A consumer should treat these as "could not measure / retry later", not
+	 * as a deliberate N/A. Always a subset: every entry here is also in
+	 * `notApplicableCategories` and `null` in `categoryScores`. Empty when every check ran.
+	 */
+	inconclusiveCategories: string[];
 	timestamp: string;
 	cached: boolean;
 	/**
@@ -193,6 +204,7 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 	const allCategoryKeys = new Set<string>([...Object.keys(sourceCategoryScores), ...result.checks.map((c) => c.category)]);
 
 	const notApplicableCategories: string[] = [];
+	const inconclusiveCategories: string[] = [];
 	const categoryScores: Record<string, number | null> = {};
 	for (const category of allCategoryKeys) {
 		const check = checksByCategory.get(category);
@@ -201,6 +213,13 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 			: undefined;
 		if (isCategoryNonApplicable(check, category, profile, rawScore)) {
 			notApplicableCategories.push(category);
+			// A category is "inconclusive" (could-not-measure) — rather than a deliberate
+			// N/A — exactly when Rule 1 fired: its check timed-out or errored. Deriving it
+			// here, inside the same branch that nulls the score, keeps `inconclusiveCategories`
+			// a guaranteed subset of `notApplicableCategories` with a null `categoryScores`.
+			if (check && (check.checkStatus === 'timeout' || check.checkStatus === 'error')) {
+				inconclusiveCategories.push(category);
+			}
 			categoryScores[category] = null;
 		} else if (rawScore !== undefined) {
 			categoryScores[category] = rawScore;
@@ -238,6 +257,7 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		dnssecSource,
 		cdnProvider,
 		notApplicableCategories,
+		inconclusiveCategories,
 		timestamp: result.timestamp,
 		cached: result.cached,
 		scoringModelVersion: SCORING_MODEL_VERSION,

--- a/test/format-report.spec.ts
+++ b/test/format-report.spec.ts
@@ -160,6 +160,50 @@ describe('buildStructuredScanResult', () => {
 		expect(s.notApplicableCategories).not.toContain('spf');
 	});
 
+	it('separates inconclusive (errored/timed-out) categories from genuine N/A (awswaf.com regression)', () => {
+		// web_only domain (no MX): dkim is a genuine non-applicable mail-only category,
+		// while http_security ERRORED (e.g. a WAF endpoint) and dnssec TIMED OUT — those
+		// two are "could not measure", not "does not apply".
+		const result = makeMockScanResult({
+			context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			score: { overall: 70, grade: 'C+', categoryScores: { ssl: 70 } as Record<CheckCategory, number>, findings: [], summary: 'ok' } as ScanScore,
+			checks: [
+				{ category: 'ssl', passed: true, score: 70, findings: [{ category: 'ssl', title: 'Valid cert', severity: 'info', detail: 'x' }], checkStatus: 'completed' },
+				{ category: 'dkim', passed: false, score: 0, findings: [{ category: 'dkim', title: 'No DKIM', severity: 'info', detail: 'x' }], checkStatus: 'completed' },
+				{ category: 'http_security', passed: false, score: 0, findings: [], checkStatus: 'error' },
+				{ category: 'dnssec', passed: false, score: 0, findings: [], checkStatus: 'timeout' },
+			] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+
+		// inconclusive = errored/timed-out checks only
+		expect(s.inconclusiveCategories).toContain('http_security');
+		expect(s.inconclusiveCategories).toContain('dnssec');
+		expect(s.inconclusiveCategories).not.toContain('dkim'); // genuine N/A, measured fine
+		expect(s.inconclusiveCategories).not.toContain('ssl'); // applicable, measured fine
+
+		// dual-listing preserved: every inconclusive category is also in notApplicableCategories
+		for (const cat of s.inconclusiveCategories) {
+			expect(s.notApplicableCategories).toContain(cat);
+		}
+		expect(s.notApplicableCategories).toContain('dkim'); // genuine N/A stays
+		expect(s.notApplicableCategories).not.toContain('ssl'); // applicable web category
+
+		// reconciliation invariant holds for both buckets: score is null
+		expect(s.categoryScores.http_security).toBeNull();
+		expect(s.categoryScores.dnssec).toBeNull();
+		expect(s.categoryScores.dkim).toBeNull();
+		expect(s.categoryScores.ssl).toBe(70);
+	});
+
+	it('returns empty inconclusiveCategories when all checks completed', () => {
+		const result = makeMockScanResult({
+			checks: [{ category: 'spf', passed: true, score: 100, findings: [], checkStatus: 'completed' }] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.inconclusiveCategories).toEqual([]);
+	});
+
 	it('returns empty checkStatuses when checks array is empty', () => {
 		const result = makeMockScanResult({ checks: [] });
 		const s = buildStructuredScanResult(result);


### PR DESCRIPTION
## What

Adds an additive-optional `inconclusiveCategories: string[]` to `StructuredScanResult`, separating two reasons a category is reported with a `null` score:

- **Genuine N/A** — deliberate skip (e.g. `dkim` on a no-MX domain) → stays in `notApplicableCategories` only.
- **Inconclusive** — a measurement *failure* (`checkStatus` `timeout`/`error`) → now also surfaced in the new `inconclusiveCategories`.

## Why

Surfaced while tailing prod worker logs for a scan of `awswaf.com`. `check_http_security` errors deterministically there (AWS WAF challenge endpoint doesn't serve normal HTTP), so it landed in `notApplicableCategories` alongside genuine no-MX skips — indistinguishable to a consumer. Only `checkStatuses` disambiguated, and nothing forced cross-referencing it.

## Design

- Derived inside the same `isCategoryNonApplicable` Rule-1 branch that nulls the score → **guaranteed subset** of `notApplicableCategories`, always `null` in `categoryScores`.
- **Zero behavior change** to existing fields: errored categories still dual-list in `notApplicableCategories`, so existing consumers (bv-web's tolerant `StructuredScanResultSchema`, agent-chat) see the identical shape. New field is opt-in.

## Verification

- TDD: RED (2 tests fail on missing field) → GREEN.
- `format-report` specs 40/40; batch + scan-domain + contracts 161/161; output-schema + structured-content + parity audit 21/21; `tsc --noEmit` clean.
- **Already live in prod** (Version `b34d3043`) via `deploy:prod`; this PR reconciles git. Verified a fresh prod scan of `awswaf.com` returns `inconclusiveCategories: ["http_security"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)