### PR TITLE
feat: resolve operator alert webhook URL dynamically via bv-web-prod

### DIFF
--- a/src/lib/operator-webhook-binding.ts
+++ b/src/lib/operator-webhook-binding.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+/**
+ * Fail-soft resolver for the shared operator alert webhook URL. Calls
+ * bv-web-prod's admin-managed value over the existing BV_WEB service binding,
+ * falling back through a KV last-known-good cache to the static
+ * ALERT_WEBHOOK_URL secret when the dynamic path is absent, confirmed-empty,
+ * or ambiguously failing.
+ *
+ * Deliberately deviates from the two-state (`T | null`) pattern in
+ * src/lib/recon-binding.ts / src/lib/tls-probe-binding.ts: the internal
+ * endpoint's contract requires distinguishing "confirmed nothing configured"
+ * (200 {webhookUrl: null}) from "couldn't tell" (401/5xx/timeout/throw) — a
+ * two-state result would collapse that distinction and either poison the
+ * last-known-good cache with emptiness or treat a real outage as configured-
+ * empty. See the design spec's "Architecture" section for the full rationale:
+ * docs/superpowers/specs/2026-07-08-operator-alert-webhook-admin-design.md
+ * (bv-web-prod repo).
+ */
+import type { ScheduledEnv } from './scheduled-env-types';
+
+const OPERATOR_WEBHOOK_TIMEOUT_MS = 8_000;
+const OPERATOR_WEBHOOK_CACHE_KEY = 'operator-webhook:last-known-good';
+const OPERATOR_WEBHOOK_URL = 'https://bv-web-internal/api/internal/ops/operator-alert-webhook';
+
+/**
+ * Resolves the operator alert webhook URL for this cron tick. The fetch is
+ * inline (not a separate `fetchOperatorWebhook` helper) because the 401-vs-
+ * 5xx distinction the design requires (401 skips the KV cache read entirely,
+ * 5xx consults it) needs `res.status` directly — a helper returning only the
+ * three-state `string | '' | undefined` result would lose that distinction.
+ *
+ * PRECEDENCE IS DELIBERATE: when the dynamic fetch returns a real URL, it
+ * wins even if env.ALERT_WEBHOOK_URL is also set. Do not flip this to
+ * "static overrides dynamic" — that would silently revert the whole
+ * rotation-without-redeploy benefit this feature exists to provide. See
+ * test/operator-webhook-binding.spec.ts's precedence-regression test.
+ */
+export async function resolveAlertWebhookUrl(env: ScheduledEnv): Promise<string | undefined> {
+	if (env.BV_WEB) {
+		let res: Response | undefined;
+		try {
+			res = await env.BV_WEB.fetch(OPERATOR_WEBHOOK_URL, {
+				method: 'GET',
+				headers: env.BV_WEB_INTERNAL_KEY ? { Authorization: `Bearer ${env.BV_WEB_INTERNAL_KEY}` } : {},
+				signal: AbortSignal.timeout(OPERATOR_WEBHOOK_TIMEOUT_MS),
+			});
+		} catch {
+			console.warn('operator-webhook-binding: fetch failed or timed out');
+		}
+
+		if (res?.status === 401) {
+			// Definitive client error — skip the cache entirely, straight to static var.
+			return env.ALERT_WEBHOOK_URL || undefined;
+		}
+
+		if (res?.ok) {
+			const body = (await res.json()) as { webhookUrl: string | null };
+			if (body.webhookUrl) {
+				await env.SCAN_CACHE?.put(OPERATOR_WEBHOOK_CACHE_KEY, body.webhookUrl, { expirationTtl: 86_400 });
+				return body.webhookUrl;
+			}
+			// Confirmed-empty: do NOT cache, fall through to static var.
+			return env.ALERT_WEBHOOK_URL || undefined;
+		}
+
+		// Ambiguous (5xx, timeout, or network throw) — consult last-known-good.
+		const cached = await env.SCAN_CACHE?.get(OPERATOR_WEBHOOK_CACHE_KEY);
+		if (cached) return cached;
+	}
+
+	return env.ALERT_WEBHOOK_URL || undefined;
+}

