### PR TITLE
chore(analytics): analytics-review follow-ups — connector format, honest error metric, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -363,12 +363,12 @@ Eight event indexes are emitted (`analytics.ts`): four core — `mcp_request`, `
 - `rate_limit`: limitType, toolName, country, authTier
 - `session`: action, country, clientType, authTier, method, keyHash
 
-**`mcp_access_log`** (D1 `INTELLIGENCE_DB`) is the faithful per-event store (vs AE's sampled rollups), enriched with geo/ASN/PTR/`key_hash`/`client_type`/colo/session/method/transport/status, gated by `ANALYTICS_PII_LEVEL` (`coarse` default → no city/lat-long/PTR/ciphertext/user_agent). Writes route through the `MCP_ANALYTICS_QUEUE` consumer (PTR reverse-lookup + encrypt-at-rest + batched D1 insert); inline-insert fallback (no PTR) when the queue is unbound. Both honor `ANALYTICS_PII_LEVEL`; fail-open throughout.
+**`mcp_access_log`** (D1 `INTELLIGENCE_DB`) is the faithful per-event store (vs AE's sampled rollups), enriched with geo/ASN/PTR/`key_hash`/`client_type`/colo/session/method/transport/status, gated by `ANALYTICS_PII_LEVEL` (`coarse` default → no city/lat-long/PTR/ciphertext/user_agent). Writes route through the `MCP_ANALYTICS_QUEUE` consumer (PTR reverse-lookup + encrypt-at-rest + batched D1 insert); inline-insert fallback (no PTR) when the queue is unbound. **In the current public/prod config the queue is NOT bound, so the inline path is the ACTIVE one (no PTR captured regardless of `ANALYTICS_PII_LEVEL`); provision `MCP_ANALYTICS_QUEUE` to enable the queue + PTR path.** Both honor `ANALYTICS_PII_LEVEL`; fail-open throughout.
 
 Per-IP investigations belong in operator-only notes. Hash IPs locally and avoid
 committing raw IPs or token-bearing analytics commands.
 
-Client detection (`client-detection.ts`): `claude_mobile`, `claude_code`, `cursor`, `vscode`, `claude_desktop`, `windsurf`, `mcp_remote`, `blackveil_dns_action`, `bv_claude_dns_proxy`, `bv_load_test`, `unknown`. For analytics + format auto-detection, never security. `bv_load_test` matches `bv-{load,chaos,tranco}-{test,scan}` UAs — non-interactive.
+Client detection (`client-detection.ts`): `claude_mobile`, `claude_code`, `cursor`, `vscode`, `claude_desktop`, `claude_connector`, `windsurf`, `mcp_remote`, `blackveil_dns_action`, `bv_claude_dns_proxy`, `bv_load_test`, `unknown`. For analytics + format auto-detection, never security. `bv_load_test` matches `bv-{load,chaos,tranco}-{test,scan}` UAs — non-interactive. `claude_connector` = the Anthropic-hosted remote MCP connector (`Claude-User` control-plane UA; the claude.ai/claude.com/Desktop custom connector — the bulk of prod traffic); it's in `INTERACTIVE_CLIENTS` (compact output). Residual: the connector's data-plane fetches use a bare `node` UA and still fall to `unknown` (durable fix = detect via `initialize` `clientInfo.name`, needs session storage).
 
 ## False Positive Reduction
 

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1034,7 +1034,10 @@ export const TOOL_REGISTRY: Record<
 };
 
 /** Known interactive LLM client types that benefit from compact output. */
-const INTERACTIVE_CLIENTS = new Set(['claude_mobile', 'claude_code', 'cursor', 'vscode', 'claude_desktop', 'windsurf']);
+// `claude_connector` = the Anthropic-hosted remote MCP connector (Claude in the
+// browser/Desktop): an interactive LLM client, so it gets compact output like the
+// other Claude clients (the LLM re-narrates; structuredContent is returned regardless).
+const INTERACTIVE_CLIENTS = new Set(['claude_mobile', 'claude_code', 'cursor', 'vscode', 'claude_desktop', 'claude_connector', 'windsurf']);
 
 /** Determine if the client type is a known interactive LLM IDE. */
 function isInteractiveClient(clientType?: string): boolean {

--- a/src/lib/analytics-queries.ts
+++ b/src/lib/analytics-queries.ts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
+// bv-oversize-ok: cohesive flat SSOT of pre-built AE SQL query builders (one fn per
+// query); splitting by consumer would scatter the telemetry-schema contract.
 
 /**
  * Pre-built SQL queries for Cloudflare Analytics Engine.
@@ -81,20 +83,33 @@ GROUP BY tool_name
 ORDER BY call_count DESC`;
 }
 
