### PR TITLE
fix(oauth): serve OAuth endpoints at root paths for connector clients (3.26.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.26.1] - 2026-06-29
+
+Patch release: fix MCP OAuth connector sign-in for clients that assume root-path OAuth endpoints. Some clients (notably Claude Desktop connectors, especially when given a pre-registered OAuth Client ID) skip authorization-server metadata discovery and request the OAuth endpoints at the server origin (`/authorize`, `/token`, `/register`) instead of the `/oauth/`-prefixed paths advertised in discovery. Confirmed in a production tail: Claude Desktop requested `GET /authorize` → 404, which surfaced to the user as "Couldn't connect to the server" / "Couldn't register with BV DNS's sign-in service."
+
+### Fixed
+
+- **Root-path OAuth aliases (`src/index.ts`).** `/register`, `/authorize` (GET+POST), and `/token` now route to the same handlers as their `/oauth/*` counterparts, behind the same `oauthGuarded` gating. Purely additive: discovery-driven clients keep using `/oauth/*`; origin-default clients (Claude Desktop connectors) now work too. No change to the OAuth flow, consent redirect, token issuance, or discovery metadata.
+
 ## [3.26.0] - 2026-06-29
 
 Minor release: the customer-facing letter grade on `scan_domain`, `batch_scan`, and `compare_domains` now uses the **NIST-aligned 6-band scale** (A+≥95, A≥90, B≥80, C≥70, D≥60, F<60), matching the BlackVeil web product so a domain shows ONE letter everywhere. **Scores are unchanged** — only which letter a customer-facing scan surface displays. `SCORING_MODEL_VERSION` unchanged, tool count unchanged (79). `@blackveil/dns-checks` bumped to 1.4.0 (additive export).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.26.0",
+	"version": "3.26.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.26.0",
+			"version": "3.26.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.26.0",
+	"version": "3.26.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.26.0",
+	"version": "3.26.1",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1259,6 +1259,18 @@ app.get('/oauth/authorize', (c) => oauthGuarded(c, () => handleAuthorizeGet(c)))
 app.post('/oauth/authorize', (c) => oauthGuarded(c, () => handleAuthorizePost(c)));
 app.post('/oauth/token', (c) => oauthGuarded(c, () => handleToken(c)));
 
