### PR TITLE
fix(mta-sts,dnssec): correct two non-apex regressions in 1.5.0 → dns-checks 1.5.1

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.5.0",
+	"version": "1.5.1",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -84,9 +84,9 @@ export async function checkDNSSEC(
 		findings.push(
 			createFinding(
 				'dnssec',
-				'DNSSEC posture inherited from signed zone',
+				'DNSSEC posture inherited from zone apex',
 				'info',
-				`${domain} has no signed zone of its own; DNSSEC posture is inherited from the zone apex ${target}.`,
+				`${domain} is not a separately delegated zone, so its DNSSEC posture is inherited from and evaluated at the zone apex ${target} — the verdict below applies to ${target}.`,
 				{ inheritedFromApex: target },
 			),
 		);

--- a/packages/dns-checks/src/checks/check-mta-sts.ts
+++ b/packages/dns-checks/src/checks/check-mta-sts.ts
@@ -185,13 +185,29 @@ export async function checkMTASTS(
 	// note. Without the branch, paypal/stripe-class domains (with real MX) get
 	// the "do not accept inbound email" copy, which is factually wrong.
 	if (shouldSummarizeMissingMailProtections(findings, hasTxtRecord, tlsRptChecked, hasTlsRptRecord)) {
-		// Non-apex short-circuit: MTA-STS is defined per mail host (RFC 8461), NOT
-		// inherited from a parent zone, so a subdomain's absent MTA-STS/TLS-RPT is
-		// out of scope rather than a deficiency. Skip the MX probe entirely (saves
-		// a query) — the apex path below is unchanged.
+		// MTA-STS applicability follows the scanned LABEL's own inbound-mail role
+		// (RFC 8461), NOT its NS-delegation status: a non-apex label can still be a
+		// genuine mail-receiving host (its own MX), so ALWAYS probe MX and treat a
+		// missing policy as a real finding whenever the label accepts inbound mail.
+		// Only when the label accepts NO inbound mail is the absence out of scope —
+		// worded as an info "not applicable" for a non-apex (e.g. an ESP sending
+		// subdomain), or the existing low informational for an apex with no mail.
+		// (Gating the info purely on `!isApex` previously suppressed the real medium
+		// on a mail-receiving subdomain — a false negative.)
+		const hasMx = await detectInboundMail(domain, queryDNS, timeout);
 		const nonApex = !!(options?.zone && !options.zone.isApex);
-		if (nonApex) {
-			findings = [];
+		findings = [];
+		if (hasMx) {
+			findings.push(
+				createFinding(
+					'mta_sts',
+					'No MTA-STS or TLS-RPT records found',
+					'medium',
+					`${domain} accepts inbound email (MX records present) but has neither MTA-STS nor TLS-RPT configured. Sending MTAs cannot enforce TLS or report failures for mail to this domain.`,
+					{ missingControl: true },
+				),
+			);
+		} else if (nonApex) {
 			findings.push(
 				createFinding(
 					'mta_sts',
@@ -201,27 +217,15 @@ export async function checkMTASTS(
 				),
 			);
 		} else {
-			const hasMx = await detectInboundMail(domain, queryDNS, timeout);
-			findings = [];
 			findings.push(
-				hasMx
-					? createFinding(
-							'mta_sts',
-							'No MTA-STS or TLS-RPT records found',
-							'medium',
-							`${domain} accepts inbound email (MX records present) but has neither MTA-STS nor TLS-RPT configured. Sending MTAs cannot enforce TLS or report failures for mail to this domain.`,
-							{ missingControl: true },
-						)
-					: createFinding(
-							'mta_sts',
-							'No MTA-STS or TLS-RPT records found',
-							// No inbound MX → this domain does not receive mail, so missing MTA-STS
-							// is NOT a deficiency (low, no missingControl → ~95). Penalizing a parked
-							// domain here harder than for a missing optional control would be
-							// inconsistent. The has-MX branch above keeps missingControl (real gap).
-							'low',
-							`Neither MTA-STS nor TLS-RPT records are present for ${domain}. This is normal for domains that do not accept inbound email, but consider adding these records if you operate a mail server.`,
-						),
+				createFinding(
+					'mta_sts',
+					'No MTA-STS or TLS-RPT records found',
+					// No inbound MX → this domain does not receive mail, so missing MTA-STS
+					// is NOT a deficiency (low, no missingControl → ~95).
+					'low',
+					`Neither MTA-STS nor TLS-RPT records are present for ${domain}. This is normal for domains that do not accept inbound email, but consider adding these records if you operate a mail server.`,
+				),
 			);
 		}
 	}

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.5.0';
+export const PARITY_CORPUS_VERSION = '1.5.1';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/test/check-dnssec-non-apex.spec.ts
+++ b/test/check-dnssec-non-apex.spec.ts
@@ -91,3 +91,54 @@ describe('checkDnssec — non-apex evaluate-at-signed-apex', () => {
 		expect(r.findings.some((f) => f.title === 'DNSSEC not enabled')).toBe(false);
 	});
 });
+
+/**
+ * NS present at `apex` (so `mg.ii.inc` classifies `inherited`), but the apex is
+ * NOT DNSSEC-signed: AD=false everywhere, no DNSKEY/DS anywhere.
+ */
+function mockUnsignedApexOnly(apex: string) {
+	globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+		const nameMatch = url.match(/[?&]name=([^&]+)/);
+		const typeMatch = url.match(/[?&]type=([^&]+)/);
+		const name = nameMatch ? decodeURIComponent(nameMatch[1]).replace(/\.$/, '') : '';
+		const type = typeMatch ? typeMatch[1] : '';
+
+		if (type === 'NS' && name === apex) {
+			const answers = [
+				{ name: apex, type: RecordType.NS, TTL: 86400, data: 'ns1.cloudflare.com.' },
+				{ name: apex, type: RecordType.NS, TTL: 86400, data: 'ns2.cloudflare.com.' },
+			];
+			return Promise.resolve(createDohResponse([{ name: apex, type: RecordType.NS }], answers));
+		}
+		if (type === 'A') {
+			// Resolves, but UNSIGNED (AD=false) — including at the apex.
+			return Promise.resolve(
+				createDohResponse([{ name, type: 1 }], [{ name, type: RecordType.A, TTL: 300, data: '93.184.216.34' }], { ad: false }),
+			);
+		}
+		// No DNSKEY/DS/NSEC3PARAM anywhere → genuinely unsigned.
+		return Promise.resolve(createDohResponse([{ name, type: RecordType.NS }], []));
+	});
+}
+
+describe('checkDnssec — inherited from an UNSIGNED apex (wording must not contradict the verdict)', () => {
+	async function run(domain: string) {
+		const { checkDnssec } = await import('../src/tools/check-dnssec');
+		return checkDnssec(domain);
+	}
+
+	it('mg.ii.inc: apex genuinely unsigned → real "not enabled" fires AND the inheritance note never claims the zone is "signed"', async () => {
+		mockUnsignedApexOnly('ii.inc');
+		const r = await run('mg.ii.inc');
+
+		// The apex is genuinely unsigned → the real verdict must still surface.
+		expect(r.findings.some((f) => f.title === 'DNSSEC not enabled')).toBe(true);
+
+		// The inheritance note must attribute posture to the apex WITHOUT asserting it is
+		// "signed" (that would contradict the "not enabled" verdict in the same result).
+		const inherited = r.findings.find((f) => f.severity === 'info' && /inherited/i.test(f.detail ?? ''));
+		expect(inherited).toBeDefined();
+		expect(inherited!.title.toLowerCase()).not.toContain('signed');
+		expect((inherited!.detail ?? '').toLowerCase()).not.toContain('signed');
+	});
+});

