### PR TITLE
fix(mta-sts): downgrade WAF-challenged policy fetch to inconclusive (#455)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.25.4] - 2026-06-25
+
+Patch release: one **server-only** `check_mta_sts` false-positive fix. No `@blackveil/dns-checks` core change, `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79). Normal-corpus scores are unaffected — the new behavior only applies when the MTA-STS policy fetch is intercepted by a WAF.
+
+### Fixed
+
+- **`check_mta_sts` no longer emits a confident `high` "policy file not accessible" on a WAF-challenged policy fetch (#455).** The `mta-sts.<domain>` policy host is often Cloudflare/Akamai-fronted, and the scanner's own probe gets a WAF challenge/block (commonly HTTP 403) while real sending MTAs fetch the policy fine — so a healthy `mode: enforce` policy (e.g. `blackveilsecurity.com`) was falsely flagged. The `check_mta_sts` worker wrapper now detects the interception (reusing the `check_http_security` WAF fingerprint, extracted to `src/lib/waf-detection.ts`) and downgrades the finding to an inconclusive `info` with a fixed `penaltyOverride` (lands ~90 — off the ceiling since the policy is unverifiable, but above a real failure since the `_mta-sts` TXT record was verified). The body sniff is bounded (8 KB) so an attacker-controlled policy host can't force a large-body read. A genuine non-WAF 4xx still surfaces the `high`.
+
 ## [3.25.3] - 2026-06-24
 
 Patch release: ships the **finding-sanitizer hardening** merged in #438 to prod. Bundles **`@blackveil/dns-checks` 1.3.18**. `SCORING_MODEL_VERSION` unchanged, scores unchanged (string-channel sanitization only), tool count unchanged (79).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.3",
+	"version": "3.25.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.25.3",
+			"version": "3.25.4",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.3",
+	"version": "3.25.4",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.25.3",
+	"version": "3.25.4",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/lib/response-body.ts
+++ b/src/lib/response-body.ts
@@ -8,3 +8,95 @@ export async function disposeUnreadResponseBody(response: Response): Promise<voi
 		// The body may already be locked or consumed.
 	}
 }
+
+/**
+ * Bounded streaming body readers.
+ *
+ * Both read at most `maxBytes` BYTES from a response body stream, then cancel
+ * the reader (always, in a `finally`). The bound is on the cumulative BYTE
+ * length of the chunks read (`Uint8Array.byteLength`) — NOT the decoded string
+ * length, which on multi-byte UTF-8 can be ~3-4x smaller than the byte count
+ * and would let an attacker-controlled endpoint buffer far more than intended.
+ *
+ * Fail-open: never throw. The body stream the caller passes is the only thing
+ * consumed — the caller owns `response.clone()` if it needs the original
+ * undisturbed.
+ */
+
+/** Drain the stream up to a byte cap. Returns the accumulated chunks, the
+ * cumulative byte total read, and whether the cap was reached/exceeded. */
+async function drainBounded(
+	body: ReadableStream<Uint8Array> | null,
+	maxBytes: number,
+): Promise<{ chunks: Uint8Array[]; total: number; overflowed: boolean }> {
+	const chunks: Uint8Array[] = [];
+	let total = 0;
+	let overflowed = false;
+	if (!body) return { chunks, total, overflowed };
+	const reader = body.getReader();
+	try {
+		for (;;) {
+			const { done, value } = await reader.read();
+			if (done) break;
+			if (!value) continue;
+			chunks.push(value);
+			total += value.byteLength;
+			if (total >= maxBytes) {
+				overflowed = true;
+				break;
+			}
+		}
+	} finally {
+		// Always release the underlying stream — best-effort, swallow errors.
+		try {
+			await reader.cancel();
+		} catch {
+			/* fail-open */
+		}
+	}
+	return { chunks, total, overflowed };
+}
+
+/** Concatenate chunks into one Uint8Array. */
+function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
+	const out = new Uint8Array(total);
+	let offset = 0;
+	for (const c of chunks) {
+		out.set(c, offset);
+		offset += c.byteLength;
+	}
+	return out;
+}
+
+/**
+ * Read at most `maxBytes` bytes from a body stream, then cancel it. Byte-accurate
+ * (bounds on cumulative `Uint8Array.byteLength`, truncating the body once the cap
+ * is reached). Fail-open: returns '' on any error or a null/empty body. Caller
+ * owns cloning the response if it needs the original undisturbed.
+ */
+export async function readBoundedText(body: ReadableStream<Uint8Array> | null, maxBytes: number): Promise<string> {
+	try {
+		const { chunks, total } = await drainBounded(body, maxBytes);
+		if (total === 0) return '';
+		return new TextDecoder().decode(concatChunks(chunks, total));
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Like {@link readBoundedText} but NULL-on-overflow: returns `null` when the body
+ * exceeds `maxBytes` (rather than truncating), and `null` on any error or a null
+ * body. Used where the caller must treat an over-cap body as "unverifiable"
+ * rather than processing a partial prefix (e.g. capability-document integrity).
+ */
+export async function readBoundedOrNull(body: ReadableStream<Uint8Array> | null, maxBytes: number): Promise<string | null> {
+	try {
+		if (!body) return null;
+		const { chunks, total, overflowed } = await drainBounded(body, maxBytes);
+		if (overflowed) return null;
+		return new TextDecoder().decode(concatChunks(chunks, total));
+	} catch {
+		return null;
+	}
+}

--- a/src/lib/waf-detection.ts
+++ b/src/lib/waf-detection.ts
@@ -16,11 +16,22 @@
  * MTA-STS policy fetch can reuse the identical detection — issue #455.
  */
 
+import { createFinding } from './scoring';
+import type { CheckCategory, Finding } from './scoring';
+
 /** A detected WAF interception — either an interstitial challenge or a terminal block. */
 export type WafEvent = { provider: 'cloudflare' | 'akamai'; kind: 'challenge' | 'block' };
 
 /** Cloudflare access-block body signatures (distinct from the "Just a moment" JS challenge). */
 const CF_BLOCK_BODY = /sorry, you have been blocked|attention required|error 10(09|10|12|13|15|20)/i;
+
+/**
+ * Akamai access-denied body signatures. `AkamaiGHost` is a generic Akamai edge
+ * Server header present on ordinary responses, so the Server header alone must
+ * never be treated as a block — a body signature on a 4xx is required to
+ * distinguish a WAF block from a genuine origin failure.
+ */
+const AKAMAI_BLOCK_BODY = /access denied|reference\s*#[0-9a-f.]+|you don't have permission/i;
 
 /** True when the response carries any Cloudflare/Akamai signal worth fetching the body to disambiguate. */
 export function looksLikeWaf(headers: Headers): boolean {
@@ -35,6 +46,10 @@ export function looksLikeWaf(headers: Headers): boolean {
  * so detection is status-aware. A block requires a 4xx plus a block-body signature or a
  * `cf-mitigated` header — `cf-ray` + 403 alone is NOT treated as a block, since a real app may
  * legitimately 403 a request. The interstitial challenge is checked first.
+ *
+ * The Akamai branch mirrors the same rigor: a bare `Server: AkamaiGHost` header is present on
+ * ordinary responses, so a block requires a 4xx PLUS an Akamai access-denied body signature —
+ * a genuine origin 403/404/500 behind Akamai is NOT mis-attributed to a WAF block.
  */
 export function detectWafEvent(headers: Headers, body: string | undefined, status: number): WafEvent | null {
 	const server = (headers.get('server') ?? '').toLowerCase();
@@ -46,6 +61,20 @@ export function detectWafEvent(headers: Headers, body: string | undefined, statu
 		if (/just a moment/i.test(b) || cfMitigated === 'challenge') return { provider: 'cloudflare', kind: 'challenge' };
 		if (status >= 400 && (CF_BLOCK_BODY.test(b) || !!cfMitigated)) return { provider: 'cloudflare', kind: 'block' };
 	}
-	if (server.includes('akamaighost')) return { provider: 'akamai', kind: 'block' };
+	if (server.includes('akamaighost') && status >= 400 && AKAMAI_BLOCK_BODY.test(b)) {
+		return { provider: 'akamai', kind: 'block' };
+	}
 	return null;
+}
+
+/** Build the canonical inconclusive WAF info-finding. Callers pass the (kind-aware) title + detail. */
+export function buildWafFinding(category: string, event: WafEvent, status: number, text: { title: string; detail: string }): Finding {
+	return createFinding(category as CheckCategory, text.title, 'info', text.detail, {
+		wafEvent: event.provider,
+		wafKind: event.kind,
+		...(event.kind === 'challenge' ? { wafChallenge: event.provider } : {}),
+		httpStatus: status,
+		inconclusive: true,
+		missingControl: true,
+	});
 }

--- a/src/lib/waf-detection.ts
+++ b/src/lib/waf-detection.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shared WAF/CDN interception detection.
+ *
+ * The scanner runs inside a Cloudflare Worker, and many origins (including
+ * Cloudflare-fronted ones) answer an automated probe with a WAF challenge or
+ * access-block page — commonly served as HTTP 403 — instead of the real
+ * resource. Reading such a page as if it were the resource produces false
+ * findings (e.g. "MTA-STS policy file not accessible" on a policy that every
+ * browser/MTA can actually fetch). These helpers fingerprint that interception
+ * so callers can mark the result inconclusive rather than emit a confident
+ * failure.
+ *
+ * Extracted from `check-http-security.ts` (where this logic originated) so the
+ * MTA-STS policy fetch can reuse the identical detection — issue #455.
+ */
+
+/** A detected WAF interception — either an interstitial challenge or a terminal block. */
+export type WafEvent = { provider: 'cloudflare' | 'akamai'; kind: 'challenge' | 'block' };
+
+/** Cloudflare access-block body signatures (distinct from the "Just a moment" JS challenge). */
+const CF_BLOCK_BODY = /sorry, you have been blocked|attention required|error 10(09|10|12|13|15|20)/i;
+
+/** True when the response carries any Cloudflare/Akamai signal worth fetching the body to disambiguate. */
+export function looksLikeWaf(headers: Headers): boolean {
+	const server = (headers.get('server') ?? '').toLowerCase();
+	return !!(headers.get('cf-ray') || headers.get('cf-mitigated') || server.includes('cloudflare') || server.includes('akamaighost'));
+}
+
+/**
+ * Detect a WAF interception (challenge or block) from response headers, optional body, and status.
+ *
+ * Cloudflare events are commonly served as HTTP 403 (both the JS challenge and access blocks),
+ * so detection is status-aware. A block requires a 4xx plus a block-body signature or a
+ * `cf-mitigated` header — `cf-ray` + 403 alone is NOT treated as a block, since a real app may
+ * legitimately 403 a request. The interstitial challenge is checked first.
+ */
+export function detectWafEvent(headers: Headers, body: string | undefined, status: number): WafEvent | null {
+	const server = (headers.get('server') ?? '').toLowerCase();
+	const cfRay = headers.get('cf-ray');
+	const cfMitigated = headers.get('cf-mitigated');
+	const b = body ?? '';
+
+	if (cfRay || cfMitigated || server.includes('cloudflare')) {
+		if (/just a moment/i.test(b) || cfMitigated === 'challenge') return { provider: 'cloudflare', kind: 'challenge' };
+		if (status >= 400 && (CF_BLOCK_BODY.test(b) || !!cfMitigated)) return { provider: 'cloudflare', kind: 'block' };
+	}
+	if (server.includes('akamaighost')) return { provider: 'akamai', kind: 'block' };
+	return null;
+}

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -17,7 +17,7 @@ import { buildCheckResult, createFinding } from '../lib/scoring';
 import { HTTPS_TIMEOUT_MS } from '../lib/config';
 import { safeFetch } from '../lib/safe-fetch';
 import { composeSignal, withAbortSignal } from '../lib/abort-signal';
-import { looksLikeWaf, detectWafEvent } from '../lib/waf-detection';
+import { looksLikeWaf, detectWafEvent, buildWafFinding } from '../lib/waf-detection';
 
 /** User-Agent for outbound probes — matches the package's scanner UA. */
 const SCANNER_USER_AGENT = 'Mozilla/5.0 (compatible; BlackVeilDNSScanner/1.0; +https://blackveilsecurity.com)';
@@ -378,23 +378,13 @@ async function checkHttpSecurityInner(domain: string, callerSignal?: AbortSignal
 		const event = detectWafEvent(headersForWaf, body, dualResult.status);
 		if (event) {
 			const provider = event.provider.charAt(0).toUpperCase() + event.provider.slice(1);
-			const finding = createFinding(
-				'http_security',
-				event.kind === 'block' ? `${provider} WAF blocked external header inspection` : `${provider} WAF challenge intercepted`,
-				'info',
+			const title =
+				event.kind === 'block' ? `${provider} WAF blocked external header inspection` : `${provider} WAF challenge intercepted`;
+			const detail =
 				event.kind === 'block'
 					? `https://${domain} returned an HTTP ${dualResult.status} ${provider} block page, not the site. Security headers cannot be inspected externally.`
-					: `The fetched response appears to be a ${provider} challenge page, not the real site. Header analysis is inconclusive.`,
-				{
-					wafEvent: event.provider,
-					wafKind: event.kind,
-					// Back-compat: challenges previously carried `wafChallenge` with the provider name.
-					...(event.kind === 'challenge' ? { wafChallenge: event.provider } : {}),
-					httpStatus: dualResult.status,
-					inconclusive: true,
-					missingControl: true,
-				},
-			);
+					: `The fetched response appears to be a ${provider} challenge page, not the real site. Header analysis is inconclusive.`;
+			const finding = buildWafFinding('http_security', event, dualResult.status, { title, detail });
 			const base = buildCheckResult('http_security', [finding]);
 			return { ...base, score: 0, passed: false, checkStatus: 'error' };
 		}

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -17,43 +17,10 @@ import { buildCheckResult, createFinding } from '../lib/scoring';
 import { HTTPS_TIMEOUT_MS } from '../lib/config';
 import { safeFetch } from '../lib/safe-fetch';
 import { composeSignal, withAbortSignal } from '../lib/abort-signal';
