### PR TITLE
fix(glama): link dns-checks workspace during pnpm build

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
 		"packages/*"
 	],
 	"scripts": {
-		"build": "tsup",
+		"build": "npm -w packages/dns-checks run build && tsup",
 		"generate:wasm-permissions": "tsx scripts/generate-wasm-permissions.ts",
 		"check:wasm-permissions": "tsx scripts/generate-wasm-permissions.ts --check",
 		"build:wasm": "npm run generate:wasm-permissions && cd crates/bv-wasm-core && wasm-pack build --target web",
@@ -76,6 +76,11 @@
 		"typescript-eslint": "8.62.1",
 		"vitest": "4.1.9",
 		"wrangler": "^4.106.0"
+	},
+	"pnpm": {
+		"overrides": {
+			"@blackveil/dns-checks": "link:packages/dns-checks"
+		}
 	},
 	"overrides": {
 		"esbuild": "0.28.1",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'packages/*'

--- a/test/audits/glama-build.audit.test.ts
+++ b/test/audits/glama-build.audit.test.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import packageJsonText from '../../package.json?raw';
+
+const packageJson = JSON.parse(packageJsonText) as {
+	dependencies?: Record<string, string>;
+	pnpm?: { overrides?: Record<string, string> };
+	scripts?: Record<string, string>;
+};
+const workspaceFiles = import.meta.glob('../../pnpm-workspace.yaml', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+});
+const npmRcFiles = import.meta.glob('../../.npmrc', {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+});
+const pnpmWorkspace = Object.values(workspaceFiles)[0] as string | undefined;
+const npmRc = Object.values(npmRcFiles)[0] as string | undefined;
+
+describe('Glama pnpm build contract', () => {
+	it('declares pnpm workspaces so Glama links the local dns-checks package', () => {
+		expect(pnpmWorkspace, 'Glama runs pnpm install, which ignores package.json workspaces without pnpm-workspace.yaml').toBeTypeOf(
+			'string',
+		);
+		expect(pnpmWorkspace).toMatch(/packages:\s*\n(?:\s*-\s*['"]?packages\/\*['"]?\s*\n?)/);
+	});
+
+	it('forces pnpm to resolve dns-checks from the workspace instead of the registry', () => {
+		const dnsChecksSpec = packageJson.dependencies?.['@blackveil/dns-checks'] ?? '';
+		const dnsChecksPnpmOverride = packageJson.pnpm?.overrides?.['@blackveil/dns-checks'] ?? '';
+		const usesWorkspaceProtocol = dnsChecksSpec.startsWith('workspace:');
+		const usesLocalPnpmOverride = dnsChecksPnpmOverride === 'link:packages/dns-checks';
+		const linksMatchingWorkspacePackages = npmRc?.split(/\r?\n/).some((line) => line.trim() === 'link-workspace-packages=true');
+
+		expect(
+			usesWorkspaceProtocol || usesLocalPnpmOverride || linksMatchingWorkspacePackages,
+			'pnpm otherwise resolves @blackveil/dns-checks from npm when the semver range matches a stale published version',
+		).toBe(true);
+	});
+
+	it('builds dns-checks before the stdio bundle imports its scoring exports', () => {
+		const buildScript = packageJson.scripts?.build ?? '';
+		const dnsChecksBuildIndex = buildScript.indexOf('npm -w packages/dns-checks run build');
+		const tsupIndex = buildScript.indexOf('tsup');
+
+		expect(dnsChecksBuildIndex, 'root build must generate packages/dns-checks/dist before building dist/stdio.js').toBeGreaterThan(
+			-1,
+		);
+		expect(tsupIndex, 'root build must still run tsup for the MCP bundles').toBeGreaterThan(-1);
+		expect(dnsChecksBuildIndex, 'dns-checks must build before tsup emits the stdio bundle').toBeLessThan(tsupIndex);
+	});
+});


### PR DESCRIPTION
## Summary
- Add pnpm workspace metadata so Glama's pnpm install sees packages/*.
- Force pnpm to resolve @blackveil/dns-checks from packages/dns-checks instead of stale registry 1.3.12.
- Build packages/dns-checks before tsup emits dist/stdio.js and add an audit guard for the Glama build contract.

## Verification
- npm run audit:repo-safety
- npm test -- test/audits/glama-build.audit.test.ts test/audits/deploy-pipeline.audit.test.ts test/audits/npm-publish-surface.audit.test.ts
- npm run typecheck
- ./node_modules/.bin/eslint test/audits/glama-build.audit.test.ts
- pnpm run build
- Temp Glama-style pnpm install resolved: @blackveil/dns-checks 1.4.1 <- packages/dns-checks
- Temp Glama-style pnpm run build passed
- Temp node dist/stdio.js initialize smoke returned a JSON-RPC initialize result

## Notes
- Repo-wide npm run lint is still blocked by pre-existing .firecrawl/* lint errors unrelated to this change.