--- a/src/lib/scheduled-env-types.ts
+++ b/src/lib/scheduled-env-types.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+/** Minimal standalone shape (NOT the real ScheduledEnv from src/scheduled.ts)
+ * — see the Task 1 Step 3 note above for why this can't just import the real
+ * type yet. Once Task 2 widens the real ScheduledEnv to a superset of this
+ * shape, structural typing makes the two interchangeable at every call site. */
+export interface ScheduledEnv {
+	BV_WEB?: Fetcher;
+	BV_WEB_INTERNAL_KEY?: string;
+	SCAN_CACHE?: KVNamespace;
+	ALERT_WEBHOOK_URL?: string;
+}

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -664,7 +664,8 @@ export async function handleFuzzingScan(env: ScheduledEnv): Promise<void> {
  */
 export async function handleDailyDigest(env: ScheduledEnv): Promise<void> {
 	// SPF canary runs even when analytics are unconfigured — it does its own
-	// outbound DoH probes and depends only on ALERT_WEBHOOK_URL for delivery.
+	// outbound DoH probes and resolves its own webhook URL via
+	// resolveAlertWebhookUrl (dynamic-first, ALERT_WEBHOOK_URL fallback).
 	await handleSpfCanary(env);
 
 	const digestWebhookUrl = await resolveAlertWebhookUrl(env);

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -28,6 +28,7 @@ import { buildFuzzingAlertPayload } from './schemas/alerting';
 import { FUZZ_THRESHOLDS } from './lib/config';
 import { reapStuckBrandAudits } from './lib/brand-audit-reaper';
 import { runSpfCanary, shouldAlertOnCanary } from './lib/spf-canary';
+import { resolveAlertWebhookUrl } from './lib/operator-webhook-binding';
 
 interface AnomalyRow {
 	total_calls?: number;
@@ -98,6 +99,12 @@ export interface ScheduledEnv {
 	ANALYTICS_ARCHIVE_RETENTION_DAYS?: string;
 	/** Phase 1, decision #3 — R2 bucket for the short-bridge access-log archive. Absent → retention cron keeps today's hard DELETE. */
 	MCP_ACCESS_LOG_ARCHIVE?: R2Bucket;
+	/** Service binding to bv-web-prod. Absent on BSL self-hosts — dynamic webhook resolution falls back to ALERT_WEBHOOK_URL. */
+	BV_WEB?: Fetcher;
+	/** Bearer token for BV_WEB internal calls. Already a live secret on production — see docs/plans/2026-07-09-operator-alert-webhook-binding.md. */
+	BV_WEB_INTERNAL_KEY?: string;
+	/** General-purpose cache KV. Used here as the operator-webhook last-known-good fallback (key: operator-webhook:last-known-good, 24h TTL). */
+	SCAN_CACHE?: KVNamespace;
 }
 
 /** Clamp ANALYTICS_RETENTION_DAYS to [1, 365]; default 90 on missing/invalid. */
@@ -294,7 +301,13 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 			});
 	}
 
-	if (!env.ALERT_WEBHOOK_URL) return;
+	// PRECEDENCE IS DELIBERATE: resolveAlertWebhookUrl prefers the dynamic
+	// (bv-web-prod admin-managed) value over env.ALERT_WEBHOOK_URL when both
+	// are available. Do not reorder this to "static wins" — see
+	// src/lib/operator-webhook-binding.ts and
+	// docs/plans/2026-07-09-operator-alert-webhook-binding.md.
+	const webhookUrl = await resolveAlertWebhookUrl(env);
+	if (!webhookUrl) return;
 	if (!env.CF_ACCOUNT_ID || !env.CF_ANALYTICS_TOKEN) return;
 
 	const parsedError = parseFloat(env.ALERT_ERROR_THRESHOLD ?? '');
