### PR TITLE
fix(rdap): surface WHOIS-sourced dates + registrant privacy on RDAP-failure fallback

### DIFF
--- a/packages/bv-whois/src/__tests__/lookup.test.ts
+++ b/packages/bv-whois/src/__tests__/lookup.test.ts
@@ -14,7 +14,11 @@ function makeKV() {
 	};
 }
 
+/** Registration-detail fields are absent for the registrar-only fixtures below. */
+const NO_DETAILS = { creationDate: null, updatedDate: null, expiryDate: null, registrantOrg: null, registrantPrivacy: false } as const;
+
 const REGISTRAR_RESPONSE = `Domain Name: example.com\nRegistrar: TestRegistrar Inc.\nDomain Status: ok\n`;
+const DATED_RESPONSE = `Domain Name: example.com\nRegistrar: TestRegistrar Inc.\nCreation Date: 2020-01-15T00:00:00Z\nUpdated Date: 2024-03-10T00:00:00Z\nRegistry Expiry Date: 2027-01-15T00:00:00Z\nRegistrant Organization: Withheld for Privacy ehf\n`;
 const REGISTRAR_IANA_RESPONSE = `Domain Name: example.com\nRegistrar: TestRegistrar Inc.\nRegistrar IANA ID: 299\nDomain Status: ok\n`;
 const REDACTED_DENIC_RESPONSE = `% The DENIC whois service on port 43 doesn't disclose any information concerning the domain holder.\nDomain: example.de\nStatus: connect\n`;
 const NOT_FOUND_RESPONSE = `No match for domain "no-such-domain.com".\n`;
@@ -36,6 +40,32 @@ describe('lookupRegistrar', () => {
 		expect(result).toEqual<WhoisLookupResult>({
 			registrar: 'TestRegistrar Inc.',
 			registrarIanaId: null,
+			...NO_DETAILS,
+			source: 'whois',
+		});
+	});
+
+	it('surfaces creation / updated / expiry dates + privacy registrant from a dated WHOIS response', async () => {
+		const kv = makeKV();
+		const deps: LookupDeps = {
+			kv: kv as never,
+			whoisQuery: vi.fn(async (server: string, query: string): Promise<string> => {
+				if (server === 'whois.iana.org') return 'whois:        whois.nic.example\n';
+				if (server === 'whois.nic.example' && query === 'example.example') return DATED_RESPONSE;
+				throw new Error(`unexpected query: ${server} ${query}`);
+			}),
+		};
+
+		const result = await lookupRegistrar('example.example', deps);
+
+		expect(result).toEqual<WhoisLookupResult>({
+			registrar: 'TestRegistrar Inc.',
+			registrarIanaId: null,
+			creationDate: '2020-01-15T00:00:00Z',
+			updatedDate: '2024-03-10T00:00:00Z',
+			expiryDate: '2027-01-15T00:00:00Z',
+			registrantOrg: 'Withheld for Privacy ehf',
+			registrantPrivacy: true,
 			source: 'whois',
 		});
 	});
@@ -56,6 +86,7 @@ describe('lookupRegistrar', () => {
 		expect(result).toEqual<WhoisLookupResult>({
 			registrar: 'TestRegistrar Inc.',
 			registrarIanaId: '299',
+			...NO_DETAILS,
 			source: 'whois',
 		});
 	});
