### PR TITLE
feat(G2): confirm + freeze brand-audit watch webhook payload (C3)

### DIFF
--- a/docs/design/brand-audit-watch-webhook.md
+++ b/docs/design/brand-audit-watch-webhook.md
@@ -1,0 +1,127 @@
+# Brand-Audit Watch Webhook — Authoritative Wire-Format Reference (C3)
+
+**Frozen 2026-06-22 by coordinator. Schema version: 1.**
+
+This document is the authoritative reference for the drift-detection webhook
+emitted by `bv-dns-security-mcp` when a brand-audit watch detects a
+classification change. The Zod schema (`src/schemas/brand-audit-watch-webhook.ts`)
+is the machine-checkable SSOT; this doc is the human-readable companion.
+
+Downstream consumers (customer webhook receivers, **bv-web-prod G1 alert
+receiver**) parse this payload. Any wire-format change requires:
+1. A `schemaVersion` bump in `BrandAuditWatchWebhookPayloadSchema`.
+2. A coordinator review of the frozen C3 contract (`contracts-frozen.md §C3`).
+3. A G1-side update to the receiver in bv-web-prod.
+
+---
+
+## How a watch fires
+
+`register_brand_audit_watch` (tool in `src/tools/brand-audit-watch.ts`) inserts
+a row into `brand_audit_watches` with `last_classification_hash = NULL`. The
+scheduled cron enqueues a brand-audit run for each active watch; on completion
+the queue consumer calls `deliverWatchWebhookIfShifted`
+(`src/queue/brand-audit-consumer.ts`).
+
+**No domain-ownership check is performed here.** The anti-enumeration owner
+check for arming a watch lives in bv-web-prod (G1), at the call site — not in
+`register_brand_audit_watch`. This is a deliberate design decision (C3 §arming).
+
+---
+
+## Delivery conditions
+
+- Fires when `computeClassificationHash(currentResult) ≠ last_classification_hash`.
+- Does NOT fire when the hash is stable (no drift).
+- Fires on the **first completed audit after registration** — when
+  `last_classification_hash IS NULL` — even though there is technically no
+  "previous" state to diff against. In this case `previousHash: null` and
+  `changes.added` is populated with the entire current candidate set.
+- For logging-only watches (no `webhook_url`), drift is detected and the new
+  hash is persisted, but no HTTP delivery is made.
+- Delivery is **best-effort**: a 4xx/5xx response or a network error does NOT
+  mark the audit as failed; customers can re-derive state via
+  `brand_audit_get_report`.
+
+---
+
+## Payload — frozen C3 shape (schemaVersion 1)
+
+POST to `webhook_url`. `Content-Type: application/json`. HTTPS-only
+(`safeFetch`, SSRF-validated). No extra auth headers — auth is in the URL token.
+
+```ts
+{
+  schemaVersion: 1;            // Literal — bump on any wire change
+  watchId: string;             // ID of the brand_audit_watches row
+  auditId: string;             // ID of the brand_audits row that triggered this
+  target: string;              // Watched domain (e.g. "apple.com")
+  interval: 'daily' | 'weekly' | 'monthly';  // Watch cadence
+  detectedAt: number;          // Epoch ms (worker clock at delivery time)
+  previousHash: string | null; // SHA-256 hex of prior classification; null on first-ever delivery
+  currentHash: string;         // SHA-256 hex of current classification
+  changes: {
+    added:    Array<{ domain: string; bucket: Bucket }>;
+    removed:  Array<{ domain: string; bucket: Bucket }>;
+    modified: Array<{ domain: string; bucket: Bucket; previousBucket?: Bucket }>;
+  };
+}
+
+// Bucket = 'consolidated' | 'shadowIt' | 'indeterminate' | 'impersonation'
+```
+
+### Field semantics
+
+| Field | Notes |
+|---|---|
+| `schemaVersion` | Always `1`. Receivers MUST check and reject unknown versions. |
+| `watchId` | Treat as **untrusted** for security decisions — bv-web G1 looks up the watch by URL token, not by this field. |
+| `auditId` | Use with `brand_audit_get_report` to fetch the full report. |
+| `target` | The domain as stored at registration time (lowercased, no trailing dot). |
+| `interval` | The cadence the customer registered with. |
+| `detectedAt` | Worker clock at the point `deliverWatchWebhookIfShifted` ran. |
+| `previousHash` | `null` on first-ever delivery (watch just registered). Receivers MUST handle null. |
+| `currentHash` | 64-char lowercase hex SHA-256. Stable for the same candidate+bucket set regardless of result order. |
+| `changes.added` | Candidates present in current run but not in previous classification. On first delivery, equals the full current candidate set. |
+| `changes.removed` | Candidates present in previous classification but absent now. Empty on first delivery. |
+| `changes.modified` | Candidates whose `bucket` changed. `previousBucket` is always set for modified entries. Empty on first delivery. |
+
+---
+
+## Classification hash algorithm
+
+`computeClassificationHash` (`src/lib/brand-audit-classification-diff.ts`):
+
+1. Extract `(domain, bucket)` tuples from `result.findings` where `metadata.candidate` and `metadata.bucket` are strings.
+2. Sort tuples lexicographically by `domain`.
+3. Join as `domain1:bucket1|domain2:bucket2|…`.
+4. SHA-256 the UTF-8 bytes. Return 64-char lowercase hex.
+
+The hash is order-independent and summary-row-independent. Two results with
+identical candidate+bucket sets always produce the same hash.
+
+---
+
+## Receiver guidance (bv-web-prod G1 / customer webhooks)
+
+1. **Verify `schemaVersion === 1`** — reject and log any unknown version rather
+   than silently parsing.
+2. **Handle `previousHash: null`** — this is the normal initial event after a
+   watch registers. Treat it as "full current state" using `changes.added`.
+3. **Treat `watchId` as untrusted** — look up the watch by the URL token, not
+   by `watchId`.
+4. **Fetch full detail via `brand_audit_get_report(auditId)`** when needed —
+   the webhook carries only the diff, not the full result JSON.
+5. **Tolerate empty `changes` arrays** — an audit could theoretically detect
+   hash drift while all three change arrays are empty (hash function collision or
+   future bucket rename); don't hard-fail on that.
+
+---
+
+## Test coverage
+
+| Test file | What it locks |
+|---|---|
+| `test/contracts/brand-audit-watch-webhook.contract.test.ts` | Schema accepts/rejects correct shape; **emitter round-trip**: real `processBrandAuditMessage` produces a `BrandAuditWatchWebhookPayloadSchema`-valid payload for both drift and first-ever delivery |
+| `test/audits/brand-audit-watch-webhook.audit.test.ts` | Every documented top-level field exists; `schemaVersion` is literal 1 |
+| `test/chaos/brand-audit-webhook-delivery.chaos.test.ts` | Failure modes: webhook 500, hash-before-delivery ordering, no-url watch, cross-owner spoof, no-drift suppression, first-ever `added` population |

