### PR TITLE
feat: ops knobs — wire global-quota env override, harden logEvent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,10 +42,10 @@ import { buildControlPlaneRateLimitResponse, resolveSseSession, validateSessionR
 import {
 	FREE_DISTINCT_DOMAIN_DAILY_LIMIT,
 	FREE_TOOL_DAILY_LIMITS,
-	GLOBAL_DAILY_TOOL_LIMIT,
 	MAX_REQUEST_BODY_BYTES,
 	isValidOAuthSigningSecret,
 	parseCacheTtl,
+	parseGlobalDailyLimit,
 	parsePerCheckTimeout,
 	parseScanTimeout,
 } from './lib/config';
@@ -302,6 +302,8 @@ type BvMcpEnv = {
 	 * `lib/scaling-flags.ts`. TODO(phase-4).
 	 */
 	TENANT_ROUTING_MODE?: string;
+	/** Optional override of the global unauthenticated daily tools/call cap (clamped [10000, 5000000]). */
+	GLOBAL_DAILY_TOOL_LIMIT?: string;
 };
 
 import type { TierAuthResult } from './lib/tier-auth';
@@ -645,7 +647,7 @@ app.get('/badge/:domain', async (c) => {
 	// executeMcpRequest — not just the per-IP + per-tool caps. Without these, an
 	// unauthenticated IP could scan up to 25 DISTINCT domains/day here (vs the
 	// intended 12) and those scans would escape the global daily cap entirely.
-	const globalResult = await checkGlobalDailyLimit(GLOBAL_DAILY_TOOL_LIMIT, c.env.RATE_LIMIT, c.env.QUOTA_COORDINATOR);
+	const globalResult = await checkGlobalDailyLimit(parseGlobalDailyLimit(c.env.GLOBAL_DAILY_TOOL_LIMIT), c.env.RATE_LIMIT, c.env.QUOTA_COORDINATOR);
 	if (!globalResult.allowed) {
 		return badgeRateLimitResponse(svgHeaders, globalResult.retryAfterMs);
 	}
@@ -812,6 +814,7 @@ app.post('/mcp', async (c) => {
 					rateLimitKv: c.env.RATE_LIMIT,
 					quotaCoordinator: c.env.QUOTA_COORDINATOR,
 					quotaShardRouting: resolveQuotaShardRouting(c.env),
+					globalDailyLimit: parseGlobalDailyLimit(c.env.GLOBAL_DAILY_TOOL_LIMIT),
 					sessionStore: c.env.SESSION_STORE,
 					scanCache: c.env.SCAN_CACHE,
 					providerSignaturesUrl: c.env.PROVIDER_SIGNATURES_URL,
@@ -912,6 +915,7 @@ app.post('/mcp', async (c) => {
 		rateLimitKv: c.env.RATE_LIMIT,
 		quotaCoordinator: c.env.QUOTA_COORDINATOR,
 		quotaShardRouting: resolveQuotaShardRouting(c.env),
+		globalDailyLimit: parseGlobalDailyLimit(c.env.GLOBAL_DAILY_TOOL_LIMIT),
 		sessionStore: c.env.SESSION_STORE,
 		scanCache: c.env.SCAN_CACHE,
 		providerSignaturesUrl: c.env.PROVIDER_SIGNATURES_URL,
@@ -1096,6 +1100,7 @@ app.post('/mcp/messages', async (c) => {
 				rateLimitKv: c.env.RATE_LIMIT,
 				quotaCoordinator: c.env.QUOTA_COORDINATOR,
 				quotaShardRouting: resolveQuotaShardRouting(c.env),
+				globalDailyLimit: parseGlobalDailyLimit(c.env.GLOBAL_DAILY_TOOL_LIMIT),
 				sessionStore: c.env.SESSION_STORE,
 				scanCache: c.env.SCAN_CACHE,
 				providerSignaturesUrl: c.env.PROVIDER_SIGNATURES_URL,

--- a/src/lib/log.ts
+++ b/src/lib/log.ts
@@ -115,6 +115,13 @@ export function logEvent(event: LogEvent): void {
 	const log = {
 		...event,
 		timestamp: event.timestamp || new Date().toISOString(),
+		// Top-level fields bypass sanitizeLogValue (they're not nested in
+		// `details`); the two that carry attacker-controlled strings get the
+		// same control-char strip + truncation so a hostile UA or domain can't
+		// inject log lines or bloat tail storage. (JSON.stringify drops the
+		// undefined keys this adds for events without them.)
+		domain: typeof event.domain === 'string' ? sanitizeString(event.domain, maxLen) : event.domain,
+		userAgent: typeof event.userAgent === 'string' ? sanitizeString(event.userAgent, maxLen) : event.userAgent,
 		details: sanitizeLogValue(event.details, undefined, maxLen),
 		error: typeof event.error === 'string' ? sanitizeString(event.error, maxLen) : event.error,
 	};

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -205,6 +205,13 @@ export interface ExecuteMcpRequestOptions {
 	tier0Lookup?: (domain: string) => Promise<import('../lib/brand-tier0-enterprise').Tier0Result>;
 	tier1Lookup?: (domain: string) => Promise<import('../lib/brand-tier1-graph').Tier1Result>;
 	tier2Lookup?: (domain: string) => Promise<import('../lib/brand-tier2-evidence').Tier2Result>;
+	/**
+	 * Global daily tools/call cap across ALL unauthenticated callers. Defaults
+	 * to the GLOBAL_DAILY_TOOL_LIMIT constant; index.ts populates it from the
+	 * GLOBAL_DAILY_TOOL_LIMIT env var via parseGlobalDailyLimit() so operators
+	 * can throttle without a code deploy.
+	 */
+	globalDailyLimit?: number;
 }
 
 function getDomainFromParams(params: Record<string, unknown> | undefined): string | undefined {
@@ -852,8 +859,9 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 
 	let rateHeaders: Record<string, string> = {};
 	if (!options.isAuthenticated && method === 'tools/call') {
+		const globalDailyLimit = options.globalDailyLimit ?? GLOBAL_DAILY_TOOL_LIMIT;
 		const globalResult = await checkGlobalDailyLimit(
-			GLOBAL_DAILY_TOOL_LIMIT,
+			globalDailyLimit,
 			options.rateLimitKv,
 			options.quotaCoordinator,
 			options.analytics,
@@ -866,7 +874,7 @@ export async function executeMcpRequest(options: ExecuteMcpRequestOptions): Prom
 			options.analytics?.emitRateLimitEvent({
 				limitType: 'daily_global',
 				toolName: 'n/a',
-				limit: GLOBAL_DAILY_TOOL_LIMIT,
+				limit: globalDailyLimit,
 				remaining: 0,
 				country: options.country,
 				authTier: options.authTier,

--- a/test/audits/global-daily-limit-wiring.audit.test.ts
+++ b/test/audits/global-daily-limit-wiring.audit.test.ts
@@ -1,0 +1,36 @@
+// Audit test: the GLOBAL_DAILY_TOOL_LIMIT env override must stay WIRED.
+//
+// Background (2026-07-08 audit finding): parseGlobalDailyLimit() existed and
+// was unit-tested, but no runtime call site used it — the global daily cap was
+// un-overridable without a deploy. This audit greps the source so the knob
+// can't silently regress to dead code again.
+
+import { describe, it, expect } from 'vitest';
+
+const sources = import.meta.glob(['../../src/index.ts', '../../src/mcp/execute.ts'], {
+	query: '?raw',
+	import: 'default',
+	eager: true,
+}) as Record<string, string>;
+
+function source(suffix: string): string {
+	const key = Object.keys(sources).find((k) => k.endsWith(suffix));
+	if (!key) throw new Error(`source not globbed: ${suffix}`);
+	return sources[key];
+}
+
+describe('GLOBAL_DAILY_TOOL_LIMIT env override wiring', () => {
+	it('index.ts parses the env override at every executeMcpRequest construction site plus the badge route', () => {
+		const idx = source('src/index.ts');
+		const parseCalls = idx.match(/parseGlobalDailyLimit\(/g) ?? [];
+		// 3 executeMcpRequest construction sites + 1 unauthenticated /badge site.
+		expect(parseCalls.length).toBeGreaterThanOrEqual(4);
+		// The badge route must not fall back to the raw constant.
+		expect(idx).not.toMatch(/checkGlobalDailyLimit\(\s*GLOBAL_DAILY_TOOL_LIMIT/);
+	});
+
+	it('execute.ts honors options.globalDailyLimit with the constant as fallback', () => {
+		const exec = source('src/mcp/execute.ts');
+		expect(exec).toContain('options.globalDailyLimit ?? GLOBAL_DAILY_TOOL_LIMIT');
+	});
+});

--- a/test/log.spec.ts
+++ b/test/log.spec.ts
@@ -198,15 +198,15 @@ describe('log string truncation', () => {
 		logEvent({
 			timestamp: '2026-07-08T00:00:00.000Z',
 			severity: 'info',
-			userAgent: 'evil\nagent[31m' + 'x'.repeat(500),
-			domain: 'bad[0mdomain.example',
+			userAgent: 'evil\nagent\u001b[31m' + 'x'.repeat(500),
+			domain: 'bad\u001b[0mdomain.example',
 		});
 		spy.mockRestore();
 		const parsed = JSON.parse(lines[0]) as { userAgent: string; domain: string };
 		expect(parsed.userAgent).not.toContain('\n');
-		expect(parsed.userAgent).not.toContain('');
+		expect(parsed.userAgent).not.toContain('\u001b');
 		expect(parsed.userAgent.length).toBeLessThanOrEqual(256);
-		expect(parsed.domain).not.toContain('');
+		expect(parsed.domain).not.toContain('\u001b');
 	});
 });
 

--- a/test/log.spec.ts
+++ b/test/log.spec.ts
@@ -188,6 +188,26 @@ describe('log string truncation', () => {
 		// Info-level uses default 256 limit; 500-char string should be truncated
 		expect(payload.details.message.length).toBeLessThan(300);
 	});
+
+	it('sanitizes top-level userAgent and domain (control chars stripped, truncated)', async () => {
+		const lines: string[] = [];
+		const spy = vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+			lines.push(String(args[0]));
+		});
+		const { logEvent } = await import('../src/lib/log');
+		logEvent({
+			timestamp: '2026-07-08T00:00:00.000Z',
+			severity: 'info',
+			userAgent: 'evil\nagent[31m' + 'x'.repeat(500),
+			domain: 'bad[0mdomain.example',
+		});
+		spy.mockRestore();
+		const parsed = JSON.parse(lines[0]) as { userAgent: string; domain: string };
+		expect(parsed.userAgent).not.toContain('\n');
+		expect(parsed.userAgent).not.toContain('');
+		expect(parsed.userAgent.length).toBeLessThanOrEqual(256);
+		expect(parsed.domain).not.toContain('');
+	});
 });
 
 describe('logError error-severity truncation', () => {


### PR DESCRIPTION
## Summary
- Wired the previously-dead `GLOBAL_DAILY_TOOL_LIMIT` env override through all 4 call sites (`src/index.ts` badge route + 3 `executeMcpRequest` construction sites, `src/mcp/execute.ts`) — `parseGlobalDailyLimit()` existed and was unit-tested but nothing called it, so the global daily cap was un-overridable without a deploy. Guarded by a new source-grep audit test so it can't silently go dead again.
- Sanitized top-level `userAgent`/`domain` fields in `logEvent` (`src/lib/log.ts`) — previously only `details`/`error` were sanitized, so a hostile UA/domain could inject control chars/ANSI into Workers logs.

Part of a 4-PR audit-remediation series (maverick-validate suite findings 11, 13). Full detail: `docs/plans/2026-07-08-audit-remediation.md` (local only, not committed).

## Test plan
- [x] `npx vitest run` on the 6 covering specs — 148/148 passing
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] Task-level review (spec ✅ / quality approved, one fix-and-reverify round for a raw-byte test-encoding issue) + whole-branch review (ready to merge, no Critical/Important)
- [x] Backward-compat verified: env var unset resolves to the exact same 500,000 constant as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)