### PR TITLE
ci: scope publish.yml pre-release audit to production deps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,10 @@ jobs:
         run: npm test
 
       - name: Security audit
-        run: npm audit --audit-level=high
+        # --omit=dev: the release artifact is the Cloudflare Worker (production
+        # deps only). Dev-tooling advisories don't reach the runtime and must not
+        # fail a release's pre-flight; Dependabot tracks them. Mirrors security.yml.
+        run: npm audit --omit=dev --audit-level=high
 
   version-bump:
     name: Sync version to tag


### PR DESCRIPTION
Mirrors the `security.yml` audit-scope fix (from the v3.34.0 release) to `publish.yml`'s **Pre-release checks → Security audit** step.

**Why:** `publish.yml` still ran `npm audit --audit-level=high` over all deps, so it fails Pre-release checks (skipping the GitHub Release + downstream jobs) on any dev-tooling advisory — as it did for v3.34.0 on GHSA-f88m-g3jw-g9cj (`sharp`→`miniflare`→`vitest-pool-workers`→`wrangler`). The deployed artifact is the Cloudflare Worker (production deps only; `npm audit --omit=dev` = 0 vulns). Dependabot still tracks dev-only advisories.

**Change:** `npm audit --audit-level=high` → `npm audit --omit=dev --audit-level=high`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)