### PR TITLE
chore: release 3.31.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.31.2] - 2026-07-20
+
+Patch release: **RDAP `rdap_lookup` WHOIS-fallback now surfaces registration dates + registrant privacy** (no new tools, schema, or API surface).
+
+### Fixed
+
+- `rdap_lookup` previously extracted only the registrar from the WHOIS fallback (used when RDAP returns HTTP 530 or the TLD has no RDAP server, e.g. `.co` / `.nz`), silently dropping the creation/updated/expiry dates and registrant-privacy state present in the same response. The WHOIS-fallback parser (`packages/dns-checks/src/whois/parse.ts`, threaded through the `bv-whois` shim and `check-rdap-lookup`) now parses Created/Updated/Expires across common label variants plus registrant org + privacy-redaction state, normalizes dates to ISO where parseable, and the RDAP-failure primary finding no longer reports "Registration data unavailable" when WHOIS answered. Fail-soft and deterministic. (#526)
+
 ## [3.31.1] - 2026-07-17
 
 Patch release: **unread-fetch-body and log-volume fixes** from a review of production Workers Observability logs/analytics (no new tools, schema, or API surface).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.31.1",
+	"version": "3.31.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.31.1",
+			"version": "3.31.2",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.31.1",
+	"version": "3.31.2",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.31.1",
+	"version": "3.31.2",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Version bump 3.31.1 → 3.31.2 for the RDAP whois-fallback fix (#526).

Syncs all version surfaces per the release runbook:
- `package.json` + `package-lock.json` (npm version)
- `server.json` top-level version (remotes-only)
- `CHANGELOG.md` [3.31.2] heading

`SERVER_VERSION` auto-derives from package.json — not hand-edited.

Next steps after merge: tag `v3.31.2` on merged main → publish.yml (GH Release; npm gated-off, registry skipped) → `npm run deploy:prod` → verify prod serverInfo.version → `mcp-publisher publish` LAST (deploy-before-registry ordering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)