+import { looksLikeWaf, detectWafEvent } from '../lib/waf-detection';
 
 /** User-Agent for outbound probes — matches the package's scanner UA. */
 const SCANNER_USER_AGENT = 'Mozilla/5.0 (compatible; BlackVeilDNSScanner/1.0; +https://blackveilsecurity.com)';
-
-/** A detected WAF interception — either an interstitial challenge or a terminal block. */
-type WafEvent = { provider: 'cloudflare' | 'akamai'; kind: 'challenge' | 'block' };
-
-/** Cloudflare access-block body signatures (distinct from the "Just a moment" JS challenge). */
-const CF_BLOCK_BODY = /sorry, you have been blocked|attention required|error 10(09|10|12|13|15|20)/i;
-
-/** True when the response carries any Cloudflare/Akamai signal worth fetching the body to disambiguate. */
-function looksLikeWaf(headers: Headers): boolean {
-	const server = (headers.get('server') ?? '').toLowerCase();
-	return !!(headers.get('cf-ray') || headers.get('cf-mitigated') || server.includes('cloudflare') || server.includes('akamaighost'));
-}
-
-/**
- * Detect a WAF interception (challenge or block) from response headers, optional body, and status.
- *
- * Cloudflare events are commonly served as HTTP 403 (both the JS challenge and access blocks),
- * so detection is status-aware. A block requires a 4xx plus a block-body signature or a
- * `cf-mitigated` header — `cf-ray` + 403 alone is NOT treated as a block, since a real app may
- * legitimately 403 a HEAD request. The interstitial challenge is checked first.
- */
-function detectWafEvent(headers: Headers, body: string | undefined, status: number): WafEvent | null {
-	const server = (headers.get('server') ?? '').toLowerCase();
-	const cfRay = headers.get('cf-ray');
-	const cfMitigated = headers.get('cf-mitigated');
-	const b = body ?? '';
-
-	if (cfRay || cfMitigated || server.includes('cloudflare')) {
-		if (/just a moment/i.test(b) || cfMitigated === 'challenge') return { provider: 'cloudflare', kind: 'challenge' };
-		if (status >= 400 && (CF_BLOCK_BODY.test(b) || !!cfMitigated)) return { provider: 'cloudflare', kind: 'block' };
-	}
-	if (server.includes('akamaighost')) return { provider: 'akamai', kind: 'block' };
-	return null;
-}
 
 /** Security headers to merge (union) across dual fetches. */
 const MERGE_HEADERS = [

--- a/src/tools/check-mta-sts.ts
+++ b/src/tools/check-mta-sts.ts
@@ -24,6 +24,16 @@ import { type WafEvent, looksLikeWaf, detectWafEvent } from '../lib/waf-detectio
 /** Titles of the package's policy-fetch findings that a WAF interception can falsely trigger. */
 const POLICY_FETCH_FALSE_POSITIVE_TITLES = new Set(['MTA-STS policy file not accessible', 'MTA-STS policy redirects']);
 
+/**
+ * Score deduction for an inconclusive (WAF-challenged) policy fetch. The finding stays
+ * labelled `info` (it is inconclusive, not a failure — the `_mta-sts` TXT record WAS
+ * verified), but the policy file's mode/coverage could not be confirmed, so this is not
+ * a perfect result either. A fixed `penaltyOverride` (à la check-dnssec) lands it ~90 —
+ * clearly off the 100 ceiling, but well above a real `high` "not accessible" (penalty 25
+ * → score 75). See SEVERITY_PENALTIES; `info` alone would deduct 0 and falsely score 100.
+ */
+const INCONCLUSIVE_POLICY_PENALTY = 10;
+
 /** True when this fetch is the MTA-STS policy-file fetch (the only thing fetchFn is used for). */
 function isPolicyFetch(url: string): boolean {
 	return url.includes('/.well-known/mta-sts.txt');
@@ -96,6 +106,9 @@ function downgradeForWaf(result: CheckResult, domain: string, event: WafEvent, s
 			...(event.kind === 'challenge' ? { wafChallenge: event.provider } : {}),
 			httpStatus: status,
 			inconclusive: true,
+			// Keep the `info` label (not alarming) but apply a deliberate, fixed deduction so an
+			// unverifiable policy doesn't score a perfect 100. See INCONCLUSIVE_POLICY_PENALTY.
+			penaltyOverride: INCONCLUSIVE_POLICY_PENALTY,
 		},
 	);
 

--- a/src/tools/check-mta-sts.ts
+++ b/src/tools/check-mta-sts.ts
@@ -3,22 +3,116 @@
 /**
  * MTA-STS (Mail Transfer Agent Strict Transport Security) check tool.
  * Thin wrapper around @blackveil/dns-checks — delegates all logic to the shared package.
+ *
+ * Post-augments the package result with WAF-challenge awareness (issue #455): when
+ * the policy-file fetch is intercepted by a Cloudflare/Akamai challenge or block
+ * page (commonly HTTP 403), the package emits a confident `high`
+ * "policy file not accessible"/"policy redirects" finding — a false positive on a
+ * policy that real MTAs can fetch. We detect the interception from the policy
+ * response (mirroring `check-http-security.ts`) and downgrade that finding to an
+ * inconclusive `info`, recomputing the score so a healthy domain is not penalised.
  */
 
 import { checkMTASTS } from '@blackveil/dns-checks';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
-import type { CheckResult } from '../lib/scoring';
+import type { CheckResult, Finding } from '../lib/scoring';
+import { buildCheckResult, createFinding } from '../lib/scoring';
 import { HTTPS_TIMEOUT_MS } from '../lib/config';
+import { type WafEvent, looksLikeWaf, detectWafEvent } from '../lib/waf-detection';
+
+/** Titles of the package's policy-fetch findings that a WAF interception can falsely trigger. */
+const POLICY_FETCH_FALSE_POSITIVE_TITLES = new Set(['MTA-STS policy file not accessible', 'MTA-STS policy redirects']);
+
+/** True when this fetch is the MTA-STS policy-file fetch (the only thing fetchFn is used for). */
+function isPolicyFetch(url: string): boolean {
+	return url.includes('/.well-known/mta-sts.txt');
+}
+
+/**
+ * Best-effort body sniff for WAF fingerprinting. Clones so the package's own
+ * handling of the original response (read or cancel) is undisturbed; returns ''
+ * if the body can't be read (fail-open — detection must never throw).
+ */
+async function sniffBody(response: Response): Promise<string> {
+	try {
+		if (typeof response.clone !== 'function') return '';
+		return await response.clone().text();
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Replace the package's false-positive policy-fetch finding(s) with a single
+ * inconclusive `info` finding and recompute the score. Other findings (the TXT
+ * record presence, TLS-RPT, MX coverage) are preserved — only the unverifiable
+ * policy-accessibility claim is downgraded.
+ */
+function downgradeForWaf(result: CheckResult, domain: string, event: WafEvent, status: number): CheckResult {
+	const provider = event.provider.charAt(0).toUpperCase() + event.provider.slice(1);
+	const kept = result.findings.filter((f: Finding) => !POLICY_FETCH_FALSE_POSITIVE_TITLES.has(f.title));
+
+	// Nothing to downgrade (e.g. the policy actually served fine on this run) — leave the result intact.
+	if (kept.length === result.findings.length) return result;
+
+	const inconclusive = createFinding(
+		'mta_sts',
+		`${provider} WAF challenge intercepted — policy accessibility inconclusive`,
+		'info',
+		`The MTA-STS policy fetch for https://mta-sts.${domain}/.well-known/mta-sts.txt was intercepted by a ${provider} ${event.kind} page (HTTP ${status}), not served by the origin. ` +
+			`Real sending MTAs are not subject to the same interactive challenge, so the policy may well be reachable for mail delivery; its accessibility could not be verified externally by the scanner.`,
+		{
+			wafEvent: event.provider,
+			wafKind: event.kind,
+			// Back-compat with http_security: challenges carry `wafChallenge` with the provider name.
+			...(event.kind === 'challenge' ? { wafChallenge: event.provider } : {}),
+			httpStatus: status,
+			inconclusive: true,
+		},
+	);
+
+	// controlPresent is preserved from the original result — the _mta-sts TXT record
+	// was still observed; only the policy file fetch was inconclusive.
+	return buildCheckResult('mta_sts', [...kept, inconclusive], result.controlPresent);
+}
 
 /**
  * Check MTA-STS configuration for a domain.
  * Queries _mta-sts.<domain> TXT records and optionally fetches the policy file.
  */
 export async function checkMtaSts(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
-	return checkMTASTS(
-		domain,
-		makeQueryDNS(dnsOptions),
-		{ timeout: dnsOptions?.timeoutMs ?? HTTPS_TIMEOUT_MS, fetchFn: fetch },
-	) as Promise<CheckResult>;
+	// Observe the policy-file fetch so a WAF challenge/block can be distinguished from a
+	// genuine origin error. The wrapper only OBSERVES — it returns the original response
+	// untouched so the package's behavior is unchanged; we post-process its result below.
+	let policyWafEvent: WafEvent | null = null;
+	let policyWafStatus = 0;
+
+	const observingFetch = async (url: string, init?: RequestInit): Promise<Response> => {
+		const response = await fetch(url, init);
+		// Observation must be completely invisible to the package: any error here
+		// (or a minimal Response without `headers`) must NOT alter the response the
+		// package sees, or it would convert a real failure into a different finding.
+		try {
+			if (isPolicyFetch(url) && !response.ok && response.headers && looksLikeWaf(response.headers)) {
+				const body = await sniffBody(response);
+				const event = detectWafEvent(response.headers, body, response.status);
+				if (event) {
+					policyWafEvent = event;
+					policyWafStatus = response.status;
+				}
+			}
+		} catch {
+			// fail-open — leave policyWafEvent null so the package's own finding stands.
+		}
+		return response;
+	};
+
+	const result = (await checkMTASTS(domain, makeQueryDNS(dnsOptions), {
+		timeout: dnsOptions?.timeoutMs ?? HTTPS_TIMEOUT_MS,
+		fetchFn: observingFetch,
+	})) as CheckResult;
+
+	if (policyWafEvent) return downgradeForWaf(result, domain, policyWafEvent, policyWafStatus);
+	return result;
 }

--- a/src/tools/check-mta-sts.ts
+++ b/src/tools/check-mta-sts.ts
@@ -9,8 +9,12 @@
  * page (commonly HTTP 403), the package emits a confident `high`
  * "policy file not accessible"/"policy redirects" finding — a false positive on a
  * policy that real MTAs can fetch. We detect the interception from the policy
- * response (mirroring `check-http-security.ts`) and downgrade that finding to an
- * inconclusive `info`, recomputing the score so a healthy domain is not penalised.
+ * response (mirroring `check-http-security.ts`) and make the whole mta_sts category
+ * INCONCLUSIVE — `checkStatus: 'error'` — so the scoring engine EXCLUDES it (neither
+ * pass, fail, nor inflate) rather than penalising a healthy domain. The same excluded
+ * shape is applied when the policy fetch THROWS (a WAF challenge that stalls past the
+ * timeout → AbortError, or a network error), which the package would otherwise surface
+ * as a confident `medium` "policy fetch failed".
  */
 
 import { checkMTASTS } from '@blackveil/dns-checks';
@@ -19,20 +23,19 @@ import type { QueryDnsOptions } from '../lib/dns-types';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { HTTPS_TIMEOUT_MS } from '../lib/config';
-import { type WafEvent, looksLikeWaf, detectWafEvent } from '../lib/waf-detection';
+import { type WafEvent, looksLikeWaf, detectWafEvent, buildWafFinding } from '../lib/waf-detection';
+import { readBoundedText } from '../lib/response-body';
 
 /** Titles of the package's policy-fetch findings that a WAF interception can falsely trigger. */
 const POLICY_FETCH_FALSE_POSITIVE_TITLES = new Set(['MTA-STS policy file not accessible', 'MTA-STS policy redirects']);
 
 /**
- * Score deduction for an inconclusive (WAF-challenged) policy fetch. The finding stays
- * labelled `info` (it is inconclusive, not a failure — the `_mta-sts` TXT record WAS
- * verified), but the policy file's mode/coverage could not be confirmed, so this is not
- * a perfect result either. A fixed `penaltyOverride` (à la check-dnssec) lands it ~90 —
- * clearly off the 100 ceiling, but well above a real `high` "not accessible" (penalty 25
- * → score 75). See SEVERITY_PENALTIES; `info` alone would deduct 0 and falsely score 100.
+ * The package's transient finding (emitted from its own catch path) when the policy
+ * fetch THROWS. Empirically a `medium` finding with NO `checkStatus`/`partial` flag,
+ * so scoring would penalise it — we exclude the category when this is present together
+ * with an observed policy-fetch throw. (Title confirmed against the built package.)
  */
-const INCONCLUSIVE_POLICY_PENALTY = 10;
+const POLICY_FETCH_THROW_TITLE = 'MTA-STS policy fetch failed';
 
 /** True when this fetch is the MTA-STS policy-file fetch (the only thing fetchFn is used for). */
 function isPolicyFetch(url: string): boolean {
@@ -42,79 +45,94 @@ function isPolicyFetch(url: string): boolean {
 /**
  * Max bytes to read when fingerprinting a WAF page. The `mta-sts.<domain>` host
  * is controlled by the domain owner being scanned, so the policy-fetch body is
- * attacker-influenced — and because Cloudflare's Worker egress injects `cf-ray`
- * onto EVERY response, `looksLikeWaf` is true for every non-ok policy fetch in
- * production, so this sniff runs on every 4xx/5xx. WAF challenge/block markers
- * ("just a moment", "you have been blocked") appear in the first bytes, so a
- * small bounded read is sufficient and prevents buffering a hostile multi-MB body.
+ * attacker-influenced. WAF challenge/block markers ("just a moment", "you have
+ * been blocked") appear in the first bytes, so a small bounded read is sufficient
+ * and prevents buffering a hostile multi-MB body.
  */
 const MAX_WAF_SNIFF_BYTES = 8192;
 
 /**
- * Best-effort, BOUNDED body sniff for WAF fingerprinting. Clones so the package's
- * own handling of the original response (read or cancel) is undisturbed; reads at
- * most MAX_WAF_SNIFF_BYTES then cancels the stream; returns '' if the body can't
- * be read (fail-open — detection must never throw).
+ * Best-effort, BOUNDED, BYTE-accurate body sniff for WAF fingerprinting. Clones so
+ * the package's own handling of the original response (read or cancel) is undisturbed,
+ * then delegates to the shared `readBoundedText` (byte-accurate cap, fail-open). Returns
+ * '' if the body can't be read — detection must never throw.
  */
 async function sniffBody(response: Response): Promise<string> {
 	try {
 		if (typeof response.clone !== 'function') return '';
-		const body = response.clone().body;
-		if (!body) return '';
-		const reader = body.getReader();
-		const decoder = new TextDecoder();
-		let text = '';
-		try {
-			while (text.length < MAX_WAF_SNIFF_BYTES) {
-				const { done, value } = await reader.read();
-				if (done) break;
-				text += decoder.decode(value, { stream: true });
-			}
-		} finally {
-			// Stop buffering attacker-controlled data and release the stream.
-			void reader.cancel().catch(() => {});
-		}
-		return text;
+		return await readBoundedText(response.clone().body, MAX_WAF_SNIFF_BYTES);
 	} catch {
 		return '';
 	}
 }
 
 /**
- * Replace the package's false-positive policy-fetch finding(s) with a single
- * inconclusive `info` finding and recompute the score. Other findings (the TXT
- * record presence, TLS-RPT, MX coverage) are preserved — only the unverifiable
- * policy-accessibility claim is downgraded.
+ * Build the kind-aware inconclusive `info` finding for a WAF-intercepted policy fetch.
+ * Provider is title-cased here; the title and detail wording branch on `event.kind`
+ * (block vs challenge) — fixing the prior bug where the title hardcoded "challenge".
  */
-function downgradeForWaf(result: CheckResult, domain: string, event: WafEvent, status: number): CheckResult {
+function buildPolicyWafFinding(domain: string, event: WafEvent, status: number): Finding {
 	const provider = event.provider.charAt(0).toUpperCase() + event.provider.slice(1);
+	const isBlock = event.kind === 'block';
+	const title = isBlock
+		? `${provider} WAF blocked policy fetch — accessibility inconclusive`
+		: `${provider} WAF challenge intercepted — policy accessibility inconclusive`;
+	const interception = isBlock ? 'block' : 'challenge';
+	const detail =
+		`The MTA-STS policy fetch for https://mta-sts.${domain}/.well-known/mta-sts.txt was intercepted by a ${provider} ${interception} page (HTTP ${status}), not served by the origin. ` +
+		`Real sending MTAs are not subject to the same interactive ${interception}, so the policy may well be reachable for mail delivery; its accessibility could not be verified externally by the scanner.`;
+	return buildWafFinding('mta_sts', event, status, { title, detail });
+}
+
+/**
+ * Replace the package's false-positive policy-fetch finding(s) with a single
+ * inconclusive WAF `info` finding and EXCLUDE the category from scoring via
+ * `checkStatus: 'error'` (mirrors check-http-security.ts). Other findings (the
+ * TXT record presence, TLS-RPT, MX coverage) are kept for display — but the
+ * `checkStatus: 'error'` still excludes the whole category from the score, so
+ * a healthy domain is neither penalised nor inflated.
+ */
+function excludeForWaf(result: CheckResult, domain: string, event: WafEvent, status: number): CheckResult {
 	const kept = result.findings.filter((f: Finding) => !POLICY_FETCH_FALSE_POSITIVE_TITLES.has(f.title));
 
 	// Nothing to downgrade (e.g. the policy actually served fine on this run) — leave the result intact.
 	if (kept.length === result.findings.length) return result;
 
-	const inconclusive = createFinding(
-		'mta_sts',
-		`${provider} WAF challenge intercepted — policy accessibility inconclusive`,
-		'info',
-		`The MTA-STS policy fetch for https://mta-sts.${domain}/.well-known/mta-sts.txt was intercepted by a ${provider} ${event.kind} page (HTTP ${status}), not served by the origin. ` +
-			`Real sending MTAs are not subject to the same interactive challenge, so the policy may well be reachable for mail delivery; its accessibility could not be verified externally by the scanner.`,
-		{
-			wafEvent: event.provider,
-			wafKind: event.kind,
-			// Back-compat with http_security: challenges carry `wafChallenge` with the provider name.
-			...(event.kind === 'challenge' ? { wafChallenge: event.provider } : {}),
-			httpStatus: status,
-			inconclusive: true,
-			// Keep the `info` label (not alarming) but apply a deliberate, fixed deduction so an
-			// unverifiable policy doesn't score a perfect 100. See INCONCLUSIVE_POLICY_PENALTY.
-			penaltyOverride: INCONCLUSIVE_POLICY_PENALTY,
-		},
-	);
+	const inconclusive = buildPolicyWafFinding(domain, event, status);
 
 	// controlPresent is preserved from the original result — the _mta-sts TXT record
 	// was still observed; only the policy file fetch was inconclusive.
-	return buildCheckResult('mta_sts', [...kept, inconclusive], result.controlPresent);
+	return { ...buildCheckResult('mta_sts', [...kept, inconclusive], result.controlPresent), score: 0, passed: false, checkStatus: 'error' };
+}
+
+/**
+ * The policy fetch THREW (WAF stall → AbortError, or a network error) and the package
+ * surfaced its transient `medium` "policy fetch failed" finding. Drop that finding,
+ * add an inconclusive WAF-style `info` note, and EXCLUDE the category — same shape as
+ * a Response-based WAF event. Conservative: only invoked when we actually observed a
+ * policy-fetch throw, so a genuine deterministic "not accessible" (a real 404 Response)
+ * is untouched and keeps the package's `high`.
+ */
+function excludeForPolicyThrow(result: CheckResult, domain: string): CheckResult {
+	const hasTransient = result.findings.some((f: Finding) => f.title === POLICY_FETCH_THROW_TITLE);
+	// The package emitted something other than its transient throw finding — don't touch it.
+	if (!hasTransient) return result;
+
+	const kept = result.findings.filter((f: Finding) => f.title !== POLICY_FETCH_THROW_TITLE);
+	// Unlike a Response-based WAF event, a throw carries NO provider evidence — do NOT
+	// fabricate a `wafEvent` provider in the metadata (it would mislead analytics). Build a
+	// plain inconclusive transient finding; `checkStatus: 'error'` below is what excludes the
+	// category, not the finding metadata. `errorKind: 'timeout'` follows the repo's transient
+	// convention (see lib/dns-error-result.ts).
+	const inconclusive = createFinding(
+		'mta_sts',
+		'MTA-STS policy fetch stalled — accessibility inconclusive',
+		'info',
+		`The MTA-STS policy fetch for https://mta-sts.${domain}/.well-known/mta-sts.txt did not complete (the connection was aborted or stalled), ` +
+			`consistent with a transient failure or a WAF challenge that real sending MTAs are not subject to. Policy accessibility could not be verified externally by the scanner.`,
+		{ inconclusive: true, missingControl: true, errorKind: 'timeout' },
+	);
+	return { ...buildCheckResult('mta_sts', [...kept, inconclusive], result.controlPresent), score: 0, passed: false, checkStatus: 'error' };
 }
 
 /**
@@ -124,17 +142,47 @@ function downgradeForWaf(result: CheckResult, domain: string, event: WafEvent, s
 export async function checkMtaSts(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
 	// Observe the policy-file fetch so a WAF challenge/block can be distinguished from a
 	// genuine origin error. The wrapper only OBSERVES — it returns the original response
-	// untouched so the package's behavior is unchanged; we post-process its result below.
+	// (or re-throws the original error) untouched so the package's behavior is unchanged;
+	// we post-process its result below.
+	//
+	// Single-fetch contract: the package makes exactly ONE policy fetch matching
+	// /.well-known/mta-sts.txt per call. We defensively capture only the FIRST observed
+	// policy WAF event / throw and ignore any subsequent policy fetches, so a future
+	// package change that retries can't overwrite or double-count the observation.
 	let policyWafEvent: WafEvent | null = null;
 	let policyWafStatus = 0;
+	let policyFetchThrew = false;
 
 	const observingFetch = async (url: string, init?: RequestInit): Promise<Response> => {
-		const response = await fetch(url, init);
+		const policy = isPolicyFetch(url);
+		let response: Response;
+		try {
+			response = await fetch(url, init);
+		} catch (err) {
+			// A policy-fetch rejection (AbortError from a stalled WAF challenge, or a network
+			// TypeError) is observed as inconclusive, then RE-THROWN so the package still runs
+			// its own catch path and emits its transient finding. Only the FIRST policy throw
+			// is recorded (single-fetch contract).
+			if (policy && !policyFetchThrew && isObservableFetchThrow(err)) {
+				policyFetchThrew = true;
+			}
+			throw err;
+		}
 		// Observation must be completely invisible to the package: any error here
 		// (or a minimal Response without `headers`) must NOT alter the response the
 		// package sees, or it would convert a real failure into a different finding.
 		try {
-			if (isPolicyFetch(url) && !response.ok && response.headers && looksLikeWaf(response.headers)) {
+			// Gate the body sniff to only run when detectWafEvent could actually fire — a
+			// non-WAF sub-400 redirect or plain origin 404 (where cf-ray rides every Cloudflare
+			// egress) must skip the clone+read entirely. Capture only the first policy event.
+			if (
+				policy &&
+				!policyWafEvent &&
+				!response.ok &&
+				response.headers &&
+				(response.status >= 400 || response.headers.get('cf-mitigated')) &&
+				looksLikeWaf(response.headers)
+			) {
 				const body = await sniffBody(response);
 				const event = detectWafEvent(response.headers, body, response.status);
 				if (event) {
@@ -153,6 +201,19 @@ export async function checkMtaSts(domain: string, dnsOptions?: QueryDnsOptions):
 		fetchFn: observingFetch,
 	})) as CheckResult;
 
-	if (policyWafEvent) return downgradeForWaf(result, domain, policyWafEvent, policyWafStatus);
+	if (policyWafEvent) return excludeForWaf(result, domain, policyWafEvent, policyWafStatus);
+	if (policyFetchThrew) return excludeForPolicyThrow(result, domain);
 	return result;
+}
+
+/**
+ * Only treat a policy-fetch rejection as inconclusive when it looks like a stall /
+ * network failure (AbortError from the package's AbortSignal.timeout, or a TypeError
+ * network error). Anything else is re-thrown unobserved so the package owns it.
+ */
+function isObservableFetchThrow(err: unknown): boolean {
+	if (err instanceof Error) {
+		return err.name === 'AbortError' || err.name === 'TimeoutError' || err instanceof TypeError;
+	}
+	return false;
 }

--- a/src/tools/check-mta-sts.ts
+++ b/src/tools/check-mta-sts.ts
@@ -30,14 +30,41 @@ function isPolicyFetch(url: string): boolean {
 }
 
 /**
- * Best-effort body sniff for WAF fingerprinting. Clones so the package's own
- * handling of the original response (read or cancel) is undisturbed; returns ''
- * if the body can't be read (fail-open — detection must never throw).
+ * Max bytes to read when fingerprinting a WAF page. The `mta-sts.<domain>` host
+ * is controlled by the domain owner being scanned, so the policy-fetch body is
+ * attacker-influenced — and because Cloudflare's Worker egress injects `cf-ray`
+ * onto EVERY response, `looksLikeWaf` is true for every non-ok policy fetch in
+ * production, so this sniff runs on every 4xx/5xx. WAF challenge/block markers
+ * ("just a moment", "you have been blocked") appear in the first bytes, so a
+ * small bounded read is sufficient and prevents buffering a hostile multi-MB body.
+ */
+const MAX_WAF_SNIFF_BYTES = 8192;
+
+/**
+ * Best-effort, BOUNDED body sniff for WAF fingerprinting. Clones so the package's
+ * own handling of the original response (read or cancel) is undisturbed; reads at
+ * most MAX_WAF_SNIFF_BYTES then cancels the stream; returns '' if the body can't
+ * be read (fail-open — detection must never throw).
  */
 async function sniffBody(response: Response): Promise<string> {
 	try {
 		if (typeof response.clone !== 'function') return '';
-		return await response.clone().text();
+		const body = response.clone().body;
+		if (!body) return '';
+		const reader = body.getReader();
+		const decoder = new TextDecoder();
+		let text = '';
+		try {
+			while (text.length < MAX_WAF_SNIFF_BYTES) {
+				const { done, value } = await reader.read();
+				if (done) break;
+				text += decoder.decode(value, { stream: true });
+			}
+		} finally {
+			// Stop buffering attacker-controlled data and release the stream.
+			void reader.cancel().catch(() => {});
+		}
+		return text;
 	} catch {
 		return '';
 	}

--- a/test/audits/mta-sts-title-coupling.audit.test.ts
+++ b/test/audits/mta-sts-title-coupling.audit.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Audit — MTA-STS policy-fetch finding-title coupling (issue #455).
+ *
+ * src/tools/check-mta-sts.ts identifies the @blackveil/dns-checks package's
+ * false-positive policy-fetch findings by EXACT title via
+ * `POLICY_FETCH_FALSE_POSITIVE_TITLES = new Set([...])`, then downgrades them
+ * when a WAF intercepts the policy fetch. That Set is a brittle cross-package
+ * string coupling: if the package ever rewords either title, the Set silently
+ * stops matching and the WAF false-positive reappears in production with no
+ * other test catching the drift.
+ *
+ * This audit pins the coupling. It drives the real production wrapper
+ * (`checkMtaSts`) against the two GENUINE (non-WAF) failure conditions — a plain
+ * 404 (policy file not accessible) and a plain 301 (policy redirects), both with
+ * NO Cloudflare/Akamai WAF signal so the wrapper's downgrade does NOT fire — and
+ * asserts the emitted finding titles are EXACTLY the strings the Set relies on.
+ * If the package rewords a title, this audit goes red, forcing a maintainer to
+ * update the Set too.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from '../helpers/dns-mock';
+import type { Finding } from '../../src/lib/scoring';
+
+// SSOT-coupling tripwire: these MUST match POLICY_FETCH_FALSE_POSITIVE_TITLES in
+// src/tools/check-mta-sts.ts. If the @blackveil/dns-checks package rewords a
+// title, update BOTH.
+const TITLE_NOT_ACCESSIBLE = 'MTA-STS policy file not accessible';
+const TITLE_REDIRECTS = 'MTA-STS policy redirects';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+function txtResponse(domain: string, records: string[]) {
+	return createDohResponse(
+		[{ name: domain, type: 16 }],
+		records.map((data) => ({ name: domain, type: 16, TTL: 300, data: `"${data}"` })),
+	);
+}
+
+/** A real Response for the policy fetch — exercises the genuine .ok/.status/.headers path. */
+function policyHttp(status: number, headers: Record<string, string> = {}, body = ''): Response {
+	return new Response(body || null, { status, headers });
+}
+
+/** Mock the DoH DNS lookups + the policy-file fetch, keyed by URL. */
+function mockFetch(opts: { mtaStsDns?: Response; tlsrptDns?: Response; policyFetch?: Response }) {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		if (url.includes('cloudflare-dns.com')) {
+			if (url.includes('_mta-sts.') && opts.mtaStsDns) return Promise.resolve(opts.mtaStsDns);
+			if (url.includes('_smtp._tls.') && opts.tlsrptDns) return Promise.resolve(opts.tlsrptDns);
+			return Promise.resolve(createDohResponse([], []));
+		}
+		if (url.includes('mta-sts.') && url.includes('.well-known')) {
+			return Promise.resolve(opts.policyFetch ?? policyHttp(404));
+		}
+		return Promise.resolve(policyHttp(404));
+	});
+}
+
+describe('audit — MTA-STS policy-fetch title coupling (issue #455 Set tripwire)', () => {
+	async function run(domain = 'example.com') {
+		// Dynamic import inside the test fn — bind the wrapper AFTER the fetch mock is installed.
+		const { checkMtaSts } = await import('../../src/tools/check-mta-sts');
+		return checkMtaSts(domain);
+	}
+
+	// A valid _mta-sts TXT record so the check proceeds to the policy fetch.
+	const validTxt = (d: string) => txtResponse(`_mta-sts.${d}`, ['v=STSv1; id=20260114010000']);
+	const validTlsRpt = (d: string) => txtResponse(`_smtp._tls.${d}`, ['v=TLSRPTv1; rua=mailto:tlsrpt@example.com']);
+
+	it(`emits the EXACT title "${TITLE_NOT_ACCESSIBLE}" on a genuine (non-WAF) 404`, async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			// Plain origin 404, no Cloudflare/Akamai signals → looksLikeWaf is false → no downgrade.
+			policyFetch: policyHttp(404, { server: 'nginx' }, 'Not Found'),
+		});
+
+		const result = await run();
+
+		// No WAF downgrade occurred — the genuine package finding passes through untouched.
+		expect(result.findings.some((f: Finding) => f.metadata?.inconclusive === true)).toBe(false);
+		// The package emits the EXACT title the Set keys on.
+		expect(result.findings.some((f: Finding) => f.title === TITLE_NOT_ACCESSIBLE)).toBe(true);
+	});
+
+	it(`emits the EXACT title "${TITLE_REDIRECTS}" on a genuine (non-WAF) 301 redirect`, async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			// Plain origin 301 redirect, no Cloudflare/Akamai signals → no downgrade.
+			policyFetch: policyHttp(301, { server: 'nginx', location: 'https://example.com/mta-sts.txt' }),
+		});
+
+		const result = await run();
+
+		expect(result.findings.some((f: Finding) => f.metadata?.inconclusive === true)).toBe(false);
+		expect(result.findings.some((f: Finding) => f.title === TITLE_REDIRECTS)).toBe(true);
+	});
+});

