### PR TITLE
fix(audit): badge anti-enumeration caps, inert WASM de-wire, CI hygiene

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -94,12 +94,11 @@ jobs:
           VERSION: ${{ steps.extract.outputs.version }}
         run: npm version "$VERSION" --no-git-tag-version --allow-same-version
 
-      - name: Update SERVER_VERSION
-        env:
-          VERSION: ${{ steps.extract.outputs.version }}
-        run: |
-          sed -i "s/export const SERVER_VERSION = '.*'/export const SERVER_VERSION = '$VERSION'/" src/lib/server-version.ts
-          grep SERVER_VERSION src/lib/server-version.ts
+      # SERVER_VERSION is intentionally NOT bumped here: src/lib/server-version.ts
+      # auto-derives it from package.json (`export const SERVER_VERSION: string =
+      # pkg.version;`), which `npm version` above already updated. The prior
+      # `sed` step targeted a hand-edited literal that no longer exists — it was
+      # a silent no-op implying it maintained a surface it did not.
 
       - name: Update server.json version
         env:
@@ -134,7 +133,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json src/lib/server-version.ts server.json
+          git add package.json package-lock.json server.json
           if git diff --cached --quiet; then
             echo "Version already matches tag"
           else

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,26 +16,33 @@
 
 import { Hono, type Context } from 'hono';
 import { cors } from 'hono/cors';
-import wasm from '../crates/bv-wasm-core/pkg/bv_wasm_core_bg.wasm';
-import * as bv_wasm from '../crates/bv-wasm-core/pkg/bv_wasm_core.js';
 
-// Initialize the Wasm module
-bv_wasm.initSync(wasm);
+// INERT — the bv-wasm-core crate (estimateTokens / checkPermission / compaction)
+// is a fully-built, fully-tested subsystem that is NOT wired into any code path
+// here. It was previously `initSync`'d at module load, adding cold-start + bundle
+// cost for functions nothing in the Worker ever called. The import + init were
+// removed so the crate stops loading on every request. It remains a STAGED SEAM:
+// the crate and its tests (test/wasm-integration.test.ts, which self-inits) are
+// intentionally retained for a future wiring. Re-add the import + `initSync(wasm)`
+// only when a real call site consumes an exported function. Operator note: safe
+// to keep unwired; do not delete the crate.
 
-import { checkRateLimit, checkToolDailyRateLimit } from './lib/rate-limiter';
+import { checkDistinctDomainDailyLimit, checkGlobalDailyLimit, checkRateLimit, checkToolDailyRateLimit } from './lib/rate-limiter';
 import { logEvent, logError, sanitizeHeadersForLog } from './lib/log';
 import { jsonRpcError, JSON_RPC_ERRORS } from './lib/json-rpc';
 import { normalizeHeaders, parseJsonRpcRequest, readRequestBody, validateContentType } from './mcp/request';
 import { createSession, deleteSession, validateSession, checkSessionCreateRateLimit } from './lib/session';
 import { unauthorizedResponse } from './lib/auth';
 import { sseEvent, acceptsSSE, createNotificationStream, sseErrorResponse, createStreamingSseResponse } from './lib/sse';
-import { createAnalyticsClient, hashForAnalytics, hashIpForAnalytics } from './lib/analytics';
+import { createAnalyticsClient, hashDomain, hashForAnalytics, hashIpForAnalytics } from './lib/analytics';
 import { detectMcpClient } from './lib/client-detection';
 import { parseAnalyticsPiiLevel } from './lib/analytics-pii';
 import type { JsonRpcRequest } from './lib/json-rpc';
 import { buildControlPlaneRateLimitResponse, resolveSseSession, validateSessionRequest } from './mcp/route-gates';
 import {
+	FREE_DISTINCT_DOMAIN_DAILY_LIMIT,
 	FREE_TOOL_DAILY_LIMITS,
+	GLOBAL_DAILY_TOOL_LIMIT,
 	MAX_REQUEST_BODY_BYTES,
 	isValidOAuthSigningSecret,
 	parseCacheTtl,
@@ -592,6 +599,15 @@ app.get('/health', async (c) => {
 	);
 });
 
