### PR TITLE
fix(chaos): harden score stability harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Score-stability chaos testing now fails closed and speaks current Streamable HTTP.** The production harness negotiates MCP `2025-06-18`, parses both JSON and SSE tool responses, consumes structured scan results, reports transport/tool failures with useful context, and returns non-zero when any domain errors instead of falsely declaring `0 stable` successful. Explicit domain files are validated and deduplicated without silently falling back to unrelated defaults.
+
+### Tests
+
+- Added regression coverage for JSON/SSE parsing, negotiated request headers, structured scan extraction, malformed-response diagnostics, error exit codes, domain-file validation, deduplication, and exact default-domain counts.
+
 ## [3.29.10] - 2026-07-13
 
 Patch release: **MCP transport and target-response hardening**.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,15 @@ The `bv_load_test` class identifies internal load/chaos/tranco-scan traffic so i
 
 The test suite ensures session stability, authentication precedence, format negotiation, and transport-specific edge cases across Streamable HTTP and Legacy SSE. Without an API key it exercises the public/free-tier path; with a valid key exported as `BV_API_KEY`, it covers Bearer authentication, legacy self-host `?api_key=` compatibility, authenticated SSE bootstrap, and authenticated batch behavior.
 
-Run the chaos tests locally: `python3 scripts/chaos/chaos-test-clients.py`
+Run the client/session chaos suite locally: `python3 scripts/chaos/chaos-test-clients.py`.
+
+Run repeat force-refresh scans to detect production scoring drift:
+
+```bash
+BV_API_KEY=... python3 scripts/chaos/score-stability-test.py --count 20 --rounds 3 --concurrency 5
+```
+
+The stability harness negotiates MCP protocol `2025-06-18`, accepts JSON and Streamable HTTP SSE responses, and exits non-zero on any transport/tool error or score/category drift. Use `--from <json-file>` with a JSON array of domains for a targeted provider-diversity sweep.
 
 SSOT guardrails are enforced by focused audit tests:
 

