### PR TITLE
fix(analytics): query AE by dataset name, not binding name (relight alerts + admin geo panel)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,15 @@ type BvMcpEnv = {
 	 */
 	PROFILE_ACCUMULATOR_SHARDING?: string;
 	MCP_ANALYTICS?: AnalyticsEngineDataset;
+	/**
+	 * Optional override for the Analytics Engine DATASET name that the alerting cron
+	 * and `/internal/analytics/*` reads query FROM. Defaults in code to
+	 * `bv_dns_security_mcp` (the dataset the `MCP_ANALYTICS` binding writes to in prod)
+	 * via `resolveAnalyticsDataset` in `lib/analytics-queries.ts`. This is the AE
+	 * DATASET name, NOT the Worker binding name (`MCP_ANALYTICS`) — querying the
+	 * binding name returns 0 rows.
+	 */
+	ANALYTICS_DATASET?: string;
 	BV_API_KEY?: string;
 	/** Comma-separated IP allowlist for owner tier. When set, an owner-tier credential (static `BV_API_KEY` or owner JWT) from a non-listed client IP is downgraded to `partner` (`applyOwnerIpGate` in `lib/tier-auth.ts`). Unset/empty → owner unrestricted (self-hosted/dev). */
 	OWNER_ALLOW_IPS?: string;

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -72,6 +72,7 @@ import {
 	queryKeyUsage,
 	queryTierDigest,
 	queryGeoRollup,
+	resolveAnalyticsDataset,
 } from './lib/analytics-queries';
 
 type InternalEnv = {
@@ -82,6 +83,12 @@ type InternalEnv = {
 	/** R10 - ProfileAccumulator write-sharding mode (default-off). See BvMcpEnv in index.ts. */
 	PROFILE_ACCUMULATOR_SHARDING?: string;
 	MCP_ANALYTICS?: AnalyticsEngineDataset;
+	/**
+	 * Optional AE DATASET-name override for the `/internal/analytics/*` read queries.
+	 * Defaults in code to `bv_dns_security_mcp` (the dataset the `MCP_ANALYTICS`
+	 * binding writes to) via `resolveAnalyticsDataset`. NOT the Worker binding name.
+	 */
+	ANALYTICS_DATASET?: string;
 	PROVIDER_SIGNATURES_URL?: string;
 	PROVIDER_SIGNATURES_ALLOWED_HOSTS?: string;
 	PROVIDER_SIGNATURES_SHA256?: string;
@@ -779,10 +786,10 @@ internalRoutes.get('/trial-keys', async (c) => {
 
 // ─── Analytics Endpoints ───────────────────────────────────────────────
 
-/** Validate analytics prerequisites (CF_ACCOUNT_ID + CF_ANALYTICS_TOKEN). */
-function requireAnalyticsConfig(env: InternalEnv): { accountId: string; token: string } | null {
+/** Validate analytics prerequisites (CF_ACCOUNT_ID + CF_ANALYTICS_TOKEN) + resolve the AE dataset name. */
+function requireAnalyticsConfig(env: InternalEnv): { accountId: string; token: string; dataset: string } | null {
 	if (!env.CF_ACCOUNT_ID || !env.CF_ANALYTICS_TOKEN) return null;
-	return { accountId: env.CF_ACCOUNT_ID, token: env.CF_ANALYTICS_TOKEN };
+	return { accountId: env.CF_ACCOUNT_ID, token: env.CF_ANALYTICS_TOKEN, dataset: resolveAnalyticsDataset(env.ANALYTICS_DATASET) };
 }
 
 /** Parse and clamp the `days` query parameter (1–90, default 7). */
@@ -814,14 +821,14 @@ internalRoutes.get('/analytics/tier-summary', async (c) => {
 
 	try {
 		const [usage, latency, errors, cache, rateLimits, sessions, trend, topTools] = await Promise.all([
-			queryAnalyticsEngine(config.accountId, config.token, queryTierToolUsage(days, tier)),
-			queryAnalyticsEngine(config.accountId, config.token, queryTierLatency(days, tier)),
-			queryAnalyticsEngine(config.accountId, config.token, queryTierErrorRate(days, tier)),
-			queryAnalyticsEngine(config.accountId, config.token, queryTierCachePerformance(days, tier)),
-			queryAnalyticsEngine(config.accountId, config.token, queryTierRateLimits(days, tier)),
-			queryAnalyticsEngine(config.accountId, config.token, queryTierSessions(days, tier)),
-			queryAnalyticsEngine(config.accountId, config.token, queryTierDailyTrend(days, tier)),
-			queryAnalyticsEngine(config.accountId, config.token, queryTierTopTools(hours)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierToolUsage(days, tier, config.dataset)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierLatency(days, tier, config.dataset)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierErrorRate(days, tier, config.dataset)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierCachePerformance(days, tier, config.dataset)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierRateLimits(days, tier, config.dataset)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierSessions(days, tier, config.dataset)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierDailyTrend(days, tier, config.dataset)),
+			queryAnalyticsEngine(config.accountId, config.token, queryTierTopTools(hours, config.dataset)),
 		]);
 
 		return c.json({
@@ -860,7 +867,7 @@ internalRoutes.get('/analytics/key-usage', async (c) => {
 	const keyHashPrefix = url.searchParams.get('key_hash') ?? undefined;
 
 	try {
-		const rows = await queryAnalyticsEngine(config.accountId, config.token, queryKeyUsage(days, keyHashPrefix));
+		const rows = await queryAnalyticsEngine(config.accountId, config.token, queryKeyUsage(days, keyHashPrefix, config.dataset));
 		return c.json({ days, keyHash: keyHashPrefix ?? 'all', usage: rows });
 	} catch (err) {
 		return c.json({ error: 'Analytics query failed', detail: err instanceof Error ? err.message.slice(0, 100) : 'unknown' }, 502);
@@ -926,7 +933,7 @@ internalRoutes.get('/analytics/digest', async (c) => {
 	const hours = String(Number(days) * 24);
 
 	try {
-		const rows = await queryAnalyticsEngine(config.accountId, config.token, queryTierDigest(hours));
+		const rows = await queryAnalyticsEngine(config.accountId, config.token, queryTierDigest(hours, config.dataset));
 		return c.json({ days, tiers: rows });
 	} catch (err) {
 		return c.json({ error: 'Analytics query failed', detail: err instanceof Error ? err.message.slice(0, 100) : 'unknown' }, 502);
@@ -945,7 +952,7 @@ internalRoutes.get('/analytics/geo', async (c) => {
 	}
 	const days = parseDays(new URL(c.req.url));
 	try {
-		const rows = await queryAnalyticsEngine(config.accountId, config.token, queryGeoRollup(days));
+		const rows = await queryAnalyticsEngine(config.accountId, config.token, queryGeoRollup(days, config.dataset));
 		return c.json({ days, geo: rows });
 	} catch (err) {
 		return c.json({ error: 'Geo query failed', detail: err instanceof Error ? err.message.slice(0, 100) : 'unknown' }, 502);

--- a/src/lib/analytics-queries.ts
+++ b/src/lib/analytics-queries.ts
@@ -4,7 +4,16 @@
  * Pre-built SQL queries for Cloudflare Analytics Engine.
  *
  * Returns query strings for the Analytics Engine SQL API.
- * Dataset name is always MCP_ANALYTICS.
+ *
+ * IMPORTANT — dataset vs binding name: AE's SQL API queries by DATASET name, NOT
+ * by Worker binding name. The binding `MCP_ANALYTICS` maps to the dataset
+ * `bv_dns_security_mcp` in prod (and `bv_mcp_usage_reporting` locally). Querying
+ * `FROM MCP_ANALYTICS` (the binding name) silently returns 0 rows. The dataset is
+ * therefore injected per-call (defaulting to {@link DEFAULT_ANALYTICS_DATASET}) and
+ * validated against `/^[a-z0-9_]+$/` before interpolation. Override via the
+ * `ANALYTICS_DATASET` env var, threaded from the query call sites the same way
+ * `CF_ACCOUNT_ID` / `CF_ANALYTICS_TOKEN` are.
+ *
  * Callers must account for _sample_interval in aggregations.
  *
  * Blob positions (mcp_request): blob1=method, blob2=transport, blob3=status,
@@ -19,7 +28,22 @@
  * Blob positions (session): blob1=action, blob2=country, blob3=clientType, blob4=tier
  */
 
-const DS = 'MCP_ANALYTICS';
+/**
+ * Default Analytics Engine DATASET name (not the Worker binding name). This is the
+ * prod dataset the `MCP_ANALYTICS` binding writes to; using it as the in-code default
+ * means prod works with zero config. Overridable per-deploy via `ANALYTICS_DATASET`.
+ */
+export const DEFAULT_ANALYTICS_DATASET = 'bv_dns_security_mcp';
+
+/**
+ * Resolve + validate a dataset name for safe SQL interpolation. Since the name can
+ * now come from env, it is validated against `/^[a-z0-9_]+$/` (defense-in-depth) and
+ * any empty/invalid value falls back to {@link DEFAULT_ANALYTICS_DATASET}. Idempotent,
+ * so call sites and the builders can both apply it.
+ */
+export function resolveAnalyticsDataset(name: string | undefined): string {
+	return name && /^[a-z0-9_]+$/.test(name) ? name : DEFAULT_ANALYTICS_DATASET;
+}
 
 /** Sanitize interval parameter to prevent SQL injection. */
 function safeInterval(value: string): string {
@@ -28,13 +52,13 @@ function safeInterval(value: string): string {
 }
 
 /** Unique sessions (by hashed session ID) in the given interval. */
-export function queryDailyActiveUsers(days: string): string {
+export function queryDailyActiveUsers(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   toStartOfDay(timestamp) AS day,
   COUNT(DISTINCT blob9) AS unique_sessions,
   SUM(_sample_interval) AS total_requests
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'mcp_request'
   AND blob9 != 'none'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
@@ -43,14 +67,14 @@ ORDER BY day DESC`;
 }
 
 /** Tool call counts ranked by popularity. */
-export function queryToolPopularity(days: string): string {
+export function queryToolPopularity(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob1 AS tool_name,
   SUM(_sample_interval) AS call_count,
   SUM(CASE WHEN blob2 = 'pass' THEN _sample_interval ELSE 0 END) AS pass_count,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) AS error_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY tool_name
@@ -58,14 +82,14 @@ ORDER BY call_count DESC`;
 }
 
 /** Error rate per tool over the given interval. */
-export function queryErrorRate(days: string): string {
+export function queryErrorRate(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob1 AS tool_name,
   SUM(_sample_interval) AS total,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) AS errors,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) * 100.0 / SUM(_sample_interval) AS error_pct
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY tool_name
@@ -74,7 +98,7 @@ ORDER BY error_pct DESC`;
 }
 
 /** Latency percentiles per tool. */
-export function queryLatencyPercentiles(days: string): string {
+export function queryLatencyPercentiles(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob1 AS tool_name,
@@ -82,7 +106,7 @@ export function queryLatencyPercentiles(days: string): string {
   quantileExactWeighted(0.50)(double1, _sample_interval) AS p50_ms,
   quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms,
   quantileExactWeighted(0.99)(double1, _sample_interval) AS p99_ms
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY tool_name
@@ -90,13 +114,13 @@ ORDER BY call_count DESC`;
 }
 
 /** Request breakdown by MCP client type. */
-export function queryClientBreakdown(days: string): string {
+export function queryClientBreakdown(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob7 AS client_type,
   SUM(_sample_interval) AS request_count,
   COUNT(DISTINCT blob9) AS unique_sessions
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'mcp_request'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY client_type
@@ -104,13 +128,13 @@ ORDER BY request_count DESC`;
 }
 
 /** Geographic distribution by country. */
-export function queryGeoDistribution(days: string): string {
+export function queryGeoDistribution(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob6 AS country,
   SUM(_sample_interval) AS request_count,
   COUNT(DISTINCT blob9) AS unique_sessions
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'mcp_request'
   AND blob6 != 'unknown'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
@@ -125,7 +149,7 @@ LIMIT 30`;
  * blob13=region, blob14=city, blob15=asn — see analytics.ts), so positions
  * 1–12 are untouched. Sampled: sums `_sample_interval`.
  */
-export function queryGeoRollup(days: string): string {
+export function queryGeoRollup(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob5 AS country,
@@ -133,7 +157,7 @@ export function queryGeoRollup(days: string): string {
   blob14 AS city,
   blob15 AS asn,
   SUM(_sample_interval) AS calls
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY country, region, city, asn
@@ -142,13 +166,13 @@ LIMIT 1000`;
 }
 
 /** Rate limit hit counts by type. */
-export function queryRateLimitHits(days: string): string {
+export function queryRateLimitHits(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob1 AS limit_type,
   blob2 AS tool_name,
   SUM(_sample_interval) AS hit_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'rate_limit'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY limit_type, tool_name
@@ -156,12 +180,12 @@ ORDER BY hit_count DESC`;
 }
 
 /** Auth tier distribution. */
-export function queryTierBreakdown(days: string): string {
+export function queryTierBreakdown(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob8 AS tier,
   SUM(_sample_interval) AS request_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'mcp_request'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY tier
@@ -169,7 +193,7 @@ ORDER BY request_count DESC`;
 }
 
 /** Anomaly detection query for alerting. Returns error rate and p95 latency for the last N minutes. */
-export function queryRecentAnomalies(minutes: string): string {
+export function queryRecentAnomalies(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	return `SELECT
   SUM(_sample_interval) AS total_calls,
@@ -177,7 +201,7 @@ export function queryRecentAnomalies(minutes: string): string {
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) * 100.0
     / GREATEST(SUM(_sample_interval), 1) AS error_pct,
   quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE`;
 }
@@ -190,7 +214,7 @@ WHERE index1 = 'tool_call'
  * `HAVING total_calls > 0` drops empty colos. Excludes the `'unknown'` colo
  * (off-CF / local) so it doesn't pollute the per-datacenter view.
  */
-export function queryRecentAnomaliesByColo(minutes: string): string {
+export function queryRecentAnomaliesByColo(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	return `SELECT
   blob11 AS colo,
@@ -199,7 +223,7 @@ export function queryRecentAnomaliesByColo(minutes: string): string {
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) * 100.0
     / GREATEST(SUM(_sample_interval), 1) AS error_pct,
   quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND blob11 != 'unknown'
   AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE
@@ -209,11 +233,11 @@ ORDER BY p95_ms DESC`;
 }
 
 /** Rate limit surge detection for alerting. */
-export function queryRateLimitSurge(minutes: string): string {
+export function queryRateLimitSurge(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	return `SELECT
   SUM(_sample_interval) AS total_hits
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'rate_limit'
   AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE`;
 }
@@ -236,13 +260,13 @@ WHERE index1 = 'rate_limit'
  *
  * Blob positions (degradation): blob1=degradationType, blob2=component.
  */
-export function queryBindingDegradation(minutes: string): string {
+export function queryBindingDegradation(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	return `SELECT
   blob2 AS component,
   blob1 AS degradation_type,
   SUM(_sample_interval) AS event_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'degradation'
   AND blob1 != 'kv_fallback'
   AND blob1 != 'quota_coordinator_fallback'
@@ -263,7 +287,7 @@ ORDER BY event_count DESC`;
  *
  * Blob positions (quota_shard): blob1=shardIndex, blob2=country, blob3=tier.
  */
-export function queryQuotaShardSkew(minutes: string): string {
+export function queryQuotaShardSkew(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	return `SELECT
   max(shard_load) AS max_shard_load,
@@ -274,7 +298,7 @@ FROM (
   SELECT
     blob1 AS shard,
     SUM(_sample_interval) AS shard_load
-  FROM ${DS}
+  FROM ${resolveAnalyticsDataset(dataset)}
   WHERE index1 = 'quota_shard'
     AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE
   GROUP BY shard
@@ -292,14 +316,14 @@ FROM (
  * Blob positions (queue_batch): blob1=handler, blob2=outcome. Doubles:
  *   double1=durationMs, double2=failureCount, double3=messageCount.
  */
-export function queryQueueFailures(minutes: string): string {
+export function queryQueueFailures(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	return `SELECT
   blob1 AS handler,
   SUM(_sample_interval) AS batch_count,
   SUM(CASE WHEN blob2 = 'error' THEN _sample_interval ELSE 0 END) AS error_batch_count,
   SUM(double2 * _sample_interval) AS failure_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'queue_batch'
   AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE
 GROUP BY handler
@@ -308,7 +332,7 @@ ORDER BY failure_count DESC`;
 }
 
 /** Fatal Worker exception detection from Tail Worker exports. */
-export function queryTailExceptions(minutes: string): string {
+export function queryTailExceptions(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	// emitTailAggregate (analytics.ts) writes blob1=colo, blob2=outcome,
 	// double1=invocations in the bucket. Fatal invocations are the ones in
@@ -316,7 +340,7 @@ export function queryTailExceptions(minutes: string): string {
 	// sampled-correct invocation count (mirrors queryQueueFailures above).
 	return `SELECT
   SUM(double1 * _sample_interval) AS exception_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tail'
   AND blob2 = 'exception'
   AND timestamp > NOW() - INTERVAL '${minutes}' MINUTE`;
@@ -350,7 +374,7 @@ function tierGroupBy(tier: string | undefined, alias: string): string {
 }
 
 /** Tool popularity breakdown per tier. Which tools does each tier use most? */
-export function queryTierToolUsage(days: string, tier?: string): string {
+export function queryTierToolUsage(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob7 AS tier,'}
@@ -358,7 +382,7 @@ export function queryTierToolUsage(days: string, tier?: string): string {
   SUM(_sample_interval) AS call_count,
   SUM(CASE WHEN blob2 = 'pass' THEN _sample_interval ELSE 0 END) AS pass_count,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) AS error_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'${tierClause(tier, 'blob7')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY ${tier ? 'tool_name' : 'tier, tool_name'}
@@ -366,7 +390,7 @@ ORDER BY ${tier ? 'call_count DESC' : 'tier, call_count DESC'}`;
 }
 
 /** P50/P95/P99 latency per tier. */
-export function queryTierLatency(days: string, tier?: string): string {
+export function queryTierLatency(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob7 AS tier,'}
@@ -374,14 +398,14 @@ export function queryTierLatency(days: string, tier?: string): string {
   quantileExactWeighted(0.50)(double1, _sample_interval) AS p50_ms,
   quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms,
   quantileExactWeighted(0.99)(double1, _sample_interval) AS p99_ms
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'${tierClause(tier, 'blob7')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY${tierGroupBy(tier, 'tier')}
 ORDER BY ${tier ? 'call_count DESC' : 'tier'}`;
 }
 
 /** Error rate per tier. */
-export function queryTierErrorRate(days: string, tier?: string): string {
+export function queryTierErrorRate(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob7 AS tier,'}
@@ -389,7 +413,7 @@ export function queryTierErrorRate(days: string, tier?: string): string {
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) AS errors,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) * 100.0
     / GREATEST(SUM(_sample_interval), 1) AS error_pct
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'${tierClause(tier, 'blob7')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY${tierGroupBy(tier, 'tier')}
 HAVING total > 0
@@ -397,13 +421,13 @@ ORDER BY ${tier ? 'error_pct DESC' : 'tier'}`;
 }
 
 /** Cache hit/miss ratio per tier. */
-export function queryTierCachePerformance(days: string, tier?: string): string {
+export function queryTierCachePerformance(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob7 AS tier,'}
   blob8 AS cache_status,
   SUM(_sample_interval) AS call_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND blob8 != 'n/a'${tierClause(tier, 'blob7')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY
@@ -412,14 +436,14 @@ ORDER BY ${tier ? 'call_count DESC' : 'tier, call_count DESC'}`;
 }
 
 /** Rate limit hits per tier. */
-export function queryTierRateLimits(days: string, tier?: string): string {
+export function queryTierRateLimits(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob4 AS tier,'}
   blob1 AS limit_type,
   blob2 AS tool_name,
   SUM(_sample_interval) AS hit_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'rate_limit'${tierClause(tier, 'blob4')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY ${tier ? 'limit_type, tool_name' : 'tier, limit_type, tool_name'}
@@ -427,13 +451,13 @@ ORDER BY ${tier ? 'hit_count DESC' : 'tier, hit_count DESC'}`;
 }
 
 /** Session creation/termination per tier. */
-export function queryTierSessions(days: string, tier?: string): string {
+export function queryTierSessions(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob4 AS tier,'}
   blob1 AS action,
   SUM(_sample_interval) AS event_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'session'${tierClause(tier, 'blob4')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY ${tier ? 'action' : 'tier, action'}
@@ -441,13 +465,13 @@ ORDER BY ${tier ? 'event_count DESC' : 'tier, event_count DESC'}`;
 }
 
 /** Unique domains scanned per tier. */
-export function queryTierDomainDiversity(days: string, tier?: string): string {
+export function queryTierDomainDiversity(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob7 AS tier,'}
   COUNT(DISTINCT blob4) AS unique_domains,
   SUM(_sample_interval) AS total_calls
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND blob4 != 'none'${tierClause(tier, 'blob7')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY${tierGroupBy(tier, 'tier')}
@@ -455,7 +479,7 @@ ORDER BY ${tier ? 'total_calls DESC' : 'tier'}`;
 }
 
 /** Scan score distribution per tier (average, min, max). */
-export function queryTierScoreDistribution(days: string, tier?: string): string {
+export function queryTierScoreDistribution(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob7 AS tier,'}
@@ -464,7 +488,7 @@ export function queryTierScoreDistribution(days: string, tier?: string): string 
   min(double2) AS min_score,
   max(double2) AS max_score,
   quantileExactWeighted(0.50)(double2, _sample_interval) AS median_score
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND blob1 = 'scan_domain'
   AND double2 > 0${tierClause(tier, 'blob7')}
@@ -473,14 +497,14 @@ ORDER BY ${tier ? 'scan_count DESC' : 'tier'}`;
 }
 
 /** Daily request volume trended over time, per tier. */
-export function queryTierDailyTrend(days: string, tier?: string): string {
+export function queryTierDailyTrend(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT
   toStartOfDay(timestamp) AS day,${tier ? '' : '\n  blob8 AS tier,'}
   SUM(_sample_interval) AS request_count,
   COUNT(DISTINCT blob9) AS unique_sessions
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'mcp_request'${tierClause(tier, 'blob8')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY ${tier ? 'day' : 'day, tier'}
@@ -488,14 +512,14 @@ ORDER BY day DESC${tier ? '' : ', tier'}`;
 }
 
 /** MCP client type distribution per tier. */
-export function queryTierClientTypes(days: string, tier?: string): string {
+export function queryTierClientTypes(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob8 AS tier,'}
   blob7 AS client_type,
   SUM(_sample_interval) AS request_count,
   COUNT(DISTINCT blob9) AS unique_sessions
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'mcp_request'${tierClause(tier, 'blob8')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY ${tier ? 'client_type' : 'tier, client_type'}
@@ -503,7 +527,7 @@ ORDER BY ${tier ? 'request_count DESC' : 'tier, request_count DESC'}`;
 }
 
 /** Per-API-key usage breakdown. Requires keyHash blob (blob9 in tool_call). */
-export function queryKeyUsage(days: string, keyHash?: string): string {
+export function queryKeyUsage(days: string, keyHash?: string, dataset?: string): string {
 	days = safeInterval(days);
 	const keyFilter = keyHash ? `\n  AND blob9 = '${safeTier(keyHash) ?? 'none'}'` : `\n  AND blob9 != 'none'`;
 	return `SELECT
@@ -514,7 +538,7 @@ export function queryKeyUsage(days: string, keyHash?: string): string {
   COUNT(DISTINCT blob4) AS unique_domains,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) AS error_count,
   quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'${keyFilter}
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY key_hash, tier
@@ -523,7 +547,7 @@ LIMIT 50`;
 }
 
 /** Daily tier usage digest — all tiers in one query, aggregated for the past N hours. */
-export function queryTierDigest(hours: string): string {
+export function queryTierDigest(hours: string, dataset?: string): string {
 	hours = safeInterval(hours);
 	return `SELECT
   blob7 AS tier,
@@ -536,7 +560,7 @@ export function queryTierDigest(hours: string): string {
   quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms,
   SUM(CASE WHEN blob8 = 'hit' THEN _sample_interval ELSE 0 END) AS cache_hits,
   SUM(CASE WHEN blob8 = 'miss' THEN _sample_interval ELSE 0 END) AS cache_misses
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${hours}' HOUR
 GROUP BY tier
@@ -544,13 +568,13 @@ ORDER BY total_calls DESC`;
 }
 
 /** Top tools per tier for digest. */
-export function queryTierTopTools(hours: string): string {
+export function queryTierTopTools(hours: string, dataset?: string): string {
 	hours = safeInterval(hours);
 	return `SELECT
   blob7 AS tier,
   blob1 AS tool_name,
   SUM(_sample_interval) AS call_count
-FROM ${DS}
+FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${hours}' HOUR
 GROUP BY tier, tool_name

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -18,6 +18,7 @@ import {
 	queryBindingDegradation,
 	queryQueueFailures,
 	queryTailExceptions,
+	resolveAnalyticsDataset,
 } from './lib/analytics-queries';
 import { buildAlertPayload, buildDigestPayload, sendAlert } from './lib/alerting';
 import { queryAnalyticsEngine } from './lib/analytics-engine';
@@ -61,6 +62,14 @@ interface TailExceptionRow {
 export interface ScheduledEnv {
 	CF_ACCOUNT_ID?: string;
 	CF_ANALYTICS_TOKEN?: string;
+	/**
+	 * Optional override for the Analytics Engine DATASET name the alert queries read
+	 * FROM. Defaults in code to `bv_dns_security_mcp` (the prod dataset the
+	 * `MCP_ANALYTICS` binding writes to) — see `resolveAnalyticsDataset`. Set only if a
+	 * deploy writes telemetry to a differently-named dataset (e.g. local
+	 * `bv_mcp_usage_reporting`). NOT the Worker binding name.
+	 */
+	ANALYTICS_DATASET?: string;
 	ALERT_WEBHOOK_URL?: string;
 	ALERT_ERROR_THRESHOLD?: string;
 	ALERT_P95_THRESHOLD?: string;
@@ -310,6 +319,11 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 	if (!webhookUrl) return;
 	if (!env.CF_ACCOUNT_ID || !env.CF_ANALYTICS_TOKEN) return;
 
+	// Resolve the AE DATASET name once (defaults to bv_dns_security_mcp — the prod
+	// dataset the MCP_ANALYTICS binding writes to; NOT the binding name). Threaded
+	// into every query builder below the same way accountId/token are.
+	const dataset = resolveAnalyticsDataset(env.ANALYTICS_DATASET);
+
 	const parsedError = parseFloat(env.ALERT_ERROR_THRESHOLD ?? '');
 	const errorThreshold = Number.isFinite(parsedError) ? parsedError : DEFAULT_ERROR_THRESHOLD;
 	const parsedP95 = parseFloat(env.ALERT_P95_THRESHOLD ?? '');
@@ -330,9 +344,30 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		const anomalyRows = (await queryAnalyticsEngine(
 			env.CF_ACCOUNT_ID,
 			env.CF_ANALYTICS_TOKEN,
-			queryRecentAnomalies(lookback),
+			queryRecentAnomalies(lookback, dataset),
 		)) as AnomalyRow[];
 		const anomaly = anomalyRows[0];
+
+		// Reader-blind self-check (log-only, non-paging). For a live service that
+		// receives traffic, an anomaly query returning ZERO tool_call rows over the
+		// lookback window almost always means the reader is querying the wrong/empty
+		// AE dataset (the exact failure this fix addresses — binding name vs dataset
+		// name) rather than a genuine traffic lull. We only LOG (never sendAlert) so a
+		// genuinely idle self-host that opted into analytics can't be paged — the line
+		// is greppable in tail/logpush where the misconfig is diagnosable.
+		if (!anomaly || !anomaly.total_calls || anomaly.total_calls <= 0) {
+			logEvent({
+				timestamp: new Date().toISOString(),
+				category: 'scheduled',
+				result: 'ok',
+				severity: 'warn',
+				details: {
+					message: 'Analytics reader saw 0 tool_call rows over the lookback window — if this service is receiving traffic, the AE reader may be querying the wrong/empty dataset (check ANALYTICS_DATASET vs the MCP_ANALYTICS binding dataset).',
+					dataset,
+					lookbackMinutes: lookback,
+				},
+			});
+		}
 
 		if (anomaly && anomaly.total_calls && anomaly.total_calls > 0) {
 			const errorPct = anomaly.error_pct ?? 0;
@@ -375,7 +410,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		const rateLimitRows = (await queryAnalyticsEngine(
 			env.CF_ACCOUNT_ID,
 			env.CF_ANALYTICS_TOKEN,
-			queryRateLimitSurge(lookback),
+			queryRateLimitSurge(lookback, dataset),
 		)) as RateLimitRow[];
 		const rateLimitData = rateLimitRows[0];
 
@@ -399,7 +434,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		const degradationRows = (await queryAnalyticsEngine(
 			env.CF_ACCOUNT_ID,
 			env.CF_ANALYTICS_TOKEN,
-			queryBindingDegradation(lookback),
+			queryBindingDegradation(lookback, dataset),
 		)) as BindingDegradationRow[];
 		const totalDegradations = degradationRows.reduce((sum, r) => sum + (r.event_count ?? 0), 0);
 
@@ -434,7 +469,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		const queueFailureRows = (await queryAnalyticsEngine(
 			env.CF_ACCOUNT_ID,
 			env.CF_ANALYTICS_TOKEN,
-			queryQueueFailures(lookback),
+			queryQueueFailures(lookback, dataset),
 		)) as QueueFailureRow[];
 		const totalQueueFailures = queueFailureRows.reduce((sum, r) => sum + (r.failure_count ?? 0), 0);
 		const totalErrorBatches = queueFailureRows.reduce((sum, r) => sum + (r.error_batch_count ?? 0), 0);
@@ -462,7 +497,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		const tailExceptionRows = (await queryAnalyticsEngine(
 			env.CF_ACCOUNT_ID,
 			env.CF_ANALYTICS_TOKEN,
-			queryTailExceptions(lookback),
+			queryTailExceptions(lookback, dataset),
 		)) as TailExceptionRow[];
 		const tailExceptionCount = tailExceptionRows[0]?.exception_count ?? 0;
 
@@ -673,7 +708,11 @@ export async function handleDailyDigest(env: ScheduledEnv): Promise<void> {
 	if (!env.CF_ACCOUNT_ID || !env.CF_ANALYTICS_TOKEN) return;
 
 	try {
-		const rows = await queryAnalyticsEngine(env.CF_ACCOUNT_ID, env.CF_ANALYTICS_TOKEN, queryTierDigest('1'));
+		const rows = await queryAnalyticsEngine(
+			env.CF_ACCOUNT_ID,
+			env.CF_ANALYTICS_TOKEN,
+			queryTierDigest('1', resolveAnalyticsDataset(env.ANALYTICS_DATASET)),
+		);
 		const payload = buildDigestPayload(rows, 1);
 		await sendAlert(digestWebhookUrl, payload);
 

--- a/src/tenants/queue-consumer.ts
+++ b/src/tenants/queue-consumer.ts
@@ -107,6 +107,8 @@ export type ScanQueueConsumerEnv = ResolverEnv & {
 	/** R10 - ProfileAccumulator write-sharding mode (default-off). See BvMcpEnv in index.ts. */
 	PROFILE_ACCUMULATOR_SHARDING?: string;
 	MCP_ANALYTICS?: AnalyticsEngineDataset;
+	/** Optional AE dataset-name override; defaults to `bv_dns_security_mcp` (see `resolveAnalyticsDataset`). NOT the binding name. */
+	ANALYTICS_DATASET?: string;
 	PROVIDER_SIGNATURES_URL?: string;
 	PROVIDER_SIGNATURES_ALLOWED_HOSTS?: string;
 	PROVIDER_SIGNATURES_SHA256?: string;

--- a/src/tenants/routes.ts
+++ b/src/tenants/routes.ts
@@ -58,6 +58,8 @@ type TenantEnv = ResolverEnv & {
 	/** R10 - ProfileAccumulator write-sharding mode (default-off). See BvMcpEnv in index.ts. */
 	PROFILE_ACCUMULATOR_SHARDING?: string;
 	MCP_ANALYTICS?: AnalyticsEngineDataset;
+	/** Optional AE dataset-name override; defaults to `bv_dns_security_mcp` (see `resolveAnalyticsDataset`). NOT the binding name. */
+	ANALYTICS_DATASET?: string;
 	PROVIDER_SIGNATURES_URL?: string;
 	PROVIDER_SIGNATURES_ALLOWED_HOSTS?: string;
 	PROVIDER_SIGNATURES_SHA256?: string;

--- a/test/analytics-queries.spec.ts
+++ b/test/analytics-queries.spec.ts
@@ -27,9 +27,11 @@ import {
 } from '../src/lib/analytics-queries';
 
 describe('analytics query builders', () => {
-	it('queryDailyActiveUsers returns valid SQL referencing MCP_ANALYTICS', () => {
+	it('queryDailyActiveUsers returns valid SQL referencing the AE dataset (not the binding name)', () => {
 		const sql = queryDailyActiveUsers('1');
-		expect(sql).toContain('MCP_ANALYTICS');
+		// AE queries by DATASET name; the binding name MCP_ANALYTICS returns 0 rows.
+		expect(sql).toContain('FROM bv_dns_security_mcp');
+		expect(sql).not.toContain('MCP_ANALYTICS');
 		expect(sql).toContain('blob9'); // session hash
 		expect(sql).toContain('SUM(_sample_interval)');
 		expect(sql).toContain("INTERVAL '1' DAY");

--- a/test/audits/analytics-dataset-name.audit.test.ts
+++ b/test/audits/analytics-dataset-name.audit.test.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Regression guard: the Analytics Engine query builders must target the DATASET
+ * name (`bv_dns_security_mcp`), never the Worker BINDING name (`MCP_ANALYTICS`).
+ *
+ * Background (empirically confirmed against the live account): AE's SQL API
+ * queries by dataset name, not by Worker binding name. The binding `MCP_ANALYTICS`
+ * maps to `dataset: "bv_dns_security_mcp"` in prod. A query of `FROM MCP_ANALYTICS`
+ * returns 0 rows silently — which made every cron alert and `/internal/analytics/*`
+ * endpoint blind. This test locks out a regression to the binding-name literal.
+ *
+ * CI-safe: the prod dataset name lives in a GITIGNORED wrangler overlay that is
+ * ABSENT in CI, so we assert against the in-code DEFAULT, not any wrangler file.
+ */
+
+import { describe, it, expect } from 'vitest';
+import * as Q from '../../src/lib/analytics-queries';
+import { DEFAULT_ANALYTICS_DATASET, resolveAnalyticsDataset } from '../../src/lib/analytics-queries';
+
+describe('analytics dataset name (regression guard)', () => {
+	it('default dataset constant is the AE dataset name, not the binding name', () => {
+		expect(DEFAULT_ANALYTICS_DATASET).toBe('bv_dns_security_mcp');
+		expect(DEFAULT_ANALYTICS_DATASET).not.toBe('MCP_ANALYTICS');
+	});
+
+	// Every query builder: calling with just the time window must produce SQL that
+	// reads FROM the dataset name and NEVER the binding name.
+	const builders: Array<[string, () => string]> = [
+		['queryDailyActiveUsers', () => Q.queryDailyActiveUsers('1')],
+		['queryToolPopularity', () => Q.queryToolPopularity('1')],
+		['queryErrorRate', () => Q.queryErrorRate('1')],
+		['queryLatencyPercentiles', () => Q.queryLatencyPercentiles('1')],
+		['queryClientBreakdown', () => Q.queryClientBreakdown('1')],
+		['queryGeoDistribution', () => Q.queryGeoDistribution('1')],
+		['queryGeoRollup', () => Q.queryGeoRollup('1')],
+		['queryRateLimitHits', () => Q.queryRateLimitHits('1')],
+		['queryTierBreakdown', () => Q.queryTierBreakdown('1')],
+		['queryRecentAnomalies', () => Q.queryRecentAnomalies('15')],
+		['queryRecentAnomaliesByColo', () => Q.queryRecentAnomaliesByColo('15')],
+		['queryRateLimitSurge', () => Q.queryRateLimitSurge('15')],
+		['queryBindingDegradation', () => Q.queryBindingDegradation('15')],
+		['queryQuotaShardSkew', () => Q.queryQuotaShardSkew('15')],
+		['queryQueueFailures', () => Q.queryQueueFailures('15')],
+		['queryTailExceptions', () => Q.queryTailExceptions('15')],
+		['queryTierToolUsage', () => Q.queryTierToolUsage('1')],
+		['queryTierLatency', () => Q.queryTierLatency('1')],
+		['queryTierErrorRate', () => Q.queryTierErrorRate('1')],
+		['queryTierCachePerformance', () => Q.queryTierCachePerformance('1')],
+		['queryTierRateLimits', () => Q.queryTierRateLimits('1')],
+		['queryTierSessions', () => Q.queryTierSessions('1')],
+		['queryTierDomainDiversity', () => Q.queryTierDomainDiversity('1')],
+		['queryTierScoreDistribution', () => Q.queryTierScoreDistribution('1')],
+		['queryTierDailyTrend', () => Q.queryTierDailyTrend('1')],
+		['queryTierClientTypes', () => Q.queryTierClientTypes('1')],
+		['queryKeyUsage', () => Q.queryKeyUsage('1')],
+		['queryTierDigest', () => Q.queryTierDigest('24')],
+		['queryTierTopTools', () => Q.queryTierTopTools('24')],
+	];
+
+	for (const [name, build] of builders) {
+		it(`${name} emits FROM ${DEFAULT_ANALYTICS_DATASET} and never FROM MCP_ANALYTICS`, () => {
+			const sql = build();
+			expect(sql).toContain(`FROM ${DEFAULT_ANALYTICS_DATASET}`);
+			expect(sql).not.toContain('FROM MCP_ANALYTICS');
+			expect(sql).not.toContain('MCP_ANALYTICS');
+		});
+	}
+
+	it('accepts a validated env override for the dataset name', () => {
+		const sql = Q.queryRecentAnomalies('15', 'bv_mcp_usage_reporting');
+		expect(sql).toContain('FROM bv_mcp_usage_reporting');
+		expect(sql).not.toContain('MCP_ANALYTICS');
+	});
+
+	it('rejects an injection-shaped override and falls back to the default (defense-in-depth)', () => {
+		const evil = "bv_mcp'; DROP TABLE users; --";
+		expect(resolveAnalyticsDataset(evil)).toBe(DEFAULT_ANALYTICS_DATASET);
+		const sql = Q.queryRecentAnomalies('15', evil);
+		expect(sql).toContain(`FROM ${DEFAULT_ANALYTICS_DATASET}`);
+		expect(sql).not.toContain('DROP');
+	});
+
+	it('resolveAnalyticsDataset returns the default for undefined/empty/invalid', () => {
+		expect(resolveAnalyticsDataset(undefined)).toBe(DEFAULT_ANALYTICS_DATASET);
+		expect(resolveAnalyticsDataset('')).toBe(DEFAULT_ANALYTICS_DATASET);
+		expect(resolveAnalyticsDataset('Bad-Name!')).toBe(DEFAULT_ANALYTICS_DATASET);
+	});
+});

--- a/test/quota-shard-observability.spec.ts
+++ b/test/quota-shard-observability.spec.ts
@@ -82,7 +82,9 @@ describe('quota_shard_salt_missing degradation member', () => {
 describe('analytics-queries — quota shard skew + degradation exclusion', () => {
 	it('queryQuotaShardSkew aggregates per-shard load into max/mean/ratio', () => {
 		const sql = queryQuotaShardSkew('60');
-		expect(sql).toContain('MCP_ANALYTICS');
+		// AE queries by DATASET name, not the binding name MCP_ANALYTICS.
+		expect(sql).toContain('FROM bv_dns_security_mcp');
+		expect(sql).not.toContain('MCP_ANALYTICS');
 		expect(sql).toContain("index1 = 'quota_shard'");
 		expect(sql).toContain('max_shard_load');
 		expect(sql).toContain('mean_shard_load');


### PR DESCRIPTION
## Problem

`src/lib/analytics-queries.ts` sent `FROM MCP_ANALYTICS` — the Worker **binding** name — to the Analytics Engine SQL API, which queries by **dataset** name (`bv_dns_security_mcp` in prod). Result: every AE read returned **0 rows**, silently:

- all six 15-min cron alerts (error-rate, p95, rate-limit surge, binding-degradation, queue-failure, tail-exception) never fired;
- the `/internal/analytics/*` endpoints returned empty — including `/internal/analytics/geo`, which bv-web-prod's admin dashboard reads, so the admin **geo panel has been silently rendering `representative: true` placeholder data**.

Verified live: `FROM MCP_ANALYTICS` → 0 rows; `FROM bv_dns_security_mcp` → ~2.8M events (90d).

## Fix

- Removed the hardcoded `const DS = 'MCP_ANALYTICS'`. Added exported `DEFAULT_ANALYTICS_DATASET = 'bv_dns_security_mcp'` and `resolveAnalyticsDataset()`, which validates against `/^[a-z0-9_]+$/` and falls back to the default (defense-in-depth, since the value can now come from env).
- Every query builder gains a trailing `dataset?` param; `scheduled.ts` and `internal.ts` resolve `env.ANALYTICS_DATASET` once and thread it exactly like `CF_ACCOUNT_ID` / `CF_ANALYTICS_TOKEN`. The in-code default means **prod works with zero config change**.
- Added a **reader-blind self-check**: if the anomaly query returns 0 `tool_call` rows over the lookback window, emit a `warn` log (never a page) naming the dataset/misconfig — so this class of failure is observable instead of silent.

## Regression guard

New `test/audits/analytics-dataset-name.audit.test.ts`: asserts the default is `bv_dns_security_mcp`, generated SQL never contains `MCP_ANALYTICS`, a valid env override flows through, and an injection-shaped override drops to the default. CI-safe — it asserts the in-code default and never reads the gitignored wrangler overlay.

## ⚠️ Deploy prerequisite (NOT addressed by this PR)

This relights alerting **only if** `CF_ACCOUNT_ID` and `CF_ANALYTICS_TOKEN` are set as prod secrets under exactly those names (`scheduled.ts` early-returns otherwise). A companion audit found `CF_ACCOUNT_ID` is currently an empty-string var and the token may have been provisioned as `CF_ANALYTICS_KEY` (the `.dev.vars` name). **Verify with `wrangler secret list` on the deployed worker.**

## Test evidence

`npm run typecheck` clean; full suite green (5984 passed, 0 failed — only the documented pool-teardown noise); new audit + `analytics-queries.spec.ts` + `quota-shard-observability.spec.ts` pass. Live-verified the corrected dataset returns rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
