### PR TITLE
fix(oauth): allow claude.com redirect_uris in DCR allowlist — 3.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.29.3] - 2026-07-02
+
+Patch release: **claude.com OAuth connector registration fix**.
+
+### Fixed
+
+- **Dynamic Client Registration now accepts `https://claude.com/...` redirect URIs.** Anthropic's claude.ai → claude.com migration changed the callback URL Claude connectors register (`https://claude.com/api/mcp/auth_callback`), which `OAUTH_REDIRECT_URI_ALLOWLIST` rejected with `400 invalid_redirect_uri` — surfacing to users as "Couldn't register with blackveil-dns's sign-in service." Added an anchored apex `claude.com` pattern (no subdomain wildcard) alongside the existing `claude.ai` entry; lookalike hosts (`claude.com.evil.example`) remain rejected.
+
 ## [3.29.2] - 2026-07-02
 
 Patch release: **MCP Streamable HTTP transport spec-compliance** for the `GET /mcp` SSE endpoint.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.2",
+	"version": "3.29.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.29.2",
+			"version": "3.29.3",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.2",
+	"version": "3.29.3",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.29.2",
+	"version": "3.29.3",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -639,6 +639,8 @@ export const OAUTH_TOKEN_AUTH_METHODS_SUPPORTED = ['none'] as const;
 export const OAUTH_CODE_CHALLENGE_METHODS_SUPPORTED = ['S256'] as const;
 export const OAUTH_REDIRECT_URI_ALLOWLIST: RegExp[] = [
 	/^https:\/\/claude\.ai(\/.*)?$/,
+	// claude.ai → claude.com migration: connectors now register https://claude.com/api/mcp/auth_callback
+	/^https:\/\/claude\.com(\/.*)?$/,
 	/^https:\/\/[^/]+\.anthropic\.com(\/.*)?$/,
 	/^http:\/\/localhost(:\d+)?(\/.*)?$/,
 	/^http:\/\/127\.0\.0\.1(:\d+)?(\/.*)?$/,

--- a/test/oauth/register.spec.ts
+++ b/test/oauth/register.spec.ts
@@ -24,6 +24,27 @@ describe('POST /oauth/register', () => {
 		expect(body.token_endpoint_auth_method).toBe('none');
 	});
 
+	it('accepts a claude.com redirect (post claude.ai → claude.com migration) and returns 201', async () => {
+		const res = await SELF.fetch('https://example.com/oauth/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ client_name: 'Claude', redirect_uris: ['https://claude.com/api/mcp/auth_callback'] }),
+		});
+		expect(res.status).toBe(201);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(typeof body.client_id).toBe('string');
+	});
+
+	it('rejects claude.com lookalike hosts', async () => {
+		const res = await SELF.fetch('https://example.com/oauth/register', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({ redirect_uris: ['https://claude.com.evil.example/cb'] }),
+		});
+		expect(res.status).toBe(400);
+		expect(((await res.json()) as Record<string, unknown>).error).toBe('invalid_redirect_uri');
+	});
+
 	it('rejects redirect_uri outside allowlist', async () => {
 		const res = await SELF.fetch('https://example.com/oauth/register', {
 			method: 'POST',


### PR DESCRIPTION
## Problem

Claude connectors fail to connect with **"Couldn't register with blackveil-dns's sign-in service"** (ref `ofid_86a28c8f6c18cc93`).

Root cause: Anthropic's claude.ai → claude.com migration changed the callback URL connectors send during Dynamic Client Registration to `https://claude.com/api/mcp/auth_callback`. `OAUTH_REDIRECT_URI_ALLOWLIST` (src/lib/config.ts) only allowed `claude.ai`, `*.anthropic.com`, and localhost, so `/register` returned `400 invalid_redirect_uri`.

Reproduced against prod:
- `https://claude.ai/api/mcp/auth_callback` → 201
- `https://claude.com/api/mcp/auth_callback` → **400 invalid_redirect_uri**

## Fix

Add an anchored apex `claude.com` pattern to the allowlist (mirrors the existing `claude.ai` entry; least privilege — no subdomain wildcard). Lookalike hosts (`claude.com.evil.example`) remain rejected.

## Tests

- New spec: claude.com callback → 201 (failed 400 before the fix)
- New spec: claude.com lookalike host → 400
- OAuth suite 46/46 green; audit suite 322 green; typecheck clean

Release: 3.29.3 (package.json/lock + server.json + CHANGELOG bumped; SERVER_VERSION auto-derives).

🤖 Generated with [Claude Code](https://claude.com/claude-code)