--- a/test/check-mta-sts-waf.spec.ts
+++ b/test/check-mta-sts-waf.spec.ts
@@ -70,9 +70,12 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 		expect(waf!.severity).toBe('info');
 		expect(waf!.metadata?.inconclusive).toBe(true);
 		expect(waf!.metadata?.httpStatus).toBe(403);
-		// …with the TXT-record control still credited and the score recovered off the floor.
+		// …with the TXT-record control still credited and the score recovered off the 75 floor,
+		// but NOT a perfect 100 — the policy itself was unverifiable, so a deliberate deduction applies.
 		expect(result.controlPresent).toBe(true);
 		expect(result.score).toBeGreaterThan(75);
+		expect(result.score).toBeLessThan(100);
+		expect(waf!.metadata?.penaltyOverride).toBe(10);
 	});
 
 	it('downgrades a Cloudflare block page (403 + block body) to an inconclusive info', async () => {

--- a/test/check-mta-sts-waf.spec.ts
+++ b/test/check-mta-sts-waf.spec.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Issue #455 — the MTA-STS policy fetch must not emit a confident `high`
+ * "policy file not accessible" finding when the fetch was intercepted by a
+ * Cloudflare/Akamai WAF challenge/block (commonly HTTP 403). Real sending MTAs
+ * are not subject to the interactive challenge, so a healthy policy (the
+ * blackveilsecurity.com repro) was being falsely flagged. The interception is
+ * downgraded to an inconclusive `info` and the score recomputed.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+function txtResponse(domain: string, records: string[]) {
+	return createDohResponse(
+		[{ name: domain, type: 16 }],
+		records.map((data) => ({ name: domain, type: 16, TTL: 300, data: `"${data}"` })),
+	);
+}
+
+/** A real Response for the policy fetch — exercises the genuine .ok/.status/.headers/.clone() path. */
+function policyHttp(status: number, headers: Record<string, string> = {}, body = ''): Response {
+	return new Response(body || null, { status, headers });
+}
+
+/** Mock the DoH DNS lookups + the policy-file fetch, keyed by URL like the sibling spec. */
+function mockFetch(opts: { mtaStsDns?: Response; tlsrptDns?: Response; policyFetch?: Response }) {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		if (url.includes('cloudflare-dns.com')) {
+			if (url.includes('_mta-sts.') && opts.mtaStsDns) return Promise.resolve(opts.mtaStsDns);
+			if (url.includes('_smtp._tls.') && opts.tlsrptDns) return Promise.resolve(opts.tlsrptDns);
+			return Promise.resolve(createDohResponse([], []));
+		}
+		if (url.includes('mta-sts.') && url.includes('.well-known')) {
+			return Promise.resolve(opts.policyFetch ?? policyHttp(404));
+		}
+		return Promise.resolve(policyHttp(404));
+	});
+}
+
+describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
+	async function run(domain = 'example.com') {
+		const { checkMtaSts } = await import('../src/tools/check-mta-sts');
+		return checkMtaSts(domain);
+	}
+
+	const validTxt = (d: string) => txtResponse(`_mta-sts.${d}`, ['v=STSv1; id=20260114010000']);
+	const validTlsRpt = (d: string) => txtResponse(`_smtp._tls.${d}`, ['v=TLSRPTv1; rua=mailto:tlsrpt@example.com']);
+
+	it('downgrades a Cloudflare challenge (403 + cf-mitigated) to an inconclusive info — no high finding', async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			policyFetch: policyHttp(403, { 'cf-ray': '91def5678-AKL', 'cf-mitigated': 'challenge', server: 'cloudflare' }),
+		});
+
+		const result = await run();
+
+		// The false-positive high must be gone…
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		expect(result.findings.some((f) => f.title === 'MTA-STS policy file not accessible')).toBe(false);
+		// …replaced by an inconclusive challenge finding…
+		const waf = result.findings.find((f) => f.metadata?.wafKind === 'challenge');
+		expect(waf).toBeDefined();
+		expect(waf!.severity).toBe('info');
+		expect(waf!.metadata?.inconclusive).toBe(true);
+		expect(waf!.metadata?.httpStatus).toBe(403);
+		// …with the TXT-record control still credited and the score recovered off the floor.
+		expect(result.controlPresent).toBe(true);
+		expect(result.score).toBeGreaterThan(75);
+	});
+
+	it('downgrades a Cloudflare block page (403 + block body) to an inconclusive info', async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			policyFetch: policyHttp(403, { 'cf-ray': '91def5678-AKL', server: 'cloudflare' }, 'Sorry, you have been blocked'),
+		});
+
+		const result = await run();
+
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		const waf = result.findings.find((f) => f.metadata?.wafEvent === 'cloudflare');
+		expect(waf).toBeDefined();
+		expect(waf!.metadata?.wafKind).toBe('block');
+		expect(waf!.metadata?.inconclusive).toBe(true);
+	});
+
+	it('does NOT downgrade a genuine (non-WAF) 403 — the high finding is preserved', async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			// Plain origin 403, no Cloudflare/Akamai signals → looksLikeWaf is false → no downgrade.
+			policyFetch: policyHttp(403, { server: 'nginx' }),
+		});
+
+		const result = await run();
+
+		expect(result.findings.some((f) => f.title === 'MTA-STS policy file not accessible' && f.severity === 'high')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(false);
+	});
+});

