### PR TITLE
feat(privacy): data-subject erasure endpoint + collection disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ The public `/mcp` path writes a per-event access log enriched with geolocation a
 | `MCP_ANALYTICS_QUEUE`     | Queue | **Operator-deploy only.** Batches access-log writes off the request path. Absent on self-hosts → inline-insert fallback (no reverse-DNS lookup).                                                      |
 | `ANALYTICS_PII_LEVEL`     | var   | `coarse` (default) \| `standard` \| `full`. Controls access-log PII depth: `coarse` = country/region/ASN + hashed/masked IP; `standard` adds encrypted IP + city; `full` adds lat/long + reverse-DNS (PTR). |
 | `ANALYTICS_RETENTION_DAYS` | var   | Access-log retention window in days (default `90`, clamped `1`–`365`). Rows older than the window are pruned by the scheduled handler.                                                                |
+| PTR third-party disclosure | — | At `ANALYTICS_PII_LEVEL=full`, caller-IP PTR lookups resolve through the configured DoH chain, whose final fallback is Google Public DNS — an external disclosure of caller-IP-derived queries that operators should weigh before enabling `full`. Per-subject erasure: `POST /internal/analytics/erase?key_hash=…\|ip_hash=…` (strict internal bearer; self-audited). |
 
 ### Internal analytics endpoints
 

--- a/docs/client-setup.md
+++ b/docs/client-setup.md
@@ -598,3 +598,14 @@ Example payload:
 | POST | `/oauth/token` | Token endpoint (authorization code grant with PKCE) |
 
 On the hosted endpoint, OAuth routes serve the customer flow. On self-hosted deployments, OAuth endpoints return `404` unless the operator sets `ENABLE_OAUTH=true`. The owner API-key consent UI remains disabled unless `ENABLE_OWNER_OAUTH=true`.
