### PR TITLE
fix: harden security prompt findings

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The server is continuously validated using a **comprehensive chaos test suite** 
 
 The `bv_load_test` class identifies internal load/chaos/tranco-scan traffic so it stays out of real-client analytics segments.
 
-The test suite ensures session stability, authentication precedence, format negotiation, and transport-specific edge cases across Streamable HTTP and Legacy SSE. Without an API key it exercises the public/free-tier path; with a valid key exported as `BV_API_KEY`, it also covers `?api_key=` authentication, Bearer precedence, authenticated SSE bootstrap, and authenticated batch behavior.
+The test suite ensures session stability, authentication precedence, format negotiation, and transport-specific edge cases across Streamable HTTP and Legacy SSE. Without an API key it exercises the public/free-tier path; with a valid key exported as `BV_API_KEY`, it covers Bearer authentication, legacy self-host `?api_key=` compatibility, authenticated SSE bootstrap, and authenticated batch behavior.
 
 Run the chaos tests locally: `python3 scripts/chaos/chaos-test-clients.py`
 
@@ -231,11 +231,12 @@ BlackVeil's hosted production at `dns-mcp.blackveilsecurity.com` flips its runti
 
 ## Client setup
 
-The free tier requires no authentication. Authenticated requests bypass per-IP rate limits and follow your tier's daily quota. Three authentication methods are supported:
+The free tier requires no authentication. Authenticated requests bypass per-IP rate limits and follow your tier's daily quota. Hosted production supports:
 
 - **Header**: `Authorization: Bearer <KEY>`
-- **Query Param**: `?api_key=<KEY>` (for clients that can't send custom headers — Smithery, Claude Code)
 - **OAuth 2.1**: optional authorization-code flow with PKCE, enabled only when operators set `ENABLE_OAUTH=true`; owner-key consent is separately gated by `ENABLE_OWNER_OAUTH=true`.
+
+The `?api_key=<KEY>` fallback is legacy/self-host compatibility only. BlackVeil hosted production sets `REJECT_QUERY_API_KEY=true`; clients that cannot send headers should use OAuth or an `mcp-remote` header bridge.
 
 For full hosted setup examples, stdio usage, OAuth setup, and legacy fallback endpoints, see [**docs/client-setup.md**](docs/client-setup.md).
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -206,13 +206,7 @@ No npm install required. MCP connectors are configured on the web and auto-sync 
    - **URL**: `https://dns-mcp.blackveilsecurity.com/mcp`
 3. Save — the connector syncs automatically to Claude iOS and Android apps
 
-**With API key** — append the key as a query parameter in the connector URL:
-
-```text
-https://dns-mcp.blackveilsecurity.com/mcp?api_key=YOUR_API_KEY
-```
-
-Alternatively, provide the API key as a Bearer token if the connector UI supports an authentication field.
+**With API key** — use OAuth from the hosted connector flow, or provide the API key as a Bearer token if the connector UI supports an authentication field. Hosted production rejects `?api_key=` URL credentials.
 
 **Limitations:**
 
@@ -245,30 +239,7 @@ Or via CLI:
 claude mcp add --transport http blackveil-dns https://dns-mcp.blackveilsecurity.com/mcp
 ```
 
-**With API key** — use the `api_key` query parameter with native HTTP (simplest):
-
-```json
-{
-  "mcpServers": {
-    "blackveil-dns": {
-      "type": "http",
-      "url": "https://dns-mcp.blackveilsecurity.com/mcp?api_key=YOUR_API_KEY"
-    }
-  }
-}
-```
-
-Use one authentication method per server entry. For Claude Code's native HTTP transport, prefer the query parameter and do not also add an `Authorization` header; some clients ignore headers from config files, and an invalid token or placeholder can cause a `401` during MCP initialization.
-
-If `.mcp.json` is committed in your project, keep it on the free-tier URL or use placeholders only. Put live keys in user-level client settings or a local ignored override, not in a tracked repository file.
-
-Or via CLI:
-
-```bash
-claude mcp add --transport http blackveil-dns "https://dns-mcp.blackveilsecurity.com/mcp?api_key=YOUR_API_KEY"
-```
-
-Alternatively, use `mcp-remote` to forward the `Authorization` header (useful when sourcing the key from an env variable):
+**With API key** — use `mcp-remote` to forward the `Authorization` header from a local bridge:
 
 ```json
 {
@@ -287,9 +258,38 @@ Alternatively, use `mcp-remote` to forward the `Authorization` header (useful wh
 }
 ```
 
-> **Note:** Claude Code's native HTTP transport does not forward custom `headers` from config files. Use the `?api_key=` query parameter or `mcp-remote` as a bridge.
+Use one authentication method per server entry. Claude Code's native HTTP transport may ignore custom `headers` from config files; use native HTTP for the free hosted tier, OAuth-capable connectors where available, or `mcp-remote` when you need static API-key auth.
 
-Important: if you script this setup, source the key from environment (`BV_API_KEY`) and avoid embedding token literals in shell history. `mcp-remote` and `npx` add a local bridge process, so native HTTP is preferred unless you specifically need header forwarding.
+If `.mcp.json` is committed in your project, keep it on the free-tier URL or use placeholders only. Put live keys in user-level client settings or a local ignored override, not in a tracked repository file.
+
+Or via CLI:
+
+```bash
+claude mcp add blackveil-dns -- npx -y mcp-remote https://dns-mcp.blackveilsecurity.com/mcp --header "Authorization: Bearer YOUR_API_KEY"
+```
+
+If you need to source the key from an environment variable, keep the same bridge shape and expand the header from your shell or ignored local client config:
+
+```json
+{
+  "mcpServers": {
+    "blackveil-dns": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "https://dns-mcp.blackveilsecurity.com/mcp",
+        "--header",
+        "Authorization: Bearer YOUR_API_KEY"
+      ]
+    }
+  }
+}
+```
+
+> **Note:** Hosted production rejects `?api_key=` credentials. Self-hosted or legacy deployments can keep that fallback only by leaving `REJECT_QUERY_API_KEY` unset or false.
+
+Important: if you script this setup, source the key from environment (`BV_API_KEY`) and avoid embedding token literals in shell history. `mcp-remote` and `npx` add a local bridge process, so native HTTP is preferred for unauthenticated/free hosted usage unless you specifically need header forwarding.
 
 ## Smithery
 
@@ -307,10 +307,10 @@ Or connect directly with your agent using the hosted URL:
 https://bv-mcp--madaburns.run.tools
 ```
 
-**With API key** — pass during setup when prompted, or embed in the connection URL:
+**With API key** — pass during setup when prompted or use an auth/header field if the client provides one. Do not embed production BlackVeil API keys in a hosted URL query string.
 
 ```
-https://bv-mcp--madaburns.run.tools?api_key=YOUR_API_KEY
+Authorization: Bearer YOUR_API_KEY
 ```
 
 ## Cursor
@@ -402,21 +402,20 @@ MCP clients fetch `tools/list` once when they connect and cache it for the lifet
 
 ## Authentication
 
-Authenticated requests bypass per-IP rate limits and apply the caller's tier quota. Three authentication methods are supported:
+Authenticated requests bypass per-IP rate limits and apply the caller's tier quota. Hosted production supports:
 
 - **Bearer Token**: `Authorization: Bearer <YOUR_API_KEY>`
