### PR TITLE
fix(mcp): spec-compliant GET /mcp SSE transport (405 + wildcard Accept) — 3.29.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
-## [3.29.1] - 2026-07-02
+## [3.29.2] - 2026-07-02
+
+Patch release: **MCP Streamable HTTP transport spec-compliance** for the `GET /mcp` SSE endpoint.
+
+### Fixed
+
+- **`GET /mcp` content negotiation now honors wildcard `Accept`.** `acceptsSSE` (`src/lib/sse.ts`) did a literal substring match for `text/event-stream`, wrongly returning `406` to clients that send `Accept: */*` or `text/*` (RFC 9110 wildcards that *do* accept SSE). It now accepts those.
+- **`GET /mcp` and `GET /mcp/sse` return `405 Method Not Allowed` (with `Allow`) instead of `406`** when SSE cannot be served, per the MCP 2025-06-18 Streamable HTTP spec (a GET yields an SSE stream or `405`). `405` is the status clients treat as "no SSE here, use POST" and fall back on. No change for compliant clients (those sending `Accept: text/event-stream` still get the stream).
 
 Patch release: **OAuth issuer fail-closed hardening** (#472). Versions the security change already deployed on top of 3.29.0.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.1",
+	"version": "3.29.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.29.1",
+			"version": "3.29.2",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.1",
+	"version": "3.29.2",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.29.1",
+	"version": "3.29.2",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1108,7 +1108,12 @@ app.post('/mcp/messages', async (c) => {
 
 app.get('/mcp', async (c) => {
 	if (!acceptsSSE(c.req.header('accept'))) {
-		return new Response('Not Acceptable: Accept must include text/event-stream', { status: 406 });
+		// MCP 2025-06-18 Streamable HTTP: a GET to the MCP endpoint yields an SSE stream or 405.
+		// 405 (not 406) is the status clients treat as "no SSE here, use POST" and fall back on.
+		return new Response('Method Not Allowed: GET requires Accept: text/event-stream', {
+			status: 405,
+			headers: { Allow: 'GET, POST' },
+		});
 	}
 
 	const sessionId = c.req.header('mcp-session-id');
@@ -1155,7 +1160,12 @@ app.get('/mcp', async (c) => {
 
 app.get('/mcp/sse', async (c) => {
 	if (!acceptsSSE(c.req.header('accept'))) {
-		return new Response('Not Acceptable: Accept must include text/event-stream', { status: 406 });
+		// MCP 2025-06-18 Streamable HTTP: a GET to the MCP endpoint yields an SSE stream or 405.
+		// 405 (not 406) is the status clients treat as "no SSE here, use POST" and fall back on.
+		return new Response('Method Not Allowed: GET requires Accept: text/event-stream', {
+			status: 405,
+			headers: { Allow: 'GET, POST' },
+		});
 	}
 
 	const ip = resolveClientIpFromRequestHeaders(c.req.raw.headers);

--- a/src/lib/sse.ts
+++ b/src/lib/sse.ts
@@ -19,9 +19,16 @@ export function sseEvent(data: unknown, eventId?: string): string {
 	return event;
 }
 
-/** Check whether the Accept header includes text/event-stream */
+/**
+ * Check whether the Accept header can satisfy a text/event-stream (SSE) response.
+ *
+ * Returns true for an explicit text/event-stream, or an RFC 9110 wildcard that includes it
+ * (a full-wildcard or a text-type-wildcard range). A bare substring check for the exact media
+ * type alone wrongly 406s clients that send a wildcard Accept even though a wildcard accepts SSE.
+ */
 export function acceptsSSE(accept: string | undefined): boolean {
-	return !!accept && accept.includes('text/event-stream');
+	if (!accept) return false;
+	return accept.includes('text/event-stream') || accept.includes('*/*') || accept.includes('text/*');
 }
 
 /**

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -968,7 +968,9 @@ describe('DNS Security MCP Server', () => {
 			expect(body.error.message).toContain('session expired or terminated');
 		});
 
-		it('GET /mcp returns 406 when Accept does not include text/event-stream', async () => {
+		it('GET /mcp returns 405 (per MCP spec) when Accept cannot satisfy text/event-stream', async () => {
+			// MCP 2025-06-18 Streamable HTTP: a GET to the MCP endpoint returns an SSE stream or
+			// 405 Method Not Allowed — 405, not 406, is the status clients handle as "use POST".
 			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
 				method: 'GET',
 				headers: {
@@ -978,7 +980,26 @@ describe('DNS Security MCP Server', () => {
 			const ctx = createExecutionContext();
 			const response = await worker.fetch(request, env, ctx);
 			await waitOnExecutionContext(ctx);
-			expect(response.status).toBe(406);
+			expect(response.status).toBe(405);
+			expect(response.headers.get('allow')).toContain('POST');
+		});
+
+		it('GET /mcp accepts a wildcard Accept (*/*) for the SSE stream — passes the accept gate', async () => {
+			// RFC 9110 content negotiation: `Accept: */*` DOES accept text/event-stream, so it must
+			// not be rejected at the SSE-accept gate. It should fall through to the normal session
+			// check (400 missing session), NOT 405/406.
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/mcp', {
+				method: 'GET',
+				headers: {
+					Accept: '*/*',
+				},
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, env, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(400);
+			const body = (await response.json()) as { error: { message: string } };
+			expect(body.error.message).toContain('missing session');
 		});
 
 		it('GET /mcp requires an existing session header', async () => {


### PR DESCRIPTION
Brings the `GET /mcp` SSE endpoint into line with the MCP 2025-06-18 Streamable HTTP spec (a GET yields an SSE stream or **405**, and clients may send wildcard `Accept`). Surfaced while debugging a Claude Desktop connector.

## Changes
- **`acceptsSSE`** (`src/lib/sse.ts`): now accepts `text/event-stream` **or** the RFC 9110 wildcards `*/*` / `text/*`. The old literal-substring check wrongly `406`'d clients sending `Accept: */*`.
- **`GET /mcp` + `GET /mcp/sse`**: return **`405 Method Not Allowed`** (with `Allow`) instead of `406` when SSE can't be served — `405` is the spec status clients fall back on ("use POST").

## Safety
- Compliant clients (`Accept: text/event-stream`) are **unchanged** (still get the stream / 400 missing-session).
- TDD: `test/index.spec.ts` updated — `application/json` → `405`, `*/*` → `400 missing session`. Full `index.spec` (81) + SSE/streaming specs green; typecheck + lint clean.

Version → 3.29.2 (package.json + lock, server.json, CHANGELOG).

🤖 Generated with [Claude Code](https://claude.com/claude-code)