--- a/test/check-mta-sts-non-apex.spec.ts
+++ b/test/check-mta-sts-non-apex.spec.ts
@@ -71,6 +71,29 @@ describe('checkMtaSts — non-apex', () => {
 		expect(r.findings.some((f) => f.severity === 'medium' || f.severity === 'high' || f.severity === 'critical')).toBe(false);
 		expect(r.passed).toBeTruthy();
 	});
+
+	it('mail.acme.com: non-apex label that ACCEPTS mail (own MX) still yields medium + missingControl', async () => {
+		// `mail.acme.com` shares nameservers with `acme.com` (no separate NS delegation →
+		// classified `inherited`, isApex:false) BUT owns an MX record, so it is a genuine
+		// mail-receiving host. MTA-STS applicability follows the label's inbound-mail role
+		// (RFC 8461), NOT its zone-delegation status — its missing policy is a real finding,
+		// not "not applicable". Regression guard for the bare-`!isApex` short-circuit.
+		mockNonApexMailQueries({
+			domain: 'mail.acme.com',
+			apex: 'acme.com',
+			apexNs: ['ns1.cloudflare.com.', 'ns2.cloudflare.com.'],
+			mxRecords: [{ priority: 10, exchange: 'mx1.acme.com' }],
+		});
+
+		const r = await run('mail.acme.com');
+
+		const missing = r.findings.find((f) => f.title.includes('No MTA-STS'));
+		expect(missing).toBeDefined();
+		expect(missing!.severity).toBe('medium');
+		expect(missing!.metadata?.missingControl).toBe(true);
+		// Must NOT be suppressed to the "not applicable" info.
+		expect(r.findings.some((f) => /not applicable/i.test(f.title))).toBe(false);
+	});
 });
 
 describe('checkMtaSts — apex regression (unchanged)', () => {


### PR DESCRIPTION
Follow-up to #542 (non-apex NS/CAA/DNSSEC/MTA-STS false-positive fix, shipped as `@blackveil/dns-checks` **1.5.0**). Review found two defects in the 1.5.0 non-apex branches; this is the **1.5.1** patch.

## Defect 1 — MTA-STS false negative (mail-receiving subdomains)
The 1.5.0 non-apex summary gated on bare `!isApex` and **skipped the MX probe**, so a non-apex label that genuinely accepts inbound mail (its own MX — e.g. `mail.acme.com`, classified `inherited`) had its real `medium`/`missingControl` finding wrongly **suppressed to an info "not applicable."**

MTA-STS applicability follows the label's own **inbound-mail role** (RFC 8461), not its NS-delegation status: always probe MX; only treat absence as out-of-scope when the label accepts no inbound mail (non-apex sending subdomain → info; apex → existing low). Apex output unchanged.

## Defect 2 — DNSSEC inheritance wording contradicts the verdict
The "DNSSEC posture inherited from **signed** zone" info finding fired unconditionally on an inherited target, contradicting the adjacent "DNSSEC not enabled" verdict when the apex is genuinely **unsigned**. Reworded neutrally ("inherited from zone apex"). No score impact.

## Changes
- `check-mta-sts.ts`: always `detectInboundMail` in the missing-protections summary; branch severity/copy on MX presence, not `!isApex`.
- `check-dnssec.ts`: neutral inheritance wording.
- Bumps `@blackveil/dns-checks` 1.5.0 → **1.5.1** + `PARITY_CORPUS_VERSION`.
- New failing-first tests: `test/check-mta-sts-non-apex.spec.ts` (+ `mail.acme.com` with-MX regression guard), `test/check-dnssec-non-apex.spec.ts` (+ unsigned-apex wording guard). **13/13 green.**

## ⚠️ Release-time TODO (not in this PR)
The `bv-mcp-release` version-sync surfaces — `SERVER_VERSION` / `server.json` / `CHANGELOG` / package-lock — still need bumping when this cuts a bv-mcp release. This PR touches only the `packages/dns-checks` package version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)