--- a/test/check-mta-sts-waf.spec.ts
+++ b/test/check-mta-sts-waf.spec.ts
@@ -91,6 +91,39 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 		expect(waf!.metadata?.inconclusive).toBe(true);
 	});
 
+	it('downgrades a WAF-intercepted redirect (301 + cf-mitigated) — replaces the policy-redirects high', async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			policyFetch: policyHttp(301, { 'cf-ray': '91def5678-AKL', 'cf-mitigated': 'challenge', server: 'cloudflare', location: 'https://challenge.cloudflare.com/' }),
+		});
+
+		const result = await run();
+
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		expect(result.findings.some((f) => f.title === 'MTA-STS policy redirects')).toBe(false);
+		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(true);
+	});
+
+	it('bounds the body sniff on a hostile oversized 403 — still detects, does not buffer the whole body', async () => {
+		// block marker up front, then ~1 MB of attacker-controlled padding. The bounded
+		// reader must detect the block from the early bytes without buffering it all.
+		const hostileBody = 'Sorry, you have been blocked' + 'A'.repeat(1_000_000);
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			policyFetch: policyHttp(403, { 'cf-ray': '91def5678-AKL', server: 'cloudflare' }, hostileBody),
+		});
+
+		const result = await run();
+
+		// Detection still works off the early bytes; the false-positive high is gone.
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		const waf = result.findings.find((f) => f.metadata?.wafEvent === 'cloudflare');
+		expect(waf).toBeDefined();
+		expect(waf!.metadata?.wafKind).toBe('block');
+	});
+
 	it('does NOT downgrade a genuine (non-WAF) 403 — the high finding is preserved', async () => {
 		mockFetch({
 			mtaStsDns: validTxt('example.com'),

--- a/test/check-mta-sts-waf.spec.ts
+++ b/test/check-mta-sts-waf.spec.ts
@@ -5,8 +5,13 @@
  * "policy file not accessible" finding when the fetch was intercepted by a
  * Cloudflare/Akamai WAF challenge/block (commonly HTTP 403). Real sending MTAs
  * are not subject to the interactive challenge, so a healthy policy (the
- * blackveilsecurity.com repro) was being falsely flagged. The interception is
- * downgraded to an inconclusive `info` and the score recomputed.
+ * blackveilsecurity.com repro) was being falsely flagged.
+ *
+ * The DECIDED treatment (aligning with check-http-security.ts): the WAF-intercepted
+ * policy fetch makes the mta_sts category INCONCLUSIVE — `checkStatus: 'error'`,
+ * `score: 0`, `passed: false` — so the scoring engine EXCLUDES the category rather
+ * than penalising it. The WAF finding itself is an `info` finding carrying
+ * `inconclusive: true` + `missingControl: true` (no `penaltyOverride`).
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -28,7 +33,7 @@ function policyHttp(status: number, headers: Record<string, string> = {}, body =
 }
 
 /** Mock the DoH DNS lookups + the policy-file fetch, keyed by URL like the sibling spec. */
-function mockFetch(opts: { mtaStsDns?: Response; tlsrptDns?: Response; policyFetch?: Response }) {
+function mockFetch(opts: { mtaStsDns?: Response; tlsrptDns?: Response; policyFetch?: Response | (() => Promise<Response>) }) {
 	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 		if (url.includes('cloudflare-dns.com')) {
@@ -37,6 +42,7 @@ function mockFetch(opts: { mtaStsDns?: Response; tlsrptDns?: Response; policyFet
 			return Promise.resolve(createDohResponse([], []));
 		}
 		if (url.includes('mta-sts.') && url.includes('.well-known')) {
+			if (typeof opts.policyFetch === 'function') return opts.policyFetch();
 			return Promise.resolve(opts.policyFetch ?? policyHttp(404));
 		}
 		return Promise.resolve(policyHttp(404));
@@ -52,7 +58,7 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 	const validTxt = (d: string) => txtResponse(`_mta-sts.${d}`, ['v=STSv1; id=20260114010000']);
 	const validTlsRpt = (d: string) => txtResponse(`_smtp._tls.${d}`, ['v=TLSRPTv1; rua=mailto:tlsrpt@example.com']);
 
-	it('downgrades a Cloudflare challenge (403 + cf-mitigated) to an inconclusive info — no high finding', async () => {
+	it('makes the category inconclusive on a Cloudflare challenge (403 + cf-mitigated) — no high, checkStatus error', async () => {
 		mockFetch({
 			mtaStsDns: validTxt('example.com'),
 			tlsrptDns: validTlsRpt('example.com'),
@@ -69,16 +75,19 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 		expect(waf).toBeDefined();
 		expect(waf!.severity).toBe('info');
 		expect(waf!.metadata?.inconclusive).toBe(true);
+		expect(waf!.metadata?.missingControl).toBe(true);
 		expect(waf!.metadata?.httpStatus).toBe(403);
-		// …with the TXT-record control still credited and the score recovered off the 75 floor,
-		// but NOT a perfect 100 — the policy itself was unverifiable, so a deliberate deduction applies.
-		expect(result.controlPresent).toBe(true);
-		expect(result.score).toBeGreaterThan(75);
-		expect(result.score).toBeLessThan(100);
-		expect(waf!.metadata?.penaltyOverride).toBe(10);
+		// Kind-aware title — a CHALLENGE, not a block.
+		expect(waf!.title).toBe('Cloudflare WAF challenge intercepted — policy accessibility inconclusive');
+		// No penaltyOverride anywhere — the category is EXCLUDED, not penalised.
+		expect(result.findings.some((f) => f.metadata?.penaltyOverride !== undefined)).toBe(false);
+		// Scoring-exclusion shape (mirrors check-http-security.ts).
+		expect(result.checkStatus).toBe('error');
+		expect(result.score).toBe(0);
+		expect(result.passed).toBe(false);
 	});
 
-	it('downgrades a Cloudflare block page (403 + block body) to an inconclusive info', async () => {
+	it('makes the category inconclusive on a Cloudflare block page (403 + block body) — kind-aware title', async () => {
 		mockFetch({
 			mtaStsDns: validTxt('example.com'),
 			tlsrptDns: validTlsRpt('example.com'),
@@ -91,14 +100,27 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 		const waf = result.findings.find((f) => f.metadata?.wafEvent === 'cloudflare');
 		expect(waf).toBeDefined();
 		expect(waf!.metadata?.wafKind).toBe('block');
+		expect(waf!.severity).toBe('info');
 		expect(waf!.metadata?.inconclusive).toBe(true);
+		expect(waf!.metadata?.missingControl).toBe(true);
+		// Kind-aware title fixes the prior bug where it hardcoded "challenge" on a block.
+		expect(waf!.title).toBe('Cloudflare WAF blocked policy fetch — accessibility inconclusive');
+		expect(waf!.metadata?.penaltyOverride).toBeUndefined();
+		expect(result.checkStatus).toBe('error');
+		expect(result.score).toBe(0);
+		expect(result.passed).toBe(false);
 	});
 
-	it('downgrades a WAF-intercepted redirect (301 + cf-mitigated) — replaces the policy-redirects high', async () => {
+	it('makes the category inconclusive on a WAF-intercepted redirect (301 + cf-mitigated) — replaces the policy-redirects high', async () => {
 		mockFetch({
 			mtaStsDns: validTxt('example.com'),
 			tlsrptDns: validTlsRpt('example.com'),
-			policyFetch: policyHttp(301, { 'cf-ray': '91def5678-AKL', 'cf-mitigated': 'challenge', server: 'cloudflare', location: 'https://challenge.cloudflare.com/' }),
+			policyFetch: policyHttp(301, {
+				'cf-ray': '91def5678-AKL',
+				'cf-mitigated': 'challenge',
+				server: 'cloudflare',
+				location: 'https://challenge.cloudflare.com/',
+			}),
 		});
 
 		const result = await run();
@@ -106,6 +128,7 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
 		expect(result.findings.some((f) => f.title === 'MTA-STS policy redirects')).toBe(false);
 		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(true);
+		expect(result.checkStatus).toBe('error');
 	});
 
 	it('bounds the body sniff on a hostile oversized 403 — still detects, does not buffer the whole body', async () => {
@@ -125,6 +148,7 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 		const waf = result.findings.find((f) => f.metadata?.wafEvent === 'cloudflare');
 		expect(waf).toBeDefined();
 		expect(waf!.metadata?.wafKind).toBe('block');
+		expect(result.checkStatus).toBe('error');
 	});
 
 	it('does NOT downgrade a genuine (non-WAF) 403 — the high finding is preserved', async () => {
@@ -139,5 +163,66 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 
 		expect(result.findings.some((f) => f.title === 'MTA-STS policy file not accessible' && f.severity === 'high')).toBe(true);
 		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(false);
+		expect(result.checkStatus).not.toBe('error');
+	});
+
+	it('does NOT suppress a genuine CF 404 (cf-ray present, NO cf-mitigated, benign body) — high preserved', async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			// Cloudflare egress always carries cf-ray, but a genuine origin 404 (no cf-mitigated,
+			// benign body) is NOT a WAF event — detectWafEvent returns null → high preserved.
+			policyFetch: policyHttp(404, { 'cf-ray': '91def5678-AKL', server: 'cloudflare' }, 'Not Found'),
+		});
+
+		const result = await run();
+
+		expect(result.findings.some((f) => f.title === 'MTA-STS policy file not accessible' && f.severity === 'high')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(false);
+		expect(result.checkStatus).not.toBe('error');
+	});
+
+	it('does NOT suppress a genuine Akamai 404 (server AkamaiGHost, benign body, no block signature) — high preserved', async () => {
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			// Bare AkamaiGHost server header on a benign 404 is NOT a block (tightened Akamai gate
+			// requires a 4xx + an access-denied body signature) → high preserved.
+			policyFetch: policyHttp(404, { server: 'AkamaiGHost' }, 'Not Found'),
+		});
+
+		const result = await run();
+
+		expect(result.findings.some((f) => f.title === 'MTA-STS policy file not accessible' && f.severity === 'high')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(false);
+		expect(result.checkStatus).not.toBe('error');
+	});
+
+	it('makes the category inconclusive when the policy fetch THROWS (AbortError / WAF stall) — excludes the package medium', async () => {
+		// Empirical: when the policy fetch rejects, the package emits a `medium`
+		// "MTA-STS policy fetch failed" finding with NO checkStatus/partial flag — so
+		// scoring would otherwise penalise it. The wrapper catches the throw for the
+		// policy fetch, re-throws (so the package still runs its catch path), then
+		// converts the result to the excluded/inconclusive shape.
+		mockFetch({
+			mtaStsDns: validTxt('example.com'),
+			tlsrptDns: validTlsRpt('example.com'),
+			policyFetch: () => {
+				const err = new Error('The operation was aborted');
+				err.name = 'AbortError';
+				return Promise.reject(err);
+			},
+		});
+
+		const result = await run();
+
+		// No medium "fetch failed" left dragging the score down…
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		// …category excluded as inconclusive.
+		expect(result.checkStatus).toBe('error');
+		expect(result.score).toBe(0);
+		expect(result.passed).toBe(false);
+		// An inconclusive finding documents the stall.
+		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(true);
 	});
 });

--- a/test/response-body.spec.ts
+++ b/test/response-body.spec.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+/** Build a ReadableStream that emits the given Uint8Array chunks. */
+function streamFrom(chunks: Uint8Array[]): ReadableStream<Uint8Array> {
+	let i = 0;
+	return new ReadableStream<Uint8Array>({
+		pull(controller) {
+			if (i < chunks.length) {
+				controller.enqueue(chunks[i++]);
+			} else {
+				controller.close();
+			}
+		},
+	});
+}
+
+/** A stream whose reader.read() rejects on the first pull. */
+function rejectingStream(): ReadableStream<Uint8Array> {
+	return new ReadableStream<Uint8Array>({
+		pull() {
+			throw new Error('boom');
+		},
+	});
+}
+
+describe('readBoundedText', () => {
+	it('bounds on UTF-8 byte length, not UTF-16 code-unit length, for multi-byte bodies', async () => {
+		const { readBoundedText } = await import('../src/lib/response-body');
+		// '€' encodes to 3 UTF-8 bytes. 1000 of them = 3000 bytes but only 1000 code units.
+		const full = new TextEncoder().encode('€'.repeat(1000));
+		expect(full.byteLength).toBe(3000);
+		// Emit in small chunks so the cap can be hit mid-stream.
+		const chunks: Uint8Array[] = [];
+		for (let o = 0; o < full.byteLength; o += 128) {
+			chunks.push(full.slice(o, o + 128));
+		}
+		const result = await readBoundedText(streamFrom(chunks), 600);
+		const resultBytes = new TextEncoder().encode(result).byteLength;
+		// Bounded by BYTES: must not exceed cap + at most one partial chunk (128 bytes here).
+		expect(resultBytes).toBeLessThanOrEqual(600 + 128);
+		// And crucially it must NOT have read the whole 3000-byte body.
+		expect(resultBytes).toBeLessThan(3000);
+		// Sanity: result.length (UTF-16 units) is far below what a length-based bound would allow.
+		expect(result.length).toBeGreaterThan(0);
+	});
+
+	it('returns the bounded prefix when the body overflows (truncate, never throws)', async () => {
+		const { readBoundedText } = await import('../src/lib/response-body');
+		// Deliver in small chunks so the cap can be hit before the whole body buffers.
+		const full = new TextEncoder().encode('a'.repeat(10000));
+		const chunks: Uint8Array[] = [];
+		for (let o = 0; o < full.byteLength; o += 50) chunks.push(full.slice(o, o + 50));
+		const result = await readBoundedText(streamFrom(chunks), 100);
+		const resultBytes = new TextEncoder().encode(result).byteLength;
+		expect(resultBytes).toBeGreaterThan(0);
+		// cap (100) + at most one partial chunk (50)
+		expect(resultBytes).toBeLessThanOrEqual(150);
+		expect(resultBytes).toBeLessThan(10000);
+	});
+
+	it('returns the full body when under the cap', async () => {
+		const { readBoundedText } = await import('../src/lib/response-body');
+		const result = await readBoundedText(streamFrom([new TextEncoder().encode('hello')]), 1024);
+		expect(result).toBe('hello');
+	});
+
+	it('returns "" for a null body', async () => {
+		const { readBoundedText } = await import('../src/lib/response-body');
+		expect(await readBoundedText(null, 1024)).toBe('');
+	});
+
+	it('returns "" for an empty stream', async () => {
+		const { readBoundedText } = await import('../src/lib/response-body');
+		expect(await readBoundedText(streamFrom([]), 1024)).toBe('');
+	});
+
+	it('returns "" (never throws) when the reader rejects', async () => {
+		const { readBoundedText } = await import('../src/lib/response-body');
+		await expect(readBoundedText(rejectingStream(), 1024)).resolves.toBe('');
+	});
+});
+
+describe('readBoundedOrNull', () => {
+	it('returns null on overflow (preserves check-agent-discovery semantics)', async () => {
+		const { readBoundedOrNull } = await import('../src/lib/response-body');
+		const full = new TextEncoder().encode('a'.repeat(10000));
+		const result = await readBoundedOrNull(streamFrom([full]), 100);
+		expect(result).toBeNull();
+	});
+
+	it('returns the decoded body when under the cap', async () => {
+		const { readBoundedOrNull } = await import('../src/lib/response-body');
+		const result = await readBoundedOrNull(streamFrom([new TextEncoder().encode('hello')]), 1024);
+		expect(result).toBe('hello');
+	});
+
+	it('returns null for a null body', async () => {
+		const { readBoundedOrNull } = await import('../src/lib/response-body');
+		expect(await readBoundedOrNull(null, 1024)).toBeNull();
+	});
+
+	it('returns null (never throws) when the reader rejects', async () => {
+		const { readBoundedOrNull } = await import('../src/lib/response-body');
+		await expect(readBoundedOrNull(rejectingStream(), 1024)).resolves.toBeNull();
+	});
+});

--- a/test/waf-detection.spec.ts
+++ b/test/waf-detection.spec.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Unit tests for the shared WAF interception detection (issue #455).
+ *
+ * Mock isolation: import the unit under test dynamically inside each test fn
+ * (bv-mcp workers-pool convention). No fetch mocking is needed here — these are
+ * pure functions over real `Headers` objects.
+ */
+
+function headers(init: Record<string, string>): Headers {
+	return new Headers(init);
+}
+
+describe('detectWafEvent — Akamai branch (tightened, #455)', () => {
+	it('returns null for a 200 with Server: akamaighost regardless of body', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ server: 'AkamaiGHost' }), 'Access Denied', 200)).toBeNull();
+	});
+
+	it('returns an akamai block for a 403 with akamaighost AND an access-denied body', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ server: 'AkamaiGHost' }), 'Access Denied Reference #18.abc', 403)).toEqual({
+			provider: 'akamai',
+			kind: 'block',
+		});
+	});
+
+	it('returns null for a genuine origin 404 with akamaighost and a benign body (NOT a WAF block)', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ server: 'AkamaiGHost' }), 'not found', 404)).toBeNull();
+	});
+
+	it('returns null for a 403 with akamaighost but no body signature (bare Server header)', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ server: 'AkamaiGHost' }), '', 403)).toBeNull();
+	});
+});
+
+describe('detectWafEvent — Cloudflare branch (unchanged)', () => {
+	it('returns a cloudflare block for a 403 with cf-mitigated present', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ 'cf-mitigated': 'block' }), '', 403)).toEqual({
+			provider: 'cloudflare',
+			kind: 'block',
+		});
+	});
+
+	it('returns null for a 403 with cf-ray only and a benign body', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ 'cf-ray': '8aabcdef1234-AKL' }), 'not found', 403)).toBeNull();
+	});
+
+	it('returns a cloudflare challenge for cf-mitigated: challenge', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ 'cf-mitigated': 'challenge' }), '', 403)).toEqual({
+			provider: 'cloudflare',
+			kind: 'challenge',
+		});
+	});
+
+	it('returns a cloudflare challenge for a "Just a moment" body with cf-ray', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ 'cf-ray': '8aabcdef1234-AKL' }), 'Just a moment...', 403)).toEqual({
+			provider: 'cloudflare',
+			kind: 'challenge',
+		});
+	});
+});
+
+describe('buildWafFinding — canonical inconclusive WAF info-finding', () => {
+	it('builds an info-severity finding with the canonical metadata contract', async () => {
+		const { buildWafFinding } = await import('../src/lib/waf-detection');
+		const finding = buildWafFinding('http_security', { provider: 'cloudflare', kind: 'block' }, 403, {
+			title: 'My Title',
+			detail: 'My detail',
+		});
+		expect(finding.severity).toBe('info');
+		expect(finding.metadata?.wafEvent).toBe('cloudflare');
+		expect(finding.metadata?.wafKind).toBe('block');
+		expect(finding.metadata?.httpStatus).toBe(403);
+		expect(finding.metadata?.inconclusive).toBe(true);
+		expect(finding.metadata?.missingControl).toBe(true);
+	});
+
+	it('adds wafChallenge=provider for a challenge event', async () => {
+		const { buildWafFinding } = await import('../src/lib/waf-detection');
+		const finding = buildWafFinding('mta_sts', { provider: 'cloudflare', kind: 'challenge' }, 403, {
+			title: 'T',
+			detail: 'D',
+		});
+		expect(finding.metadata?.wafChallenge).toBe('cloudflare');
+	});
+
+	it('omits wafChallenge for a block event', async () => {
+		const { buildWafFinding } = await import('../src/lib/waf-detection');
+		const finding = buildWafFinding('http_security', { provider: 'akamai', kind: 'block' }, 403, {
+			title: 'T',
+			detail: 'D',
+		});
+		expect(finding.metadata && 'wafChallenge' in finding.metadata).toBe(false);
+	});
+});