-/** Error rate per tool over the given interval. */
+/**
+ * Error rate per tool over the given interval.
+ *
+ * Splits errors into `input_errors` (blob3='error' AND blob4='none' — the request
+ * failed at pre-dispatch arg validation, e.g. a missing/invalid domain, so no tool
+ * work ran) and `real_errors` (blob3='error' AND blob4!='none' — the tool actually
+ * executed and errored). `real_error_pct` is the honest per-tool failure signal;
+ * `error_pct` (kept for back-compat) conflates both. Rationale: a small fixed floor
+ * of fuzz/probe calls with no domain otherwise inflates the error % of low-volume
+ * domain-required tools (e.g. check_mx read ~16% but was ~0% real failures).
+ */
 export function queryErrorRate(days: string, dataset?: string): string {
 	days = safeInterval(days);
 	return `SELECT
   blob1 AS tool_name,
   SUM(_sample_interval) AS total,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) AS errors,
-  SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) * 100.0 / SUM(_sample_interval) AS error_pct
+  SUM(CASE WHEN blob3 = 'error' AND blob4 = 'none' THEN _sample_interval ELSE 0 END) AS input_errors,
+  SUM(CASE WHEN blob3 = 'error' AND blob4 != 'none' THEN _sample_interval ELSE 0 END) AS real_errors,
+  SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) * 100.0 / SUM(_sample_interval) AS error_pct,
+  SUM(CASE WHEN blob3 = 'error' AND blob4 != 'none' THEN _sample_interval ELSE 0 END) * 100.0 / SUM(_sample_interval) AS real_error_pct
 FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'
   AND timestamp > NOW() - INTERVAL '${days}' DAY
 GROUP BY tool_name
 HAVING total > 10
-ORDER BY error_pct DESC`;
+ORDER BY real_error_pct DESC`;
 }
 
 /** Latency percentiles per tool. */
@@ -404,20 +419,29 @@ WHERE index1 = 'tool_call'${tierClause(tier, 'blob7')}
 ORDER BY ${tier ? 'call_count DESC' : 'tier'}`;
 }
 
