### PR TITLE
fix(alerting): dead tail-exception alert + pipeline watchdog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -354,7 +354,7 @@ The free-tier paid-gating (HTTP 403 for offensive tools) and the distinct-domain
 
 ## Analytics
 
-Eight event indexes are emitted (`analytics.ts`): four core — `mcp_request`, `tool_call`, `rate_limit`, `session` — plus `degradation` (e.g. `kv_fallback` from `session.ts` on a KV write throw, `quota_shard_salt_missing` from the sharded quota path), `queue_batch`, `tail`, and `quota_shard` (emitted from `execute.ts` when quota sharding is enabled). Queries in `analytics-queries.ts` cover the four core types plus `quota_shard` (`queryQuotaShardSkew`); nothing queries/alerts on `degradation`, `queue_batch`, or `tail` yet. Scheduled handler (`scheduled.ts`) every 15 min: anomaly alerts + `handleFuzzingScan`. Optional — requires `CF_ACCOUNT_ID` + `CF_ANALYTICS_TOKEN` + `ALERT_WEBHOOK_URL`.
+Eight event indexes are emitted (`analytics.ts`): four core — `mcp_request`, `tool_call`, `rate_limit`, `session` — plus `degradation` (e.g. `kv_fallback` from `session.ts` on a KV write throw, `quota_shard_salt_missing` from the sharded quota path), `queue_batch`, `tail`, and `quota_shard` (emitted from `execute.ts` when quota sharding is enabled). Queries in `analytics-queries.ts` cover the four core types plus `quota_shard` (`queryQuotaShardSkew`), `degradation` (binding-degradation alert), `queue_batch` (queue-failure alert), and `tail` (fatal-exception alert) — all wired into the 15-min cron in `scheduled.ts`. Scheduled handler (`scheduled.ts`) every 15 min: anomaly alerts + `handleFuzzingScan`. Optional — requires `CF_ACCOUNT_ID` + `CF_ANALYTICS_TOKEN` + `ALERT_WEBHOOK_URL`.
 
 **Blob layout** (keep in sync when adding dimensions):
 

--- a/src/lib/analytics-queries.ts
+++ b/src/lib/analytics-queries.ts
@@ -310,11 +310,15 @@ ORDER BY failure_count DESC`;
 /** Fatal Worker exception detection from Tail Worker exports. */
 export function queryTailExceptions(minutes: string): string {
 	minutes = safeInterval(minutes);
+	// emitTailAggregate (analytics.ts) writes blob1=colo, blob2=outcome,
+	// double1=invocations in the bucket. Fatal invocations are the ones in
+	// outcome='exception' buckets; double1 × _sample_interval is the
+	// sampled-correct invocation count (mirrors queryQueueFailures above).
 	return `SELECT
-  SUM(_sample_interval) AS exception_count
+  SUM(double1 * _sample_interval) AS exception_count
 FROM ${DS}
 WHERE index1 = 'tail'