--- a/test/contracts/brand-audit-watch-webhook.contract.test.ts
+++ b/test/contracts/brand-audit-watch-webhook.contract.test.ts
@@ -2,18 +2,28 @@
 /**
  * Contract: brand-audit watch webhook payload shape.
  *
- * Downstream consumers (customer webhook receivers, bv-web alert UI) parse
- * this payload. The schema is the source of truth for the wire format —
- * publishing any field-name or type change requires a `schemaVersion` bump.
+ * Two complementary layers:
+ *   1. Schema-only contract — the Zod schema rejects any malformed payload.
+ *      Per testing-methodology.md principle 3: Zod schemas ARE the inter-service
+ *      contract.
+ *   2. Emitter round-trip contract — the LIVE emitter path
+ *      (`processBrandAuditMessage` → `deliverWatchWebhookIfShifted`) produces a
+ *      payload that `BrandAuditWatchWebhookPayloadSchema.safeParse()` accepts.
+ *      This locks the emitter against silent drift from the frozen C3 contract
+ *      (`contracts-frozen.md §C3`) regardless of future refactors. Two cases
+ *      are exercised: drift delivery (previousHash = prior hash) and first-ever
+ *      delivery (previousHash = null, `added` contains the full current set).
  *
- * Per testing-methodology.md principle 3: Zod schemas ARE the inter-service contract.
+ * Downstream consumers (customer webhook receivers, bv-web G1 alert receiver)
+ * parse this payload; any wire-format change requires a `schemaVersion` bump.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import {
 	BrandAuditWatchWebhookPayloadSchema,
 	type BrandAuditWatchWebhookPayload,
 } from '../../src/schemas/brand-audit-watch-webhook';
+import type { BrandAuditConsumerDeps } from '../../src/queue/brand-audit-consumer';
 
 const validPayload: BrandAuditWatchWebhookPayload = {
 	schemaVersion: 1,
@@ -75,5 +85,177 @@ describe('BrandAuditWatchWebhookPayloadSchema contract', () => {
 			changes: { added: [], removed: [] },
 		});
 		expect(partial.success).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Emitter round-trip: the LIVE emitter produces schema-valid C3 payloads
+//
+// Motivation: the schema-only tests above confirm the Zod schema rejects
+// malformed data, but they don't prove the emitter (`deliverWatchWebhookIfShifted`
+// inside `processBrandAuditMessage`) actually constructs a conforming payload.
+// These tests run the real emitter path end-to-end and validate its output
+// against `BrandAuditWatchWebhookPayloadSchema` — locking the emitter against
+// silent drift from the frozen C3 contract regardless of future refactors.
+// ---------------------------------------------------------------------------
+
+function makeEmitterD1(opts: {
+	target: { status: string; completed_at: number | null };
+	auditAfter: { completed_targets: number; total_targets: number };
+	watch: {
+		id: string;
+		owner_id: string;
+		domain: string;
+		interval: string;
+		webhook_url: string | null;
+		last_classification_hash: string | null;
+	};
+	priorResult?: { result_json: string } | null;
+}): D1Database {
+	const db = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) { binds = args; return stmt; },
+				async first() {
+					if (sql.includes('SELECT status, completed_at FROM brand_audit_targets')) return opts.target;
+					if (sql.includes('SELECT completed_targets, total_targets FROM brand_audits')) return opts.auditAfter;
+					if (sql.includes('FROM brand_audit_watches WHERE id =')) return opts.watch;
+					if (sql.includes('FROM brand_audit_targets WHERE target =')) return opts.priorResult ?? null;
+					void binds;
+					return null;
+				},
+				async run() { return { success: true, meta: { changes: 1 } }; },
+				async all() { return { results: [], success: true, meta: {} }; },
+			};
+			return stmt;
+		},
+	} as unknown as D1Database;
+	return db;
+}
+
+function makeBrandAuditResult(domains: Array<{ domain: string; bucket: string }>) {
+	return {
+		category: 'brand_discovery' as const,
+		passed: true,
+		score: 100,
+		findings: domains.map((d) => ({
+			category: 'brand_discovery',
+			title: `Candidate: ${d.domain}`,
+			severity: 'info' as const,
+			detail: '',
+			metadata: { candidate: d.domain, bucket: d.bucket, signals: ['ns'], combinedConfidence: 0.9, registrar: 'X', registrarSource: 'rdap' },
+		})),
+	};
+}
+
+describe('emitter round-trip: processBrandAuditMessage → BrandAuditWatchWebhookPayloadSchema', () => {
+	it('drift delivery (previousHash ≠ null) emits a C3-valid payload with all required fields', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+
+		const currentResult = makeBrandAuditResult([
+			{ domain: 'apple-new.com', bucket: 'consolidated' },
+			{ domain: 'apple-shift.com', bucket: 'impersonation' },
+		]);
+		const priorResult = makeBrandAuditResult([
+			{ domain: 'apple-old.com', bucket: 'shadowIt' },
+			{ domain: 'apple-shift.com', bucket: 'consolidated' },
+		]);
+		const priorHash = 'a'.repeat(64); // arbitrary non-matching sentinel
+
+		const db = makeEmitterD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 1, total_targets: 1 },
+			watch: {
+				id: 'w-drift',
+				owner_id: 'owner-1',
+				domain: 'apple.com',
+				interval: 'weekly',
+				webhook_url: 'https://hooks.example.com/drift',
+				last_classification_hash: priorHash,
+			},
+			priorResult: { result_json: JSON.stringify(priorResult) },
+		});
+		const deliverWebhook = vi.fn().mockResolvedValue(true);
+		const brandAuditSingle = vi.fn().mockResolvedValue(currentResult);
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-drift', target: 'apple.com', format: 'json', watchId: 'w-drift', ownerId: 'owner-1' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_000, deliverWebhook } as BrandAuditConsumerDeps,
+		);
+
+		expect(verdict).toBe('ack');
+		expect(deliverWebhook).toHaveBeenCalledOnce();
+
+		const [, payload] = deliverWebhook.mock.calls[0] as [string, unknown];
+
+		// THE LOCK: emitted payload must be a valid C3 payload.
+		const parsed = BrandAuditWatchWebhookPayloadSchema.safeParse(payload);
+		expect(parsed.success, `emitter produced a non-C3 payload: ${JSON.stringify((parsed as { error?: unknown }).error)}`).toBe(true);
+
+		if (parsed.success) {
+			expect(parsed.data.schemaVersion).toBe(1);
+			expect(parsed.data.watchId).toBe('w-drift');
+			expect(parsed.data.auditId).toBe('aud-drift');
+			expect(parsed.data.target).toBe('apple.com');
+			expect(parsed.data.interval).toBe('weekly');
+			expect(parsed.data.detectedAt).toBe(1_750_000_000_000);
+			// previousHash is the PRE-UPDATE value (priorHash sentinel), not currentHash
+			expect(parsed.data.previousHash).toBe(priorHash);
+			expect(typeof parsed.data.currentHash).toBe('string');
+			expect(parsed.data.currentHash).toHaveLength(64);
+			// changes are populated
+			expect(parsed.data.changes.added.map((e) => e.domain)).toContain('apple-new.com');
+			expect(parsed.data.changes.removed.map((e) => e.domain)).toContain('apple-old.com');
+			expect(parsed.data.changes.modified.map((e) => e.domain)).toContain('apple-shift.com');
+		}
+	});
+
+	it('first-ever delivery (previousHash = null) emits a C3-valid payload with added = full set', async () => {
+		const { processBrandAuditMessage } = await import('../../src/queue/brand-audit-consumer');
+
+		const currentResult = makeBrandAuditResult([
+			{ domain: 'brand-x.com', bucket: 'consolidated' },
+			{ domain: 'brand-x.net', bucket: 'shadowIt' },
+		]);
+
+		const db = makeEmitterD1({
+			target: { status: 'queued', completed_at: null },
+			auditAfter: { completed_targets: 1, total_targets: 1 },
+			watch: {
+				id: 'w-first',
+				owner_id: 'owner-1',
+				domain: 'brand-x.com',
+				interval: 'daily',
+				webhook_url: 'https://hooks.example.com/first',
+				last_classification_hash: null, // first-ever delivery
+			},
+			// No priorResult row — genuinely first run.
+		});
+		const deliverWebhook = vi.fn().mockResolvedValue(true);
+		const brandAuditSingle = vi.fn().mockResolvedValue(currentResult);
+
+		const verdict = await processBrandAuditMessage(
+			{ auditId: 'aud-first', target: 'brand-x.com', format: 'json', watchId: 'w-first', ownerId: 'owner-1' },
+			{ db, brandAuditSingle, now: () => 1_750_000_000_001, deliverWebhook } as BrandAuditConsumerDeps,
+		);
+
+		expect(verdict).toBe('ack');
+		expect(deliverWebhook).toHaveBeenCalledOnce();
+
+		const [, payload] = deliverWebhook.mock.calls[0] as [string, unknown];
+
+		// THE LOCK: first-ever delivery must also be a valid C3 payload.
+		const parsed = BrandAuditWatchWebhookPayloadSchema.safeParse(payload);
+		expect(parsed.success, `first-ever emitter produced a non-C3 payload: ${JSON.stringify((parsed as { error?: unknown }).error)}`).toBe(true);
+
+		if (parsed.success) {
+			expect(parsed.data.previousHash).toBeNull(); // C3: null on first-ever delivery
+			// G1 invariant: on first delivery, `added` must carry the entire current candidate set.
+			const addedDomains = parsed.data.changes.added.map((e) => e.domain).sort();
+			expect(addedDomains).toEqual(['brand-x.com', 'brand-x.net']);
+			expect(parsed.data.changes.removed).toEqual([]);
+			expect(parsed.data.changes.modified).toEqual([]);
+		}
 	});
 });


### PR DESCRIPTION
## Summary

- **Confirm**: live emitter in `src/queue/brand-audit-consumer.ts` (`deliverWatchWebhookIfShifted`) already matches the frozen C3 contract exactly — no emitter code changes required
- **Lock**: two new emitter round-trip tests in `test/contracts/brand-audit-watch-webhook.contract.test.ts` validate that `processBrandAuditMessage` produces a `BrandAuditWatchWebhookPayloadSchema`-valid payload for both drift delivery and first-ever delivery (`previousHash: null`)
- **Document**: `docs/design/brand-audit-watch-webhook.md` — authoritative human-readable wire-format reference (field semantics, delivery conditions, hash algorithm, receiver guidance for bv-web G1)

## What changed

- `test/contracts/brand-audit-watch-webhook.contract.test.ts` — +2 `describe('emitter round-trip…')` blocks; existing schema-only tests untouched
- `docs/design/brand-audit-watch-webhook.md` — new authoritative doc

## What was NOT changed (guardrails respected)

- No ownership check added to `register_brand_audit_watch` (arming guard lives in bv-web G1 by design)
- `server.json`, tool-count, scoring, `tool-definitions.ts` — untouched
- No deploy

## Test plan

- [x] `npx vitest run test/contracts/brand-audit-watch-webhook.contract.test.ts test/audits/brand-audit-watch-webhook.audit.test.ts test/chaos/brand-audit-webhook-delivery.chaos.test.ts test/brand-audit-watch.integration.test.ts` → 29/29 pass
- [x] `npm run typecheck` → clean
- [x] `npm run lint` → clean
- [x] `npm run build` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)