### PR TITLE
fix: drain unread fetch response bodies and trim scan_domain log volume

### DIFF
--- a/packages/dns-checks/src/robots-gate.ts
+++ b/packages/dns-checks/src/robots-gate.ts
@@ -140,7 +140,10 @@ export function withRobotsGate(
 						headers: { 'User-Agent': userAgent },
 						signal: AbortSignal.timeout(timeoutMs),
 					});
-					if (!res.ok) return null;
+					if (!res.ok) {
+						void res.body?.cancel();
+						return null;
+					}
 					const text = await res.text();
 					return selectGroup(parseRobotsGroups(text), productToken);
 				} catch {

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1247,7 +1247,18 @@ export async function handleToolsCall(
 					const scanOptions = { ...runtimeOptions, ...(profile && { profile }), ...(forceRefresh && { forceRefresh }) };
 					const result = await scanDomain(validDomain, scanCacheKV, scanOptions);
 					logResult = result.score.grade;
-					logDetails = result;
+					// Summary only, not the full result: scan_domain's ~19-category CheckResult[]
+					// (with per-category findings + metadata) logged in full on every call was the
+					// dominant contributor to "Log size limit exceeded" warnings on the tenant
+					// scan-queue path, where a whole MessageBatch's worth of domains accumulate
+					// against the Workers 256KB-per-invocation log cap in one queue invocation.
+					logDetails = {
+						grade: result.score.grade,
+						overall: result.score.overall,
+						cached: result.cached,
+						categoryCount: result.checks.length,
+						findingCount: result.checks.reduce((n, c) => n + c.findings.length, 0),
+					};
 					// scanDomain sets `cached: true` only when the top-level cache:<domain>
 					// key returned a hit. Threading that into the analytics emit so
 					// `tool_call.blob8` reflects the orchestrator-level cache hit/miss

--- a/src/tools/check-agent-discovery.ts
+++ b/src/tools/check-agent-discovery.ts
@@ -177,6 +177,7 @@ async function verifyCapIntegrity(rec: ParsedSvcb, findings: Finding[]): Promise
 	try {
 		const resp = await safeFetch(capUri, { redirect: 'manual', signal: controller.signal });
 		if (!resp.ok) {
+			void resp.body?.cancel();
 			findings.push(
 				createFinding(
 					CATEGORY,

--- a/src/tools/check-dnssec.ts
+++ b/src/tools/check-dnssec.ts
@@ -31,7 +31,10 @@ async function confirmAdWithGoogle(domain: string, timeoutMs = AD_CONFIRM_TIMEOU
 			headers: { Accept: 'application/dns-json' },
 			signal: AbortSignal.timeout(timeoutMs),
 		});
-		if (!resp.ok) return false;
+		if (!resp.ok) {
+			void resp.body?.cancel();
+			return false;
+		}
 		const data = (await resp.json()) as { AD?: boolean };
 		return data.AD === true;
 	} catch {

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -176,6 +176,10 @@ async function fetchWithRedirects(url: string, timeoutMs: number, callerSignal?:
 		// signals into edgeSignals BEFORE following. The hop we eventually stop on
 		// (non-redirect) is the origin and is left out of edgeSignals.
 		accumulateCdnSignals(edgeSignals, response.headers);
+		// Only .headers/.status were ever read on this hop and `response` is about
+		// to be overwritten by the next hop's fetch — drain its body so it doesn't
+		// trip the platform's "stalled HTTP response" deadlock-prevention warning.
+		void response.body?.cancel();
 
 		const location = response.headers.get('location');
 		if (!location) break;
@@ -267,6 +271,10 @@ async function dualFetchHeaders(
 	for (const s of settled) accumulateCdnSignals(edgeSignals, s.edgeSignals);
 
 	const responses = settled.map((s) => s.response);
+	// Only .headers/.status/.ok/.type are ever read below — no caller of this
+	// function reads a body. Drain all of them now so an unread HEAD-probe body
+	// doesn't trip the platform's "stalled HTTP response" deadlock-prevention warning.
+	for (const r of responses) void r.body?.cancel();
 
 	// Only treat 2xx/3xx as usable headers for analysis.
 	const usable = responses.filter((r) => r.ok || (r.status >= 300 && r.status < 400));
@@ -359,11 +367,26 @@ const gatedSafeFetch = withRobotsGate((url, init) => safeFetch(url, init), { use
 
 export async function checkHttpSecurity(domain: string, options: { signal?: AbortSignal } = {}): Promise<CheckResult> {
 	let budgetTimeoutId: ReturnType<typeof setTimeout> | undefined;
+	// Abort in-flight fetches when the budget is exceeded rather than merely
+	// out-racing them: a bare setTimeout race left the loser's fetch running with
+	// its eventual Response never read, which is exactly what the platform's
+	// "stalled HTTP response ... canceled to prevent deadlock" warning flags.
+	const budgetController = new AbortController();
 	const budgetExceeded = new Promise<'budget_exceeded'>((resolve) => {
-		budgetTimeoutId = setTimeout(() => resolve('budget_exceeded'), TOTAL_BUDGET_MS);
+		budgetTimeoutId = setTimeout(() => {
+			budgetController.abort();
+			resolve('budget_exceeded');
+		}, TOTAL_BUDGET_MS);
 	});
+	const innerSignal = options.signal ? AbortSignal.any([options.signal, budgetController.signal]) : budgetController.signal;
+	const innerPromise = checkHttpSecurityInner(domain, innerSignal);
+	// The abort above makes innerPromise reject shortly after budgetExceeded has
+	// already won the race below — attach a no-op catch so that expected,
+	// already-handled-via-the-timeout-finding rejection doesn't surface as an
+	// unhandled rejection.
+	innerPromise.catch(() => undefined);
 	try {
-		const raced = await Promise.race([checkHttpSecurityInner(domain, options.signal), budgetExceeded]);
+		const raced = await Promise.race([innerPromise, budgetExceeded]);
 		if (raced === 'budget_exceeded') {
 			const finding = createFinding(
 				'http_security',

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -665,7 +665,10 @@ async function probeRdap(domain: string): Promise<RdapProbeResult> {
 			signal: AbortSignal.timeout(RDAP_PROBE_TIMEOUT_MS),
 			headers: { Accept: 'application/rdap+json, application/json' },
 		});
-		if (!resp.ok) return EMPTY_RDAP_PROBE;
+		if (!resp.ok) {
+			void resp.body?.cancel();
+			return EMPTY_RDAP_PROBE;
+		}
 		const data = (await resp.json()) as { events?: Array<{ eventAction?: string; eventDate?: string }> };
 		const registration = Array.isArray(data.events) ? data.events.find((e) => e.eventAction === 'registration') : undefined;
 		let registrationDays: number | null = null;

--- a/src/tools/get-domain-rank.ts
+++ b/src/tools/get-domain-rank.ts
@@ -101,16 +101,27 @@ export async function getDomainRank(
 		if (args.country) body.country = args.country;
 		if (args.sector) body.sector = args.sector;
 
-		const response = await Promise.race([
-			bvWeb.fetch(BENCHMARK_BASE_URL, {
-				method: 'POST',
-				headers,
-				body: JSON.stringify(body),
-			}),
-			new Promise<never>((_, reject) =>
-				setTimeout(() => reject(new Error('C1 timeout')), TIMEOUT_MS),
-			),
-		]);
+		const fetchPromise = bvWeb.fetch(BENCHMARK_BASE_URL, {
+			method: 'POST',
+			headers,
+			body: JSON.stringify(body),
+		});
+		let response: Response;
+		try {
+			response = await Promise.race([
+				fetchPromise,
+				new Promise<never>((_, reject) =>
+					setTimeout(() => reject(new Error('C1 timeout')), TIMEOUT_MS),
+				),
+			]);
+		} catch (err) {
+			// Timeout won the race: fetchPromise's eventual Response would otherwise
+			// go undrained, which is what the platform's "stalled HTTP response ...
+			// canceled to prevent deadlock" warning flags. Harmless no-op if
+			// fetchPromise itself was what rejected (nothing to drain).
+			fetchPromise.then((r) => void r.body?.cancel()).catch(() => undefined);
+			throw err;
+		}
 
 		if (!response.ok) {
 			// Consume body to avoid leaking the connection.


### PR DESCRIPTION
## Summary

Root-caused and fixed the two recurring warning classes surfaced by 7 days of Cloudflare Workers Observability on `bv-dns-security-mcp` (prod). Zero unhandled exceptions / non-`ok` outcomes in that window — this PR addresses everything else on the board.

- **"A stalled HTTP response was canceled to prevent deadlock"** (~10/wk, via `POST /mcp`): several early-return/race-loser fetch call sites checked `response.status`/`.ok`/`.headers` without ever reading or cancelling the body.
  - `packages/dns-checks/src/robots-gate.ts` — the shared `withRobotsGate` helper (independently instantiated by 5 tools: check-http-security, check-bimi, check-mta-sts, check-ssl, check-subdomain-takeover) never drained its own robots.txt fetch on non-2xx — the highest-frequency contributor since most scanned domains either lack `/robots.txt` or return non-2xx for it.
  - `src/tools/check-http-security.ts` — the `TOTAL_BUDGET_MS` timeout was a bare `setTimeout` race that let the losing fetch keep running unmanaged; now an `AbortController` actually cancels in-flight work when the budget fires. Also drains bodies on discarded intermediate redirect hops (`fetchWithRedirects`) and both HEAD-probe responses in `dualFetchHeaders` (headers-only consumers — no caller ever reads a body there).
  - `src/tools/get-domain-rank.ts` — same bare-`setTimeout`-race pattern against bv-web's C1 endpoint; drains the eventual response when the timeout wins.
  - `src/tools/check-dnssec.ts`, `check-lookalikes.ts`, `check-agent-discovery.ts` — three smaller `if (!resp.ok) return ...` sites with the same gap.

- **"Log size limit exceeded: More than 256KB..."** (~30/wk, `bv-scanner-queue` — the tenant-scan Cloudflare Queue): `scan_domain`'s success log (`src/handlers/tools.ts`) serialized the *entire* ~19-category `CheckResult[]` (every finding + metadata) unconditionally, on every call. A single queue invocation processes a whole `MessageBatch` of domains, so N domains' full results stacked against the Workers 256KB-per-invocation log cap. Replaced with a small summary (`grade`/`overall`/`cached`/`categoryCount`/`findingCount`) — matching the pattern `batch_scan` already used two cases below in the same file.

Investigated via Cloudflare's `cloudflare-observability` MCP tools directly against prod, plus parallel root-cause tracing with the Explore agent (systematic-debugging: read the actual error messages/call chains before touching code — confirmed the domain-validation warnings in the same window are legitimate input rejection, not bugs, so left untouched).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm -w packages/dns-checks run build` — rebuilt (Worker imports built `dist/`, not `src/`)
- [x] ESLint clean on all 7 changed files
- [x] 251 tests passing across every touched spec: `check-http-security`, `check-dnssec`, `check-lookalikes`, `check-agent-discovery`, `get-domain-rank`, `handlers-tools`, `scan-domain` + the 4 robots-gate specs in `packages/dns-checks`
- [x] Security self-review (devsecops-reviewer): 0 findings — no new fetch targets, no attack-surface change, all touched call sites already route through `safeFetch`/`gatedSafeFetch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRoQJjTAF7JDiYgJieGaVe