-  AND blob1 = 'exception'
+  AND blob2 = 'exception'
   AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE`;
 }
 

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -486,6 +486,20 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 			category: 'scheduled',
 			details: { message: 'Analytics alerting check failed' },
 		});
+		// Watchdog: the alerting pipeline ITSELF failed (AE query error, expired
+		// token, network) — every threshold alert above is silently disabled.
+		// The webhook is configured (guard at the top of this function), so page
+		// through it. Best-effort: if the webhook is down too there is nothing
+		// left to do in-band.
+		await sendAlert(
+			env.ALERT_WEBHOOK_URL,
+			buildAlertPayload({
+				title: 'Alerting pipeline failure: analytics check could not run',
+				severity: 'critical',
+				metrics: { pipeline_failed: 1 },
+				threshold: 'alerting_self_check',
+			}),
+		).catch(() => {});
 	}
 }
 

--- a/test/analytics-queries.spec.ts
+++ b/test/analytics-queries.spec.ts
@@ -198,8 +198,13 @@ describe('analytics query builders', () => {
 	it('queryTailExceptions counts fatal Worker exceptions exported by the tail consumer', () => {
 		const sql = queryTailExceptions('15');
 		expect(sql).toContain("index1 = 'tail'");
-		expect(sql).toContain("blob1 = 'exception'");
-		expect(sql).toContain('exception_count');
+		// The tail emitter writes blob1=colo, blob2=outcome (emitTailAggregate in
+		// analytics.ts); a fatal invocation lands in an outcome='exception' bucket
+		// whose double1 carries the invocation count. Multiply by _sample_interval
+		// for AE sampling correctness (same pattern as queryQueueFailures).
+		expect(sql).toContain("blob2 = 'exception'");
+		expect(sql).not.toContain("blob1 = 'exception'");
+		expect(sql).toContain('SUM(double1 * _sample_interval) AS exception_count');
 		expect(sql).toContain("INTERVAL '15' MINUTE");
 	});
 });

--- a/test/scheduled.spec.ts
+++ b/test/scheduled.spec.ts
@@ -194,6 +194,7 @@ describe('handleScheduled', () => {
 				if (query.includes('tool_call'))
 					return new Response(JSON.stringify({ data: [{ total_calls: 100, error_count: 1, error_pct: 1.0, p95_ms: 500 }] }));
 				if (query.includes('rate_limit')) return new Response(JSON.stringify({ data: [{ total_hits: 2 }] }));
+				return new Response(JSON.stringify({ data: [] }));
 			}
 			return new Response('ok');
 		}) as typeof fetch;
@@ -215,6 +216,7 @@ describe('handleScheduled', () => {
 				if (query.includes('tool_call'))
 					return new Response(JSON.stringify({ data: [{ total_calls: 100, error_count: 1, error_pct: 1.0, p95_ms: 500 }] }));
 				if (query.includes('rate_limit')) return new Response(JSON.stringify({ data: [{ total_hits: 2 }] }));
+				return new Response(JSON.stringify({ data: [] }));
 			}
 			return new Response('ok');
 		}) as typeof fetch;
@@ -242,6 +244,7 @@ describe('handleScheduled', () => {
 				if (query.includes('rate_limit')) {
 					return new Response(JSON.stringify({ data: [{ total_hits: 2 }] }));
 				}
+				return new Response(JSON.stringify({ data: [] }));
 			}
 			return new Response('ok');
 		}) as typeof fetch;
@@ -256,5 +259,28 @@ describe('handleScheduled', () => {
 		// Should NOT have called the webhook
 		const webhookCalls = fetchCalls.filter((u) => u.includes('hooks.slack.com'));
 		expect(webhookCalls).toHaveLength(0);
+	});
+
+	it('sends a watchdog alert through the webhook when the analytics query pipeline fails', async () => {
+		const fetchCalls: Array<{ url: string; body: string }> = [];
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			fetchCalls.push({ url, body: init?.body as string });
+			if (url.includes('analytics_engine/sql')) {
+				throw new Error('Authentication error: token expired');
+			}
+			return new Response('ok');
+		}) as typeof fetch;
+
+		const { handleScheduled } = await import('../src/scheduled');
+		await handleScheduled({
+			CF_ACCOUNT_ID: 'test-account',
+			CF_ANALYTICS_TOKEN: 'test-token',
+			ALERT_WEBHOOK_URL: 'https://hooks.slack.com/test',
+		} as ScheduledEnv);
+
+		const webhookCall = fetchCalls.find((c) => c.url.includes('hooks.slack.com'));
+		expect(webhookCall).toBeDefined();
+		expect(webhookCall!.body).toContain('Alerting pipeline failure');
 	});
 });


### PR DESCRIPTION
## Summary
- The tail-exception AE query filtered `blob1` (colo) instead of `blob2` (outcome), so the fatal-Worker-exception alert could never fire; the unit test asserted the same wrong blob. Fixed the query and its test.
- Added a watchdog self-alert through the webhook when the alerting pipeline's own AE queries fail (e.g. an expired `CF_ANALYTICS_TOKEN`) — previously that failure mode was log-only and every threshold alert would silently stop.
- Corrected a stale CLAUDE.md claim: `degradation`/`queue_batch`/`tail` events are now queried and alerted in the 15-min cron.

Part of a 4-PR audit-remediation series (maverick-validate suite findings 1, 9, 14). Full detail: `docs/plans/2026-07-08-audit-remediation.md` (local only, not committed).

## Test plan
- [x] `npx vitest run test/analytics-queries.spec.ts test/scheduled.spec.ts` — 46/46 passing
- [x] `npm run typecheck` — clean
- [x] Task-level review (spec ✅ / quality approved) + whole-branch review (ready to merge, no Critical/Important)

🤖 Generated with [Claude Code](https://claude.com/claude-code)