### PR TITLE
fix(internal): wire BRAND_AUDIT_DB/QUEUE into the internal-door tool options

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -117,6 +117,16 @@ type InternalEnv = {
 		getDomainEvidence: (params: { domain: string; includeHistory?: boolean }) => Promise<unknown>;
 	};
 	BV_ENTERPRISE?: Fetcher;
+	/**
+	 * D1 + Queue backing the async brand-audit subsystem (`discover_brand_domains_start`,
+	 * `brand_audit_batch_start`, `register_brand_audit_watch`). Bound to the SAME worker
+	 * as the public `/mcp` path (`BvMcpEnv` in `src/index.ts`) — the internal door MUST
+	 * thread them into the tool runtime options or the async `*_start` tools short-circuit
+	 * to `unprovisioned` with no `auditId` (the caller polls forever, nothing is stored).
+	 * Absent on BSL self-hosts → the tools degrade cleanly to `unprovisioned`.
+	 */
+	BRAND_AUDIT_DB?: D1Database;
+	BRAND_AUDIT_QUEUE?: { send(message: unknown, options?: { contentType?: 'json' }): Promise<void> };
 	/** FIND-17: Base64-encoded 32-byte AES-256 key for app-layer KV envelope encryption. */
 	KV_ENVELOPE_KEY?: string;
 	/** D1 store backing mcp_access_log — precise per-customer usage/forensics. Mirrors BvMcpEnv in index.ts. */
@@ -277,6 +287,14 @@ internalRoutes.post('/tools/call', async (c) => {
 			// which silently stalled the bv2-ops recon-sweep queue (fixed 2026-06-23).
 			reconBinding: c.env.BV_RECON,
 			reconAuthToken: c.env.BV_RECON_KEY,
+			// Async brand-audit subsystem (discover_brand_domains_start /
+			// brand_audit_batch_start / register_brand_audit_watch). Same
+			// failure mode as the recon binding above: without these the
+			// async *_start tools short-circuit to `unprovisioned` with no
+			// auditId, so the bv2-ops csc-discovery sweep polls forever and
+			// stores nothing. Bound to the same worker as the public path.
+			brandAuditDb: c.env.BRAND_AUDIT_DB,
+			brandAuditQueue: c.env.BRAND_AUDIT_QUEUE,
 			// Tier 0/1/2 lookup closures — internal callers (load tests, bv-web
 			// service binding, ops scripts) get the same tiered discovery path as
 			// public `/mcp`. Closures stay `undefined` on BSL self-hosts where
@@ -547,6 +565,10 @@ internalRoutes.post('/tools/batch', async (c) => {
 							: undefined,
 						whoisBinding: c.env.BV_WHOIS,
 						infraProbe: c.env.BV_INFRA_PROBE,
+						// Async brand-audit subsystem — parity with the single-call door
+						// so a batched brand tool can also reach the D1 store + queue.
+						brandAuditDb: c.env.BRAND_AUDIT_DB,
+						brandAuditQueue: c.env.BRAND_AUDIT_QUEUE,
 						// Tier 0/1/2 lookup closures — batch invocations of brand tools
 						// from internal callers must also exercise tiered mode when the
 						// bindings are provisioned.

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -99,6 +99,42 @@ describe('Internal service binding routes', () => {
 		});
 	});
 
+	describe('brand-audit subsystem wiring', () => {
+		// Regression: the internal door built tool options without brandAuditDb/
+		// brandAuditQueue (only the public /mcp path wired them), so the async
+		// discover_brand_domains_start / brand_audit_batch_start tools short-circuited
+		// to `unprovisioned` with no auditId over the door — the bv2-ops csc-discovery
+		// sweep polled forever and stored nothing. This asserts the door reaches the
+		// D1 store + queue so the async producer actually enqueues.
+		it('passes BRAND_AUDIT_DB/QUEUE through the internal door so discover_brand_domains_start enqueues', async () => {
+			const queueSend = vi.fn(async () => {});
+			const dbRun = vi.fn(async () => ({ success: true }));
+			// Minimal chainable D1 stub: prepare().bind().run()
+			const brandAuditDb = {
+				prepare: () => ({ bind: () => ({ run: dbRun }) }),
+			};
+			const brandEnv = {
+				...testEnv,
+				BRAND_AUDIT_DB: brandAuditDb,
+				BRAND_AUDIT_QUEUE: { send: queueSend },
+			} as unknown as typeof testEnv;
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+				method: 'POST',
+				headers: { 'Content-Type': 'application/json' },
+				body: JSON.stringify({ name: 'discover_brand_domains_start', arguments: { domain: 'example.com' } }),
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, brandEnv, ctx);
+			await waitOnExecutionContext(ctx);
+			expect(response.status).toBe(200);
+			// Both bindings threaded → the async producer wrote the audit row and
+			// enqueued the discovery job (never reaches enqueue if the door left
+			// brandAuditDb/brandAuditQueue undefined → unprovisioned short-circuit).
+			expect(dbRun).toHaveBeenCalled();
+			expect(queueSend).toHaveBeenCalled();
+		});
+	});
+
 	describe('POST /internal/tools/call', () => {
 		it('dispatches check_spf and returns raw result', async () => {
 			const { mockTxtRecords } = await import('./helpers/dns-mock');


### PR DESCRIPTION
## Problem
The internal door (`/internal/tools/{call,batch}`) built the tool runtime options **without** `brandAuditDb`/`brandAuditQueue` — only the public `/mcp` path (`src/index.ts`, 3 sites) wired them. So the async brand-audit `*_start` tools invoked over the door (`discover_brand_domains_start`, `brand_audit_batch_start`, `register_brand_audit_watch`) short-circuited to `unprovisioned` with no `auditId`: the caller polled forever and nothing was stored.

This is the **exact failure mode already documented for the recon binding** (`internal.ts` reconBinding comment, "silently stalled the bv2-ops recon-sweep queue", fixed 2026-06-23).

## Why now
The forthcoming **bv-web-prod registrar discovered-domain store** ([bv-web-prod#845](https://github.com/MadaBurns/bv-web-prod/pull/845)) drives its discovery sweep through this door. Without this wiring the sweep is a silent no-op — the final whole-branch review of that feature surfaced this cross-repo gap.

## Fix
Both bindings are already bound to the **same worker** as the public path (the internal routes share `c.env`), so this is a **pure code-threading fix — no new binding provisioning**. Absent on BSL self-hosts → the tools still degrade cleanly to `unprovisioned` (fail-soft preserved).

- Add `BRAND_AUDIT_DB`/`BRAND_AUDIT_QUEUE` to `InternalEnv`
- Wire both at the single-call **and** batch door option sites
- Add a door wiring regression test: binds a mock D1 + queue, calls `discover_brand_domains_start` over the door, asserts the async producer wrote the audit row and enqueued (proving the door reached both — it never enqueues if the door left the bindings undefined)

## Verification (Node 22)
- `npx vitest run test/internal.spec.ts` — **30/30 pass** (29 existing + the new wiring test)
- `npm run typecheck` — exit 0

## Note
This is a code fix, not a release. It takes effect on the next `deploy:prod` (operator-gated). No version bump included — bump + release at deploy time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)