@@ -328,7 +341,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 			if (errorPct > errorThreshold) {
 				const severity = errorPct > errorThreshold * 2 ? 'critical' : 'warning';
 				await sendAlert(
-					env.ALERT_WEBHOOK_URL,
+					webhookUrl,
 					buildAlertPayload({
 						title: `Error rate ${errorPct.toFixed(1)}% (last ${lookback}m)`,
 						severity,
@@ -345,7 +358,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 
 			if (p95Ms > p95Threshold) {
 				await sendAlert(
-					env.ALERT_WEBHOOK_URL,
+					webhookUrl,
 					buildAlertPayload({
 						title: `P95 latency ${Math.round(p95Ms)}ms (last ${lookback}m)`,
 						severity: p95Ms > p95Threshold * 2 ? 'critical' : 'warning',
@@ -368,7 +381,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 
 		if (rateLimitData && (rateLimitData.total_hits ?? 0) > rateLimitThreshold) {
 			await sendAlert(
-				env.ALERT_WEBHOOK_URL,
+				webhookUrl,
 				buildAlertPayload({
 					title: `Rate limit surge: ${rateLimitData.total_hits} hits (last ${lookback}m)`,
 					severity: (rateLimitData.total_hits ?? 0) > rateLimitThreshold * 3 ? 'critical' : 'warning',
@@ -403,7 +416,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 			const hasBinding = degradationRows.some((r) => r.degradation_type !== 'cost_ceiling_degraded');
 			const subject = hasCostCeiling && hasBinding ? 'Degradation' : hasCostCeiling ? 'Global cost-ceiling degraded' : 'Service-binding degradation';
 			await sendAlert(
-				env.ALERT_WEBHOOK_URL,
+				webhookUrl,
 				buildAlertPayload({
 					title: `${subject}: ${totalDegradations} event(s) (${components}, last ${lookback}m)`,
 					severity: totalDegradations > bindingDegradationThreshold * 5 ? 'critical' : 'warning',
@@ -432,7 +445,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 				.map((r) => `${r.handler ?? 'unknown'}:errors=${r.error_batch_count ?? 0}/failures=${r.failure_count ?? 0}`)
 				.join(' · ');
 			await sendAlert(
-				env.ALERT_WEBHOOK_URL,
+				webhookUrl,
 				buildAlertPayload({
 					title: `Async-path failures: ${totalQueueFailures} failed message(s), ${totalErrorBatches} errored batch(es) (${handlers}, last ${lookback}m)`,
 					severity: totalQueueFailures > queueFailureThreshold * 5 || totalErrorBatches > 5 ? 'critical' : 'warning',
@@ -455,7 +468,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 
 		if (tailExceptionCount >= tailExceptionThreshold) {
 			await sendAlert(
-				env.ALERT_WEBHOOK_URL,
+				webhookUrl,
 				buildAlertPayload({
 					title: `Fatal Worker exceptions: ${tailExceptionCount} event(s) (last ${lookback}m)`,
 					severity: tailExceptionCount > tailExceptionThreshold * 5 ? 'critical' : 'warning',
@@ -492,7 +505,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		// through it. Best-effort: if the webhook is down too there is nothing
 		// left to do in-band.
 		await sendAlert(
-			env.ALERT_WEBHOOK_URL,
+			webhookUrl,
 			buildAlertPayload({
 				title: 'Alerting pipeline failure: analytics check could not run',
 				severity: 'critical',
@@ -560,7 +573,8 @@ const MAX_ALERTS_PER_TICK = 10;
  * See docs/plans/2026-05-07-fuzzing-detection-tdd-plan.md.
  */
 export async function handleFuzzingScan(env: ScheduledEnv): Promise<void> {
-	if (!env.ALERT_WEBHOOK_URL || !env.RATE_LIMIT) return;
+	const fuzzingWebhookUrl = await resolveAlertWebhookUrl(env);
+	if (!fuzzingWebhookUrl || !env.RATE_LIMIT) return;
 
 	const nowSec = Math.floor(Date.now() / 1000);
 	const observedAt = new Date().toISOString();
@@ -623,7 +637,7 @@ export async function handleFuzzingScan(env: ScheduledEnv): Promise<void> {
 			const rawHash = principalId.startsWith('i_') ? principalId.slice(2) : principalId;
 			const principalIdHash = rawHash.padEnd(16, '0').slice(0, 16);
 			const payload = buildFuzzingAlertPayload(verdict, { principalKind, principalIdHash, observedAt });
-			await sendFuzzingAlert(env.ALERT_WEBHOOK_URL, payload);
+			await sendFuzzingAlert(fuzzingWebhookUrl, payload);
 			alertsSent++;
 
 			// Mark suppression AFTER successful dispatch attempt. sendFuzzingAlert is
@@ -653,13 +667,14 @@ export async function handleDailyDigest(env: ScheduledEnv): Promise<void> {
 	// outbound DoH probes and depends only on ALERT_WEBHOOK_URL for delivery.
 	await handleSpfCanary(env);
 
-	if (!env.ALERT_WEBHOOK_URL) return;
+	const digestWebhookUrl = await resolveAlertWebhookUrl(env);
+	if (!digestWebhookUrl) return;
 	if (!env.CF_ACCOUNT_ID || !env.CF_ANALYTICS_TOKEN) return;
 
 	try {
 		const rows = await queryAnalyticsEngine(env.CF_ACCOUNT_ID, env.CF_ANALYTICS_TOKEN, queryTierDigest('1'));
 		const payload = buildDigestPayload(rows, 1);
-		await sendAlert(env.ALERT_WEBHOOK_URL, payload);
+		await sendAlert(digestWebhookUrl, payload);
 
 		logEvent({
 			timestamp: new Date().toISOString(),
@@ -712,11 +727,12 @@ export async function handleSpfCanary(env: ScheduledEnv): Promise<void> {
 			},
 		});
 
-		if (!env.ALERT_WEBHOOK_URL) return;
+		const spfWebhookUrl = await resolveAlertWebhookUrl(env);
+		if (!spfWebhookUrl) return;
 		if (!shouldAlertOnCanary(result, threshold)) return;
 
 		await sendAlert(
-			env.ALERT_WEBHOOK_URL,
+			spfWebhookUrl,
 			buildAlertPayload({
 				title: `SPF canary null rate ${(result.nullRate * 100).toFixed(1)}% (${result.nullCount}/${result.totalProbed})`,
 				severity: result.nullRate >= threshold * 2 ? 'critical' : 'warning',

--- a/test/operator-webhook-binding.spec.ts
+++ b/test/operator-webhook-binding.spec.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// Local shape matching ScheduledEnv's relevant fields — avoids importing the
+// real ScheduledEnv before Task 2 widens it.
+interface TestEnv {
+	BV_WEB?: { fetch: (url: string, init?: RequestInit) => Promise<Response> };
+	BV_WEB_INTERNAL_KEY?: string;
+	SCAN_CACHE?: {
+		get: (key: string) => Promise<string | null>;
+		put: (key: string, value: string, opts?: { expirationTtl?: number }) => Promise<void>;
+	};
+	ALERT_WEBHOOK_URL?: string;
+}
+
+function mockFetch(status: number, body?: unknown): (url: string, init?: RequestInit) => Promise<Response> {
+	return vi.fn(async () => new Response(body !== undefined ? JSON.stringify(body) : undefined, { status }));
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+});
+
+describe('resolveAlertWebhookUrl', () => {
+	it('dynamic succeeds and wins over static (precedence regression guard)', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const put = vi.fn(async () => {});
+		const env: TestEnv = {
+			BV_WEB: { fetch: mockFetch(200, { webhookUrl: 'https://hooks.example.com/dynamic' }) },
+			BV_WEB_INTERNAL_KEY: 'test-key',
+			SCAN_CACHE: { get: vi.fn(async () => null), put },
+			ALERT_WEBHOOK_URL: 'https://hooks.example.com/static',
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBe('https://hooks.example.com/dynamic');
+		expect(put).toHaveBeenCalledWith('operator-webhook:last-known-good', 'https://hooks.example.com/dynamic', {
+			expirationTtl: 86_400,
+		});
+	});
+
+	it('dynamic confirmed-empty falls through to static WITHOUT caching', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const put = vi.fn(async () => {});
+		const env: TestEnv = {
+			BV_WEB: { fetch: mockFetch(200, { webhookUrl: null }) },
+			BV_WEB_INTERNAL_KEY: 'test-key',
+			SCAN_CACHE: { get: vi.fn(async () => null), put },
+			ALERT_WEBHOOK_URL: 'https://hooks.example.com/static',
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBe('https://hooks.example.com/static');
+		expect(put).not.toHaveBeenCalled();
+	});
+
+	it('dynamic ambiguous failure (5xx) falls to KV last-known-good cache', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const env: TestEnv = {
+			BV_WEB: { fetch: mockFetch(503) },
+			BV_WEB_INTERNAL_KEY: 'test-key',
+			SCAN_CACHE: { get: vi.fn(async () => 'https://hooks.example.com/cached'), put: vi.fn(async () => {}) },
+			ALERT_WEBHOOK_URL: 'https://hooks.example.com/static',
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBe('https://hooks.example.com/cached');
+	});
+
+	it('dynamic ambiguous failure with EMPTY cache falls to static var', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const env: TestEnv = {
+			BV_WEB: { fetch: mockFetch(503) },
+			BV_WEB_INTERNAL_KEY: 'test-key',
+			SCAN_CACHE: { get: vi.fn(async () => null), put: vi.fn(async () => {}) },
+			ALERT_WEBHOOK_URL: 'https://hooks.example.com/static',
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBe('https://hooks.example.com/static');
+	});
+
+	it('401 (definitive) skips the cache entirely and goes straight to static var', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const get = vi.fn(async () => 'https://hooks.example.com/cached');
+		const env: TestEnv = {
+			BV_WEB: { fetch: mockFetch(401) },
+			BV_WEB_INTERNAL_KEY: 'test-key',
+			SCAN_CACHE: { get, put: vi.fn(async () => {}) },
+			ALERT_WEBHOOK_URL: 'https://hooks.example.com/static',
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBe('https://hooks.example.com/static');
+		expect(get).not.toHaveBeenCalled();
+	});
+
+	it('BV_WEB binding absent (BSL self-host) skips the dynamic path — byte-identical to today', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const env: TestEnv = { ALERT_WEBHOOK_URL: 'https://hooks.example.com/static' };
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBe('https://hooks.example.com/static');
+	});
+
+	it('nothing resolves anywhere returns undefined (today\'s no-op behavior, unchanged)', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const env: TestEnv = {};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBeUndefined();
+	});
+
+	it('network throw (fetch rejects) is treated as ambiguous, falls to KV cache', async () => {
+		const { resolveAlertWebhookUrl } = await import('../src/lib/operator-webhook-binding');
+		const env: TestEnv = {
+			BV_WEB: {
+				fetch: vi.fn(async () => {
+					throw new Error('network down');
+				}),
+			},
+			BV_WEB_INTERNAL_KEY: 'test-key',
+			SCAN_CACHE: { get: vi.fn(async () => 'https://hooks.example.com/cached'), put: vi.fn(async () => {}) },
+			ALERT_WEBHOOK_URL: 'https://hooks.example.com/static',
+		};
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- ScheduledEnv widened in Task 2
+		const result = await resolveAlertWebhookUrl(env as any);
+		expect(result).toBe('https://hooks.example.com/cached');
+	});
+});

--- a/test/scheduled.spec.ts
+++ b/test/scheduled.spec.ts
@@ -284,3 +284,42 @@ describe('handleScheduled', () => {
 		expect(webhookCall!.body).toContain('Alerting pipeline failure');
 	});
 });
+
+describe('scheduled.ts alert webhook resolution', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+		vi.resetModules();
+	});
+
+	it('the main alert checker passes the RESOLVED value to sendAlert, not the literal env var', async () => {
+		// Force a clean module graph: earlier tests in this file already imported
+		// '../src/scheduled' (which statically imports operator-webhook-binding),
+		// so without this the doMock below would register too late to affect the
+		// cached module instance.
+		vi.resetModules();
+		vi.doMock('../src/lib/operator-webhook-binding', () => ({
+			resolveAlertWebhookUrl: vi.fn(async () => 'https://hooks.example.com/resolved'),
+		}));
+		const alertingModule = await import('../src/lib/alerting');
+		const sendAlertSpy = vi.spyOn(alertingModule, 'sendAlert').mockResolvedValue(undefined);
+
+		const { handleScheduled } = await import('../src/scheduled');
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal env for this targeted test
+		const env: any = {
+			ALERT_WEBHOOK_URL: 'https://hooks.example.com/static-should-not-be-used',
+			CF_ACCOUNT_ID: 'acct',
+			CF_ANALYTICS_TOKEN: 'token',
+		};
+
+		await handleScheduled(env);
+
+		// Every sendAlert call this tick must have received the RESOLVED value,
+		// never the literal static env var — this is the precedence-regression
+		// guard at the scheduled.ts integration layer (Task 1 already pins the
+		// resolver's own precedence in isolation).
+		for (const call of sendAlertSpy.mock.calls) {
+			expect(call[0]).toBe('https://hooks.example.com/resolved');
+			expect(call[0]).not.toBe('https://hooks.example.com/static-should-not-be-used');
+		}
+	});
+});


### PR DESCRIPTION
## Summary
Second of two plans for the cross-repo operator-alert-webhook feature. The bv-web-prod side (admin UI, internal endpoint, D1 migration) is already merged and deployed to production. This PR is the bv-mcp side: the alerting cron now resolves its Slack webhook URL dynamically from bv-web-prod's admin-managed value at runtime, falling back to the existing static `ALERT_WEBHOOK_URL` secret when the dynamic path is absent, confirmed-empty, or ambiguously failing.

- New `src/lib/operator-webhook-binding.ts` — `resolveAlertWebhookUrl(env)`, a fail-soft resolver over the existing `BV_WEB` service binding, with a `SCAN_CACHE` last-known-good fallback for ambiguous failures (5xx/timeout/network-throw). Correctly distinguishes 401 (definitive, skip cache) from ambiguous failures (consult cache first).
- `src/scheduled.ts`: widened `ScheduledEnv` (3 new optional fields, all already live runtime bindings — type-only change), replaced all 4 guard sites and 10 `sendAlert`/`sendFuzzingAlert` call sites that previously read `env.ALERT_WEBHOOK_URL` directly.
- Precedence is dynamic-wins-over-static, deliberately, with a pinning test guarding against silent regression.
- `BV_WEB` absent (BSL self-host) → byte-identical to today's behavior.

Design spec: `docs/superpowers/specs/2026-07-08-operator-alert-webhook-admin-design.md` (bv-web-prod repo). Plan: `docs/plans/2026-07-09-operator-alert-webhook-binding.md` (gitignored in this repo, not in this diff).

Built via Subagent-Driven Development: 2 tasks, each independently implemented and reviewed (0 Critical/Important findings), plus a final whole-branch review (1 trivial merge-gating fix applied — a stale comment). Several Minor follow-ups were explicitly deferred by the reviewers as non-blocking (log-volume dedup, error-detail capture on a swallowed catch, defensive guard on a malformed-200 JSON parse).

## Test plan
- [x] `npx vitest run test/operator-webhook-binding.spec.ts test/scheduled.spec.ts` — 19/19 passing
- [x] `npx tsc --noEmit` — clean
- [x] Full suite (`npm test`) — 5879/5879 real tests passing (10 pool-teardown errors are this repo's documented known flake, not real failures)
- [ ] Live verification after deploy: confirm the cron resolves the webhook dynamically once `BV_WEB_INTERNAL_KEY` round-trips against bv-web-prod's now-live internal endpoint (already confirmed reachable via post-deploy probes on the bv-web-prod side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)