### PR TITLE
feat(registrar): lock posture + registrar product mapping + sales lead prioritization (Specs A–C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.27.0] - 2026-07-01
+
+Minor release: CSC engagement — domain lock posture + CSC product mapping + sales lead prioritization (Specs A–C). Adds two MCP tools (79 → 81).
+
+### Added
+
+- **`map_csc_products` — CSC product mapping.** Maps a domain's security gaps to CSC commercial products (MultiLock, Managed DMARC, Digital Certificates, DNSSEC) by reading lock posture plus the DMARC/SSL/DNSSEC checks. Standalone `intelligence` tool (`scanIncluded: false`, no scoring impact). Scan and RDAP lookups run in parallel to stay within the tool-call budget.
+- **`prioritize_csc_leads` — sales lead prioritization.** Ranks a brand portfolio (or an explicit `domains[]` set) into prioritized CSC sales leads by gap-severity × product-fit. Multi-domain, paid-gated (developer+).
+
+### Changed
+
+- **`rdap_lookup` — domain lock posture.** `check_rdap_lookup` now classifies EPP / registry-lock status via `deriveLockPosture` (handles both EPP camelCase and RDAP space-separated status forms) and surfaces `metadata.lockPosture` plus a transfer-driven finding (unlocked = medium; registrar/registry lock = info). Feeds the CSC MultiLock signal in `map_csc_products`. No scoring impact (`rdap` is `scanIncluded: false`).
+
 ## [3.26.1] - 2026-06-29
 
 Patch release: fix MCP OAuth connector sign-in for clients that assume root-path OAuth endpoints. Some clients (notably Claude Desktop connectors, especially when given a pre-registered OAuth Client ID) skip authorization-server metadata discovery and request the OAuth endpoints at the server origin (`/authorize`, `/token`, `/register`) instead of the `/oauth/`-prefixed paths advertised in discovery. Confirmed in a production tail: Claude Desktop requested `GET /authorize` → 404, which surfaced to the user as "Couldn't connect to the server" / "Couldn't register with BV DNS's sign-in service."

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 [![GitHub stars](https://img.shields.io/github/stars/MadaBurns/bv-mcp?style=flat&logo=github)](https://github.com/MadaBurns/bv-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
-[![MCP tools](https://img.shields.io/badge/MCP%20tools-80-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
+[![MCP tools](https://img.shields.io/badge/MCP%20tools-81-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-2025--06--18-blue)](https://modelcontextprotocol.io/)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com/)
@@ -25,7 +25,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 
 **Claude Desktop** (one-click install):
 
-Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 80-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
+Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 81-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
 
 **Claude Code** (one command):
 
@@ -65,7 +65,7 @@ Transport support:
 
 ## What you get
 
-- **80 MCP tools with 19 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, reverse DNS (PTR/FCrDNS), brand discovery, and authoritative DNS infrastructure
+- **81 MCP tools with 19 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, reverse DNS (PTR/FCrDNS), brand discovery, and authoritative DNS infrastructure
 - **Maturity staging** — Stage 0-4 classification (Unprotected to Hardened) with score-based capping to prevent inflated labels
 - **Trust surface analysis** — detects shared SaaS platforms (Google, M365, SendGrid) and cross-references DMARC enforcement to determine real exposure
 - **Guided remediation** — `generate` (artifact=`fix_plan`) produces provider-aware prioritized actions; its record artifacts (`spf_record`, `dmarc_record`, `dkim_config`, `mta_sts_policy`, `rollout_plan`) output ready-to-publish records; `validate_fix` confirms whether a fix was applied successfully
@@ -81,7 +81,7 @@ Transport support:
 ## Tools
 
 ```
-  80 MCP tools · 7 prompts · 6 resources
+  81 MCP tools · 7 prompts · 6 resources
 
   Email Auth             Infrastructure          Brand & Threats       Meta
  ─────────────          ──────────────          ───────────────       ───────────────
@@ -107,6 +107,7 @@ Transport support:
   discover_subdomains     walkability           brand_audit_get_
   map_compliance        check_dnssec_chain        report
   map_csc_products
+  prioritize_csc_leads
   simulate_attack_paths check_fast_flux         list_brand_audit_watches
   check_agent_discovery check_dnskey_strength
                         check_authoritative_dns_infra

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 [![GitHub stars](https://img.shields.io/github/stars/MadaBurns/bv-mcp?style=flat&logo=github)](https://github.com/MadaBurns/bv-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
-[![MCP tools](https://img.shields.io/badge/MCP%20tools-79-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
+[![MCP tools](https://img.shields.io/badge/MCP%20tools-80-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-2025--06--18-blue)](https://modelcontextprotocol.io/)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com/)
@@ -25,7 +25,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 
 **Claude Desktop** (one-click install):
 
-Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 79-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
+Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 80-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
 
 **Claude Code** (one command):
 
@@ -65,7 +65,7 @@ Transport support:
 
 ## What you get
 
-- **79 MCP tools with 19 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, reverse DNS (PTR/FCrDNS), brand discovery, and authoritative DNS infrastructure
+- **80 MCP tools with 19 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, reverse DNS (PTR/FCrDNS), brand discovery, and authoritative DNS infrastructure
 - **Maturity staging** — Stage 0-4 classification (Unprotected to Hardened) with score-based capping to prevent inflated labels
 - **Trust surface analysis** — detects shared SaaS platforms (Google, M365, SendGrid) and cross-references DMARC enforcement to determine real exposure
 - **Guided remediation** — `generate` (artifact=`fix_plan`) produces provider-aware prioritized actions; its record artifacts (`spf_record`, `dmarc_record`, `dkim_config`, `mta_sts_policy`, `rollout_plan`) output ready-to-publish records; `validate_fix` confirms whether a fix was applied successfully
@@ -81,7 +81,7 @@ Transport support:
 ## Tools
 
 ```
-  79 MCP tools · 7 prompts · 6 resources
+  80 MCP tools · 7 prompts · 6 resources
 
   Email Auth             Infrastructure          Brand & Threats       Meta
  ─────────────          ──────────────          ───────────────       ───────────────
@@ -106,6 +106,7 @@ Transport support:
   resolve_spf_chain     check_nsec_             brand_audit_status
   discover_subdomains     walkability           brand_audit_get_
   map_compliance        check_dnssec_chain        report
+  map_csc_products
   simulate_attack_paths check_fast_flux         list_brand_audit_watches
   check_agent_discovery check_dnskey_strength
                         check_authoritative_dns_infra

--- a/crates/bv-wasm-core/src/generated_tool_permissions.rs
+++ b/crates/bv-wasm-core/src/generated_tool_permissions.rs
@@ -74,6 +74,7 @@ pub fn required_mode_for_tool(tool: &str) -> PermissionMode {
         "osint_investigate_username_start" => PermissionMode::WorkspaceWrite,
         "osint_investigation_report" => PermissionMode::ReadOnly,
         "osint_investigation_status" => PermissionMode::ReadOnly,
+        "prioritize_csc_leads" => PermissionMode::ReadOnly,
         "query_signins" => PermissionMode::ReadOnly,
         "query_ual" => PermissionMode::ReadOnly,
         "rdap_lookup" => PermissionMode::ReadOnly,

--- a/crates/bv-wasm-core/src/generated_tool_permissions.rs
+++ b/crates/bv-wasm-core/src/generated_tool_permissions.rs
@@ -65,6 +65,7 @@ pub fn required_mode_for_tool(tool: &str) -> PermissionMode {
         "get_provider_insights" => PermissionMode::ReadOnly,
         "list_brand_audit_watches" => PermissionMode::ReadOnly,
         "map_compliance" => PermissionMode::ReadOnly,
+        "map_csc_products" => PermissionMode::ReadOnly,
         "map_supply_chain" => PermissionMode::ReadOnly,
         "osint_investigate_domain_start" => PermissionMode::WorkspaceWrite,
         "osint_investigate_email_start" => PermissionMode::WorkspaceWrite,

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -4,7 +4,7 @@ These settings must be configured manually in the GitHub web UI.
 
 ## Repository description
 
-Set to: `Source-available DNS & email security scanner for MCP clients. 79 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
+Set to: `Source-available DNS & email security scanner for MCP clients. 80 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
 
 ## Repository topics
 

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -4,7 +4,7 @@ These settings must be configured manually in the GitHub web UI.
 
 ## Repository description
 
-Set to: `Source-available DNS & email security scanner for MCP clients. 80 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
+Set to: `Source-available DNS & email security scanner for MCP clients. 81 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
 
 ## Repository topics
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,6 +1,6 @@
 # Blackveil DNS — MCP Security Scanner
 
-**80 DNS & email security tools** for GitHub Copilot Chat. No install, no API key — just ask Copilot to scan any domain.
+**81 DNS & email security tools** for GitHub Copilot Chat. No install, no API key — just ask Copilot to scan any domain.
 
 ![Blackveil DNS](https://raw.githubusercontent.com/MadaBurns/bv-mcp/main/assets/bv-logo-full.png)
 
@@ -10,7 +10,7 @@
 2. Open GitHub Copilot Chat (`Ctrl+Shift+I` / `Cmd+Shift+I`)
 3. Ask: **"scan example.com"**
 
-That's it. All 80 tools are available instantly.
+That's it. All 81 tools are available instantly.
 
 ## What You Get
 
@@ -22,9 +22,9 @@ That's it. All 80 tools are available instantly.
 - **Attack path simulation** — enumerated spoofing, takeover, and hijack paths
 - **Compliance mapping** — NIST 800-177, PCI DSS 4.0, SOC 2, CIS Controls
 
-## Tools (80)
+## Tools (81)
 
-The extension exposes the hosted MCP `tools/list` surface: 80 tools, including 35 `check_*` tools. The table below groups the most common workflows; Copilot can call every registered tool returned by the server.
+The extension exposes the hosted MCP `tools/list` surface: 81 tools, including 35 `check_*` tools. The table below groups the most common workflows; Copilot can call every registered tool returned by the server.
 
 | Email Auth | Infrastructure | Brand & Threats | Intelligence |
 |---|---|---|---|

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,6 +1,6 @@
 # Blackveil DNS — MCP Security Scanner
 
-**79 DNS & email security tools** for GitHub Copilot Chat. No install, no API key — just ask Copilot to scan any domain.
+**80 DNS & email security tools** for GitHub Copilot Chat. No install, no API key — just ask Copilot to scan any domain.
 
 ![Blackveil DNS](https://raw.githubusercontent.com/MadaBurns/bv-mcp/main/assets/bv-logo-full.png)
 
@@ -10,7 +10,7 @@
 2. Open GitHub Copilot Chat (`Ctrl+Shift+I` / `Cmd+Shift+I`)
 3. Ask: **"scan example.com"**
 
-That's it. All 79 tools are available instantly.
+That's it. All 80 tools are available instantly.
 
 ## What You Get
 
@@ -22,9 +22,9 @@ That's it. All 79 tools are available instantly.
 - **Attack path simulation** — enumerated spoofing, takeover, and hijack paths
 - **Compliance mapping** — NIST 800-177, PCI DSS 4.0, SOC 2, CIS Controls
 
-## Tools (79)
+## Tools (80)
 
-The extension exposes the hosted MCP `tools/list` surface: 79 tools, including 35 `check_*` tools. The table below groups the most common workflows; Copilot can call every registered tool returned by the server.
+The extension exposes the hosted MCP `tools/list` surface: 80 tools, including 35 `check_*` tools. The table below groups the most common workflows; Copilot can call every registered tool returned by the server.
 
 | Email Auth | Infrastructure | Brand & Threats | Intelligence |
 |---|---|---|---|

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "blackveil-dns",
 	"displayName": "Blackveil DNS — MCP Security Scanner",
-	"description": "79 DNS & email security tools for GitHub Copilot Chat via MCP. Scan SPF, DMARC, DKIM, DNSSEC, SSL, MTA-STS, and more — no install, no API key required.",
+	"description": "80 DNS & email security tools for GitHub Copilot Chat via MCP. Scan SPF, DMARC, DKIM, DNSSEC, SSL, MTA-STS, and more — no install, no API key required.",
 	"version": "1.0.0",
 	"publisher": "BlackveilSecurity",
 	"license": "BUSL-1.1",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "blackveil-dns",
 	"displayName": "Blackveil DNS — MCP Security Scanner",
-	"description": "80 DNS & email security tools for GitHub Copilot Chat via MCP. Scan SPF, DMARC, DKIM, DNSSEC, SSL, MTA-STS, and more — no install, no API key required.",
+	"description": "81 DNS & email security tools for GitHub Copilot Chat via MCP. Scan SPF, DMARC, DKIM, DNSSEC, SSL, MTA-STS, and more — no install, no API key required.",
 	"version": "1.0.0",
 	"publisher": "BlackveilSecurity",
 	"license": "BUSL-1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.26.1",
+	"version": "3.27.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.26.1",
+			"version": "3.27.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.26.1",
+	"version": "3.27.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 	"name": "com.blackveilsecurity/dns",
-	"description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"description": "DNS and email security scanner with 81 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
 	"repository": {
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 	"name": "com.blackveilsecurity/dns",
-	"description": "DNS and email security scanner with 79 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
 	"repository": {
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.26.1",
+	"version": "3.27.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,6 +1,6 @@
 name: BlackVeil DNS Security MCP
 description: >-
-  DNS and email security scanner with 80 MCP tools. Bulk-scan multiple domains
+  DNS and email security scanner with 81 MCP tools. Bulk-scan multiple domains
   at once, benchmark against the industry average and sector percentile, detect
   whether a domain's posture improved or regressed via drift analysis, and catch
   SubdoMailing risks where an SPF include chain exposes a dangling domain.

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,6 +1,6 @@
 name: BlackVeil DNS Security MCP
 description: >-
-  DNS and email security scanner with 79 MCP tools. Bulk-scan multiple domains
+  DNS and email security scanner with 80 MCP tools. Bulk-scan multiple domains
   at once, benchmark against the industry average and sector percentile, detect
   whether a domain's posture improved or regressed via drift analysis, and catch
   SubdoMailing risks where an SPF include chain exposes a dangling domain.

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -53,6 +53,7 @@ import { computeDrift, formatDriftReport } from '../tools/analyze-drift';
 import { resolveSpfChain, formatSpfChain } from '../tools/resolve-spf-chain';
 import { discoverSubdomains, formatSubdomainDiscovery, DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS } from '../tools/discover-subdomains';
 import { mapCompliance, formatCompliance } from '../tools/map-compliance';
+import { mapCscProducts, formatCscProducts } from '../tools/map-csc-products';
 import { simulateAttackPaths, formatAttackPaths } from '../tools/simulate-attack-paths';
 import { checkDbl } from '../tools/check-dbl';
 import { checkRbl } from '../tools/check-rbl';
@@ -1508,6 +1509,15 @@ export async function handleToolsCall(
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
 					return buildToolResult(formatCompliance(result, effectiveFormat), result, effectiveFormat);
+				}
+				case 'map_csc_products': {
+					const forceRefresh = extractForceRefresh(validatedArgs);
+					const scanOptions = { ...runtimeOptions, ...(forceRefresh && { forceRefresh }) };
+					const result = await mapCscProducts(validDomain, scanCacheKV, scanOptions);
+					logResult = `${result.recommendedCount} recommended`;
+					logDetails = result;
+					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
+					return buildToolResult(formatCscProducts(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'simulate_attack_paths': {
 					const result = await simulateAttackPaths(validDomain, buildDnsOptions(runtimeOptions));

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -54,6 +54,7 @@ import { resolveSpfChain, formatSpfChain } from '../tools/resolve-spf-chain';
 import { discoverSubdomains, formatSubdomainDiscovery, DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS } from '../tools/discover-subdomains';
 import { mapCompliance, formatCompliance } from '../tools/map-compliance';
 import { mapCscProducts, formatCscProducts } from '../tools/map-csc-products';
+import { prioritizeCscLeads, formatCscLeads } from '../tools/prioritize-csc-leads';
 import { simulateAttackPaths, formatAttackPaths } from '../tools/simulate-attack-paths';
 import { checkDbl } from '../tools/check-dbl';
 import { checkRbl } from '../tools/check-rbl';
@@ -1518,6 +1519,23 @@ export async function handleToolsCall(
 					logDetails = result;
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
 					return buildToolResult(formatCscProducts(result, effectiveFormat), result, effectiveFormat);
+				}
+				case 'prioritize_csc_leads': {
+					const forceRefresh = extractForceRefresh(validatedArgs);
+					const scanOptions = { ...runtimeOptions, ...(forceRefresh && { forceRefresh }) };
+					const result = await prioritizeCscLeads(
+						{
+							domains: validatedArgs.domains as string[] | undefined,
+							brand: validatedArgs.brand as string | undefined,
+							force_refresh: forceRefresh,
+						},
+						scanCacheKV,
+						scanOptions,
+					);
+					logResult = `${result.rankedLeads.length} leads, ${result.summary.hotLeads} hot`;
+					logDetails = { totalDomains: result.totalDomains, hotLeads: result.summary.hotLeads };
+					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
+					return buildToolResult(formatCscLeads(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'simulate_attack_paths': {
 					const result = await simulateAttackPaths(validDomain, buildDnsOptions(runtimeOptions));

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -312,6 +312,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	resolve_spf_chain: 15,
 	discover_subdomains: 0,
 	map_compliance: 5,
+	map_csc_products: 5,
 	simulate_attack_paths: 0,
 	check_dbl: 5,
 	check_rbl: 5,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -243,6 +243,7 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		register_brand_audit_watch: 0,
 		delete_brand_audit_watch: 0,
 		list_brand_audit_watches: 0,
+		prioritize_csc_leads: 0,
 	},
 	free: {
 		discover_subdomains: 0,
@@ -267,6 +268,7 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		register_brand_audit_watch: 0,
 		delete_brand_audit_watch: 0,
 		list_brand_audit_watches: 0,
+		prioritize_csc_leads: 0,
 	},
 };
 
@@ -313,6 +315,7 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	discover_subdomains: 0,
 	map_compliance: 5,
 	map_csc_products: 5,
+	prioritize_csc_leads: 0,
 	simulate_attack_paths: 0,
 	check_dbl: 5,
 	check_rbl: 5,
@@ -380,6 +383,7 @@ export const GATED_PAID_ONLY_TOOLS: ReadonlySet<string> = new Set<string>([
 	// multi-domain tools (any multi-domain tool is paid)
 	'batch_scan',
 	'compare_domains',
+	'prioritize_csc_leads',
 	// already paid-only; folded in for a consistent upgrade message
 	'discover_brand_domains',
 	'discover_brand_domains_start',

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -189,6 +189,29 @@ export const MapSupplyChainArgs = BaseDomainArgs;
 /** map_csc_products — single-domain, no extra args */
 export const MapCscProductsArgs = BaseDomainArgs;
 
+/** prioritize_csc_leads — multi-domain OR a brand seed (exactly one). */
+export const PrioritizeCscLeadsArgs = z
+	.object({
+		domains: z
+			.array(z.string().min(1).max(253))
+			.min(1)
+			.max(10)
+			.optional()
+			.describe('Explicit domain set to rank (max 10). Ownership bucket = "unknown".'),
+		brand: z
+			.string()
+			.min(1)
+			.max(253)
+			.optional()
+			.describe('Brand seed apex; discovers the portfolio, derives ownership buckets, then ranks the top candidates.'),
+		force_refresh: z.boolean().optional().describe('Bypass cache and run fresh scans.'),
+		format: FormatSchema.optional().describe('Output verbosity. Auto-detected if omitted.'),
+	})
+	.passthrough()
+	.refine((v) => (v.domains == null) !== (v.brand == null), {
+		message: 'Provide exactly one of `domains` or `brand`.',
+	});
+
 /** analyze_drift */
 export const AnalyzeDriftArgs = z
 	.object({
@@ -669,6 +692,7 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	discover_subdomains: BaseDomainArgs,
 	map_compliance: BaseDomainArgs,
 	map_csc_products: MapCscProductsArgs,
+	prioritize_csc_leads: PrioritizeCscLeadsArgs,
 	simulate_attack_paths: BaseDomainArgs,
 	check_dbl: BaseDomainArgs,
 	check_rbl: BaseDomainArgs,

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -186,6 +186,9 @@ export const ValidateFixArgs = z
 /** map_supply_chain — same as BaseDomainArgs */
 export const MapSupplyChainArgs = BaseDomainArgs;
 
+/** map_csc_products — single-domain, no extra args */
+export const MapCscProductsArgs = BaseDomainArgs;
+
 /** analyze_drift */
 export const AnalyzeDriftArgs = z
 	.object({
@@ -665,6 +668,7 @@ export const TOOL_SCHEMA_MAP: Record<string, z.ZodTypeAny> = {
 	resolve_spf_chain: BaseDomainArgs,
 	discover_subdomains: BaseDomainArgs,
 	map_compliance: BaseDomainArgs,
+	map_csc_products: MapCscProductsArgs,
 	simulate_attack_paths: BaseDomainArgs,
 	check_dbl: BaseDomainArgs,
 	check_rbl: BaseDomainArgs,

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -17,6 +17,7 @@ import {
 	ValidateFixArgs,
 	MapSupplyChainArgs,
 	MapCscProductsArgs,
+	PrioritizeCscLeadsArgs,
 	AnalyzeDriftArgs,
 	CheckFastFluxArgs,
 	CheckAgentDiscoveryArgs,
@@ -463,6 +464,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		group: 'intelligence',
 		scanIncluded: false,
 	},
+	prioritize_csc_leads: {
+		description:
+			'Rank a brand’s portfolio (or an explicit domain set) into prioritized CSC sales leads by product-gap value × severity. Multi-domain, paid. Reuses map_csc_products per domain, then ranks. Distinct from map_csc_products (per-domain product mapping) and batch_scan (raw scores).',
+		schema: PrioritizeCscLeadsArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
 	simulate_attack_paths: {
 		description:
 			'Analyze current DNS posture and enumerate specific attack paths an adversary could exploit, with severity, feasibility, steps, and mitigations.',
@@ -794,6 +802,7 @@ export const NON_CHECK_RESULT_TOOLS = new Set<string>([
 	'discover_subdomains',
 	'map_compliance',
 	'map_csc_products',
+	'prioritize_csc_leads',
 	'simulate_attack_paths',
 	// discover_brand_domains async trio — custom summary-metadata shape
 	'discover_brand_domains_start',

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -16,6 +16,7 @@ import {
 	GetProviderInsightsArgs,
 	ValidateFixArgs,
 	MapSupplyChainArgs,
+	MapCscProductsArgs,
 	AnalyzeDriftArgs,
 	CheckFastFluxArgs,
 	CheckAgentDiscoveryArgs,
@@ -455,6 +456,13 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		group: 'intelligence',
 		scanIncluded: false,
 	},
+	map_csc_products: {
+		description:
+			'Map a domain’s observed security gaps to CSC commercial products (CSC MultiLock, Managed DMARC, Digital Certificates, DNSSEC management) for sales/upsell prioritization. Reads the scan plus RDAP lock posture. Distinct from map_compliance, which maps findings to compliance frameworks (NIST/PCI/SOC2/CIS).',
+		schema: MapCscProductsArgs,
+		group: 'intelligence',
+		scanIncluded: false,
+	},
 	simulate_attack_paths: {
 		description:
 			'Analyze current DNS posture and enumerate specific attack paths an adversary could exploit, with severity, feasibility, steps, and mitigations.',
@@ -785,6 +793,7 @@ export const NON_CHECK_RESULT_TOOLS = new Set<string>([
 	'resolve_spf_chain',
 	'discover_subdomains',
 	'map_compliance',
+	'map_csc_products',
 	'simulate_attack_paths',
 	// discover_brand_domains async trio — custom summary-metadata shape
 	'discover_brand_domains_start',

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -12,6 +12,65 @@ import { safeFetch } from '../lib/safe-fetch';
 
 const CATEGORY = 'rdap' as CheckCategory;
 
+/** Domain lock posture derived from EPP/RDAP status codes (RFC 5731 / RFC 9083). */
+export interface LockPosture {
+	/** Highest-level posture: registry > registrar > unlocked; unknown when no status reported. */
+	level: 'registry-lock' | 'registrar-lock' | 'unlocked' | 'unknown';
+	/** Transfer prohibited at client OR server level. */
+	transferLocked: boolean;
+	/** Delete prohibited at client OR server level. */
+	deleteLocked: boolean;
+	/** Update prohibited at client OR server level. */
+	updateLocked: boolean;
+	/** Any server*Prohibited present → registry lock service in effect. */
+	registryLevel: boolean;
+	/** Any client*Prohibited present → basic registrar lock. */
+	registrarLevel: boolean;
+}
+
+/**
+ * Classify a domain's lock posture from its EPP/RDAP status codes.
+ *
+ * Handles BOTH value formats seen in the wild: EPP camelCase
+ * (`serverTransferProhibited`) and RDAP canonical space-separated lowercase
+ * (`server transfer prohibited`, per RFC 8056/9083). Normalizes by lowercasing
+ * and stripping all whitespace before matching. Pure; no I/O.
+ */
+export function deriveLockPosture(eppStatus: readonly string[]): LockPosture {
+	const norm = new Set((Array.isArray(eppStatus) ? eppStatus : []).map((s) => String(s).toLowerCase().replace(/\s+/g, '')));
+	const has = (code: string) => norm.has(code);
+
+	const serverTransfer = has('servertransferprohibited');
+	const serverDelete = has('serverdeleteprohibited');
+	const serverUpdate = has('serverupdateprohibited');
+	const clientTransfer = has('clienttransferprohibited');
+	const clientDelete = has('clientdeleteprohibited');
+	const clientUpdate = has('clientupdateprohibited');
+
+	const registryLevel = serverTransfer || serverDelete || serverUpdate;
+	const registrarLevel = clientTransfer || clientDelete || clientUpdate;
+
+	let level: LockPosture['level'];
+	if (norm.size === 0) {
+		level = 'unknown';
+	} else if (serverTransfer) {
+		level = 'registry-lock';
+	} else if (clientTransfer) {
+		level = 'registrar-lock';
+	} else {
+		level = 'unlocked';
+	}
+
+	return {
+		level,
+		transferLocked: serverTransfer || clientTransfer,
+		deleteLocked: serverDelete || clientDelete,
+		updateLocked: serverUpdate || clientUpdate,
+		registryLevel,
+		registrarLevel,
+	};
+}
+
 /**
  * Wall-clock budget for the synchronous `rdap_lookup` tool path, threaded into
  * the orchestrator as the caller AbortSignal AND as `deadlineMs` so retry

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -37,7 +37,11 @@ export interface LockPosture {
  * and stripping all whitespace before matching. Pure; no I/O.
  */
 export function deriveLockPosture(eppStatus: readonly string[]): LockPosture {
-	const norm = new Set((Array.isArray(eppStatus) ? eppStatus : []).map((s) => String(s).toLowerCase().replace(/\s+/g, '')));
+	const norm = new Set(
+		(Array.isArray(eppStatus) ? eppStatus : [])
+			.map((s) => String(s).toLowerCase().replace(/\s+/g, ''))
+			.filter((s) => s.length > 0),
+	);
 	const has = (code: string) => norm.has(code);
 
 	const serverTransfer = has('servertransferprohibited');

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -798,6 +798,7 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 
 	// EPP status
 	const eppStatus = Array.isArray(rdapData.status) ? rdapData.status : [];
+	const lockPosture = deriveLockPosture(eppStatus);
 
 	// Build metadata
 	const metadata: Record<string, unknown> = {
@@ -812,6 +813,7 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 		expirationDate: expirationEvent?.eventDate ?? null,
 		lastChanged: lastChangedEvent?.eventDate ?? null,
 		eppStatus,
+		lockPosture,
 		rdapServer: rdapServerUrl,
 	};
 
@@ -850,6 +852,41 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 		);
 	}
 
+	// Lock posture finding (transfer-driven; at most one). Severities per Spec A:
+	// only a genuine gap (unlocked) escalates above info; the MultiLock upsell is
+	// derived by the sales layer from metadata.lockPosture.level, not from severity.
+	if (lockPosture.level === 'unlocked') {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Domain transfer not locked',
+				'medium',
+				`${domain} has no transfer-prohibited status at the registrar or registry level. Without a transfer lock the domain is exposed to unauthorized transfer (domain hijacking). Recommend enabling at minimum a registrar transfer lock (clientTransferProhibited).`,
+				metadata,
+			),
+		);
+	} else if (lockPosture.level === 'registrar-lock') {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Registrar lock active (no registry lock)',
+				'info',
+				`${domain} has a registrar-level transfer lock but no registry-level (server) lock. A registry lock adds out-of-band manual authorization for the strongest protection against unauthorized transfer.`,
+				metadata,
+			),
+		);
+	} else if (lockPosture.level === 'registry-lock') {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'Registry lock active',
+				'info',
+				`${domain} has a registry-level transfer lock (server-prohibited), the strongest standard protection against unauthorized transfer.`,
+				metadata,
+			),
+		);
+	}
+
 	// Info: standard registration details (always present)
 	const parts: string[] = [];
 	if (registrarName) parts.push(`Registrar: ${registrarName}`);
@@ -859,6 +896,7 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 	if (expirationEvent?.eventDate) parts.push(`Expires: ${expirationEvent.eventDate.split('T')[0]}`);
 	if (lastChangedEvent?.eventDate) parts.push(`Updated: ${lastChangedEvent.eventDate.split('T')[0]}`);
 	if (eppStatus.length > 0) parts.push(`Status: ${eppStatus.join(', ')}`);
+	if (lockPosture.level !== 'unknown') parts.push(`Lock posture: ${lockPosture.level}`);
 	if (domainAgeDays !== null) parts.push(`Age: ${domainAgeDays} days`);
 
 	findings.push(

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * CSC product mapping tool (sales-upsell layer).
+ * Maps a domain's observed security gaps to the four CSC commercial products.
+ * Reads existing CheckResults (dmarc/ssl/dnssec) plus Spec A's RDAP lock posture.
+ * Emits NO new security finding/severity — `priority` here is a SALES priority,
+ * deliberately distinct from a security severity. Modeled on map-compliance.ts.
+ */
+
+import type { CheckResult } from '../lib/scoring';
+import type { LockPosture } from './check-rdap-lookup';
+
+export type CscProductKey = 'csc_multilock' | 'managed_dmarc' | 'digital_certificates' | 'dnssec_management';
+
+/** Sales-upsell priority — NOT a security severity. */
+export type CscPriority = 'high' | 'medium' | 'low' | 'none';
+
+export interface CscProductRecommendation {
+	product: CscProductKey;
+	productName: string;
+	recommended: boolean;
+	priority: CscPriority;
+	justifyingGap: string;
+	relatedFindings: string[];
+}
+
+export interface CscProductReport {
+	domain: string;
+	score: number;
+	grade: string;
+	lockPosture: LockPosture | null;
+	recommendations: CscProductRecommendation[];
+	recommendedCount: number;
+}
+
+const CSC_PRODUCT_NAMES: Record<CscProductKey, string> = {
+	csc_multilock: 'CSC MultiLock',
+	managed_dmarc: 'Managed DMARC',
+	digital_certificates: 'Digital Certificates',
+	dnssec_management: 'DNSSEC management',
+};
+
+/** Non-info finding titles from a failing CheckResult (mirrors map-compliance). */
+function nonInfoTitles(result: CheckResult | undefined): string[] {
+	if (!result) return [];
+	return result.findings.filter((f) => f.severity !== 'info').map((f) => f.title);
+}
+
+/** MultiLock recommendation — reads the booleans, not `level` alone (Spec A handoff). */
+function evalMultiLock(lockPosture: LockPosture | null): CscProductRecommendation {
+	const base = { product: 'csc_multilock' as const, productName: CSC_PRODUCT_NAMES.csc_multilock, relatedFindings: [] as string[] };
+	if (lockPosture == null || lockPosture.level === 'unknown') {
+		return { ...base, recommended: false, priority: 'none', justifyingGap: 'Lock posture unobservable (RDAP unavailable/redacted)' };
+	}
+	if (lockPosture.registryLevel === true) {
+		return { ...base, recommended: false, priority: 'none', justifyingGap: 'Registry lock already in effect' };
+	}
+	if (lockPosture.transferLocked === false) {
+		return { ...base, recommended: true, priority: 'high', justifyingGap: 'Domain transfer not locked — no registry or registrar lock' };
+	}
+	// registrarLevel true (or defensive fallback): registrar lock only, no server lock.
+	return { ...base, recommended: true, priority: 'medium', justifyingGap: 'Registrar lock only — no registry-level (server) lock' };
+}
+
+/** Scan-driven product (dmarc/ssl/dnssec). Missing category → low-priority "not observed" lead. */
+function evalScanProduct(
+	product: Exclude<CscProductKey, 'csc_multilock'>,
+	result: CheckResult | undefined,
+	gaps: { passing: string; failing: string; absent: string },
+): CscProductRecommendation {
+	const base = { product, productName: CSC_PRODUCT_NAMES[product] };
+	if (result === undefined) {
+		return { ...base, recommended: true, priority: 'low', justifyingGap: gaps.absent, relatedFindings: [] };
+	}
+	if (result.passed) {
+		return { ...base, recommended: false, priority: 'none', justifyingGap: gaps.passing, relatedFindings: [] };
+	}
+	const titles = nonInfoTitles(result);
+	const hasSevere = result.findings.some((f) => f.severity === 'critical' || f.severity === 'high');
+	return { ...base, recommended: true, priority: hasSevere ? 'high' : 'medium', justifyingGap: gaps.failing, relatedFindings: titles };
+}
+
+/**
+ * Evaluate CSC product recommendations from scan results + RDAP lock posture (PURE).
+ * Exported for direct unit testing without mocking scanDomain/checkRdapLookup.
+ */
+export function evaluateCscProducts(
+	checkResults: CheckResult[],
+	lockPosture: LockPosture | null,
+	domain: string,
+	score: number,
+	grade: string,
+): CscProductReport {
+	const byCategory = new Map<string, CheckResult>();
+	for (const r of checkResults) byCategory.set(r.category, r);
+
+	const recommendations: CscProductRecommendation[] = [
+		evalMultiLock(lockPosture),
+		evalScanProduct('managed_dmarc', byCategory.get('dmarc'), {
+			passing: 'DMARC policy in effect',
+			failing: 'DMARC present but not passing',
+			absent: 'DMARC not observed',
+		}),
+		evalScanProduct('digital_certificates', byCategory.get('ssl'), {
+			passing: 'TLS/SSL configuration healthy',
+			failing: 'TLS/SSL issues detected',
+			absent: 'TLS/SSL not observed',
+		}),
+		evalScanProduct('dnssec_management', byCategory.get('dnssec'), {
+			passing: 'DNSSEC enabled',
+			failing: 'DNSSEC not enabled',
+			absent: 'DNSSEC not observed',
+		}),
+	];
+
+	return {
+		domain,
+		score,
+		grade,
+		lockPosture,
+		recommendations,
+		recommendedCount: recommendations.filter((r) => r.recommended).length,
+	};
+}

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -10,6 +10,9 @@
 
 import type { CheckResult } from '../lib/scoring';
 import type { LockPosture } from './check-rdap-lookup';
+import { checkRdapLookup, RDAP_LOOKUP_SYNC_BUDGET_MS } from './check-rdap-lookup';
+import { scanDomain } from './scan-domain';
+import type { ScanRuntimeOptions } from './scan/post-processing';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 
@@ -172,4 +175,22 @@ export function formatCscProducts(report: CscProductReport, format: OutputFormat
 	}
 
 	return lines.join('\n').trimEnd();
+}
+
+/** runtimeOptions accepted by the orchestrator — ScanRuntimeOptions plus the optional WHOIS binding the RDAP call threads. */
+type CscRuntimeOptions = ScanRuntimeOptions & { whoisBinding?: { fetch: typeof fetch } };
+
+/**
+ * Map a domain's security gaps to CSC products (orchestrator — the only impure unit).
+ * Runs a full scan (cached) + a budget-bounded RDAP lookup, then evaluates.
+ */
+export async function mapCscProducts(domain: string, kv?: KVNamespace, runtimeOptions?: CscRuntimeOptions): Promise<CscProductReport> {
+	const scanResult = await scanDomain(domain, kv, runtimeOptions);
+	const rdap = await checkRdapLookup(domain, {
+		whoisBinding: runtimeOptions?.whoisBinding,
+		signal: AbortSignal.timeout(RDAP_LOOKUP_SYNC_BUDGET_MS),
+		deadlineMs: Date.now() + RDAP_LOOKUP_SYNC_BUDGET_MS,
+	});
+	const lockPosture = extractLockPosture(rdap);
+	return evaluateCscProducts(scanResult.checks, lockPosture, domain, scanResult.score.overall, scanResult.score.grade);
 }

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -185,12 +185,17 @@ type CscRuntimeOptions = ScanRuntimeOptions & { whoisBinding?: { fetch: typeof f
  * Runs a full scan (cached) + a budget-bounded RDAP lookup, then evaluates.
  */
 export async function mapCscProducts(domain: string, kv?: KVNamespace, runtimeOptions?: CscRuntimeOptions): Promise<CscProductReport> {
-	const scanResult = await scanDomain(domain, kv, runtimeOptions);
-	const rdap = await checkRdapLookup(domain, {
-		whoisBinding: runtimeOptions?.whoisBinding,
-		signal: AbortSignal.timeout(RDAP_LOOKUP_SYNC_BUDGET_MS),
-		deadlineMs: Date.now() + RDAP_LOOKUP_SYNC_BUDGET_MS,
-	});
+	// Capture the deadline epoch BEFORE kicking off both calls so the RDAP budget
+	// is not charged for scan elapsed time (the two calls are independent).
+	const deadlineMs = Date.now() + RDAP_LOOKUP_SYNC_BUDGET_MS;
+	const [scanResult, rdap] = await Promise.all([
+		scanDomain(domain, kv, runtimeOptions),
+		checkRdapLookup(domain, {
+			whoisBinding: runtimeOptions?.whoisBinding,
+			signal: AbortSignal.timeout(RDAP_LOOKUP_SYNC_BUDGET_MS),
+			deadlineMs,
+		}),
+	]);
 	const lockPosture = extractLockPosture(rdap);
 	return evaluateCscProducts(scanResult.checks, lockPosture, domain, scanResult.score.overall, scanResult.score.grade);
 }

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -10,6 +10,8 @@
 
 import type { CheckResult } from '../lib/scoring';
 import type { LockPosture } from './check-rdap-lookup';
+import type { OutputFormat } from '../handlers/tool-args';
+import { sanitizeOutputText } from '../lib/output-sanitize';
 
 export type CscProductKey = 'csc_multilock' | 'managed_dmarc' | 'digital_certificates' | 'dnssec_management';
 
@@ -138,4 +140,36 @@ export function extractLockPosture(rdap: CheckResult): LockPosture | null {
 		if (posture && typeof posture === 'object') return posture as LockPosture;
 	}
 	return null;
+}
+
+const CSC_PRODUCT_ORDER: CscProductKey[] = ['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management'];
+
+/** Render a CSC product report for display. */
+export function formatCscProducts(report: CscProductReport, format: OutputFormat = 'full'): string {
+	const lines: string[] = [];
+	const byKey = new Map(report.recommendations.map((r) => [r.product, r]));
+
+	if (format === 'compact') {
+		lines.push(`CSC products: ${sanitizeOutputText(report.domain, 253)} — ${report.score}/100 (${report.grade}) — ${report.recommendedCount} upsell(s)`);
+		for (const key of CSC_PRODUCT_ORDER) {
+			const r = byKey.get(key)!;
+			const icon = r.recommended ? ' →' : ' ✓';
+			const suffix = r.recommended ? ` [${r.priority}] ${sanitizeOutputText(r.justifyingGap, 80)}` : '';
+			lines.push(`${icon} ${sanitizeOutputText(r.productName, 40)}${suffix}`);
+		}
+	} else {
+		lines.push(`# CSC Product Recommendations: ${sanitizeOutputText(report.domain, 253)}`);
+		lines.push(`**Score:** ${report.score}/100 (${report.grade}) | **${report.recommendedCount}** recommended`);
+		lines.push('');
+		for (const key of CSC_PRODUCT_ORDER) {
+			const r = byKey.get(key)!;
+			const icon = r.recommended ? '✅' : '➖';
+			const tag = r.recommended ? ` — ${r.priority.toUpperCase()}` : ' — OK';
+			lines.push(`${icon} **${sanitizeOutputText(r.productName, 40)}**${tag}`);
+			lines.push(`  - ${sanitizeOutputText(r.justifyingGap, 160)}`);
+			for (const f of r.relatedFindings) lines.push(`  - ${sanitizeOutputText(f, 120)}`);
+		}
+	}
+
+	return lines.join('\n').trimEnd();
 }

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -123,3 +123,19 @@ export function evaluateCscProducts(
 		recommendedCount: recommendations.filter((r) => r.recommended).length,
 	};
 }
+
+/**
+ * Extract the LockPosture from a check_rdap_lookup CheckResult.
+ * Spec A attaches one shared `metadata` object (with `lockPosture`) to all RDAP
+ * findings, so the first finding carrying it is authoritative. Returns null when
+ * none (lookup_failed / redacted) — the MultiLock line then degrades to
+ * "unobservable" while the scan-driven products still evaluate.
+ */
+export function extractLockPosture(rdap: CheckResult): LockPosture | null {
+	for (const f of rdap.findings) {
+		const meta = (f as { metadata?: Record<string, unknown> }).metadata;
+		const posture = meta?.lockPosture;
+		if (posture && typeof posture === 'object') return posture as LockPosture;
+	}
+	return null;
+}

--- a/src/tools/prioritize-csc-leads.ts
+++ b/src/tools/prioritize-csc-leads.ts
@@ -98,3 +98,69 @@ function gapValue(report: CscProductReport): number {
 export function computeGapSeverity(report: CscProductReport, bucket: OwnershipBucket): number {
 	return Math.round(gapValue(report) * OWNERSHIP_MULTIPLIER[bucket]);
 }
+
+/** Recommended product keys in fixed product order. */
+function recommendedProducts(report: CscProductReport): CscProductKey[] {
+	return CSC_PRODUCT_ORDER.filter((k) => report.recommendations.find((r) => r.product === k)?.recommended === true);
+}
+
+const PRIORITY_RANK: Record<CscPriority, number> = { high: 3, medium: 2, low: 1, none: 0 };
+
+/** Highest sales priority among the recommended products ('none' when nothing recommended). */
+function topPriorityOf(report: CscProductReport): CscPriority {
+	let best: CscPriority = 'none';
+	for (const r of report.recommendations) {
+		if (r.recommended && PRIORITY_RANK[r.priority] > PRIORITY_RANK[best]) best = r.priority;
+	}
+	return best;
+}
+
+/**
+ * Rank a set of per-domain CSC product reports into prioritized sales leads (PURE).
+ * Sort: gapSeverity desc, then lower score, then domain asc (total order). The
+ * heart of Spec C's TDD — no I/O.
+ */
+export function rankCscLeads(
+	entries: CscLeadEntry[],
+	brand: string | null = null,
+	skipped: Array<{ domain: string; reason: string }> = [],
+): CscLeadReport {
+	const leads: CscLead[] = entries.map((e) => ({
+		domain: e.report.domain,
+		score: e.report.score,
+		grade: e.report.grade,
+		ownershipBucket: e.ownershipBucket,
+		recommendedCscProducts: recommendedProducts(e.report),
+		gapSeverity: computeGapSeverity(e.report, e.ownershipBucket),
+		priorityRank: 0, // assigned after the sort
+		recommendedCount: e.report.recommendedCount,
+		topPriority: topPriorityOf(e.report),
+	}));
+
+	leads.sort((a, b) => b.gapSeverity - a.gapSeverity || a.score - b.score || a.domain.localeCompare(b.domain));
+	leads.forEach((lead, i) => {
+		lead.priorityRank = i + 1;
+	});
+
+	const byProduct: Record<CscProductKey, number> = {
+		csc_multilock: 0,
+		managed_dmarc: 0,
+		digital_certificates: 0,
+		dnssec_management: 0,
+	};
+	for (const lead of leads) {
+		for (const key of lead.recommendedCscProducts) byProduct[key] += 1;
+	}
+
+	return {
+		brand,
+		totalDomains: leads.length,
+		rankedLeads: leads,
+		summary: {
+			totalRecommendations: leads.reduce((sum, l) => sum + l.recommendedCount, 0),
+			byProduct,
+			hotLeads: leads.filter((l) => l.gapSeverity >= HOT_LEAD_THRESHOLD).length,
+			skipped,
+		},
+	};
+}

--- a/src/tools/prioritize-csc-leads.ts
+++ b/src/tools/prioritize-csc-leads.ts
@@ -11,9 +11,15 @@
 
 import type { Bucket } from '../lib/brand-classification';
 import type { CscProductKey, CscPriority, CscProductReport } from './map-csc-products';
+import { evaluateCscProducts, extractLockPosture } from './map-csc-products';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import type { CheckResult } from '../lib/scoring';
+import { scanDomain } from './scan-domain';
+import { checkRdapLookup, RDAP_LOOKUP_SYNC_BUDGET_MS } from './check-rdap-lookup';
+import { brandAuditSingle } from './brand-audit-single';
+import { validateDomain, sanitizeDomain } from '../lib/sanitize';
+import type { ScanRuntimeOptions } from './scan/post-processing';
 
 /** Portfolio ownership lens (from classifyCandidate) + 'unknown' for a bare domain list. */
 export type OwnershipBucket =
@@ -236,4 +242,130 @@ export function formatCscLeads(report: CscLeadReport, format: OutputFormat = 'fu
 	}
 
 	return lines.join('\n').trimEnd();
+}
+
+const TOTAL_BUDGET_MS = 25_000; // parity with batch_scan
+const SCAN_CONCURRENCY = 3; // scan_domain is already ~16× parallel internally
+const LEAD_BUDGET = 10; // max leads ranked (parity with the domains[] cap)
+
+/** runtimeOptions accepted by the orchestrator — ScanRuntimeOptions plus the optional WHOIS binding the RDAP call threads. */
+export type CscRuntimeOptions = ScanRuntimeOptions & { whoisBinding?: { fetch: typeof fetch } };
+
+export type DiscoverPortfolioFn = (
+	brand: string,
+	opts: { kv?: KVNamespace; runtimeOptions?: CscRuntimeOptions; deadlineMs: number },
+) => Promise<DiscoveredCandidate[]>;
+
+export interface PrioritizeCscLeadsDeps {
+	/** Override the brand portfolio discoverer (default wraps brandAuditSingle). */
+	discoverPortfolio?: DiscoverPortfolioFn;
+}
+
+export interface PrioritizeCscLeadsArgsShape {
+	domains?: string[];
+	brand?: string;
+	force_refresh?: boolean;
+}
+
+/** Buckets CSC can actually sell a lock — preferred when truncating to LEAD_BUDGET. */
+const SELLABLE_BUCKETS: ReadonlySet<OwnershipBucket> = new Set<OwnershipBucket>(['consolidated', 'shadowIt']);
+
+/** Default brand discoverer — runs a bounded brand audit, then extracts candidates+buckets. */
+const defaultDiscoverPortfolio: DiscoverPortfolioFn = async (brand, opts) => {
+	const result = await brandAuditSingle(
+		brand,
+		{ timeoutBehavior: 'async_handoff', deadlineMs: opts.deadlineMs, kv: opts.kv, ...opts.runtimeOptions } as never,
+		{},
+	);
+	return extractDiscoveredCandidates(result);
+};
+
+/** Evaluate one domain → a CscLeadEntry (scan + RDAP + Spec B pure evaluation). */
+async function evaluateOne(domain: string, ownershipBucket: OwnershipBucket, kv: KVNamespace | undefined, runtimeOptions: CscRuntimeOptions | undefined): Promise<CscLeadEntry> {
+	const scanResult = await scanDomain(domain, kv, runtimeOptions);
+	const rdap = await checkRdapLookup(domain, {
+		whoisBinding: runtimeOptions?.whoisBinding,
+		signal: AbortSignal.timeout(RDAP_LOOKUP_SYNC_BUDGET_MS),
+		deadlineMs: Date.now() + RDAP_LOOKUP_SYNC_BUDGET_MS,
+	});
+	const lockPosture = extractLockPosture(rdap);
+	const report = evaluateCscProducts(scanResult.checks, lockPosture, domain, scanResult.score.overall, scanResult.score.grade);
+	return { report, ownershipBucket };
+}
+
+/**
+ * Prioritize CSC sales leads across a domain set or a brand portfolio (orchestrator — impure).
+ * Per-domain isolation + a wall-clock budget (batch_scan pattern): one bad domain
+ * lands in summary.skipped and never sinks the batch. NEVER throws a non-allowlisted error.
+ */
+export async function prioritizeCscLeads(
+	args: PrioritizeCscLeadsArgsShape,
+	kv?: KVNamespace,
+	runtimeOptions?: CscRuntimeOptions,
+	deps: PrioritizeCscLeadsDeps = {},
+): Promise<CscLeadReport> {
+	const deadline = Date.now() + TOTAL_BUDGET_MS;
+	const skipped: Array<{ domain: string; reason: string }> = [];
+	let brand: string | null = null;
+
+	// 1. Resolve the work set.
+	let work: Array<{ domain: string; ownershipBucket: OwnershipBucket }> = [];
+	if (args.brand != null) {
+		brand = args.brand;
+		const discover = deps.discoverPortfolio ?? defaultDiscoverPortfolio;
+		let candidates: DiscoveredCandidate[] = [];
+		try {
+			candidates = await discover(args.brand, { kv, runtimeOptions, deadlineMs: deadline });
+		} catch {
+			candidates = [];
+		}
+		if (candidates.length === 0) {
+			skipped.push({ domain: args.brand, reason: 'discovery_incomplete' });
+			return rankCscLeads([], brand, skipped);
+		}
+		// Prefer sellable buckets when truncating to the lead budget.
+		const ordered = [...candidates].sort((a, b) => Number(SELLABLE_BUCKETS.has(b.ownershipBucket)) - Number(SELLABLE_BUCKETS.has(a.ownershipBucket)));
+		work = ordered.slice(0, LEAD_BUDGET).map((c) => ({ domain: c.domain, ownershipBucket: c.ownershipBucket }));
+	} else {
+		const domains = (args.domains ?? []).slice(0, LEAD_BUDGET);
+		for (const raw of domains) {
+			const validation = validateDomain(raw);
+			if (!validation.valid) {
+				skipped.push({ domain: raw, reason: validation.error ?? 'invalid_domain' });
+				continue;
+			}
+			work.push({ domain: sanitizeDomain(raw), ownershipBucket: 'unknown' });
+		}
+	}
+
+	// 2. Evaluate with bounded concurrency + per-domain budget (batch_scan pattern).
+	const entries: CscLeadEntry[] = [];
+	let cursor = 0;
+	const worker = async (): Promise<void> => {
+		while (cursor < work.length) {
+			const task = work[cursor++];
+			if (!task) return;
+			const remaining = deadline - Date.now();
+			if (remaining <= 0) {
+				skipped.push({ domain: task.domain, reason: 'budget_exceeded' });
+				continue;
+			}
+			let timeoutId: ReturnType<typeof setTimeout> | undefined;
+			try {
+				const evalPromise = evaluateOne(task.domain, task.ownershipBucket, kv, runtimeOptions);
+				const timeoutPromise = new Promise<never>((_, reject) => {
+					timeoutId = setTimeout(() => reject(new Error('budget_exceeded')), remaining);
+				});
+				entries.push(await Promise.race([evalPromise, timeoutPromise]));
+			} catch (err) {
+				skipped.push({ domain: task.domain, reason: err instanceof Error ? err.message : 'scan_failed' });
+			} finally {
+				if (timeoutId !== undefined) clearTimeout(timeoutId);
+			}
+		}
+	};
+	await Promise.all(Array.from({ length: Math.max(1, Math.min(SCAN_CONCURRENCY, work.length || 1)) }, () => worker()));
+
+	// 3. Rank (pure).
+	return rankCscLeads(entries, brand, skipped);
 }

--- a/src/tools/prioritize-csc-leads.ts
+++ b/src/tools/prioritize-csc-leads.ts
@@ -13,6 +13,7 @@ import type { Bucket } from '../lib/brand-classification';
 import type { CscProductKey, CscPriority, CscProductReport } from './map-csc-products';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
+import type { CheckResult } from '../lib/scoring';
 
 /** Portfolio ownership lens (from classifyCandidate) + 'unknown' for a bare domain list. */
 export type OwnershipBucket =
@@ -165,6 +166,36 @@ export function rankCscLeads(
 			skipped,
 		},
 	};
+}
+
+const KNOWN_BUCKETS: ReadonlySet<Bucket> = new Set<Bucket>([
+	'consolidated',
+	'shadowIt',
+	'indeterminate',
+	'impersonation',
+	'impersonationSurface',
+]);
+
+/**
+ * Extract {domain, ownershipBucket} candidates from a brandAuditSingle CheckResult.
+ * The pipeline stamps each candidate finding with metadata.candidate (the domain)
+ * and metadata.bucket (a classifier Bucket — brand-audit-pipeline.ts:962-964).
+ * A candidate with no/unknown bucket defaults to 'indeterminate' (0.6 multiplier —
+ * honest, doesn't over-claim consolidation). Non-candidate findings (summary,
+ * async-handoff) are ignored — an async-handoff result yields []. PURE.
+ */
+export function extractDiscoveredCandidates(result: CheckResult): DiscoveredCandidate[] {
+	const out: DiscoveredCandidate[] = [];
+	for (const f of result.findings) {
+		const meta = (f as { metadata?: Record<string, unknown> }).metadata;
+		const candidate = meta?.candidate;
+		if (typeof candidate !== 'string' || candidate.length === 0) continue;
+		const rawBucket = meta?.bucket;
+		const bucket: OwnershipBucket =
+			typeof rawBucket === 'string' && KNOWN_BUCKETS.has(rawBucket as Bucket) ? bucketFromClassification(rawBucket as Bucket) : 'indeterminate';
+		out.push({ domain: candidate, ownershipBucket: bucket });
+	}
+	return out;
 }
 
 /** Render a ranked CSC lead report for display. */

--- a/src/tools/prioritize-csc-leads.ts
+++ b/src/tools/prioritize-csc-leads.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * CSC sales-lead prioritization tool (portfolio aggregation layer).
+ * Aggregates a brand's portfolio (or an operator-supplied domain set) into a
+ * ranked sales-lead list, ordered by product-gap value × ownership actionability,
+ * reusing Spec B's PURE units (evaluateCscProducts + extractLockPosture) per domain.
+ * Emits NO new security finding/severity — gapSeverity/priorityRank are SALES
+ * signals, deliberately distinct from a security severity. Paid-gated, multi-domain.
+ */
+
+import type { Bucket } from '../lib/brand-classification';
+import type { CscProductKey, CscPriority, CscProductReport } from './map-csc-products';
+
+/** Portfolio ownership lens (from classifyCandidate) + 'unknown' for a bare domain list. */
+export type OwnershipBucket =
+	| 'consolidated'
+	| 'shadowIt'
+	| 'indeterminate'
+	| 'impersonation'
+	| 'impersonationSurface'
+	| 'unknown';
+
+/** A single ranked sales lead. */
+export interface CscLead {
+	domain: string;
+	score: number;
+	grade: string;
+	ownershipBucket: OwnershipBucket;
+	recommendedCscProducts: CscProductKey[];
+	gapSeverity: number;
+	priorityRank: number;
+	recommendedCount: number;
+	topPriority: CscPriority;
+}
+
+export interface CscLeadReport {
+	brand: string | null;
+	totalDomains: number;
+	rankedLeads: CscLead[];
+	summary: {
+		totalRecommendations: number;
+		byProduct: Record<CscProductKey, number>;
+		hotLeads: number;
+		skipped: Array<{ domain: string; reason: string }>;
+	};
+}
+
+/** A domain to rank, paired with its portfolio ownership lens. */
+export interface CscLeadEntry {
+	report: CscProductReport;
+	ownershipBucket: OwnershipBucket;
+}
+
+/** A discovered candidate from the brand path. */
+export interface DiscoveredCandidate {
+	domain: string;
+	ownershipBucket: OwnershipBucket;
+}
+
+const CSC_PRODUCT_ORDER: CscProductKey[] = ['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management'];
+
+// Product sales value — MultiLock is the flagship anti-hijacking product.
+const PRODUCT_VALUE: Record<CscProductKey, number> = {
+	csc_multilock: 4,
+	managed_dmarc: 3,
+	digital_certificates: 2,
+	dnssec_management: 2,
+};
+// Spec B sales priority → weight.
+const PRIORITY_WEIGHT: Record<CscPriority, number> = { high: 3, medium: 2, low: 1, none: 0 };
+// Ownership actionability — can CSC actually sell THIS domain a lock?
+const OWNERSHIP_MULTIPLIER: Record<OwnershipBucket, number> = {
+	consolidated: 1.0,
+	shadowIt: 1.0,
+	unknown: 1.0,
+	indeterminate: 0.6,
+	impersonation: 0.3,
+	impersonationSurface: 0.3,
+};
+const HOT_LEAD_THRESHOLD = 6; // gapSeverity at/above = "hot"
+
+/** Pure mapper from classifyCandidate's Bucket to OwnershipBucket (identity for the 5 shared values). */
+export function bucketFromClassification(b: Bucket): OwnershipBucket {
+	return b;
+}
+
+/** Σ over recommended products of PRODUCT_VALUE × PRIORITY_WEIGHT. */
+function gapValue(report: CscProductReport): number {
+	let total = 0;
+	for (const r of report.recommendations) {
+		if (r.recommended) total += PRODUCT_VALUE[r.product] * PRIORITY_WEIGHT[r.priority];
+	}
+	return total;
+}
+
+/** "Product-gap value × ownership severity", rounded. PURE. */
+export function computeGapSeverity(report: CscProductReport, bucket: OwnershipBucket): number {
+	return Math.round(gapValue(report) * OWNERSHIP_MULTIPLIER[bucket]);
+}

--- a/src/tools/prioritize-csc-leads.ts
+++ b/src/tools/prioritize-csc-leads.ts
@@ -272,11 +272,11 @@ const SELLABLE_BUCKETS: ReadonlySet<OwnershipBucket> = new Set<OwnershipBucket>(
 
 /** Default brand discoverer — runs a bounded brand audit, then extracts candidates+buckets. */
 const defaultDiscoverPortfolio: DiscoverPortfolioFn = async (brand, opts) => {
-	const result = await brandAuditSingle(
-		brand,
-		{ timeoutBehavior: 'async_handoff', deadlineMs: opts.deadlineMs, kv: opts.kv, ...opts.runtimeOptions } as never,
-		{},
-	);
+	// Pass only the fields BrandAuditSingleOptions accepts: timeoutBehavior + deadlineMs.
+	// kv is not part of BrandAuditPipelineOptions (the latent bug hidden by `as never`).
+	// ScanRuntimeOptions fields spread in from opts.runtimeOptions are silently ignored
+	// by the pipeline; the spread is kept for any future overlap but is currently a no-op.
+	const result = await brandAuditSingle(brand, { timeoutBehavior: 'async_handoff', deadlineMs: opts.deadlineMs, ...opts.runtimeOptions }, {});
 	return extractDiscoveredCandidates(result);
 };
 

--- a/src/tools/prioritize-csc-leads.ts
+++ b/src/tools/prioritize-csc-leads.ts
@@ -11,6 +11,8 @@
 
 import type { Bucket } from '../lib/brand-classification';
 import type { CscProductKey, CscPriority, CscProductReport } from './map-csc-products';
+import type { OutputFormat } from '../handlers/tool-args';
+import { sanitizeOutputText } from '../lib/output-sanitize';
 
 /** Portfolio ownership lens (from classifyCandidate) + 'unknown' for a bare domain list. */
 export type OwnershipBucket =
@@ -163,4 +165,44 @@ export function rankCscLeads(
 			skipped,
 		},
 	};
+}
+
+/** Render a ranked CSC lead report for display. */
+export function formatCscLeads(report: CscLeadReport, format: OutputFormat = 'full'): string {
+	const lines: string[] = [];
+	const brandLabel = report.brand ? sanitizeOutputText(report.brand, 253) : 'domain set';
+
+	if (format === 'compact') {
+		lines.push(`CSC leads (${brandLabel}): ${report.totalDomains} ranked, ${report.summary.hotLeads} hot`);
+		for (const lead of report.rankedLeads) {
+			lines.push(
+				`${lead.priorityRank}. ${sanitizeOutputText(lead.domain, 253)} — sev ${lead.gapSeverity} — ${lead.score}/100 (${lead.grade}) — ${lead.recommendedCount} product(s)`,
+			);
+		}
+		return lines.join('\n').trimEnd();
+	}
+
+	lines.push(`# CSC Sales Leads: ${brandLabel}`);
+	lines.push(`**${report.totalDomains}** domain(s) ranked | **${report.summary.hotLeads}** hot lead(s)`);
+	lines.push('');
+	for (const lead of report.rankedLeads) {
+		lines.push(`## ${lead.priorityRank}. ${sanitizeOutputText(lead.domain, 253)} — gap severity ${lead.gapSeverity}`);
+		lines.push(`  - Score: ${lead.score}/100 (${lead.grade}) | Ownership: ${lead.ownershipBucket} | Top priority: ${lead.topPriority}`);
+		if (lead.recommendedCscProducts.length > 0) {
+			lines.push(`  - Recommended CSC products: ${lead.recommendedCscProducts.join(', ')}`);
+		} else {
+			lines.push('  - No CSC upsell — posture clean');
+		}
+	}
+	lines.push('');
+	lines.push('## Summary');
+	lines.push(`  - Total recommendations: ${report.summary.totalRecommendations}`);
+	for (const key of CSC_PRODUCT_ORDER) {
+		lines.push(`  - ${key}: ${report.summary.byProduct[key]} domain(s)`);
+	}
+	if (report.summary.skipped.length > 0) {
+		lines.push(`  - Skipped: ${report.summary.skipped.map((s) => `${sanitizeOutputText(s.domain, 253)} (${sanitizeOutputText(s.reason, 60)})`).join(', ')}`);
+	}
+
+	return lines.join('\n').trimEnd();
 }

--- a/test/audits/tool-count-ssot.audit.test.ts
+++ b/test/audits/tool-count-ssot.audit.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../../src/schemas/tool-definitions';
 
-const EXPECTED_TOOL_COUNT = 79;
+const EXPECTED_TOOL_COUNT = 80;
 
 describe('tool-count SSOT', () => {
 	it(`exposes exactly ${EXPECTED_TOOL_COUNT} tools (intentional acknowledgment gate)`, () => {

--- a/test/audits/tool-count-ssot.audit.test.ts
+++ b/test/audits/tool-count-ssot.audit.test.ts
@@ -19,7 +19,7 @@
 import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../../src/schemas/tool-definitions';
 
-const EXPECTED_TOOL_COUNT = 80;
+const EXPECTED_TOOL_COUNT = 81;
 
 describe('tool-count SSOT', () => {
 	it(`exposes exactly ${EXPECTED_TOOL_COUNT} tools (intentional acknowledgment gate)`, () => {

--- a/test/chaos/varied-domain-all-tools.chaos.test.ts
+++ b/test/chaos/varied-domain-all-tools.chaos.test.ts
@@ -335,6 +335,7 @@ function makeToolCases(): ToolCase[] {
 		{ name: 'resolve_spf_chain', arguments: domainArgs() },
 		{ name: 'discover_subdomains', arguments: domainArgs() },
 		{ name: 'map_compliance', arguments: domainArgs() },
+		{ name: 'map_csc_products', arguments: domainArgs() },
 		{ name: 'simulate_attack_paths', arguments: domainArgs() },
 		{ name: 'check_dbl', arguments: domainArgs() },
 		{ name: 'check_rbl', arguments: domainArgs() },

--- a/test/chaos/varied-domain-all-tools.chaos.test.ts
+++ b/test/chaos/varied-domain-all-tools.chaos.test.ts
@@ -336,6 +336,7 @@ function makeToolCases(): ToolCase[] {
 		{ name: 'discover_subdomains', arguments: domainArgs() },
 		{ name: 'map_compliance', arguments: domainArgs() },
 		{ name: 'map_csc_products', arguments: domainArgs() },
+		{ name: 'prioritize_csc_leads', arguments: { domains: baseDomains.slice(0, 3), format: 'compact' } },
 		{ name: 'simulate_attack_paths', arguments: domainArgs() },
 		{ name: 'check_dbl', arguments: domainArgs() },
 		{ name: 'check_rbl', arguments: domainArgs() },

--- a/test/check-rdap-lookup.spec.ts
+++ b/test/check-rdap-lookup.spec.ts
@@ -607,6 +607,54 @@ describe('checkRdapLookup', () => {
 			expect(bootstrapFetchCount).toBe(1);
 		});
 	});
+
+	async function runWithStatus(status: string[]) {
+		globalThis.fetch = mockFetchRouter({
+			'data.iana.org/rdap/dns.json': () => makeBootstrap(),
+			'rdap.verisign.com': () => makeRdapResponse({ status }),
+		});
+		return run();
+	}
+
+	it('unlocked domain → one medium "transfer not locked" finding', async () => {
+		const result = await runWithStatus(['active']);
+		const medium = result.findings.find((f) => f.severity === 'medium' && /transfer not locked/i.test(f.title));
+		expect(medium).toBeDefined();
+	});
+
+	it('registrar-lock (default fixture) → info "Registrar lock active", no medium/low lock finding', async () => {
+		const result = await runWithStatus(['clientTransferProhibited', 'serverDeleteProhibited']);
+		const info = result.findings.find((f) => /registrar lock active/i.test(f.title));
+		expect(info).toBeDefined();
+		expect(info!.severity).toBe('info');
+		expect(result.findings.find((f) => /transfer not locked/i.test(f.title))).toBeUndefined();
+	});
+
+	it('registry-lock → info "Registry lock active", no medium', async () => {
+		const result = await runWithStatus(['serverTransferProhibited', 'serverDeleteProhibited', 'serverUpdateProhibited']);
+		const info = result.findings.find((f) => /^registry lock active/i.test(f.title));
+		expect(info).toBeDefined();
+		expect(info!.severity).toBe('info');
+		expect(result.findings.find((f) => f.severity === 'medium' && /transfer not locked/i.test(f.title))).toBeUndefined();
+	});
+
+	it('exposes metadata.lockPosture with the expected shape', async () => {
+		const result = await runWithStatus(['serverTransferProhibited']);
+		const withPosture = result.findings.find((f) => f.metadata?.lockPosture);
+		expect(withPosture).toBeDefined();
+		expect(withPosture!.metadata!.lockPosture).toMatchObject({ level: 'registry-lock', registryLevel: true });
+	});
+
+	it('Registration details info string includes "Lock posture:"', async () => {
+		const result = await runWithStatus(['clientTransferProhibited']);
+		const info = result.findings.find((f) => f.severity === 'info' && f.title.toLowerCase().includes('registration'));
+		expect(info!.detail).toMatch(/Lock posture: registrar-lock/);
+	});
+
+	it('empty status → no lock finding added', async () => {
+		const result = await runWithStatus([]);
+		expect(result.findings.find((f) => /transfer not locked|registrar lock active|registry lock active/i.test(f.title))).toBeUndefined();
+	});
 });
 
 describe('deriveLockPosture', () => {

--- a/test/check-rdap-lookup.spec.ts
+++ b/test/check-rdap-lookup.spec.ts
@@ -608,3 +608,69 @@ describe('checkRdapLookup', () => {
 		});
 	});
 });
+
+describe('deriveLockPosture', () => {
+	async function derive(status: string[]) {
+		const { deriveLockPosture } = await import('../src/tools/check-rdap-lookup');
+		return deriveLockPosture(status);
+	}
+
+	it('empty status → unknown, all booleans false', async () => {
+		expect(await derive([])).toEqual({
+			level: 'unknown',
+			transferLocked: false,
+			deleteLocked: false,
+			updateLocked: false,
+			registryLevel: false,
+			registrarLevel: false,
+		});
+	});
+
+	it('client transfer prohibited (RDAP spaced form) → registrar-lock', async () => {
+		const p = await derive(['client transfer prohibited']);
+		expect(p.level).toBe('registrar-lock');
+		expect(p.registrarLevel).toBe(true);
+		expect(p.registryLevel).toBe(false);
+		expect(p.transferLocked).toBe(true);
+	});
+
+	it('serverTransferProhibited (EPP camelCase) → registry-lock', async () => {
+		const p = await derive(['serverTransferProhibited']);
+		expect(p.level).toBe('registry-lock');
+		expect(p.registryLevel).toBe(true);
+	});
+
+	it('full server lock set → registry-lock with all booleans true', async () => {
+		const p = await derive(['server transfer prohibited', 'server delete prohibited', 'server update prohibited']);
+		expect(p.level).toBe('registry-lock');
+		expect(p.transferLocked).toBe(true);
+		expect(p.deleteLocked).toBe(true);
+		expect(p.updateLocked).toBe(true);
+		expect(p.registryLevel).toBe(true);
+	});
+
+	it('clientUpdateProhibited only (no transfer lock) → unlocked', async () => {
+		const p = await derive(['clientUpdateProhibited']);
+		expect(p.level).toBe('unlocked');
+		expect(p.updateLocked).toBe(true);
+		expect(p.transferLocked).toBe(false);
+	});
+
+	it('active / ok (no prohibitions) → unlocked', async () => {
+		expect((await derive(['active'])).level).toBe('unlocked');
+		expect((await derive(['ok'])).level).toBe('unlocked');
+	});
+
+	it('mixed case + extra whitespace → still registry-lock (normalization)', async () => {
+		const p = await derive(['  Server Transfer Prohibited ']);
+		expect(p.level).toBe('registry-lock');
+		expect(p.registryLevel).toBe(true);
+	});
+
+	it('both client + server transfer present → registry-lock (server precedence)', async () => {
+		const p = await derive(['clientTransferProhibited', 'serverTransferProhibited']);
+		expect(p.level).toBe('registry-lock');
+		expect(p.registrarLevel).toBe(true);
+		expect(p.registryLevel).toBe(true);
+	});
+});

--- a/test/check-rdap-lookup.spec.ts
+++ b/test/check-rdap-lookup.spec.ts
@@ -721,4 +721,9 @@ describe('deriveLockPosture', () => {
 		expect(p.registrarLevel).toBe(true);
 		expect(p.registryLevel).toBe(true);
 	});
+
+	it('empty / whitespace-only status entries → unknown (malformed-input guard)', async () => {
+		expect((await derive([''])).level).toBe('unknown');
+		expect((await derive(['   '])).level).toBe('unknown');
+	});
 });

--- a/test/map-csc-products.integration.test.ts
+++ b/test/map-csc-products.integration.test.ts
@@ -36,6 +36,29 @@ afterEach(() => {
 	mockCheckRdap.mockReset();
 });
 
+describe('mapCscProducts — concurrency', () => {
+	it('runs scan and RDAP in parallel (total ≈ max(delays), not sum)', async () => {
+		const DELAY_MS = 40;
+		mockScanDomain.mockImplementation(
+			() =>
+				new Promise<{ checks: never[]; score: { overall: number; grade: string } }>((r) =>
+					setTimeout(() => r({ checks: [], score: { overall: 90, grade: 'A' } }), DELAY_MS),
+				),
+		);
+		mockCheckRdap.mockImplementation(() => new Promise<CheckResult>((r) => setTimeout(() => r(rdapFailed()), DELAY_MS)));
+
+		const { mapCscProducts } = await import('../src/tools/map-csc-products');
+		const t0 = Date.now();
+		await mapCscProducts('parallel.com');
+		const elapsed = Date.now() - t0;
+
+		// Sequential (await scan THEN rdap) would be ≥ 2 × DELAY_MS ≈ 80ms.
+		// Parallel: both calls start before either resolves → elapsed ≈ DELAY_MS.
+		// Allow generous slack (×1.7) for CI scheduler jitter.
+		expect(elapsed).toBeLessThan(DELAY_MS * 1.7);
+	});
+});
+
 describe('mapCscProducts — wiring', () => {
 	it('unlocked RDAP + failing DMARC + passing SSL/DNSSEC → MultiLock high + Managed DMARC; count 2', async () => {
 		mockScanDomain.mockResolvedValue({

--- a/test/map-csc-products.integration.test.ts
+++ b/test/map-csc-products.integration.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { CheckResult } from '../src/lib/scoring';
+import type { LockPosture } from '../src/tools/check-rdap-lookup';
+
+const mockScanDomain = vi.fn();
+const mockCheckRdap = vi.fn();
+
+vi.mock('../src/tools/scan-domain', () => ({
+	scanDomain: (...args: unknown[]) => mockScanDomain(...args),
+}));
+
+vi.mock('../src/tools/check-rdap-lookup', async (importOriginal) => {
+	const orig = await importOriginal<typeof import('../src/tools/check-rdap-lookup')>();
+	return {
+		...orig,
+		checkRdapLookup: (...args: unknown[]) => mockCheckRdap(...args),
+	};
+});
+
+function check(category: string, passed: boolean, findings: Array<{ title: string; severity: string }> = []): CheckResult {
+	return { category, passed, score: passed ? 100 : 0, findings: findings.map((f) => ({ category, title: f.title, severity: f.severity, detail: '' })) } as CheckResult;
+}
+
+function rdapWithPosture(posture: LockPosture): CheckResult {
+	return { category: 'rdap', passed: true, score: 100, findings: [{ category: 'rdap', title: 'Registration details', severity: 'info', detail: '', metadata: { lockPosture: posture } } as never] } as CheckResult;
+}
+
+function rdapFailed(): CheckResult {
+	return { category: 'rdap', passed: false, score: 0, findings: [{ category: 'rdap', title: 'RDAP lookup failed', severity: 'low', detail: '', metadata: { registrarSource: 'lookup_failed' } } as never] } as CheckResult;
+}
+
+afterEach(() => {
+	mockScanDomain.mockReset();
+	mockCheckRdap.mockReset();
+});
+
+describe('mapCscProducts — wiring', () => {
+	it('unlocked RDAP + failing DMARC + passing SSL/DNSSEC → MultiLock high + Managed DMARC; count 2', async () => {
+		mockScanDomain.mockResolvedValue({
+			checks: [check('dmarc', false, [{ title: 'No DMARC record', severity: 'high' }]), check('ssl', true), check('dnssec', true)],
+			score: { overall: 55, grade: 'F' },
+		});
+		mockCheckRdap.mockResolvedValue(rdapWithPosture({ level: 'unlocked', transferLocked: false, deleteLocked: false, updateLocked: false, registryLevel: false, registrarLevel: false }));
+
+		const { mapCscProducts } = await import('../src/tools/map-csc-products');
+		const report = await mapCscProducts('unlocked.com');
+
+		const multilock = report.recommendations.find((r) => r.product === 'csc_multilock')!;
+		const dmarc = report.recommendations.find((r) => r.product === 'managed_dmarc')!;
+		expect(multilock.recommended).toBe(true);
+		expect(multilock.priority).toBe('high');
+		expect(dmarc.recommended).toBe(true);
+		expect(report.recommendations.find((r) => r.product === 'digital_certificates')!.recommended).toBe(false);
+		expect(report.recommendations.find((r) => r.product === 'dnssec_management')!.recommended).toBe(false);
+		expect(report.recommendedCount).toBe(2);
+		expect(report.domain).toBe('unlocked.com');
+		expect(report.score).toBe(55);
+		expect(report.grade).toBe('F');
+	});
+
+	it('RDAP lookup_failed isolates the MultiLock line — scan-driven products still evaluate', async () => {
+		mockScanDomain.mockResolvedValue({
+			checks: [check('dmarc', false, [{ title: 'No DMARC record', severity: 'high' }]), check('ssl', false, [{ title: 'Cert expired', severity: 'high' }]), check('dnssec', true)],
+			score: { overall: 40, grade: 'F' },
+		});
+		mockCheckRdap.mockResolvedValue(rdapFailed());
+
+		const { mapCscProducts } = await import('../src/tools/map-csc-products');
+		const report = await mapCscProducts('failrdap.com');
+
+		expect(report.lockPosture).toBeNull();
+		expect(report.recommendations.find((r) => r.product === 'csc_multilock')!.recommended).toBe(false);
+		expect(report.recommendations.find((r) => r.product === 'managed_dmarc')!.recommended).toBe(true);
+		expect(report.recommendations.find((r) => r.product === 'digital_certificates')!.recommended).toBe(true);
+	});
+});

--- a/test/map-csc-products.spec.ts
+++ b/test/map-csc-products.spec.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import type { CheckResult } from '../src/lib/scoring';
 import type { LockPosture } from '../src/tools/check-rdap-lookup';
-import { evaluateCscProducts, extractLockPosture } from '../src/tools/map-csc-products';
+import { evaluateCscProducts, extractLockPosture, formatCscProducts } from '../src/tools/map-csc-products';
 import type { CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
 
 /** Minimal CheckResult fixture. */
@@ -174,5 +174,37 @@ describe('extractLockPosture', () => {
 			findings: [{ category: 'rdap', title: 'RDAP lookup failed', severity: 'low', detail: '', metadata: { registrarSource: 'lookup_failed' } }],
 		} as unknown as CheckResult;
 		expect(extractLockPosture(rdap)).toBeNull();
+	});
+});
+
+describe('formatCscProducts', () => {
+	function sampleReport(): CscProductReport {
+		return evaluateCscProducts(
+			[makeCheck('dmarc', false, [{ title: 'No DMARC record', severity: 'high' }]), makeCheck('ssl', true), makeCheck('dnssec', true)],
+			lp({ level: 'unlocked', transferLocked: false }),
+			'fmt.com',
+			55,
+			'F',
+		);
+	}
+
+	it('full output names every product and shows justifyingGap for recommended lines', () => {
+		const out = formatCscProducts(sampleReport(), 'full');
+		expect(out).toContain('CSC MultiLock');
+		expect(out).toContain('Managed DMARC');
+		expect(out).toContain('Digital Certificates');
+		expect(out).toContain('DNSSEC management');
+		expect(out).toContain('fmt.com');
+		// recommended MultiLock + DMARC gaps surfaced
+		expect(out).toContain('Domain transfer not locked');
+		expect(out).toContain('DMARC present but not passing');
+	});
+
+	it('compact output is shorter than full and still names the products', () => {
+		const report = sampleReport();
+		const full = formatCscProducts(report, 'full');
+		const compact = formatCscProducts(report, 'compact');
+		expect(compact.length).toBeLessThan(full.length);
+		expect(compact).toContain('CSC MultiLock');
 	});
 });

--- a/test/map-csc-products.spec.ts
+++ b/test/map-csc-products.spec.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import type { CheckResult } from '../src/lib/scoring';
+import type { LockPosture } from '../src/tools/check-rdap-lookup';
+import { evaluateCscProducts } from '../src/tools/map-csc-products';
+import type { CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
+
+/** Minimal CheckResult fixture. */
+function makeCheck(category: string, passed: boolean, findings: Array<{ title: string; severity: string }> = []): CheckResult {
+	return {
+		category,
+		passed,
+		score: passed ? 100 : 0,
+		findings: findings.map((f) => ({ category, title: f.title, severity: f.severity, detail: '' })),
+	} as CheckResult;
+}
+
+/** LockPosture literal builder. */
+function lp(over: Partial<LockPosture>): LockPosture {
+	return {
+		level: 'unknown',
+		transferLocked: false,
+		deleteLocked: false,
+		updateLocked: false,
+		registryLevel: false,
+		registrarLevel: false,
+		...over,
+	};
+}
+
+/** All three scan products passing. */
+function allPassing(): CheckResult[] {
+	return [makeCheck('dmarc', true), makeCheck('ssl', true), makeCheck('dnssec', true)];
+}
+
+function recFor(report: CscProductReport, key: CscProductRecommendation['product']): CscProductRecommendation {
+	const r = report.recommendations.find((x) => x.product === key);
+	if (!r) throw new Error(`no recommendation for ${key}`);
+	return r;
+}
+
+describe('evaluateCscProducts — CSC MultiLock (reads booleans, not level)', () => {
+	it('registry-lock posture (registryLevel true) → not recommended, none', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'registry-lock', registryLevel: true, transferLocked: true }), 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.recommended).toBe(false);
+		expect(m.priority).toBe('none');
+	});
+
+	it('unlocked posture → recommended high, gap mentions transfer', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'unlocked', transferLocked: false }), 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.recommended).toBe(true);
+		expect(m.priority).toBe('high');
+		expect(m.justifyingGap.toLowerCase()).toContain('transfer');
+	});
+
+	it('registrar-lock posture (registrarLevel true, registryLevel false) → recommended medium', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'registrar-lock', registrarLevel: true, transferLocked: true }), 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.recommended).toBe(true);
+		expect(m.priority).toBe('medium');
+	});
+
+	it('null posture → not recommended, gap mentions unobservable', () => {
+		const r = evaluateCscProducts(allPassing(), null, 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.recommended).toBe(false);
+		expect(m.priority).toBe('none');
+		expect(m.justifyingGap.toLowerCase()).toContain('unobservable');
+	});
+
+	it('unknown level → treated like null (unknown is never a gap)', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'unknown' }), 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.recommended).toBe(false);
+		expect(m.priority).toBe('none');
+	});
+
+	it('BOOLEANS guard: level=unlocked but registryLevel=true (server delete lock, no transfer lock) → NOT recommended', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'unlocked', registryLevel: true, transferLocked: false, deleteLocked: true }), 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.recommended).toBe(false);
+	});
+});
+
+describe('evaluateCscProducts — scan-driven products', () => {
+	it('dmarc passing → managed_dmarc not recommended', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'registry-lock', registryLevel: true }), 'a.com', 90, 'A');
+		expect(recFor(r, 'managed_dmarc').recommended).toBe(false);
+	});
+
+	it('dmarc failing with a high finding → recommended high, relatedFindings carries title', () => {
+		const checks = [makeCheck('dmarc', false, [{ title: 'No DMARC record', severity: 'high' }]), makeCheck('ssl', true), makeCheck('dnssec', true)];
+		const m = recFor(evaluateCscProducts(checks, null, 'a.com', 50, 'F'), 'managed_dmarc');
+		expect(m.recommended).toBe(true);
+		expect(m.priority).toBe('high');
+		expect(m.relatedFindings).toContain('No DMARC record');
+	});
+
+	it('dmarc failing with only medium findings → priority medium', () => {
+		const checks = [makeCheck('dmarc', false, [{ title: 'Weak DMARC policy', severity: 'medium' }]), makeCheck('ssl', true), makeCheck('dnssec', true)];
+		expect(recFor(evaluateCscProducts(checks, null, 'a.com', 60, 'D'), 'managed_dmarc').priority).toBe('medium');
+	});
+
+	it('dmarc absent from checks → recommended low, gap "not observed"', () => {
+		const checks = [makeCheck('ssl', true), makeCheck('dnssec', true)];
+		const m = recFor(evaluateCscProducts(checks, null, 'a.com', 60, 'D'), 'managed_dmarc');
+		expect(m.recommended).toBe(true);
+		expect(m.priority).toBe('low');
+		expect(m.justifyingGap.toLowerCase()).toContain('not observed');
+	});
+
+	it('ssl failing → digital_certificates recommended; ssl passing → not', () => {
+		const fail = [makeCheck('dmarc', true), makeCheck('ssl', false, [{ title: 'Certificate expired', severity: 'high' }]), makeCheck('dnssec', true)];
+		expect(recFor(evaluateCscProducts(fail, null, 'a.com', 60, 'D'), 'digital_certificates').recommended).toBe(true);
+		expect(recFor(evaluateCscProducts(allPassing(), null, 'a.com', 90, 'A'), 'digital_certificates').recommended).toBe(false);
+	});
+
+	it('dnssec failing → dnssec_management medium; absent → low', () => {
+		const fail = [makeCheck('dmarc', true), makeCheck('ssl', true), makeCheck('dnssec', false, [{ title: 'DNSSEC not enabled', severity: 'medium' }])];
+		expect(recFor(evaluateCscProducts(fail, null, 'a.com', 70, 'C'), 'dnssec_management').priority).toBe('medium');
+		const absent = [makeCheck('dmarc', true), makeCheck('ssl', true)];
+		expect(recFor(evaluateCscProducts(absent, null, 'a.com', 70, 'C'), 'dnssec_management').priority).toBe('low');
+	});
+
+	it('relatedFindings excludes info-severity findings', () => {
+		const checks = [makeCheck('dmarc', false, [{ title: 'Real gap', severity: 'high' }, { title: 'Just info', severity: 'info' }]), makeCheck('ssl', true), makeCheck('dnssec', true)];
+		const m = recFor(evaluateCscProducts(checks, null, 'a.com', 50, 'F'), 'managed_dmarc');
+		expect(m.relatedFindings).toContain('Real gap');
+		expect(m.relatedFindings).not.toContain('Just info');
+	});
+});
+
+describe('evaluateCscProducts — report shape', () => {
+	it('exactly 4 recommendations in fixed order; recommendedCount matches; passthrough fields', () => {
+		const posture = lp({ level: 'unlocked', transferLocked: false });
+		const r = evaluateCscProducts([makeCheck('dmarc', false, [{ title: 'x', severity: 'high' }]), makeCheck('ssl', true), makeCheck('dnssec', true)], posture, 'shape.com', 42, 'F');
+		expect(r.recommendations.map((x) => x.product)).toEqual(['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management']);
+		expect(r.recommendedCount).toBe(r.recommendations.filter((x) => x.recommended).length);
+		expect(r.recommendedCount).toBe(2); // multilock high + dmarc high
+		expect(r.lockPosture).toEqual(posture);
+		expect(r.domain).toBe('shape.com');
+		expect(r.score).toBe(42);
+		expect(r.grade).toBe('F');
+	});
+
+	it('all-clean: all-pass checks + registry-lock posture → recommendedCount 0, every priority none', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'registry-lock', registryLevel: true, transferLocked: true }), 'clean.com', 98, 'A+');
+		expect(r.recommendedCount).toBe(0);
+		expect(r.recommendations.every((x) => x.priority === 'none')).toBe(true);
+		expect(r.recommendations.every((x) => x.recommended === false)).toBe(true);
+	});
+});

--- a/test/map-csc-products.spec.ts
+++ b/test/map-csc-products.spec.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import type { CheckResult } from '../src/lib/scoring';
 import type { LockPosture } from '../src/tools/check-rdap-lookup';
-import { evaluateCscProducts } from '../src/tools/map-csc-products';
+import { evaluateCscProducts, extractLockPosture } from '../src/tools/map-csc-products';
 import type { CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
 
 /** Minimal CheckResult fixture. */
@@ -151,5 +151,28 @@ describe('evaluateCscProducts — report shape', () => {
 		expect(r.recommendedCount).toBe(0);
 		expect(r.recommendations.every((x) => x.priority === 'none')).toBe(true);
 		expect(r.recommendations.every((x) => x.recommended === false)).toBe(true);
+	});
+});
+
+describe('extractLockPosture', () => {
+	it('returns the posture from a finding carrying metadata.lockPosture', () => {
+		const posture = lp({ level: 'registrar-lock', registrarLevel: true, transferLocked: true });
+		const rdap = {
+			category: 'rdap',
+			passed: true,
+			score: 100,
+			findings: [{ category: 'rdap', title: 'Registration details', severity: 'info', detail: '', metadata: { lockPosture: posture } }],
+		} as unknown as CheckResult;
+		expect(extractLockPosture(rdap)).toEqual(posture);
+	});
+
+	it('returns null when no finding carries lock metadata (lookup_failed shape)', () => {
+		const rdap = {
+			category: 'rdap',
+			passed: false,
+			score: 0,
+			findings: [{ category: 'rdap', title: 'RDAP lookup failed', severity: 'low', detail: '', metadata: { registrarSource: 'lookup_failed' } }],
+		} as unknown as CheckResult;
+		expect(extractLockPosture(rdap)).toBeNull();
 	});
 });

