### PR TITLE
feat(registrar): portfolio-grade rollup on prioritize_portfolio_leads (3.28.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.28.0] - 2026-07-01
+
+Minor release: brand-level **portfolio grade rollup** on `prioritize_csc_leads` (Spec D backend prerequisite). Unblocks the deferred bv-web-prod CSC portal by moving the brand-grade math into bv-mcp so the portal consumes one SSOT-sourced letter instead of forking the scoring engine client-side.
+
+### Added
+
+- **`portfolioGrade` on `prioritize_csc_leads`'s report** (`src/tools/prioritize-csc-leads.ts`). New optional `PortfolioGrade { grade, weightedScore, contributingDomains } | null` on `CscLeadReport`, flowing through to `structuredContent` (no handler/schema/tool-count/README change — additive field). Computed by a pure, tested `computePortfolioGrade()`: a per-domain **weighted average of scan scores** (`consolidated` 2×, `shadowIt`/`indeterminate`/`unknown` 1×, `impersonation`/`impersonationSurface` excluded), rounded once, then a single `nistScoreToGrade()` call for the NIST 6-band letter — never averages letters, never forks the parity-guarded band thresholds. Its weighting map is deliberately **distinct** from the existing `OWNERSHIP_MULTIPLIER` (sales-actionability ranking). Domains whose individual `grade` is `N/A` (non-resolving / inconclusive) are excluded from the rollup rather than counted at 0, consistent with the scan-domain aggregator contract. Empty / all-excluded portfolios return `null` (division-safe). Surfaced in `formatCscLeads` (full + compact).
+
 ## [3.27.1] - 2026-07-01
 
 Patch release (security): make `map_csc_products` **internal-only**. It shipped in 3.27.0 as a public, free-tier-callable MCP tool, but it maps domains to CSC's specific commercial products and belongs off the public surface.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.27.1",
+	"version": "3.28.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.27.1",
+			"version": "3.28.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.27.1",
+	"version": "3.28.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.27.1",
+	"version": "3.28.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/tools/prioritize-csc-leads.ts
+++ b/src/tools/prioritize-csc-leads.ts
@@ -15,6 +15,7 @@ import { evaluateCscProducts, extractLockPosture } from './map-csc-products';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import type { CheckResult } from '../lib/scoring';
+import { nistScoreToGrade } from '../lib/scoring';
 import { scanDomain } from './scan-domain';
 import { checkRdapLookup, RDAP_LOOKUP_SYNC_BUDGET_MS } from './check-rdap-lookup';
 import { brandAuditSingle } from './brand-audit-single';
@@ -43,10 +44,22 @@ export interface CscLead {
 	topPriority: CscPriority;
 }
 
