### PR TITLE
fix(internal): wire BV_RECON into the /internal/tools/call door

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -89,6 +89,8 @@ type InternalEnv = {
 	BV_DOH_TOKEN?: string;
 	BV_WHOIS?: Fetcher;
 	BV_INFRA_PROBE?: Fetcher;
+	BV_RECON?: Fetcher;
+	BV_RECON_KEY?: string;
 	CF_ACCOUNT_ID?: string;
 	CF_ANALYTICS_TOKEN?: string;
 	BV_WEB_INTERNAL_KEY?: string;
@@ -254,6 +256,12 @@ internalRoutes.post('/tools/call', async (c) => {
 				: undefined,
 			whoisBinding: c.env.BV_WHOIS,
 			infraProbe: c.env.BV_INFRA_PROBE,
+			// Recon backend (bv2-recon) — powers scan_buckets_* / osint_investigate_*.
+			// The internal door (recon-sweep caller) MUST wire these or those tools
+			// always degrade to the "unprovisioned" stub even when BV_RECON is bound,
+			// which silently stalled the bv2-ops recon-sweep queue (fixed 2026-06-23).
+			reconBinding: c.env.BV_RECON,
+			reconAuthToken: c.env.BV_RECON_KEY,
 			// Tier 0/1/2 lookup closures — internal callers (load tests, bv-web
 			// service binding, ops scripts) get the same tiered discovery path as
 			// public `/mcp`. Closures stay `undefined` on BSL self-hosts where

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -67,6 +67,38 @@ describe('Internal service binding routes', () => {
 		});
 	});
 
+	describe('recon backend wiring', () => {
+		// Regression (2026-06-23): the internal door built tool options without
+		// reconBinding/reconAuthToken, so scan_buckets_* / osint_* always degraded to
+		// the "unprovisioned" stub even with BV_RECON bound — silently stalling the
+		// bv2-ops recon-sweep queue. This asserts the door reaches the recon worker.
+		it('passes BV_RECON through the internal door so scan_buckets_start reaches bv2-recon', async () => {
+			const reconFetch = vi.fn(
+				async () =>
+					new Response(JSON.stringify({ scanId: 'test-scan-123', status: 'started' }), {
+						status: 200,
+						headers: { 'Content-Type': 'application/json' },
+					}),
+			);
+			const reconEnv = {
+				...testEnv,
+				BV_RECON: { fetch: reconFetch },
+				BV_RECON_KEY: 'test-recon-key',
+			} as typeof testEnv;
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: 'scan_buckets_start', arguments: { target: 'example.com' } }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, reconEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			expect(reconFetch).toHaveBeenCalled();
+			expect(String(reconFetch.mock.calls[0]?.[0])).toContain('/buckets/api/scan/trigger');
+		});
+	});
+
 	describe('POST /internal/tools/call', () => {
 		it('dispatches check_spf and returns raw result', async () => {
 			const { mockTxtRecords } = await import('./helpers/dns-mock');


### PR DESCRIPTION
## Problem
The `/internal/tools/call` door (the bv2-ops **recon-sweep** path) built tool options with `whoisBinding` + `infraProbe` but **omitted `reconBinding`/`reconAuthToken`**. So `scan_buckets_*` / `osint_investigate_*` always returned the "unprovisioned" stub when invoked through this door — even with `BV_RECON` bound. This silently stalled the recon-sweep queue (47 jobs stuck `pending` indefinitely). The OAuth/public `/mcp` handlers already wired recon correctly; only the internal door was missing it.

## Fix
- Pass `reconBinding: c.env.BV_RECON` + `reconAuthToken: c.env.BV_RECON_KEY` in the internal-door tool options.
- Add `BV_RECON?` / `BV_RECON_KEY?` to `InternalEnv`.
- Regression test: `scan_buckets_start` through the door now reaches `bv2-recon` (fails without the fix).

## Verification
- `npm run typecheck` clean; internal-door suite green (39 + new test).
- Deployed to prod (version `4283e413`); live probe via `dns-mcp.blackveilsecurity.com` returns a real `scanId` / `investigationId` (was the unprovisioned stub).

Context: surfaced during the bv-web OLD-fleet decom — the recon backend was re-homed bv-recon → bv2-recon, and this latent door bug blocked drainage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)