### PR TITLE
feat(internal): registrar portal backend prereqs + unknown-tool count hardening (3.29.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.29.0] - 2026-07-01
+
+Minor release: **CSC portal backend prerequisites** (unblocks the deferred bv-web-prod "Penumbra" portal) plus a small info-disclosure hardening. Surfaced by grounding the portal design against the live bv-web-prod codebase.
+
+### Added
+
+- **Internal `?format=structured` now surfaces custom-shape tools' `structuredContent` as top-level `result`** (`src/internal.ts`, `/internal/tools/call`). Previously only CheckResult tools (via `resultCapture`) returned a top-level `result`; custom-shape tools (`prioritize_csc_leads`, `map_csc_products`, `scan_domain`) exposed their report only under `structuredContent`. bv-web's internal door reads `payload.result`, so it would have received `undefined` for those tools. The change is **additive** — the MCP-framed `content`/`structuredContent` fields are preserved, so existing `?format=structured` callers are unaffected; new callers get the report under `result`.
+
+### Security
+
+- **Unknown-tool error message no longer reveals a tool count.** Both the dispatch (`src/handlers/tools.ts`) and the public internal-only rejection (`src/mcp/execute.ts`) previously said "Call tools/list to see all N available tools" using the raw `TOOLS.length` (81). Since the public `tools/list` is 80 (internal-only `map_csc_products` hidden, 3.27.1), the aggregate count hinted that a hidden tool exists. Both messages now omit the count and stay byte-identical, so an internal-only tool remains indistinguishable from a nonexistent one. `smithery.yaml` and its audit corrected to the public count (80).
+
 ## [3.28.0] - 2026-07-01
 
 Minor release: brand-level **portfolio grade rollup** on `prioritize_csc_leads` (Spec D backend prerequisite). Unblocks the deferred bv-web-prod CSC portal by moving the brand-grade math into bv-mcp so the portal consumes one SSOT-sourced letter instead of forking the scoring engine client-side.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.28.0",
+	"version": "3.29.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.28.0",
+			"version": "3.29.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.28.0",
+	"version": "3.29.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.28.0",
+	"version": "3.29.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,6 +1,6 @@
 name: BlackVeil DNS Security MCP
 description: >-
-  DNS and email security scanner with 81 MCP tools. Bulk-scan multiple domains
+  DNS and email security scanner with 80 MCP tools. Bulk-scan multiple domains
   at once, benchmark against the industry average and sector percentile, detect
   whether a domain's posture improved or regressed via drift analysis, and catch
   SubdoMailing risks where an SPF include chain exposes a dangling domain.

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1604,7 +1604,7 @@ export async function handleToolsCall(
 				}
 				default:
 					logToolFailure({ ...ctx(), error: `Unknown tool: ${name}`, args });