+/** Brand-level portfolio rollup grade (weighted average of contributing domains' scan scores). */
+export interface PortfolioGrade {
+	/** NIST 6-band DISPLAY letter (A+/A/B/C/D/F) from nistScoreToGrade(weightedScore). */
+	grade: string;
+	/** Weighted-average scan score across contributing domains, 0–100, Math.round'd to an integer. */
+	weightedScore: number;
+	/** Count of leads whose ownership bucket carries a non-zero rollup weight (and grade ≠ 'N/A'). */
+	contributingDomains: number;
+}
+
 export interface CscLeadReport {
 	brand: string | null;
 	totalDomains: number;
 	rankedLeads: CscLead[];
+	/** NEW — additive/optional. rankCscLeads ALWAYS sets it (PortfolioGrade or null). */
+	portfolioGrade?: PortfolioGrade | null;
 	summary: {
 		totalRecommendations: number;
 		byProduct: Record<CscProductKey, number>;
@@ -88,6 +101,45 @@ const OWNERSHIP_MULTIPLIER: Record<OwnershipBucket, number> = {
 	impersonationSurface: 0.3,
 };
 const HOT_LEAD_THRESHOLD = 6; // gapSeverity at/above = "hot"
+
+// Portfolio-grade rollup weights — the weight each domain's SCORE carries toward the
+// brand-level grade. DISTINCT concern from OWNERSHIP_MULTIPLIER (sales actionability);
+// do NOT reuse or mutate that map. Impersonation buckets are excluded (weight 0).
+const PORTFOLIO_ROLLUP_WEIGHTS: Record<OwnershipBucket, number> = {
+	consolidated: 2,
+	shadowIt: 1,
+	indeterminate: 1,
+	unknown: 1,
+	impersonationSurface: 0,
+	impersonation: 0,
+};
+
+/**
+ * Weighted portfolio rollup grade (PURE). weightedScore = round( Σ(w[bucket]*score) / Σ(w[bucket]) )
+ * over all leads, where w = PORTFOLIO_ROLLUP_WEIGHTS. Domains with weight 0 (impersonation buckets)
+ * and graceful `grade === 'N/A'` results (NXDOMAIN / SERVFAIL-broken / scoring-bundle failure) drop
+ * out — averaging their 0 score would silently sink the portfolio (see scan-domain.ts aggregator
+ * contract). Returns null when `leads` is empty OR Σ(weight) === 0 (no contributing domains).
+ * NEVER averages letters and NEVER inlines band thresholds — it rounds the numeric weighted average
+ * once, then calls nistScoreToGrade(weightedScore) exactly once so the displayed score and letter
+ * never disagree at a band edge.
+ */
+export function computePortfolioGrade(leads: Pick<CscLead, 'score' | 'ownershipBucket' | 'grade'>[]): PortfolioGrade | null {
+	let numerator = 0;
+	let denominator = 0;
+	let contributingDomains = 0;
+	for (const lead of leads) {
+		if (lead.grade === 'N/A') continue;
+		const weight = PORTFOLIO_ROLLUP_WEIGHTS[lead.ownershipBucket];
+		if (weight === 0) continue;
+		numerator += weight * lead.score;
+		denominator += weight;
+		contributingDomains += 1;
+	}
+	if (denominator === 0) return null; // empty or all-excluded — never divide, never reach nistScoreToGrade
+	const weightedScore = Math.round(numerator / denominator);
+	return { grade: nistScoreToGrade(weightedScore), weightedScore, contributingDomains };
+}
 
 /** Pure mapper from classifyCandidate's Bucket to OwnershipBucket (identity for the 5 shared values). */
 export function bucketFromClassification(b: Bucket): OwnershipBucket {
@@ -161,10 +213,13 @@ export function rankCscLeads(
 		for (const key of lead.recommendedCscProducts) byProduct[key] += 1;
 	}
 
+	const portfolioGrade = computePortfolioGrade(leads);
+
 	return {
 		brand,
 		totalDomains: leads.length,
 		rankedLeads: leads,
+		portfolioGrade,
 		summary: {
 			totalRecommendations: leads.reduce((sum, l) => sum + l.recommendedCount, 0),
 			byProduct,
@@ -210,7 +265,9 @@ export function formatCscLeads(report: CscLeadReport, format: OutputFormat = 'fu
 	const brandLabel = report.brand ? sanitizeOutputText(report.brand, 253) : 'domain set';
 
 	if (format === 'compact') {
-		lines.push(`CSC leads (${brandLabel}): ${report.totalDomains} ranked, ${report.summary.hotLeads} hot`);
+		// Append the portfolio segment only when gradeable; omit entirely when null (keeps compact lean).
+		const portfolioSegment = report.portfolioGrade ? ` — portfolio ${report.portfolioGrade.grade} (${report.portfolioGrade.weightedScore})` : '';
+		lines.push(`CSC leads (${brandLabel}): ${report.totalDomains} ranked, ${report.summary.hotLeads} hot${portfolioSegment}`);
 		for (const lead of report.rankedLeads) {
 			lines.push(
 				`${lead.priorityRank}. ${sanitizeOutputText(lead.domain, 253)} — sev ${lead.gapSeverity} — ${lead.score}/100 (${lead.grade}) — ${lead.recommendedCount} product(s)`,
@@ -221,6 +278,11 @@ export function formatCscLeads(report: CscLeadReport, format: OutputFormat = 'fu
 
 	lines.push(`# CSC Sales Leads: ${brandLabel}`);
 	lines.push(`**${report.totalDomains}** domain(s) ranked | **${report.summary.hotLeads}** hot lead(s)`);
+	if (report.portfolioGrade) {
+		lines.push(`**Portfolio grade: ${report.portfolioGrade.grade}** (weighted ${report.portfolioGrade.weightedScore}/100 across ${report.portfolioGrade.contributingDomains} domain(s))`);
+	} else {
+		lines.push('**Portfolio grade: N/A** (no gradeable domains)');
+	}
 	lines.push('');
 	for (const lead of report.rankedLeads) {
 		lines.push(`## ${lead.priorityRank}. ${sanitizeOutputText(lead.domain, 253)} — gap severity ${lead.gapSeverity}`);

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -563,12 +563,15 @@ describe('formatCheckResult - via handleToolsCall', () => {
 // -- handleToolsList --
 
 describe('handleToolsList', () => {
-	it('returns an object with a tools array covering the full registry', async () => {
+	it('returns an object with a tools array covering the public registry (internal-only excluded)', async () => {
 		const { handleToolsList } = await import('../src/handlers/tools');
 		const { TOOLS } = await import('../src/schemas/tool-definitions');
+		const { INTERNAL_ONLY_TOOLS, isInternalOnlyTool } = await import('../src/lib/config');
 		const result = handleToolsList();
 		expect(Array.isArray(result.tools)).toBe(true);
-		expect(result.tools).toHaveLength(TOOLS.length);
+		// handleToolsList filters out internal-only tools (e.g. map_csc_products) — public count.
+		expect(result.tools).toHaveLength(TOOLS.length - INTERNAL_ONLY_TOOLS.size);
+		expect(result.tools.some((t) => isInternalOnlyTool(t.name))).toBe(false);
 	});
 
 	it('every tool entry has name, description, and inputSchema', async () => {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -429,8 +429,11 @@ describe('DNS Security MCP Server', () => {
 			await waitOnExecutionContext(ctx);
 			const body = (await response.json()) as { result: { tools: Array<{ name: string }> } };
 			const { TOOLS } = await import('../src/schemas/tool-definitions');
-			expect(body.result.tools).toHaveLength(TOOLS.length);
+			const { INTERNAL_ONLY_TOOLS } = await import('../src/lib/config');
+			// The public tools/list excludes internal-only tools (e.g. map_csc_products).
+			expect(body.result.tools).toHaveLength(TOOLS.length - INTERNAL_ONLY_TOOLS.size);
 			const toolNames = body.result.tools.map((t) => t.name);
+			expect(toolNames).not.toContain('map_csc_products');
 			expect(toolNames).toContain('check_spf');
 			expect(toolNames).toContain('check_dmarc');
 			expect(toolNames).toContain('check_bimi');

--- a/test/prioritize-csc-leads.spec.ts
+++ b/test/prioritize-csc-leads.spec.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 import type { Bucket } from '../src/lib/brand-classification';
 import type { CscProductKey, CscPriority, CscProductReport, CscProductRecommendation } from '../src/tools/map-csc-products';
 import type { CheckResult } from '../src/lib/scoring';
-import { bucketFromClassification, computeGapSeverity, rankCscLeads, formatCscLeads, extractDiscoveredCandidates } from '../src/tools/prioritize-csc-leads';
+import { bucketFromClassification, computeGapSeverity, computePortfolioGrade, rankCscLeads, formatCscLeads, extractDiscoveredCandidates } from '../src/tools/prioritize-csc-leads';
 import type { OwnershipBucket, CscLeadEntry } from '../src/tools/prioritize-csc-leads';
 
 const PRODUCT_ORDER: CscProductKey[] = ['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management'];
@@ -164,6 +164,120 @@ describe('rankCscLeads — summary', () => {
 		const e = entry('z.com', 50, 'F', [], 'unknown');
 		expect(rankCscLeads([e], 'acme').brand).toBe('acme');
 		expect(rankCscLeads([e]).brand).toBeNull();
+	});
+});
+
+/** Build a minimal lead-shaped object for the pure portfolio-grade helper (score + bucket + grade). */
+function pl(bucket: OwnershipBucket, score: number, grade = 'B'): Pick<CscLeadEntry['report'], 'score' | 'grade'> & { ownershipBucket: OwnershipBucket } {
+	return { score, grade, ownershipBucket: bucket };
+}
+
+describe('computePortfolioGrade', () => {
+	it('consolidated-heavy weighting pulls harder than a flat average', () => {
+		// weighted (2*90 + 1*60)/3 = 240/3 = 80 → B (flat avg 75 would be C)
+		expect(computePortfolioGrade([pl('consolidated', 90), pl('shadowIt', 60)])).toEqual({ grade: 'B', weightedScore: 80, contributingDomains: 2 });
+	});
+
+	it('impersonation buckets are excluded (weight 0) and do not drag the grade down', () => {
+		// only the consolidated 90 counts → 180/2 = 90 → A
+		expect(computePortfolioGrade([pl('consolidated', 90), pl('impersonation', 10), pl('impersonationSurface', 0)])).toEqual({
+			grade: 'A',
+			weightedScore: 90,
+			contributingDomains: 1,
+		});
+	});
+
+	it('all-excluded (only impersonation/impersonationSurface) → null', () => {
+		expect(computePortfolioGrade([pl('impersonation', 30), pl('impersonationSurface', 20)])).toBeNull();
+	});
+
+	it('zero domains → null', () => {
+		expect(computePortfolioGrade([])).toBeNull();
+	});
+
+	it('single contributing domain', () => {
+		expect(computePortfolioGrade([pl('unknown', 72)])).toEqual({ grade: 'C', weightedScore: 72, contributingDomains: 1 });
+	});
+
+	it('mixed buckets exact numeric check', () => {
+		// numerator 2*100 + 80 + 60 + 40 = 380, denom 5 → 76 → C; impersonation 0 excluded
+		expect(
+			computePortfolioGrade([pl('consolidated', 100), pl('shadowIt', 80), pl('indeterminate', 60), pl('unknown', 40), pl('impersonation', 0)]),
+		).toEqual({ grade: 'C', weightedScore: 76, contributingDomains: 4 });
+	});
+
+	it('letter comes from the weighted numeric score, not an average of per-domain letters', () => {
+		// (2*96 + 60)/3 = 252/3 = 84 → B (letter-average of A+ and D is meaningless)
+		expect(computePortfolioGrade([pl('consolidated', 96, 'A+'), pl('shadowIt', 60, 'D')])).toEqual({ grade: 'B', weightedScore: 84, contributingDomains: 2 });
+	});
+
+	it('does NOT reuse OWNERSHIP_MULTIPLIER (indeterminate rolls up at weight 1, not 0.6)', () => {
+		// rollup (2*90 + 1*60)/3 = 80 → B. OWNERSHIP_MULTIPLIER would give (1.0*90+0.6*60)/1.6 = 78.75 → 79 → C.
+		expect(computePortfolioGrade([pl('consolidated', 90), pl('indeterminate', 60)])).toEqual({ grade: 'B', weightedScore: 80, contributingDomains: 2 });
+	});
+
+	it('rounding is applied once and the letter derives from the rounded integer', () => {
+		// (2*95 + 96)/3 = 286/3 = 95.33 → round 95 → A+
+		expect(computePortfolioGrade([pl('consolidated', 95), pl('shadowIt', 96)])).toEqual({ grade: 'A+', weightedScore: 95, contributingDomains: 2 });
+		// (2*90 + 91)/3 = 271/3 = 90.33 → round 90 → A
+		expect(computePortfolioGrade([pl('consolidated', 90), pl('unknown', 91)])).toEqual({ grade: 'A', weightedScore: 90, contributingDomains: 2 });
+	});
+
+	it('excludes graceful N/A leads (NXDOMAIN / broken) from the rollup entirely', () => {
+		// N/A unknown lead skipped: (2*95 + 2*90)/4 = 370/4 = 92.5 → round 93 → A, contributing 2 (not 3)
+		const withNa = computePortfolioGrade([pl('consolidated', 95, 'A+'), pl('consolidated', 90, 'A'), pl('unknown', 0, 'N/A')]);
+		const withoutNa = computePortfolioGrade([pl('consolidated', 95, 'A+'), pl('consolidated', 90, 'A')]);
+		expect(withNa).toEqual({ grade: 'A', weightedScore: 93, contributingDomains: 2 });
+		expect(withNa).toEqual(withoutNa);
+	});
+});
+
+describe('rankCscLeads — portfolioGrade field', () => {
+	it('sets portfolioGrade equal to computePortfolioGrade(rankedLeads)', () => {
+		const e1 = entry('one.com', 90, 'A', [rec('csc_multilock', true, 'high')], 'consolidated');
+		const e2 = entry('two.com', 60, 'D', [rec('managed_dmarc', true, 'medium')], 'shadowIt');
+		const report = rankCscLeads([e1, e2]);
+		expect(report.portfolioGrade).toEqual(computePortfolioGrade(report.rankedLeads));
+		expect(report.portfolioGrade).toEqual({ grade: 'B', weightedScore: 80, contributingDomains: 2 });
+	});
+
+	it('empty input → portfolioGrade null', () => {
+		expect(rankCscLeads([]).portfolioGrade).toBeNull();
+		expect(rankCscLeads([], 'acme', []).portfolioGrade).toBeNull();
+	});
+
+	it('only impersonation buckets → portfolioGrade null', () => {
+		const e = entry('imp.com', 20, 'F', [rec('csc_multilock', true, 'high')], 'impersonation');
+		expect(rankCscLeads([e]).portfolioGrade).toBeNull();
+	});
+});
+
+describe('formatCscLeads — portfolio grade line', () => {
+	it('full output renders the portfolio grade line when present', () => {
+		const report = rankCscLeads([entry('one.com', 90, 'A', [], 'consolidated'), entry('two.com', 60, 'D', [], 'shadowIt')], 'acme');
+		const out = formatCscLeads(report, 'full');
+		expect(out).toContain('Portfolio grade: B');
+		expect(out).toContain('weighted 80/100');
+		expect(out).toContain('2 domain(s)');
+	});
+
+	it('full output renders an N/A portfolio line when there are no gradeable domains', () => {
+		const report = rankCscLeads([], 'acme');
+		const out = formatCscLeads(report, 'full');
+		expect(out).toContain('Portfolio grade: N/A');
+		expect(out).toContain('no gradeable domains');
+	});
+
+	it('compact output appends a portfolio segment when present', () => {
+		const report = rankCscLeads([entry('one.com', 90, 'A', [], 'consolidated'), entry('two.com', 60, 'D', [], 'shadowIt')], 'acme');
+		const compact = formatCscLeads(report, 'compact');
+		expect(compact).toContain('portfolio B (80)');
+	});
+
+	it('compact output omits the portfolio segment entirely when null', () => {
+		const report = rankCscLeads([], 'acme');
+		const compact = formatCscLeads(report, 'compact');
+		expect(compact.toLowerCase()).not.toContain('portfolio');
 	});
 });
 

--- a/test/tool-recommended-meta.spec.ts
+++ b/test/tool-recommended-meta.spec.ts
@@ -13,6 +13,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../src/schemas/tool-definitions';
+import { INTERNAL_ONLY_TOOLS } from '../src/lib/config';
 import { handleToolsList } from '../src/handlers/tools';
 import { SERVER_INSTRUCTIONS } from '../src/mcp/server-instructions';
 
@@ -44,9 +45,10 @@ describe('_meta.recommended starter-set flag', () => {
 		}
 	});
 
-	it('is purely additive — every tool is still listed', () => {
+	it('is purely additive — every public tool is still listed', () => {
 		const { tools } = handleToolsList();
-		expect(tools.length).toBe(TOOLS.length);
+		// handleToolsList excludes internal-only tools; the recommended flag adds nothing/removes nothing.
+		expect(tools.length).toBe(TOOLS.length - INTERNAL_ONLY_TOOLS.size);
 	});
 
 	it('keeps the flag coupled to the instructions string — each recommended tool is named there', () => {


### PR DESCRIPTION
## What

Adds an optional **`portfolioGrade`** rollup to `prioritize_portfolio_leads`'s report — the brand-level grade the deferred bv-web-prod registrar portal will consume. This is the **Spec D backend prerequisite**: it moves the brand-grade math into bv-mcp so the portal renders one SSOT-sourced letter instead of forking the parity-guarded scoring engine client-side.

## How

- New `PortfolioGrade { grade, weightedScore, contributingDomains } | null` on `PortfolioLeadReport` — additive/optional, flows through to `structuredContent` with **no handler/schema/tool-count/README/audit change** (not a new tool).
- Pure `computePortfolioGrade()`: per-domain **weighted average of scan scores**, rounded once, then a single `nistScoreToGrade()` call for the NIST 6-band letter.
  - Weighting (user-pinned): `consolidated` 2×, `shadowIt`/`indeterminate`/`unknown` 1×, `impersonation`/`impersonationSurface` excluded (0).
  - Deliberately **distinct** from the existing `OWNERSHIP_MULTIPLIER` (that's sales-actionability ranking — a different concern).
  - **Never averages letters** and never inlines band thresholds → no SSOT/parity drift.
  - Domains whose individual `grade` is `N/A` (non-resolving / inconclusive) are **excluded** from the rollup rather than counted at 0 — consistent with the scan-domain aggregator contract ("inconclusive excluded, not zeroed").
  - Empty / all-excluded portfolios → `null` (division-safe; `nistScoreToGrade` never reached with NaN).
- Surfaced in `formatPortfolioLeads` (full + compact).

## Verification

- `test/prioritize-portfolio-leads.spec.ts`: **38 passed** (16 new assertions, TDD — failed first).
- `test/prioritize-portfolio-leads.integration.test.ts`: **6 passed** (additive field doesn't break the shape).
- `npm run typecheck`: clean.

Built via a design → adversarial-review (SSOT-parity + edge-case lenses) → TDD-implement → verify workflow; the edge-case reviewer caught the N/A-exclusion requirement, which is included.

## Scope boundary

The bv-web-prod portal + onboarding wizard remain **deferred to a dedicated bv-web-prod session** (separate repo, its own canary-deploy flow + vendored-dns-checks parity contract). This PR is only the bv-mcp side they depend on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)