### PR TITLE
feat(gating): add machine-consumable cta to the gated-tool 403 upgrade envelope

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -555,6 +555,30 @@ export interface UpgradeData {
 	url: string;
 	tool: string;
 	tier_required: 'developer';
+	/**
+	 * Ready-to-display call-to-action, co-located with the structured affordance so
+	 * a programmatic client can render an actionable upgrade prompt WITHOUT parsing
+	 * the top-level prose `error.message`. Names the gated tool; self-serve copy also
+	 * names the minimum tier. PUBLIC-SURFACE, operator-owned copy — price-free and
+	 * plan-name-free by design (see the operator note below); the destination URL
+	 * lives in `url`, not the string.
+	 */
+	cta: string;
+}
+
+/**
+ * Build the human-readable CTA for a paywalled response.
+ *
+ * OPERATOR NOTE (public-surface copy): intentionally neutral — it names only the
+ * gated tool and the existing `developer` tier, and carries NO price, plan name, or
+ * marketing headline (the operator owns those; the destination URL is in `url`).
+ * Edit this copy or route it through an env-configured string if the operator wants
+ * different wording.
+ */
+function buildUpgradeCta(toolName: string, channel: UpgradeChannel): string {
+	return channel === 'self_serve'
+		? `Upgrade to the developer tier to unlock ${toolName}.`
+		: `Contact us to enable ${toolName} on a vetted plan.`;
 }
 
 /** Build the `data.upgrade` envelope for a paywalled (403) response. */
@@ -566,6 +590,7 @@ export function buildUpgradeData(toolName: string, isVolume429 = false): { upgra
 			url: channel === 'self_serve' ? UPGRADE_SELF_SERVE_URL : UPGRADE_SALES_URL,
 			tool: toolName,
 			tier_required: 'developer',
+			cta: buildUpgradeCta(toolName, channel),
 		},
 	};
 }

--- a/test/audits/upgrade-channel-ssot.audit.test.ts
+++ b/test/audits/upgrade-channel-ssot.audit.test.ts
@@ -69,13 +69,14 @@ describe('upgrade-channel SSOT', () => {
 		expect(resolveUpgradeChannel('scan_domain', true)).toBe('self_serve');
 	});
 
-	it('buildUpgradeData attaches the channel-correct URL and developer tier', () => {
+	it('buildUpgradeData attaches the channel-correct URL, developer tier, and a tool-naming CTA', () => {
 		const selfServe = buildUpgradeData('batch_scan');
 		expect(selfServe.upgrade).toEqual({
 			channel: 'self_serve',
 			url: UPGRADE_SELF_SERVE_URL,
 			tool: 'batch_scan',
 			tier_required: 'developer',
+			cta: 'Upgrade to the developer tier to unlock batch_scan.',
 		});
 
 		const sales = buildUpgradeData('discover_subdomains');
@@ -84,6 +85,17 @@ describe('upgrade-channel SSOT', () => {
 			url: UPGRADE_SALES_URL,
 			tool: 'discover_subdomains',
 			tier_required: 'developer',
+			cta: 'Contact us to enable discover_subdomains on a vetted plan.',
 		});
+	});
+
+	it('the CTA is price-free and plan-name-free (public-surface copy invariant)', () => {
+		// The CTA must never leak a price or a marketing plan name — those are
+		// operator-owned. It may name the existing `developer` tier and the tool.
+		for (const tool of ['batch_scan', 'discover_subdomains', 'map_supply_chain']) {
+			const { cta } = buildUpgradeData(tool).upgrade;
+			expect(cta).toContain(tool);
+			expect(cta).not.toMatch(/\$\d|\bUSD\b|\bpro\b|\benterprise\b|\bstarter\b|\bbusiness\b/i);
+		}
 	});
 });

--- a/test/free-tier-gating.spec.ts
+++ b/test/free-tier-gating.spec.ts
@@ -70,7 +70,53 @@ describe('executeMcpRequest — paid-gated tool enforcement', () => {
 			tool: 'discover_subdomains',
 			tier_required: 'developer',
 		});
