### PR TITLE
chore: release 3.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.30.0] - 2026-07-04
+
 ### Added
 
 - **Citation link-back on tool results (`source` / `report_url`).** Every domain-bearing, non-error tool result now carries `source` and `report_url` in its `structuredContent`, pointing at the public per-domain scorecard (`https://www.blackveilsecurity.com/security-report/<domain>`). Additive and schema-safe — the keys ride through the `.loose()` CheckResult `outputSchema`, so strict MCP clients still validate; non-domain tools (`domain` undefined) and error results are unaffected. Feeds the public-scorecard SEO / AI-search funnel and mirrors the `source` link comparable hosted scanners return. Single injection point at the central `handleToolsCall` return (`withReportCitation`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.5",
+	"version": "3.30.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.29.5",
+			"version": "3.30.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.29.5",
+	"version": "3.30.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.29.5",
+	"version": "3.30.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Version pre-bump for the **3.30.0** release, per the documented pre-bump-before-tag flow (CLAUDE.md §Release) so the `publish.yml` version-sync step is a no-op.

## Changes
- `package.json` + `package-lock.json`: 3.29.5 → **3.30.0** (`npm version --no-git-tag-version`). `SERVER_VERSION` auto-derives from `package.json`.
- `server.json`: top-level `version` → **3.30.0** (remotes-only, single version field).
- `CHANGELOG.md`: `[Unreleased]` → **`[3.30.0] - 2026-07-04`**.

## Why 3.30.0 (minor)
Additive new envelope field (`source` / `report_url` citation link-back) merged in #487 — backward-compatible, so a minor bump.

## Release steps AFTER merging this PR
1. `git tag v3.30.0 && git push origin v3.30.0` → `publish.yml` (validate + version-sync no-op + GitHub release).
2. Manual publish (CI publish jobs are `if:false` pending NPM_TOKEN rotation): `npm publish --access public` (`blackveil-dns`) + `npm -w packages/dns-checks publish --access public`.
3. `mcp-publisher publish` (MCP Registry — needs `MCP_PUBLISHER_KEY` + apex DNS auth).
4. `npm run deploy:prod` (Worker — needs `CLOUDFLARE_API_TOKEN` + `.dev/` private config).

No code changes — version surfaces only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)