@@ -72,7 +103,7 @@ describe('lookupRegistrar', () => {
 
 		const result = await lookupRegistrar('example.de', deps);
 
-		expect(result).toEqual<WhoisLookupResult>({ registrar: null, registrarIanaId: null, source: 'redacted' });
+		expect(result).toEqual<WhoisLookupResult>({ registrar: null, registrarIanaId: null, ...NO_DETAILS, source: 'redacted' });
 	});
 
 	it('short-circuits .de domains to source=redacted without any whoisQuery (DENIC blocks CF egress + always-redacted by law)', async () => {
@@ -82,7 +113,7 @@ describe('lookupRegistrar', () => {
 
 		const result = await lookupRegistrar('example.de', deps);
 
-		expect(result).toEqual<WhoisLookupResult>({ registrar: null, registrarIanaId: null, source: 'redacted' });
+		expect(result).toEqual<WhoisLookupResult>({ registrar: null, registrarIanaId: null, ...NO_DETAILS, source: 'redacted' });
 		expect(whoisQuery).not.toHaveBeenCalled();
 	});
 
@@ -94,26 +125,31 @@ describe('lookupRegistrar', () => {
 		await expect(lookupRegistrar('example.ph', deps)).resolves.toEqual({
 			registrar: null,
 			registrarIanaId: null,
+			...NO_DETAILS,
 			source: 'redacted',
 		} satisfies WhoisLookupResult);
 		await expect(lookupRegistrar('example.co.jp', deps)).resolves.toEqual({
 			registrar: null,
 			registrarIanaId: null,
+			...NO_DETAILS,
 			source: 'redacted',
 		} satisfies WhoisLookupResult);
 		await expect(lookupRegistrar('example.ch', deps)).resolves.toEqual({
 			registrar: null,
 			registrarIanaId: null,
+			...NO_DETAILS,
 			source: 'redacted',
 		} satisfies WhoisLookupResult);
 		await expect(lookupRegistrar('example.pt', deps)).resolves.toEqual({
 			registrar: null,
 			registrarIanaId: null,
+			...NO_DETAILS,
 			source: 'redacted',
 		} satisfies WhoisLookupResult);
 		await expect(lookupRegistrar('example.gr', deps)).resolves.toEqual({
 			registrar: null,
 			registrarIanaId: null,
+			...NO_DETAILS,
 			source: 'redacted',
 		} satisfies WhoisLookupResult);
 		expect(whoisQuery).not.toHaveBeenCalled();
@@ -134,6 +170,7 @@ describe('lookupRegistrar', () => {
 		expect(result).toEqual<WhoisLookupResult>({
 			registrar: 'Whois Corp.(http://whois.co.kr)',
 			registrarIanaId: null,
+			...NO_DETAILS,
 			source: 'whois',
 		});
 	});
@@ -150,7 +187,7 @@ describe('lookupRegistrar', () => {
 
 		const result = await lookupRegistrar('no-such-domain.com', deps);
 
-		expect(result).toEqual<WhoisLookupResult>({ registrar: null, registrarIanaId: null, source: 'notfound' });
+		expect(result).toEqual<WhoisLookupResult>({ registrar: null, registrarIanaId: null, ...NO_DETAILS, source: 'notfound' });
 	});
 
 	it('returns source=error when registry unreachable', async () => {

--- a/packages/bv-whois/src/__tests__/route.test.ts
+++ b/packages/bv-whois/src/__tests__/route.test.ts
@@ -28,7 +28,7 @@ describe('POST /lookup', () => {
 		});
 
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({ registrar: 'TestReg Inc.', registrarIanaId: null, source: 'whois' });
+		expect(await res.json()).toEqual({ registrar: 'TestReg Inc.', registrarIanaId: null, creationDate: null, updatedDate: null, expiryDate: null, registrantOrg: null, registrantPrivacy: false, source: 'whois' });
 	});
 
 	it('returns registrar IANA ID in the JSON response when WHOIS includes it', async () => {
@@ -43,7 +43,7 @@ describe('POST /lookup', () => {
 		});
 
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({ registrar: 'TestReg Inc.', registrarIanaId: '299', source: 'whois' });
+		expect(await res.json()).toEqual({ registrar: 'TestReg Inc.', registrarIanaId: '299', creationDate: null, updatedDate: null, expiryDate: null, registrantOrg: null, registrantPrivacy: false, source: 'whois' });
 	});
 
 	it('returns 400 when domain field is missing', async () => {
@@ -110,7 +110,7 @@ describe('POST /lookup', () => {
 		});
 
 		expect(res.status).toBe(200);
-		expect(await res.json()).toEqual({ registrar: null, registrarIanaId: null, source: 'redacted' });
+		expect(await res.json()).toEqual({ registrar: null, registrarIanaId: null, creationDate: null, updatedDate: null, expiryDate: null, registrantOrg: null, registrantPrivacy: false, source: 'redacted' });
 	});
 
 	it('rejects body larger than 1KB', async () => {

--- a/packages/bv-whois/src/app.ts
+++ b/packages/bv-whois/src/app.ts
@@ -3,7 +3,9 @@
  * Hono app for the bv-whois shim Worker.
  *
  * Routes:
- *   POST /lookup   — body { domain }, returns { registrar, source }
+ *   POST /lookup   — body { domain }, returns { registrar, registrarIanaId,
+ *                    creationDate, updatedDate, expiryDate, registrantOrg,
+ *                    registrantPrivacy, source }
  *   GET  /health   — liveness probe
  */
 

--- a/packages/bv-whois/src/lookup.ts
+++ b/packages/bv-whois/src/lookup.ts
@@ -10,8 +10,27 @@ import { resolveWhoisServer, type KVLike, type WhoisQueryFn } from './resolver';
 export interface WhoisLookupResult {
 	registrar: string | null;
 	registrarIanaId: string | null;
+	/** Raw creation/registration date (ISO where the registry emits it). */
+	creationDate: string | null;
+	/** Raw last-updated/last-modified date. */
+	updatedDate: string | null;
+	/** Raw expiry/expiration date. */
+	expiryDate: string | null;
+	/** Registrant organisation/name (may be a privacy-proxy label). */
+	registrantOrg: string | null;
+	/** True when the registrant record is redacted behind a privacy/proxy service. */
+	registrantPrivacy: boolean;
 	source: 'whois' | 'redacted' | 'notfound' | 'error';
 }
+
+/** Registration-detail fields default to absent — the registrar-only short-circuit paths carry no dates. */
+const EMPTY_REGISTRATION_DETAILS = {
+	creationDate: null,
+	updatedDate: null,
+	expiryDate: null,
+	registrantOrg: null,
+	registrantPrivacy: false,
+} as const;
 
 export interface LookupDeps {
 	kv: KVLike;
@@ -52,30 +71,39 @@ const ALWAYS_REDACTED_TLDS = new Set<string>([
  */
 export async function lookupRegistrar(domain: string, deps: LookupDeps): Promise<WhoisLookupResult> {
 	if (typeof domain !== 'string' || !DOMAIN_RE.test(domain)) {
-		return { registrar: null, registrarIanaId: null, source: 'error' };
+		return { registrar: null, registrarIanaId: null, ...EMPTY_REGISTRATION_DETAILS, source: 'error' };
 	}
 
 	const labels = domain.toLowerCase().split('.');
 	const tld = labels[labels.length - 1];
 
 	if (ALWAYS_REDACTED_TLDS.has(tld)) {
-		return { registrar: null, registrarIanaId: null, source: 'redacted' };
+		return { registrar: null, registrarIanaId: null, ...EMPTY_REGISTRATION_DETAILS, source: 'redacted' };
 	}
 
 	const server = await resolveWhoisServer(tld, deps);
-	if (!server) return { registrar: null, registrarIanaId: null, source: 'error' };
+	if (!server) return { registrar: null, registrarIanaId: null, ...EMPTY_REGISTRATION_DETAILS, source: 'error' };
 
 	let response: string;
 	try {
 		response = await deps.whoisQuery(server, domain);
 	} catch {
-		return { registrar: null, registrarIanaId: null, source: 'error' };
+		return { registrar: null, registrarIanaId: null, ...EMPTY_REGISTRATION_DETAILS, source: 'error' };
 	}
 
 	const parsed = parseWhoisResponse(response);
+	// Registration details ride along with every parsed response — a redacted or
+	// not-found registrar can still carry public creation/expiry dates.
+	const details = {
+		creationDate: parsed.creationDate,
+		updatedDate: parsed.updatedDate,
+		expiryDate: parsed.expiryDate,
+		registrantOrg: parsed.registrantOrg,
+		registrantPrivacy: parsed.registrantPrivacy,
+	};
 
-	if (parsed.registrar) return { registrar: parsed.registrar, registrarIanaId: parsed.registrarIanaId ?? null, source: 'whois' };
-	if (parsed.redacted) return { registrar: null, registrarIanaId: null, source: 'redacted' };
-	if (parsed.notFound) return { registrar: null, registrarIanaId: null, source: 'notfound' };
-	return { registrar: null, registrarIanaId: null, source: 'error' };
+	if (parsed.registrar) return { registrar: parsed.registrar, registrarIanaId: parsed.registrarIanaId ?? null, ...details, source: 'whois' };
+	if (parsed.redacted) return { registrar: null, registrarIanaId: null, ...details, source: 'redacted' };
+	if (parsed.notFound) return { registrar: null, registrarIanaId: null, ...details, source: 'notfound' };
+	return { registrar: null, registrarIanaId: null, ...details, source: 'error' };
 }

--- a/packages/dns-checks/src/__tests__/whois-parse.test.ts
+++ b/packages/dns-checks/src/__tests__/whois-parse.test.ts
@@ -234,6 +234,72 @@ Organization: SomeRegistrar GmbH
 	});
 });
 
+describe('parseWhoisResponse registration dates + registrant privacy', () => {
+	// Real-world shape from `.co` (RDAP 530 → whois.registry.co → whois.namecheap.com).
+	// The dates + privacy registrant are present in the same WHOIS response the RDAP
+	// fallback drops today.
+	const CO_WHOIS = `Domain Name: EXAMPLE.CO
+Registry Domain ID: D1234-CO
+Registrar: NameCheap, Inc.
+Registrar IANA ID: 1068
+Creation Date: 2025-12-29T20:37:51.0Z
+Updated Date: 2026-02-03T12:00:51.0Z
+Registry Expiry Date: 2026-12-29T23:59:59.0Z
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Registrant Organization: Privacy service provided by Withheld for Privacy ehf
+Registrant Country: IS
+Name Server: DNS1.REGISTRAR-SERVERS.COM
+`;
+
+	// Real-world shape from `.nz` (no RDAP server for the TLD).
+	const NZ_WHOIS = `% Provided by .nz Domain Name Registry
+domain_name: example.nz
+Registrar Name: Example NZ Registrar Ltd
+Original Created: 2010-03-07T02:29:35Z
+`;
+
+	it('extracts creation / updated / expiry dates from a .co WHOIS response', () => {
+		const parsed = parseWhoisResponse(CO_WHOIS);
+		expect(parsed.registrar).toBe('NameCheap, Inc.');
+		expect(parsed.creationDate).toBe('2025-12-29T20:37:51.0Z');
+		expect(parsed.updatedDate).toBe('2026-02-03T12:00:51.0Z');
+		expect(parsed.expiryDate).toBe('2026-12-29T23:59:59.0Z');
+	});
+
+	it('detects registrant privacy redaction and surfaces the registrant org from a .co WHOIS response', () => {
+		const parsed = parseWhoisResponse(CO_WHOIS);
+		expect(parsed.registrantPrivacy).toBe(true);
+		expect(parsed.registrantOrg).toBe('Privacy service provided by Withheld for Privacy ehf');
+	});
+
+	it('extracts the .nz "Original Created" creation date + registrar', () => {
+		const parsed = parseWhoisResponse(NZ_WHOIS);
+		expect(parsed.creationDate).toBe('2010-03-07T02:29:35Z');
+		expect(parsed.registrar).toBe('Example NZ Registrar Ltd');
+	});
+
+	it('parses lowercase RIPE-style ccTLD date labels (created: / expires:)', () => {
+		const ripe = `domain: example.test\nregistrar: RIPE Registrar\ncreated: 2015-06-01T00:00:00Z\nexpires: 2027-06-01T00:00:00Z\n`;
+		const parsed = parseWhoisResponse(ripe);
+		expect(parsed.creationDate).toBe('2015-06-01T00:00:00Z');
+		expect(parsed.expiryDate).toBe('2027-06-01T00:00:00Z');
+	});
+
+	it('is fail-soft: a response without dates/privacy yields null dates and privacy=false', () => {
+		const parsed = parseWhoisResponse(`Domain Name: EXAMPLE.TEST\nRegistrar: Plain Registrar Inc.\n`);
+		expect(parsed.creationDate).toBeNull();
+		expect(parsed.updatedDate).toBeNull();
+		expect(parsed.expiryDate).toBeNull();
+		expect(parsed.registrantPrivacy).toBe(false);
+		expect(parsed.registrantOrg).toBeNull();
+	});
+
+	it('detects the "Redacted for Privacy" and "Data Protected" privacy markers', () => {
+		expect(parseWhoisResponse(`Registrant Name: Redacted for Privacy\n`).registrantPrivacy).toBe(true);
+		expect(parseWhoisResponse(`Registrant Organization: Data Protected\n`).registrantPrivacy).toBe(true);
+	});
+});
+
 describe('parseIanaReferral', () => {
 	it('extracts whois server from .me IANA response', () => {
 		expect(parseIanaReferral(fixture('iana-me.txt'))).toBe('whois.me.example');

--- a/packages/dns-checks/src/whois/parse.ts
+++ b/packages/dns-checks/src/whois/parse.ts
@@ -13,10 +13,99 @@ export const MAX_RESPONSE_BYTES = 64 * 1024;
 export interface WhoisParseResult {
 	registrar: string | null;
 	registrarIanaId: string | null;
+	/** Raw registration/creation date string as found (label variants normalised at the surface). */
+	creationDate: string | null;
+	/** Raw last-updated/last-modified date string as found. */
+	updatedDate: string | null;
+	/** Raw expiry/expiration date string as found. */
+	expiryDate: string | null;
+	/** Registrant organisation/name string as found (may be a privacy-proxy name). */
+	registrantOrg: string | null;
+	/** True when the registrant record is redacted behind a privacy/proxy service. */
+	registrantPrivacy: boolean;
 	/** True when the registry explicitly indicated no record exists. */
 	notFound: boolean;
 	/** True when the registry returned data but redacted the registrar (e.g. DENIC). */
 	redacted: boolean;
+}
+
+/**
+ * Registration-date label variants seen across gTLD/ccTLD WHOIS templates,
+ * ordered specific → generic. The matcher (`matchLabelledValue`) returns the
+ * first label with any line hit, so a specific `Creation Date` wins over a bare
+ * `Created`. Anchored strictly at line start after a colon, so a label can't
+ * false-match a longer field name (`^Created:` never matches `Created On:`).
+ */
+const CREATION_DATE_LABELS = [
+	'Creation Date',
+	'Created On',
+	'Created Date',
+	'Domain Registration Date',
+	'Original Created', // .nz
+	'Registered On',
+	'Registered on',
+	'Created', // includes lowercase `created:` via the /i flag (RIPE-style ccTLD)
+	'Registered',
+] as const;
+
+const UPDATED_DATE_LABELS = [
+	'Updated Date',
+	'Last Modified',
+	'Last Updated',
+	'Last Update',
+	'Updated On',
+	'Updated', // includes lowercase `changed:` below
+	'changed',
+	'modified',
+] as const;
+
+const EXPIRY_DATE_LABELS = [
+	'Registry Expiry Date',
+	'Registrar Registration Expiration Date',
+	'Expiration Date',
+	'Expiry Date',
+	'Expire Date',
+	'Expires On',
+	'Expires', // includes lowercase `expires:` via the /i flag (RIPE-style ccTLD)
+	'paid-till',
+] as const;
+
+const REGISTRANT_ORG_LABELS = [
+	'Registrant Organization',
+	'Registrant Organisation',
+	'Registrant Org',
+	'Registrant Name',
+	'Registrant',
+] as const;
+
+/** Privacy/proxy registrant markers — the redaction states the RDAP fallback must surface. */
+const REGISTRANT_PRIVACY_RE = /redacted for privacy|withheld for privacy|privacy service|data protected/i;
+
+/** Longest usable value length per field — keeps values under the RDAP tool's Zod caps (dates 64, org 256). */
+const MAX_DATE_LEN = 64;
+const MAX_ORG_LEN = 256;
+
+function escapeWhoisLabel(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Return the first non-empty value for any of `labels` (label priority order),
+ * matching `^Label:\s*<value>$` line-anchored + case-insensitively. Pure.
+ */
+function matchLabelledValue(lines: readonly string[], labels: readonly string[], maxLen: number): string | null {
+	for (const label of labels) {
+		const re = new RegExp(`^${escapeWhoisLabel(label)}\\s*:\\s*(.+?)\\s*$`, 'i');
+		for (const raw of lines) {
+			const line = raw.replace(/\r$/, '').replace(/^\s+/, '');
+			const m = line.match(re);
+			if (m) {
+				const value = m[1].trim();
+				if (value.length > 0) return value.length > maxLen ? value.slice(0, maxLen) : value;
+			}
+		}
+	}
+	return null;
 }
 
 /**
@@ -138,9 +227,20 @@ export function parseWhoisResponse(input: string): WhoisParseResult {
 
 	const resolved = registrar ?? registrarName ?? sponsoring ?? registrarOrganization ?? authorizedAgency;
 
+	const creationDate = matchLabelledValue(lines, CREATION_DATE_LABELS, MAX_DATE_LEN);
+	const updatedDate = matchLabelledValue(lines, UPDATED_DATE_LABELS, MAX_DATE_LEN);
+	const expiryDate = matchLabelledValue(lines, EXPIRY_DATE_LABELS, MAX_DATE_LEN);
+	const registrantOrg = matchLabelledValue(lines, REGISTRANT_ORG_LABELS, MAX_ORG_LEN);
+	const registrantPrivacy = REGISTRANT_PRIVACY_RE.test(truncated);
+
 	return {
 		registrar: resolved,
 		registrarIanaId,
+		creationDate,
+		updatedDate,
+		expiryDate,
+		registrantOrg,
+		registrantPrivacy,
 		notFound: notFound && !resolved,
 		redacted: !resolved && denicRedacted,
 	};

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -490,19 +490,21 @@ interface FetcherLike {
 }
 
 import { z } from 'zod';
+import { parseWhoisResponse } from '@blackveil/dns-checks/whois';
 
 const WhoisFallbackPayloadSchema = z.object({
 	registrar: z.string().max(256).nullable(),
 	registrarIanaId: z.string().max(64).nullable().optional(),
+	// Registration details surfaced by the bv-whois shim (3.32.0+) — optional so
+	// an older shim that omits them still Zod-validates; missing = simply absent.
+	creationDate: z.string().max(64).nullable().optional(),
+	updatedDate: z.string().max(64).nullable().optional(),
+	expiryDate: z.string().max(64).nullable().optional(),
+	registrantOrg: z.string().max(256).nullable().optional(),
+	registrantPrivacy: z.boolean().optional(),
 	source: z.enum(['whois', 'redacted', 'notfound', 'error']),
 });
 type WhoisFallbackPayload = z.infer<typeof WhoisFallbackPayloadSchema>;
-
-const WHOIS_REGISTRAR_LABELS = ['Registrar', 'Registrar Name', 'Sponsoring Registrar', 'Registrar Organization'] as const;
-
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-}
 
 function parseStructuredWhoisPayload(body: string): WhoisFallbackPayload | null {
 	const trimmed = body.trim();
@@ -515,15 +517,48 @@ function parseStructuredWhoisPayload(body: string): WhoisFallbackPayload | null 
 	}
 }
 
-function extractWhoisRegistrarLabel(body: string): string | null {
-	for (const line of body.split(/\r?\n/)) {
-		for (const label of WHOIS_REGISTRAR_LABELS) {
-			const match = line.match(new RegExp(`^\\s*${escapeRegExp(label)}\\s*:\\s*(.+?)\\s*$`, 'i'));
-			const registrar = match?.[1]?.trim();
-			if (registrar && registrar.length <= 256) return registrar;
-		}
+/**
+ * Parse a raw (non-JSON) WHOIS body via the shared `@blackveil/dns-checks/whois`
+ * core so the fallback text path surfaces the SAME registrar + date + privacy
+ * fidelity as the structured shim payload. Returns null when nothing usable is
+ * found (caller treats that as a soft error).
+ */
+function parseRawWhoisBody(body: string): WhoisFallbackPayload | null {
+	const parsed = parseWhoisResponse(body);
+	const hasData = Boolean(parsed.registrar || parsed.creationDate || parsed.updatedDate || parsed.expiryDate);
+	if (!hasData) return null;
+	return {
+		registrar: parsed.registrar,
+		registrarIanaId: parsed.registrarIanaId ?? null,
+		creationDate: parsed.creationDate,
+		updatedDate: parsed.updatedDate,
+		expiryDate: parsed.expiryDate,
+		registrantOrg: parsed.registrantOrg,
+		registrantPrivacy: parsed.registrantPrivacy,
+		source: 'whois',
+	};
+}
+
+/**
+ * Normalise a raw WHOIS date to ISO where parseable; keep the raw string when
+ * not. Returns a display form (date-only, matching the RDAP success path) plus
+ * the machine value for metadata. `null` for empty/absent input.
+ */
+function normalizeWhoisDate(raw: string | null | undefined): { value: string; display: string } | null {
+	if (typeof raw !== 'string') return null;
+	const trimmed = raw.trim();
+	if (trimmed.length === 0) return null;
+	const ms = Date.parse(trimmed);
+	if (Number.isFinite(ms)) {
+		const iso = new Date(ms).toISOString();
+		return { value: iso, display: iso.split('T')[0] };
 	}
-	return null;
+	return { value: trimmed, display: trimmed };
+}
+
+/** True when the WHOIS fallback yielded any registration detail worth surfacing. */
+function whoisHasRegistrationData(w: WhoisFallbackPayload | null): boolean {
+	return Boolean(w && (w.registrar || w.creationDate || w.updatedDate || w.expiryDate));
 }
 
 /**
@@ -556,8 +591,10 @@ async function fetchWhoisRegistrar(
 		const body = await resp.text();
 		const structured = parseStructuredWhoisPayload(body);
 		if (structured) return structured;
-		const registrar = extractWhoisRegistrarLabel(body);
-		if (registrar) return { registrar, source: 'whois' };
+		// Non-JSON body (a shim that streams raw port-43 text): parse it with the
+		// shared core so registrar + dates + privacy still surface.
+		const raw = parseRawWhoisBody(body);
+		if (raw) return raw;
 		return { registrar: null, source: 'error' };
 	} catch {
 		return { registrar: null, source: 'error' };
@@ -599,8 +636,18 @@ function buildWhoisFallbackFinding(domain: string, w: WhoisFallbackPayload | nul
 	const outcome = reconcileWithWhois(rdapOutcome, w);
 	const registrar = w?.registrar ?? null;
 	const registrarIanaId = w?.registrarIanaId ?? null;
+	const creation = normalizeWhoisDate(w?.creationDate);
+	const updated = normalizeWhoisDate(w?.updatedDate);
+	const expiry = normalizeWhoisDate(w?.expiryDate);
+	const registrantOrg = w?.registrantOrg ?? null;
+	const registrantPrivacy = w?.registrantPrivacy ?? false;
 	const detailParts: string[] = [];
 	if (registrar) detailParts.push(`Registrar: ${registrar}`);
+	if (creation) detailParts.push(`Created: ${creation.display}`);
+	if (updated) detailParts.push(`Updated: ${updated.display}`);
+	if (expiry) detailParts.push(`Expires: ${expiry.display}`);
+	if (registrantOrg) detailParts.push(`Registrant: ${registrantOrg}`);
+	if (registrantPrivacy) detailParts.push('Registrant privacy: enabled');
 	detailParts.push(`Source: ${outcome.source}`);
 	if (outcome.failureReason) detailParts.push(`Reason: ${outcome.failureReason}`);
 	return createFinding(CATEGORY, 'Registration details', 'info', detailParts.join('. ') + '.', {
@@ -609,6 +656,14 @@ function buildWhoisFallbackFinding(domain: string, w: WhoisFallbackPayload | nul
 		registrarIanaId,
 		registrarSource: outcome.source,
 		...(outcome.failureReason ? { registrarFailureReason: outcome.failureReason } : {}),
+		// Registration details recovered from WHOIS (the #1 OSINT pivot RDAP-failure
+		// paths used to drop). Normalised to ISO where parseable, raw otherwise; a
+		// missing field is simply absent (fail-soft).
+		creationDate: creation?.value ?? null,
+		updatedDate: updated?.value ?? null,
+		expirationDate: expiry?.value ?? null,
+		registrantOrg,
+		registrantPrivacy,
 	});
 }
 
@@ -685,21 +740,25 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 	// Resolve RDAP server
 	const rdapServerUrl = await resolveRdapServer(tld);
 	if (!rdapServerUrl) {
+		// Deterministic: TLD has no RDAP server. Fetch WHOIS FIRST so the primary
+		// finding can present WHOIS-sourced registration details instead of a bare
+		// "unavailable" when WHOIS answered. reconcileWithWhois handles provenance.
+		const whois = await fetchWhoisRegistrar(domain, options.whoisBinding, callerSignal, deadlineMs);
+		const hasData = whoisHasRegistrationData(whois);
 		findings.push(
 			createFinding(
 				CATEGORY,
 				'No RDAP server found',
 				'info',
-				`No RDAP server found for TLD ".${tld}". RDAP data unavailable for this domain.`,
+				hasData
+					? `No RDAP server found for TLD ".${tld}"; registration details sourced from WHOIS instead.`
+					: `No RDAP server found for TLD ".${tld}". RDAP data unavailable for this domain.`,
 				{
 					domain,
 					tld,
 				},
 			),
 		);
-		// Deterministic: TLD has no RDAP server. Not transient — keep as 'unknown'
-		// (or whichever WHOIS provides). reconcileWithWhois handles the rest.
-		const whois = await fetchWhoisRegistrar(domain, options.whoisBinding, callerSignal, deadlineMs);
 		findings.push(buildWhoisFallbackFinding(domain, whois, { source: 'unknown' }));
 		return buildCheckResult(CATEGORY, findings) as CheckResult;
 	}
@@ -712,19 +771,25 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 		const resp = await fetchRdapResponse(rdapUrl, callerSignal, deadlineMs);
 
 		if (!resp.ok) {
+			// e.g. .co registries return HTTP 530. Fetch WHOIS first so we present
+			// the WHOIS-sourced registration details rather than asserting the data
+			// is unavailable when it isn't.
+			const whois = await fetchWhoisRegistrar(domain, options.whoisBinding, callerSignal, deadlineMs);
+			const hasData = whoisHasRegistrationData(whois);
 			findings.push(
 				createFinding(
 					CATEGORY,
 					'RDAP lookup failed',
 					'info',
-					`RDAP server returned HTTP ${resp.status} for ${domain}. Registration data unavailable.`,
+					hasData
+						? `RDAP server returned HTTP ${resp.status} for ${domain}; registration details sourced from WHOIS instead.`
+						: `RDAP server returned HTTP ${resp.status} for ${domain}. Registration data unavailable.`,
 					{
 						domain,
 						httpStatus: resp.status,
 					},
 				),
 			);
-			const whois = await fetchWhoisRegistrar(domain, options.whoisBinding, callerSignal, deadlineMs);
 			findings.push(buildWhoisFallbackFinding(domain, whois, { source: 'lookup_failed', failureReason: `rdap_http_${resp.status}` }));
 			return buildCheckResult(CATEGORY, findings) as CheckResult;
 		}
@@ -735,13 +800,22 @@ export async function checkRdapLookup(domain: string, options: RdapCheckOptions 
 		// Caller-abort during fetch surfaces as a distinct reason so the retry
 		// policy can distinguish budget exhaustion from upstream RDAP flake.
 		const reason = callerSignal?.aborted ? 'caller_aborted' : 'rdap_fetch_error';
-		findings.push(
-			createFinding(CATEGORY, 'RDAP lookup failed', 'info', `RDAP lookup failed for ${domain}: ${message}`, {
-				domain,
-				error: message,
-			}),
-		);
 		const whois = await fetchWhoisRegistrar(domain, options.whoisBinding, callerSignal, deadlineMs);
+		const hasData = whoisHasRegistrationData(whois);
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'RDAP lookup failed',
+				'info',
+				hasData
+					? `RDAP lookup failed for ${domain}: ${message}; registration details sourced from WHOIS instead.`
+					: `RDAP lookup failed for ${domain}: ${message}`,
+				{
+					domain,
+					error: message,
+				},
+			),
+		);
 		findings.push(buildWhoisFallbackFinding(domain, whois, { source: 'lookup_failed', failureReason: reason }));
 		return buildCheckResult(CATEGORY, findings) as CheckResult;
 	}

--- a/test/check-rdap-whois-fallback.integration.test.ts
+++ b/test/check-rdap-whois-fallback.integration.test.ts
@@ -36,7 +36,18 @@ function mockIanaAndRdap(bootstrap: unknown, rdap?: unknown) {
 	}) as never;
 }
 
-function makeWhoisBinding(payload: { registrar: string | null; source: 'whois' | 'redacted' | 'notfound' | 'error' }) {
+interface WhoisPayload {
+	registrar: string | null;
+	registrarIanaId?: string | null;
+	creationDate?: string | null;
+	updatedDate?: string | null;
+	expiryDate?: string | null;
+	registrantOrg?: string | null;
+	registrantPrivacy?: boolean;
+	source: 'whois' | 'redacted' | 'notfound' | 'error';
+}
+
+function makeWhoisBinding(payload: WhoisPayload) {
 	return {
 		fetch: vi.fn(async () =>
 			new Response(JSON.stringify(payload), { status: 200, headers: { 'Content-Type': 'application/json' } }),
@@ -133,6 +144,64 @@ describe('checkRdapLookup WHOIS fallback', () => {
 		const reg = result.findings.find(f => f.metadata?.registrarSource === 'lookup_failed');
 		expect(reg, 'binding throw should yield lookup_failed').toBeDefined();
 		expect(reg!.metadata!.registrarFailureReason).toBe('whois_error');
+	});
+
+	it('surfaces WHOIS-sourced creation/updated/expiry dates + privacy when RDAP returns HTTP 530 (.co case)', async () => {
+		// Real production shape: rdap.nic.co returns 530; WHOIS carries the dates.
+		mockIanaAndRdap({ services: [[['co'], ['https://rdap.verisign.com/co/v1/']]] });
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === 'string' ? input : input.toString();
+			if (url.includes('data.iana.org')) {
+				return new Response(JSON.stringify({ services: [[['co'], ['https://rdap.nic.co/']]] }), { status: 200 });
+			}
+			// RDAP server 530s for .co.
+			return new Response('unavailable', { status: 530 });
+		}) as never;
+		const whoisBinding = makeWhoisBinding({
+			registrar: 'NameCheap, Inc.',
+			creationDate: '2025-12-29T20:37:51.0Z',
+			updatedDate: '2026-02-03T12:00:51.0Z',
+			expiryDate: '2026-12-29T23:59:59.0Z',
+			registrantOrg: 'Privacy service provided by Withheld for Privacy ehf',
+			registrantPrivacy: true,
+			source: 'whois',
+		});
+
+		const result = await (await freshChecker())('example.co', { whoisBinding });
+
+		const reg = result.findings.find(f => f.metadata?.registrarSource === 'whois');
+		expect(reg, 'a WHOIS-sourced Registration details finding should exist').toBeDefined();
+		expect(reg!.metadata!.creationDate).toBe('2025-12-29T20:37:51.000Z');
+		expect(reg!.metadata!.expirationDate).toBe('2026-12-29T23:59:59.000Z');
+		expect(reg!.metadata!.updatedDate).toBe('2026-02-03T12:00:51.000Z');
+		expect(reg!.metadata!.registrantPrivacy).toBe(true);
+		expect(reg!.metadata!.registrar).toBe('NameCheap, Inc.');
+		// The detail line presents the dates, not just the registrar.
+		expect(reg!.detail).toContain('Created: 2025-12-29');
+		expect(reg!.detail).toContain('Expires: 2026-12-29');
+		// The primary finding no longer asserts the data is unavailable.
+		const primary = result.findings.find(f => f.title === 'RDAP lookup failed');
+		expect(primary!.detail).not.toContain('Registration data unavailable');
+		expect(primary!.detail).toContain('sourced from WHOIS');
+	});
+
+	it('surfaces the WHOIS creation date when the TLD has no RDAP server (.nz case)', async () => {
+		mockIanaAndRdap(EMPTY_BOOTSTRAP);
+		const whoisBinding = makeWhoisBinding({
+			registrar: 'Example NZ Registrar Ltd',
+			creationDate: '2010-03-07T02:29:35Z',
+			source: 'whois',
+		});
+
+		const result = await (await freshChecker())('example.nz', { whoisBinding });
+
+		const reg = result.findings.find(f => f.metadata?.registrarSource === 'whois');
+		expect(reg!.metadata!.creationDate).toBe('2010-03-07T02:29:35.000Z');
+		expect(reg!.metadata!.registrar).toBe('Example NZ Registrar Ltd');
+		expect(reg!.detail).toContain('Created: 2010-03-07');
+		const primary = result.findings.find(f => f.title === 'No RDAP server found');
+		expect(primary!.detail).toContain('sourced from WHOIS');
+		expect(primary!.detail).not.toContain('RDAP data unavailable');
 	});
 
 	it('treats malformed shim payload as lookup_failed (Zod-validates the response shape)', async () => {


### PR DESCRIPTION
## The gap

\`rdap_lookup\`'s WHOIS fallback extracted **only the registrar**, silently dropping the creation / updated / expiry dates and registrant-privacy state that are present in the *same* WHOIS response. Those dates are the #1 OSINT pivot, so the tool was not wrong (registrar was correct) but **incomplete on exactly the fields that matter**, on any TLD where RDAP 530s or is absent.

## Two reproducible TLD cases (verified against live data)

1. **\`.co\` (RDAP 530):** \`rdap.nic.co\` returns HTTP 530. The tool reported \`RDAP server returned HTTP 530 ... Registration data unavailable\` + \`Registrar: NameCheap, Inc.\` only — while the WHOIS response (whois.registry.co → whois.namecheap.com) carried \`Creation Date: 2025-12-29T20:37:51.0Z\`, \`Updated Date: 2026-02-03T12:00:51.0Z\`, \`Registry Expiry Date: 2026-12-29T23:59:59.0Z\`, \`clientTransferProhibited\`, and a privacy-redacted \`Registrant Organization: Privacy service provided by Withheld for Privacy ehf\`.
2. **\`.nz\` (no RDAP for the TLD):** the tool reported \`No RDAP server found for TLD .nz\` + registrar only — while WHOIS carried \`Original Created: 2010-03-07T02:29:35Z\` + the registrar.

## The fix

- **\`packages/dns-checks/src/whois/parse.ts\`** — \`parseWhoisResponse\` now also extracts registration dates + registrant privacy. Label variants parsed:
  - **creation:** \`Creation Date\`, \`Created On\`, \`Created Date\`, \`Domain Registration Date\`, \`Original Created\` (.nz), \`Registered On\`, \`Created\`/\`created:\`, \`Registered\`
  - **updated:** \`Updated Date\`, \`Last Modified\`, \`Last Updated\`, \`Last Update\`, \`Updated On\`, \`Updated\`, \`changed:\`, \`modified\`
  - **expiry:** \`Registry Expiry Date\`, \`Registrar Registration Expiration Date\`, \`Expiration Date\`, \`Expiry Date\`, \`Expire Date\`, \`Expires On\`, \`Expires\`/\`expires:\`, \`paid-till\`
  - **registrant org:** \`Registrant Organization/Organisation/Org/Name/Registrant\`
  - **privacy boolean:** \`Redacted for Privacy\`, \`Withheld for Privacy\`, \`Privacy service\`, \`Data Protected\`
  - Line-anchored, case-insensitive, values capped to the tool's Zod field caps.
- **\`packages/bv-whois\`** (\`lookup.ts\` + \`app.ts\`) — the shim threads the new fields through \`WhoisLookupResult\` and the \`/lookup\` JSON response.
- **\`src/tools/check-rdap-lookup.ts\`** — \`WhoisFallbackPayload\` gains the (optional, back-compatible) fields; the \`Registration details\` fallback finding now surfaces \`Created / Updated / Expires / Registrant / Registrant privacy\` in both the finding **detail** and structured **metadata** (dates ISO-normalised where parseable, raw string otherwise). The raw-text fallback path now reuses the shared core parser for identical fidelity. The RDAP-530 / no-RDAP / fetch-error primary findings no longer assert \`Registration data unavailable\` when WHOIS answered — they now read \`... sourced from WHOIS instead\` and label the source \`whois\`.

## Fail-soft posture (preserved)

A missing field is simply absent (null / false) — never an error. The tool still succeeds and never throws, the existing registrar extraction + \`confidence: 'deterministic'\` posture are unchanged, and unparseable dates are kept raw. No change to scoring, tool **count**, tool schema/name.

## Red → green evidence

- New failing-first core tests in \`whois-parse.test.ts\` (the \`.co\` / \`.nz\` blobs, lowercase RIPE \`created:\`/\`expires:\`, privacy markers, fail-soft null case) — now green.
- New tool integration tests in \`check-rdap-whois-fallback.integration.test.ts\` for the \`.co\` (HTTP 530) and \`.nz\` (no-RDAP) cases assert the surfaced ISO dates + \`registrantPrivacy\` + reworded primary finding — now green.
- New \`lookupRegistrar\` dated-response test in the shim.
- Full local verification (in an isolated worktree): affected suites **106 passed**, \`npm run typecheck\` clean, \`npm run lint\` clean, \`tool-count-ssot\` + \`domain-required-ssot\` audits pass, full \`packages/dns-checks\` suite (455) + brand-audit-pipeline suites (93) green. No snapshot/tool-count audit needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)