### PR TITLE
fix(scan): maturity label, DKIM aggregate parity, DNSSEC source mislabel (3.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **`scan_domain` maturity no longer labels a spoofable domain "Hardened".** The web-only maturity ladder's Stage 2 label `"Hardened"` both overstated a mid-tier rung and **collided** with the mail ladder's Stage 4 `"Hardened"`, so a fully-spoofable web-only domain (no SPF/`-all`, no DMARC `reject`) displayed the same word as a fully-protected mail domain (e.g. a `57/D+` domain read "Hardened"). Stage 2 is renamed **`"Transport-Hardened"`**, and the top web-only tiers (`Defensive`/`Comprehensive`) now **require an anti-spoof email policy** — infrastructure hardening (TLS/DNSSEC/HSTS/CAA) alone no longer lifts a spoofable domain above Stage 2. Server-only (`src/tools/scan/maturity-staging.ts`); no scoring-model or `@blackveil/dns-checks` change.
+- **`scan_domain` DKIM category score now matches the dedicated `check_dkim`.** When a known DKIM-signing provider (e.g. Microsoft 365) is detected via MX, `applyProviderDkimContext` softened the "no DKIM found" finding from high→medium for triage — which silently inflated the category score from the probe-miss floor (50) to 85, even though no DKIM was actually discovered (`controlPresent: false`). The floor is now re-applied, so the aggregate score equals what `check_dkim` returns (50). Server-only (`src/tools/check-dkim.ts`).
+- **`dnssecSource` no longer mislabels an unsigned zone as `"domain_configured"`.** An unsigned zone scores 60 (penaltyOverride −40) and therefore `passed === true`, so the `passed`-only fallback in the structured-result builder wrongly stamped unsigned domains `domain_configured`. The fallback now excludes the DNSSEC deficiency findings (`DNSSEC not enabled` / `chain of trust incomplete` / `validation failing`). Server-only (`src/tools/scan/format-report.ts`). The DNSSEC score (60) and CAA score (85 when absent) are unchanged — those are intended, NIST/RFC-justified scoring with `controlPresent: false` set.
+
 ## [3.25.0] - 2026-06-23
 
 Minor release: adds the **79th tool `get_domain_rank`** (domain cohort-percentile via the bv-web C1 benchmark endpoint), pickability-tuned tool descriptions, a `priorTool` analytics dimension, a frozen brand-audit-watch webhook contract, and a hot-path latency/concurrency guard. No scoring/scan-model change; `SCORING_MODEL_VERSION` unchanged; **tool count 78 → 79**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.25.1] - 2026-06-24
