### PR TITLE
feat(tools): add source/report_url citation link-back to tool results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Added
+
+- **Citation link-back on tool results (`source` / `report_url`).** Every domain-bearing, non-error tool result now carries `source` and `report_url` in its `structuredContent`, pointing at the public per-domain scorecard (`https://www.blackveilsecurity.com/security-report/<domain>`). Additive and schema-safe — the keys ride through the `.loose()` CheckResult `outputSchema`, so strict MCP clients still validate; non-domain tools (`domain` undefined) and error results are unaffected. Feeds the public-scorecard SEO / AI-search funnel and mirrors the `source` link comparable hosted scanners return. Single injection point at the central `handleToolsCall` return (`withReportCitation`).
+
 ## [3.29.5] - 2026-07-02
 
 Patch release: **cross-repo audit remediation** (#480).

--- a/src/handlers/tool-formatters.ts
+++ b/src/handlers/tool-formatters.ts
@@ -69,6 +69,45 @@ export function buildToolResult(
 	return sc === undefined ? { content } : { content, structuredContent: sc };
 }
 
+/**
+ * Public per-domain security scorecard base — the citation link-back target that
+ * feeds the GSI SEO / AI-search funnel (mirrors the `source` link a caller sees
+ * from comparable hosted scanners).
+ */
+const PUBLIC_REPORT_BASE_URL = 'https://www.blackveilsecurity.com/security-report';
+
+/**
+ * Public scorecard URL for a domain. `domain` has already passed
+ * `extractAndValidateDomain` (validateDomain + sanitizeDomain) upstream;
+ * `encodeURIComponent` is defence-in-depth against any stray character.
+ */
+export function buildReportUrl(domain: string): string {
+	return `${PUBLIC_REPORT_BASE_URL}/${encodeURIComponent(domain)}`;
+}
+
+/**
+ * Attach a citation link back to the public per-domain scorecard. Emitted ONLY
+ * for a domain-bearing, non-error result — non-domain tools (`domain` undefined)
+ * and error results are a no-op. Additive: the `source`/`report_url` keys ride
+ * through the `.loose()` CheckResult outputSchema, so strict MCP clients that
+ * validate against the schema still pass.
+ */
+export function withReportCitation<T extends { structuredContent?: Record<string, unknown>; isError?: boolean }>(
+	result: T,
+	domain: string | undefined,
+): T {
+	if (!domain || result.isError) return result;
+	const reportUrl = buildReportUrl(domain);
+	return {
+		...result,
+		structuredContent: {
+			...(result.structuredContent ?? {}),
+			source: reportUrl,
+			report_url: reportUrl,
+		},
+	};
+}
+
 export function formatCheckResult(result: CheckResult, format: OutputFormat = 'full'): string {
 	const lines: string[] = [];
 	lines.push(`## ${result.category.toUpperCase()} Check`);

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -100,7 +100,7 @@ import {
 import type { OutputFormat } from './tool-args';
 import { buildLogContext, logToolFailure, logToolSuccess } from './tool-execution';
 import { readAndUpdateLastTool } from '../lib/session-memory';
-import { formatCheckResult, mcpError, buildToolResult } from './tool-formatters';
+import { formatCheckResult, mcpError, buildToolResult, withReportCitation } from './tool-formatters';
 import type { McpContent } from './tool-formatters';
 import { TOOLS } from '../schemas/tool-definitions';
 import type { McpTool } from '../schemas/tool-definitions';
@@ -1634,10 +1634,13 @@ export async function handleToolsCall(
 						)
 				: executeDispatch;
 
-		return await Promise.race([
+		const dispatched = await Promise.race([
 			dispatch(),
 			new Promise<never>((_, reject) => setTimeout(() => reject(new Error('__tool_timeout__')), TOOL_CALL_TIMEOUT_MS)),
 		]);
+		// Citation link-back to the public scorecard (GSI SEO / AI-search funnel).
+		// No-op for non-domain tools (`domain` undefined) and error results.
+		return withReportCitation(dispatched, domain);
 	} catch (err) {
 		if (err instanceof Error && err.message === '__tool_timeout__') {
 			logToolFailure({ ...ctx(), error: 'Tool call timed out', args });

--- a/test/tool-result-report-citation.spec.ts
+++ b/test/tool-result-report-citation.spec.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Unit + integration coverage for the citation link-back on tool-call results.
+// Domain-bearing, non-error results carry a `source` / `report_url` field pointing
+// at the public per-domain scorecard (`/security-report/<domain>`) — the GSI SEO /
+// AI-search funnel target. The field is additive and rides through the `.loose()`
+// CheckResult outputSchema; non-domain tools and errors get no citation.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { setupFetchMock, mockTxtRecords } from './helpers/dns-mock';
+import { IN_MEMORY_CACHE } from '../src/lib/cache';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+const EXPECTED = 'https://www.blackveilsecurity.com/security-report/example.com';
+
+describe('buildReportUrl', () => {
+	it('builds the public scorecard URL for a domain', async () => {
+		const { buildReportUrl } = await import('../src/handlers/tool-formatters');
+		expect(buildReportUrl('example.com')).toBe(EXPECTED);
+	});
+
+	it('URL-encodes any stray character (defence-in-depth)', async () => {
+		const { buildReportUrl } = await import('../src/handlers/tool-formatters');
+		expect(buildReportUrl('a b.com')).toBe(
+			'https://www.blackveilsecurity.com/security-report/a%20b.com',
+		);
+	});
+});
+
+describe('withReportCitation', () => {
+	it('injects source + report_url for a domain-bearing result', async () => {
+		const { withReportCitation } = await import('../src/handlers/tool-formatters');
+		const out = withReportCitation(
+			{ content: [{ type: 'text', text: 'x' }], structuredContent: { score: 80 } },
+			'example.com',
+		);
+		expect(out.structuredContent).toEqual({ score: 80, source: EXPECTED, report_url: EXPECTED });
+	});
+
+	it('is a no-op when domain is undefined (non-domain tools)', async () => {
+		const { withReportCitation } = await import('../src/handlers/tool-formatters');
+		const input = { content: [{ type: 'text' as const, text: 'x' }], structuredContent: { a: 1 } };
+		const out = withReportCitation(input, undefined);
+		expect(out).toBe(input);
+		expect('source' in (out.structuredContent ?? {})).toBe(false);
+	});
+
+	it('is a no-op for error results', async () => {
+		const { withReportCitation } = await import('../src/handlers/tool-formatters');
+		const input: {
+			content: { type: 'text'; text: string }[];
+			structuredContent?: Record<string, unknown>;
+			isError?: boolean;
+		} = { content: [{ type: 'text', text: 'x' }], isError: true };
+		const out = withReportCitation(input, 'example.com');
+		expect(out).toBe(input);
+		expect(out.structuredContent).toBeUndefined();
+	});
+
+	it('preserves existing structuredContent keys', async () => {
+		const { withReportCitation } = await import('../src/handlers/tool-formatters');
+		const out = withReportCitation(
+			{ content: [], structuredContent: { category: 'spf', passed: true } },
+			'example.com',
+		);
+		const sc = out.structuredContent as Record<string, unknown>;
+		expect(sc.category).toBe('spf');
+		expect(sc.passed).toBe(true);
+		expect(sc.source).toBe(EXPECTED);
+	});
+});
+
+describe('citation - integration through handleToolsCall', () => {
+	it('check_spf carries source + report_url pointing at the domain scorecard', async () => {
+		IN_MEMORY_CACHE.clear();
+		mockTxtRecords(['v=spf1 -all']);
+
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall({ name: 'check_spf', arguments: { domain: 'example.com' } });
+
+		expect(result.isError).toBeUndefined();
+		const sc = result.structuredContent as Record<string, unknown>;
+		expect(sc.source).toBe(EXPECTED);
+		expect(sc.report_url).toBe(EXPECTED);
+		// the original CheckResult keys survive alongside the citation
+		expect(sc.category).toBe('spf');
+	});
+});


### PR DESCRIPTION
## What

Adds a citation link-back to the public per-domain scorecard on every tool result. Domain-bearing, non-error results now carry `source` and `report_url` in their `structuredContent`, pointing at `https://www.blackveilsecurity.com/security-report/<domain>`.

## Why

Closes the one capability gap vs. comparable hosted DNS/email scanners (e.g. DNSai returns a `source` link on every call): our tool envelopes had no link back to our own public scorecard, so agent answers didn't funnel back to the GSI SEO / AI-search surface. This is "Gap C" from the DNSai competitive-response analysis.

## How

- New `withReportCitation` + `buildReportUrl` in `src/handlers/tool-formatters.ts`.
- Single injection point at the central `handleToolsCall` return (`src/handlers/tools.ts`) — covers all single-domain tools without touching ~30 individual call sites.
- **No-op** for non-domain tools (`domain` undefined) and error results.
- **Additive + schema-safe:** the keys ride through the `.loose()` CheckResult `outputSchema`, so strict MCP clients still validate. `encodeURIComponent` on the (already validated/sanitized) domain as defence-in-depth.

## Scope / follow-ups

- v1 covers single-domain tools. Per-result citation for batch/compare (multi-domain) tools is a deliberate follow-up (`domain` is undefined there).
- No tool-count change → count audits untouched.

## Tests

- New `test/tool-result-report-citation.spec.ts`: unit (`buildReportUrl`, `withReportCitation` inject/no-op/preserve) + integration through `handleToolsCall` (`check_spf` carries `source`/`report_url`).
- Full local suite: **5825 passed** + the WASM integration file (4 passed after building the crate). Typecheck + lint clean.

## Release note

Added under `CHANGELOG.md` `[Unreleased]`. New user-visible envelope field → suggest a **minor** bump (3.29.5 → 3.30.0) when released; `server.json` version-sync per the usual publish flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)