### PR TITLE
chore: release 3.31.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.31.1] - 2026-07-17
+
+Patch release: **unread-fetch-body and log-volume fixes** from a review of production Workers Observability logs/analytics (no new tools, schema, or API surface).
+
+### Fixed
+
+- **"A stalled HTTP response was canceled to prevent deadlock"** (~10 occurrences/week in prod). Several early-return/race-loser fetch call sites checked `response.status`/`.ok`/`.headers` without ever reading or cancelling the body, holding the underlying connection open until the platform force-cancelled it. Fixed the shared `withRobotsGate` helper (`packages/dns-checks/src/robots-gate.ts`, independently instantiated by `check_http_security`/`check_bimi`/`check_mta_sts`/`check_ssl`/`check_subdomain_takeover` — the highest-frequency contributor since most scanned domains lack or block `/robots.txt`); `check_http_security`'s `TOTAL_BUDGET_MS` timeout, which now aborts the losing fetch via `AbortController` instead of merely out-racing it, and drains discarded redirect-hop and dual-HEAD-probe bodies; `get_domain_rank`'s C1-benchmark timeout race; and three smaller `if (!resp.ok) return ...` sites in `check_dnssec`, `check_lookalikes`, and `check_agent_discovery`.
+- **"Log size limit exceeded: More than 256KB..."** (~30 occurrences/week on the `bv-scanner-queue` tenant-scan queue). `scan_domain`'s success log unconditionally serialized the full ~19-category `CheckResult[]` (every finding + metadata) on every call; a single queue invocation processing a whole `MessageBatch` of domains stacked N domains' full results against the Workers 256KB-per-invocation log cap. Replaced with a small summary (`grade`/`overall`/`cached`/`categoryCount`/`findingCount`), matching the pattern `batch_scan` already used.
+
 ## [3.31.0] - 2026-07-16
 
 Minor release: **checkout exit-door + INERT enumeration entitlement gate** — the D1/D2 monetization surface from the commercialization review. Paywall (403) and free-tier volume (429) responses now carry a structured `error.data.upgrade` affordance with a self-serve-vs-sales channel partition ("money alone never opens the enumeration surface"); the D2 contract-flag gate ships wired-but-dormant (default OFF).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.31.0",
+	"version": "3.31.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.31.0",
+			"version": "3.31.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.31.0",
+	"version": "3.31.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.31.0",
+	"version": "3.31.1",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Summary

Version-sync for the fixes merged in #524 (unread fetch response bodies causing "stalled HTTP response" warnings + `scan_domain` log-volume reduction fixing "Log size limit exceeded" on the tenant scan queue). No code changes — this PR only bumps `package.json`/`package-lock.json`, `server.json`, and adds the `[3.31.1]` CHANGELOG entry, per the pre-bump-before-tag convention (avoids `publish.yml`'s auto-bump push getting rejected by branch protection).

## Test plan

- [x] All 4 version-sync surfaces confirmed at `3.31.1` (package.json, package-lock.json, server.json, CHANGELOG.md heading)
- [x] No code touched — relying on #524's already-passing CI/tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRoQJjTAF7JDiYgJieGaVe