### PR TITLE
feat(score): NIST 6-band display grade on scan tools (#461) + dns-checks 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.26.0] - 2026-06-29
+
+Minor release: the customer-facing letter grade on `scan_domain`, `batch_scan`, and `compare_domains` now uses the **NIST-aligned 6-band scale** (A+≥95, A≥90, B≥80, C≥70, D≥60, F<60), matching the BlackVeil web product so a domain shows ONE letter everywhere. **Scores are unchanged** — only which letter a customer-facing scan surface displays. `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79). `@blackveil/dns-checks` bumped to 1.4.0 (additive export).
+
+### Changed
+
+- **Scan-output tools now display the NIST 6-band grade (#461).** `scan_domain` / `batch_scan` / `compare_domains` recompute the displayed letter from the 0–100 score via the new `nistScoreToGrade` at the output chokepoint (`src/tools/scan/format-report.ts`). The engine's canonical 9-band `scoreToGrade` (`score.grade`) is **retained unchanged** for every internal/other consumer — `compare_baseline` grade-ordering, the `/badge` SVG, `analyze_drift`, `map_compliance`, `generate_fix_plan`, and the cohort-percentile math — so policy/comparison semantics and external `@blackveil/dns-checks` lib consumers are unaffected. The degraded `'N/A'` sentinel is preserved.
+
+### Added
+
+- **`@blackveil/dns-checks` exports `nistScoreToGrade`, `NIST_GRADE_THRESHOLDS`, and the `NistGrade` type (1.4.0).** Additive, non-breaking — the canonical 9-band `scoreToGrade` is unchanged. Lets every BlackVeil surface (web + MCP) share one band definition; bv-web-prod pins this via its vendored tarball with a threshold-parity contract test.
+
 ## [3.25.4] - 2026-06-25
 
 Patch release: one **server-only** `check_mta_sts` false-positive fix. No `@blackveil/dns-checks` core change, `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79). Normal-corpus scores are unaffected — the new behavior only applies when the MTA-STS policy fetch is intercepted by a WAF.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.4",