-					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see all ${TOOLS.length} available tools.`);
+					return buildToolErrorResult(`Unknown tool: ${name}. Call tools/list to see the available tools.`);
 			}
 		};
 

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -307,10 +307,19 @@ internalRoutes.post('/tools/call', async (c) => {
 		});
 	}
 
-	// If structured format was requested and a CheckResult was captured (TOOL_REGISTRY tools only),
-	// return the raw result instead of MCP-framed text.
+	// If structured format was requested and a CheckResult was captured (TOOL_REGISTRY
+	// CheckResult tools), return the raw CheckResult instead of MCP-framed text.
 	if (wantStructured && capturedResult !== null) {
 		return c.json({ result: capturedResult, isError: result.isError ?? false });
+	}
+	// Custom-shape tools (e.g. prioritize_csc_leads, map_csc_products, scan_domain) don't
+	// produce a CheckResult but DO set structuredContent. Surface that report under the
+	// top-level `result` field the internal door contract uses (bv-web's door reads
+	// `payload.result`; without this it would only see `structuredContent`, a different
+	// field, and get undefined). ADDITIVE — the MCP-framed `content`/`structuredContent`
+	// are preserved, so existing `?format=structured` callers that read them are unaffected.
+	if (wantStructured && result.structuredContent !== undefined) {
+		return c.json({ ...result, result: result.structuredContent });
 	}
 
 	return c.json(result);

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -28,7 +28,6 @@ import {
 } from '../lib/config';
 import { jsonRpcSuccess } from '../lib/json-rpc';
 import { mcpError } from '../handlers/tool-formatters';
-import { TOOLS } from '../schemas/tool-definitions';
 import { normalizeToolName } from '../handlers/tool-args';
 import { shardIndexForKey, isQuotaShardSaltMissing } from '../lib/quota-coordinator';
 import { acceptsSSE } from '../lib/sse';
@@ -763,8 +762,8 @@ function buildGatedToolResponse(
  *
  * Returns the SAME unknown-tool result a nonexistent tool name produces via the
  * dispatch path (handlers/tools.ts `default` case) — a JSON-RPC success wrapping a
- * tool-error result whose text references the full TOOLS.length — so the tool's
- * existence is NOT leaked on the public surface and no 403/UPGRADE_REQUIRED is
+ * countless tool-error result (no tool count that would hint a hidden tool) — so the
+ * tool's existence is NOT leaked on the public surface and no 403/UPGRADE_REQUIRED is
  * emitted. executeMcpRequest is the public path only; the internal path
  * (src/internal.ts → handleToolsCall) bypasses this and remains fully callable,
  * as does the direct FUNCTION call from prioritize_csc_leads.
@@ -777,10 +776,12 @@ function buildInternalOnlyToolResponse(
 	eventId: string | undefined,
 	accessLogInput: { toolName: string; domain: string; method: string } | undefined,
 ): Extract<ProcessedRequestResult, { kind: 'response' }> {
-	// Byte-identical to the genuine unknown-tool wire payload (uses TOOLS.length,
-	// NOT the public count, so it is indistinguishable from a nonexistent tool).
+	// Byte-identical to the genuine unknown-tool wire payload (same countless message
+	// as handlers/tools.ts), so an internal-only tool is indistinguishable from a
+	// nonexistent one — and neither response reveals a tool count that would hint a
+	// hidden tool exists (public tools/list = TOOLS.length − INTERNAL_ONLY_TOOLS.size).
 	const payload = jsonRpcSuccess(id, {
-		content: [mcpError(`Unknown tool: ${toolName}. Call tools/list to see all ${TOOLS.length} available tools.`)],
+		content: [mcpError(`Unknown tool: ${toolName}. Call tools/list to see the available tools.`)],
 		isError: true,
 	});
 	// Mirror the dispatch unknown-tool bookkeeping: not a JSON-RPC error (result.isError),

--- a/test/audits/server-json-tool-count.audit.test.ts
+++ b/test/audits/server-json-tool-count.audit.test.ts
@@ -34,12 +34,14 @@ describe('smithery.yaml manifest', () => {
 		expect(smitheryYamlText).toContain('url:');
 	});
 
-	it('contains a description or displayName with the honest tool count', () => {
-		const toolCount = TOOLS.length;
-		const countPattern = new RegExp(`${toolCount}`);
+	it('contains a description or displayName with the honest PUBLIC tool count', () => {
+		// Smithery is a public directory listing; a user connects to the public /mcp
+		// endpoint and sees the PUBLIC tools (internal-only tools are hidden from
+		// tools/list). Advertise the public count, matching server.json above.
+		const countPattern = new RegExp(`${PUBLIC_TOOL_COUNT}`);
 		expect(smitheryYamlText).toMatch(
 			countPattern,
-			`smithery.yaml must mention the tool count (${toolCount}) so the Smithery directory listing is honest`,
+			`smithery.yaml must mention the public tool count (${PUBLIC_TOOL_COUNT}) so the Smithery directory listing is honest`,
 		);
 	});
 

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -446,11 +446,12 @@ describe('handleToolsCall - input validation & errors', () => {
 	});
 
 	it('unknown tool name returns isError with "Unknown tool"', async () => {
-		const { TOOLS } = await import('../src/schemas/tool-definitions');
 		const result = await call('nonexistent_tool', { domain: 'example.com' });
 		expect(result.isError).toBe(true);
 		expect(result.content[0].text).toContain('Unknown tool');
-		expect(result.content[0].text).toContain(`all ${TOOLS.length} available tools`);
+		expect(result.content[0].text).toContain('Call tools/list to see the available tools');
+		// No tool count in the message — an aggregate count would hint a hidden internal-only tool exists.
+		expect(result.content[0].text).not.toMatch(/\d+ available tools/);
 	});
 });
 

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -235,7 +235,7 @@ describe('Internal service binding routes', () => {
 			expect(body.result).toBeUndefined();
 		});
 
-		it('falls through to MCP-framed response for non-registry tools with format=structured', async () => {
+		it('surfaces structuredContent as top-level result for custom-shape tools with format=structured (additive)', async () => {
 			const { httpResponse, createDohResponse } = await import('./helpers/dns-mock');
 
 			globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
@@ -259,7 +259,14 @@ describe('Internal service binding routes', () => {
 			await waitOnExecutionContext(ctx);
 
 			expect(response.status).toBe(200);
-			const body = (await response.json()) as { content?: unknown; result?: unknown };
+			const body = (await response.json()) as { content?: unknown; structuredContent?: unknown; result?: Record<string, unknown> };
+			// scan_domain (and prioritize_csc_leads / map_csc_products) set structuredContent
+			// but produce no CheckResult. It is surfaced under the top-level `result` field
+			// the internal door contract uses — so bv-web's door (which reads payload.result)
+			// gets the report instead of undefined.
+			expect(body.result).toBeDefined();
+			expect(body.result).toEqual(body.structuredContent);
+			// ADDITIVE: the MCP-framed content is still present (no existing caller breaks).
 			expect(body.content).toBeDefined();
 		});
 	});


### PR DESCRIPTION
## What

Two small bv-mcp changes that **unblock the deferred bv-web-prod "Penumbra" registrar portal**, surfaced by grounding the portal design against the live bv-web-prod codebase (three recon agents).

### 1. `?format=structured` surfaces custom-shape reports as `result` (the portal prereq)
The internal door (`/internal/tools/call?format=structured`) only returned a top-level `result` for **CheckResult** tools (via `resultCapture`). Custom-shape tools — `prioritize_portfolio_leads`, `map_registrar_products`, `scan_domain` — set `structuredContent` but no CheckResult, so they fell through to the MCP-framed `{content, structuredContent}`. bv-web's internal door reads **`payload.result`**, so it would have gotten `undefined` for exactly the tools the portal consumes.

Fix: when structured is requested and the tool set `structuredContent`, surface it under the top-level `result` field. **Additive** — the framed `content`/`structuredContent` are preserved (`{ ...result, result: structuredContent }`), so no existing `?format=structured` caller breaks. Verified: `scan_domain?format=structured` now returns `payload.result === payload.structuredContent` **and** still carries `content`.

### 2. Unknown-tool message no longer leaks a tool count (info-disclosure hardening)
Both the dispatch (`handlers/tools.ts`) and the public internal-only rejection (`execute.ts`) said "Call tools/list to see all **N** available tools" using raw `TOOLS.length` (81). The public `tools/list` is 80 (internal-only `map_registrar_products` hidden, 3.27.1), so the count hinted a hidden tool exists. Both now omit the count and stay **byte-identical** (an internal-only tool remains indistinguishable from a nonexistent one). `smithery.yaml` + its audit corrected to the public count (80).

## Verification

- `test/internal.spec.ts`: **29 passed** (updated structured test asserts `payload.result` = report + `content` preserved).
- `test/handlers-tools.spec.ts`, `test/map-registrar-products-internal-only.spec.ts`, `test/audits/server-json-tool-count.audit.test.ts`: green.
- `npm run typecheck` + `eslint` clean. No tool-count change (80 public / 81 registered).

## Context

This is the bv-mcp half of "continue with all deferred registrar items." The Penumbra portal + onboarding wizard remain a bv-web-prod build; grounding confirmed they depend on this `payload.result` contract (their "B1" blocker) and on a human design-governance decision (brass accent vs the audited mono-mint system) — tracked in the gitignored local directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)