### PR TITLE
docs: drop stale npm badges from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 Source-available DNS & email security scanner for Claude, Cursor, VS Code, and MCP clients across Streamable HTTP, stdio, and legacy HTTP+SSE.
 
 [![GitHub stars](https://img.shields.io/github/stars/MadaBurns/bv-mcp?style=flat&logo=github)](https://github.com/MadaBurns/bv-mcp/stargazers)
-[![npm version](https://img.shields.io/npm/v/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
-[![npm downloads](https://img.shields.io/npm/dm/blackveil-dns)](https://www.npmjs.com/package/blackveil-dns)
 [![MCP tools](https://img.shields.io/badge/MCP%20tools-80-brightgreen)](https://github.com/MadaBurns/bv-mcp/actions)
 [![BUSL-1.1 License](https://img.shields.io/badge/License-BUSL--1.1-blue.svg)](LICENSE)
 [![MCP](https://img.shields.io/badge/MCP-2025--06--18-blue)](https://modelcontextprotocol.io/)


### PR DESCRIPTION
## What
Removes the two npm badges (version + downloads) from the README header.

## Why
npm publishing is intentionally gated (`NPM_TOKEN` unconfigured) — the npm package `blackveil-dns` is stuck at **2.13.0** while source is **3.29.5**, and the MCP registry is remotes-only *because* the 3.x line isn't on npm. The badges advertised a stale, effectively-unmaintained npm package, implying an install path that isn't current. Removing them makes the README reflect the intentional hosted-MCP / not-on-npm distribution model.

MCP-tools count badge and BUSL-1.1 license badge are retained.

Verified: `readme-tool-surface.audit.test.ts` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)