+
+## What the hosted server logs about you
+
+Requests to the hosted endpoint (`dns-mcp.blackveilsecurity.com`) generate operational telemetry:
+
+- **Always:** tool name, scanned-domain fingerprint (hashed), country, client type, auth tier, a lossy hash of your IP, and (for authenticated callers) a SHA-256 hash of your credential. Raw IPs are never stored at the default (`coarse`) telemetry level.
+- **Operator-elevated levels** (`standard`/`full`, not the public default) additionally capture region/city, user agent, encrypted IP evidence, and — at `full` — a PTR (reverse-DNS) lookup of the calling IP. PTR lookups are resolved via DNS-over-HTTPS and may fall back to Google Public DNS, so at that level the calling IP is disclosed to the DoH resolver.
+- **Retention:** access-log rows are purged on a rolling window (90 days by default, operator-configurable 1–365).
+- **Erasure/export:** to request the data held for your API key or IP, or its deletion, contact the operator — per-subject export and erasure tooling exists on the operator side.
+
+Self-hosted (BSL) deployments control all of this via `ANALYTICS_PII_LEVEL` and `ANALYTICS_RETENTION_DAYS`.

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -231,7 +231,10 @@ internalRoutes.post('/tools/call', async (c) => {
 	// Mirrors the public /mcp limit (MAX_REQUEST_BODY_BYTES = 10 KB).
 	const raw = await c.req.text();
 	if (raw.length > MAX_REQUEST_BODY_BYTES) {
-		return c.json({ content: [{ type: 'text', text: `Request body exceeds maximum of ${MAX_REQUEST_BODY_BYTES} bytes` }], isError: true }, 413);
+		return c.json(
+			{ content: [{ type: 'text', text: `Request body exceeds maximum of ${MAX_REQUEST_BODY_BYTES} bytes` }], isError: true },
+			413,
+		);
 	}
 
 	let body: { name: string; arguments?: Record<string, unknown> };
@@ -239,7 +242,10 @@ internalRoutes.post('/tools/call', async (c) => {
 		body = InternalToolCallSchema.parse(JSON.parse(raw));
 	} catch (err) {
 		if (err instanceof ZodError) {
-			return c.json({ content: [{ type: 'text', text: `Invalid ${err.issues[0].path.join('.')}: ${err.issues[0].message}` }], isError: true }, 400);
+			return c.json(
+				{ content: [{ type: 'text', text: `Invalid ${err.issues[0].path.join('.')}: ${err.issues[0].message}` }], isError: true },
+				400,
+			);
 		}
 		return c.json({ content: [{ type: 'text', text: 'Missing required field: name' }], isError: true }, 400);
 	}
@@ -259,50 +265,50 @@ internalRoutes.post('/tools/call', async (c) => {
 
 	const cacheTtlSeconds = parseCacheTtl(c.env.CACHE_TTL_SECONDS);
 
-	const result = await handleToolsCall(
-		{ name: body.name, arguments: body.arguments },
-		c.env.SCAN_CACHE,
-		{
-			providerSignaturesUrl: c.env.PROVIDER_SIGNATURES_URL,
-			providerSignaturesAllowedHosts: c.env.PROVIDER_SIGNATURES_ALLOWED_HOSTS?.split(',')
-				.map((h) => h.trim())
-				.filter(Boolean),
-			providerSignaturesSha256: c.env.PROVIDER_SIGNATURES_SHA256,
-			analytics: createAnalyticsClient(c.env.MCP_ANALYTICS),
-			profileAccumulator: c.env.PROFILE_ACCUMULATOR,
-			profileAccumulatorShardMode: resolveAccumulatorShardModeFromEnv(c.env.PROFILE_ACCUMULATOR_SHARDING),
-			waitUntil: (promise: Promise<unknown>) => c.executionCtx.waitUntil(promise),
-			scoringConfig: parseScoringConfigCached(c.env.SCORING_CONFIG),
-			cacheTtlSeconds,
-			scanTimeoutMs: parseScanTimeout(c.env.SCAN_TIMEOUT_MS),
-			perCheckTimeoutMs: parsePerCheckTimeout(c.env.PER_CHECK_TIMEOUT_MS),
-			secondaryDoh: c.env.BV_DOH_ENDPOINT
-				? { endpoint: c.env.BV_DOH_ENDPOINT, token: c.env.BV_DOH_TOKEN }
-				: undefined,
-			whoisBinding: c.env.BV_WHOIS,
-			infraProbe: c.env.BV_INFRA_PROBE,
-			// Recon backend (bv2-recon) — powers scan_buckets_* / osint_investigate_*.
-			// The internal door (recon-sweep caller) MUST wire these or those tools
-			// always degrade to the "unprovisioned" stub even when BV_RECON is bound,
-			// which silently stalled the bv2-ops recon-sweep queue (fixed 2026-06-23).
-			reconBinding: c.env.BV_RECON,
-			reconAuthToken: c.env.BV_RECON_KEY,
-			// Async brand-audit subsystem (discover_brand_domains_start /
-			// brand_audit_batch_start / register_brand_audit_watch). Same
-			// failure mode as the recon binding above: without these the
-			// async *_start tools short-circuit to `unprovisioned` with no
-			// auditId, so the bv2-ops csc-discovery sweep polls forever and
-			// stores nothing. Bound to the same worker as the public path.
-			brandAuditDb: c.env.BRAND_AUDIT_DB,
-			brandAuditQueue: c.env.BRAND_AUDIT_QUEUE,
-			// Tier 0/1/2 lookup closures — internal callers (load tests, bv-web
-			// service binding, ops scripts) get the same tiered discovery path as
-			// public `/mcp`. Closures stay `undefined` on BSL self-hosts where
-			// the bindings aren't provisioned.
-			...buildBrandTierLookups(c.env),
-			...(wantStructured ? { resultCapture: (r: import('@blackveil/dns-checks/scoring').CheckResult) => { capturedResult = r; } } : {}),
-		},
-	);
+	const result = await handleToolsCall({ name: body.name, arguments: body.arguments }, c.env.SCAN_CACHE, {
+		providerSignaturesUrl: c.env.PROVIDER_SIGNATURES_URL,
+		providerSignaturesAllowedHosts: c.env.PROVIDER_SIGNATURES_ALLOWED_HOSTS?.split(',')
+			.map((h) => h.trim())
+			.filter(Boolean),
+		providerSignaturesSha256: c.env.PROVIDER_SIGNATURES_SHA256,
+		analytics: createAnalyticsClient(c.env.MCP_ANALYTICS),
+		profileAccumulator: c.env.PROFILE_ACCUMULATOR,
+		profileAccumulatorShardMode: resolveAccumulatorShardModeFromEnv(c.env.PROFILE_ACCUMULATOR_SHARDING),
+		waitUntil: (promise: Promise<unknown>) => c.executionCtx.waitUntil(promise),
+		scoringConfig: parseScoringConfigCached(c.env.SCORING_CONFIG),
+		cacheTtlSeconds,
+		scanTimeoutMs: parseScanTimeout(c.env.SCAN_TIMEOUT_MS),
+		perCheckTimeoutMs: parsePerCheckTimeout(c.env.PER_CHECK_TIMEOUT_MS),
+		secondaryDoh: c.env.BV_DOH_ENDPOINT ? { endpoint: c.env.BV_DOH_ENDPOINT, token: c.env.BV_DOH_TOKEN } : undefined,
+		whoisBinding: c.env.BV_WHOIS,
+		infraProbe: c.env.BV_INFRA_PROBE,
+		// Recon backend (bv2-recon) — powers scan_buckets_* / osint_investigate_*.
+		// The internal door (recon-sweep caller) MUST wire these or those tools
+		// always degrade to the "unprovisioned" stub even when BV_RECON is bound,
+		// which silently stalled the bv2-ops recon-sweep queue (fixed 2026-06-23).
+		reconBinding: c.env.BV_RECON,
+		reconAuthToken: c.env.BV_RECON_KEY,
+		// Async brand-audit subsystem (discover_brand_domains_start /
+		// brand_audit_batch_start / register_brand_audit_watch). Same
+		// failure mode as the recon binding above: without these the
+		// async *_start tools short-circuit to `unprovisioned` with no
+		// auditId, so the bv2-ops csc-discovery sweep polls forever and
+		// stores nothing. Bound to the same worker as the public path.
+		brandAuditDb: c.env.BRAND_AUDIT_DB,
+		brandAuditQueue: c.env.BRAND_AUDIT_QUEUE,
+		// Tier 0/1/2 lookup closures — internal callers (load tests, bv-web
+		// service binding, ops scripts) get the same tiered discovery path as
+		// public `/mcp`. Closures stay `undefined` on BSL self-hosts where
+		// the bindings aren't provisioned.
+		...buildBrandTierLookups(c.env),
+		...(wantStructured
+			? {
+					resultCapture: (r: import('@blackveil/dns-checks/scoring').CheckResult) => {
+						capturedResult = r;
+					},
+				}
+			: {}),
+	});
 
 	// B1: record an internal-source access-log row for domain-bearing tools (parity
 	// with the public path, which only logs domain-bearing calls). No-domain tools
@@ -397,11 +403,10 @@ internalRoutes.post('/oauth/grants', async (c) => {
 	const redirectTo = new URL(body.redirectUri);
 	redirectTo.searchParams.set('code', code);
 	redirectTo.searchParams.set('state', body.state);
-	return c.json(
-		{ redirectTo: redirectTo.toString(), expiresIn: OAUTH_CODE_TTL_SECONDS },
-		200,
-		{ 'Cache-Control': 'no-store', Pragma: 'no-cache' },
-	);
+	return c.json({ redirectTo: redirectTo.toString(), expiresIn: OAUTH_CODE_TTL_SECONDS }, 200, {
+		'Cache-Control': 'no-store',
+		Pragma: 'no-cache',
+	});
 });
 
 /**
@@ -560,9 +565,7 @@ internalRoutes.post('/tools/batch', async (c) => {
 						cacheTtlSeconds,
 						scanTimeoutMs: parseScanTimeout(c.env.SCAN_TIMEOUT_MS),
 						perCheckTimeoutMs: parsePerCheckTimeout(c.env.PER_CHECK_TIMEOUT_MS),
-						secondaryDoh: c.env.BV_DOH_ENDPOINT
-							? { endpoint: c.env.BV_DOH_ENDPOINT, token: c.env.BV_DOH_TOKEN }
-							: undefined,
+						secondaryDoh: c.env.BV_DOH_ENDPOINT ? { endpoint: c.env.BV_DOH_ENDPOINT, token: c.env.BV_DOH_TOKEN } : undefined,
 						whoisBinding: c.env.BV_WHOIS,
 						infraProbe: c.env.BV_INFRA_PROBE,
 						// Async brand-audit subsystem — parity with the single-call door
@@ -573,7 +576,13 @@ internalRoutes.post('/tools/batch', async (c) => {
 						// from internal callers must also exercise tiered mode when the
 						// bindings are provisioned.
 						...buildBrandTierLookups(c.env),
-						...(wantStructured ? { resultCapture: (r: import('@blackveil/dns-checks/scoring').CheckResult) => { capturedResult = r; } } : {}),
+						...(wantStructured
+							? {
+									resultCapture: (r: import('@blackveil/dns-checks/scoring').CheckResult) => {
+										capturedResult = r;
+									},
+								}
+							: {}),
 					},
 				);
 
@@ -1027,5 +1036,60 @@ internalRoutes.get('/analytics/forensics', async (c) => {
 		return c.json({ days: String(days), count: events.length, events });
 	} catch (err) {
 		return c.json({ error: 'Forensics query failed', detail: err instanceof Error ? err.message.slice(0, 100) : 'unknown' }, 502);
+	}
+});
+
+internalRoutes.use('/analytics/erase', internalStrictAuthGate);
+
+/**
+ * POST /internal/analytics/erase (D1, STRICT) — data-subject erasure.
+ *
+ * Deletes every `mcp_access_log` row matching the given `key_hash` and/or
+ * `ip_hash` (at least one required; both = AND). The `mcp_access_log_audit`
+ * trail is deliberately NOT erased — the self-audit row written below is the
+ * durable evidence that the erasure happened. Same strict bearer gate as
+ * forensics: this endpoint destroys evidence, so the network guard alone is
+ * insufficient. Query: ?key_hash=<hash>&ip_hash=<hash>
+ */
+internalRoutes.post('/analytics/erase', async (c) => {
+	const db = c.env.INTELLIGENCE_DB;
+	if (!db) return c.json({ error: 'Analytics store not configured (INTELLIGENCE_DB required)' }, 500);
+	const url = new URL(c.req.url);
+	const ipHash = url.searchParams.get('ip_hash');
+	const keyHash = url.searchParams.get('key_hash');
+	if (!ipHash && !keyHash) return c.json({ error: 'Missing required parameter: key_hash or ip_hash' }, 400);
+	try {
+		const filters: string[] = [];
+		const binds: unknown[] = [];
+		if (ipHash) {
+			filters.push('ip_hash = ?');
+			binds.push(ipHash);
+		}
+		if (keyHash) {
+			filters.push('key_hash = ?');
+			binds.push(keyHash);
+		}
+		const result = await db
+			.prepare(`DELETE FROM mcp_access_log WHERE ${filters.join(' AND ')}`)
+			.bind(...binds)
+			.run();
+		const deleted = result.meta?.changes ?? 0;
+
+		const auditScope = JSON.stringify({ ipHashFilter: ipHash ?? null, keyHashFilter: keyHash ?? null, deleted });
+		await db
+			.prepare(`INSERT INTO mcp_access_log_audit (id, actor, action, ip_hash, scope, outcome) VALUES (?, ?, ?, ?, ?, ?)`)
+			.bind(crypto.randomUUID(), 'internal_bearer', 'analytics.subject.erase', ipHash ?? null, auditScope, 'success')
+			.run()
+			.catch((auditErr) =>
+				logError(auditErr instanceof Error ? auditErr : String(auditErr), {
+					severity: 'warn',
+					category: 'audit',
+					details: { event: 'analytics.subject.erase', auditWriteFailed: true },
+				}),
+			);
+
+		return c.json({ deleted, key_hash: keyHash ?? null, ip_hash: ipHash ?? null });
+	} catch (err) {
+		return c.json({ error: 'Erase failed', detail: err instanceof Error ? err.message.slice(0, 100) : 'unknown' }, 502);
 	}
 });

--- a/test/internal-analytics-erase.spec.ts
+++ b/test/internal-analytics-erase.spec.ts
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+afterEach(() => vi.restoreAllMocks());
+
+describe('POST /internal/analytics/erase', () => {
+	it('503s when BV_WEB_INTERNAL_KEY unset; 401 on wrong bearer (strict gate ignores REQUIRE_INTERNAL_AUTH=false)', async () => {
+		const { internalRoutes } = await import('../src/internal');
+		const env = { REQUIRE_INTERNAL_AUTH: 'false', INTELLIGENCE_DB: {} as D1Database };
+		const r503 = await internalRoutes.request('/analytics/erase', { method: 'POST' }, env);
+		expect(r503.status).toBe(503);
+		const r401 = await internalRoutes.request(
+			'/analytics/erase',
+			{ method: 'POST', headers: { authorization: 'Bearer wrong' } },
+			{ ...env, BV_WEB_INTERNAL_KEY: 'right' },
+		);
+		expect(r401.status).toBe(401);
+	});
+
+	it('400s when neither key_hash nor ip_hash is given', async () => {
+		const { internalRoutes } = await import('../src/internal');
+		const env = { BV_WEB_INTERNAL_KEY: 'right', INTELLIGENCE_DB: {} as D1Database };
+		const res = await internalRoutes.request('/analytics/erase', { method: 'POST', headers: { authorization: 'Bearer right' } }, env);
+		expect(res.status).toBe(400);
+	});
+
+	it('deletes matching rows, returns the count, and writes a self-audit row', async () => {
+		const { internalRoutes } = await import('../src/internal');
+		const auditRun = vi.fn(async () => ({ success: true }));
+		const deleteRun = vi.fn(async () => ({ success: true, meta: { changes: 7 } }));
+		const bindArgs: unknown[][] = [];
+		const prepare = vi.fn((sql: string) =>
+			sql.includes('mcp_access_log_audit')
+				? { bind: (...args: unknown[]) => (bindArgs.push(args), { run: auditRun }) }
+				: { bind: (...args: unknown[]) => (bindArgs.push(args), { run: deleteRun }) },
+		);
+		const env = { BV_WEB_INTERNAL_KEY: 'right', INTELLIGENCE_DB: { prepare } as unknown as D1Database };
+		const res = await internalRoutes.request(
+			'/analytics/erase?key_hash=abc123',
+			{ method: 'POST', headers: { authorization: 'Bearer right' } },
+			env,
+		);
+		expect(res.status).toBe(200);
+		const body = (await res.json()) as { deleted: number };
+		expect(body.deleted).toBe(7);
+		expect(deleteRun).toHaveBeenCalledTimes(1);
+		expect(auditRun).toHaveBeenCalledTimes(1);
+		// The DELETE must be filtered — never an unfiltered table wipe.
+		const deleteSql = (prepare.mock.calls.find(([sql]) => !String(sql).includes('mcp_access_log_audit')) ?? [''])[0];
+		expect(String(deleteSql)).toContain('WHERE');
+		expect(String(deleteSql)).toContain('key_hash = ?');
+	});
+});


### PR DESCRIPTION
## Summary
- Added `POST /internal/analytics/erase?key_hash=<hash>|ip_hash=<hash>` — strict-gated (same bearer gate as `/internal/analytics/forensics`) data-subject erasure of `mcp_access_log` rows. Self-audits every call to `mcp_access_log_audit` (action `analytics.subject.erase`); the audit trail itself is never a DELETE target. The DELETE is unconditionally filtered — a 400 guard (`Missing required parameter: key_hash or ip_hash`) precedes filter construction, so an unfiltered table wipe is unreachable.
- Added caller-facing "what we log" disclosure to `docs/client-setup.md` (PII levels, retention default, the Google-DoH PTR fallback at `full` level) and a pointer to the erasure endpoint in the README.

Previously there was no data-subject deletion/export mechanism beyond the scheduled retention purge, and no caller-facing disclosure of what's collected. Part of a 4-PR audit-remediation series (maverick-validate suite findings 5, 8, 10). Full detail: `docs/plans/2026-07-08-audit-remediation.md` (local only, not committed).

## Test plan
- [x] `npx vitest run` on the 4 covering specs — 15/15 passing (gate 503/401, 400 missing-params, happy-path delete+audit, neighbor guard specs unaffected)
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] Task-level review + whole-branch review independently re-verified all 4 named security risks at the code level: unconditional DELETE filter, gate registered before handler, audit-trail INSERT-only immutability, docs/route parity — ready to merge, no Critical/Important
- [x] The large `src/internal.ts` diff is mostly a PostToolUse Prettier hook reflowing pre-existing unrelated code in the same file — verified byte-equivalent (zero semantic change) by two independent reviewers

🤖 Generated with [Claude Code](https://claude.com/claude-code)