### PR TITLE
fix(scan): mark transient query/fetch failures inconclusive, not scored (dns-checks 1.5.2)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -114,10 +114,14 @@ describe('checkMX', () => {
 });
 
 describe('checkNS', () => {
-	it('returns critical when NS query fails', async () => {
+	it('marks the category inconclusive (not a scored deficiency) when the NS query fails transiently', async () => {
+		// A thrown NS query is a transient resolver failure — we could not MEASURE the posture, so
+		// the category is excluded from scoring (checkStatus 'error') with an info-only finding,
+		// rather than penalizing a possibly-healthy domain with a critical "NS query failed".
 		const queryDNS: DNSQueryFunction = vi.fn(async () => { throw new Error('fail'); });
 		const result = await checkNS('example.com', queryDNS);
-		expect(result.findings[0].severity).toBe('critical');
+		expect(result.checkStatus).toBe('error');
+		expect(result.findings[0].severity).toBe('info');
 	});
 
 	it('detects single nameserver', async () => {

--- a/packages/dns-checks/src/__tests__/checks/transient-inconclusive.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/transient-inconclusive.test.ts
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Class-A regression guard: "transient failure scored as a deficiency".
+ *
+ * Six checks used to catch a THROWN DNS query / fetch (a momentary resolver
+ * timeout / SERVFAIL / network flake) and return a SCORED finding via
+ * buildCheckResult(...) WITHOUT setting `checkStatus`. The scoring engine only
+ * EXCLUDES a category when `checkStatus` is 'timeout'/'error' — so a healthy
+ * domain hit by a blip was penalized. The correct posture is to mark the
+ * category INCONCLUSIVE (info finding + checkStatus) so the engine renormalizes
+ * over the remaining categories instead of zeroing/penalizing this one.
+ *
+ * subdomailing is deliberately covered too, to DOCUMENT that it does NOT exhibit
+ * the FP: extractSpfIncludeChain swallows a thrown queryDNS internally, so the
+ * check degrades to a non-penalizing info ("No SPF record") path, never the
+ * scored catch.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkNS } from '../../checks/check-ns';
+import { checkMX } from '../../checks/check-mx';
+import { checkCAA } from '../../checks/check-caa';
+import { checkDNSSEC } from '../../checks/check-dnssec';
+import { checkSubdomailing } from '../../checks/check-subdomailing';
+import { checkSSL } from '../../checks/check-ssl';
+import type { DNSQueryFunction, FetchFunction, RawDNSQueryFunction, Finding } from '../../types';
+
+/** A DNS resolver that always throws — models a transient SERVFAIL/timeout/network flake. */
+const throwingDNS: DNSQueryFunction = async () => {
+	throw new Error('transient resolver failure');
+};
+
+/** A raw DoH resolver that always throws (used by checkDNSSEC's AD-flag probe). */
+const throwingRawDNS: RawDNSQueryFunction = async () => {
+	throw new Error('transient resolver failure');
+};
+
+/** True when a finding would actually penalize the score (medium and above). */
+function hasScoredDeficiency(findings: Finding[]): boolean {
+	return findings.some((f) => f.severity === 'medium' || f.severity === 'high' || f.severity === 'critical');
+}
+
+describe('transient DNS failure → category is INCONCLUSIVE, not a scored deficiency', () => {
+	it('checkNS: a thrown NS query is excluded (checkStatus error), not a critical finding', async () => {
+		const result = await checkNS('example.com', throwingDNS);
+		expect(result.checkStatus).toBe('error');
+		expect(hasScoredDeficiency(result.findings)).toBe(false);
+	});
+
+	it('checkMX: a thrown MX query is excluded (checkStatus error), not a medium finding', async () => {
+		const result = await checkMX('example.com', throwingDNS);
+		expect(result.checkStatus).toBe('error');
+		expect(hasScoredDeficiency(result.findings)).toBe(false);
+	});
+
+	it('checkCAA: a thrown CAA query is excluded (checkStatus error), not a medium finding', async () => {
+		const result = await checkCAA('example.com', throwingDNS);
+		expect(result.checkStatus).toBe('error');
+		expect(hasScoredDeficiency(result.findings)).toBe(false);
+	});
+
+	it('checkDNSSEC: a thrown AD-flag query is excluded (checkStatus error), not a medium/high finding', async () => {
+		const result = await checkDNSSEC('example.com', throwingDNS, { rawQueryDNS: throwingRawDNS });
+		expect(result.checkStatus).toBe('error');
+		expect(hasScoredDeficiency(result.findings)).toBe(false);
+	});
+
+	it('checkSubdomailing: does NOT exhibit the FP — a thrown queryDNS is swallowed internally and degrades to a non-penalizing info path', async () => {
+		const result = await checkSubdomailing('example.com', throwingDNS);
+		// The throw is caught inside extractSpfIncludeChain (resolve), so the scored
+		// "SubdoMailing check failed" catch is unreachable; the check reports info-only.
+		expect(result.checkStatus).toBeUndefined();
+		expect(hasScoredDeficiency(result.findings)).toBe(false);
+	});
+});
+
+describe('checkSSL: transient / unassessable HTTPS → INCONCLUSIVE, not a scored deficiency', () => {
+	it('(i) a fetch timeout is excluded with checkStatus timeout', async () => {
+		const fetchFn: FetchFunction = async () => {
+			throw new Error('fetch timeout');
+		};
+		const result = await checkSSL('example.com', fetchFn);
+		expect(result.checkStatus).toBe('timeout');
+	});
+
+	it('(ii) a connection refusal is excluded with checkStatus error', async () => {
+		const fetchFn: FetchFunction = async () => {
+			throw new Error('ECONNREFUSED');
+		};
+		const result = await checkSSL('example.com', fetchFn);
+		expect(result.checkStatus).toBe('error');
+	});
+
+	it('(iii) an origin-unreachable 530 is not assessable — checkStatus error and no scored HSTS finding', async () => {
+		const fetchFn: FetchFunction = async () => new Response(null, { status: 530 });
+		const result = await checkSSL('example.com', fetchFn);
+		expect(result.checkStatus).toBe('error');
+		// The old code emitted a medium "No HSTS header" against an unreachable origin.
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(false);
+		expect(hasScoredDeficiency(result.findings)).toBe(false);
+	});
+});

--- a/packages/dns-checks/src/checks/check-caa.ts
+++ b/packages/dns-checks/src/checks/check-caa.ts
@@ -76,8 +76,21 @@ export async function checkCAA(
 	try {
 		rawRecords = await queryDNS(domain, 'CAA', { timeout });
 	} catch {
-		findings.push(createFinding('caa', 'CAA query failed', 'medium', `Could not query CAA records for ${domain}.`));
-		return buildCheckResult('caa', findings);
+		// Transient resolver failure — we could not MEASURE the CAA posture. Mark the category
+		// INCONCLUSIVE (checkStatus) so the scoring engine renormalizes over the remaining
+		// categories instead of penalizing a possibly-healthy domain with a scored deficiency.
+		// (The per-ancestor climb catch above is a legitimate fail-soft and stays unchanged.)
+		return {
+			...buildCheckResult('caa', [
+				createFinding(
+					'caa',
+					'CAA records not assessed',
+					'info',
+					`Could not query CAA records for ${domain} due to a transient DNS failure; this control was not assessed.`,
+				),
+			]),
+			checkStatus: 'error',
+		};
 	}
 
 	// Parse raw CAA record data into structured records

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -49,10 +49,22 @@ export async function checkDNSSEC(
 		}
 		// If no rawQueryDNS provided, we can't check AD flag — continue without it
 	} catch {
-		findings.push(
-			createFinding('dnssec', 'DNSSEC check failed', 'medium', `Could not verify DNSSEC status for ${target}. The DNS query failed.`),
-		);
-		return buildCheckResult('dnssec', findings);
+		// Transient resolver failure on the AD-flag probe — we could not MEASURE DNSSEC. Mark the
+		// category INCONCLUSIVE (checkStatus) so the scoring engine renormalizes over the remaining
+		// categories instead of penalizing a possibly-healthy domain with a scored deficiency.
+		// (The DNSKEY/DS/NSEC3PARAM catches below are legitimate fail-soft "treat as absent" and
+		// stay unchanged.)
+		return {
+			...buildCheckResult('dnssec', [
+				createFinding(
+					'dnssec',
+					'DNSSEC not assessed',
+					'info',
+					`Could not query DNSSEC status for ${target} due to a transient DNS failure; this control was not assessed.`,
+				),
+			]),
+			checkStatus: 'error',
+		};
 	}
 
 	// Query DNSKEY, DS, and NSEC3PARAM records independently; default to empty on failure

--- a/packages/dns-checks/src/checks/check-mx.ts
+++ b/packages/dns-checks/src/checks/check-mx.ts
@@ -31,7 +31,20 @@ export async function checkMX(
 	try {
 		answers = await queryDNS(domain, 'MX', { timeout });
 	} catch {
-		return buildCheckResult('mx', [createFinding('mx', 'DNS query failed', 'medium', 'MX record lookup failed')]);
+		// Transient resolver failure — we could not MEASURE the mail-exchange posture. Mark the
+		// category INCONCLUSIVE (checkStatus) so the scoring engine renormalizes over the remaining
+		// categories instead of penalizing a possibly-healthy domain with a scored deficiency.
+		return {
+			...buildCheckResult('mx', [
+				createFinding(
+					'mx',
+					'MX records not assessed',
+					'info',
+					`Could not query mail-exchange (MX) records for ${domain} due to a transient DNS failure; this control was not assessed.`,
+				),
+			]),
+			checkStatus: 'error',
+		};
 	}
 
 	if (!answers || answers.length === 0) {

--- a/packages/dns-checks/src/checks/check-ns.ts
+++ b/packages/dns-checks/src/checks/check-ns.ts
@@ -64,8 +64,21 @@ export async function checkNS(
 	try {
 		nsRecords = normalizeNsRecords(await queryDNS(domain, 'NS', { timeout }));
 	} catch {
-		findings.push(createFinding('ns', 'NS query failed', 'critical', `Could not query nameserver records for ${domain}.`));
-		return buildCheckResult('ns', findings);
+		// Transient resolver failure (timeout / SERVFAIL / network flake) — we could not
+		// MEASURE the nameserver posture. Mark the category INCONCLUSIVE (checkStatus) so the
+		// scoring engine renormalizes over the remaining categories instead of penalizing a
+		// possibly-healthy domain with a scored "NS query failed" deficiency.
+		return {
+			...buildCheckResult('ns', [
+				createFinding(
+					'ns',
+					'Nameserver configuration not assessed',
+					'info',
+					`Could not query nameserver (NS) records for ${domain} due to a transient DNS failure; this control was not assessed.`,
+				),
+			]),
+			checkStatus: 'error',
+		};
 	}
 
 	if (nsRecords.length === 0) {

--- a/packages/dns-checks/src/checks/check-ssl.ts
+++ b/packages/dns-checks/src/checks/check-ssl.ts
@@ -27,7 +27,7 @@ export async function checkSSL(domain: string, fetchFn: FetchFunction, options?:
 	const timeoutMs = options?.timeout ?? HTTPS_TIMEOUT_MS;
 	const findings: Finding[] = [];
 
-	const { findings: httpsFindings, reachable, robotsDisallowed } = await checkHttps(domain, fetchFn, timeoutMs);
+	const { findings: httpsFindings, reachable, robotsDisallowed, inconclusive } = await checkHttps(domain, fetchFn, timeoutMs);
 	findings.push(...httpsFindings);
 
 	// The entire `ssl` category signal comes from fetching the target — when robots.txt disallows
@@ -35,6 +35,14 @@ export async function checkSSL(domain: string, fetchFn: FetchFunction, options?:
 	// findings = 100) or letting a downstream check run against a target we were told not to touch.
 	if (robotsDisallowed) {
 		return { ...buildCheckResult('ssl', findings, undefined), checkStatus: 'error' };
+	}
+
+	// A transient connection failure/timeout, or an origin the server itself could not serve
+	// (status 0 / 5xx), means the HTTPS/HSTS posture could not be MEASURED. Exclude the category
+	// (checkStatus) so a momentary blip doesn't score a false "No HSTS"/"redirect" deficiency, and
+	// skip the HTTP-redirect leg (there's nothing reliable to compare it against).
+	if (inconclusive) {
+		return { ...buildCheckResult('ssl', findings, reachable), checkStatus: inconclusive };
 	}
 
 	// Only check HTTP redirect if HTTPS is working (no critical findings)
@@ -70,9 +78,13 @@ async function checkHttps(
 	domain: string,
 	fetchFn: FetchFunction,
 	timeoutMs: number,
-): Promise<{ findings: Finding[]; reachable: boolean | undefined; robotsDisallowed: boolean }> {
+): Promise<{ findings: Finding[]; reachable: boolean | undefined; robotsDisallowed: boolean; inconclusive?: 'timeout' | 'error' }> {
 	const findings: Finding[] = [];
 	let reachable = false;
+	// Set when the HTTPS/HSTS posture could not actually be MEASURED (execution failure or an
+	// unassessable origin), as opposed to a real header gap. checkSSL excludes the category from
+	// scoring when this is set — see the scoring-engine transientFailures handling.
+	let inconclusive: 'timeout' | 'error' | undefined;
 
 	try {
 		const response = await fetchFn(`https://${domain}`, {
@@ -82,14 +94,29 @@ async function checkHttps(
 		});
 		reachable = true;
 
-		const isRedirect = response.status >= 300 && response.status < 400;
-		const location = isRedirect ? response.headers.get('location') : null;
-		const isDowngrade = location?.startsWith('http://') ?? false;
-		const isHttpsRedirect = isRedirect && !isDowngrade;
+		if (response.status === 0 || response.status >= 500) {
+			// Origin-unreachable / server error (e.g. Cloudflare 530): the page is NOT assessable, so
+			// do NOT emit the "No HSTS"/redirect scored findings — a transient origin blip must not
+			// read as a security deficiency. One honest info finding + exclude from scoring.
+			inconclusive = 'error';
+			findings.push(
+				createFinding(
+					'ssl',
+					`HTTPS endpoint not assessable (status ${response.status})`,
+					'info',
+					`https://${domain} returned status ${response.status}; the HTTPS endpoint could not be reached to assess HSTS/redirect posture, so this control was not assessed.`,
+				),
+			);
+		} else {
+			const isRedirect = response.status >= 300 && response.status < 400;
+			const location = isRedirect ? response.headers.get('location') : null;
+			const isDowngrade = location?.startsWith('http://') ?? false;
+			const isHttpsRedirect = isRedirect && !isDowngrade;
 
-		if (!isHttpsRedirect) {
-			const redirectTarget = isDowngrade ? (location ?? undefined) : undefined;
-			findings.push(...getHttpsFindings(domain, redirectTarget, response.headers.get('strict-transport-security')));
+			if (!isHttpsRedirect) {
+				const redirectTarget = isDowngrade ? (location ?? undefined) : undefined;
+				findings.push(...getHttpsFindings(domain, redirectTarget, response.headers.get('strict-transport-security')));
+			}
 		}
 	} catch (err) {
 		if (err instanceof RobotsDisallowedError) {
@@ -103,10 +130,13 @@ async function checkHttps(
 			err instanceof Error && (err.message.includes('timeout') || err.message.includes('abort'))
 				? 'Connection timeout'
 				: 'Connection failed';
+		// A thrown fetch is a transient execution failure — exclude the category rather than scoring
+		// the connection-failure finding as a real deficiency. The existing finding is retained.
+		inconclusive = message === 'Connection timeout' ? 'timeout' : 'error';
 		findings.push(getHttpsErrorFinding(domain, message));
 	}
 
-	return { findings, reachable, robotsDisallowed: false };
+	return { findings, reachable, robotsDisallowed: false, inconclusive };
 }
 
 /** Check if HTTP redirects to HTTPS */

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.5.1';
+export const PARITY_CORPUS_VERSION = '1.5.2';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/src/tools/check-dnssec.ts
+++ b/src/tools/check-dnssec.ts
@@ -119,20 +119,19 @@ export async function checkDnssec(domain: string, dnsOptions?: QueryDnsOptions, 
 		},
 	) as CheckResult;
 
-	// If the inner check returned a transport-error sentinel finding, surface checkStatus='error'.
-	// checkDNSSEC catches transport failures internally and returns a 'DNSSEC check failed' finding
-	// rather than throwing — we detect this to distinguish transport errors from "no DNSSEC deployed".
-	const isDnsTransportError = baseResult.findings.some((f) => f.title === 'DNSSEC check failed');
-	if (isDnsTransportError) {
-		return { ...baseResult, checkStatus: 'error' as const };
+	// checkDNSSEC marks a transient transport failure as inconclusive (checkStatus:'error' + an
+	// info "DNSSEC not assessed" finding) rather than throwing — propagate that so a transient DNS
+	// failure is excluded from scoring, not misread as "no DNSSEC deployed".
+	if (baseResult.checkStatus === 'error') {
+		return baseResult;
 	}
 
 	// Skip augmentation when DNSSEC is definitively absent, failed, or misconfigured at the domain level.
 	// 'DNSSEC chain of trust incomplete' means the domain has DNSKEY but no DS — it is domain-operator-configured
 	// (just broken), not TLD-inherited.
+	// (A transient transport failure already returned above via checkStatus:'error'.)
 	const dnssecAbsent =
 		baseResult.findings.some((f) => f.title === 'DNSSEC not enabled') ||
-		baseResult.findings.some((f) => f.title === 'DNSSEC check failed') ||
 		baseResult.findings.some((f) => f.title === 'DNSSEC chain of trust incomplete');
 	if (dnssecAbsent) {
 		return baseResult;

--- a/src/tools/check-mx.ts
+++ b/src/tools/check-mx.ts
@@ -34,8 +34,10 @@ export async function checkMx(domain: string, options?: CheckMxOptions, dnsOptio
 	// Early return if MX check already returned critical/error findings (no MX records, etc.)
 	// Only add provider detection when we have meaningful MX records
 	const hasCritical = baseResult.findings.some((f) => f.severity === 'critical');
-	const hasMediumQueryFailed = baseResult.findings.some((f) => f.title === 'DNS query failed');
-	if (hasCritical || hasMediumQueryFailed) {
+	// A transient MX-query failure is now marked inconclusive (checkStatus:'error') by the package
+	// check — skip provider-detection augmentation and propagate it rather than sniffing a title.
+	const isInconclusive = baseResult.checkStatus === 'error';
+	if (hasCritical || isInconclusive) {
 		return baseResult;
 	}
 

--- a/test/check-caa.spec.ts
+++ b/test/check-caa.spec.ts
@@ -35,12 +35,15 @@ describe('checkCaa', () => {
 		expect(result.findings[0].title).toMatch(/No CAA/i);
 	});
 
-	it('should report medium finding when CAA query fails', async () => {
+	it('marks the category inconclusive (not a scored deficiency) when the CAA query fails transiently', async () => {
+		// A thrown CAA query is a transient resolver failure — excluded from scoring (checkStatus
+		// 'error') with an info-only "not assessed" finding, not a scored medium deficiency.
 		mockCaaFailure();
 		const result = await run();
+		expect(result.checkStatus).toBe('error');
 		expect(result.findings).toHaveLength(1);
-		expect(result.findings[0].severity).toBe('medium');
-		expect(result.findings[0].title).toMatch(/failed/i);
+		expect(result.findings[0].severity).toBe('info');
+		expect(result.findings[0].title).toMatch(/not assessed/i);
 	});
 
 	it('should report medium finding when no issue tag present', async () => {

--- a/test/check-dnssec.spec.ts
+++ b/test/check-dnssec.spec.ts
@@ -46,12 +46,15 @@ describe('checkDnssec', () => {
 		expect(result.findings[0].title).toMatch(/Modern DNSSEC algorithm/i);
 	});
 
-	it('returns medium finding when DNS query fails entirely', async () => {
+	it('marks the category inconclusive (not a scored deficiency) when the DNS query fails transiently', async () => {
+		// A thrown AD-probe is a transient resolver failure — excluded from scoring (checkStatus
+		// 'error') with an info-only "not assessed" finding, not a scored medium deficiency.
 		mockFetchError();
 		const r = await run();
-		const f = r.findings.find((f) => f.title.includes('check failed'));
+		expect(r.checkStatus).toBe('error');
+		const f = r.findings.find((f) => f.title.includes('not assessed'));
 		expect(f).toBeDefined();
-		expect(f!.severity).toBe('medium');
+		expect(f!.severity).toBe('info');
 	});
 
 	it('adds tld_inherited info finding when AD=true but no DNSKEY/DS on domain', async () => {

--- a/test/check-ns.spec.ts
+++ b/test/check-ns.spec.ts
@@ -118,12 +118,16 @@ describe('checkNs', () => {
 		expect(r.findings[0].detail).toContain('parent zone');
 	});
 
-	it('returns critical finding when NS query fails', async () => {
+	it('marks the category inconclusive (not a scored deficiency) when the NS query fails transiently', async () => {
+		// A thrown NS query is a transient resolver failure — the posture could not be MEASURED, so
+		// the category is excluded from scoring (checkStatus 'error') with an info-only finding,
+		// not a scored "NS query failed" critical against a possibly-healthy domain.
 		mockFetchError();
 		const r = await run();
+		expect(r.checkStatus).toBe('error');
 		expect(r.findings).toHaveLength(1);
-		expect(r.findings[0].severity).toBe('critical');
-		expect(r.findings[0].title).toContain('NS query failed');
+		expect(r.findings[0].severity).toBe('info');
+		expect(r.findings[0].title).toContain('not assessed');
 	});
 
 	it('returns medium finding when no SOA record exists', async () => {


### PR DESCRIPTION
## Class-A false positive: a transient failure scored as a real deficiency
Six scan checks caught a **thrown** DNS query / HTTPS fetch (transient resolver timeout / SERVFAIL / network flake / origin 5xx) and returned a **scored** finding via `buildCheckResult` **without** setting `checkStatus`. The scoring engine excludes only categories with `checkStatus: 'timeout'|'error'`, so a healthy domain hit by a momentary blip was **penalized**. The correct pattern already existed in `check-http-security.ts` and `check-ns.ts:48-49`.

## Fix
On a transient failure the affected checks now return the category **inconclusive** (one `info` "… not assessed" finding + `checkStatus`), so the engine renormalizes over the remaining categories:

| Check | Was | Now |
|-------|-----|-----|
| `check-ns` | CRITICAL "NS query failed" | info + `checkStatus:'error'` |
| `check-ssl` | CRITICAL/HIGH connect fail/timeout; **5xx/530 origin scored as "No HSTS"/redirect gap** | `checkStatus` `timeout`/`error`; 0/5xx → one info "not assessable"; 2xx/3xx/4xx unchanged |
| `check-dnssec` | MEDIUM "DNSSEC check failed" | info + `checkStatus:'error'` |
| `check-mx` | MEDIUM "DNS query failed" | info + `checkStatus:'error'` |
| `check-caa` | MEDIUM "CAA query failed" | info + `checkStatus:'error'` |

`check-subdomailing` was investigated and **left unchanged** — `extractSpfIncludeChain` swallows a thrown query internally, so its scored catch is unreachable on a transient failure (no FP).

**Untouched:** the legitimately fail-soft catches (CAA ancestor-climb, DNSSEC DNSKEY/DS/NSEC3PARAM, MTA-STS `detectInboundMail`), every empty-NOERROR-answer "record absent" path, and all scoring weights. Apex/normal output is **byte-identical**.

Worker wrappers (`src/tools/`, not the vendored package) that sniffed the old finding **titles** to set `checkStatus` were rewired to **propagate** the package's `checkStatus` — removing a fragile coupling.

## Verification
- TDD: new failing-first `transient-inconclusive.test.ts` (RED 7/8 → GREEN 8/8); updated the unit tests that locked the old behavior.
- Full suite **5888 passed / 0 failed**; package + repo typecheck clean; parity contract green (no fixture exercises a throw path).
- Bumps `@blackveil/dns-checks` 1.5.1 → **1.5.2** + `PARITY_CORPUS_VERSION`.

## ⚠️ Release-time TODO (not in this PR)
The `bv-mcp-release` version-sync surfaces (`SERVER_VERSION` / `server.json` / `CHANGELOG` / package-lock) still need bumping when this cuts a bv-mcp release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)