-- **Query Parameter**: `?api_key=<YOUR_API_KEY>`
 - **OAuth 2.1** (authorization code + PKCE) — optional operator-enabled flow. See the [OAuth 2.1](#oauth-21) section below.
 
-The query parameter method is the simplest for clients that only support URL configuration (like Claude Code, Smithery, or simple HTTP connectors).
+The `?api_key=<YOUR_API_KEY>` fallback is legacy/self-host compatibility only. Hosted production sets `REJECT_QUERY_API_KEY=true`, so URL credentials are ignored and the request proceeds as unauthenticated/free tier.
 
-**Important:** Claude Code and some other clients' native HTTP transport do not forward custom `headers` from config files. Use the `?api_key=` query parameter or the `mcp-remote` bridge approach shown in the per-client sections.
+**Important:** Claude Code and some other clients' native HTTP transport do not forward custom `headers` from config files. Use OAuth-capable hosted connectors where available, or the `mcp-remote` bridge approach shown in the per-client sections.
 
-Do not configure both `?api_key=` and `Authorization` for the same server unless both values are intentionally valid. A stale placeholder in either location can make startup fail with `401 Unauthorized` instead of falling back to the free tier.
+Do not configure both legacy `?api_key=` and `Authorization` for the same server. A stale placeholder in either location can make startup fail with `401 Unauthorized` or silently drop to the free tier, depending on deployment flags.
 
 ### Static API Key Tiers
 
-Static API keys (via `?api_key=` or `Authorization: Bearer`) authenticate as a specific tier:
+Static API keys via `Authorization: Bearer` authenticate as a specific tier:
 
 | Tier | Quota | Use Case | Source |
 |---|---|---|---|
@@ -439,12 +438,15 @@ Free hosted usage keeps core DNS and email checks open for trial traffic, while 
 # .env (local) or CI/CD secrets
 BV_API_KEY="bv_Kx8eZ2rdtUPfdzR8e_..."
 
-# In MCP config
+# In MCP config that supports headers
 {
-  "server": "https://dns-mcp.blackveilsecurity.com/mcp?api_key=${BV_API_KEY}"
+  "server": "https://dns-mcp.blackveilsecurity.com/mcp",
+  "headers": {
+    "Authorization": "Bearer ${BV_API_KEY}"
+  }
 }
 
-# Or as header (where supported)
+# Or as a raw HTTP header
 Authorization: Bearer bv_Kx8eZ2rdtUPfdzR8e_...
 ```
 
@@ -461,9 +463,9 @@ Authorization: Bearer bv_Kx8eZ2rdtUPfdzR8e_...
 
 | Client | Recommended Auth Method | Notes |
 |--------|-------------------------|-------|
-| Claude Mobile | Hosted connector URL | Customer OAuth is enabled on the hosted endpoint; use `?api_key=` for static-key quota |
-| Claude Code | `?api_key=` in URL | Simple and native |
-| Smithery | `?api_key=` in URL | Native integration |
+| Claude Mobile | Hosted connector OAuth | Customer OAuth is enabled on the hosted endpoint |
+| Claude Code | `mcp-remote --header` | Native HTTP is fine for free hosted usage; use the bridge for static keys |
+| Smithery | Provider auth field or OAuth | Do not put production API keys in URL query strings |
 | VS Code / Copilot | `headers` field | Supports secret prompt |
 | Cursor | `headers` field | Direct header support |
 | Windsurf | `headers` field | Direct header support |
@@ -508,7 +510,7 @@ If you are a developer troubleshooting how different MCP clients handle authenti
 python3 scripts/chaos/chaos-test-clients.py
 ```
 
-This test covers all 9 detected MCP client types across session management, auth precedence, format negotiation, and transport-specific edge cases. With no `BV_API_KEY`, it exercises the public/free-tier path. With a valid API key exported as `BV_API_KEY`, it also covers `?api_key=` authentication, Bearer precedence, authenticated Legacy SSE bootstrap, and batch `scan_domain` behavior.
+This test covers all 9 detected MCP client types across session management, auth precedence, format negotiation, and transport-specific edge cases. With no `BV_API_KEY`, it exercises the public/free-tier path. With a valid API key exported as `BV_API_KEY`, it also covers Bearer authentication, legacy self-host `?api_key=` compatibility, authenticated Legacy SSE bootstrap, and batch `scan_domain` behavior.
 
 Expected assertion count:
 

--- a/docs/tenant-ops-runbook.md
+++ b/docs/tenant-ops-runbook.md
@@ -24,6 +24,22 @@ approved secret manager only.
 Private deployment bindings belong in `.dev/wrangler.deploy.jsonc`, which is
 ignored and merged into `wrangler.production.jsonc` at deploy time.
 
+## Production Overlay Gates
+
+`npm run deploy:prod` runs `scripts/inject-private-config.cjs` before Wrangler.
+The injector must fail closed unless the private overlay provides these
+production safety vars:
+
+- `OAUTH_ISSUER`: `https://dns-mcp.blackveilsecurity.com`.
+- `REJECT_QUERY_API_KEY`: `true`, so hosted production ignores URL credentials.
+- `REQUIRE_PRODUCTION_BINDINGS`: `true`, so `/health?deep=1` degrades on missing
+  tenant, brand-audit, queue, storage, or alert bindings.
+- `ALERT_WEBHOOK_URL`: non-empty. Keep the real webhook URL in the ignored
+  overlay or secret manager, never in tracked docs.
+
+Run `npm run deploy:prod` from a clean checkout. If the injector rejects the
+overlay, fix the private deployment config instead of bypassing the gate.
+
 ## Scheduled Work
 
 Tenant jobs are handled by scheduled handlers:
@@ -80,6 +96,38 @@ Per-tenant limits live in `src/tenants/per-tenant-rate-limit.ts`. The limiter is
 KV-backed and fail-soft in local development when `RATE_LIMIT` is unbound. Use
 tenant scope/tier data, not hardcoded customer identifiers, when changing
 limits.
+
+## Data Lifecycle and Recovery
+
+Use bounded, operator-owned procedures for tenant data. Keep real identifiers and
+export locations in ignored notes.
+
+- retention: access-log rows are pruned by the scheduled job according to
+  `ANALYTICS_RETENTION_DAYS` or the 90-day default. Tenant scan/finding retention
+  should be set per contract in the private tenant inventory before provisioning.
+- export: use D1 export or read-only SQL against placeholder tenant IDs first,
+  then write customer exports only to approved private storage. Do not commit
+  exports, generated reports, PDFs, CSC output, or tenant databases.
+- erasure: deactivate the `sub_tenants` row, revoke tenant keys, stop scheduled
+  scans, delete or tombstone per-tenant D1 data under the approved retention
+  policy, then record the operator action in the registry audit log.
+- restore drill: at least once per release window that changes tenant schema or
+  migrations, restore a synthetic tenant backup into a disposable D1 database,
+  run the tenant schema/audit tests, and verify a queued scan can complete.
+
+## Cost Governance
+
+Quota changes must be explicit and audited. The public quota maps in
+`src/lib/config.ts` are the SSOT for daily tool limits; brand audit has an
+additional monthly quota in `src/lib/brand-audit-quota.ts`.
+
+- identity-secops tools are paid-only and capped per principal because they proxy
+  Microsoft Graph-backed M365 reads through bv-web.
+- brand audit writes are capped daily and monthly; async starts debit quota at
+  submission time, not in the queue consumer.
+- weekly tenant rescans cap active-tenant and due-domain enumeration per tick.
+- alert on quota-coordinator fallback, tail exceptions, and repeated queue
+  failures before raising any cap.
 
 ## QuotaCoordinator sharding cutover
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -96,7 +96,7 @@ curl -X POST https://dns-mcp.blackveilsecurity.com/mcp \
 
 Should return JSON with a tools array including `scan_domain`.
 
-If this returns `401 Unauthorized`, remove any configured API key to use the free tier, or replace it with a valid key. Do not mix `?api_key=` and `Authorization` in the same server entry unless both values are valid; stale placeholders can cause initialization to fail instead of falling back to unauthenticated access.
+If this returns `401 Unauthorized`, remove any configured API key to use the free tier, or replace it with a valid Bearer key. Hosted production rejects `?api_key=` URL credentials; use OAuth or an `Authorization: Bearer` header bridge such as `mcp-remote` for static-key auth.
 
 **6. If tools still don't connect, check Claude Desktop logs**
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,7 +2,7 @@ import tseslint from 'typescript-eslint';
 
 export default tseslint.config(
 	{
-		ignores: ['coverage/**', 'node_modules/**', '.dev/**', '.worktrees/**', 'dist/**', 'crates/**/pkg/**', 'worker-configuration.d.ts'],
+		ignores: ['coverage/**', 'node_modules/**', '.dev/**', '.firecrawl/**', '.worktrees/**', 'dist/**', 'crates/**/pkg/**', 'worker-configuration.d.ts'],
 	},
 	{
 		files: ['**/*.ts', '**/*.mts'],

--- a/scripts/inject-private-config.cjs
+++ b/scripts/inject-private-config.cjs
@@ -44,6 +44,32 @@ function mergeServices(publicServices, privateServices) {
     return [...merged.values()];
 }
 
+const REQUIRED_PRODUCTION_VARS = {
+    OAUTH_ISSUER: 'https://dns-mcp.blackveilsecurity.com',
+    REJECT_QUERY_API_KEY: 'true',
+    REQUIRE_PRODUCTION_BINDINGS: 'true',
+};
+const REQUIRED_NONEMPTY_PRODUCTION_VARS = ['ALERT_WEBHOOK_URL'];
+
+function validateProductionSecurityConfig(config) {
+    const vars = config && typeof config.vars === 'object' && config.vars ? config.vars : {};
+    const failures = [];
+    for (const [name, expected] of Object.entries(REQUIRED_PRODUCTION_VARS)) {
+        if (vars[name] !== expected) {
+            failures.push(`${name} must be ${JSON.stringify(expected)}`);
+        }
+    }
+    for (const name of REQUIRED_NONEMPTY_PRODUCTION_VARS) {
+        if (typeof vars[name] !== 'string' || vars[name].trim() === '') {
+            failures.push(`${name} must be non-empty`);
+        }
+    }
+    if (failures.length > 0) {
+        console.error(`FATAL: Unsafe production config: ${failures.join('; ')}.`);
+        process.exit(1);
+    }
+}
+
 /**
  * Automates the "Private Injection" process.
  * Merges the public engine build with local private overrides.
@@ -80,6 +106,7 @@ function inject() {
     if (privateConfig.r2_buckets) {
         publicConfig.r2_buckets = privateConfig.r2_buckets;
     }
+    validateProductionSecurityConfig(publicConfig);
     
     fs.writeFileSync('wrangler.production.jsonc', JSON.stringify(publicConfig, null, 2));
     console.log("Successfully generated wrangler.production.jsonc with injected private configuration.");

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -886,6 +886,7 @@ export const TOOL_REGISTRY: Record<
 						reconBinding: ro?.reconBinding,
 						reconAuthToken: ro?.reconAuthToken,
 						bucketScanKv: ro?.rateLimitKv,
+						principalId: ro?.keyHash ?? ro?.principalId,
 						onBindingDegradation: ro?.onBindingDegradation,
 					},
 				),
@@ -893,7 +894,7 @@ export const TOOL_REGISTRY: Record<
 		cacheTtlSeconds: 0,
 	},
 	scan_buckets_status: {
-		cacheKey: (a) => `bucketstatus:${String(a.scanId)}`,
+		cacheKey: (a, ro) => `bucketstatus:${ro?.keyHash ?? ro?.principalId ?? 'anon'}:${String(a.scanId)}`,
 		execute: (_d, a, ro) =>
 			import('../tools/scan-buckets').then((m) =>
 				m.scanBucketsStatus(
@@ -902,6 +903,7 @@ export const TOOL_REGISTRY: Record<
 						reconBinding: ro?.reconBinding,
 						reconAuthToken: ro?.reconAuthToken,
 						bucketScanKv: ro?.rateLimitKv,
+						principalId: ro?.keyHash ?? ro?.principalId,
 						onBindingDegradation: ro?.onBindingDegradation,
 					},
 				),
@@ -909,12 +911,12 @@ export const TOOL_REGISTRY: Record<
 		cacheTtlSeconds: 15,
 	},
 	scan_buckets_findings: {
-		cacheKey: (a) => `bucketfindings:${String(a.scanId ?? 'all')}:${String(a.target ?? '')}:${JSON.stringify(a.providers ?? [])}`,
+		cacheKey: (a, ro) => `bucketfindings:${ro?.keyHash ?? ro?.principalId ?? 'anon'}:${String(a.scanId)}:${String(a.target ?? '')}:${JSON.stringify(a.providers ?? [])}`,
 		execute: (_d, a, ro) =>
 			import('../tools/scan-buckets').then((m) =>
 				m.scanBucketsFindings(
 					{
-						scanId: a.scanId ? String(a.scanId) : undefined,
+						scanId: String(a.scanId),
 						target: a.target ? String(a.target) : undefined,
 						providers: Array.isArray(a.providers) ? (a.providers as string[]) : undefined,
 					},
@@ -922,6 +924,7 @@ export const TOOL_REGISTRY: Record<
 						reconBinding: ro?.reconBinding,
 						reconAuthToken: ro?.reconAuthToken,
 						bucketScanKv: ro?.rateLimitKv,
+						principalId: ro?.keyHash ?? ro?.principalId,
 						onBindingDegradation: ro?.onBindingDegradation,
 					},
 				),
@@ -935,6 +938,8 @@ export const TOOL_REGISTRY: Record<
 				m.osintInvestigateDomainStart(String(a.query), {
 					reconBinding: ro?.reconBinding,
 					reconAuthToken: ro?.reconAuthToken,
+					reconJobKv: ro?.rateLimitKv,
+					principalId: ro?.keyHash ?? ro?.principalId,
 					onBindingDegradation: ro?.onBindingDegradation,
 				}),
 			),
@@ -947,6 +952,8 @@ export const TOOL_REGISTRY: Record<
 				m.osintInvestigateInfrastructureStart(String(a.query), {
 					reconBinding: ro?.reconBinding,
 					reconAuthToken: ro?.reconAuthToken,
+					reconJobKv: ro?.rateLimitKv,
+					principalId: ro?.keyHash ?? ro?.principalId,
 					onBindingDegradation: ro?.onBindingDegradation,
 				}),
 			),
@@ -959,6 +966,8 @@ export const TOOL_REGISTRY: Record<
 				m.osintInvestigateSupplyChainStart(String(a.query), {
 					reconBinding: ro?.reconBinding,
 					reconAuthToken: ro?.reconAuthToken,
+					reconJobKv: ro?.rateLimitKv,
+					principalId: ro?.keyHash ?? ro?.principalId,
 					onBindingDegradation: ro?.onBindingDegradation,
 				}),
 			),
@@ -971,6 +980,8 @@ export const TOOL_REGISTRY: Record<
 				m.osintInvestigateUsernameStart(String(a.query), {
 					reconBinding: ro?.reconBinding,
 					reconAuthToken: ro?.reconAuthToken,
+					reconJobKv: ro?.rateLimitKv,
+					principalId: ro?.keyHash ?? ro?.principalId,
 					authTier: ro?.authTier,
 					onBindingDegradation: ro?.onBindingDegradation,
 				}),
@@ -984,6 +995,8 @@ export const TOOL_REGISTRY: Record<
 				m.osintInvestigateEmailStart(String(a.query), {
 					reconBinding: ro?.reconBinding,
 					reconAuthToken: ro?.reconAuthToken,
+					reconJobKv: ro?.rateLimitKv,
+					principalId: ro?.keyHash ?? ro?.principalId,
 					authTier: ro?.authTier,
 					onBindingDegradation: ro?.onBindingDegradation,
 				}),
@@ -991,24 +1004,28 @@ export const TOOL_REGISTRY: Record<
 		cacheTtlSeconds: 0,
 	},
 	osint_investigation_status: {
-		cacheKey: (a) => `osintstatus:${String(a.investigationId)}`,
+		cacheKey: (a, ro) => `osintstatus:${ro?.keyHash ?? ro?.principalId ?? 'anon'}:${String(a.investigationId)}`,
 		execute: (_d, a, ro) =>
 			import('../tools/osint-investigate').then((m) =>
 				m.osintInvestigationStatus(String(a.investigationId), {
 					reconBinding: ro?.reconBinding,
 					reconAuthToken: ro?.reconAuthToken,
+					reconJobKv: ro?.rateLimitKv,
+					principalId: ro?.keyHash ?? ro?.principalId,
 					onBindingDegradation: ro?.onBindingDegradation,
 				}),
 			),
 		cacheTtlSeconds: 15,
 	},
 	osint_investigation_report: {
-		cacheKey: (a) => `osintreport:${String(a.investigationId)}`,
+		cacheKey: (a, ro) => `osintreport:${ro?.keyHash ?? ro?.principalId ?? 'anon'}:${String(a.investigationId)}`,
 		execute: (_d, a, ro) =>
 			import('../tools/osint-investigate').then((m) =>
 				m.osintInvestigationReport(String(a.investigationId), {
 					reconBinding: ro?.reconBinding,
 					reconAuthToken: ro?.reconAuthToken,
+					reconJobKv: ro?.rateLimitKv,
+					principalId: ro?.keyHash ?? ro?.principalId,
 					onBindingDegradation: ro?.onBindingDegradation,
 				}),
 			),
@@ -1033,6 +1050,18 @@ function resolveFormat(args: Record<string, unknown>, clientType?: string): Outp
 
 function buildToolErrorResult(message: string): McpToolResult {
 	return { content: [mcpError(message)], isError: true };
+}
+
+function summarizeM365LogResult(result: unknown): Record<string, unknown> {
+	const r = result && typeof result === 'object' && !Array.isArray(result) ? (result as Record<string, unknown>) : {};
+	const data = r.data && typeof r.data === 'object' && !Array.isArray(r.data) ? (r.data as Record<string, unknown>) : undefined;
+	const rows = data && Array.isArray(data.rows) ? data.rows : undefined;
+	return {
+		ok: r.ok === true,
+		unprovisioned: r.unprovisioned === true,
+		...(typeof r.error === 'string' ? { error: r.error } : {}),
+		...(typeof data?.count === 'number' ? { rowCount: data.count } : rows ? { rowCount: rows.length } : {}),
+	};
 }
 
 function handleExplainFindingValidationError(
@@ -1558,7 +1587,7 @@ export async function handleToolsCall(
 						{ authToken: runtimeOptions?.m365ProxyAuthToken, keyHash: runtimeOptions?.keyHash },
 					);
 					logResult = result.ok ? 'ok' : 'error';
-					logDetails = result;
+					logDetails = summarizeM365LogResult(result);
 					logToolSuccess({ ...ctx(), status: result.ok ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
 					const text = JSON.stringify(result, null, effectiveFormat === 'compact' ? 0 : 2);
 					return buildToolResult(text, result, effectiveFormat);
@@ -1575,7 +1604,7 @@ export async function handleToolsCall(
 						{ authToken: runtimeOptions?.m365ProxyAuthToken, keyHash: runtimeOptions?.keyHash },
 					);
 					logResult = result.ok ? 'ok' : 'error';
-					logDetails = result;
+					logDetails = summarizeM365LogResult(result);
 					logToolSuccess({ ...ctx(), status: result.ok ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
 					const text = JSON.stringify(result, null, effectiveFormat === 'compact' ? 0 : 2);
 					return buildToolResult(text, result, effectiveFormat);
@@ -1586,7 +1615,7 @@ export async function handleToolsCall(
 						keyHash: runtimeOptions?.keyHash,
 					});
 					logResult = result.ok ? 'ok' : 'error';
-					logDetails = result;
+					logDetails = summarizeM365LogResult(result);
 					logToolSuccess({ ...ctx(), status: result.ok ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
 					const text = JSON.stringify(result, null, effectiveFormat === 'compact' ? 0 : 2);
 					return buildToolResult(text, result, effectiveFormat);
@@ -1597,7 +1626,7 @@ export async function handleToolsCall(
 						keyHash: runtimeOptions?.keyHash,
 					});
 					logResult = result.ok ? 'ok' : 'error';
-					logDetails = result;
+					logDetails = summarizeM365LogResult(result);
 					logToolSuccess({ ...ctx(), status: result.ok ? 'pass' : 'fail', logResult, logDetails, severity: 'info' });
 					const text = JSON.stringify(result, null, effectiveFormat === 'compact' ? 0 : 2);
 					return buildToolResult(text, result, effectiveFormat);

--- a/src/index.ts
+++ b/src/index.ts
@@ -554,6 +554,14 @@ async function probeQuotaCoordinator(ns: DurableObjectNamespace | undefined): Pr
 	});
 }
 
+function bindingPresence(value: unknown): 'ok' | 'absent' {
+	return value ? 'ok' : 'absent';
+}
+
+function envFlagEnabled(value: unknown): boolean {
+	return typeof value === 'string' && value.toLowerCase() === 'true';
+}
+
 app.get('/health', async (c) => {
 	const deep = c.req.query('deep');
 	if (deep !== '1' && deep !== 'true') {
@@ -583,10 +591,22 @@ app.get('/health', async (c) => {
 		probeQuotaCoordinator(c.env.QUOTA_COORDINATOR),
 	]);
 
-	const bindings = { scanCache, quotaCoordinator };
+	const e = c.env as Record<string, unknown>;
+	const bindings = {
+		scanCache,
+		quotaCoordinator,
+		tenantRegistryDb: bindingPresence(e.TENANT_REGISTRY_DB),
+		scannerQueue: bindingPresence(e.BV_SCANNER_QUEUE),
+		brandAuditDb: bindingPresence(e.BRAND_AUDIT_DB),
+		brandReports: bindingPresence(e.BRAND_REPORTS),
+		brandAuditQueue: bindingPresence(e.BRAND_AUDIT_QUEUE),
+		brandAuditPdfQueue: bindingPresence(e.BRAND_AUDIT_PDF_QUEUE),
+		alertWebhook: bindingPresence(e.ALERT_WEBHOOK_URL),
+	};
 	// Overall status degrades only on an actual probe error; an 'absent' binding
 	// (BSL self-host) is not a failure of a provisioned dependency.
-	const degraded = Object.values(bindings).some((status) => status === 'error');
+	const requireProductionBindings = envFlagEnabled(e.REQUIRE_PRODUCTION_BINDINGS);
+	const degraded = Object.values(bindings).some((status) => status === 'error') || (requireProductionBindings && Object.values(bindings).some((status) => status === 'absent'));
 
 	return c.json(
 		{

--- a/src/lib/analytics-queries.ts
+++ b/src/lib/analytics-queries.ts
@@ -307,6 +307,17 @@ HAVING error_batch_count > 0 OR failure_count > 0
 ORDER BY failure_count DESC`;
 }
 
+/** Fatal Worker exception detection from Tail Worker exports. */
+export function queryTailExceptions(minutes: string): string {
+	minutes = safeInterval(minutes);
+	return `SELECT
+  SUM(_sample_interval) AS exception_count
+FROM ${DS}
+WHERE index1 = 'tail'
+  AND blob1 = 'exception'
+  AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE`;
+}
+
 // ---------------------------------------------------------------------------
 // Per-Tier Analytics Queries
 // ---------------------------------------------------------------------------

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -199,6 +199,10 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		list_brand_audit_watches: 100,
 		register_brand_audit_watch: 100,
 		delete_brand_audit_watch: 100,
+		query_signins: 2_000,
+		query_ual: 2_000,
+		get_ca_policies: 2_000,
+		assess_coverage: 2_000,
 	},
 	developer: {
 		brand_audit_single: 50,
@@ -208,6 +212,10 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		list_brand_audit_watches: 20,
 		register_brand_audit_watch: 20,
 		delete_brand_audit_watch: 20,
+		query_signins: 100,
+		query_ual: 100,
+		get_ca_policies: 100,
+		assess_coverage: 100,
 	},
 	enterprise: {
 		brand_audit_single: 500,
@@ -217,6 +225,10 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		list_brand_audit_watches: 100,
 		register_brand_audit_watch: 100,
 		delete_brand_audit_watch: 100,
+		query_signins: 2_000,
+		query_ual: 2_000,
+		get_ca_policies: 2_000,
+		assess_coverage: 2_000,
 	},
 	agent: {
 		discover_subdomains: 0,
@@ -244,6 +256,10 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		delete_brand_audit_watch: 0,
 		list_brand_audit_watches: 0,
 		prioritize_csc_leads: 0,
+		query_signins: 0,
+		query_ual: 0,
+		get_ca_policies: 0,
+		assess_coverage: 0,
 	},
 	free: {
 		discover_subdomains: 0,
@@ -269,6 +285,10 @@ export const TIER_TOOL_DAILY_LIMITS: Partial<Record<McpApiKeyTier, Record<string
 		delete_brand_audit_watch: 0,
 		list_brand_audit_watches: 0,
 		prioritize_csc_leads: 0,
+		query_signins: 0,
+		query_ual: 0,
+		get_ca_policies: 0,
+		assess_coverage: 0,
 	},
 };
 
@@ -352,6 +372,10 @@ export const FREE_TOOL_DAILY_LIMITS: Record<string, number> = {
 	osint_investigate_email_start: 0,
 	osint_investigation_status: 25,
 	osint_investigation_report: 25,
+	query_signins: 0,
+	query_ual: 0,
+	get_ca_policies: 0,
+	assess_coverage: 0,
 };
 
 /** Free-tier daily cap on cache-bypassing (force_refresh) requests. Far below the
@@ -393,6 +417,11 @@ export const GATED_PAID_ONLY_TOOLS: ReadonlySet<string> = new Set<string>([
 	'register_brand_audit_watch',
 	'delete_brand_audit_watch',
 	'list_brand_audit_watches',
+	// sensitive/costly Microsoft Graph-backed tools
+	'query_signins',
+	'query_ual',
+	'get_ca_policies',
+	'assess_coverage',
 ]);
 
 /** True when a tool is gated to paid tiers (developer+). */
@@ -483,7 +512,9 @@ export const FREE_DISTINCT_DOMAIN_DAILY_LIMIT = 12;
  * reach them — the public `/mcp` gate in src/mcp/execute.ts rejects an
  * unauthenticated tools/call for any member with HTTP 401 BEFORE dispatch
  * (see isAuthRequiredTool), and the registry execute path (handlers/tools.ts)
- * additionally hard-rejects when no real principal (keyHash) is present.
+ * additionally hard-rejects when no real principal (keyHash) is present. Free
+ * and agent API-key tiers are pinned to 0 in TIER_TOOL_DAILY_LIMITS and the
+ * paid tiers have explicit per-principal caps to bound Microsoft Graph cost.
  * Single source of truth for both gates.
  */
 export const AUTH_REQUIRED_TOOLS: ReadonlySet<string> = new Set<string>([
@@ -499,17 +530,7 @@ export function isAuthRequiredTool(toolName: string): boolean {
 }
 
 /** Tools intentionally governed by per-IP rate limits only (no per-tool free-tier quota). Audited by test/audits/tool-quota-coverage.audit.test.ts. */
-export const INTENTIONALLY_UNLIMITED_TOOLS: ReadonlySet<string> = new Set<string>([
-	// identity_secops tools are auth-required (AUTH_REQUIRED_TOOLS): the public /mcp
-	// gate rejects unauthenticated callers with HTTP 401 before dispatch, and the
-	// registry path hard-rejects calls without a real principal. They carry no
-	// per-tool free-tier quota because they are never reachable by free/anon
-	// callers in the first place — so they sit outside the daily-tool-quota matrix.
-	'query_signins',
-	'query_ual',
-	'get_ca_policies',
-	'assess_coverage',
-]);
+export const INTENTIONALLY_UNLIMITED_TOOLS: ReadonlySet<string> = new Set<string>();
 
 /**
  * Per-tier concurrent tool execution limits (per-isolate, best-effort fairness).

--- a/src/lib/db/brand-audit-schema.ts
+++ b/src/lib/db/brand-audit-schema.ts
@@ -74,7 +74,10 @@ export const brandAuditTargets = sqliteTable(
 		created_at: integer('created_at').notNull(),
 		completed_at: integer('completed_at'),
 	},
-	(t) => [primaryKey({ columns: [t.audit_id, t.target] })],
+	(t) => [
+		primaryKey({ columns: [t.audit_id, t.target] }),
+		index('idx_brand_audit_targets_status_created_at').on(t.status, t.created_at),
+	],
 );
 
 export const brandAuditSteps = sqliteTable(

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -46,7 +46,7 @@ const REDACTED = '[redacted]';
 const MAX_LOG_STRING_LENGTH = 256;
 const MAX_ERROR_STRING_LENGTH = 1024;
 export const SENSITIVE_KEY_PATTERN =
-	/(^ip$|cf-connecting-ip|authorization|mcp-session-id|session|token|api[-_]?key|secret|password|cookie|rawbody)/i;
+	/(^ip$|cf-connecting-ip|authorization|mcp-session-id|session|token|api[-_]?key|secret|password|cookie|rawbody|^query$|^email$|e[-_]?mail|user[-_]?principal[-_]?name|userPrincipalName|ms[-_]?tenant[-_]?id|tenantId)/i;
 
 export function isSensitiveKey(key: string): boolean {
 	return !/^has[A-Z]/.test(key) && SENSITIVE_KEY_PATTERN.test(key);

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -17,6 +17,7 @@ import {
 	queryTierDigest,
 	queryBindingDegradation,
 	queryQueueFailures,
+	queryTailExceptions,
 } from './lib/analytics-queries';
 import { buildAlertPayload, buildDigestPayload, sendAlert } from './lib/alerting';
 import { queryAnalyticsEngine } from './lib/analytics-engine';
@@ -52,6 +53,10 @@ interface QueueFailureRow {
 	failure_count?: number;
 }
 
+interface TailExceptionRow {
+	exception_count?: number;
+}
+
 export interface ScheduledEnv {
 	CF_ACCOUNT_ID?: string;
 	CF_ANALYTICS_TOKEN?: string;
@@ -65,6 +70,8 @@ export interface ScheduledEnv {
 	ALERT_BINDING_DEGRADATION_THRESHOLD?: string;
 	/** Min async-path (queue/cron) failed messages/sub-tasks in the lookback window to alert (default 1). */
 	ALERT_QUEUE_FAILURE_THRESHOLD?: string;
+	/** Min fatal Worker exceptions exported by the tail consumer in the lookback window to alert (default 1). */
+	ALERT_TAIL_EXCEPTION_THRESHOLD?: string;
 	RATE_LIMIT?: KVNamespace;
 	BRAND_AUDIT_DB?: D1Database;
 	INTELLIGENCE_DB?: D1Database;
@@ -302,6 +309,8 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		: DEFAULT_BINDING_DEGRADATION_THRESHOLD;
 	const parsedQueueFailure = parseFloat(env.ALERT_QUEUE_FAILURE_THRESHOLD ?? '');
 	const queueFailureThreshold = Number.isFinite(parsedQueueFailure) ? parsedQueueFailure : DEFAULT_QUEUE_FAILURE_THRESHOLD;
+	const parsedTailException = parseFloat(env.ALERT_TAIL_EXCEPTION_THRESHOLD ?? '');
+	const tailExceptionThreshold = Number.isFinite(parsedTailException) ? parsedTailException : 1;
 	const lookback = env.ALERT_LOOKBACK_MINUTES ?? String(DEFAULT_LOOKBACK_MINUTES);
 
 	try {
@@ -437,6 +446,25 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 			);
 		}
 
+		const tailExceptionRows = (await queryAnalyticsEngine(
+			env.CF_ACCOUNT_ID,
+			env.CF_ANALYTICS_TOKEN,
+			queryTailExceptions(lookback),
+		)) as TailExceptionRow[];
+		const tailExceptionCount = tailExceptionRows[0]?.exception_count ?? 0;
+
+		if (tailExceptionCount >= tailExceptionThreshold) {
+			await sendAlert(
+				env.ALERT_WEBHOOK_URL,
+				buildAlertPayload({
+					title: `Fatal Worker exceptions: ${tailExceptionCount} event(s) (last ${lookback}m)`,
+					severity: tailExceptionCount > tailExceptionThreshold * 5 ? 'critical' : 'warning',
+					metrics: { exception_count: tailExceptionCount },
+					threshold: `tail_exceptions >= ${tailExceptionThreshold}`,
+				}),
+			);
+		}
+
 		logEvent({
 			timestamp: new Date().toISOString(),
 			category: 'scheduled',
@@ -449,6 +477,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 				rateLimitHits: rateLimitData?.total_hits ?? 0,
 				bindingDegradations: totalDegradations,
 				queueFailures: totalQueueFailures,
+				tailExceptions: tailExceptionCount,
 			},
 		});
 	} catch (err) {

--- a/src/schemas/tool-args.ts
+++ b/src/schemas/tool-args.ts
@@ -599,7 +599,7 @@ export const ScanBucketsStatusArgs = z
 
 export const ScanBucketsFindingsArgs = z
 	.object({
-		scanId: z.string().min(1).max(128).optional(),
+		scanId: z.string().min(1).max(128),
 		target: z.string().min(1).max(253).optional(),
 		providers: z.array(z.string().max(32)).max(8).optional(),
 	})

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -675,7 +675,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	scan_buckets_findings: {
 		description:
-			'Retrieve findings from a completed cloud-bucket discovery scan. Operator-deploy only; degrades to info when unprovisioned. Optionally scoped to a specific scanId, target, and provider list; omit scanId to retrieve the most recent findings.',
+			'Retrieve findings from a completed cloud-bucket discovery scan by scanId. Operator-deploy only; degrades to info when unprovisioned. The scanId is required so reads can be owner-scoped; target and provider filters are optional.',
 		schema: ScanBucketsFindingsArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/tenants/db/migrations/tenant/0002_findings_scan_id_index.sql
+++ b/src/tenants/db/migrations/tenant/0002_findings_scan_id_index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX `idx_findings_scan_id` ON `findings` (`scan_id`);

--- a/src/tenants/db/schema/tenant.ts
+++ b/src/tenants/db/schema/tenant.ts
@@ -87,7 +87,10 @@ export const findings = sqliteTable(
 		detail: text('detail'),
 		metadata: text('metadata'),
 	},
-	(t) => [index('idx_findings_domain_severity').on(t.domain, t.severity)],
+	(t) => [
+		index('idx_findings_domain_severity').on(t.domain, t.severity),
+		index('idx_findings_scan_id').on(t.scan_id),
+	],
 );
 
 export const alerts = sqliteTable(

--- a/src/tenants/queue-consumer.ts
+++ b/src/tenants/queue-consumer.ts
@@ -40,13 +40,20 @@ export const QUEUE_MESSAGE_TIMEOUT_MS = 20_000;
 /** After this many delivery attempts, the consumer writes a DLQ row and acks. */
 export const MAX_ATTEMPTS = 3;
 
-const SCAN_PROBE_BY_DOMAIN_SQL = 'SELECT id FROM scans WHERE cycle_id = ? AND domain = ? LIMIT 1';
+const SCAN_COMPLETION_PROBE_SQL =
+	'SELECT s.id, s.finding_count, COUNT(f.id) AS persisted_findings ' +
+	'FROM scans s LEFT JOIN findings f ON f.scan_id = s.id ' +
+	'WHERE s.cycle_id = ? AND s.domain = ? ' +
+	'GROUP BY s.id, s.finding_count ' +
+	'LIMIT 1';
 const SCANS_INSERT_SQL =
 	'INSERT INTO scans (id, domain, scan_at, score, grade, maturity_stage, finding_count, result_json, cycle_id) ' +
 	'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
 const FINDINGS_INSERT_SQL =
 	'INSERT INTO findings (id, scan_id, domain, category, severity, title, detail, metadata) ' +
 	'VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
+const DELETE_FINDINGS_FOR_SCAN_SQL = 'DELETE FROM findings WHERE scan_id = ?';
+const DELETE_SCAN_SQL = 'DELETE FROM scans WHERE id = ?';
 
 /**
  * T3 (write amplification): persist findings as a small number of multi-row
@@ -202,6 +209,22 @@ async function persistScan(
 	}
 }
 
+async function repairPartialScanIfNeeded(tenantDb: TenantDbHandle, cycleId: string, domain: string): Promise<'complete' | 'repaired' | 'missing'> {
+	const existing = await tenantDb
+		.prepare(SCAN_COMPLETION_PROBE_SQL)
+		.bind(cycleId, domain)
+		.first<{ id: string; finding_count: number | null; persisted_findings: number | null }>();
+	if (!existing) return 'missing';
+
+	const expectedFindings = Number(existing.finding_count ?? 0);
+	const persistedFindings = Number(existing.persisted_findings ?? 0);
+	if (persistedFindings >= expectedFindings) return 'complete';
+
+	await tenantDb.prepare(DELETE_FINDINGS_FOR_SCAN_SQL).bind(existing.id).run();
+	await tenantDb.prepare(DELETE_SCAN_SQL).bind(existing.id).run();
+	return 'repaired';
+}
+
 /**
  * Process one message. Returns:
  *   - `'ack'`     → caller should `message.ack()`
@@ -236,10 +259,9 @@ export async function processScanMessage(
 	try {
 		tenant = await resolveTenant(env, parsed.sub_tenant_id);
 	} catch {
-		// Tenant missing or registry unreachable — without a tenant DB we can't
-		// even write a DLQ row. The cycle report won't include the domain; the
-		// surrounding system already logs orchestrator-level errors.
-		return 'ack';
+		// Registry or tenant-binding resolution can fail transiently. Retry before
+		// the final attempt so a brief D1/binding outage does not silently drop work.
+		return attempts >= MAX_ATTEMPTS ? 'ack' : 'retry';
 	}
 
 	// Phase 4: the resolver returns a backend-agnostic handle; an absent backend
@@ -247,17 +269,15 @@ export async function processScanMessage(
 	const tenantDb = tenant.db;
 
 	// Idempotency probe — survives retries and re-deliveries without producing
-	// duplicate scan rows.
+	// duplicate scan rows. A partial scan row is not considered complete until
+	// the expected findings are present; retry repairs the stale row first.
 	try {
-		const existing = await tenantDb
-			.prepare(SCAN_PROBE_BY_DOMAIN_SQL)
-			.bind(parsed.cycle_id, parsed.domain)
-			.first<{ id: string }>();
-		if (existing) return 'ack';
+		const status = await repairPartialScanIfNeeded(tenantDb, parsed.cycle_id, parsed.domain);
+		if (status === 'complete') return 'ack';
 	} catch {
-		// Probe failed — fall through to the full path. Worst case we get a UNIQUE
-		// constraint violation on insert and the message retries; better than
-		// silently dropping work.
+		// Probe/repair failed — retry rather than risk UNIQUE conflicts or silently
+		// accepting an incomplete scan.
+		return attempts >= MAX_ATTEMPTS ? 'ack' : 'retry';
 	}
 
 	// On the LAST allowed attempt the budget can still time out — record a DLQ

--- a/src/tenants/routes.ts
+++ b/src/tenants/routes.ts
@@ -82,6 +82,8 @@ type TenantEnv = ResolverEnv & {
 export const tenantRoutes = new Hono<{ Bindings: TenantEnv }>();
 
 const DEFAULT_SCAN_CONCURRENCY = 10;
+/** Keep default sync scans small; larger sets use the existing queue producer. */
+export const MAX_DEFAULT_SYNC_SCAN_DOMAINS = 50;
 const PORTFOLIO_UPSERT_SQL =
 	'INSERT INTO domains (domain, source, added_at) VALUES (?, ?, ?) ' +
 	'ON CONFLICT(domain) DO UPDATE SET source = excluded.source';
@@ -723,7 +725,8 @@ tenantRoutes.post('/scan', async (c) => {
 	// Validation has already run above, so the producer never burns queue
 	// space on bad input. The consumer (handleScanQueue) is responsible for
 	// running the actual scan + persisting rows.
-	if (body.mode === 'queue') {
+	const shouldQueue = body.mode === 'queue' || (body.mode === undefined && validated.length > MAX_DEFAULT_SYNC_SCAN_DOMAINS);
+	if (shouldQueue) {
 		if (!c.env.BV_SCANNER_QUEUE) {
 			dispatchAudit(c, {
 				action: 'scan.start',
@@ -731,9 +734,9 @@ tenantRoutes.post('/scan', async (c) => {
 				resourceId: cycleId,
 				subTenantId: safeResourceId(tenantOrErr),
 				outcome: 'denied',
-				blob: { reason: 'queue_binding_missing' },
+				blob: { reason: 'queue_binding_missing', requestedMode: body.mode ?? 'auto' },
 			});
-			return c.json({ error: 'Invalid mode: queue dispatch is not configured on this deployment' }, 400);
+			return c.json({ error: 'Invalid mode: queue dispatch is required for this scan size but is not configured on this deployment' }, 400);
 		}
 		let queued = 0;
 		for (const domain of validated) {

--- a/src/tenants/scheduled-handlers.ts
+++ b/src/tenants/scheduled-handlers.ts
@@ -52,15 +52,21 @@ const STALE_RESCAN_MULTIPLIER = 2;
 
 /** Per-tick cap on number of cycles processed in the alert sweep — defense against runaway batches. */
 const MAX_CYCLES_PER_ALERT_TICK = 100;
+/** Per-tick cap on active tenants inspected by the weekly rescan dispatcher. */
+const MAX_ACTIVE_TENANTS_PER_WEEKLY_TICK = 100;
+/** Per-tick cap on due domains inspected for one tenant by the weekly rescan dispatcher. */
+const MAX_DUE_DOMAINS_PER_TENANT_TICK = 500;
 
 const ACTIVE_TENANTS_SQL =
-	'SELECT id, super_tenant_id FROM sub_tenants WHERE active = 1';
+	'SELECT id, super_tenant_id FROM sub_tenants WHERE active = 1 ORDER BY id LIMIT ?';
 const DUE_DOMAINS_SQL = `
 	SELECT domain, last_scanned_at, watch_interval_hours, fingerprint
 	FROM domains
 	WHERE watch = 1
 	  AND (last_scanned_at IS NULL
 	       OR last_scanned_at + COALESCE(watch_interval_hours, ?) * 3600000 < ?)
+	ORDER BY COALESCE(last_scanned_at, 0), domain
+	LIMIT ?
 `;
 const UPDATE_FINGERPRINT_SQL =
 	'UPDATE domains SET fingerprint = ?, fingerprint_at = ? WHERE domain = ?';
@@ -198,7 +204,7 @@ export async function handleTenantWeeklyRescan(
 
 	let tenants: ActiveTenantRow[];
 	try {
-		const result = await env.TENANT_REGISTRY_DB.prepare(ACTIVE_TENANTS_SQL).all<ActiveTenantRow>();
+		const result = await env.TENANT_REGISTRY_DB.prepare(ACTIVE_TENANTS_SQL).bind(MAX_ACTIVE_TENANTS_PER_WEEKLY_TICK).all<ActiveTenantRow>();
 		tenants = result.results ?? [];
 	} catch (err) {
 		logError(err instanceof Error ? err : String(err), {
@@ -253,7 +259,7 @@ async function rescanTenant(
 	try {
 		const result = await tenantDb
 			.prepare(DUE_DOMAINS_SQL)
-			.bind(DEFAULT_WATCH_INTERVAL_HOURS, tNow)
+			.bind(DEFAULT_WATCH_INTERVAL_HOURS, tNow, MAX_DUE_DOMAINS_PER_TENANT_TICK)
 			.all<DueDomainRow>();
 		dueDomains = result.results ?? [];
 	} catch (err) {

--- a/src/tools/osint-investigate.ts
+++ b/src/tools/osint-investigate.ts
@@ -16,6 +16,8 @@ const CATEGORY = 'osint_investigation' as CheckCategory;
 export interface ReconToolOptions {
 	reconBinding?: ReconBinding;
 	reconAuthToken?: string;
+	reconJobKv?: KVNamespace;
+	principalId?: string;
 	onBindingDegradation?: BindingDegradationSink;
 }
 
@@ -23,6 +25,33 @@ function unprovisioned(detail: string): CheckResult {
 	return buildCheckResult(CATEGORY, [
 		createFinding(CATEGORY, 'OSINT investigation unavailable', 'info', detail, { unprovisioned: true }),
 	]) as CheckResult;
+}
+
+const OSINT_OWNER_TTL_SECONDS = 24 * 60 * 60;
+const SAFE_INVESTIGATION_ID = /^[A-Za-z0-9._:-]+$/;
+
+function ownerKey(id: string): string {
+	return `osint-investigation-owner:${id}`;
+}
+
+function notOwned(id: string): CheckResult {
+	return buildCheckResult(CATEGORY, [
+		createFinding(CATEGORY, 'OSINT investigation not available', 'info', `OSINT investigation ${id} is not owned by this principal.`, {
+			notOwned: true,
+			investigationId: id,
+		}),
+	]) as CheckResult;
+}
+
+async function rememberInvestigationOwner(id: string | undefined, options: ReconToolOptions): Promise<void> {
+	if (!id || !options.reconJobKv || !options.principalId || !SAFE_INVESTIGATION_ID.test(id)) return;
+	await options.reconJobKv.put(ownerKey(id), options.principalId, { expirationTtl: OSINT_OWNER_TTL_SECONDS }).catch(() => undefined);
+}
+
+async function investigationOwnerMismatch(id: string, options: ReconToolOptions): Promise<boolean> {
+	if (!options.reconJobKv || !SAFE_INVESTIGATION_ID.test(id)) return false;
+	const owner = await options.reconJobKv.get(ownerKey(id)).catch(() => null);
+	return Boolean(owner && owner !== options.principalId);
 }
 
 export async function osintInvestigateStart(
@@ -40,6 +69,7 @@ export async function osintInvestigateStart(
 		options.onBindingDegradation,
 	);
 	if (!started) return unprovisioned(`OSINT ${type} investigation is not provisioned in this deployment for ${query}.`);
+	await rememberInvestigationOwner(started.investigationId, options);
 	return buildCheckResult(CATEGORY, [
 		createFinding(
 			CATEGORY,
@@ -139,6 +169,7 @@ function shortText(s: string, max: number): string {
 }
 
 export async function osintInvestigationStatus(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
+	if (await investigationOwnerMismatch(id, options)) return notOwned(id);
 	const s = await callReconInvestigationStatus(options.reconBinding, options.reconAuthToken, id, undefined, options.onBindingDegradation);
 	if (!s) return unprovisioned(`Investigation status unavailable for ${id} (unprovisioned or not found).`);
 	const status = typeof s.status === 'string' ? s.status : 'unknown';
@@ -158,6 +189,7 @@ export async function osintInvestigationStatus(id: string, options: ReconToolOpt
 }
 
 export async function osintInvestigationReport(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
+	if (await investigationOwnerMismatch(id, options)) return notOwned(id);
 	const r = await callReconInvestigationReport(options.reconBinding, options.reconAuthToken, id, undefined, options.onBindingDegradation);
 	if (!r) return unprovisioned(`Investigation report unavailable for ${id} (unprovisioned or not ready).`);
 	const total = typeof r.total === 'number' ? r.total : Array.isArray(r.findings) ? r.findings.length : 0;

--- a/src/tools/scan-buckets.ts
+++ b/src/tools/scan-buckets.ts
@@ -23,6 +23,7 @@ export interface ReconToolOptions {
 	reconBinding?: ReconBinding;
 	reconAuthToken?: string;
 	bucketScanKv?: KVNamespace;
+	principalId?: string;
 	onBindingDegradation?: BindingDegradationSink;
 }
 
@@ -35,10 +36,11 @@ function unprovisioned(detail: string): CheckResult {
 interface BucketScanScope {
 	target?: string;
 	providers?: string[];
+	owner?: string;
 }
 
 interface BucketScanFindingArgs extends BucketScanScope {
-	scanId?: string;
+	scanId: string;
 }
 
 interface TargetScopeTokens {
@@ -162,12 +164,18 @@ function findingInTargetScope(finding: Record<string, unknown>, tokens: TargetSc
 	return tokens.segment.some((token) => segments.has(token));
 }
 
+function notOwned(id: string): CheckResult {
+	return buildCheckResult(CATEGORY, [
+		createFinding(CATEGORY, 'Bucket scan not available', 'info', `Bucket scan ${id} is not owned by this principal.`, { notOwned: true, scanId: id }),
+	]) as CheckResult;
+}
+
 async function rememberBucketScanScope(scanId: string | undefined, scope: BucketScanScope, kv: KVNamespace | undefined): Promise<void> {
 	if (!scanId || !kv || !SAFE_SCAN_ID.test(scanId)) return;
 	const target = normalizeTarget(scope.target);
-	if (!target && !scope.providers?.length) return;
+	if (!target && !scope.providers?.length && !scope.owner) return;
 	await kv
-		.put(scopeKey(scanId), JSON.stringify({ target, providers: scope.providers }), { expirationTtl: BUCKET_SCAN_SCOPE_TTL_SECONDS })
+		.put(scopeKey(scanId), JSON.stringify({ target, providers: scope.providers, owner: scope.owner }), { expirationTtl: BUCKET_SCAN_SCOPE_TTL_SECONDS })
 		.catch(() => undefined);
 }
 
@@ -177,10 +185,18 @@ async function loadBucketScanScope(scanId: string | undefined, kv: KVNamespace |
 	if (!raw) return {};
 	try {
 		const parsed = JSON.parse(raw) as BucketScanScope;
-		return { target: normalizeTarget(parsed.target), providers: Array.isArray(parsed.providers) ? parsed.providers : undefined };
+		return {
+			target: normalizeTarget(parsed.target),
+			providers: Array.isArray(parsed.providers) ? parsed.providers : undefined,
+			owner: typeof parsed.owner === 'string' ? parsed.owner : undefined,
+		};
 	} catch {
 		return {};
 	}
+}
+
+function ownerMismatch(scope: BucketScanScope, caller: string | undefined): boolean {
+	return Boolean(scope.owner && scope.owner !== caller);
 }
 
 function filterBucketPayload(payload: Record<string, unknown>, scope: BucketScanScope): Record<string, unknown> {
@@ -238,7 +254,7 @@ export async function scanBucketsStart(
 		options.onBindingDegradation,
 	);
 	if (!started) return unprovisioned(`Bucket discovery is not provisioned in this deployment for ${args.target}.`);
-	await rememberBucketScanScope(started.scanId, args, options.bucketScanKv);
+	await rememberBucketScanScope(started.scanId, { ...args, owner: options.principalId }, options.bucketScanKv);
 	return buildCheckResult(CATEGORY, [
 		createFinding(
 			CATEGORY,
@@ -256,6 +272,8 @@ export async function scanBucketsStart(
 }
 
 export async function scanBucketsStatus(args: { scanId: string }, options: ReconToolOptions = {}): Promise<CheckResult> {
+	const scope = await loadBucketScanScope(args.scanId, options.bucketScanKv);
+	if (ownerMismatch(scope, options.principalId)) return notOwned(args.scanId);
 	const s = await callReconBucketScanStatus(
 		options.reconBinding,
 		options.reconAuthToken,
@@ -264,7 +282,6 @@ export async function scanBucketsStatus(args: { scanId: string }, options: Recon
 		options.onBindingDegradation,
 	);
 	if (!s) return unprovisioned(`Bucket scan status is unavailable for ${args.scanId} (unprovisioned or not found).`);
-	const scope = await loadBucketScanScope(args.scanId, options.bucketScanKv);
 	return buildCheckResult(CATEGORY, [
 		createFinding(CATEGORY, `Bucket scan ${args.scanId}`, 'info', JSON.stringify(s).slice(0, 800), {
 			...s, // F7: opaque upstream payload sanitized at the createFinding chokepoint
@@ -277,6 +294,8 @@ export async function scanBucketsStatus(args: { scanId: string }, options: Recon
 }
 
 export async function scanBucketsFindings(args: BucketScanFindingArgs, options: ReconToolOptions = {}): Promise<CheckResult> {
+	const rememberedScope = await loadBucketScanScope(args.scanId, options.bucketScanKv);
+	if (ownerMismatch(rememberedScope, options.principalId)) return notOwned(args.scanId);
 	const f = await callReconBucketFindings(
 		options.reconBinding,
 		options.reconAuthToken,
@@ -285,7 +304,6 @@ export async function scanBucketsFindings(args: BucketScanFindingArgs, options: 
 		options.onBindingDegradation,
 	);
 	if (!f) return unprovisioned('Bucket findings are unavailable (unprovisioned or no scan).');
-	const rememberedScope = await loadBucketScanScope(args.scanId, options.bucketScanKv);
 	const target = normalizeTarget(args.target) ?? rememberedScope.target;
 	const providers = args.providers ?? rememberedScope.providers;
 	const filtered = filterBucketPayload(f, { target, providers });

--- a/test/analytics-queries.spec.ts
+++ b/test/analytics-queries.spec.ts
@@ -23,6 +23,7 @@ import {
 	queryTierDigest,
 	queryBindingDegradation,
 	queryQueueFailures,
+	queryTailExceptions,
 } from '../src/lib/analytics-queries';
 
 describe('analytics query builders', () => {
@@ -192,6 +193,14 @@ describe('analytics query builders', () => {
 		const sql = queryQueueFailures("10'; DROP TABLE --");
 		expect(sql).toContain("INTERVAL '10' MINUTE");
 		expect(sql).not.toContain('DROP TABLE');
+	});
+
+	it('queryTailExceptions counts fatal Worker exceptions exported by the tail consumer', () => {
+		const sql = queryTailExceptions('15');
+		expect(sql).toContain("index1 = 'tail'");
+		expect(sql).toContain("blob1 = 'exception'");
+		expect(sql).toContain('exception_count');
+		expect(sql).toContain("INTERVAL '15' MINUTE");
 	});
 });
 

--- a/test/audits/private-config-injection.node.test.ts
+++ b/test/audits/private-config-injection.node.test.ts
@@ -24,15 +24,18 @@ describe('private Wrangler config injection', () => {
 				],
 			}),
 		);
-		writeFileSync(
-			join(cwd, '.dev/wrangler.deploy.jsonc'),
-			JSON.stringify({
-				services: [
-					{ binding: 'BV_WEB', service: 'blackveil-web-prod' },
-					{ binding: 'BV_CERTSTREAM', service: 'bv-certstream-worker' },
-				],
-			}),
-		);
+		writePrivateOverlay(cwd, {
+			vars: {
+				ALERT_WEBHOOK_URL: 'https://alerts.example.test/webhook',
+				OAUTH_ISSUER: 'https://dns-mcp.blackveilsecurity.com',
+				REQUIRE_PRODUCTION_BINDINGS: 'true',
+				REJECT_QUERY_API_KEY: 'true',
+			},
+			services: [
+				{ binding: 'BV_WEB', service: 'blackveil-web-prod' },
+				{ binding: 'BV_CERTSTREAM', service: 'bv-certstream-worker' },
+			],
+		});
 
 		execFileSync(process.execPath, ['scripts/inject-private-config.cjs'], { cwd, stdio: 'pipe' });
 		const injected = JSON.parse(readFileSync(join(cwd, 'wrangler.production.jsonc'), 'utf8')) as {
@@ -45,4 +48,48 @@ describe('private Wrangler config injection', () => {
 			{ binding: 'BV_CERTSTREAM', service: 'bv-certstream-worker' },
 		]);
 	});
+
+	it('fails closed when required production security vars are missing or unsafe', () => {
+		const cwd = mkdtempSync(join(tmpdir(), 'bv-mcp-inject-'));
+		mkdirSync(join(cwd, 'scripts'));
+		mkdirSync(join(cwd, '.dev'));
+		copyFileSync(join(process.cwd(), 'scripts/inject-private-config.cjs'), join(cwd, 'scripts/inject-private-config.cjs'));
+		writeFileSync(join(cwd, 'wrangler.jsonc'), JSON.stringify({ name: 'bv-mcp-test', main: 'src/index.ts' }));
+		writePrivateOverlay(cwd, {
+			vars: {
+				ALERT_WEBHOOK_URL: 'https://alerts.example.test/webhook',
+				OAUTH_ISSUER: 'https://dns-mcp.blackveilsecurity.com',
+				REQUIRE_PRODUCTION_BINDINGS: 'true',
+				REJECT_QUERY_API_KEY: 'false',
+			},
+		});
+
+		expect(() => execFileSync(process.execPath, ['scripts/inject-private-config.cjs'], { cwd, stdio: 'pipe' })).toThrow(
+			/REJECT_QUERY_API_KEY/,
+		);
+	});
+
+	it('fails closed when production alert delivery is not configured', () => {
+		const cwd = mkdtempSync(join(tmpdir(), 'bv-mcp-inject-'));
+		mkdirSync(join(cwd, 'scripts'));
+		mkdirSync(join(cwd, '.dev'));
+		copyFileSync(join(process.cwd(), 'scripts/inject-private-config.cjs'), join(cwd, 'scripts/inject-private-config.cjs'));
+		writeFileSync(join(cwd, 'wrangler.jsonc'), JSON.stringify({ name: 'bv-mcp-test', main: 'src/index.ts' }));
+		writePrivateOverlay(cwd, {
+			vars: {
+				ALERT_WEBHOOK_URL: '',
+				OAUTH_ISSUER: 'https://dns-mcp.blackveilsecurity.com',
+				REQUIRE_PRODUCTION_BINDINGS: 'true',
+				REJECT_QUERY_API_KEY: 'true',
+			},
+		});
+
+		expect(() => execFileSync(process.execPath, ['scripts/inject-private-config.cjs'], { cwd, stdio: 'pipe' })).toThrow(
+			/ALERT_WEBHOOK_URL/,
+		);
+	});
 });
+
+function writePrivateOverlay(cwd: string, config: Record<string, unknown>): void {
+	writeFileSync(join(cwd, '.dev/wrangler.deploy.jsonc'), JSON.stringify(config));
+}

--- a/test/audits/public-quota-surface.audit.test.ts
+++ b/test/audits/public-quota-surface.audit.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it } from 'vitest';
 import readme from '../../README.md?raw';
 import clientSetup from '../../docs/client-setup.md?raw';
+import troubleshooting from '../../docs/troubleshooting.md?raw';
 import vscodeReadme from '../../extensions/vscode/README.md?raw';
 import { FREE_TOOL_DAILY_LIMITS, TIER_DAILY_LIMITS } from '../../src/lib/config';
 import { handleResourcesRead } from '../../src/handlers/resources';
@@ -25,6 +26,16 @@ describe('public quota surface audit', () => {
 		expect(clientSetup).toContain(`| **agent** | **${TIER_DAILY_LIMITS.agent} scans/day, 5 concurrent**`);
 		expect(clientSetup).toContain(`| developer | ${TIER_DAILY_LIMITS.developer} scans/day, 10 concurrent`);
 		expect(clientSetup).toContain(`| enterprise | ${TIER_DAILY_LIMITS.enterprise.toLocaleString('en-US')} scans/day, 25 concurrent`);
+	});
+
+	it('keeps hosted static-key auth docs on Bearer/OAuth, not query-string credentials', () => {
+		expect(clientSetup).toContain('Hosted production rejects `?api_key=` credentials');
+		expect(clientSetup).toContain('Static API keys via `Authorization: Bearer` authenticate as a specific tier');
+		expect(clientSetup).not.toContain('https://dns-mcp.blackveilsecurity.com/mcp?api_key=');
+		expect(clientSetup).not.toContain('"url": "https://dns-mcp.blackveilsecurity.com/mcp?api_key=');
+		expect(readme).toContain('BlackVeil hosted production sets `REJECT_QUERY_API_KEY=true`');
+		expect(readme).not.toContain('Query Param');
+		expect(troubleshooting).toContain('Hosted production rejects `?api_key=` URL credentials');
 	});
 
 	it('keeps MCP resources aligned with free high-cost tool limits', () => {

--- a/test/audits/tenant-ops-runbook.audit.test.ts
+++ b/test/audits/tenant-ops-runbook.audit.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import runbook from '../../docs/tenant-ops-runbook.md?raw';
+
+describe('tenant operations runbook audit', () => {
+	it('documents production overlay gates, data lifecycle, recovery, and cost controls', () => {
+		expect(runbook).toContain('## Production Overlay Gates');
+		expect(runbook).toContain('REJECT_QUERY_API_KEY');
+		expect(runbook).toContain('OAUTH_ISSUER');
+		expect(runbook).toContain('REQUIRE_PRODUCTION_BINDINGS');
+		expect(runbook).toContain('ALERT_WEBHOOK_URL');
+		expect(runbook).toContain('## Data Lifecycle and Recovery');
+		expect(runbook).toContain('retention');
+		expect(runbook).toContain('export');
+		expect(runbook).toContain('erasure');
+		expect(runbook).toContain('restore drill');
+		expect(runbook).toContain('## Cost Governance');
+		expect(runbook).toContain('identity-secops');
+		expect(runbook).toContain('brand audit');
+	});
+});

--- a/test/audits/tier-tool-daily-limits.audit.test.ts
+++ b/test/audits/tier-tool-daily-limits.audit.test.ts
@@ -30,6 +30,8 @@ const BRAND_AUDIT_TOOLS = [
 	'delete_brand_audit_watch',
 ] as const;
 
+const IDENTITY_SECOPS_TOOLS = ['query_signins', 'query_ual', 'get_ca_policies', 'assess_coverage'] as const;
+
 describe('TIER_DAILY_LIMITS audit (flat per-tier defaults)', () => {
 	it('covers every tier from the McpApiKeyTier union', () => {
 		expect(new Set(Object.keys(TIER_DAILY_LIMITS))).toEqual(new Set(ALL_TIERS));
@@ -67,7 +69,7 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 
 	it('developer brand-audit ceilings match the published monthly tier (50 audits/month, 5000 read calls/day)', () => {
 		const developerOverrides = TIER_TOOL_DAILY_LIMITS.developer ?? {};
-		expect(developerOverrides).toEqual({
+		expect(pick(developerOverrides, BRAND_AUDIT_TOOLS)).toEqual({
 			brand_audit_single: 50,
 			brand_audit_batch_start: 50,
 			brand_audit_status: 5_000,
@@ -80,7 +82,7 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 
 	it('enterprise brand-audit ceilings match the published monthly tier (500 audits/month, 25k read calls/day)', () => {
 		const enterpriseOverrides = TIER_TOOL_DAILY_LIMITS.enterprise ?? {};
-		expect(enterpriseOverrides).toEqual({
+		expect(pick(enterpriseOverrides, BRAND_AUDIT_TOOLS)).toEqual({
 			brand_audit_single: 500,
 			brand_audit_batch_start: 500,
 			brand_audit_status: 25_000,
@@ -113,6 +115,22 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 		for (const tool of ['brand_audit_single', 'brand_audit_batch_start'] as const) {
 			expect(dev[tool], `${tool}: developer ≤ partner`).toBeLessThanOrEqual(part[tool] ?? Infinity);
 			expect(part[tool], `${tool}: partner ≤ enterprise`).toBeLessThanOrEqual(ent[tool] ?? Infinity);
+		}
+	});
+
+	it('identity-secops M365 tools are paid-only and explicitly bounded per principal', () => {
+		const free = TIER_TOOL_DAILY_LIMITS.free ?? {};
+		const agent = TIER_TOOL_DAILY_LIMITS.agent ?? {};
+		const developer = TIER_TOOL_DAILY_LIMITS.developer ?? {};
+		const enterprise = TIER_TOOL_DAILY_LIMITS.enterprise ?? {};
+		const partner = TIER_TOOL_DAILY_LIMITS.partner ?? {};
+
+		for (const tool of IDENTITY_SECOPS_TOOLS) {
+			expect(free[tool], `${tool}: free must be blocked`).toBe(0);
+			expect(agent[tool], `${tool}: agent must be blocked`).toBe(0);
+			expect(developer[tool], `${tool}: developer daily cap`).toBe(100);
+			expect(enterprise[tool], `${tool}: enterprise daily cap`).toBe(2_000);
+			expect(partner[tool], `${tool}: partner daily cap`).toBe(2_000);
 		}
 	});
 
@@ -155,6 +173,10 @@ describe('TIER_TOOL_DAILY_LIMITS audit (per-tool per-tier overrides)', () => {
 			'list_brand_audit_watches',
 			'register_brand_audit_watch',
 			'delete_brand_audit_watch',
+			'query_signins',
+			'query_ual',
+			'get_ca_policies',
+			'assess_coverage',
 		]);
 		expect(new Set(Object.keys(partner))).toEqual(expectedKeys);
 	});
@@ -172,3 +194,7 @@ describe('TIER_CONCURRENT_LIMITS audit', () => {
 		});
 	});
 });
+
+function pick<T extends readonly string[]>(source: Record<string, number>, keys: T): Record<T[number], number | undefined> {
+	return Object.fromEntries(keys.map((key) => [key, source[key]])) as Record<T[number], number | undefined>;
+}

--- a/test/audits/tool-quota-coverage.audit.test.ts
+++ b/test/audits/tool-quota-coverage.audit.test.ts
@@ -14,6 +14,8 @@ import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../../src/schemas/tool-definitions';
 import { FREE_TOOL_DAILY_LIMITS, INTENTIONALLY_UNLIMITED_TOOLS, INTERNAL_ONLY_TOOLS } from '../../src/lib/config';
 
+const IDENTITY_SECOPS_TOOLS = ['query_signins', 'query_ual', 'get_ca_policies', 'assess_coverage'] as const;
+
 describe('tool-quota-coverage audit', () => {
 	it('every public TOOL_DEFS entry is either quota-limited or explicitly unlimited (never neither, never both)', () => {
 		const limited = new Set(Object.keys(FREE_TOOL_DAILY_LIMITS));
@@ -36,9 +38,16 @@ describe('tool-quota-coverage audit', () => {
 		expect(both, `tools listed in BOTH (must pick one): ${both.join(', ')}`).toEqual([]);
 	});
 
-	it('INTENTIONALLY_UNLIMITED_TOOLS membership is a non-empty subset of TOOL_DEFS names', () => {
+	it('INTENTIONALLY_UNLIMITED_TOOLS membership is a subset of TOOL_DEFS names', () => {
 		const validNames = new Set(TOOLS.map((t) => t.name));
 		const stale = [...INTENTIONALLY_UNLIMITED_TOOLS].filter((name) => !validNames.has(name));
 		expect(stale, `INTENTIONALLY_UNLIMITED_TOOLS contains names not in TOOL_DEFS: ${stale.join(', ')}`).toEqual([]);
+	});
+
+	it('identity-secops tools are quota-limited, not in the unlimited exception set', () => {
+		for (const tool of IDENTITY_SECOPS_TOOLS) {
+			expect(FREE_TOOL_DAILY_LIMITS[tool], `${tool}: public free quota decision`).toBe(0);
+			expect(INTENTIONALLY_UNLIMITED_TOOLS.has(tool), `${tool}: must not be intentionally unlimited`).toBe(false);
+		}
 	});
 });

--- a/test/brand-audit-schema.spec.ts
+++ b/test/brand-audit-schema.spec.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { getTableConfig } from 'drizzle-orm/sqlite-core';
+import { brandAuditTargets } from '../src/lib/db/brand-audit-schema';
+
+describe('brand audit schema', () => {
+	it('declares status/created_at index for the running-target reaper', () => {
+		const t = getTableConfig(brandAuditTargets);
+		const idx = t.indexes.find((i) => i.config.name === 'idx_brand_audit_targets_status_created_at');
+		expect(idx).toBeDefined();
+	});
+});

--- a/test/chaos/tenant-queue.chaos.test.ts
+++ b/test/chaos/tenant-queue.chaos.test.ts
@@ -7,10 +7,11 @@
  *   - Given a `processScanMessage` that throws unexpectedly mid-batch, the
  *     handleScanQueue wrapper still acks/retries the surrounding messages
  *     correctly (the catch in `handleScanQueue` forces 'retry' on throw).
- *   - Given a tenant D1 that fails on a specific INSERT, idempotency on the
- *     next delivery prevents duplicate scan rows.
+ *   - Given a tenant D1 that fails on a specific INSERT, the completion probe on
+ *     each delivery prevents duplicate complete scan rows and lets retries repair
+ *     partial persistence.
  *   - Given a tenant resolver that throws (registry D1 down), the consumer
- *     acks (no DB to write to) without crashing the rest of the batch.
+ *     retries without crashing the rest of the batch.
  *
  * Each case asserts a fail-soft invariant — "no crash propagates" /
  * "queue still drains" — rather than precise output.
@@ -38,7 +39,12 @@ const REGISTRY_LOOKUP_SQL =
 // FINDING #2). Per-message queue resolution warm-hits this, so the mock must model it
 // or cache-hit resolutions see no row and treat the tenant as deactivated.
 const ACTIVE_PROBE_SQL = 'SELECT active FROM sub_tenants WHERE id = ? LIMIT 1';
-const SCAN_PROBE_BY_DOMAIN_SQL = 'SELECT id FROM scans WHERE cycle_id = ? AND domain = ? LIMIT 1';
+const SCAN_COMPLETION_PROBE_SQL =
+	'SELECT s.id, s.finding_count, COUNT(f.id) AS persisted_findings ' +
+	'FROM scans s LEFT JOIN findings f ON f.scan_id = s.id ' +
+	'WHERE s.cycle_id = ? AND s.domain = ? ' +
+	'GROUP BY s.id, s.finding_count ' +
+	'LIMIT 1';
 const SCANS_INSERT_SQL =
 	'INSERT INTO scans (id, domain, scan_at, score, grade, maturity_stage, finding_count, result_json, cycle_id) ' +
 	'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
@@ -250,13 +256,13 @@ describe('Tenant queue consumer chaos: handleScanQueue wrapper resilience', () =
 		expect(acks).toEqual([0, 2]);
 		expect(retries).toEqual([1]);
 
-		// The idempotency probe ran for all 3 — guarantees re-delivery sees the
-		// existing row and short-circuits without duplicate inserts.
-		const probeCalls = tenant.calls.filter((c) => c.sql === SCAN_PROBE_BY_DOMAIN_SQL);
+		// The completion probe ran for all 3 — guarantees re-delivery can distinguish
+		// complete rows from partial rows before deciding to ack or repair.
+		const probeCalls = tenant.calls.filter((c) => c.sql === SCAN_COMPLETION_PROBE_SQL);
 		expect(probeCalls.length).toBe(3);
 	});
 
-	it('acks the message and never crashes when the tenant resolver D1 throws', async () => {
+	it('retries the message and never crashes when the tenant resolver D1 throws', async () => {
 		const { handleScanQueue } = await import('../../src/tenants/queue-consumer');
 		const brokenRegistry = makeMockD1({ throwOnSql: new Set([REGISTRY_LOOKUP_SQL]) });
 		const customEnv = {
@@ -273,8 +279,8 @@ describe('Tenant queue consumer chaos: handleScanQueue wrapper resilience', () =
 		const { batch, acks, retries } = makeMessageBatch([validBody]);
 
 		await expect(handleScanQueue(batch, customEnv, ctx)).resolves.toBeUndefined();
-		expect(acks).toEqual([0]);
-		expect(retries).toEqual([]);
+		expect(acks).toEqual([]);
+		expect(retries).toEqual([0]);
 		expect(handleToolsCallMock).not.toHaveBeenCalled();
 	});
 });

--- a/test/chaos/varied-domain-all-tools.chaos.test.ts
+++ b/test/chaos/varied-domain-all-tools.chaos.test.ts
@@ -384,7 +384,7 @@ function makeToolCases(): ToolCase[] {
 		{ name: 'check_realtime_threat_feed', arguments: domainArgs() },
 		{ name: 'scan_buckets_start', arguments: { target: 'example.com' } },
 		{ name: 'scan_buckets_status', arguments: { scanId: 's1' } },
-		{ name: 'scan_buckets_findings', arguments: {} },
+		{ name: 'scan_buckets_findings', arguments: { scanId: 's1' } },
 		{ name: 'osint_investigate_domain_start', arguments: { query: 'example.com' } },
 		{ name: 'osint_investigate_infrastructure_start', arguments: { query: 'example.com' } },
 		{ name: 'osint_investigate_supply_chain_start', arguments: { query: 'example.com' } },

--- a/test/identity-secops-auth-gate.spec.ts
+++ b/test/identity-secops-auth-gate.spec.ts
@@ -121,29 +121,6 @@ describe('executeMcpRequest — identity_secops auth gate', () => {
 	}
 
 	it('does NOT reject an authenticated developer-tier caller for query_signins', async () => {
-		const { vi } = await import('vitest');
-		vi.doMock('../src/mcp/dispatch', () => ({
-			dispatchMcpMethod: vi.fn().mockResolvedValue({
-				kind: 'success',
-				payload: { jsonrpc: '2.0', id: 201, result: { content: [] } },
-				headers: {},
-				newSessionId: undefined,
-				logTool: 'query_signins',
-				logCategory: 'tool',
-				logResult: 'ok',
-				logDetails: {},
-			}),
-		}));
-		vi.doMock('../src/lib/rate-limiter', async (importOriginal) => {
-			const actual = await importOriginal<typeof import('../src/lib/rate-limiter')>();
-			return {
-				...actual,
-				checkToolDailyRateLimit: vi.fn().mockResolvedValue({ allowed: true, remaining: 499, limit: 500 }),
-				acquireConcurrencySlot: vi.fn().mockReturnValue({ allowed: true, active: 1, limit: 10 }),
-				releaseConcurrencySlot: vi.fn(),
-			};
-		});
-
 		const { executeMcpRequest } = await import('../src/mcp/execute');
 		const result = await executeMcpRequest(
 			baseOptions({
@@ -164,6 +141,31 @@ describe('executeMcpRequest — identity_secops auth gate', () => {
 		expect(result.httpStatus).not.toBe(401);
 		const payload = result.payload as { error?: { code: number } } | undefined;
 		expect(payload?.error?.code).not.toBe(-32001);
+		expect(result.headers['x-quota-limit']).toBe('100');
+	});
+
+	it('rejects an authenticated free-tier identity-secops caller with upgrade required', async () => {
+		const { executeMcpRequest } = await import('../src/mcp/execute');
+		const result = await executeMcpRequest(
+			baseOptions({
+				body: {
+					jsonrpc: '2.0',
+					id: 202,
+					method: 'tools/call',
+					params: { name: 'query_signins', arguments: { ms_tenant_id: 'tenant-abc' } },
+				} as JsonRpcRequest,
+				isAuthenticated: true,
+				tierAuthResult: { authenticated: true, tier: 'free', keyHash: 'k_free' },
+				authTier: 'free',
+			}),
+		);
+
+		expect(result.kind).toBe('response');
+		if (result.kind !== 'response') throw new Error('expected response');
+		expect(result.httpStatus).toBe(403);
+		const payload = result.payload as { error?: { code: number; message: string } } | undefined;
+		expect(payload?.error?.code).toBe(-32003);
+		expect(payload?.error?.message).toContain('Upgrade required');
 	});
 });
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -338,6 +338,29 @@ describe('DNS Security MCP Server', () => {
 			expect(['ok', 'error', 'absent']).toContain(body.bindings.scanCache);
 			expect(['ok', 'error', 'absent']).toContain(body.bindings.quotaCoordinator);
 		});
+
+		it('deep mode reports production-critical binding presence beyond scan cache and quota coordinator', async () => {
+			const authEnv = {
+				...env,
+				BV_API_KEY: TEST_API_KEY,
+				REQUIRE_PRODUCTION_BINDINGS: 'true',
+			} as Env & Record<string, unknown>;
+			const request = new Request<unknown, IncomingRequestCfProperties>('http://example.com/health?deep=1', {
+				headers: { Authorization: `Bearer ${TEST_API_KEY}` },
+			});
+			const ctx = createExecutionContext();
+			const response = await worker.fetch(request, authEnv as Env, ctx);
+			await waitOnExecutionContext(ctx);
+			const body = (await response.json()) as {
+				status: string;
+				bindings: Record<string, string>;
+			};
+			expect(response.status).toBe(503);
+			expect(body.status).toBe('degraded');
+			for (const key of ['tenantRegistryDb', 'scannerQueue', 'brandAuditDb', 'brandReports', 'brandAuditQueue', 'brandAuditPdfQueue', 'alertWebhook']) {
+				expect(body.bindings[key]).toBe('absent');
+			}
+		});
 	});
 
 	describe('POST /mcp - initialize', () => {

--- a/test/log.spec.ts
+++ b/test/log.spec.ts
@@ -39,6 +39,32 @@ describe('log redaction', () => {
 		});
 	});
 
+	it('redacts PII-capable tool fields from nested log details', () => {
+		const sanitized = sanitizeLogValue({
+			query: 'person@example.com',
+			email: 'person@example.com',
+			ms_tenant_id: '00000000-1111-2222-3333-444444444444',
+			user_principal_name: 'admin@example.com',
+			filters: {
+				userPrincipalName: 'nested@example.com',
+				tenantId: 'tenant-guid',
+			},
+			summary: 'visible aggregate',
+		});
+
+		expect(sanitized).toEqual({
+			query: '[redacted]',
+			email: '[redacted]',
+			ms_tenant_id: '[redacted]',
+			user_principal_name: '[redacted]',
+			filters: {
+				userPrincipalName: '[redacted]',
+				tenantId: '[redacted]',
+			},
+			summary: 'visible aggregate',
+		});
+	});
+
 	it('audit logs do not emit raw session identifiers', () => {
 		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 

--- a/test/m365-logging.spec.ts
+++ b/test/m365-logging.spec.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { handleToolsCall } from '../src/handlers/tools';
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+function getConsoleLogs(spy: ReturnType<typeof vi.spyOn>): Record<string, unknown>[] {
+	const logs: Record<string, unknown>[] = [];
+	for (const call of spy.mock.calls) {
+		const arg = call[0];
+		if (typeof arg !== 'string') continue;
+		try {
+			logs.push(JSON.parse(arg) as Record<string, unknown>);
+		} catch {
+			// not JSON
+		}
+	}
+	return logs;
+}
+
+describe('M365 tool logging', () => {
+	it('logs only aggregate success details, not raw proxy result rows', async () => {
+		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const m365Proxy = {
+			fetch: vi.fn(async () =>
+				new Response(JSON.stringify({ rows: [{ mail: 'admin@example.com', ipAddress: '192.0.2.10' }], count: 1 }), {
+					status: 200,
+					headers: { 'content-type': 'application/json' },
+				}),
+			),
+		};
+
+		await handleToolsCall(
+			{ name: 'query_signins', arguments: { ms_tenant_id: 'tenant-abc', user_principal_name: 'admin@example.com' } },
+			undefined,
+			{ m365Proxy, m365ProxyAuthToken: 'internal-token', keyHash: 'key_abc', authTier: 'developer' },
+		);
+
+		const logs = getConsoleLogs(consoleSpy);
+		const toolLog = logs.find((log) => log.tool === 'query_signins');
+		expect(toolLog).toBeDefined();
+		expect(toolLog!.details).toEqual({ ok: true, unprovisioned: false, rowCount: 1 });
+		expect(JSON.stringify(toolLog)).not.toContain('admin@example.com');
+		expect(JSON.stringify(toolLog)).not.toContain('192.0.2.10');
+	});
+});

--- a/test/recon-async-owner.spec.ts
+++ b/test/recon-async-owner.spec.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+import { describe, expect, it, vi } from 'vitest';
+import { handleToolsCall } from '../src/handlers/tools';
+
+function fakeKv() {
+	const store = new Map<string, string>();
+	return {
+		get: vi.fn(async (key: string) => store.get(key) ?? null),
+		put: vi.fn(async (key: string, value: string) => {
+			store.set(key, value);
+		}),
+	} as unknown as KVNamespace;
+}
+
+function binding(routes: Record<string, unknown>) {
+	return {
+		fetch: vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			void init;
+			const url = String(input);
+			for (const [fragment, body] of Object.entries(routes)) {
+				if (url.includes(fragment)) return new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+			}
+			return new Response(JSON.stringify({ error: 'not found' }), { status: 404, headers: { 'content-type': 'application/json' } });
+		}),
+	};
+}
+
+function asJson(result: unknown): string {
+	return JSON.stringify(result);
+}
+
+describe('async recon owner binding', () => {
+	it('binds bucket scan status/findings to the principal that started the scan', async () => {
+		const kv = fakeKv();
+		const reconBinding = binding({
+			'/buckets/api/scan/trigger': { scanId: 'scan_own_1', status: 'running' },
+			'/buckets/api/scan/status/scan_own_1': { scanId: 'scan_own_1', status: 'completed' },
+			'/buckets/api/findings': { count: 0, data: [] },
+		});
+
+		await handleToolsCall(
+			{ name: 'scan_buckets_start', arguments: { target: 'example.com' } },
+			undefined,
+			{ reconBinding, reconAuthToken: 'tok', rateLimitKv: kv, keyHash: 'owner-a', principalId: 'owner-a' },
+		);
+
+		const denied = await handleToolsCall(
+			{ name: 'scan_buckets_status', arguments: { scanId: 'scan_own_1' } },
+			undefined,
+			{ reconBinding, reconAuthToken: 'tok', rateLimitKv: kv, keyHash: 'owner-b', principalId: 'owner-b' },
+		);
+		expect(asJson(denied)).toContain('not owned by this principal');
+
+		const allowed = await handleToolsCall(
+			{ name: 'scan_buckets_findings', arguments: { scanId: 'scan_own_1' } },
+			undefined,
+			{ reconBinding, reconAuthToken: 'tok', rateLimitKv: kv, keyHash: 'owner-a', principalId: 'owner-a' },
+		);
+		expect(asJson(allowed)).toContain('Bucket findings');
+	});
+
+	it('requires scanId for bucket findings so reads can be owner-bound', async () => {
+		const reconBinding = binding({
+			'/buckets/api/findings': { count: 1, data: [{ bucket: 'leak-example' }] },
+		});
+
+		const denied = await handleToolsCall(
+			{ name: 'scan_buckets_findings', arguments: {} },
+			undefined,
+			{ reconBinding, reconAuthToken: 'tok', rateLimitKv: fakeKv(), keyHash: 'owner-a', principalId: 'owner-a' },
+		);
+
+		expect(asJson(denied)).toContain('Missing required parameter: scanId');
+		expect(reconBinding.fetch).not.toHaveBeenCalled();
+	});
+
+	it('binds OSINT status/report to the principal that started the investigation', async () => {
+		const kv = fakeKv();
+		const reconBinding = binding({
+			'/osint/api/investigate/domain': { investigationId: 'inv_own_1', status: 'running' },
+			'/osint/api/investigation/inv_own_1/report': { total: 0, findings: [] },
+			'/osint/api/investigation/inv_own_1': { investigationId: 'inv_own_1', status: 'completed' },
+		});
+
+		await handleToolsCall(
+			{ name: 'osint_investigate_domain_start', arguments: { query: 'example.com' } },
+			undefined,
+			{ reconBinding, reconAuthToken: 'tok', rateLimitKv: kv, keyHash: 'owner-a', principalId: 'owner-a' },
+		);
+
+		const denied = await handleToolsCall(
+			{ name: 'osint_investigation_report', arguments: { investigationId: 'inv_own_1' } },
+			undefined,
+			{ reconBinding, reconAuthToken: 'tok', rateLimitKv: kv, keyHash: 'owner-b', principalId: 'owner-b' },
+		);
+		expect(asJson(denied)).toContain('not owned by this principal');
+
+		const allowed = await handleToolsCall(
+			{ name: 'osint_investigation_status', arguments: { investigationId: 'inv_own_1' } },
+			undefined,
+			{ reconBinding, reconAuthToken: 'tok', rateLimitKv: kv, keyHash: 'owner-a', principalId: 'owner-a' },
+		);
+		expect(asJson(allowed)).toContain('Investigation inv_own_1');
+	});
+});

--- a/test/scan-buckets.spec.ts
+++ b/test/scan-buckets.spec.ts
@@ -33,7 +33,7 @@ describe('scan_buckets tools', () => {
 	});
 	it('findings: unprovisioned when absent; passes through when bound', async () => {
 		const { scanBucketsFindings } = await import('../src/tools/scan-buckets');
-		expect((await scanBucketsFindings({}, {})).findings.some(f => f.metadata?.unprovisioned === true)).toBe(true);
+		expect((await scanBucketsFindings({ scanId: 's1' }, {})).findings.some(f => f.metadata?.unprovisioned === true)).toBe(true);
 		const r = await scanBucketsFindings({ scanId: 's1' }, { reconBinding: binding({ findings: [] }), reconAuthToken: 't' });
 		expect(r.findings.some(f => f.metadata?.summary === true)).toBe(true);
 	});

--- a/test/tenants/db/tenant-schema.spec.ts
+++ b/test/tenants/db/tenant-schema.spec.ts
@@ -155,6 +155,11 @@ describe('tenant schema — findings', () => {
 		const idx = t.indexes.find((i) => i.config.name === 'idx_findings_domain_severity');
 		expect(idx).toBeDefined();
 	});
+
+	it('declares idx_findings_scan_id for cycle report and alert joins', () => {
+		const idx = t.indexes.find((i) => i.config.name === 'idx_findings_scan_id');
+		expect(idx).toBeDefined();
+	});
 });
 
 describe('tenant schema — alerts', () => {

--- a/test/tenants/queue-consumer.integration.test.ts
+++ b/test/tenants/queue-consumer.integration.test.ts
@@ -34,13 +34,20 @@ const TEST_TENANT_ID = 'tenant-1';
 const TEST_TENANT_BINDING = 'TENANT_DB_TENANT_1';
 const REGISTRY_LOOKUP_SQL =
 	'SELECT id, super_tenant_id, d1_db_id, routing_mode, active FROM sub_tenants WHERE id = ? LIMIT 1';
-const SCAN_PROBE_BY_DOMAIN_SQL = 'SELECT id FROM scans WHERE cycle_id = ? AND domain = ? LIMIT 1';
+const SCAN_COMPLETION_PROBE_SQL =
+	'SELECT s.id, s.finding_count, COUNT(f.id) AS persisted_findings ' +
+	'FROM scans s LEFT JOIN findings f ON f.scan_id = s.id ' +
+	'WHERE s.cycle_id = ? AND s.domain = ? ' +
+	'GROUP BY s.id, s.finding_count ' +
+	'LIMIT 1';
 const SCANS_INSERT_SQL =
 	'INSERT INTO scans (id, domain, scan_at, score, grade, maturity_stage, finding_count, result_json, cycle_id) ' +
 	'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
 const FINDINGS_INSERT_SQL =
 	'INSERT INTO findings (id, scan_id, domain, category, severity, title, detail, metadata) ' +
 	'VALUES (?, ?, ?, ?, ?, ?, ?, ?)';
+const DELETE_FINDINGS_FOR_SCAN_SQL = 'DELETE FROM findings WHERE scan_id = ?';
+const DELETE_SCAN_SQL = 'DELETE FROM scans WHERE id = ?';
 
 type RecordedCall = { sql: string; binds: unknown[] };
 
@@ -187,7 +194,7 @@ describe('processScanMessage', () => {
 		});
 		const tenant = makeMockD1({
 			rowsBySql: {
-				[SCAN_PROBE_BY_DOMAIN_SQL]: [{ id: 'pre-existing-scan-row' }],
+				[SCAN_COMPLETION_PROBE_SQL]: [{ id: 'pre-existing-scan-row', finding_count: 2, persisted_findings: 2 }],
 			},
 		});
 		const customEnv = {
@@ -213,13 +220,60 @@ describe('processScanMessage', () => {
 		expect(handleToolsCallMock).not.toHaveBeenCalled();
 	});
 
-	it('returns ack when the tenant resolver throws (no DB binding to write to)', async () => {
+	it('returns retry when the tenant resolver throws before the final attempt', async () => {
 		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
 		const customEnv = { ...env };
 
 		const outcome = await processScanMessage(validMsg, 1, customEnv, makeCtx());
+		expect(outcome).toBe('retry');
+		expect(handleToolsCallMock).not.toHaveBeenCalled();
+	});
+
+	it('returns ack when the tenant resolver still throws on the final attempt', async () => {
+		const { processScanMessage, MAX_ATTEMPTS } = await import('../../src/tenants/queue-consumer');
+		const customEnv = { ...env };
+
+		const outcome = await processScanMessage(validMsg, MAX_ATTEMPTS, customEnv, makeCtx());
 		expect(outcome).toBe('ack');
 		expect(handleToolsCallMock).not.toHaveBeenCalled();
+	});
+
+	it('does not treat a partial scan row as idempotently complete', async () => {
+		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
+			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
+			opts?.resultCapture?.({
+				category: 'spf',
+				passed: true,
+				score: 90,
+				findings: [{ category: 'spf', severity: 'info', title: 'spf_ok', detail: 'looks good' }],
+			});
+			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
+		});
+		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
+		const registry = makeMockD1({
+			rowsBySql: {
+				[REGISTRY_LOOKUP_SQL]: [
+					{ id: TEST_TENANT_ID, super_tenant_id: 'super-tenant-1', d1_db_id: 'x', active: 1 },
+				],
+			},
+		});
+		const tenant = makeMockD1({
+			rowsBySql: {
+				[SCAN_COMPLETION_PROBE_SQL]: [{ id: 'partial-scan-row', finding_count: 2, persisted_findings: 0 }],
+			},
+		});
+		const customEnv = {
+			...env,
+			TENANT_REGISTRY_DB: registry.db,
+			[TEST_TENANT_BINDING]: tenant.db,
+		};
+
+		const outcome = await processScanMessage(validMsg, 1, customEnv, makeCtx());
+		expect(outcome).toBe('ack');
+		expect(tenant.calls).toContainEqual({ sql: DELETE_FINDINGS_FOR_SCAN_SQL, binds: ['partial-scan-row'] });
+		expect(tenant.calls).toContainEqual({ sql: DELETE_SCAN_SQL, binds: ['partial-scan-row'] });
+		expect(handleToolsCallMock).toHaveBeenCalledOnce();
+		expect(tenant.calls.filter((c) => c.sql === SCANS_INSERT_SQL)).toHaveLength(1);
 	});
 
 	it('returns retry when handleToolsCall returns isError on the first attempt', async () => {

--- a/test/tenants/queue-producer.integration.test.ts
+++ b/test/tenants/queue-producer.integration.test.ts
@@ -199,6 +199,18 @@ describe('POST /internal/tenants/scan (mode=queue producer)', () => {
 		expect(queueSend).not.toHaveBeenCalled();
 	});
 
+	it('default mode auto-queues large domain sets instead of running synchronously', async () => {
+		const { customEnv, queueSend } = buildEnvWithQueue();
+		const domains = Array.from({ length: 51 }, (_, i) => `tenant-${i}.example.com`);
+		const res = await sendRequest(makeReq({ domains }), customEnv);
+		expect(res.status).toBe(202);
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body.total).toBe(51);
+		expect(body.queued).toBe(51);
+		expect(body).not.toHaveProperty('completed');
+		expect(queueSend).toHaveBeenCalledTimes(51);
+	});
+
 	it('returns 400 when mode=queue but BV_SCANNER_QUEUE binding is absent', async () => {
 		const registry = makeMockD1({
 			[REGISTRY_LOOKUP_SQL]: [{ id: TEST_TENANT_ID, super_tenant_id: 'super-tenant-1', d1_db_id: 'x', active: 1 }],

--- a/test/tenants/scheduled-handlers.integration.test.ts
+++ b/test/tenants/scheduled-handlers.integration.test.ts
@@ -467,6 +467,30 @@ describe('handleTenantWeeklyRescan', () => {
 		// baseline_cycle_id is the 6th bind (zero-indexed 5).
 		expect(inserts[0].binds[5]).toBe('baseline-cycle-7');
 	});
+
+	it('bounds active-tenant and due-domain enumeration per weekly tick', async () => {
+		const { handleTenantWeeklyRescan } = await import('../../src/tenants/scheduled-handlers');
+		const registry = makeMockD1({
+			rowsBySql: { [ACTIVE_TENANTS_SQL]: [{ id: TENANT_A, super_tenant_id: SUPER }] },
+		});
+		const tenant = makeMockD1({ rowsBySql: { [DUE_DOMAINS_SQL]: [] } });
+		const queue = makeMockQueue();
+		const customEnv: TenantScheduledEnv = {
+			...env,
+			TENANT_REGISTRY_DB: registry.db,
+			BV_SCANNER_QUEUE: queue,
+			[TENANT_A_BINDING]: tenant.db,
+		} as TenantScheduledEnv;
+
+		await handleTenantWeeklyRescan(customEnv, makeCtx(), { now: () => 1, dnsQuery: makeDnsQuery({}) });
+
+		const tenantEnum = registry.calls.find((c) => callMatches(c.sql, ACTIVE_TENANTS_SQL));
+		const dueEnum = tenant.calls.find((c) => callMatches(c.sql, DUE_DOMAINS_SQL));
+		expect(tenantEnum?.sql).toContain('LIMIT ?');
+		expect(tenantEnum?.binds).toEqual([100]);
+		expect(dueEnum?.sql).toContain('LIMIT ?');
+		expect(dueEnum?.binds).toEqual([168, 1, 500]);
+	});
 });
 
 // =========================================================================

--- a/test/tool-execution.spec.ts
+++ b/test/tool-execution.spec.ts
@@ -295,6 +295,36 @@ describe('logToolFailure', () => {
 		expect(errorLog!.domain).toBe('example.com');
 	});
 
+	it('redacts PII-capable failure args before structured logging', async () => {
+		const { logToolFailure } = await import('../src/handlers/tool-execution');
+
+		const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+		logToolFailure({
+			toolName: 'query_signins',
+			durationMs: 150,
+			error: new Error('proxy failed'),
+			args: {
+				ms_tenant_id: '00000000-1111-2222-3333-444444444444',
+				user_principal_name: 'admin@example.com',
+				query: 'admin@example.com',
+				since_hours: 24,
+			},
+		});
+
+		const logs = getConsoleLogs(consoleSpy);
+		const errorLog = logs.find((l) => l.severity === 'error') as { details?: Record<string, unknown> } | undefined;
+		expect(errorLog).toBeDefined();
+		expect(errorLog!.details).toMatchObject({
+			ms_tenant_id: '[redacted]',
+			user_principal_name: '[redacted]',
+			query: '[redacted]',
+			since_hours: 24,
+		});
+		expect(JSON.stringify(errorLog)).not.toContain('admin@example.com');
+		expect(JSON.stringify(errorLog)).not.toContain('00000000-1111-2222-3333-444444444444');
+	});
+
 	it('handles non-Error objects as error argument', async () => {
 		const { logToolFailure } = await import('../src/handlers/tool-execution');
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -40,6 +40,7 @@ export default defineConfig({
 			'node_modules/**',
 			'.claude/**',
 			'.dev/**',
+			'.firecrawl/**',
 			'.worktrees/**',
 			// BrandAudit audit calibration specs are run via vitest.calibration.config.mts
 			// (node env, can read fs). Excluding from the default workers-pool run.


### PR DESCRIPTION
## Summary
- Harden log redaction, M365 logging, async recon ownership, and deploy-time production security checks.
- Improve tenant queue durability, scheduler limits, health binding visibility, tail-exception alerting, and schema indexes.
- Update public auth/runbook docs and add focused audit, regression, and chaos coverage for the fixed findings.

## Verification
- npm run typecheck
- npm run lint
- npm run audit:repo-safety
- npm run drizzle:check:tenant
- npm test -- --config vitest.node.config.mts test/audits/private-config-injection.node.test.ts
- git diff --check
- npm test: 5,863 passed, 13 skipped; command exited 0, with 10 Cloudflare pool worker-exit teardown errors reported by Vitest.