+/** 429 SVG badge response with an optional retry-after header (seconds). */
+function badgeRateLimitResponse(svgHeaders: Record<string, string>, retryAfterMs?: number): Response {
+	const headers: Record<string, string> = { ...svgHeaders };
+	if (retryAfterMs !== undefined) {
+		headers['retry-after'] = String(Math.ceil(retryAfterMs / 1000));
+	}
+	return new Response(errorBadge(), { status: 429, headers });
+}
+
 app.get('/badge/:domain', async (c) => {
 	const svgHeaders = {
 		'Content-Type': 'image/svg+xml',
@@ -601,7 +617,17 @@ app.get('/badge/:domain', async (c) => {
 	const ip = resolveClientIpFromRequestHeaders(c.req.raw.headers);
 	const rateResult = await checkRateLimit(ip, c.env.RATE_LIMIT, c.env.QUOTA_COORDINATOR);
 	if (!rateResult.allowed) {
-		return new Response(errorBadge(), { status: 429, headers: svgHeaders });
+		return badgeRateLimitResponse(svgHeaders, rateResult.retryAfterMs);
+	}
+
+	// The badge runs the full scan engine unauthenticated, so it must apply the
+	// SAME anti-enumeration caps the anonymous POST /mcp path enforces in
+	// executeMcpRequest — not just the per-IP + per-tool caps. Without these, an
+	// unauthenticated IP could scan up to 25 DISTINCT domains/day here (vs the
+	// intended 12) and those scans would escape the global daily cap entirely.
+	const globalResult = await checkGlobalDailyLimit(GLOBAL_DAILY_TOOL_LIMIT, c.env.RATE_LIMIT, c.env.QUOTA_COORDINATOR);
+	if (!globalResult.allowed) {
+		return badgeRateLimitResponse(svgHeaders, globalResult.retryAfterMs);
 	}
 
 	const toolQuota = await checkToolDailyRateLimit(
@@ -624,6 +650,14 @@ app.get('/badge/:domain', async (c) => {
 	const domain = sanitizeDomain(rawDomain);
 	if (!domain) {
 		return new Response(errorBadge(), { status: 400, headers: svgHeaders });
+	}
+
+	// Distinct-domain/day cap (tighter than the per-tool 25/day) — mirrors the
+	// executeMcpRequest speed-bump so /badge can't be used to enumerate a wider
+	// distinct-domain set than /mcp. Keyed on the per-IP principal; fail-open.
+	const distinctResult = await checkDistinctDomainDailyLimit(ip, hashDomain(domain), FREE_DISTINCT_DOMAIN_DAILY_LIMIT, c.env.RATE_LIMIT);
+	if (!distinctResult.allowed) {
+		return badgeRateLimitResponse(svgHeaders, distinctResult.retryAfterMs);
 	}
 
 	try {

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1444,6 +1444,37 @@ describe('DNS Security MCP Server', () => {
 			expect(differentIpResponse.status).toBe(429);
 		});
 
+		it('applies the distinct-domain/day cap on /badge (12, not the 25 per-tool cap)', async () => {
+			// Audit FIND-1: the public /badge handler runs the full scan engine
+			// unauthenticated but previously only enforced per-IP + per-tool caps,
+			// letting one IP scan up to 25 DISTINCT domains/day here (vs the 12
+			// intended by executeMcpRequest). It must now mirror the tighter
+			// distinct-domain cap. Seed the per-IP distinct-domain COUNTER to the
+			// limit so a FRESH distinct domain trips the cap without running 12 real
+			// scans; the check runs BEFORE scanDomain, so no fan-out occurs.
+			vi.useFakeTimers();
+			vi.setSystemTime(new Date('2026-03-08T00:00:00Z'));
+			try {
+				const ip = '203.0.113.44';
+				const DAY_MS = 86_400_000;
+				const dayWindow = Math.floor(Date.now() / DAY_MS);
+				// FREE_DISTINCT_DOMAIN_DAILY_LIMIT is 12.
+				await env.RATE_LIMIT.put(`rl:day:ddc:count:${ip}:${dayWindow}`, '12', { expirationTtl: 86_400 });
+
+				const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/badge/example.com', {
+					headers: { 'cf-connecting-ip': ip },
+				});
+				const ctx = createExecutionContext();
+				const response = await worker.fetch(request, env, ctx);
+				await waitOnExecutionContext(ctx);
+
+				expect(response.status).toBe(429);
+				expect(response.headers.get('Content-Type')).toBe('image/svg+xml');
+			} finally {
+				vi.useRealTimers();
+			}
+		});
+
 		it('authenticated scan_domain requests are not subject to free daily cap', async () => {
 			const authEnv = { ...env, BV_API_KEY: TEST_API_KEY } as Env;
 			const sessionId = await initSession({ authToken: TEST_API_KEY, targetEnv: authEnv });

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -54,10 +54,19 @@ export default defineConfig({
 		// shutdown that the pool's transport bridge reports as 2 file-level
 		// unhandled errors, even though every test assertion passes (3103/3103).
 		// The errors don't carry an exit code by themselves — they only flip the
-		// suite to red when vitest's Errors count is non-zero. Suppressing
-		// because no userland code can produce these workerd teardown messages in
-		// this test environment; the npm Vitest wrapper keeps the matching raw
-		// stderr line out of user-visible test output.
+		// suite to red when vitest's Errors count is non-zero.
+		//
+		// KNOWN TRADE-OFF (audit FIND-4, flagged for operator): this is GLOBAL —
+		// it swallows *every* unhandled error in the ~3300-test suite, so a real
+		// floating-promise rejection would no longer fail CI. It is NOT redundant
+		// with scripts/vitest-filter-workerd.mjs: that wrapper is output-only (it
+		// strips the matching raw stderr LINE from user-visible output) and does
+		// NOT affect vitest's unhandled-error count or exit code. Removing this
+		// flag and relying on the stderr filter alone WOULD re-red the full suite
+		// on the teardown noise. Vitest exposes no per-message narrow for this at
+		// config level, so tightening safely requires a pool-workers fix (or a
+		// vitest onUnhandledError filter hook) — left as operator follow-up rather
+		// than silently reintroducing a flaky-red full suite.
 		dangerouslyIgnoreUnhandledErrors: true,
 		// No coverage config: the @vitest/coverage-v8 provider can't run under the
 		// @cloudflare/vitest-pool-workers runtime (workerd lacks `node:inspector`,


### PR DESCRIPTION
Remediation of the bv-mcp findings from the cross-repo deep review. The scoring core (`packages/dns-checks`) was reviewed as **correct** and is untouched. Companion PR in bv-web-prod: `MadaBurns/bv-web-prod#856`.

## Verification
- `tsc --noEmit` 0 · `eslint` 0
- 82 index/badge tests pass · gitleaks clean

## What changed
- **`/badge/:domain`** now applies the anonymous `/mcp` path's distinct-domain (12/day) and global daily caps, so the public badge can't bypass the tighter anti-enumeration speed bump (was effectively 25 distinct/day and uncounted against the global cap).
- **`src/index.ts`** — removed the inert `bv-wasm-core` `initSync` (no exported function is called anywhere) to drop its bundle/cold-start cost; documented the crate as a retained-but-inert staged seam (not deleted).
- **`publish.yml`** — removed the dead "Update SERVER_VERSION" `sed` step; `server-version.ts` auto-derives from `pkg.version`, so the pattern never matched.
- **`vitest.config.mts`** — kept `dangerouslyIgnoreUnhandledErrors` (verified the stderr filter is output-only and can't replace it) but documented the trade-off + a proper narrow as follow-up.

## Operator follow-up (not in this PR)
Set `REJECT_QUERY_API_KEY=true` in the prod deploy config to retire the `?api_key=` query-param credential path (documented low finding; credentials-in-URL leak to edge logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)