--- a/test/prioritize-csc-leads.integration.test.ts
+++ b/test/prioritize-csc-leads.integration.test.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { CheckResult } from '../src/lib/scoring';
+import type { LockPosture } from '../src/tools/check-rdap-lookup';
+import type { DiscoveredCandidate } from '../src/tools/prioritize-csc-leads';
+import { IN_MEMORY_CACHE } from '../src/lib/cache';
+
+const mockScanDomain = vi.fn();
+const mockCheckRdap = vi.fn();
+
+vi.mock('../src/tools/scan-domain', () => ({
+	scanDomain: (...args: unknown[]) => mockScanDomain(...args),
+}));
+
+vi.mock('../src/tools/check-rdap-lookup', async (importOriginal) => {
+	const orig = await importOriginal<typeof import('../src/tools/check-rdap-lookup')>();
+	return {
+		...orig,
+		checkRdapLookup: (...args: unknown[]) => mockCheckRdap(...args),
+	};
+});
+
+function check(category: string, passed: boolean, findings: Array<{ title: string; severity: string }> = []): CheckResult {
+	return { category, passed, score: passed ? 100 : 0, findings: findings.map((f) => ({ category, title: f.title, severity: f.severity, detail: '' })) } as CheckResult;
+}
+
+function scan(checks: CheckResult[], overall: number, grade: string) {
+	return { checks, score: { overall, grade } };
+}
+
+function rdapWithPosture(posture: LockPosture): CheckResult {
+	return { category: 'rdap', passed: true, score: 100, findings: [{ category: 'rdap', title: 'Registration details', severity: 'info', detail: '', metadata: { lockPosture: posture } } as never] } as CheckResult;
+}
+
+function rdapFailed(): CheckResult {
+	return { category: 'rdap', passed: false, score: 0, findings: [{ category: 'rdap', title: 'RDAP lookup failed', severity: 'low', detail: '', metadata: { registrarSource: 'lookup_failed' } } as never] } as CheckResult;
+}
+
+const lp = (over: Partial<LockPosture>): LockPosture => ({ level: 'unknown', transferLocked: false, deleteLocked: false, updateLocked: false, registryLevel: false, registrarLevel: false, ...over });
+
+afterEach(() => {
+	mockScanDomain.mockReset();
+	mockCheckRdap.mockReset();
+	IN_MEMORY_CACHE.clear();
+});
+
+describe('prioritizeCscLeads — domains[] path', () => {
+	it('ranks three domains hottest-first; each ownershipBucket is "unknown"', async () => {
+		// hot: unlocked + failing DMARC; warm: registrar-lock + failing SSL; cold: registry-lock + clean
+		mockScanDomain.mockImplementation((domain: string) => {
+			if (domain === 'hot.com') return Promise.resolve(scan([check('dmarc', false, [{ title: 'No DMARC', severity: 'high' }]), check('ssl', true), check('dnssec', true)], 45, 'F'));
+			if (domain === 'warm.com') return Promise.resolve(scan([check('dmarc', true), check('ssl', false, [{ title: 'Cert expired', severity: 'high' }]), check('dnssec', true)], 70, 'C'));
+			return Promise.resolve(scan([check('dmarc', true), check('ssl', true), check('dnssec', true)], 95, 'A+'));
+		});
+		mockCheckRdap.mockImplementation((domain: string) => {
+			if (domain === 'hot.com') return Promise.resolve(rdapWithPosture(lp({ level: 'unlocked', transferLocked: false })));
+			if (domain === 'warm.com') return Promise.resolve(rdapWithPosture(lp({ level: 'registrar-lock', registrarLevel: true, transferLocked: true })));
+			return Promise.resolve(rdapWithPosture(lp({ level: 'registry-lock', registryLevel: true, transferLocked: true })));
+		});
+
+		const { prioritizeCscLeads } = await import('../src/tools/prioritize-csc-leads');
+		const report = await prioritizeCscLeads({ domains: ['cold.com', 'warm.com', 'hot.com'] });
+
+		expect(report.brand).toBeNull();
+		expect(report.totalDomains).toBe(3);
+		expect(report.rankedLeads[0].domain).toBe('hot.com');
+		expect(report.rankedLeads[report.rankedLeads.length - 1].domain).toBe('cold.com');
+		expect(report.rankedLeads.every((l) => l.ownershipBucket === 'unknown')).toBe(true);
+		// cold.com: registry locked + all passing → 0 recommendations
+		const cold = report.rankedLeads.find((l) => l.domain === 'cold.com')!;
+		expect(cold.recommendedCount).toBe(0);
+	});
+
+	it('per-domain isolation: a scan throw lands in summary.skipped, others still rank', async () => {
+		mockScanDomain.mockImplementation((domain: string) => {
+			if (domain === 'boom.com') return Promise.reject(new Error('scan exploded'));
+			return Promise.resolve(scan([check('dmarc', false, [{ title: 'No DMARC', severity: 'high' }]), check('ssl', true), check('dnssec', true)], 50, 'F'));
+		});
+		mockCheckRdap.mockResolvedValue(rdapWithPosture(lp({ level: 'unlocked', transferLocked: false })));
+
+		const { prioritizeCscLeads } = await import('../src/tools/prioritize-csc-leads');
+		const report = await prioritizeCscLeads({ domains: ['ok1.com', 'boom.com', 'ok2.com'] });
+
+		expect(report.totalDomains).toBe(2);
+		expect(report.rankedLeads.map((l) => l.domain).sort()).toEqual(['ok1.com', 'ok2.com']);
+		expect(report.summary.skipped.map((s) => s.domain)).toContain('boom.com');
+	});
+
+	it('RDAP failure isolation: MultiLock not recommended while scan-driven products still evaluate', async () => {
+		mockScanDomain.mockResolvedValue(scan([check('dmarc', false, [{ title: 'No DMARC', severity: 'high' }]), check('ssl', false, [{ title: 'Cert expired', severity: 'high' }]), check('dnssec', true)], 40, 'F'));
+		mockCheckRdap.mockResolvedValue(rdapFailed());
+
+		const { prioritizeCscLeads } = await import('../src/tools/prioritize-csc-leads');
+		const report = await prioritizeCscLeads({ domains: ['failrdap.com'] });
+
+		const lead = report.rankedLeads[0];
+		expect(lead.recommendedCscProducts).not.toContain('csc_multilock');
+		expect(lead.recommendedCscProducts).toContain('managed_dmarc');
+		expect(lead.recommendedCscProducts).toContain('digital_certificates');
+	});
+});
+
+describe('prioritizeCscLeads — brand path (injected discovery)', () => {
+	it('maps discovered buckets; impersonation discounted by the 0.3 multiplier; report.brand set', async () => {
+		mockScanDomain.mockResolvedValue(scan([check('dmarc', false, [{ title: 'No DMARC', severity: 'high' }]), check('ssl', true), check('dnssec', true)], 50, 'F'));
+		mockCheckRdap.mockResolvedValue(rdapWithPosture(lp({ level: 'unlocked', transferLocked: false })));
+
+		const discoverPortfolio = vi.fn(async (): Promise<DiscoveredCandidate[]> => [
+			{ domain: 'owned1.com', ownershipBucket: 'consolidated' },
+			{ domain: 'owned2.com', ownershipBucket: 'consolidated' },
+			{ domain: 'typo.com', ownershipBucket: 'impersonation' },
+		]);
+
+		const { prioritizeCscLeads } = await import('../src/tools/prioritize-csc-leads');
+		const report = await prioritizeCscLeads({ brand: 'acme' }, undefined, undefined, { discoverPortfolio });
+
+		expect(report.brand).toBe('acme');
+		expect(report.totalDomains).toBe(3);
+		const typo = report.rankedLeads.find((l) => l.domain === 'typo.com')!;
+		const owned = report.rankedLeads.find((l) => l.domain === 'owned1.com')!;
+		// identical reports → owned (×1.0) outranks typo (×0.3)
+		expect(typo.gapSeverity).toBeLessThan(owned.gapSeverity);
+		expect(typo.ownershipBucket).toBe('impersonation');
+	});
+
+	it('discovery yielding no candidates → rankedLeads [] + a discovery_incomplete skipped note; report.brand set', async () => {
+		const discoverPortfolio = vi.fn(async (): Promise<DiscoveredCandidate[]> => []);
+		const { prioritizeCscLeads } = await import('../src/tools/prioritize-csc-leads');
+		const report = await prioritizeCscLeads({ brand: 'empty' }, undefined, undefined, { discoverPortfolio });
+
+		expect(report.brand).toBe('empty');
+		expect(report.rankedLeads).toEqual([]);
+		expect(report.summary.skipped.some((s) => s.reason === 'discovery_incomplete')).toBe(true);
+	});
+});

