### PR TITLE
feat(analytics): differentiate internal vs external traffic in /usage

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -839,17 +839,31 @@ internalRoutes.get('/analytics/usage', async (c) => {
 	const days = Number(parseDays(url));
 	const windowSec = days * 86400;
 	const keyHash = url.searchParams.get('key_hash') ?? undefined;
+	// Differentiate internal (bv-web service-binding `/internal/tools/*`) from external
+	// (public `/mcp`) traffic. Legacy rows predate the `source` column → COALESCE to
+	// 'public'. An unrecognized `?source=` value is ignored (treated as 'all'), matching
+	// the endpoint's lenient posture — only the known set is ever bound into the filter.
+	const sourceParam = url.searchParams.get('source');
+	const sourceFilter = sourceParam === 'public' || sourceParam === 'internal' ? sourceParam : undefined;
 	try {
-		const sql = keyHash
-			? `SELECT key_hash, tool_name, COUNT(*) AS calls, MAX(created_at) AS last_seen
-			   FROM mcp_access_log WHERE created_at >= (strftime('%s','now') - ?) AND key_hash = ?
-			   GROUP BY key_hash, tool_name ORDER BY calls DESC LIMIT 500`
-			: `SELECT key_hash, tool_name, COUNT(*) AS calls, MAX(created_at) AS last_seen
-			   FROM mcp_access_log WHERE created_at >= (strftime('%s','now') - ?)
-			   GROUP BY key_hash, tool_name ORDER BY calls DESC LIMIT 500`;
-		const stmt = keyHash ? db.prepare(sql).bind(windowSec, keyHash) : db.prepare(sql).bind(windowSec);
-		const { results } = await stmt.all();
-		return c.json({ days: String(days), keyHash: keyHash ?? 'all', usage: results ?? [] });
+		const filters: string[] = [`created_at >= (strftime('%s','now') - ?)`];
+		const binds: unknown[] = [windowSec];
+		if (keyHash) {
+			filters.push('key_hash = ?');
+			binds.push(keyHash);
+		}
+		if (sourceFilter) {
+			filters.push(`COALESCE(source, 'public') = ?`);
+			binds.push(sourceFilter);
+		}
+		const sql = `SELECT key_hash, tool_name, COALESCE(source, 'public') AS source, COUNT(*) AS calls, MAX(created_at) AS last_seen
+			   FROM mcp_access_log WHERE ${filters.join(' AND ')}
+			   GROUP BY key_hash, tool_name, COALESCE(source, 'public') ORDER BY calls DESC LIMIT 500`;
+		const { results } = await db
+			.prepare(sql)
+			.bind(...binds)
+			.all();
+		return c.json({ days: String(days), keyHash: keyHash ?? 'all', source: sourceFilter ?? 'all', usage: results ?? [] });
 	} catch (err) {
 		return c.json({ error: 'Usage query failed', detail: err instanceof Error ? err.message.slice(0, 100) : 'unknown' }, 502);
 	}

--- a/test/internal-analytics-usage.spec.ts
+++ b/test/internal-analytics-usage.spec.ts
@@ -16,4 +16,55 @@ describe('GET /internal/analytics/usage', () => {
 		// window clamped + passed as a bind param (days*86400 seconds)
 		expect(bind).toHaveBeenCalledWith(7 * 86400);
 	});
+
+	it('labels each row with source (public|internal) and groups by it', async () => {
+		const { internalRoutes } = await import('../src/internal');
+		const all = vi.fn(async () => ({
+			results: [
+				{ key_hash: 'abc', tool_name: 'check_spf', source: 'public', calls: 9 },
+				{ key_hash: null, tool_name: 'check_spf', source: 'internal', calls: 3 },
+			],
+		}));
+		let capturedSql = '';
+		const bind = vi.fn(() => ({ all }));
+		const prepare = vi.fn((sql: string) => {
+			capturedSql = sql;
+			return { bind };
+		});
+		const env = { REQUIRE_INTERNAL_AUTH: 'false', INTELLIGENCE_DB: { prepare } as unknown as D1Database };
+		const res = await internalRoutes.request('/analytics/usage?days=7', {}, env);
+		expect(res.status).toBe(200);
+		const body = await res.json();
+		expect(body.source).toBe('all');
+		expect(body.usage.map((r: { source: string }) => r.source)).toEqual(['public', 'internal']);
+		// legacy NULL rows surface as 'public'; grouped by the coalesced source
+		expect(capturedSql).toMatch(/COALESCE\(source, 'public'\) AS source/);
+		expect(capturedSql).toMatch(/GROUP BY[\s\S]*COALESCE\(source, 'public'\)/i);
+		// no filter ⇒ only the window is bound (back-compat with the base case)
+		expect(bind).toHaveBeenCalledWith(7 * 86400);
+	});
+
+	it('filters to a single source when ?source= is a known value', async () => {
+		const { internalRoutes } = await import('../src/internal');
+		const all = vi.fn(async () => ({ results: [] }));
+		const bind = vi.fn(() => ({ all }));
+		const prepare = vi.fn(() => ({ bind }));
+		const env = { REQUIRE_INTERNAL_AUTH: 'false', INTELLIGENCE_DB: { prepare } as unknown as D1Database };
+		const res = await internalRoutes.request('/analytics/usage?days=7&source=internal', {}, env);
+		expect(res.status).toBe(200);
+		expect((await res.json()).source).toBe('internal');
+		expect(bind).toHaveBeenCalledWith(7 * 86400, 'internal');
+	});
+
+	it('ignores an unrecognized ?source= value (treats as all, no extra bind)', async () => {
+		const { internalRoutes } = await import('../src/internal');
+		const all = vi.fn(async () => ({ results: [] }));
+		const bind = vi.fn(() => ({ all }));
+		const prepare = vi.fn(() => ({ bind }));
+		const env = { REQUIRE_INTERNAL_AUTH: 'false', INTELLIGENCE_DB: { prepare } as unknown as D1Database };
+		const res = await internalRoutes.request('/analytics/usage?days=7&source=bogus', {}, env);
+		expect(res.status).toBe(200);
+		expect((await res.json()).source).toBe('all');
+		expect(bind).toHaveBeenCalledWith(7 * 86400);
+	});
 });


