### PR TITLE
fix(http-security): attribute origin CDN vs redirect-hop edge CDN (3.25.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.25.2] - 2026-06-24
+
+Patch release: one **server-only** `check_http_security` / `scan_domain` attribution fix. No `@blackveil/dns-checks` core change, `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79). Security-header analysis and scores are unaffected — this only refines CDN attribution.
+
+### Fixed
+
+- **CDN attribution now distinguishes the origin's CDN from a redirect-hop (edge) CDN.** When an apex 301-redirects to its real origin through a different CDN (e.g. `stuff.co.nz`: a CloudFront-fronted apex redirector → a Fastly-served `www` origin), the redirector's CDN signal was accumulated across hops and — because it was checked before the origin's signal — shadowed the origin, so the finding (and the scan-level `cdnProvider`) named the redirector (`CloudFront`) rather than where the site is actually served (`Fastly`). The check still follows the redirect and analyzes the origin's headers (unchanged); intermediate-hop CDN signals are now kept separate from the final origin response. The annotation names the **origin** CDN as primary (`metadata.cdnProvider`) and surfaces any distinct **edge** CDN separately (`metadata.edgeCdnProvider`); an edge-only CDN (origin exposes no CDN signal) is flagged with `metadata.cdnRole: "edge"`. Server-only (`src/tools/check-http-security.ts`).
+
 ## [3.25.1] - 2026-06-24
 
 Patch release: three **server-only** `scan_domain` output fixes (maturity label, DKIM aggregate parity with `check_dkim`, and DNSSEC `dnssecSource` mislabel). No `@blackveil/dns-checks` core change, `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.1",
