### PR TITLE
chore: bump version to 3.29.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.29.4] - 2026-07-02
+
+Patch release: **internal-door brand-audit binding wiring** (#477).
+
+### Fixed
+
+- **`/internal/tools/{call,batch}` now threads `BRAND_AUDIT_DB` / `BRAND_AUDIT_QUEUE` into the tool runtime options.** Only the public `/mcp` path wired them, so the async brand-audit `*_start` tools (`discover_brand_domains_start`, `brand_audit_batch_start`, `register_brand_audit_watch`) invoked over the internal service binding short-circuited to `unprovisioned` with no `auditId` — the caller polled forever and nothing was stored (the same failure mode already fixed for the recon binding). Both bindings are on the same Worker as the public path, so this is a pure code-threading fix; absent on BSL self-hosts the tools still degrade cleanly to `unprovisioned`.
+
+### Changed
+
+- Dev-dependency bumps: `@cloudflare/vitest-pool-workers` 0.16→0.17, `wrangler` 4.105→4.106, `@cloudflare/workers-types`, `typescript-eslint` 8.62.0→8.62.1, `eslint` 10.5.0→10.6.0, `actions/cache` 6.0.0→6.1.0 (Dependabot #468–471).
+
 ## [3.29.3] - 2026-07-02
 
 Patch release: **claude.com OAuth connector registration fix**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.3",
+	"version": "3.29.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.29.3",
+			"version": "3.29.4",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.3",
+	"version": "3.29.4",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.29.3",
+	"version": "3.29.4",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Patch release **3.29.4** to version + deploy the internal-door brand-audit binding fix (#477) already merged to main, avoiding version-label drift (prod would otherwise report 3.29.3 with 3.29.4 code).

## Contents
- **#477** — `/internal/tools/{call,batch}` now threads `BRAND_AUDIT_DB`/`BRAND_AUDIT_QUEUE` into tool runtime options so async brand-audit `*_start` tools (incl. `discover_brand_domains_start`, which the bv-web-prod registrar discovery sweep drives) actually enqueue over the door instead of returning `unprovisioned`.
- Dependabot dev-dep bumps #468–471 (vitest-pool-workers 0.16→0.17, wrangler 4.105→4.106, workers-types, typescript-eslint, eslint, actions/cache).

## Surfaces synced
package.json + lock (SERVER_VERSION auto-derives), server.json (remotes-only single version), CHANGELOG `[3.29.4]`.

Deploy path: PR merge → `deploy:prod` (worker deploy; tag/registry optional reconciliation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)