### PR TITLE
fix(license-gate): close header-gate coverage gap + walk optionalDependencies

### DIFF
--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 /**
  * @blackveil/dns-checks
  *

--- a/packages/dns-checks/src/types.ts
+++ b/packages/dns-checks/src/types.ts
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: BUSL-1.1
+
 /**
  * Shared types for @blackveil/dns-checks
  *

--- a/scripts/license-check.mjs
+++ b/scripts/license-check.mjs
@@ -198,7 +198,12 @@ function readProdDeps(path) {
 	if (!existsSync(path)) return {};
 	try {
 		const pkg = JSON.parse(readFileSync(path, 'utf8'));
-		return pkg.dependencies && typeof pkg.dependencies === 'object' ? pkg.dependencies : {};
+		// Include optionalDependencies: `npm ci` installs them by default and they
+		// ship into production node_modules (e.g. drizzle-orm's driver adapters),
+		// so their licenses must be gated too.
+		const deps = pkg.dependencies && typeof pkg.dependencies === 'object' ? pkg.dependencies : {};
+		const optDeps = pkg.optionalDependencies && typeof pkg.optionalDependencies === 'object' ? pkg.optionalDependencies : {};
+		return { ...deps, ...optDeps };
 	} catch {
 		return {};
 	}
@@ -258,9 +263,12 @@ while (queue.length > 0) {
 		});
 	}
 
-	// Recurse into this package's own production dependencies.
+	// Recurse into this package's own production + optional dependencies
+	// (optionalDependencies are installed and shipped by default).
 	const childDeps = resolved.pkg.dependencies && typeof resolved.pkg.dependencies === 'object' ? resolved.pkg.dependencies : {};
-	for (const childName of Object.keys(childDeps)) {
+	const childOptDeps =
+		resolved.pkg.optionalDependencies && typeof resolved.pkg.optionalDependencies === 'object' ? resolved.pkg.optionalDependencies : {};
+	for (const childName of Object.keys({ ...childDeps, ...childOptDeps })) {
 		queue.push({ name: childName, fromDir: resolved.dir, parent: `${name}@${version}` });
 	}
 }

--- a/test/audits/license-headers.audit.test.ts
+++ b/test/audits/license-headers.audit.test.ts
@@ -13,13 +13,20 @@ const repoRoot = process.cwd();
 const SPDX_HEADER = '// SPDX-License-Identifier: BUSL-1.1';
 
 function trackedSourceFiles(): string[] {
-	const out = execFileSync('git', ['ls-files', 'src/**/*.ts', 'packages/*/src/**/*.ts'], {
+	// List everything tracked under src/ and packages/, then filter in JS to the
+	// shipped-source .ts set. NOTE: do NOT use git pathspec globs like
+	// 'src/**/*.ts' here — git's `**/` requires an intermediate path segment, so
+	// it silently MISSES files directly in src/ or packages/*/src/ (e.g.
+	// packages/dns-checks/src/index.ts). Directory pathspecs + a JS regex filter
+	// cover every depth.
+	const out = execFileSync('git', ['ls-files', '--', 'src', 'packages'], {
 		cwd: repoRoot,
 		encoding: 'utf8',
 	});
 	return out
 		.split('\n')
 		.filter(Boolean)
+		.filter((f) => /^src\/.*\.ts$/.test(f) || /^packages\/[^/]+\/src\/.*\.ts$/.test(f))
 		.filter((f) => !/\.(test|spec)\.ts$/.test(f))
 		.filter((f) => !f.includes('/__tests__/'));
 }


### PR DESCRIPTION
## What
Fix-forward addressing two findings from the independent code-review of #482.

### High — header gate had a coverage gap (glob `**/`)
`license-headers.audit.test.ts` listed files with git pathspec globs `src/**/*.ts` / `packages/*/src/**/*.ts`. Git's `**/` requires an intermediate path segment, so files **directly** in `src/` or `packages/*/src/` were silently skipped — the gate reported 100% coverage while missing them. Switched to directory pathspecs (`git ls-files -- src packages`) + a JS regex filter covering every depth.

This surfaced **two shipped files with no SPDX line** (invisible to both the buggy glob and the earlier backfill): `packages/dns-checks/src/index.ts` and `packages/dns-checks/src/types.ts` — headers added.

### High — `license-check.mjs` ignored `optionalDependencies`
`npm ci` installs optional deps into production `node_modules` (e.g. drizzle-orm's driver adapters). The walker read only `dependencies`, so a future copyleft optional dep would slip the gate. Now merges `optionalDependencies` at both the seed and recursion steps. No new packages in the current tree — structural defense-in-depth.

## Verification
`npm run audit:oss-safety` green (48 workers-pool + 7 node-pool); `license-check` exit 0 (14 pkgs); `typecheck` clean.

Refs #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)