+		// Enriched actionable surface: a ready-to-display CTA co-located in the
+		// structured data (so a programmatic client need not parse the prose message),
+		// naming the gated tool.
+		expect(typeof payload.error.data?.upgrade?.cta).toBe('string');
+		expect(payload.error.data?.upgrade?.cta).toContain('discover_subdomains');
 		expect(result.useErrorEnvelope).toBe(true);
+	});
+
+	it('carries a self-serve enriched data.upgrade CTA for a free caller hitting batch_scan', async () => {
+		const { executeMcpRequest } = await import('../src/mcp/execute');
+		const result = await executeMcpRequest(
+			baseOptions({
+				body: {
+					jsonrpc: '2.0',
+					id: 110,
+					method: 'tools/call',
+					params: { name: 'batch_scan', arguments: { domains: ['example.com'] } },
+				} as JsonRpcRequest,
+				isAuthenticated: false,
+			}),
+		);
+
+		expect(result.kind).toBe('response');
+		if (result.kind !== 'response') throw new Error('expected response');
+		expect(result.httpStatus).toBe(403);
+		const payload = result.payload as {
+			error: {
+				code: number;
+				message: string;
+				data?: { upgrade?: { channel: string; url: string; tool: string; tier_required: string; cta: string } };
+			};
+		};
+		expect(payload.error.code).toBe(-32003);
+		// batch_scan is a bounded multi-domain tool → self-serve upgrade channel.
+		expect(payload.error.data?.upgrade).toMatchObject({
+			channel: 'self_serve',
+			tool: 'batch_scan',
+			tier_required: 'developer',
+		});
+		// The upgrade pointer is a real URL (reused operator-owned const), not empty.
+		expect(payload.error.data?.upgrade?.url).toMatch(/^https:\/\//);
+		// A self-serve CTA names the tool AND the minimum tier so the caller knows
+		// exactly what to buy and what it unlocks.
+		const cta = payload.error.data?.upgrade?.cta;
+		expect(typeof cta).toBe('string');
+		expect(cta).toContain('batch_scan');
+		expect(cta).toContain('developer');
 	});
 
 	it('returns HTTP 403 for authenticated free-tier caller hitting simulate_attack_paths', async () => {


### PR DESCRIPTION
## Context

Free / anon callers hitting paid-gated tools get an HTTP 403 `UPGRADE_REQUIRED` (JSON-RPC `-32003`). In the telemetry these are the warmest conversion leads (`batch_scan`, `discover_subdomains`, `map_supply_chain`, `simulate_attack_paths`, `compare_domains`, …). The 403 already carried a structured `error.data.upgrade` (`{ channel, url, tool, tier_required }`, with self-serve vs sales routing), but a client had to parse the prose `error.message` to render an upgrade prompt.

## Change

- Adds a `cta` string to `UpgradeData`, co-located in `data.upgrade`, so a programmatic client can render an actionable prompt **without parsing prose**.
- Reuses the existing operator-owned URL consts (`UPGRADE_SELF_SERVE_URL` / `UPGRADE_SALES_URL`); the CTA itself is **price-free and plan-name-free** by design (URL stays in `url`).
- Backward-compatible: no change to the 403 status, the `-32003` code, the gated-tool set, or the four existing `data.upgrade` fields. Confirmed the message still bypasses `sanitizeErrorMessage` (delivered verbatim).

## ⚠️ Operator decision

The CTA wording is a **neutral placeholder** (`"Upgrade to the developer tier to unlock <tool>."` / `"Contact us to enable <tool> on a vetted plan."`) — no price, plan name, or marketing headline invented. Confirm or replace the copy in `buildUpgradeCta()`, and confirm `/pricing` + `/contact` are the intended conversion destinations.

## Test evidence

`test/free-tier-gating.spec.ts` (TDD, written failing first) + `test/audits/upgrade-channel-ssot.audit.test.ts` extended to assert the enriched shape and that the CTA is price/plan-name-free. 16 pass; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