+
+Patch release: three **server-only** `scan_domain` output fixes (maturity label, DKIM aggregate parity with `check_dkim`, and DNSSEC `dnssecSource` mislabel). No `@blackveil/dns-checks` core change, `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79).
+
 ### Fixed
 
 - **`scan_domain` maturity no longer labels a spoofable domain "Hardened".** The web-only maturity ladder's Stage 2 label `"Hardened"` both overstated a mid-tier rung and **collided** with the mail ladder's Stage 4 `"Hardened"`, so a fully-spoofable web-only domain (no SPF/`-all`, no DMARC `reject`) displayed the same word as a fully-protected mail domain (e.g. a `57/D+` domain read "Hardened"). Stage 2 is renamed **`"Transport-Hardened"`**, and the top web-only tiers (`Defensive`/`Comprehensive`) now **require an anti-spoof email policy** — infrastructure hardening (TLS/DNSSEC/HSTS/CAA) alone no longer lifts a spoofable domain above Stage 2. Server-only (`src/tools/scan/maturity-staging.ts`); no scoring-model or `@blackveil/dns-checks` change.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.0",
+	"version": "3.25.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.25.0",
+			"version": "3.25.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.0",
+	"version": "3.25.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.25.0",
+	"version": "3.25.1",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/tools/check-dkim.ts
+++ b/src/tools/check-dkim.ts
@@ -96,5 +96,17 @@ export function applyProviderDkimContext(dkimResult: CheckResult, provider: stri
 
 	// Preserve controlPresent — this branch only runs when DKIM was not found
 	// (controlPresent already false); detectDomainContext reads it, not finding prose.
-	return buildCheckResult('dkim', newFindings, dkimResult.controlPresent) as CheckResult;
+	const adjusted = buildCheckResult('dkim', newFindings, dkimResult.controlPresent) as CheckResult;
+
+	// Parity with checkDKIM's probe-miss floor: softening the finding severity
+	// (high → medium) for a provider-implied selector lowers the penalty and would
+	// otherwise inflate the score from the floor (50) up to 85 — even though no DKIM
+	// was actually discovered (controlPresent === false). The provider-implied context
+	// is a TRIAGE signal, not evidence the control exists, so the category score must
+	// stay on the same "nothing found" floor the dedicated check_dkim returns. Without
+	// this, scan_domain reported dkim:85 for a domain check_dkim scored 50 (no records).
+	if (dkimResult.controlPresent === false && adjusted.score > 50) {
+		return { ...adjusted, score: 50 };
+	}
+	return adjusted;
 }

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -171,7 +171,20 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 				break;
 			}
 		}
-		if (dnssecSource === null && dnssecCheck.passed && (checkStatuses['dnssec'] ?? 'completed') === 'completed') {
+		// Only infer `domain_configured` when the zone is actually signed. An UNSIGNED
+		// zone now scores 60 (penaltyOverride −40) and therefore `passed === true`
+		// (60 ≥ 50, no missingControl), so a `passed`-only fallback wrongly stamped
+		// unsigned domains as `domain_configured`. Exclude the DNSSEC deficiency findings
+		// — "DNSSEC not enabled" (60, passes), and the broken/failing chains (0, fail) —
+		// so only a genuinely validated/configured zone (no deficiency finding) defaults
+		// to `domain_configured`.
+		const dnssecDeficient = dnssecCheck.findings.some(
+			(f) =>
+				f.title === 'DNSSEC not enabled' ||
+				f.title === 'DNSSEC chain of trust incomplete' ||
+				f.title === 'DNSSEC validation failing',
+		);
+		if (dnssecSource === null && dnssecCheck.passed && !dnssecDeficient && (checkStatuses['dnssec'] ?? 'completed') === 'completed') {
 			dnssecSource = 'domain_configured';
 		}
 	}

--- a/src/tools/scan/maturity-staging.ts
+++ b/src/tools/scan/maturity-staging.ts
@@ -77,7 +77,6 @@ function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
 	const sslCheck = byCategory.get('ssl');
 	const dnssecCheck = byCategory.get('dnssec');
 	const httpSecurityCheck = byCategory.get('http_security');
-	const caaCheck = byCategory.get('caa');
 	const spfCheck = byCategory.get('spf');
 	const dmarcCheck = byCategory.get('dmarc');
 
@@ -85,8 +84,6 @@ function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
 	const hasDnssec = dnssecCheck?.passed ?? false;
 	const hasHsts =
 		httpSecurityCheck?.findings.some((f: Finding) => /HSTS/i.test(f.title) && !/missing|no HSTS|no\s+HSTS/i.test(f.title)) ?? false;
-	const hasHttpHardening = httpSecurityCheck?.passed ?? false;
-	const hasCaa = caaCheck?.passed ?? false;
 	// Anti-spoof posture: a published SPF -all (or restrictive include) + DMARC reject is
 	// strong evidence even on a non-sending domain (defence against impersonation).
 	const hasSpfRecord = spfCheck != null && !spfCheck.findings.some((f: Finding) => /No SPF record/i.test(f.title));
@@ -96,35 +93,46 @@ function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
 		!dmarcCheck.findings.some((f: Finding) => /policy set to (none|quarantine)/i.test(f.title));
 	const hasAntiSpoof = hasSpfRecord || hasDmarcReject;
 
-	// Stage 4 — Comprehensive: SSL + DNSSEC + HSTS + (CAA OR anti-spoof SPF/DMARC)
-	if (hasSsl && hasDnssec && hasHsts && (hasCaa || hasAntiSpoof)) {
+	// Stage 4 — Comprehensive: SSL + DNSSEC + HSTS + anti-spoof email policy.
+	// Anti-spoof (SPF -all / DMARC reject) is REQUIRED for the top tier. A no-MX domain
+	// is still freely impersonated in the From: header without it, so infrastructure
+	// hardening alone (TLS/DNSSEC/HSTS/CAA) does not make the posture "comprehensive".
+	if (hasSsl && hasDnssec && hasHsts && hasAntiSpoof) {
 		return {
 			stage: 4,
 			label: 'Comprehensive',
-			description: 'This web-only domain has full transport (SSL), DNS integrity (DNSSEC), browser hardening (HSTS), and either CAA pinning or anti-spoof email posture.',
+			description: 'This web-only domain has full transport (SSL), DNS integrity (DNSSEC), browser hardening (HSTS), and an anti-spoof email policy (SPF -all / DMARC reject).',
 			nextStep: '',
 		};
 	}
 
-	// Stage 3 — Defensive: SSL + DNSSEC + (HSTS or anti-spoof SPF/DMARC)
-	// CAA is NOT required at stage 3 — a domain can have strong defensive posture without it
-	// (DNSSEC + HSTS already provide DNS-integrity + transport-hardening guarantees).
-	if (hasSsl && hasDnssec && (hasHsts || hasAntiSpoof || hasHttpHardening)) {
+	// Stage 3 — Defensive: SSL + DNSSEC + anti-spoof email policy.
+	// Anti-spoof is required here too — a spoofable domain is not "defensive" no matter how
+	// strong its transport/DNS hardening is. HSTS/CAA push toward Comprehensive (stage 4).
+	if (hasSsl && hasDnssec && hasAntiSpoof) {
 		return {
 			stage: 3,
 			label: 'Defensive',
-			description: 'This web-only domain has SSL, DNSSEC, and additional web/anti-spoof hardening. Strong defensive posture.',
-			nextStep: 'Add HSTS preload, CAA pinning, and explicit anti-spoof DMARC reject to reach full hardening.',
+			description: 'This web-only domain has SSL, DNSSEC, and an anti-spoof email policy (SPF -all / DMARC reject). Strong defensive posture.',
+			nextStep: 'Add HSTS preload and CAA pinning to reach full hardening.',
 		};
 	}
 
-	// Stage 2 — Hardened-baseline: SSL + DNSSEC OR SSL + HSTS
-	if (hasSsl && (hasDnssec || hasHsts)) {
+	// Stage 2 — Transport-Hardened: SSL plus a DNS/browser/anti-spoof control, but not a
+	// complete defensive stack. Renamed from the former "Hardened" — that label both
+	// overstated a mid-tier rung ("resists most passive attacks" for a domain that may be
+	// fully spoofable) and COLLIDED with the mail ladder's Stage 4 "Hardened", so a
+	// spoofable web-only domain displayed the same word as a protected mail domain.
+	if (hasSsl && (hasDnssec || hasHsts || hasAntiSpoof)) {
 		return {
 			stage: 2,
-			label: 'Hardened',
-			description: 'Browser-facing TLS plus one DNS-or-browser hardening control. Resists most passive attacks.',
-			nextStep: 'Add DNSSEC and HSTS for layered protection.',
+			label: 'Transport-Hardened',
+			description: hasAntiSpoof
+				? 'Transport (TLS) plus an anti-spoof email policy (SPF -all / DMARC reject). Add DNSSEC and HSTS for full hardening.'
+				: 'Transport (TLS) plus a DNS- or browser-hardening control. NOTE: without an anti-spoof email policy (SPF -all + DMARC reject) the domain name can still be impersonated in email, even though it sends no mail.',
+			nextStep: hasAntiSpoof
+				? 'Add DNSSEC and HSTS to reach a full defensive posture.'
+				: 'Publish SPF (-all) and DMARC (p=reject) to block impersonation, then add DNSSEC and HSTS.',
 		};
 	}
 

--- a/test/check-dkim.spec.ts
+++ b/test/check-dkim.spec.ts
@@ -343,12 +343,17 @@ describe('provider-informed DKIM', () => {
 				selectorsChecked: ['default', 'google'],
 			}),
 		];
-		const result = buildCheckResult('dkim', findings);
+		// Real "no DKIM found" results carry controlPresent: false.
+		const result = buildCheckResult('dkim', findings, false);
 		const adjusted = applyProviderDkimContext(result, 'google workspace');
 		expect(adjusted.findings[0].severity).toBe('medium');
 		expect(adjusted.findings[0].title).toBe('DKIM selector not discovered');
 		expect(adjusted.findings[0].metadata?.detectionMethod).toBe('provider-implied');
-		expect(adjusted.score).toBe(85); // single medium = -15
+		// The severity downgrade (high→medium) softens the FINDING for triage, but DKIM
+		// was still not discovered (controlPresent false), so the score must stay on the
+		// same probe-miss floor (50) that the dedicated check_dkim returns — NOT inflate to
+		// 85. This keeps scan_domain's dkim category in parity with check_dkim.
+		expect(adjusted.score).toBe(50);
 	});
 
 	it('applyProviderDkimContext preserves controlPresent (DKIM not found stays false, not undefined)', async () => {
@@ -375,12 +380,14 @@ describe('provider-informed DKIM', () => {
 				selectorsChecked: ['default'],
 			}),
 		];
-		const result = buildCheckResult('dkim', findings);
+		const result = buildCheckResult('dkim', findings, false);
 		const adjusted = applyProviderDkimContext(result, 'proofpoint');
 		expect(adjusted.findings).toHaveLength(2);
 		expect(adjusted.findings[0].severity).toBe('medium');
 		expect(adjusted.findings[1].severity).toBe('low');
-		expect(adjusted.score).toBe(80); // medium (-15) + low (-5)
+		// controlPresent false (no DKIM discovered) → score floored to 50, same as the
+		// dedicated check_dkim; the softened findings are triage-only, not evidence of DKIM.
+		expect(adjusted.score).toBe(50);
 	});
 
 	it('applyProviderDkimContext does nothing for unknown provider', async () => {

--- a/test/format-report.spec.ts
+++ b/test/format-report.spec.ts
@@ -62,6 +62,25 @@ describe('buildStructuredScanResult', () => {
 		expect(s.dnssecSource).toBe('domain_configured');
 	});
 
+	it('sets dnssecSource to null for an UNSIGNED zone (passed=true at score 60, "DNSSEC not enabled")', () => {
+		// Regression: an unsigned zone scores 60 (penaltyOverride −40) and therefore
+		// passes (60 ≥ 50, no missingControl). The old passed-only fallback wrongly stamped
+		// it "domain_configured". It must report null — the zone is not actually signed.
+		const result = makeMockScanResult({
+			checks: [
+				{
+					category: 'dnssec',
+					passed: true,
+					score: 60,
+					findings: [{ category: 'dnssec', title: 'DNSSEC not enabled', severity: 'high', detail: 'unsigned' }],
+					checkStatus: 'completed',
+				},
+			] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.dnssecSource).toBeNull();
+	});
+
 	it('sets dnssecSource to null when dnssec check failed', () => {
 		const result = makeMockScanResult({
 			checks: [{ category: 'dnssec', passed: false, score: 0, findings: [], checkStatus: 'completed' }] as CheckResult[],

--- a/test/maturity-staging-profile.spec.ts
+++ b/test/maturity-staging-profile.spec.ts
@@ -140,4 +140,52 @@ describe('Defect I — computeMaturityStage accepts profile and respects it', ()
 		const stage = computeMaturityStage(checks, 'web_only');
 		expect(stage.stage).toBeGreaterThanOrEqual(2);
 	});
+
+	// Regression — a spoofable web_only domain (no SPF -all / no DMARC reject) must NOT be
+	// labelled "Hardened" (the word collided with the mail ladder's Stage 4) and must NOT
+	// reach the top "Defensive"/"Comprehensive" tiers on infrastructure hardening alone,
+	// because it is still freely impersonated in the From: header. (dunninghams.net case:
+	// score 57/D+, spf:0 dmarc:0, yet previously labelled "Hardened".)
+	function spoofableWebOnlyChecks(): CheckResult[] {
+		return [
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only')]),
+			buildCheckResult('spf', [createFinding('spf', 'No SPF record found', 'high', 'Missing SPF')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'No DMARC record found', 'high', 'Missing DMARC')]),
+			passingCheck('ssl', 'SSL certificate valid'),
+			passingCheck('dnssec', 'DNSSEC validated'),
+		];
+	}
+
+	it('web_only spoofable domain (SSL+DNSSEC, no anti-spoof) is Stage 2 "Transport-Hardened", never "Hardened"', () => {
+		const stage = computeMaturityStage(spoofableWebOnlyChecks(), 'web_only');
+		expect(stage.stage).toBe(2);
+		expect(stage.label).toBe('Transport-Hardened');
+		expect(stage.label).not.toBe('Hardened');
+		// Honesty: the rating must flag the spoofability gap.
+		expect(`${stage.description} ${stage.nextStep}`).toMatch(/SPF|DMARC|impersonat/i);
+	});
+
+	it('web_only spoofable domain never reaches Defensive/Comprehensive on infra hardening alone', () => {
+		// Even with SSL + DNSSEC + HSTS, no anti-spoof policy caps the ceiling at Stage 2.
+		const checks = [
+			...spoofableWebOnlyChecks(),
+			buildCheckResult('http_security', [createFinding('http_security', 'HSTS configured (preload)', 'info', 'HSTS')]),
+		];
+		const stage = computeMaturityStage(checks, 'web_only');
+		expect(stage.stage).toBeLessThanOrEqual(2);
+		expect(['Defensive', 'Comprehensive', 'Hardened']).not.toContain(stage.label);
+	});
+
+	it('web_only domain WITH anti-spoof (SPF -all + DMARC reject) + SSL + DNSSEC reaches Defensive', () => {
+		const checks: CheckResult[] = [
+			buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only')]),
+			buildCheckResult('spf', [createFinding('spf', 'SPF record found', 'info', 'v=spf1 -all')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+			passingCheck('ssl', 'SSL certificate valid'),
+			passingCheck('dnssec', 'DNSSEC validated'),
+		];
+		const stage = computeMaturityStage(checks, 'web_only');
+		expect(stage.stage).toBeGreaterThanOrEqual(3);
+		expect(stage.label).toBe('Defensive');
+	});
 });


### PR DESCRIPTION
## Summary

Three **server-only** `scan_domain` output bugs surfaced while producing a client report. All fixes are MCP-server-side — **no `@blackveil/dns-checks` core change, no re-vendor, no `parity.contract.test.ts` impact, no bv-web-prod change**. `SCORING_MODEL_VERSION` unchanged; tool count unchanged (79). Patch release **3.25.1**.

### 1. Maturity no longer labels a spoofable domain "Hardened"
`src/tools/scan/maturity-staging.ts` — the web-only ladder's Stage 2 label `"Hardened"` both overstated a mid-tier rung **and collided** with the mail ladder's Stage 4 `"Hardened"`, so a fully-spoofable web-only domain (no SPF `-all` / no DMARC `reject`, e.g. `57/D+`) displayed the same word as a protected mail domain. Stage 2 → **`"Transport-Hardened"`**, and the top web tiers (`Defensive`/`Comprehensive`) now **require an anti-spoof email policy** — TLS/DNSSEC/HSTS/CAA alone can't lift a spoofable domain above Stage 2.

### 2. `scan_domain` DKIM score now matches `check_dkim`
`src/tools/check-dkim.ts` — when a known DKIM provider (M365 etc.) is detected via MX, `applyProviderDkimContext` softened the "no DKIM found" finding high→medium for triage, which silently inflated the category score from the probe-miss floor (50) to 85 even though `controlPresent: false`. The floor is re-applied, restoring parity with the dedicated `check_dkim` (50).

### 3. `dnssecSource` no longer mislabels an unsigned zone
`src/tools/scan/format-report.ts` — an unsigned zone scores 60 (penaltyOverride −40) and therefore `passed === true`, so the `passed`-only fallback stamped unsigned domains `domain_configured`. Now excludes the DNSSEC deficiency findings.

**Not changed (confirmed by-design):** DNSSEC `60` and CAA `85`-when-absent are intended NIST/RFC-justified scores in the vendored core, with `controlPresent: false` set.

## Tests
Updated 2 tests that encoded the DKIM bug; added regression tests for all three. **201 related tests pass** (maturity, check-dkim, format-report, scan-domain, batch-scan, fix-plan, profiles, na-reconciliation). Typecheck clean on changed files, lint clean, build succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)