+// Root-path OAuth aliases. Some MCP clients (notably Claude Desktop connectors,
+// especially when given a pre-registered OAuth Client ID) skip authorization-server
+// metadata discovery and assume the OAuth endpoints live at the server origin
+// (/register, /authorize, /token), ignoring the /oauth/ prefix advertised in
+// discovery metadata. Serving both makes the connector flow work for discovery-driven
+// clients (/oauth/*) and origin-default clients (root) alike — same handlers, same
+// oauthGuarded gating. Confirmed via prod tail: Claude Desktop requested GET /authorize → 404.
+app.post('/register', (c) => oauthGuarded(c, () => handleRegister(c)));
+app.get('/authorize', (c) => oauthGuarded(c, () => handleAuthorizeGet(c)));
+app.post('/authorize', (c) => oauthGuarded(c, () => handleAuthorizePost(c)));
+app.post('/token', (c) => oauthGuarded(c, () => handleToken(c)));
+
 app.all('*', (c) => {
 	// Plain text — avoids mcp-remote misinterpreting JSON as an OAuth error.
 	// OAuth well-known paths are handled explicitly above.

--- a/test/oauth/root-path-aliases.spec.ts
+++ b/test/oauth/root-path-aliases.spec.ts
@@ -1,0 +1,80 @@
+import { SELF, env } from 'cloudflare:test';
+import { afterEach, describe, expect, it } from 'vitest';
+
+// Regression: some MCP clients (notably Claude Desktop connectors, especially when given a
+// pre-registered OAuth Client ID) skip authorization-server metadata discovery and request the
+// OAuth endpoints at the server origin (/register, /authorize, /token) instead of the /oauth/-
+// prefixed paths advertised in discovery. A production tail showed Claude Desktop hitting
+// `GET /authorize` → 404, surfacing as "Couldn't connect" / "Couldn't register". The root-path
+// aliases (src/index.ts) fix this by routing root paths to the same handlers as /oauth/*.
+
+async function clearPrefix(prefix: string) {
+	const list = await env.SESSION_STORE.list({ prefix });
+	await Promise.all(list.keys.map((k) => env.SESSION_STORE.delete(k.name)));
+}
+
+afterEach(async () => {
+	await clearPrefix('oauth:');
+});
+
+describe('root-path OAuth aliases', () => {
+	it('POST /register behaves like /oauth/register (201 + client_id, not 404)', async () => {
+		const res = await SELF.fetch('https://example.com/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ client_name: 'Claude Desktop', redirect_uris: ['https://claude.ai/cb'] }),
+		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(typeof body.client_id).toBe('string');
+		expect(body.token_endpoint_auth_method).toBe('none');
+	});
+
+	it('GET /authorize resolves a registered client (not 404)', async () => {
+		// Register via the root alias, then authorize via the root alias.
+		const reg = await SELF.fetch('https://example.com/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ redirect_uris: ['https://claude.ai/cb'] }),
+		});
+		const cid = ((await reg.json()) as { client_id: string }).client_id;
+
+		const url = new URL('https://example.com/authorize');
+		url.searchParams.set('client_id', cid);
+		url.searchParams.set('redirect_uri', 'https://claude.ai/cb');
+		url.searchParams.set('response_type', 'code');
+		url.searchParams.set('state', 'stateval');
+		url.searchParams.set('code_challenge', 'x'.repeat(43));
+		url.searchParams.set('code_challenge_method', 'S256');
+		const res = await SELF.fetch(url.toString(), { redirect: 'manual' });
+		// The customer-OAuth path (ENABLE_OWNER_OAUTH unset) 302-redirects to the consent URL;
+		// the owner path renders 200 HTML. Either way it must NOT 404 — that's the bug.
+		expect(res.status).not.toBe(404);
+		expect([200, 302, 503]).toContain(res.status);
+	});
+
+	it('POST /token reaches the token handler (not 404)', async () => {
+		const res = await SELF.fetch('https://example.com/token', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+			body: '',
+		});
+		// Empty/invalid body → handler returns a 4xx OAuth error, NOT a 404 route miss.
+		expect(res.status).not.toBe(404);
+		expect(res.status).toBeGreaterThanOrEqual(400);
+		expect(res.status).toBeLessThan(500);
+	});
+
+	it('GET /authorize with an unknown client_id is handled (not 404 route miss)', async () => {
+		const url = new URL('https://example.com/authorize');
+		url.searchParams.set('client_id', 'nonexistent-client');
+		url.searchParams.set('redirect_uri', 'https://claude.ai/cb');
+		url.searchParams.set('response_type', 'code');
+		url.searchParams.set('state', 'stateval');
+		url.searchParams.set('code_challenge', 'x'.repeat(43));
+		url.searchParams.set('code_challenge_method', 'S256');
+		const res = await SELF.fetch(url.toString(), { redirect: 'manual' });
+		// Handler returns 400 "Unknown client_id"; the catch-all route miss would be 404.
+		expect(res.status).toBe(400);
+	});
+});


### PR DESCRIPTION
## Problem

A partner (Claude Desktop connector) could not connect to the hosted MCP server. Two sequential errors:
1. *"Couldn't register with BV DNS's sign-in service"* (DCR step)
2. *"Couldn't connect to the server"* after pasting a pre-registered OAuth Client ID

A **production `wrangler tail` caught the actual request**:

```
GET https://dns-mcp.blackveilsecurity.com/authorize?response_type=code&client_id=… → 404
```

## Root cause

Claude Desktop connectors (especially when given a manual OAuth Client ID) **skip authorization-server metadata discovery** and assume the OAuth endpoints live at the **server origin** — `/authorize`, `/token`, `/register` — ignoring the `/oauth/`-prefixed paths our discovery metadata advertises. We only served `/oauth/*`, so every such request 404'd. This unifies both errors:
- DCR → `POST /register` (root) → 404 → "Couldn't register"
- Manual Client ID → `GET /authorize` (root) → 404 → "Couldn't connect"

Affects **all** origin-default connector clients, not just this partner.

## Fix

Add root-path aliases (`/register`, `/authorize` GET+POST, `/token`) routing to the **same handlers** as their `/oauth/*` counterparts, behind the same `oauthGuarded` gating. Purely additive — discovery-driven clients keep using `/oauth/*`; origin-default clients now work too. No change to the OAuth flow, consent redirect, token issuance, or discovery metadata.

## Verification

Deployed to prod (version `3.26.1`, `05e2bc31`) and verified live:

| Endpoint | Before | After |
|---|---|---|
| `GET /authorize` (root) | 404 | 302 → consent ✅ |
| `POST /register` (root) | 404 | 201 ✅ |
| `POST /token` (root) | 404 | 400 (route live) ✅ |

- All 94 existing OAuth tests pass.
- New regression test `test/oauth/root-path-aliases.spec.ts` (4 cases) asserting the root paths reach the handlers (never 404).
- `npm run typecheck` clean.

## Notes

- **Already deployed to prod** to unblock the partner (release 3.26.1 = 3.26.0 + this fix). This PR reconciles git with the live state.
- Version-synced: `package.json` + lock, `server.json`, `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)