--- a/scripts/chaos/score-stability-test.py
+++ b/scripts/chaos/score-stability-test.py
@@ -19,7 +19,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 BASE = "https://dns-mcp.blackveilsecurity.com"
-API_KEY = os.getenv("BV_API_KEY")
+API_KEY = os.getenv("BV_API_KEY") or os.getenv("BV_INTERNAL_DEV_KEY")
 
 DEFAULT_DOMAINS = [
     "cloudflare.com", "google.com", "github.com", "microsoft.com",
@@ -30,6 +30,7 @@ DEFAULT_DOMAINS = [
 ]
 
 DOMAINS: list[str] = []
+PROTOCOL_VERSION = "2025-06-18"
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -38,7 +39,7 @@ def curl_json(method, path, body, headers, timeout=30, params=None):
     if params:
         qs = "&".join(f"{k}={v}" for k, v in params.items())
         url = f"{url}?{qs}"
-    cmd = ["curl", "-s", "-w", "\n%{http_code}",
+    cmd = ["curl", "-sS", "-w", "\n%{http_code}",
            "--connect-timeout", "10", "--max-time", str(timeout)]
     if method != "GET":
         cmd += ["-X", method]
@@ -51,16 +52,24 @@ def curl_json(method, path, body, headers, timeout=30, params=None):
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout + 5)
         output = r.stdout.strip()
         if not output:
-            return 0, ""
+            return 0, r.stderr.strip() or "curl returned no response"
         lines = output.split("\n")
         status = int(lines[-1]) if lines[-1].isdigit() else 0
-        return status, "\n".join(lines[:-1])
+        response_body = "\n".join(lines[:-1])
+        if r.returncode != 0:
+            return 0, r.stderr.strip() or response_body or f"curl exited {r.returncode}"
+        return status, response_body
     except Exception as e:
         return 0, str(e)
 
 
 def make_headers(sid=None):
-    h = ["Content-Type: application/json", "User-Agent: score-stability-test/1.0"]
+    h = [
+        "Content-Type: application/json",
+        "Accept: application/json, text/event-stream",
+        f"MCP-Protocol-Version: {PROTOCOL_VERSION}",
+        "User-Agent: score-stability-test/1.0",
+    ]
     if API_KEY:
         h.append(f"Authorization: Bearer {API_KEY}")
     if sid:
@@ -68,14 +77,50 @@ def make_headers(sid=None):
     return h
 
 
+def parse_mcp_payload(text):
+    """Parse a single JSON-RPC response from JSON or Streamable HTTP SSE."""
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("empty MCP response body")
+
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+
+    # Streamable HTTP may frame a JSON-RPC response as one or more SSE events.
+    # Join multiple data lines as required by the SSE field folding rules and
+    # return the first valid JSON-RPC payload for this single-request harness.
+    for event in re.split(r"\r?\n\r?\n", stripped):
+        data_lines = []
+        for line in event.splitlines():
+            if line == "data":
+                data_lines.append("")
+            elif line.startswith("data:"):
+                data_lines.append(line[5:].lstrip(" "))
+        if not data_lines:
+            continue
+        data = "\n".join(data_lines)
+        if data == "[DONE]":
+            continue
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError:
+            continue
+
+    preview = stripped[:120].replace("\n", "\\n")
+    raise ValueError(f"invalid MCP response body: {preview}")
+
+
 def create_session():
     body = {"jsonrpc": "2.0", "method": "initialize", "id": 1,
-            "params": {"protocolVersion": "2025-03-26", "capabilities": {},
+            "params": {"protocolVersion": PROTOCOL_VERSION, "capabilities": {},
                        "clientInfo": {"name": "score-stability-test", "version": "1.0"}}}
-    cmd = ["curl", "-s", "-D-", "-w", "\n%{http_code}",
+    cmd = ["curl", "-sS", "-D-", "-w", "\n%{http_code}",
            "--connect-timeout", "10", "--max-time", "15",
            "-X", "POST", f"{BASE}/mcp",
            "-H", "Content-Type: application/json",
+           "-H", "Accept: application/json, text/event-stream",
            "-H", "User-Agent: score-stability-test/1.0"]
     if API_KEY:
         cmd += ["-H", f"Authorization: Bearer {API_KEY}"]
@@ -104,29 +149,53 @@ def scan_domain(sid, domain):
                        "arguments": {"domain": domain, "force_refresh": True, "format": "compact"}}}
     status, text = curl_json("POST", "/mcp", body, make_headers(sid), timeout=30)
     if status != 200:
-        return domain, None, None, {}, 0, f"HTTP {status}"
+        detail = text[:160].replace("\n", " ") if text else "no response body"
+        return domain, None, None, {}, 0, f"HTTP {status}: {detail}"
 
     try:
-        d = json.loads(text)
+        d = parse_mcp_payload(text)
         if "error" in d:
             msg = d["error"].get("message", "unknown")
             return domain, None, None, {}, 0, msg
 
-        content = d.get("result", {}).get("content", [])
+        result = d.get("result")
+        if not isinstance(result, dict):
+            return domain, None, None, {}, 0, "MCP response missing result object"
+
+        content = result.get("content", [])
         full_text = "\n".join(c.get("text", "") for c in content)
+        if result.get("isError"):
+            return domain, None, None, {}, 0, full_text[:240] or "tool returned isError"
+
+        structured = result.get("structuredContent", {})
+        if not isinstance(structured, dict):
+            structured = {}
 
         # Extract score and grade
         m = re.search(r"Overall Score:\s*(\d+)/100\s*\(([A-F][+]?)\)", full_text)
-        score = int(m.group(1)) if m else None
-        grade = m.group(2) if m else None
+        structured_score = structured.get("score")
+        score = structured_score if isinstance(structured_score, (int, float)) else (int(m.group(1)) if m else None)
+        structured_grade = structured.get("grade")
+        grade = structured_grade if isinstance(structured_grade, str) else (m.group(2) if m else None)
+
+        if score is None or grade is None:
+            return domain, None, None, {}, 0, "scan result missing score or grade"
 
         # Extract category scores
-        cats = {}
-        for cm in re.finditer(r"(?:✓|✗|⚠)\s+(\w+)\s+(\d+)/100", full_text):
-            cats[cm.group(1)] = int(cm.group(2))
+        structured_categories = structured.get("categoryScores")
+        if isinstance(structured_categories, dict):
+            cats = structured_categories
+        else:
+            cats = {}
+            for cm in re.finditer(r"(?:✓|✗|⚠)\s+(\w+)\s+(\d+)/100", full_text):
+                cats[cm.group(1)] = int(cm.group(2))
 
         # Count findings
-        findings = len(re.findall(r"\[(HIGH|MEDIUM|LOW|INFO|CRITICAL)\]", full_text))
+        finding_counts = structured.get("findingCounts")
+        if isinstance(finding_counts, dict):
+            findings = sum(value for value in finding_counts.values() if isinstance(value, int))
+        else:
+            findings = len(re.findall(r"\[(HIGH|MEDIUM|LOW|INFO|CRITICAL)\]", full_text))
 
         return domain, score, grade, cats, findings, None
     except Exception as e:
@@ -233,9 +302,15 @@ def compare_multi(rounds):
     print(f"  RESULTS: {stable} stable, {len(drifts)} drifted, {errors} errors")
     print(f"{'='*70}")
 
-    if drifts:
-        print(f"\n  DRIFT DETECTED — {len(drifts)}/{len(DOMAINS)} domain(s) drifted "
-              f"({100*len(drifts)/max(len(DOMAINS),1):.1f}%)")
+    if drifts or errors:
+        reasons = []
+        if drifts:
+            reasons.append(f"{len(drifts)}/{len(DOMAINS)} domain(s) drifted")
+        if errors:
+            reasons.append(f"{errors}/{len(DOMAINS)} domain(s) errored")
+        print(f"\n  FAILED — {'; '.join(reasons)}")
+        if drifts:
+            print(f"  DRIFT RATE: {100*len(drifts)/max(len(DOMAINS),1):.1f}%")
         return 1
     else:
         print(f"\n  STABLE — all {stable} domains scored identically across all {len(rounds)} rounds")
@@ -248,18 +323,30 @@ def load_domains(from_file, count):
         try:
             with open(from_file) as f:
                 data = json.load(f)
-            if isinstance(data, list) and data and isinstance(data[0], dict):
-                return [d['domain'] for d in data[:count] if 'domain' in d]
-            elif isinstance(data, list):
-                return data[:count]
-        except Exception as e:
-            print(f"  WARN: failed to load {from_file}: {e}", file=sys.stderr)
+        except (OSError, json.JSONDecodeError) as e:
+            raise ValueError(f"could not load domain file {from_file}: {e}") from e
+
+        if not isinstance(data, list):
+            raise ValueError("domain file must be a JSON array")
+
+        domains = []
+        for index, item in enumerate(data):
+            domain = item.get("domain") if isinstance(item, dict) else item
+            if not isinstance(domain, str) or not domain.strip():
+                raise ValueError(f"domain file entry {index + 1} must be a non-empty domain string")
+            normalized = domain.strip().lower()
+            if normalized not in domains:
+                domains.append(normalized)
+
+        if not domains:
+            raise ValueError("domain file must contain at least one domain")
+        return domains[:count]
 
     if count <= len(DEFAULT_DOMAINS):
         return DEFAULT_DOMAINS[:count]
 
     # Extend default list by cycling if count > 20 and no file provided
-    return DEFAULT_DOMAINS * (count // len(DEFAULT_DOMAINS) + 1)
+    return (DEFAULT_DOMAINS * (count // len(DEFAULT_DOMAINS) + 1))[:count]
 
 
 def main():
@@ -270,11 +357,21 @@ def main():
     parser.add_argument('--from', dest='from_file', default=None, help='Load domains from JSON file')
     args = parser.parse_args()
 
+    if args.count < 1:
+        parser.error("--count must be at least 1")
+    if args.rounds < 2:
+        parser.error("--rounds must be at least 2 to measure stability")
+    if args.concurrency < 1:
+        parser.error("--concurrency must be at least 1")
+
     global DOMAINS
-    DOMAINS = load_domains(args.from_file, args.count)
+    try:
+        DOMAINS = load_domains(args.from_file, args.count)
+    except ValueError as error:
+        parser.error(str(error))
 
     if len(DOMAINS) < args.count:
-        print(f"  WARN: requested {args.count} domains, only loaded {len(DOMAINS)}", file=sys.stderr)
+        parser.error(f"requested {args.count} domains, but only {len(DOMAINS)} unique domains were loaded")
 
     print("="*70)
     print(f"  Score Stability Chaos Test — {len(DOMAINS)} domains x {args.rounds} rounds")

--- a/test/audits/score-stability-chaos-script.node.test.ts
+++ b/test/audits/score-stability-chaos-script.node.test.ts
@@ -1,0 +1,156 @@
+/** @vitest-environment node */
+// SPDX-License-Identifier: BUSL-1.1
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '../..');
+const scriptPath = join(repoRoot, 'scripts/chaos/score-stability-test.py');
+
+function runProbe(source: string) {
+	return spawnSync('python3', ['-c', source, scriptPath], {
+		cwd: repoRoot,
+		encoding: 'utf8',
+	});
+}
+
+const loadModule = String.raw`
+import importlib.util
+import sys
+spec = importlib.util.spec_from_file_location("score_stability", sys.argv[1])
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+`;
+
+describe('score stability chaos script', () => {
+	it('parses JSON and Streamable HTTP SSE payloads', () => {
+		const result = runProbe(`${loadModule}
+import json
+json_payload = module.parse_mcp_payload('{"jsonrpc":"2.0","id":1,"result":{"ok":true}}')
+sse_payload = module.parse_mcp_payload('event: message\\nid: 7\\ndata: {"jsonrpc":"2.0","id":2,"result":{"ok":true}}\\n\\n')
+print(json.dumps([json_payload, sse_payload]))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual([
+			{ jsonrpc: '2.0', id: 1, result: { ok: true } },
+			{ jsonrpc: '2.0', id: 2, result: { ok: true } },
+		]);
+	});
+
+	it('sends the negotiated protocol version and both MCP response media types', () => {
+		const result = runProbe(`${loadModule}
+import json
+print(json.dumps(module.make_headers('session-1')))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		const headers = JSON.parse(result.stdout) as string[];
+		expect(headers).toContain('Accept: application/json, text/event-stream');
+		expect(headers).toContain('MCP-Protocol-Version: 2025-06-18');
+		expect(headers).toContain('Mcp-Session-Id: session-1');
+	});
+
+	it('fails closed when any domain errors instead of reporting stable zero', () => {
+		const result = runProbe(`${loadModule}
+module.DOMAINS = ['example.com', 'example.net']
+stable = {
+    'example.com': (80, 'B', {'spf': 85}, 1, None),
+    'example.net': (None, None, {}, 0, 'HTTP 503'),
+}
+print(module.compare_multi([stable, stable]))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(result.stdout.trim().endsWith('1')).toBe(true);
+		expect(result.stdout).toContain('RESULTS: 1 stable, 0 drifted, 1 errors');
+		expect(result.stdout).toContain('FAILED');
+	});
+
+	it('rejects empty and malformed MCP response bodies with useful errors', () => {
+		const result = runProbe(`${loadModule}
+for payload in ['', 'event: message\\ndata: not-json\\n\\n']:
+    try:
+        module.parse_mcp_payload(payload)
+    except ValueError as error:
+        print(str(error))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(result.stdout).toContain('empty MCP response body');
+		expect(result.stdout).toContain('invalid MCP response body');
+	});
+
+	it('extracts structured scan results from an SSE tools/call response', () => {
+		const result = runProbe(`${loadModule}
+import json
+payload = {
+    'jsonrpc': '2.0',
+    'id': 10,
+    'result': {
+        'content': [{'type': 'text', 'text': 'scan complete'}],
+        'structuredContent': {
+            'score': 85,
+            'grade': 'B',
+            'categoryScores': {'spf': 85, 'ssl': None},
+            'findingCounts': {'critical': 0, 'high': 1, 'medium': 2, 'low': 0},
+        },
+    },
+}
+module.curl_json = lambda *args, **kwargs: (200, 'event: message\\ndata: ' + json.dumps(payload) + '\\n\\n')
+print(json.dumps(module.scan_domain('session-1', 'example.com')))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual(['example.com', 85, 'B', { spf: 85, ssl: null }, 3, null]);
+	});
+
+	it('returns exactly the requested domain count when cycling defaults', () => {
+		const result = runProbe(`${loadModule}
+import json
+print(json.dumps(module.load_domains(None, 21)))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(JSON.parse(result.stdout)).toHaveLength(21);
+	});
+
+	it('fails closed when an explicit domain file is malformed or empty', () => {
+		const result = runProbe(`${loadModule}
+import json
+import pathlib
+import tempfile
+with tempfile.TemporaryDirectory() as directory:
+    malformed = pathlib.Path(directory) / 'malformed.json'
+    malformed.write_text('{not-json')
+    empty = pathlib.Path(directory) / 'empty.json'
+    empty.write_text('[]')
+    for path in [malformed, empty]:
+        try:
+            module.load_domains(str(path), 10)
+        except ValueError as error:
+            print(str(error))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(result.stdout).toContain('could not load domain file');
+		expect(result.stdout).toContain('domain file must contain at least one domain');
+	});
+
+	it('deduplicates an explicit domain file without substituting defaults', () => {
+		const result = runProbe(`${loadModule}
+import json
+import pathlib
+import tempfile
+with tempfile.TemporaryDirectory() as directory:
+    path = pathlib.Path(directory) / 'domains.json'
+    path.write_text(json.dumps(['example.com', 'example.com', 'example.net']))
+    print(json.dumps(module.load_domains(str(path), 10)))
+`);
+
+		expect(result.status, result.stderr).toBe(0);
+		expect(JSON.parse(result.stdout)).toEqual(['example.com', 'example.net']);
+	});
+});

--- a/vitest.node.config.mts
+++ b/vitest.node.config.mts
@@ -14,6 +14,7 @@ export default defineConfig({
 			'test/audits/license-headers.audit.test.ts',
 			'test/audits/dependency-license.audit.test.ts',
 			'test/audits/vitest-workerd-stderr-filter.node.test.ts',
+			'test/audits/score-stability-chaos-script.node.test.ts',
 		],
 		environment: 'node',
 		pool: 'forks',


### PR DESCRIPTION
## Summary
- negotiate MCP 2025-06-18 and parse JSON or Streamable HTTP SSE responses
- consume structured scan output and fail closed on transport, tool, input-file, or stability errors
- validate and deduplicate explicit domain matrices without silent fallback
- document targeted provider-diversity chaos runs

## TDD evidence
- red: 4/4 initial protocol and fail-closed regression tests failed
- red: 2/2 explicit-domain validation tests failed
- green: 8/8 focused regression tests passed

## Verification
- live production harness: 24/24 force-refresh scans passed; 12/12 enterprise domains stable
- npm run audit:oss-safety (55 tests passed)
- npm run audit:repo-safety
- npm run lint
- npm run typecheck
- git diff --check