+	"version": "3.26.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.25.4",
+			"version": "3.26.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"
@@ -5139,7 +5139,7 @@
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"@blackveil/dns-checks": "*",
-				"hono": "4.12.27",
+				"hono": "^4.12.27",
 				"zod": "^4.4.3"
 			},
 			"devDependencies": {
@@ -5152,7 +5152,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.3.18",
+			"version": "1.4.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.25.4",
+	"version": "3.26.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.3.18",
+	"version": "1.4.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
@@ -21,6 +21,8 @@ type ScoringModule = typeof import('../../scoring');
 export function defineScoringEngineSuite(s: ScoringModule): void {
 	const {
 		scoreToGrade,
+		nistScoreToGrade,
+		NIST_GRADE_THRESHOLDS,
 		computeScanScore,
 		IMPORTANCE_WEIGHTS,
 		CORE_WEIGHTS,
@@ -35,6 +37,32 @@ export function defineScoringEngineSuite(s: ScoringModule): void {
 			expect(scoreToGrade(92)).toBe('A+');
 			expect(scoreToGrade(87)).toBe('A');
 			expect(scoreToGrade(49)).toBe('F');
+		});
+
+		it('maps numeric scores to the NIST-aligned 6-band DISPLAY grade', () => {
+			// Cut-points: A+≥95, A≥90, B≥80, C≥70, D≥60, F<60.
+			expect(nistScoreToGrade(100)).toBe('A+');
+			expect(nistScoreToGrade(95)).toBe('A+');
+			expect(nistScoreToGrade(94)).toBe('A');
+			expect(nistScoreToGrade(90)).toBe('A');
+			expect(nistScoreToGrade(89)).toBe('B');
+			expect(nistScoreToGrade(80)).toBe('B');
+			expect(nistScoreToGrade(79)).toBe('C');
+			expect(nistScoreToGrade(70)).toBe('C');
+			expect(nistScoreToGrade(69)).toBe('D');
+			expect(nistScoreToGrade(60)).toBe('D');
+			expect(nistScoreToGrade(59)).toBe('F');
+			expect(nistScoreToGrade(0)).toBe('F');
+		});
+
+		it('NIST 6-band emits no +/- bands (distinct from the 9-band canonical scale)', () => {
+			const seen = new Set(
+				Array.from({ length: 101 }, (_, score) => nistScoreToGrade(score)),
+			);
+			expect([...seen].sort()).toEqual(['A', 'A+', 'B', 'C', 'D', 'F']);
+			// thresholds are exported + consistent with the mapping
+			expect(NIST_GRADE_THRESHOLDS.A_PLUS).toBe(95);
+			expect(NIST_GRADE_THRESHOLDS.D).toBe(60);
 		});
 
 		it('returns excellent summary when no check results are present', () => {

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.3.18';
+export const PARITY_CORPUS_VERSION = '1.4.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -86,6 +86,34 @@ export function scoreToGrade(score: number, config?: ScoringConfig): string {
 	return 'F';
 }
 
+/** The 6 letters the NIST-aligned DISPLAY scale can emit. */
+export type NistGrade = 'A+' | 'A' | 'B' | 'C' | 'D' | 'F';
+
+/**
+ * NIST-aligned 6-band thresholds — the SINGLE customer-facing DISPLAY scale that
+ * BlackVeil products consolidated on (2026-06-29). This is intentionally DISTINCT
+ * from the canonical 9-band {@link scoreToGrade}, which stays for internal logic,
+ * back-compat, and cohort/percentile math (and any third-party lib consumer). The
+ * score is unchanged; only which letter a customer-facing surface displays.
+ */
+export const NIST_GRADE_THRESHOLDS = {
+	A_PLUS: 95,
+	A: 90,
+	B: 80,
+	C: 70,
+	D: 60,
+} as const;
+
+/** Map a 0-100 score to the NIST-aligned 6-band DISPLAY grade. Pure; no config. */
+export function nistScoreToGrade(score: number): NistGrade {
+	if (score >= NIST_GRADE_THRESHOLDS.A_PLUS) return 'A+';
+	if (score >= NIST_GRADE_THRESHOLDS.A) return 'A';
+	if (score >= NIST_GRADE_THRESHOLDS.B) return 'B';
+	if (score >= NIST_GRADE_THRESHOLDS.C) return 'C';
+	if (score >= NIST_GRADE_THRESHOLDS.D) return 'D';
+	return 'F';
+}
+
 /** Default critical categories used when no context is provided. */
 const DEFAULT_CRITICAL_CATEGORIES: CheckCategory[] = ['spf', 'dmarc', 'dkim', 'ssl'];
 

--- a/packages/dns-checks/src/scoring/index.ts
+++ b/packages/dns-checks/src/scoring/index.ts
@@ -33,10 +33,12 @@ export {
 	CORE_WEIGHTS,
 	PROTECTIVE_WEIGHTS,
 	scoreToGrade,
+	nistScoreToGrade,
+	NIST_GRADE_THRESHOLDS,
 	computeScanScore,
 	computeProfileAwareScanScore,
 } from './engine';
-export type { ProfileAwareScanScore } from './engine';
+export type { ProfileAwareScanScore, NistGrade } from './engine';
 
 export {
 	DEFAULT_SCORING_CONFIG,

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.25.4",
+	"version": "3.26.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/lib/scoring.ts
+++ b/src/lib/scoring.ts
@@ -17,6 +17,8 @@ export {
 	computeScanScore,
 	computeProfileAwareScanScore,
 	scoreToGrade,
+	nistScoreToGrade,
+	NIST_GRADE_THRESHOLDS,
 	IMPORTANCE_WEIGHTS,
 	CORE_WEIGHTS,
 	PROTECTIVE_WEIGHTS,
@@ -44,6 +46,7 @@ export type {
 	DomainProfile,
 	ScoringConfig,
 	ProfileAwareScanScore,
+	NistGrade,
 } from '@blackveil/dns-checks/scoring';
 
 export {

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -308,14 +308,14 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	scan_domain: {
 		description:
-			'Run a full DNS and email security audit for a single domain. Aggregates every scan-included check in parallel (SPF, DKIM, DMARC, DNSSEC, TLS/SSL, MTA-STS, CAA, BIMI, subdomain takeover, and more) and returns an overall security score, letter grade (A–F), maturity stage, and prioritized findings. Use for a comprehensive single-domain audit, to get a domain\'s overall security grade, or to assess email security maturity.',
+			'Run a full DNS and email security audit for a single domain. Aggregates every scan-included check in parallel (SPF, DKIM, DMARC, DNSSEC, TLS/SSL, MTA-STS, CAA, BIMI, subdomain takeover, and more) and returns an overall security score, NIST-aligned letter grade (6-band A+/A/B/C/D/F), maturity stage, and prioritized findings. Use for a comprehensive single-domain audit, to get a domain\'s overall security grade, or to assess email security maturity.',
 		schema: ScanDomainArgs,
 		group: 'meta',
 		scanIncluded: false,
 		recommended: true,
 	},
 	batch_scan: {
-		description: 'Bulk-scan up to 10 domains in parallel. Runs a full security audit on each domain in the list and returns score, letter grade, and finding counts per domain. Use when you want to audit multiple domains at once or do a bulk scan of several domains simultaneously — distinct from compare_domains which does a side-by-side analysis of 2–5 domains.',
+		description: 'Bulk-scan up to 10 domains in parallel. Runs a full security audit on each domain in the list and returns score, NIST-aligned letter grade (6-band A+/A/B/C/D/F), and finding counts per domain. Use when you want to audit multiple domains at once or do a bulk scan of several domains simultaneously — distinct from compare_domains which does a side-by-side analysis of 2–5 domains.',
 		schema: BatchScanArgs,
 		group: 'meta',
 		scanIncluded: false,

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -2,10 +2,23 @@
 
 import type { ScanDomainResult } from '../scan-domain';
 import type { CheckResult, Finding } from '../../lib/scoring';
+import { nistScoreToGrade } from '../../lib/scoring';
 import type { OutputFormat } from '../../handlers/tool-args';
 import { sanitizeOutputText } from '../../lib/output-sanitize';
 import { resolveImpactNarrative } from '../explain-finding';
 import { SCORING_MODEL_VERSION, computeScoringConfigHash } from '../../lib/scoring-version';
+
+/**
+ * The SINGLE customer-facing display grade for the scan-output tools
+ * (`scan_domain` / `batch_scan` / `compare_domains`): the NIST-aligned 6-band
+ * letter, recomputed from the unchanged 0-100 score. The engine's `score.grade`
+ * stays on the canonical 9-band scale for every OTHER consumer (compare_baseline
+ * ordering, the badge, drift/compliance/fix-plan); only these display surfaces
+ * switch. The degraded `'N/A'` sentinel (unscored scans) is preserved verbatim.
+ */
+function displayGradeFor(score: { overall: number; grade: string }): string {
+	return score.grade === 'N/A' ? 'N/A' : nistScoreToGrade(score.overall);
+}
 
 /** Structured scan result for machine-readable consumption (e.g., CI/CD actions). */
 export interface StructuredScanResult {
@@ -244,7 +257,7 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 	return {
 		domain: result.domain,
 		score: result.score.overall,
-		grade: result.score.grade,
+		grade: displayGradeFor(result.score),
 		passed: result.score.overall >= 50,
 		maturityStage: result.maturity?.stage ?? null,
 		maturityLabel: result.maturity?.label ?? null,
@@ -284,10 +297,18 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 export function formatScanReport(result: ScanDomainResult, format: OutputFormat = 'full'): string {
 	const lines: string[] = [];
 
+	const displayGrade = displayGradeFor(result.score);
 	lines.push(`DNS Security Scan: ${result.domain}`);
 	lines.push(`${'='.repeat(40)}`);
-	lines.push(`Overall Score: ${result.score.overall}/100 (${result.score.grade})`);
-	lines.push(`${result.score.summary}`);
+	lines.push(`Overall Score: ${result.score.overall}/100 (${displayGrade})`);
+	// The engine bakes the canonical 9-band grade into `summary` ("…Grade: X"); rewrite
+	// that one token to the display (NIST) grade so the text never disagrees with the
+	// score line above. No-op when the summary carries no grade (e.g. degraded 'N/A').
+	lines.push(
+		displayGrade === 'N/A'
+			? `${result.score.summary}`
+			: result.score.summary.replace(/Grade: [A-F][+-]?/g, `Grade: ${displayGrade}`),
+	);
 	lines.push('');
 
 	if (result.maturity) {

--- a/test/format-scan-report.spec.ts
+++ b/test/format-scan-report.spec.ts
@@ -81,7 +81,11 @@ describe('format-scan-report', () => {
 
 		const report = formatScanReport(result);
 		expect(report).toContain('DNS Security Scan: example.com');
-		expect(report).toContain('Overall Score: 72/100 (C+)');
+		// Customer-facing letter is the NIST 6-band display grade recomputed from the
+		// score (72 → 'C'; the 9-band canonical would be 'C+'). The summary's embedded
+		// grade is rewritten to match.
+		expect(report).toContain('Overall Score: 72/100 (C)');
+		expect(report).toContain('Grade: C');
 		expect(report).toContain('Takeover Verification: potential');
 		expect(report).toContain('Proof Required: authorized proof of control');
 		expect(report).toContain('Confidence: heuristic');
@@ -172,7 +176,9 @@ describe('format-scan-report', () => {
 		const structured = buildStructuredScanResult(result);
 		expect(structured.domain).toBe('test.com');
 		expect(structured.score).toBe(85);
-		expect(structured.grade).toBe('A');
+		// NIST 6-band display grade recomputed from the score (85 → 'B'), not echoed
+		// from the engine's canonical 9-band `score.grade`.
+		expect(structured.grade).toBe('B');
 		expect(structured.passed).toBe(true);
 		expect(structured.maturityStage).toBe(3);
 		expect(structured.maturityLabel).toBe('Enforcing');

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -370,8 +370,14 @@ describe('formatScanReport', () => {
 
 		// Contains domain header
 		expect(report).toContain('DNS Security Scan: example.com');
-		// Contains overall score and grade
-		expect(report).toContain('Overall Score: 85/100 (A-)');
+		// Contains overall score and the NIST-aligned DISPLAY grade. The customer-facing
+		// letter is recomputed from the 0-100 score (85 → 'B' on the 6-band NIST scale),
+		// NOT echoed from the engine's canonical `score.grade` — so the mock's input grade
+		// ('A-') is intentionally NOT what renders.
+		expect(report).toContain('Overall Score: 85/100 (B)');
+		// The grade baked into the engine summary is rewritten to the same display grade.
+		expect(report).toContain('Grade: B');
+		expect(report).not.toContain('Grade: A-');
 		// Contains category scores section
 		expect(report).toContain('Category Scores:');
 		expect(report).toContain('SPF');


### PR DESCRIPTION
## What

**One letter everywhere.** `scan_domain` / `batch_scan` / `compare_domains` now display the **NIST-aligned 6-band** grade (A+≥95, A≥90, B≥80, C≥70, D≥60, F<60), matching the BlackVeil web product (bv-web-prod #759). **Scores are unchanged** — only which letter a customer-facing scan surface shows (e.g. score 83: was B+, now B; score 78: was B, now C).

## Design (minimal blast radius)
- `@blackveil/dns-checks` **1.4.0** — additive `nistScoreToGrade` + `NIST_GRADE_THRESHOLDS` + `NistGrade` exports. The canonical 9-band `scoreToGrade` is **unchanged** → non-breaking for any external lib consumer.
- The display switch is confined to the output chokepoint `displayGradeFor()` in `src/tools/scan/format-report.ts` (recompute NIST from the 0–100 score; preserves the degraded `'N/A'` sentinel; rewrites the grade token embedded in the engine `summary`).
- The engine's `score.grade` **stays 9-band**, so every other consumer is untouched: `compare_baseline` grade-ordering, the `/badge` SVG, `analyze_drift`, `map_compliance`, `generate_fix_plan`, and the cohort-percentile math.
- Tool-def descriptions note the NIST 6-band scale.

## Verification
- New NIST suite (`scoring-engine.suite.ts`) runs against **source + built** package; updated `format-scan-report` / `scan-domain` grade assertions.
- Targeted: **109 tests** (scoring both surfaces + the 3 tool specs + format-report) pass; **full audits** 322 pass; typecheck + lint clean.
- Full suite: 5636 pass (only pre-existing `.firecrawl/*` file-read probes fail — unrelated).

## Versions
server 3.25.4 → **3.26.0** (package.json+lock, server.json, CHANGELOG); package 1.3.18 → **1.4.0**.

## Release/deploy (post-merge, operator order per bv-mcp-release)
1. tag `v3.26.0` on the squashed merge → `publish.yml` (npm step gated/no-op) cuts GH Release.
2. `npm -w packages/dns-checks run build && npm run build` → **`npm run deploy:prod`** → verify `serverInfo.version` 3.26.0 + a live `scan_domain` shows the NIST letter.
3. **only then** `mcp-publisher publish` (registry must follow prod).
4. bv-web-prod: re-vendor `blackveil-dns-checks-1.4.0.tgz` + threshold-parity contract test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)