### PR TITLE
release 3.24.0: add inconclusiveCategories to structured scan result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.24.0] - 2026-06-22
+
+Minor release: adds an additive `inconclusiveCategories` field to the structured scan result, separating a *measurement failure* (a check that timed-out or errored) from a *deliberate N/A* (a control that genuinely doesn't apply). No scoring/scan-model change; `SCORING_MODEL_VERSION` unchanged; tool count unchanged (78).
+
+### Added
+
+- **`inconclusiveCategories` in `StructuredScanResult` (additive, non-breaking).** `notApplicableCategories` previously conflated two reasons a category is reported with a `null` score: a deliberate skip (e.g. DKIM on a no-MX domain) and a measurement failure (a check whose `checkStatus` is `timeout`/`error` — e.g. `check_http_security` against an AWS WAF endpoint that doesn't serve normal HTTP). The new field surfaces the latter as a guaranteed **subset** of `notApplicableCategories` (always `null` in `categoryScores`), so a consumer can distinguish "could not measure / retry later" from "does not apply". Errored categories still dual-list in `notApplicableCategories`, so existing consumers see the identical shape — the field is opt-in.
+
 ## [3.23.0] - 2026-06-20
 
 Minor release: ships the three architectural scalability items that 3.22.0 deliberately held back as proposals (QuotaCoordinator sharding, global-cost-ceiling KV fallback, ProfileAccumulator sharding), each landed behind a default-OFF flag after a Linus-correctness + Adam-security adversarial review. **These deploy dark — every flag defaults to today's exact behavior, so prod is byte-for-byte unchanged until an operator explicitly flips a flag** (which requires its own load-test / reset-window prerequisites). No scoring/scan-model change; `SCORING_MODEL_VERSION` unchanged; tool count unchanged (78).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.23.0",
+	"version": "3.24.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.23.0",
+			"version": "3.24.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.23.0",
+	"version": "3.24.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.23.0",
+	"version": "3.24.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Version bump for the additive `inconclusiveCategories` field merged in #430.

## Surfaces bumped to 3.24.0
- `package.json` + `package-lock.json` (`SERVER_VERSION` auto-derives)
- `server.json` (remotes-only top-level `version`)
- `CHANGELOG.md` (`[3.24.0]` heading)

## Notes
- **MINOR** — additive, non-breaking output-contract field.
- `SCORING_MODEL_VERSION` unchanged; tool count unchanged (78).
- The code itself is already merged (#430) and already live in prod (Version `b34d3043`); this bump makes prod *advertise* 3.24.0 on the next `deploy:prod`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)