### PR DESCRIPTION
Fixes #455.

## Problem

A Cloudflare/Akamai WAF challenge or block on the **MTA-STS policy fetch** (commonly HTTP 403) made `check_mta_sts` emit a confident `high` **"MTA-STS policy file not accessible"** finding — a false positive on a policy that real MTAs can fetch fine. Reproduction: `blackveilsecurity.com` serves `mode: enforce` at `200` to every non-scanner client (`Mozilla`, `Go-http-client`, empty-UA), but the scanner's own probe is WAF-challenged → `403` → a scary `high` on a healthy domain, dropping the category to 75.

Same root cause as the inconclusive `http_security` result on CF-fronted origins — `check_http_security` already detects the challenge and degrades gracefully; `check_mta_sts` did not.

## Fix

Mirror the WAF detection already used by `check_http_security`, at the **same (worker) layer** — not the package — so the portable `@blackveil/dns-checks` core stays pure and there's no parity-contract / publish / re-vendor churn:

- **`src/lib/waf-detection.ts`** (new) — extract the shared `looksLikeWaf` / `detectWafEvent` helpers (were private to `check-http-security.ts`). No behavior change.
- **`src/tools/check-http-security.ts`** — import the extracted helpers.
- **`src/tools/check-mta-sts.ts`** — wrap the policy `fetch` to **observe** the response; on a detected challenge/block, replace the `high` finding with an inconclusive `info` and recompute the score via `buildCheckResult`. Observation is **fail-open**: it never alters the response the package sees, so a genuine non-WAF 4xx still surfaces the `high`.

## Tests

`test/check-mta-sts-waf.spec.ts` (new):
- CF challenge (`403` + `cf-mitigated: challenge`) → no `high`, inconclusive `info`, control still credited, score recovered.
- CF block (`403` + block body) → inconclusive `info`, `wafKind: block`.
- Plain `nginx` `403` (no CF/Akamai signals) → `high` **preserved** (guards against over-broad suppression).

All green locally: new spec 3/3; existing `check-mta-sts.spec.ts` 15/15 (no regression); `check-http-security`, `mta-sts-analysis`, `handlers-tools`, `format-scan-report` pass. Typecheck + ESLint clean on changed files.

## Tradeoff to review

Downgrading a challenged 403 to *inconclusive* means a domain that genuinely blocks **all** automation (incl. real MTAs) now reads "inconclusive" rather than "high failure." Mitigations: the finding is explicitly inconclusive (never a pass), and TLS-RPT reports remain the authoritative real-delivery signal. The score does recover off the 75 floor (info findings are non-penalizing in the model) — whether *inconclusive* should score that high is a judgment call; left as-is and flagged here rather than deepening the scoring model in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)