+	"version": "3.25.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.25.1",
+			"version": "3.25.2",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.1",
+	"version": "3.25.2",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.25.1",
+	"version": "3.25.2",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -162,22 +162,25 @@ function detectCdnProvider(headers: Headers): string | null {
 
 /**
  * The final response of a redirect chain, plus a union of vendor-specific CDN
- * signal headers observed across EVERY hop. The chain's intermediate hops are
- * otherwise discarded — only the final response is the site's; `cdnSignals`
- * exists so CDN attribution doesn't lose a signal that appeared on an earlier
- * hop (or on a hop the security analysis path can't see).
+ * signal headers observed only on the chain's INTERMEDIATE (redirecting) hops.
+ * The final response keeps its own headers intact (inspect them directly for the
+ * ORIGIN's CDN); `edgeSignals` captures any CDN fronting a redirect hop (e.g. an
+ * apex 301 served by CloudFront ahead of a Fastly-served www origin) so the two
+ * can be attributed separately ("origin: Fastly, edge: CloudFront") instead of
+ * the edge signal shadowing the origin.
  */
-type RedirectResult = { response: Response; cdnSignals: Headers };
+type RedirectResult = { response: Response; edgeSignals: Headers };
 
 /**
  * Fetch a URL with HEAD and follow up to MAX_REDIRECT_HOPS HTTPS redirects
  * manually. Mirrors the package's own redirect follow logic — used only for the
  * dual-fetch probe ahead of the package call. Accumulates vendor-specific CDN
- * headers from every hop so a CDN fronting an intermediate (or final) hop is
- * still attributable even when the final security response omits the signal.
+ * headers from each hop that REDIRECTS (intermediate hops only) into
+ * `edgeSignals`; the final (non-redirect) response is returned with its own
+ * headers untouched so origin-vs-edge CDN attribution stays distinct.
  */
 async function fetchWithRedirects(url: string, timeoutMs: number, callerSignal?: AbortSignal): Promise<RedirectResult> {
-	const cdnSignals = new Headers();
+	const edgeSignals = new Headers();
 	// Initial fetch goes to https://<domain> where <domain> is already validated
 	// upstream. Use raw fetch to keep the cost off the validation path. Subsequent
 	// redirect targets ARE attacker-controlled (Location header) and go via
@@ -198,13 +201,17 @@ async function fetchWithRedirects(url: string, timeoutMs: number, callerSignal?:
 			callerSignal,
 		),
 	);
-	accumulateCdnSignals(cdnSignals, response.headers);
 
 	for (let hop = 0; hop < MAX_REDIRECT_HOPS; hop++) {
 		const status = response.status;
 		const isRedirect =
 			(status >= 300 && status < 400) || response.type === 'opaqueredirect' || (status === 0 && response.headers.get('location'));
 		if (!isRedirect) break;
+
+		// This hop redirects, so it is an intermediate/edge hop — harvest its CDN
+		// signals into edgeSignals BEFORE following. The hop we eventually stop on
+		// (non-redirect) is the origin and is left out of edgeSignals.
+		accumulateCdnSignals(edgeSignals, response.headers);
 
 		const location = response.headers.get('location');
 		if (!location) break;
@@ -237,10 +244,9 @@ async function fetchWithRedirects(url: string, timeoutMs: number, callerSignal?:
 			// redirect destination, not a real failure.
 			break;
 		}
-		accumulateCdnSignals(cdnSignals, response.headers);
 	}
 
-	return { response, cdnSignals };
+	return { response, edgeSignals };
 }
 
 /**
@@ -277,7 +283,7 @@ async function dualFetchHeaders(
 	domain: string,
 	timeoutMs: number,
 	callerSignal?: AbortSignal,
-): Promise<{ headers: Headers; ok: boolean; status: number; usable: boolean } | null> {
+): Promise<{ headers: Headers; edgeSignals: Headers; ok: boolean; status: number; usable: boolean } | null> {
 	const url = `https://${domain}`;
 	const results = await Promise.allSettled([
 		fetchWithRedirects(url, timeoutMs, callerSignal),
@@ -288,13 +294,13 @@ async function dualFetchHeaders(
 
 	if (settled.length === 0) return null;
 
-	// Union of vendor-specific CDN signals seen on ANY hop of EITHER probe's chain.
-	// Folded into the analysed headers so `detectCdnProvider` attributes a CDN that
-	// fronted an intermediate (or final) hop even when the final security response
-	// omits the signal. Security-header analysis is unaffected — these headers are
-	// not in MERGE_HEADERS and are not scored by the package.
-	const allCdnSignals = new Headers();
-	for (const s of settled) accumulateCdnSignals(allCdnSignals, s.cdnSignals);
+	// Union of vendor-specific CDN signals seen on the INTERMEDIATE (redirecting)
+	// hops of EITHER probe's chain. Returned alongside (NOT folded into) the
+	// analysed headers so the caller can attribute the redirector's CDN (edge)
+	// separately from the final origin's own headers, instead of an edge signal
+	// shadowing the origin. Not in MERGE_HEADERS, so security analysis is unaffected.
+	const edgeSignals = new Headers();
+	for (const s of settled) accumulateCdnSignals(edgeSignals, s.edgeSignals);
 
 	const responses = settled.map((s) => s.response);
 
@@ -305,31 +311,17 @@ async function dualFetchHeaders(
 		// attribute/short-circuit it; otherwise return null so the package's GET-fallback handles
 		// it as a generic block. usable:false means "don't analyze these headers as the site's".
 		const cf = responses.find((r) => looksLikeWaf(r.headers));
-		if (cf) return { headers: cf.headers, ok: false, status: cf.status, usable: false };
+		if (cf) return { headers: cf.headers, edgeSignals, ok: false, status: cf.status, usable: false };
 		return null;
 	}
 
 	if (usable.length === 1) {
-		const headers = withCdnSignals(usable[0].headers, allCdnSignals);
-		return { headers, ok: usable[0].ok, status: usable[0].status, usable: true };
+		return { headers: usable[0].headers, edgeSignals, ok: usable[0].ok, status: usable[0].status, usable: true };
 	}
 
 	const merged = mergeSecurityHeaders(usable[0].headers, usable[1].headers);
-	const headers = withCdnSignals(merged, allCdnSignals);
 	const primary = usable[0].ok ? usable[0] : usable[1].ok ? usable[1] : usable[0];
-	return { headers, ok: primary.ok, status: primary.status, usable: true };
-}
-
-/**
- * Return a copy of `base` with any cross-hop CDN-signal headers folded in
- * (without overwriting a same-named header already present on the final
- * response). Used so `detectCdnProvider` sees signals from intermediate hops.
- */
-function withCdnSignals(base: Headers, cdnSignals: Headers): Headers {
-	const out = new Headers();
-	base.forEach((value, key) => out.set(key, value));
-	accumulateCdnSignals(out, cdnSignals);
-	return out;
+	return { headers: merged, edgeSignals, ok: primary.ok, status: primary.status, usable: true };
 }
 
 /**
@@ -474,8 +466,17 @@ async function checkHttpSecurityInner(domain: string, callerSignal?: AbortSignal
 
 	if (!capturedHeaders) return result;
 
-	const cdnProvider = detectCdnProvider(capturedHeaders);
-	if (!cdnProvider) return result;
+	// Attribute the ORIGIN's CDN from the final analyzed response's own headers,
+	// and any redirector's CDN from the intermediate-hop (edge) signals — kept
+	// distinct so an apex 301 fronted by one CDN (e.g. CloudFront) doesn't shadow
+	// a different origin CDN (e.g. Fastly serving www). edgeSignals is only
+	// populated on the dual-fetch path; the safeFetch fallback has no edge tracking.
+	const originCdn = detectCdnProvider(capturedHeaders);
+	let edgeCdn = dualResult ? detectCdnProvider(dualResult.edgeSignals) : null;
+	// A CDN fronting the whole chain (same front-to-back) is one provider, not an
+	// origin/edge split — collapse it so we don't redundantly name it twice.
+	if (edgeCdn === originCdn) edgeCdn = null;
+	if (!originCdn && !edgeCdn) return result;
 
 	// Only annotate CDN when headers were actually analyzed.
 	// If the check was blocked (WAF, connection refused, etc.) or timed out,
@@ -484,13 +485,33 @@ async function checkHttpSecurityInner(domain: string, callerSignal?: AbortSignal
 		result.checkStatus === 'error' || result.checkStatus === 'timeout' || result.findings.some((f) => f.metadata?.missingControl === true);
 	if (isUnanalyzable) return result;
 
-	const cdnFinding = createFinding(
-		'http_security',
-		`HTTP headers via ${cdnProvider} CDN`,
-		'info',
-		`HTTP security headers may be provided by ${cdnProvider} CDN rather than the origin server. CDN-applied headers do not reflect the origin server's security configuration.`,
-		{ cdnProvider },
-	);
+	let title: string;
+	let detail: string;
+	let metadata: Record<string, unknown>;
+	if (originCdn && edgeCdn) {
+		// Both present and distinct — name the origin as primary, edge separately.
+		title = `HTTP headers via ${originCdn} CDN (origin), ${edgeCdn} at edge`;
+		detail =
+			`Security headers were analyzed from the ${originCdn}-served origin response; an intermediate redirect hop is fronted by ${edgeCdn}. ` +
+			`CDN-applied headers do not reflect the origin server's own security configuration.`;
+		// cdnProvider stays the ORIGIN so scan-level CDN attribution (format-report)
+		// names where the site is actually served from, not the redirector.
+		metadata = { cdnProvider: originCdn, edgeCdnProvider: edgeCdn };
+	} else if (originCdn) {
+		title = `HTTP headers via ${originCdn} CDN`;
+		detail = `HTTP security headers may be provided by ${originCdn} CDN rather than the origin server. CDN-applied headers do not reflect the origin server's security configuration.`;
+		metadata = { cdnProvider: originCdn };
+	} else {
+		// edge-only: the origin exposed no recognizable CDN signal; only a redirect
+		// hop is CDN-fronted. Flag the role so the provider isn't read as the origin's.
+		title = `HTTP headers via ${edgeCdn} CDN (edge/redirect hop)`;
+		detail =
+			`An intermediate redirect hop for this domain is fronted by ${edgeCdn} CDN; the final origin response exposed no recognizable CDN signal. ` +
+			`CDN-applied headers do not reflect the origin server's security configuration.`;
+		metadata = { cdnProvider: edgeCdn, cdnRole: 'edge' };
+	}
+
+	const cdnFinding = createFinding('http_security', title, 'info', detail, metadata);
 
 	return { ...result, findings: [...result.findings, cdnFinding] };
 }

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -709,5 +709,43 @@ describe('checkHttpSecurity — dual-fetch header union', () => {
 			const result = await run();
 			expect(cdnFinding(result.findings)).toBe('Akamai');
 		});
+
+		// --- origin vs edge attribution ("annotate both") ---
+		// The metadata of the CDN annotation finding (the one carrying cdnProvider).
+		function cdnMeta(findings: Array<{ metadata?: Record<string, unknown> }>): Record<string, unknown> | undefined {
+			return findings.find((x) => typeof x.metadata?.cdnProvider === 'string')?.metadata;
+		}
+
+		it('names the ORIGIN CDN as primary and the edge/redirect CDN separately when they differ', async () => {
+			// Real-world shape (stuff.co.nz): apex 301 fronted by CloudFront → final
+			// origin served by Fastly. Primary cdnProvider must be the ORIGIN (Fastly);
+			// the redirector's CDN (CloudFront) is surfaced as edgeCdnProvider.
+			mockChain({ 'x-amz-cf-id': 'edge==' }, { 'x-served-by': 'cache-akl10335-AKL' });
+			const meta = cdnMeta((await run()).findings);
+			expect(meta?.cdnProvider).toBe('Fastly');
+			expect(meta?.edgeCdnProvider).toBe('CloudFront');
+		});
+
+		it('does not emit a separate edge annotation when origin and edge are the SAME CDN', async () => {
+			mockChain({ 'x-amz-cf-id': 'edge==' }, { 'x-amz-cf-id': 'final==' });
+			const meta = cdnMeta((await run()).findings);
+			expect(meta?.cdnProvider).toBe('CloudFront');
+			expect(meta?.edgeCdnProvider).toBeUndefined();
+		});
+
+		it('marks an edge-only CDN (origin exposes no CDN signal) with cdnRole "edge"', async () => {
+			mockChain({ 'x-amz-cf-id': 'edge==' }, {});
+			const meta = cdnMeta((await run()).findings);
+			expect(meta?.cdnProvider).toBe('CloudFront');
+			expect(meta?.cdnRole).toBe('edge');
+		});
+
+		it('omits cdnRole/edgeCdnProvider for a plain single-CDN origin (no redirect)', async () => {
+			mockChain({}, { 'x-amz-cf-id': 'final==' });
+			const meta = cdnMeta((await run()).findings);
+			expect(meta?.cdnProvider).toBe('CloudFront');
+			expect(meta?.cdnRole).toBeUndefined();
+			expect(meta?.edgeCdnProvider).toBeUndefined();
+		});
 	});
 });


### PR DESCRIPTION
## What

Refines CDN attribution in `check_http_security` / `scan_domain` so it distinguishes the **origin's** CDN from a **redirect-hop (edge)** CDN.

### The bug (found while verifying a stuff.co.nz scan)
`stuff.co.nz` apex 301-redirects to `www.stuff.co.nz`. The apex redirector is fronted by **CloudFront**; the real `www` origin is served by **Fastly**. The check *already follows the redirect* and analyzes the origin's headers correctly — but CDN signals were accumulated across **every** hop and folded into the analyzed headers, and `x-amz-cf-id` (CloudFront) is checked before `x-served-by` (Fastly). So the redirector's CDN **shadowed** the origin, and both the finding and the scan-level `cdnProvider` reported `CloudFront` instead of `Fastly`.

### The fix (server-only)
- `fetchWithRedirects` now harvests CDN signals only from **intermediate (redirecting)** hops into `edgeSignals`; the final (origin) response keeps its own headers untouched.
- `dualFetchHeaders` returns `edgeSignals` **separately** instead of folding them into the analyzed headers (removed `withCdnSignals`).
- The annotation names the **origin** CDN as primary (`metadata.cdnProvider` — so the scan-level `cdnProvider` in `format-report` names where the site is actually served), surfaces a distinct **edge** CDN as `metadata.edgeCdnProvider`, and flags an edge-only CDN (origin exposes no CDN signal) with `metadata.cdnRole: "edge"`.

Title now reads e.g. `HTTP headers via Fastly CDN (origin), CloudFront at edge`.

## Scope / safety
- **Server-only** (`src/tools/check-http-security.ts`). No `@blackveil/dns-checks` core change → no re-vendor, no parity impact.
- `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79). **Security-header analysis and scores are unaffected** — this only refines attribution.
- SSRF posture unchanged (redirect targets still go through `safeFetch`).
- Redirect-following behavior unchanged — it already followed the apex→www 301; the earlier "doesn't follow the redirect" hypothesis was falsified (HSTS, the only header differing apex↔www, isn't even in the `http_security` set).

## Tests (TDD)
- 4 new tests in the redirect-chain suite: origin-vs-edge differ (Fastly origin / CloudFront edge), same-CDN front-to-back (no dup), edge-only (`cdnRole: "edge"`), plain single-CDN origin.
- All 6 existing intermediate-hop tests still green (the edge CDN remains surfaced).
- Full suite: **5557 passed**, typecheck + lint + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)