-/** Error rate per tier. */
+/**
+ * Error rate per tier. Adds the same input-vs-real error split as {@link queryErrorRate}:
+ * `input_errors` (pre-dispatch validation rejections, blob4='none') vs `real_errors`
+ * (the tool actually ran and errored, blob4!='none'), with `real_error_pct` as the
+ * honest signal. `error_pct` is kept for back-compat.
+ */
 export function queryTierErrorRate(days: string, tier?: string, dataset?: string): string {
 	days = safeInterval(days);
 	tier = safeTier(tier);
 	return `SELECT${tier ? '' : '\n  blob7 AS tier,'}
   SUM(_sample_interval) AS total,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) AS errors,
+  SUM(CASE WHEN blob3 = 'error' AND blob4 = 'none' THEN _sample_interval ELSE 0 END) AS input_errors,
+  SUM(CASE WHEN blob3 = 'error' AND blob4 != 'none' THEN _sample_interval ELSE 0 END) AS real_errors,
   SUM(CASE WHEN blob3 = 'error' THEN _sample_interval ELSE 0 END) * 100.0
-    / GREATEST(SUM(_sample_interval), 1) AS error_pct
+    / GREATEST(SUM(_sample_interval), 1) AS error_pct,
+  SUM(CASE WHEN blob3 = 'error' AND blob4 != 'none' THEN _sample_interval ELSE 0 END) * 100.0
+    / GREATEST(SUM(_sample_interval), 1) AS real_error_pct
 FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'${tierClause(tier, 'blob7')}
   AND timestamp > NOW() - INTERVAL '${days}' DAY${tierGroupBy(tier, 'tier')}
 HAVING total > 0
-ORDER BY ${tier ? 'error_pct DESC' : 'tier'}`;
+ORDER BY ${tier ? 'real_error_pct DESC' : 'tier'}`;
 }
 
 /** Cache hit/miss ratio per tier. */

--- a/test/analytics-queries.spec.ts
+++ b/test/analytics-queries.spec.ts
@@ -49,6 +49,18 @@ describe('analytics query builders', () => {
 		expect(sql).toContain('tool_call');
 	});
 
+	it('queryErrorRate splits input-validation vs real errors', () => {
+		const sql = queryErrorRate('1');
+		// input_errors = errored WITH no domain dispatched (blob4='none' → pre-dispatch rejection)
+		expect(sql).toContain('input_errors');
+		expect(sql).toContain("blob4 = 'none'");
+		// real_errors / real_error_pct = the tool actually ran and errored (blob4!='none')
+		expect(sql).toContain('real_errors');
+		expect(sql).toContain('real_error_pct');
+		expect(sql).toContain("blob4 != 'none'");
+		expect(sql).toContain('error_pct'); // back-compat column retained
+	});
+
 	it('queryLatencyPercentiles uses quantile function', () => {
 		const sql = queryLatencyPercentiles('1');
 		expect(sql).toMatch(/quantile/i);
@@ -244,6 +256,14 @@ describe('per-tier analytics query builders', () => {
 		expect(sql).toContain("blob3 = 'error'");
 		expect(sql).toContain('error_pct');
 		expect(sql).toContain('GREATEST');
+	});
+
+	it('queryTierErrorRate splits input-validation vs real errors', () => {
+		const sql = queryTierErrorRate('7');
+		expect(sql).toContain('input_errors');
+		expect(sql).toContain('real_errors');
+		expect(sql).toContain('real_error_pct');
+		expect(sql).toContain("blob4 != 'none'");
 	});
 
 	it('queryTierCachePerformance groups by cache status', () => {


### PR DESCRIPTION
Follow-ups from the analytics & usage review, batched (they overlap in CLAUDE.md + the client-detection path, so one PR rather than parallel branches).

## What's addressed
- **Client format (C):** `claude_connector` added to `INTERACTIVE_CLIENTS`. ⚠️ **Behavior change** — the remote MCP connector (the majority of prod traffic, per the review) now gets **compact** output like the other Claude clients instead of `full`. This is correct for an LLM client (Claude re-narrates the output; `structuredContent` is returned regardless of format), matches claude_desktop/claude_code, and is a one-line revert if undesired.
- **Analytics metric (B):** `queryErrorRate` + `queryTierErrorRate` now split errors into `input_errors` (blob4=`none` → pre-dispatch arg-validation rejection, no tool ran) vs `real_errors` + `real_error_pct` (the tool actually ran and errored). `error_pct` kept for back-compat; ordering now by `real_error_pct`. Additive columns — the `/internal/analytics/tier-summary` consumer passes rows through unchanged. Makes per-tool failure % honest: check_mx *read* ~16% but was ~0% real failures (a fixed floor of no-domain fuzz/probe calls).
- **Docs (C+G):** CLAUDE.md documents `claude_connector` + the residual bare-`node`-UA data-plane gap, and clarifies that `MCP_ANALYTICS_QUEUE` is unbound in the prod config so the **inline (no-PTR)** `mcp_access_log` path is the active one (provision the queue to enable PTR).

## Deliberately deferred (needs its own scoped change)
The connector's *data-plane* fetches use a bare `node` UA that can't be classified from the UA alone. The durable fix — detecting via `initialize` `params.clientInfo.name` — requires **new session storage** (clientInfo isn't persisted today), so it's a larger, riskier change not bundled here.

## Not changed (verified fine)
The gated-403 `cta` copy (#530) and its URLs — `blackveilsecurity.com/pricing` + `/contact` are confirmed live bv-web-prod routes; copy passes the price/plan-name-free invariant.

## Test
`npm run typecheck` clean; new split-assertions + the dataset audit + client-detection specs pass (85 tests). Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)