### PR TITLE
feat(analytics): detect the Claude-User remote MCP connector (claude_connector)

### DIFF
--- a/src/lib/client-detection.ts
+++ b/src/lib/client-detection.ts
@@ -5,12 +5,17 @@
  * Used for analytics segmentation — not security decisions.
  */
 
-export type McpClientType = 'claude_mobile' | 'claude_code' | 'cursor' | 'vscode' | 'claude_desktop' | 'windsurf' | 'mcp_remote' | 'blackveil_dns_action' | 'bv_claude_dns_proxy' | 'bv_load_test' | 'unknown';
+export type McpClientType = 'claude_mobile' | 'claude_code' | 'cursor' | 'vscode' | 'claude_desktop' | 'claude_connector' | 'windsurf' | 'mcp_remote' | 'blackveil_dns_action' | 'bv_claude_dns_proxy' | 'bv_load_test' | 'unknown';
 
 const CLIENT_PATTERNS: ReadonlyArray<[RegExp, McpClientType]> = [
 	[/claude[-_]?mobile|claude\.ai\/(android|ios)|claudeai[-_]?mobile/i, 'claude_mobile'],
 	[/claude[-_]?code/i, 'claude_code'],
 	[/claude[-_]?desktop/i, 'claude_desktop'],
+	// Anthropic-hosted remote MCP connector (claude.ai / claude.com / Desktop / mobile
+	// "custom connector"). Reaches the worker from Anthropic's cloud infra with the
+	// `Claude-User` control-plane UA (verified in the 2026-07-02 connector-unblock
+	// incident). Its data-plane fetches use a bare `node` UA, too generic to classify.
+	[/claude[-_]?user/i, 'claude_connector'],
 	[/cursor/i, 'cursor'],
 	[/windsurf/i, 'windsurf'],
 	[/visual studio code|vscode|github copilot/i, 'vscode'],

--- a/test/client-detection.spec.ts
+++ b/test/client-detection.spec.ts
@@ -38,6 +38,24 @@ describe('detectMcpClient', () => {
 		expect(detectMcpClient('ClaudeDesktop/1.0.0')).toBe('claude_desktop');
 	});
 
+	it('detects the Anthropic-hosted remote MCP connector (Claude-User UA)', () => {
+		// The claude.ai / claude.com / Desktop / mobile "custom connector" reaches the
+		// worker from Anthropic's cloud infra with User-Agent `Claude-User` (verified via
+		// the 2026-07-02 connector-unblock incident). Robust to a version/URL suffix.
+		expect(detectMcpClient('Claude-User/1.0')).toBe('claude_connector');
+		expect(detectMcpClient('Claude-User/1.0 (+https://claude.ai)')).toBe('claude_connector');
+		expect(detectMcpClient('claude_user/2.0')).toBe('claude_connector');
+		expect(detectMcpClient('ClaudeUser')).toBe('claude_connector');
+	});
+
+	it('does not confuse the connector with local Claude clients', () => {
+		// Claude-User must NOT steal claude_code / claude_desktop / claude_mobile, and
+		// those local-client UAs must NOT collapse into the connector bucket.
+		expect(detectMcpClient('claude-code/2.1.0')).toBe('claude_code');
+		expect(detectMcpClient('claude-desktop/1.0.0')).toBe('claude_desktop');
+		expect(detectMcpClient('claude-mobile/1.0.0')).toBe('claude_mobile');
+	});
+
 	it('detects Windsurf', () => {
 		expect(detectMcpClient('windsurf/1.0.0')).toBe('windsurf');
 		expect(detectMcpClient('Windsurf/2.0')).toBe('windsurf');


### PR DESCRIPTION
## Context

91% of `mcp_request` traffic (trailing 90d) was landing as client `unknown`. Investigation shows it is the **Anthropic-hosted remote MCP connector** (claude.ai / claude.com / Desktop / mobile "custom connector"), which reaches the worker with the `Claude-User` control-plane User-Agent — matching none of the existing `claude_*` patterns, so it fell through to `unknown`.

Evidence: a full healthy MCP lifecycle (27k+ `initialize`, **zero** malformed), 96% SSE transport, `tools/call` overwhelmingly authenticated (real OAuth'd customers), ipHash mostly `none` (connects from Anthropic cloud infra). The `unknown` surge aligns exactly with the **2026-07-02** connector-unblock — which also explains the ~12× usage growth over the window.

## Change

- Adds `claude_connector` to `McpClientType` and a `/claude[-_]?user/i` pattern, placed with the other `claude_*` patterns (verified no overlap in either direction — it can't shadow or be shadowed by claude_code/desktop/mobile).
- **Analytics-only:** deliberately **not** added to `INTERACTIVE_CLIENTS`, so output-format resolution (compact vs full) is unchanged. This is a labeling fix, not a behavior change.

## Known residual (deferred)

The connector's *data-plane* fetches use a bare `node` UA — too generic to classify safely. The durable fix is detecting via the `initialize` `params.clientInfo.name`, which requires plumbing `clientInfo` into `detectMcpClient`'s call sites — out of scope here.

## Test evidence

`test/client-detection.spec.ts` extended with connector UA variants (`Claude-User/1.0`, version/URL suffixes, `claude_user`, `ClaudeUser`) plus a disambiguation test proving it doesn't steal `claude_code` / `claude_desktop` / `claude_mobile`. 14/14 pass; `npm run typecheck` clean. No exact-set client-type audit exists, so adding a union member trips no SSOT tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
