### PR TITLE
fix(containment): remove proprietary BV_WEB binding from public wrangler.jsonc

### DIFF
--- a/test/audits/wrangler-public-no-private-bindings.audit.test.ts
+++ b/test/audits/wrangler-public-no-private-bindings.audit.test.ts
@@ -5,11 +5,18 @@
 //
 // Background: `BV_INFRA_GRAPH`, `BV_INTEL_GATEWAY`, and `BV_ENTERPRISE` are
 // service bindings to bv-web-owned Workers. `BV_RECON` is an operator-only
-// recon service binding; `BV_RECON_KEY` is its companion secret. bv-mcp is
-// BUSL-1.1 source-available; `discovery_mode: 'classic'` is the only supported
+// recon service binding; `BV_RECON_KEY` is its companion secret. `BV_WEB` is the
+// proprietary bv-web-prod service binding (OAuth consent proxy + the m365Proxy
+// for the identity_secops tools) — CLAUDE.md documents it as "not in public
+// wrangler.jsonc", and its `service: bv-web-prod` reference both leaks the
+// proprietary service name and breaks a BSL self-host `wrangler deploy`. bv-mcp
+// is BUSL-1.1 source-available; `discovery_mode: 'classic'` is the only supported
 // mode for self-hosted BSL deployments. The private overlay
 // (`scripts/inject-private-config.cjs` + `.dev/wrangler.deploy.jsonc`) injects
 // these bindings at deploy time for BlackVeil production only.
+//
+// NOTE: matched as quoted-exact tokens (`"BV_WEB"`) so the legitimately-public
+// `BV_WEB_OAUTH_CONSENT_URL` var (a public consent URL) is not a false positive.
 //
 // If anyone accidentally promotes one of these binding names into the public
 // `wrangler.jsonc`, this audit fails loudly — protecting the BSL self-host
@@ -31,11 +38,14 @@ const FORBIDDEN_PUBLIC_BINDINGS = [
 	'BV_RECON_KEY',
 	'BV_TLS_PROBE',
 	'BV_TLS_PROBE_KEY',
+	'BV_WEB',
 ] as const;
 
 describe('public wrangler.jsonc license-boundary audit', () => {
 	it('does not reference any private brand-discovery service binding', () => {
-		const offenders = FORBIDDEN_PUBLIC_BINDINGS.filter((name) => wranglerPublic.includes(name));
+		// Quoted-exact match so `"BV_WEB"` (the binding) is caught while
+		// `"BV_WEB_OAUTH_CONSENT_URL"` (a legitimately-public var) is not.
+		const offenders = FORBIDDEN_PUBLIC_BINDINGS.filter((name) => wranglerPublic.includes(`"${name}"`));
 		expect(
 			offenders,
 			`Forbidden private binding(s) found in public wrangler.jsonc: ${offenders.join(', ')}. ` +

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -72,10 +72,6 @@
   ],
   "services": [
     {
-      "binding": "BV_WEB",
-      "service": "bv-web-prod"
-    },
-    {
       "binding": "BV_WHOIS",
       "service": "bv-whois"
     },


### PR DESCRIPTION
## What

The IP-containment audit found `BV_WEB` — the proprietary bv-web-prod service binding (OAuth consent proxy + `m365Proxy` for the `identity_secops` tools) — declared in the **public** `wrangler.jsonc`, contradicting CLAUDE.md which documents it as *"not in public `wrangler.jsonc`"*. The public entry `"service": "bv-web-prod"` leaked the proprietary Worker name and would break a BSL self-host `wrangler deploy` (a service binding to a non-existent Worker fails).

## Change
- Removed the `BV_WEB` service block from `wrangler.jsonc`.
- Added `BV_WEB` to `FORBIDDEN_PUBLIC_BINDINGS` in `wrangler-public-no-private-bindings.audit.test.ts` (quoted-exact match so the legitimately-public `BV_WEB_OAUTH_CONSENT_URL` var isn't a false positive).

## Deploy-safe (verified)
The private overlay `.dev/wrangler.deploy.jsonc` already defines `BV_WEB`, and `mergeServices` keys by binding name — so the generated prod config **still binds `BV_WEB → bv-web-prod`**. Ran `inject-private-config.cjs`: prod config unchanged; public config no longer binds BV_WEB; `BV_WEB_OAUTH_CONSENT_URL` retained.

## Connection to the new bv-web-prod (verified)
- Binding targets `service: bv-web-prod`; the new bv-web-prod repo deploys as Worker `name: bv-web-prod` — exact match.
- Target Worker `bv-web-prod` exists and is deployed in-account (service binding resolves at runtime).
- No references to the decommissioned `bv-web`/`blackveil-web` remain.

## Verification
`wrangler-public-no-private-bindings` + `infra-probe-wrangler` + `private-config-injection` audits pass; `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)