### PR TITLE
fix(security): make map_registrar_products internal-only (3.27.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.27.1] - 2026-07-01
+
+Patch release (security): make `map_csc_products` **internal-only**. It shipped in 3.27.0 as a public, free-tier-callable MCP tool, but it maps domains to CSC's specific commercial products and belongs off the public surface.
+
+### Security
+
+- **`map_csc_products` removed from the public MCP surface.** New `INTERNAL_ONLY_TOOLS` concept (`src/lib/config.ts`): the tool stays registered in `TOOL_DEFS`/`TOOLS` — still callable via `/internal/tools/*` and internally by `prioritize_csc_leads` — but is filtered out of the public `tools/list` and rejected on public `tools/call` with the same unknown-tool result a nonexistent tool returns (no existence leak, no `403`). Rejection is enforced only in `executeMcpRequest` (public `/mcp` path); the internal path is unaffected. Public tool count is now 80 (`TOOLS.length` stays 81); `map_csc_products` dropped from `FREE_TOOL_DAILY_LIMITS`.
+
 ## [3.27.0] - 2026-07-01
 
 Minor release: CSC engagement — domain lock posture + CSC product mapping + sales lead prioritization (Specs A–C). Adds two MCP tools (79 → 81).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 [![GitHub stars](https://img.shields.io/github/stars/MadaBurns/bv-mcp?style=flat&logo=github)](https://github.com/MadaBurns/bv-mcp/stargazers)
 [![npm version](https://img.shields.io/npm/v/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
-[![MCP tools](https://img.shields.io/badge/MCP%20tools-81-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
+[![MCP tools](https://img.shields.io/badge/MCP%20tools-80-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-2025--06--18-blue)](https://modelcontextprotocol.io/)
 [![Cloudflare Workers](https://img.shields.io/badge/Cloudflare%20Workers-F38020?logo=cloudflare&logoColor=white)](https://workers.cloudflare.com/)
@@ -25,7 +25,7 @@ Source-available DNS & email security scanner for Claude, Cursor, VS Code, and M
 
 **Claude Desktop** (one-click install):
 
-Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 81-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
+Download the [Blackveil DNS extension](https://github.com/MadaBurns/bv-claude-dns/releases/latest/download/bv-claude-dns.mcpb) and open it — the current 80-tool surface is available instantly. [Verify your download](https://blackveilsecurity.com/extensions/claude-dns#install).
 
 **Claude Code** (one command):
 
@@ -65,7 +65,7 @@ Transport support:
 
 ## What you get
 
-- **81 MCP tools with 19 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, reverse DNS (PTR/FCrDNS), brand discovery, and authoritative DNS infrastructure
+- **80 MCP tools with 19 scoring categories** — SPF, DMARC, DKIM, DNSSEC, SSL/TLS, MTA-STS, NS, CAA, MX, BIMI, TLS-RPT, subdomain takeover, HTTP security headers, DANE, SVCB/HTTPS, subdomailing, reverse DNS (PTR/FCrDNS), brand discovery, and authoritative DNS infrastructure
 - **Maturity staging** — Stage 0-4 classification (Unprotected to Hardened) with score-based capping to prevent inflated labels
 - **Trust surface analysis** — detects shared SaaS platforms (Google, M365, SendGrid) and cross-references DMARC enforcement to determine real exposure
 - **Guided remediation** — `generate` (artifact=`fix_plan`) produces provider-aware prioritized actions; its record artifacts (`spf_record`, `dmarc_record`, `dkim_config`, `mta_sts_policy`, `rollout_plan`) output ready-to-publish records; `validate_fix` confirms whether a fix was applied successfully
@@ -81,7 +81,7 @@ Transport support:
 ## Tools
 
 ```
-  81 MCP tools · 7 prompts · 6 resources
+  80 MCP tools · 7 prompts · 6 resources
 
   Email Auth             Infrastructure          Brand & Threats       Meta
  ─────────────          ──────────────          ───────────────       ───────────────

--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -4,7 +4,7 @@ These settings must be configured manually in the GitHub web UI.
 
 ## Repository description
 
-Set to: `Source-available DNS & email security scanner for MCP clients. 81 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
+Set to: `Source-available DNS & email security scanner for MCP clients. 80 MCP tools for SPF, DMARC, DKIM, DNSSEC, SSL/TLS, brand audit, authoritative DNS infrastructure, and more.`
 
 ## Repository topics
 

--- a/extensions/vscode/README.md
+++ b/extensions/vscode/README.md
@@ -1,6 +1,6 @@
 # Blackveil DNS — MCP Security Scanner
 
-**81 DNS & email security tools** for GitHub Copilot Chat. No install, no API key — just ask Copilot to scan any domain.
+**80 DNS & email security tools** for GitHub Copilot Chat. No install, no API key — just ask Copilot to scan any domain.
 
 ![Blackveil DNS](https://raw.githubusercontent.com/MadaBurns/bv-mcp/main/assets/bv-logo-full.png)
 
@@ -10,7 +10,7 @@
 2. Open GitHub Copilot Chat (`Ctrl+Shift+I` / `Cmd+Shift+I`)
 3. Ask: **"scan example.com"**
 
-That's it. All 81 tools are available instantly.
+That's it. All 80 tools are available instantly.
 
 ## What You Get
 
@@ -22,9 +22,9 @@ That's it. All 81 tools are available instantly.
 - **Attack path simulation** — enumerated spoofing, takeover, and hijack paths
 - **Compliance mapping** — NIST 800-177, PCI DSS 4.0, SOC 2, CIS Controls
 
-## Tools (81)
+## Tools (80)
 
-The extension exposes the hosted MCP `tools/list` surface: 81 tools, including 35 `check_*` tools. The table below groups the most common workflows; Copilot can call every registered tool returned by the server.
+The extension exposes the hosted MCP `tools/list` surface: 80 tools, including 35 `check_*` tools. The table below groups the most common workflows; Copilot can call every registered tool returned by the server.
 
 | Email Auth | Infrastructure | Brand & Threats | Intelligence |
 |---|---|---|---|

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "blackveil-dns",
 	"displayName": "Blackveil DNS — MCP Security Scanner",
-	"description": "81 DNS & email security tools for GitHub Copilot Chat via MCP. Scan SPF, DMARC, DKIM, DNSSEC, SSL, MTA-STS, and more — no install, no API key required.",
+	"description": "80 DNS & email security tools for GitHub Copilot Chat via MCP. Scan SPF, DMARC, DKIM, DNSSEC, SSL, MTA-STS, and more — no install, no API key required.",
 	"version": "1.0.0",
 	"publisher": "BlackveilSecurity",
 	"license": "BUSL-1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.27.0",
+	"version": "3.27.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.27.0",
+			"version": "3.27.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.27.0",
+	"version": "3.27.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.27.0",
+	"version": "3.27.1",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
 	"name": "com.blackveilsecurity/dns",
-	"description": "DNS and email security scanner with 81 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
 	"repository": {
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -4,7 +4,7 @@ import type { CheckResult } from '../lib/scoring';
 import type { QueryDnsOptions, SecondaryDohConfig } from '../lib/dns-types';
 import { buildCheckCacheKey, buildScanCacheKey, runWithCacheTracked } from '../lib/cache';
 import { withRequestDedup } from '../lib/request-dedup';
-import { isAuthRequiredTool } from '../lib/config';
+import { isAuthRequiredTool, isInternalOnlyTool } from '../lib/config';
 import { sanitizeErrorMessage } from '../lib/json-rpc';
 import { checkSpf } from '../tools/check-spf';
 import { checkSubdomainTakeover } from '../tools/check-subdomain-takeover';
@@ -140,7 +140,9 @@ interface WireTool {
  */
 export function handleToolsList(): { tools: WireTool[] } {
 	return {
-		tools: TOOLS.map((tool) => ({
+		// Internal-only tools (INTERNAL_ONLY_TOOLS, e.g. map_csc_products) stay in
+		// TOOLS for internal-path callability but are hidden from the PUBLIC surface.
+		tools: TOOLS.filter((tool) => !isInternalOnlyTool(tool.name)).map((tool) => ({
 			name: tool.name,
 			description: tool.description,
 			inputSchema: tool.inputSchema,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -314,7 +314,8 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	resolve_spf_chain: 15,
 	discover_subdomains: 0,
 	map_compliance: 5,
-	map_csc_products: 5,
+	// map_csc_products is INTERNAL_ONLY_TOOLS — not public-callable, so it carries
+	// no public free-tier quota (tool-quota-coverage audit exempts internal-only tools).
 	prioritize_csc_leads: 0,
 	simulate_attack_paths: 0,
 	check_dbl: 5,
@@ -397,6 +398,28 @@ export const GATED_PAID_ONLY_TOOLS: ReadonlySet<string> = new Set<string>([
 /** True when a tool is gated to paid tiers (developer+). */
 export function isGatedPaidOnlyTool(toolName: string): boolean {
 	return GATED_PAID_ONLY_TOOLS.has(toolName);
+}
+
+/**
+ * Tools removed from the PUBLIC `/mcp` surface but still registered in
+ * TOOL_DEFS/TOOLS so they remain callable over the internal path
+ * (`/internal/tools/*` → handleToolsCall) and usable internally by other tools
+ * (e.g. `prioritize_csc_leads` calls the map_csc_products FUNCTION directly).
+ *
+ * Enforcement (public path only, in src/mcp/execute.ts): a public `tools/call`
+ * for a member short-circuits and returns the SAME unknown-tool result a
+ * nonexistent tool name produces — no existence leak, no 403/UPGRADE_REQUIRED.
+ * The public `tools/list` (handlers/tools.ts) filters these out. The internal
+ * path (src/internal.ts) bypasses executeMcpRequest entirely and is unaffected.
+ *
+ * Members carry NO FREE_TOOL_DAILY_LIMITS entry (they are not public-callable);
+ * the tool-quota-coverage audit exempts them.
+ */
+export const INTERNAL_ONLY_TOOLS: ReadonlySet<string> = new Set<string>(['map_csc_products']);
+
+/** True when a tool is internal-only (hidden from + rejected on the public /mcp surface). */
+export function isInternalOnlyTool(toolName: string): boolean {
+	return INTERNAL_ONLY_TOOLS.has(toolName);
 }
 
 /**

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -23,8 +23,12 @@ import {
 	TIER_CONCURRENT_LIMITS,
 	isGatedPaidOnlyTool,
 	isAuthRequiredTool,
+	isInternalOnlyTool,
 	UPGRADE_URL,
 } from '../lib/config';
+import { jsonRpcSuccess } from '../lib/json-rpc';
+import { mcpError } from '../handlers/tool-formatters';
+import { TOOLS } from '../schemas/tool-definitions';
 import { normalizeToolName } from '../handlers/tool-args';
 import { shardIndexForKey, isQuotaShardSaltMissing } from '../lib/quota-coordinator';
 import { acceptsSSE } from '../lib/sse';
@@ -754,6 +758,48 @@ function buildGatedToolResponse(
 	};
 }
 
+/**
+ * Reject a PUBLIC `/mcp` tools/call for an INTERNAL-ONLY tool (e.g. map_csc_products).
+ *
+ * Returns the SAME unknown-tool result a nonexistent tool name produces via the
+ * dispatch path (handlers/tools.ts `default` case) — a JSON-RPC success wrapping a
+ * tool-error result whose text references the full TOOLS.length — so the tool's
+ * existence is NOT leaked on the public surface and no 403/UPGRADE_REQUIRED is
+ * emitted. executeMcpRequest is the public path only; the internal path
+ * (src/internal.ts → handleToolsCall) bypasses this and remains fully callable,
+ * as does the direct FUNCTION call from prioritize_csc_leads.
+ */
+function buildInternalOnlyToolResponse(
+	id: JsonRpcRequest['id'],
+	toolName: string,
+	method: string,
+	options: ExecuteMcpRequestOptions,
+	eventId: string | undefined,
+	accessLogInput: { toolName: string; domain: string; method: string } | undefined,
+): Extract<ProcessedRequestResult, { kind: 'response' }> {
+	// Byte-identical to the genuine unknown-tool wire payload (uses TOOLS.length,
+	// NOT the public count, so it is indistinguishable from a nonexistent tool).
+	const payload = jsonRpcSuccess(id, {
+		content: [mcpError(`Unknown tool: ${toolName}. Call tools/list to see all ${TOOLS.length} available tools.`)],
+		isError: true,
+	});
+	// Mirror the dispatch unknown-tool bookkeeping: not a JSON-RPC error (result.isError),
+	// so request analytics logs 'ok' and the fuzz counter records an unknown_tool hit.
+	emitRequestAnalytics(options, method, 'ok', false);
+	recordMcpToolErrorIfUnknownTool(options, method, payload);
+	if (accessLogInput) {
+		recordMcpAccessLog(options, { ...accessLogInput, rateLimited: false, status: 'pass' });
+	}
+	return {
+		kind: 'response',
+		payload,
+		headers: {},
+		httpStatus: 200,
+		useErrorEnvelope: false,
+		eventId,
+	};
+}
+
 export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Promise<ProcessedRequestResult> {
 	const validationError = validateJsonRpcRequest(options.body);
 	if (validationError) {
@@ -786,6 +832,21 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			useErrorEnvelope: true,
 			eventId,
 		};
+	}
+
+	// PUBLIC-PATH-ONLY internal-only gate. map_csc_products (INTERNAL_ONLY_TOOLS) is
+	// removed from the public /mcp surface: reject BEFORE any tier branching so it
+	// applies to ALL callers (unauthenticated, free, developer, owner) with the same
+	// unknown-tool result — no existence leak, no 403. The internal path
+	// (src/internal.ts → handleToolsCall) never reaches executeMcpRequest, so the
+	// tool stays callable there and via the direct prioritize_csc_leads function call.
+	if (method === 'tools/call') {
+		const internalOnlyNameRaw =
+			typeof params === 'object' && params !== null && 'name' in params ? (params as Record<string, unknown>).name : undefined;
+		const internalOnlyName = typeof internalOnlyNameRaw === 'string' ? normalizeToolName(internalOnlyNameRaw) : '';
+		if (internalOnlyName && isInternalOnlyTool(internalOnlyName)) {
+			return buildInternalOnlyToolResponse(id, internalOnlyName, method, options, eventId, accessLogInput);
+		}
 	}
 
 	let rateHeaders: Record<string, string> = {};

--- a/test/audits/readme-tool-surface.audit.test.ts
+++ b/test/audits/readme-tool-surface.audit.test.ts
@@ -10,12 +10,16 @@ import resourcesSource from '../../src/handlers/resources.ts?raw';
 import vscodePackageText from '../../extensions/vscode/package.json?raw';
 import vscodeReadme from '../../extensions/vscode/README.md?raw';
 import { TOOLS } from '../../src/schemas/tool-definitions';
+import { INTERNAL_ONLY_TOOLS } from '../../src/lib/config';
+
+// Public-facing count advertised in customer-facing prose. Internal-only tools
+// (e.g. map_csc_products) are removed from the public /mcp surface; the count
+// tripwire on the full TOOLS.length lives in tool-count-ssot.audit.test.ts.
+const PUBLIC_TOOL_COUNT = TOOLS.length - INTERNAL_ONLY_TOOLS.size;
 
 describe('README tool surface', () => {
-	it('keeps published tool counts and authoritative DNS infra tools current', () => {
-		// The headline count tripwire lives in tool-count-ssot.audit.test.ts; here we
-		// only assert the README prose stays in lockstep with the derived TOOLS.length.
-		const toolCount = TOOLS.length;
+	it('keeps published PUBLIC tool counts and authoritative DNS infra tools current', () => {
+		const toolCount = PUBLIC_TOOL_COUNT;
 
 		expect(readme).toContain(`MCP%20tools-${toolCount}`);
 		expect(readme).toContain(`current ${toolCount}-tool surface`);
@@ -26,7 +30,7 @@ describe('README tool surface', () => {
 	});
 
 	it('keeps supporting docs aligned with the authoritative DNS infra surface', () => {
-		expect(githubSettings).toContain(`${TOOLS.length} MCP tools`);
+		expect(githubSettings).toContain(`${PUBLIC_TOOL_COUNT} MCP tools`);
 		expect(scoringDocs).toContain('Authoritative DNS Infrastructure');
 		expect(scoringDocs).toContain('authoritative_dns_infra');
 		expect(packageReadme).toContain('authoritative_dns_infra');
@@ -34,7 +38,7 @@ describe('README tool surface', () => {
 	});
 
 	it('keeps MCP resources and VS Code extension metadata aligned with the tool registry', () => {
-		const toolCount = TOOLS.length;
+		const toolCount = PUBLIC_TOOL_COUNT;
 		const checkToolCount = TOOLS.filter((tool) => tool.name.startsWith('check_')).length;
 		const vscodePackage = JSON.parse(vscodePackageText) as { description: string };
 

--- a/test/audits/server-json-tool-count.audit.test.ts
+++ b/test/audits/server-json-tool-count.audit.test.ts
@@ -4,14 +4,19 @@ import { describe, expect, it } from 'vitest';
 import smitheryYamlText from '../../smithery.yaml?raw';
 import serverJsonText from '../../server.json?raw';
 import { TOOLS } from '../../src/schemas/tool-definitions';
+import { INTERNAL_ONLY_TOOLS } from '../../src/lib/config';
+
+// Public-facing count: internal-only tools (e.g. map_csc_products) are removed
+// from the public /mcp surface, so registry-listing prose advertises this count.
+const PUBLIC_TOOL_COUNT = TOOLS.length - INTERNAL_ONLY_TOOLS.size;
 
 describe('server.json tool count', () => {
-	it('keeps the MCP Registry description tool count in sync with TOOLS.length', () => {
+	it('keeps the MCP Registry description tool count in sync with the PUBLIC tool count', () => {
 		const serverJson = JSON.parse(serverJsonText) as { description: string };
 		const match = serverJson.description.match(/(\d+) MCP tools/);
 
 		expect(match, 'server.json description must contain "N MCP tools"').not.toBeNull();
-		expect(Number(match![1])).toBe(TOOLS.length);
+		expect(Number(match![1])).toBe(PUBLIC_TOOL_COUNT);
 	});
 
 	// NOTE: the MCP Registry hard-caps server.json `description` at 100 chars

--- a/test/audits/tool-quota-coverage.audit.test.ts
+++ b/test/audits/tool-quota-coverage.audit.test.ts
@@ -12,10 +12,10 @@
 
 import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../../src/schemas/tool-definitions';
-import { FREE_TOOL_DAILY_LIMITS, INTENTIONALLY_UNLIMITED_TOOLS } from '../../src/lib/config';
+import { FREE_TOOL_DAILY_LIMITS, INTENTIONALLY_UNLIMITED_TOOLS, INTERNAL_ONLY_TOOLS } from '../../src/lib/config';
 
 describe('tool-quota-coverage audit', () => {
-	it('every TOOL_DEFS entry is either quota-limited or explicitly unlimited (never neither, never both)', () => {
+	it('every public TOOL_DEFS entry is either quota-limited or explicitly unlimited (never neither, never both)', () => {
 		const limited = new Set(Object.keys(FREE_TOOL_DAILY_LIMITS));
 		const unlimited = INTENTIONALLY_UNLIMITED_TOOLS;
 
@@ -23,6 +23,9 @@ describe('tool-quota-coverage audit', () => {
 		const both: string[] = [];
 
 		for (const tool of TOOLS) {
+			// Internal-only tools are removed from the public surface (rejected on /mcp),
+			// so they carry no public free-tier quota — exempt from the coverage requirement.
+			if (INTERNAL_ONLY_TOOLS.has(tool.name)) continue;
 			const inLimited = limited.has(tool.name);
 			const inUnlimited = unlimited.has(tool.name);
 			if (!inLimited && !inUnlimited) missing.push(tool.name);

--- a/test/map-csc-products-internal-only.spec.ts
+++ b/test/map-csc-products-internal-only.spec.ts
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Security hotfix: map_csc_products is INTERNAL-ONLY. It stays registered in
+// TOOL_DEFS/TOOLS (so it is callable on the /internal/tools/* path and usable
+// internally by prioritize_csc_leads), but is hidden from and rejected on the
+// PUBLIC /mcp surface. These tests pin all four halves of that contract:
+//   1. isInternalOnlyTool / INTERNAL_ONLY_TOOLS membership.
+//   2. handleToolsList (public) hides it → 80 tools; scan_domain still present.
+//   3. TOOLS registry still contains it (length 81) — internal callability.
+//   4. Public executeMcpRequest tools/call → unknown-tool result (NOT 403, NOT
+//      executed), for both an unauthenticated and an authenticated owner caller.
+//   5. handleToolsCall (the internal-path entrypoint) still executes it.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resetAllRateLimits, resetGlobalDailyLimit, resetConcurrencyLimits } from '../src/lib/rate-limiter';
+import { resetSessions } from '../src/lib/session';
+import { handleToolsList } from '../src/handlers/tools';
+import { TOOLS } from '../src/schemas/tool-definitions';
+import { INTERNAL_ONLY_TOOLS, isInternalOnlyTool } from '../src/lib/config';
+import type { ExecuteMcpRequestOptions } from '../src/mcp/execute';
+import type { JsonRpcRequest } from '../src/lib/json-rpc';
+
+const PUBLIC_TOOL_COUNT = TOOLS.length - INTERNAL_ONLY_TOOLS.size;
+
+// Keep the internal-path execution assertion fast: stub scan + RDAP so
+// mapCscProducts resolves without live DNS. (Mirrors map-csc-products.integration.test.ts.)
+const mockScanDomain = vi.fn();
+const mockCheckRdap = vi.fn();
+vi.mock('../src/tools/scan-domain', () => ({ scanDomain: (...a: unknown[]) => mockScanDomain(...a) }));
+vi.mock('../src/tools/check-rdap-lookup', async (importOriginal) => {
+	const orig = await importOriginal<typeof import('../src/tools/check-rdap-lookup')>();
+	return { ...orig, checkRdapLookup: (...a: unknown[]) => mockCheckRdap(...a) };
+});
+
+function baseOptions(overrides: Partial<ExecuteMcpRequestOptions> = {}): ExecuteMcpRequestOptions {
+	return {
+		body: { jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} } as JsonRpcRequest,
+		allowStreaming: false,
+		batchMode: false,
+		batchSize: 1,
+		responseTransport: 'json',
+		startTime: Date.now(),
+		ip: '203.0.113.9',
+		isAuthenticated: false,
+		validateSession: false,
+		serverVersion: '2.3.0',
+		...overrides,
+	};
+}
+
+beforeEach(() => {
+	resetAllRateLimits();
+	resetGlobalDailyLimit();
+	resetConcurrencyLimits();
+	resetSessions();
+});
+
+afterEach(() => {
+	mockScanDomain.mockReset();
+	mockCheckRdap.mockReset();
+});
+
+describe('INTERNAL_ONLY_TOOLS membership', () => {
+	it('map_csc_products is internal-only; scan_domain is not', () => {
+		expect(isInternalOnlyTool('map_csc_products')).toBe(true);
+		expect(isInternalOnlyTool('scan_domain')).toBe(false);
+		expect(INTERNAL_ONLY_TOOLS.has('map_csc_products')).toBe(true);
+	});
+});
+
+describe('tool registry vs public surface', () => {
+	it('TOOLS still includes map_csc_products (internal callability preserved) — length 81', () => {
+		expect(TOOLS.some((t) => t.name === 'map_csc_products')).toBe(true);
+		expect(TOOLS.length).toBe(81);
+	});
+
+	it('handleToolsList hides map_csc_products and returns the public count (80)', () => {
+		const { tools } = handleToolsList();
+		const names = tools.map((t) => t.name);
+		expect(names).not.toContain('map_csc_products');
+		expect(names).toContain('scan_domain');
+		expect(tools.length).toBe(PUBLIC_TOOL_COUNT);
+		expect(tools.length).toBe(80);
+	});
+});
+
+describe('executeMcpRequest — internal-only tool rejected on public /mcp', () => {
+	it('unauthenticated public map_csc_products → unknown-tool result (200, not 403, not executed)', async () => {
+		const { executeMcpRequest } = await import('../src/mcp/execute');
+		const result = await executeMcpRequest(
+			baseOptions({
+				body: {
+					jsonrpc: '2.0',
+					id: 200,
+					method: 'tools/call',
+					params: { name: 'map_csc_products', arguments: { domain: 'example.com' } },
+				} as JsonRpcRequest,
+				isAuthenticated: false,
+			}),
+		);
+
+		expect(result.kind).toBe('response');
+		if (result.kind !== 'response') throw new Error('expected response');
+		expect(result.httpStatus).toBe(200);
+		expect(result.httpStatus).not.toBe(403);
+		const payload = result.payload as {
+			result?: { isError?: boolean; content?: { text?: string }[] };
+			error?: { code?: number };
+		};
+		expect(payload.error).toBeUndefined();
+		expect(payload.result?.isError).toBe(true);
+		expect(payload.result?.content?.[0]?.text ?? '').toContain('Unknown tool');
+		expect(mockScanDomain).not.toHaveBeenCalled();
+	});
+
+	it('authenticated OWNER-tier public map_csc_products is also rejected (removed from surface entirely)', async () => {
+		const { executeMcpRequest } = await import('../src/mcp/execute');
+		const result = await executeMcpRequest(
+			baseOptions({
+				body: {
+					jsonrpc: '2.0',
+					id: 201,
+					method: 'tools/call',
+					params: { name: 'map_csc_products', arguments: { domain: 'example.com' } },
+				} as JsonRpcRequest,
+				isAuthenticated: true,
+				tierAuthResult: { authenticated: true, tier: 'owner', keyHash: 'k_owner' },
+				authTier: 'owner',
+			}),
+		);
+
+		expect(result.kind).toBe('response');
+		if (result.kind !== 'response') throw new Error('expected response');
+		expect(result.httpStatus).not.toBe(403);
+		const payload = result.payload as {
+			result?: { isError?: boolean; content?: { text?: string }[] };
+			error?: { code?: number };
+		};
+		expect(payload.result?.isError).toBe(true);
+		expect(payload.result?.content?.[0]?.text ?? '').toContain('Unknown tool');
+		expect(mockScanDomain).not.toHaveBeenCalled();
+	});
+});
+
+describe('handleToolsCall — internal path still executes map_csc_products', () => {
+	it('resolves map_csc_products (does NOT return an unknown-tool error)', async () => {
+		mockScanDomain.mockResolvedValue({ checks: [], score: { overall: 90, grade: 'A' } });
+		mockCheckRdap.mockResolvedValue({ category: 'rdap', passed: true, score: 100, findings: [] });
+
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall({ name: 'map_csc_products', arguments: { domain: 'example.com' } });
+
+		const text = result.content?.[0]?.text ?? '';
+		expect(text).not.toContain('Unknown tool');
+		expect(result.isError).not.toBe(true);
+		expect(mockScanDomain).toHaveBeenCalled();
+	});
+});


### PR DESCRIPTION
## Security patch — `map_registrar_products` is now internal-only

`map_registrar_products` shipped in 3.27.0 as a **public, free-tier-callable** MCP tool and is **live in prod**. It maps domains to a specific registrar's commercial products, so it belongs off the public surface. This closes that exposure.

### Change
New `INTERNAL_ONLY_TOOLS` concept (`src/lib/config.ts` + `isInternalOnlyTool`). The tool **stays registered** in `TOOL_DEFS`/`TOOLS` — still callable via `/internal/tools/*` and internally by `prioritize_portfolio_leads` (direct function call) — but on the public surface it is:
- **filtered out** of `handleToolsList()` (public `tools/list` → 80 tools), and
- **rejected** on public `tools/call` with the *same unknown-tool result* a nonexistent tool returns — **no existence leak, no 403**.

The reject guard lives only in `executeMcpRequest` (the public-`/mcp`-only seam, alongside the paid-gating). The internal path (`src/internal.ts → handleToolsCall`) bypasses it and is untouched.

### SSOT
`TOOLS.length` stays **81** (`EXPECTED_TOOL_COUNT` unchanged). Public-facing counts → **80**: `server.json` description, README, `docs/github-settings.md`, vscode prose; the `server-json-tool-count` + `readme-tool-surface` audits now assert the public count (`TOOLS.length − INTERNAL_ONLY_TOOLS`). `map_registrar_products` dropped from `FREE_TOOL_DAILY_LIMITS`; `tool-quota-coverage` exempts internal-only tools.

### Verification
`tsc --noEmit` exit 0; new spec + the 3 changed audits + tool-count + registrar integration → green (22/22 on the focused run; full `test/audits/` 322 pass per impl). Bump 3.27.0 → **3.27.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