### PR DESCRIPTION
## Why

B1 (PR #458, deployed) added the `source` column so every `mcp_access_log` row is tagged `'public'` (external `/mcp`) or `'internal'` (bv-web service-binding `/internal/tools/*`). But the one query that consumes this — `GET /internal/analytics/usage` — never surfaced it. Internal forwards (`key_hash=NULL`) folded into the same NULL bucket as **unauthenticated public** calls, with no way to tell them apart. The storage differentiated; the read surface didn't.

## What

`GET /internal/analytics/usage` now:
- Selects `COALESCE(source,'public') AS source` and **groups by it**, so every usage row is labeled `public` / `internal`. Legacy NULL rows (pre-B1) surface as `public`, consistent with the migration's documented semantics.
- Honors an optional `?source=public|internal` filter. An unrecognized value is ignored (treated as `all`) — only the known set is ever bound, matching the endpoint's lenient posture.
- Echoes `source: <filter>|'all'` in the response.

**Backward-compatible:** adds a per-row `source` field + a top-level `source` echo. Drops no rows, removes no fields. The base case still binds only the window param.

## Differentiation, end to end
| Signal | External `/mcp` | Internal `/internal/tools/*` |
|--------|----------------|------------------------------|
| `source` | `'public'` | `'internal'` |
| `transport` | `'json'` / `'sse'` | `'internal'` |
| `key_hash` | real hash / NULL | always NULL |
| `ip_hash` | real | sentinel `'unknown'` |

AE telemetry (`tool_call`/`mcp_request`) remains public-only by construction — the internal path never enters AE emission — so the geo/digest dashboards are already external-only.

## Tests
`test/internal-analytics-usage.spec.ts` — base case preserved + 3 new: source-labeled rows & GROUP BY, `?source=` filter binding, unknown-value-ignored. `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)