--- a/test/prioritize-csc-leads.integration.test.ts
+++ b/test/prioritize-csc-leads.integration.test.ts
@@ -8,6 +8,7 @@ import { IN_MEMORY_CACHE } from '../src/lib/cache';
 
 const mockScanDomain = vi.fn();
 const mockCheckRdap = vi.fn();
+const mockBrandAuditSingle = vi.fn();
 
 vi.mock('../src/tools/scan-domain', () => ({
 	scanDomain: (...args: unknown[]) => mockScanDomain(...args),
@@ -18,6 +19,14 @@ vi.mock('../src/tools/check-rdap-lookup', async (importOriginal) => {
 	return {
 		...orig,
 		checkRdapLookup: (...args: unknown[]) => mockCheckRdap(...args),
+	};
+});
+
+vi.mock('../src/tools/brand-audit-single', async (importOriginal) => {
+	const orig = await importOriginal<typeof import('../src/tools/brand-audit-single')>();
+	return {
+		...orig,
+		brandAuditSingle: (...args: unknown[]) => mockBrandAuditSingle(...args),
 	};
 });
 
@@ -42,6 +51,7 @@ const lp = (over: Partial<LockPosture>): LockPosture => ({ level: 'unknown', tra
 afterEach(() => {
 	mockScanDomain.mockReset();
 	mockCheckRdap.mockReset();
+	mockBrandAuditSingle.mockReset();
 	IN_MEMORY_CACHE.clear();
 });
 
@@ -132,5 +142,49 @@ describe('prioritizeCscLeads — brand path (injected discovery)', () => {
 		expect(report.brand).toBe('empty');
 		expect(report.rankedLeads).toEqual([]);
 		expect(report.summary.skipped.some((s) => s.reason === 'discovery_incomplete')).toBe(true);
+	});
+});
+
+describe('prioritizeCscLeads — brand path (real defaultDiscoverPortfolio, no injected deps)', () => {
+	it('calls brandAuditSingle with async_handoff + deadlineMs and WITHOUT kv; extracts candidates into a ranked report', async () => {
+		// brandAuditSingle returns a result with one consolidated candidate
+		const candidateResult = {
+			category: 'brand_discovery',
+			passed: true,
+			score: 100,
+			findings: [
+				{
+					category: 'brand_discovery',
+					title: 'Brand candidate: portfolio.com',
+					severity: 'info',
+					detail: '',
+					metadata: { candidate: 'portfolio.com', bucket: 'consolidated' },
+				},
+			],
+		};
+		mockBrandAuditSingle.mockResolvedValue(candidateResult);
+
+		// evaluateOne (scan + RDAP) for the discovered candidate
+		mockScanDomain.mockResolvedValue({ checks: [], score: { overall: 80, grade: 'B' } });
+		mockCheckRdap.mockResolvedValue(rdapFailed());
+
+		const { prioritizeCscLeads } = await import('../src/tools/prioritize-csc-leads');
+		// Omit deps entirely — exercises defaultDiscoverPortfolio (the real brand path)
+		const report = await prioritizeCscLeads({ brand: 'real-brand' });
+
+		// brandAuditSingle was called by defaultDiscoverPortfolio
+		expect(mockBrandAuditSingle).toHaveBeenCalledOnce();
+		const [target, options] = mockBrandAuditSingle.mock.calls[0] as [string, Record<string, unknown>];
+		expect(target).toBe('real-brand');
+		expect(options.timeoutBehavior).toBe('async_handoff');
+		expect(typeof options.deadlineMs).toBe('number');
+		// kv was the latent bug — it is not part of BrandAuditSingleOptions and must not be forwarded
+		expect(options).not.toHaveProperty('kv');
+
+		// The discovered candidate feeds into the lead report
+		expect(report.brand).toBe('real-brand');
+		expect(report.totalDomains).toBe(1);
+		expect(report.rankedLeads[0].domain).toBe('portfolio.com');
+		expect(report.rankedLeads[0].ownershipBucket).toBe('consolidated');
 	});
 });

--- a/test/prioritize-csc-leads.spec.ts
+++ b/test/prioritize-csc-leads.spec.ts
@@ -3,8 +3,8 @@
 import { describe, it, expect } from 'vitest';
 import type { Bucket } from '../src/lib/brand-classification';
 import type { CscProductKey, CscPriority, CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
-import { bucketFromClassification, computeGapSeverity } from '../src/tools/prioritize-csc-leads';
-import type { OwnershipBucket } from '../src/tools/prioritize-csc-leads';
+import { bucketFromClassification, computeGapSeverity, rankCscLeads } from '../src/tools/prioritize-csc-leads';
+import type { OwnershipBucket, CscLeadEntry } from '../src/tools/prioritize-csc-leads';
 
 const PRODUCT_ORDER: CscProductKey[] = ['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management'];
 
@@ -71,5 +71,97 @@ describe('computeGapSeverity', () => {
 	it('bucket unknown multiplier is 1.0 (bare-list path not penalized)', () => {
 		const report = makeReport('a.com', 50, 'F', [rec('csc_multilock', true, 'high')]);
 		expect(computeGapSeverity(report, 'unknown')).toBe(12);
+	});
+});
+
+/** Build a lead entry: a report (with the given recommendations) + an ownership bucket. */
+function entry(domain: string, score: number, grade: string, recs: CscProductRecommendation[], bucket: OwnershipBucket): CscLeadEntry {
+	return { report: makeReport(domain, score, grade, recs), ownershipBucket: bucket };
+}
+
+describe('rankCscLeads — ordering and ranks', () => {
+	it('orders by gapSeverity descending; priorityRank is 1-based', () => {
+		// sev 12 (multilock high), 4 (multilock high × impersonation 0.3), 20 (multilock high + dmarc medium + dnssec low)
+		const e12 = entry('twelve.com', 80, 'B', [rec('csc_multilock', true, 'high')], 'unknown');
+		const e4 = entry('four.com', 80, 'B', [rec('csc_multilock', true, 'high')], 'impersonation');
+		const e20 = entry('twenty.com', 80, 'B', [rec('csc_multilock', true, 'high'), rec('managed_dmarc', true, 'medium'), rec('dnssec_management', true, 'low')], 'unknown');
+		const report = rankCscLeads([e12, e4, e20]);
+		expect(report.rankedLeads.map((l) => l.domain)).toEqual(['twenty.com', 'twelve.com', 'four.com']);
+		expect(report.rankedLeads.map((l) => l.priorityRank)).toEqual([1, 2, 3]);
+		expect(report.rankedLeads[0].gapSeverity).toBe(20);
+	});
+
+	it('tie on gapSeverity → lower score ranks first', () => {
+		const a = entry('a.com', 70, 'C', [rec('csc_multilock', true, 'high')], 'unknown'); // sev 12, score 70
+		const b = entry('b.com', 40, 'F', [rec('csc_multilock', true, 'high')], 'unknown'); // sev 12, score 40
+		const report = rankCscLeads([a, b]);
+		expect(report.rankedLeads.map((l) => l.domain)).toEqual(['b.com', 'a.com']);
+	});
+
+	it('tie on gapSeverity AND score → domain ascending (lexical total order)', () => {
+		const b = entry('b.com', 50, 'F', [rec('csc_multilock', true, 'high')], 'unknown');
+		const a = entry('a.com', 50, 'F', [rec('csc_multilock', true, 'high')], 'unknown');
+		const report = rankCscLeads([b, a]);
+		expect(report.rankedLeads.map((l) => l.domain)).toEqual(['a.com', 'b.com']);
+	});
+});
+
+describe('rankCscLeads — per-lead fields', () => {
+	it('recommendedCscProducts = recommended keys in fixed product order; recommendedCount matches', () => {
+		const e = entry('x.com', 60, 'D', [rec('csc_multilock', true, 'high'), rec('digital_certificates', true, 'medium')], 'consolidated');
+		const lead = rankCscLeads([e]).rankedLeads[0];
+		expect(lead.recommendedCscProducts).toEqual(['csc_multilock', 'digital_certificates']);
+		expect(lead.recommendedCount).toBe(2);
+	});
+
+	it('topPriority = max priority among recommended; none when nothing recommended', () => {
+		const hi = entry('hi.com', 60, 'D', [rec('csc_multilock', true, 'medium'), rec('managed_dmarc', true, 'high')], 'unknown');
+		expect(rankCscLeads([hi]).rankedLeads[0].topPriority).toBe('high');
+		const clean = entry('clean.com', 98, 'A+', [], 'unknown');
+		expect(rankCscLeads([clean]).rankedLeads[0].topPriority).toBe('none');
+	});
+
+	it('pass-through: domain/score/grade/ownershipBucket copied verbatim; grade "N/A" preserved', () => {
+		const e = entry('p.com', 0, 'N/A', [rec('csc_multilock', true, 'high')], 'shadowIt');
+		const lead = rankCscLeads([e]).rankedLeads[0];
+		expect(lead.domain).toBe('p.com');
+		expect(lead.score).toBe(0);
+		expect(lead.grade).toBe('N/A');
+		expect(lead.ownershipBucket).toBe('shadowIt');
+	});
+});
+
+describe('rankCscLeads — summary', () => {
+	it('byProduct counts domains needing each product; totalRecommendations = Σ recommendedCount; hotLeads counts gapSeverity >= 6', () => {
+		const e1 = entry('one.com', 50, 'F', [rec('csc_multilock', true, 'high'), rec('managed_dmarc', true, 'medium')], 'unknown'); // sev 18, recs 2
+		const e2 = entry('two.com', 90, 'A', [rec('managed_dmarc', true, 'low')], 'unknown'); // sev 3, recs 1
+		const report = rankCscLeads([e1, e2]);
+		expect(report.summary.byProduct).toEqual({ csc_multilock: 1, managed_dmarc: 2, digital_certificates: 0, dnssec_management: 0 });
+		expect(report.summary.totalRecommendations).toBe(3);
+		expect(report.summary.hotLeads).toBe(1); // only one.com (18) clears 6; two.com (3) does not
+	});
+
+	it('skipped passed through; totalDomains counts only ranked leads, not skipped', () => {
+		const e = entry('ok.com', 50, 'F', [rec('csc_multilock', true, 'high')], 'unknown');
+		const report = rankCscLeads([e], null, [{ domain: 'bad.com', reason: 'invalid_domain' }]);
+		expect(report.summary.skipped).toEqual([{ domain: 'bad.com', reason: 'invalid_domain' }]);
+		expect(report.totalDomains).toBe(1);
+		expect(report.rankedLeads).toHaveLength(1);
+	});
+
+	it('empty input → rankedLeads [], summary zeroes, no throw', () => {
+		const report = rankCscLeads([]);
+		expect(report.rankedLeads).toEqual([]);
+		expect(report.totalDomains).toBe(0);
+		expect(report.summary.totalRecommendations).toBe(0);
+		expect(report.summary.hotLeads).toBe(0);
+		expect(report.summary.byProduct).toEqual({ csc_multilock: 0, managed_dmarc: 0, digital_certificates: 0, dnssec_management: 0 });
+		expect(report.summary.skipped).toEqual([]);
+	});
+
+	it('brand pass-through: report.brand set when provided, null otherwise', () => {
+		const e = entry('z.com', 50, 'F', [], 'unknown');
+		expect(rankCscLeads([e], 'acme').brand).toBe('acme');
+		expect(rankCscLeads([e]).brand).toBeNull();
 	});
 });

--- a/test/prioritize-csc-leads.spec.ts
+++ b/test/prioritize-csc-leads.spec.ts
@@ -3,7 +3,7 @@
 import { describe, it, expect } from 'vitest';
 import type { Bucket } from '../src/lib/brand-classification';
 import type { CscProductKey, CscPriority, CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
-import { bucketFromClassification, computeGapSeverity, rankCscLeads } from '../src/tools/prioritize-csc-leads';
+import { bucketFromClassification, computeGapSeverity, rankCscLeads, formatCscLeads } from '../src/tools/prioritize-csc-leads';
 import type { OwnershipBucket, CscLeadEntry } from '../src/tools/prioritize-csc-leads';
 
 const PRODUCT_ORDER: CscProductKey[] = ['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management'];
@@ -163,5 +163,34 @@ describe('rankCscLeads — summary', () => {
 		const e = entry('z.com', 50, 'F', [], 'unknown');
 		expect(rankCscLeads([e], 'acme').brand).toBe('acme');
 		expect(rankCscLeads([e]).brand).toBeNull();
+	});
+});
+
+describe('formatCscLeads', () => {
+	function sampleReport() {
+		const hot = entry('hot.com', 40, 'F', [rec('csc_multilock', true, 'high'), rec('managed_dmarc', true, 'high')], 'consolidated');
+		const cold = entry('cold.com', 95, 'A+', [], 'unknown');
+		return rankCscLeads([hot, cold], 'acme');
+	}
+
+	it('full output lists leads in rank order with domain, score/grade, products and a summary block', () => {
+		const out = formatCscLeads(sampleReport(), 'full');
+		expect(out).toContain('acme');
+		expect(out).toContain('hot.com');
+		expect(out).toContain('cold.com');
+		expect(out).toContain('40/100');
+		expect(out).toContain('csc_multilock');
+		// rank order: hot.com (rank 1) appears before cold.com
+		expect(out.indexOf('hot.com')).toBeLessThan(out.indexOf('cold.com'));
+		// a summary rollup is present
+		expect(out.toLowerCase()).toContain('summary');
+	});
+
+	it('compact output is shorter than full and still names the top lead', () => {
+		const report = sampleReport();
+		const full = formatCscLeads(report, 'full');
+		const compact = formatCscLeads(report, 'compact');
+		expect(compact.length).toBeLessThan(full.length);
+		expect(compact).toContain('hot.com');
 	});
 });

--- a/test/prioritize-csc-leads.spec.ts
+++ b/test/prioritize-csc-leads.spec.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import type { Bucket } from '../src/lib/brand-classification';
+import type { CscProductKey, CscPriority, CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
+import { bucketFromClassification, computeGapSeverity } from '../src/tools/prioritize-csc-leads';
+import type { OwnershipBucket } from '../src/tools/prioritize-csc-leads';
+
+const PRODUCT_ORDER: CscProductKey[] = ['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management'];
+
+/** Build one recommendation. productName is cosmetic for these pure tests. */
+function rec(product: CscProductKey, recommended: boolean, priority: CscPriority): CscProductRecommendation {
+	return { product, productName: product, recommended, priority, justifyingGap: '', relatedFindings: [] };
+}
+
+/** Build a CscProductReport with all 4 recommendations in fixed order; missing ones default to not-recommended/none. */
+function makeReport(domain: string, score: number, grade: string, recs: CscProductRecommendation[]): CscProductReport {
+	const byKey = new Map(recs.map((r) => [r.product, r]));
+	const recommendations = PRODUCT_ORDER.map((k) => byKey.get(k) ?? rec(k, false, 'none'));
+	return {
+		domain,
+		score,
+		grade,
+		lockPosture: null,
+		recommendations,
+		recommendedCount: recommendations.filter((r) => r.recommended).length,
+	};
+}
+
+describe('bucketFromClassification', () => {
+	it('maps each classifyCandidate Bucket to the same-named OwnershipBucket', () => {
+		const cases: Array<[Bucket, OwnershipBucket]> = [
+			['consolidated', 'consolidated'],
+			['shadowIt', 'shadowIt'],
+			['indeterminate', 'indeterminate'],
+			['impersonation', 'impersonation'],
+			['impersonationSurface', 'impersonationSurface'],
+		];
+		for (const [input, expected] of cases) {
+			expect(bucketFromClassification(input)).toBe(expected);
+		}
+	});
+});
+
+describe('computeGapSeverity', () => {
+	it('all-clean report (recommendedCount 0) + any bucket → 0', () => {
+		const report = makeReport('clean.com', 98, 'A+', []);
+		expect(computeGapSeverity(report, 'consolidated')).toBe(0);
+		expect(computeGapSeverity(report, 'impersonation')).toBe(0);
+	});
+
+	it('MultiLock high only (4×3=12), bucket consolidated (×1.0) → 12', () => {
+		const report = makeReport('a.com', 90, 'A', [rec('csc_multilock', true, 'high')]);
+		expect(computeGapSeverity(report, 'consolidated')).toBe(12);
+	});
+
+	it('same report, bucket impersonation (×0.3) → round(3.6) = 4', () => {
+		const report = makeReport('a.com', 90, 'A', [rec('csc_multilock', true, 'high')]);
+		expect(computeGapSeverity(report, 'impersonation')).toBe(4);
+	});
+
+	it('multiple recommendations sum: MultiLock high(12) + DMARC medium(6) + DNSSEC low(2), bucket unknown → 20', () => {
+		const report = makeReport('a.com', 50, 'F', [
+			rec('csc_multilock', true, 'high'),
+			rec('managed_dmarc', true, 'medium'),
+			rec('dnssec_management', true, 'low'),
+		]);
+		expect(computeGapSeverity(report, 'unknown')).toBe(20);
+	});
+
+	it('bucket unknown multiplier is 1.0 (bare-list path not penalized)', () => {
+		const report = makeReport('a.com', 50, 'F', [rec('csc_multilock', true, 'high')]);
+		expect(computeGapSeverity(report, 'unknown')).toBe(12);
+	});
+});

--- a/test/prioritize-csc-leads.spec.ts
+++ b/test/prioritize-csc-leads.spec.ts
@@ -3,7 +3,8 @@
 import { describe, it, expect } from 'vitest';
 import type { Bucket } from '../src/lib/brand-classification';
 import type { CscProductKey, CscPriority, CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
-import { bucketFromClassification, computeGapSeverity, rankCscLeads, formatCscLeads } from '../src/tools/prioritize-csc-leads';
+import type { CheckResult } from '../src/lib/scoring';
+import { bucketFromClassification, computeGapSeverity, rankCscLeads, formatCscLeads, extractDiscoveredCandidates } from '../src/tools/prioritize-csc-leads';
 import type { OwnershipBucket, CscLeadEntry } from '../src/tools/prioritize-csc-leads';
 
 const PRODUCT_ORDER: CscProductKey[] = ['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management'];
@@ -192,5 +193,48 @@ describe('formatCscLeads', () => {
 		const compact = formatCscLeads(report, 'compact');
 		expect(compact.length).toBeLessThan(full.length);
 		expect(compact).toContain('hot.com');
+	});
+});
+
+describe('extractDiscoveredCandidates', () => {
+	function candidateResult(): CheckResult {
+		return {
+			category: 'brand_discovery',
+			passed: true,
+			score: 100,
+			findings: [
+				{ category: 'brand_discovery', title: 'Summary', severity: 'info', detail: '', metadata: { surfaced: 2 } },
+				{ category: 'brand_discovery', title: 'Brand candidate: owned.com', severity: 'low', detail: '', metadata: { candidate: 'owned.com', bucket: 'consolidated' } },
+				{ category: 'brand_discovery', title: 'Brand candidate: typo.com', severity: 'info', detail: '', metadata: { candidate: 'typo.com', bucket: 'impersonation' } },
+			],
+		} as unknown as CheckResult;
+	}
+
+	it('maps candidate findings to {domain, ownershipBucket}; ignores non-candidate findings', () => {
+		const out = extractDiscoveredCandidates(candidateResult());
+		expect(out).toEqual([
+			{ domain: 'owned.com', ownershipBucket: 'consolidated' },
+			{ domain: 'typo.com', ownershipBucket: 'impersonation' },
+		]);
+	});
+
+	it('defaults a candidate with no bucket metadata to indeterminate', () => {
+		const result = {
+			category: 'brand_discovery',
+			passed: true,
+			score: 100,
+			findings: [{ category: 'brand_discovery', title: 'Brand candidate: x.com', severity: 'info', detail: '', metadata: { candidate: 'x.com' } }],
+		} as unknown as CheckResult;
+		expect(extractDiscoveredCandidates(result)).toEqual([{ domain: 'x.com', ownershipBucket: 'indeterminate' }]);
+	});
+
+	it('returns [] when no finding carries a candidate (async-handoff / failure shape)', () => {
+		const result = {
+			category: 'brand_discovery',
+			passed: false,
+			score: 0,
+			findings: [{ category: 'brand_discovery', title: 'Brand audit requires async processing', severity: 'info', detail: '', metadata: { asyncHandoff: true } }],
+		} as unknown as CheckResult;
+		expect(extractDiscoveredCandidates(result)).toEqual([]);
 	});
 });


### PR DESCRIPTION
## Corporate-registrar engagement — Specs A–C (branch bundles three dependent features)

Delivers the backend the registrar portal consumes, from the 2026-07-01 partner meeting. Design docs/plans live in a gitignored local directory (not in this diff).

### Spec A — Domain lock posture (`rdap_lookup`)
Enriches `check_rdap_lookup` to classify EPP/registry-lock status. Pure `deriveLockPosture()` handles both EPP camelCase and RDAP space-separated forms; surfaces `metadata.lockPosture` + a transfer-driven finding (`unlocked`=medium, registrar/registry lock=info). **No scoring impact** (`rdap` is `scanIncluded:false`, not in `CATEGORY_TIERS`).

### Spec B — Registrar product mapping (`map_registrar_products`)
Maps a domain's gaps → registrar products (registry lock, Managed DMARC, Digital Certificates, DNSSEC), reading lock posture + DMARC/SSL/DNSSEC. Standalone `intelligence` tool. Scan + RDAP now run in parallel (`Promise.all`, bounded ~24s < 28s tool timeout).

### Spec C — Sales lead prioritization (`prioritize_portfolio_leads`)
Ranks a brand portfolio (or explicit `domains[]`) into prioritized portfolio leads by gap-severity × product-fit. Multi-domain, **paid-gated** (developer+). Real brand path now covered by a smoke test; removed an `as never` cast that was hiding a `kv`-forwarding bug.

### SSOT / audits
Two new tools → `EXPECTED_TOOL_COUNT` 79→81. Both wired across all non-scoring SSOT surfaces (TOOL_DEFS, tool-args, registry, quotas, gating, README/vscode counts, generated Rust perms, chaos matrix).

### Verification
- `npm run typecheck` → **exit 0**
- Full suite → **5789 passed** (the only 2 "failures" are gitignored `.firecrawl/*` scratch, 0 tracked files under it)
- SSOT/gating audits + both new tools' specs+integration → green (49/49 on the new files)

### Deferred (design-only, not in this PR)
Spec D (Penumbra 3-brand portal + onboarding wizard) — self-reviewed design specs + TDD impl plans in the gitignored local directory, for a bv-web-prod session. Two known follow-ups for that session: brand-grade aggregation belongs in a bv-mcp endpoint (not client-side); `OwnershipBucket` weights need pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
