### PR TITLE
fix(oauth): fail closed on Host≠pinned OAUTH_ISSUER at mint + verify

### DIFF
--- a/src/lib/tier-auth.ts
+++ b/src/lib/tier-auth.ts
@@ -16,7 +16,7 @@ import { TierCacheEntrySchema, ValidateKeyResponseSchema } from '../schemas/auth
 import { resolveTrialKey } from './trial-keys';
 import { parseEnvelopeKey } from './kv-envelope';
 import { verifyJwt } from '../oauth/jwt';
-import { resolveIssuer } from '../oauth/discovery';
+import { resolveIssuerStrict } from '../oauth/discovery';
 import { isRevoked, getTokenVersion } from '../oauth/storage';
 import { z } from 'zod';
 
@@ -115,7 +115,12 @@ export async function resolveTier(
 	// self-hosted/dev installations that don't IP-gate their owner.
 	if (env.OAUTH_SIGNING_SECRET && env.SESSION_STORE && token.split('.').length === 3) {
 		try {
-			const issuer = resolveIssuer(requestUrl, env.OAUTH_ISSUER);
+			// Fail closed on a Host that doesn't match a pinned OAUTH_ISSUER: resolveIssuerStrict
+			// throws, the surrounding catch swallows it, and control falls through to the static-key
+			// path — which a 3-segment JWT can't satisfy, yielding an unauthenticated result. When
+			// OAUTH_ISSUER is unset (self-hosts) it stays a no-op Host-derivation, so their tokens
+			// still verify against their own Host (security-audit item 9).
+			const issuer = resolveIssuerStrict(requestUrl, env.OAUTH_ISSUER);
 			const claims = await verifyJwt(token, {
 				secret: env.OAUTH_SIGNING_SECRET,
 				issuer,

--- a/src/oauth/token.ts
+++ b/src/oauth/token.ts
@@ -5,7 +5,7 @@ import { TokenRequestSchema } from '../schemas/oauth';
 import { consumeCode, getTokenVersion } from './storage';
 import { signJwt, newJti, constantTimeEqual } from './jwt';
 import { OAUTH_JWT_TTL_SECONDS, OAUTH_KV_PREFIX, OAUTH_SIGNING_SECRET_MIN_BYTES } from '../lib/config';
-import { resolveIssuer } from './discovery';
+import { resolveIssuerStrict } from './discovery';
 import { resolveClientIpFromRequestHeaders } from '../lib/client-ip';
 import { parseEnvelopeKey } from '../lib/kv-envelope';
 
@@ -160,7 +160,17 @@ export async function handleToken(c: Context<AppEnv>): Promise<Response> {
 		return c.json({ error: 'server_error', error_description: 'OAUTH_SIGNING_SECRET not configured' }, 500);
 	}
 
-	const issuer = resolveIssuer(c.req.url, env.OAUTH_ISSUER);
+	// Fail closed when OAUTH_ISSUER is pinned and the request Host does not match it: refuse to
+	// mint a JWT whose iss/aud would embed an anomalous origin. When OAUTH_ISSUER is unset (BSL
+	// self-hosts) resolveIssuerStrict is a no-op and derives the issuer from the request Host, so
+	// self-hosters are unaffected. Cloudflare's route binding constrains Host in prod — this is the
+	// defense-in-depth layer behind it (security-audit item 9).
+	let issuer: string;
+	try {
+		issuer = resolveIssuerStrict(c.req.url, env.OAUTH_ISSUER);
+	} catch {
+		return c.json({ error: 'invalid_request', error_description: 'Invalid issuer' }, 400);
+	}
 	const subject = codeRec.subject ?? 'owner';
 	const tier = codeRec.tier ?? 'owner';
 

--- a/test/oauth/bearer-jwt.spec.ts
+++ b/test/oauth/bearer-jwt.spec.ts
@@ -173,6 +173,26 @@ describe('POST /mcp Bearer JWT acceptance', () => {
 		expect(res.status).toBe(401);
 	});
 
+	it('OAUTH_ISSUER pinned → valid JWT presented over a non-canonical Host → 401 (fail closed)', async () => {
+		// Hardening (security-audit item 9): with OAUTH_ISSUER pinned, the verify path pins the
+		// expected issuer regardless of Host — so Host-injection can't forge acceptance. Wiring
+		// resolveIssuerStrict makes it additionally FAIL CLOSED: a request arriving on a Host that
+		// differs from the pinned issuer is rejected (falls through to the static-key path, which a
+		// 3-segment JWT can't satisfy → 401) rather than silently normalized. Legit OAuth traffic
+		// always arrives on the canonical Host, so this only rejects anomalous/alternate-Host calls.
+		const { token } = await mintOAuthJwt({ issuer: 'https://example.com' }); // iss = pinned host
+		// jwtEnv pins OAUTH_ISSUER to https://example.com, but present the token over a different Host.
+		const req = new Request<unknown, IncomingRequestCfProperties>('https://spoofed.example/mcp', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+			body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, jwtEnv, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(res.status).toBe(401);
+	});
+
 	it('expired JWT → 401', async () => {
 		// ttlSeconds: -60 puts exp well past the clock-skew window, so verifyJwt throws
 		// `token expired`. Control flow falls through to the static-key branch which also

--- a/test/oauth/token.spec.ts
+++ b/test/oauth/token.spec.ts
@@ -364,6 +364,57 @@ describe('POST /oauth/token', () => {
 		expect(payload.error).toBe('service_unavailable');
 	});
 
+	it('rejects with invalid_request when the request Host does not match the pinned OAUTH_ISSUER (fail closed)', async () => {
+		// Hardening (security-audit item 9): when OAUTH_ISSUER is pinned, a token request arriving
+		// on a different Host must NOT mint a JWT. resolveIssuerStrict rejects the Host mismatch
+		// instead of silently normalizing to the pinned issuer, so a spoofed Host can never bake an
+		// anomalous origin into a minted credential. Cloudflare's route binding already constrains
+		// Host in prod — this is the fail-closed defense-in-depth layer behind it.
+		const { verifier, challenge } = await pkcePair();
+		const cid = await registerClient();
+		const code = await getAuthCode(cid, challenge);
+		expect(code).not.toBe('');
+		// postToken issues to https://example.com/oauth/token → Host ('example.com') ≠ pinned host.
+		const pinnedEnv = { ...authEnv, OAUTH_ISSUER: 'https://dns-mcp.blackveilsecurity.com' } as TestEnv;
+		const res = await postToken(
+			new URLSearchParams({
+				grant_type: 'authorization_code',
+				code,
+				client_id: cid,
+				redirect_uri: 'https://claude.ai/cb',
+				code_verifier: verifier,
+			}),
+			pinnedEnv,
+		);
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as Record<string, unknown>).error).toBe('invalid_request');
+	});
+
+	it('mints normally when the request Host matches the pinned OAUTH_ISSUER (happy-path regression guard)', async () => {
+		const { verifier, challenge } = await pkcePair();
+		const cid = await registerClient();
+		const code = await getAuthCode(cid, challenge);
+		expect(code).not.toBe('');
+		// Pinned issuer host == request Host (example.com) → strict resolution succeeds, token mints.
+		const pinnedEnv = { ...authEnv, OAUTH_ISSUER: 'https://example.com' } as TestEnv;
+		const res = await postToken(
+			new URLSearchParams({
+				grant_type: 'authorization_code',
+				code,
+				client_id: cid,
+				redirect_uri: 'https://claude.ai/cb',
+				code_verifier: verifier,
+			}),
+			pinnedEnv,
+		);
+		expect(res.status).toBe(200);
+		const tok = (await res.json()) as { access_token: string };
+		const [, payload] = tok.access_token.split('.');
+		const claims = JSON.parse(atob(payload.replace(/-/g, '+').replace(/_/g, '/'))) as Record<string, unknown>;
+		expect(claims.iss).toBe('https://example.com');
+		expect(claims.aud).toBe('https://example.com/mcp');
+	});
+
 	it('rate-limits token requests at 30/min per IP', async () => {
 		// Mirrors the fixed-window limiter pattern in authorize.ts: 30 requests per IP per 60s.
 		// The 31st call from the same IP must return 429 with invalid_request. We fire requests


### PR DESCRIPTION
## What

Wires `resolveIssuerStrict` into the two OAuth auth chokepoints so a request whose `Host` does not match a **pinned** `OAUTH_ISSUER` is **rejected** rather than silently normalized to the pinned issuer. Closes the residual gap in security-audit item 9 (`.dev/security-audit-2026-06-10.md`): *"resolveIssuerStrict exists but is unwired (no prod caller)."*

## Why

`OAUTH_ISSUER` is already pinned in the prod deploy overlay, so `resolveIssuer` returns it verbatim and Host-injection is neutralized for what gets **advertised/minted**. This change adds the **fail-closed** layer the audit recommends: an anomalous `Host` (one that bypasses Cloudflare's route binding) is refused instead of ignored.

## Changes

| File | Path | Behavior on `Host ≠ pinned OAUTH_ISSUER` |
|------|------|------------------------------------------|
| `src/oauth/token.ts` | mint (`handleToken`) | `resolveIssuerStrict` in try/catch → **`400 invalid_request`**, refuses to mint |
| `src/lib/tier-auth.ts` | verify (Bearer JWT path) | throw caught by the existing `catch` → falls through to static-key path → **`401`** |

## Semantics (all fail-closed)

- **`OAUTH_ISSUER` unset (BSL self-hosts):** `resolveIssuerStrict` is a **no-op** — derives issuer from `Host`, never throws. Self-hosted OAuth unaffected; the existing backward-compat pin (`bearer-jwt.spec.ts`) stays green.
- **Pinned + Host matches (prod, legit traffic):** unchanged.
- **Pinned + Host differs:** rejected.

## Behavior note

A valid OAuth **JWT** presented over a *non-canonical* hostname (e.g. `*.workers.dev`) now returns `401` instead of authenticating. No real flow does this (connectors use the prod domain; static-key owner testing is not a JWT and is unaffected).

## Tests (TDD)

- `token.spec.ts`: `Host ≠ pinned` → `400 invalid_request`; `Host == pinned` → mints `200` with `iss`/`aud` = pinned (happy-path regression guard).
- `bearer-jwt.spec.ts`: valid JWT over a non-canonical Host → `401`.

RED verified (both new negative tests failed as `200` before the fix), then GREEN. `typecheck` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)