### PR TITLE
Fix tenant scan persistence: wire resultCapture for scan_domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+### Fixed
+
+- **Tenant scan rows persisted null scores (`resultCapture` never fired for `scan_domain`).** `runtimeOptions.resultCapture` was only invoked on the `TOOL_REGISTRY` dispatch path, but `scan_domain` is dispatched from the `switch` in `handlers/tools.ts`. Both tenant scan paths (the sync `POST /internal/tenants/scan` route and the queue consumer) pass a `resultCapture` and so always received nothing: every `scans` row persisted `score: null`, `grade: null`, `finding_count: 0`, a null `result_json`, and no `findings` rows. The `/report/:cycle_id` aggregates were consequently meaningless — `mean_score` always `0`, `grade_dist` always `{ unknown: N }`. `scan_domain` now emits the structured report plus its flattened per-category findings. Historical null-score rows **cannot be backfilled** (the scan output was never stored); see the tenant ops runbook for identification and handling.
+- **`resultCapture` type lie.** The callback was declared `(result: CheckResult) => void` while the tenant sites consumed the aggregate scan shape, so `tsc` saw `score` as a plain `number` and `grade` only through an `as unknown as { grade?: string }` cast — hiding nullability at the exact sites that persist those columns. Replaced with a `CheckResult | CapturedScanResult` union plus an `isCapturedScanResult()` guard (`src/lib/captured-result.ts`). The `?format=structured` contract on `/internal/tools/{call,batch}` is unchanged.
+
 ## [3.34.1] - 2026-07-24
 
 Follow-up bugfix release to 3.34.0: two non-apex regressions found in review, plus a broader false-positive class where a **transient** query/fetch failure was scored as a real deficiency. All corrections are in `@blackveil/dns-checks` (**1.5.0 → 1.5.2**); apex-domain output stays byte-identical.

--- a/docs/tenant-ops-runbook.md
+++ b/docs/tenant-ops-runbook.md
@@ -117,6 +117,52 @@ export locations in ignored notes.
   migrations, restore a synthetic tenant backup into a disposable D1 database,
   run the tenant schema/audit tests, and verify a queued scan can complete.
 
+### Legacy `scans` rows with a null score (pre-`resultCapture` fix)
+
+Until the `scan_domain` `resultCapture` wiring was fixed, both tenant scan paths
+persisted every row with `score NULL`, `grade NULL`, `finding_count 0`,
+`result_json NULL`, and no matching `findings` rows. `scan_domain` is dispatched
+from the `switch` in `src/handlers/tools.ts`, not from `TOOL_REGISTRY`, so the
+capture callback the tenant paths pass was never invoked.
+
+**These rows cannot be backfilled.** The scan output was never written anywhere —
+`result_json` is null, and the per-finding rows were never inserted — so there is
+no stored artifact to recompute from. A re-scan measures the domain's DNS *today*,
+which is a new observation, not a reconstruction of the historical one. Do not
+present a re-scan as a backfill of a past cycle.
+
+Identify the affected rows (placeholder tenant, read-only first):
+
+```sql
+SELECT cycle_id, COUNT(*) AS rows, MIN(scan_at), MAX(scan_at)
+FROM scans WHERE score IS NULL GROUP BY cycle_id ORDER BY MIN(scan_at);
+```
+
+Recommended handling:
+
+- **Flag, don't fabricate.** Leave the columns null and exclude null-score rows
+  from the `/report/:cycle_id` `mean_score` denominator rather than coercing them
+  to `0` — a coerced zero reads as "measured and terrible" instead of "never
+  measured". Report the measured-row count alongside `domains` so a consumer can
+  see the denominator shrink.
+- **Treat historical `mean_score` / `grade_dist` as void**, not merely inaccurate.
+  Before the fix `mean_score` was always `0` and `grade_dist` was always
+  `{ unknown: N }`. Any report, alert threshold, or customer-facing trend derived
+  from a pre-fix cycle should be withdrawn rather than reinterpreted.
+- **Re-scan forward.** Run a fresh cycle per affected tenant to establish a valid
+  current baseline, and label it as a new baseline in any customer communication.
+- Note that DLQ rows (`writeDlqRow`) are a separate case: they carry a hardcoded
+  `score = 0` with `result_json = {"error": ...}`, so they are NOT null-filtered
+  and will drag a mean down as if the domain genuinely scored zero. Exclude them
+  explicitly when computing a cycle mean.
+
+One behaviour change to expect on the first post-fix cycle: the 24-hour
+fingerprint pre-flight in both scan paths requires a non-null `result_json` to
+short-circuit a re-scan. With every historical row null it could never fire, so
+every cycle did full work. Once rows carry `result_json`, unchanged domains
+within the window start being skipped as designed — a drop in per-cycle scan
+volume there is expected, not a regression.
+
 ## Cost Governance
 
 Quota changes must be explicit and audited. The public quota maps in

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import type { CheckResult } from '../lib/scoring';
+// Re-exported so existing `handlers/tools` importers keep working; the canonical
+// home is `lib/captured-result` (see the note there about vi.mock).
+export { isCapturedScanResult, type CapturedScanResult, type CapturedToolResult } from '../lib/captured-result';
+import type { CapturedToolResult } from '../lib/captured-result';
 import type { QueryDnsOptions, SecondaryDohConfig } from '../lib/dns-types';
 import { buildCheckCacheKey, buildScanCacheKey, runWithCacheTracked } from '../lib/cache';
 import { withRequestDedup } from '../lib/request-dedup';
@@ -203,8 +207,18 @@ interface ToolRuntimeOptions {
 	profileAccumulatorShardMode?: import('../lib/profile-accumulator').AccumulatorShardMode;
 	waitUntil?: (promise: Promise<unknown>) => void;
 	scoringConfig?: import('@blackveil/dns-checks/scoring').ScoringConfig;
-	/** When provided, receives the raw CheckResult before MCP text formatting. Used by internal structured response mode. */
-	resultCapture?: (result: CheckResult) => void;
+	/**
+	 * When provided, receives the raw tool result before MCP text formatting. Used by
+	 * the internal structured response mode and by the tenant scan-persistence paths.
+	 *
+	 * The payload is NOT always a `CheckResult`: registry (per-category) tools emit a
+	 * `CheckResult`, while `scan_domain` emits the aggregate `CapturedScanResult`.
+	 * Declaring the union is deliberate — the old `(result: CheckResult) => void`
+	 * signature was a type lie that let the tenant call sites read `score` as a plain
+	 * `number` and hid both the missing `grade` field and its nullability. Consumers
+	 * must narrow with `isCapturedScanResult()`.
+	 */
+	resultCapture?: (result: CapturedToolResult) => void;
 	/** Override cache TTL in seconds for scan results. Threaded to scanDomain. */
 	cacheTtlSeconds?: number;
 	/** Scan-level wall-clock budget in milliseconds. Threaded to scanDomain. */
@@ -1278,6 +1292,16 @@ export async function handleToolsCall(
 					});
 					const structured = buildStructuredScanResult(result, {
 						scoringConfigHash: computeScoringConfigHash(runtimeOptions?.scoringConfig),
+					});
+					// scan_domain is dispatched from this switch, NOT from TOOL_REGISTRY, so it
+					// never reached the registry path's resultCapture call. Every tenant scan row
+					// therefore persisted `score: null, grade: null` and zero findings, which made
+					// the /reports `mean_score` and `grade_dist` aggregates meaningless. The
+					// payload is the structured report plus the flattened per-category findings —
+					// see CapturedScanResult.
+					runtimeOptions?.resultCapture?.({
+						...structured,
+						findings: result.checks.flatMap((c) => c.findings),
 					});
 					return buildToolResult(formatScanReport(result, effectiveFormat), structured, effectiveFormat);
 				}

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -34,6 +34,7 @@ import { ZodError } from 'zod';
 import { logError } from './lib/log';
 import { tenantRoutes } from './tenants/routes';
 import { handleToolsCall } from './handlers/tools';
+import { isCapturedScanResult } from './lib/captured-result';
 import { isAuthorizedRequest } from './lib/auth';
 import { createAnalyticsClient } from './lib/analytics';
 import { parseScoringConfigCached } from './lib/scoring-config';
@@ -310,8 +311,13 @@ internalRoutes.post('/tools/call', async (c) => {
 		...buildBrandTierLookups(c.env),
 		...(wantStructured
 			? {
-					resultCapture: (r: import('@blackveil/dns-checks/scoring').CheckResult) => {
-						capturedResult = r;
+					// resultCapture now also fires for scan_domain (previously it never did).
+					// scan_domain is NOT a CheckResult tool, and this door already surfaces its
+					// report via the `result.structuredContent` branch below — which bv-web reads
+					// as `payload.result`. Ignoring the scan aggregate here keeps that contract
+					// byte-identical instead of silently swapping in a differently-shaped payload.
+					resultCapture: (r) => {
+						if (!isCapturedScanResult(r)) capturedResult = r;
 					},
 				}
 			: {}),
@@ -585,8 +591,11 @@ internalRoutes.post('/tools/batch', async (c) => {
 						...buildBrandTierLookups(c.env),
 						...(wantStructured
 							? {
-									resultCapture: (r: import('@blackveil/dns-checks/scoring').CheckResult) => {
-										capturedResult = r;
+									// See the single-call door above: scan_domain's aggregate is
+									// deliberately not captured here so the batch structured
+									// contract stays unchanged.
+									resultCapture: (r) => {
+										if (!isCapturedScanResult(r)) capturedResult = r;
 									},
 								}
 							: {}),

--- a/src/lib/captured-result.ts
+++ b/src/lib/captured-result.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Shapes delivered to `ToolRuntimeOptions.resultCapture` (see `handlers/tools.ts`).
+ *
+ * These live in their own module rather than in `handlers/tools.ts` on purpose: the
+ * tenant and internal call sites need the type guard, and several suites `vi.mock()`
+ * `handlers/tools` down to just `handleToolsCall`. Importing the guard from there
+ * would leave it `undefined` under those mocks and throw at runtime inside the very
+ * persistence path this guard protects.
+ */
+
+import type { CheckResult, Finding } from './scoring';
+import type { StructuredScanResult } from '../tools/scan/format-report';
+
+/**
+ * `scan_domain`'s `resultCapture` payload: the same `StructuredScanResult` that is
+ * surfaced as `structuredContent`, plus the per-category findings flattened out of
+ * the raw `ScanDomainResult` (which `StructuredScanResult` summarises only as
+ * `findingCounts`). Consumers that persist a scan — the tenant scan paths — need
+ * both the aggregate score/grade AND the individual findings.
+ */
+export interface CapturedScanResult extends StructuredScanResult {
+	/** Findings flattened across every scan category, in category order. */
+	findings: Finding[];
+}
+
+/**
+ * Payload delivered to `ToolRuntimeOptions.resultCapture`. Per-category registry
+ * tools emit a `CheckResult`; `scan_domain` emits a `CapturedScanResult`.
+ *
+ * Declaring the union is deliberate. The previous `(result: CheckResult) => void`
+ * signature was a type lie: it let the tenant call sites read `score` as a plain
+ * `number` and hid `grade` behind an `as unknown as { grade?: string }` cast, so
+ * `tsc` could not flag nullability at the sites that persist those columns.
+ */
+export type CapturedToolResult = CheckResult | CapturedScanResult;
+
+/**
+ * Narrow a captured payload to `scan_domain`'s aggregate shape.
+ *
+ * Discriminates on `categoryScores`, which only the scan aggregate carries — a
+ * `CheckResult` has a single `category` string and no per-category score map.
+ */
+export function isCapturedScanResult(result: CapturedToolResult): result is CapturedScanResult {
+	const candidate = (result as CapturedScanResult).categoryScores;
+	return typeof candidate === 'object' && candidate !== null;
+}

--- a/src/tenants/queue-consumer.ts
+++ b/src/tenants/queue-consumer.ts
@@ -21,11 +21,12 @@
  * per-message Worker CPU budget proves tight; for the first cut we fold writes
  * into the scanner consumer to keep the blast radius small. If this becomes a
  * bottleneck, introduce `BV_SCAN_WRITER_QUEUE` and have the scanner emit its
- * captured `CheckResult` to it instead of inserting directly.
+ * captured `CapturedScanResult` to it instead of inserting directly.
  */
 
 import { ZodError } from 'zod';
 import { handleToolsCall } from '../handlers/tools';
+import { isCapturedScanResult, type CapturedScanResult } from '../lib/captured-result';
 import { createAnalyticsClient } from '../lib/analytics';
 import { parseScoringConfigCached } from '../lib/scoring-config';
 import { parseCacheTtl, parsePerCheckTimeout, parseScanTimeout } from '../lib/config';
@@ -33,7 +34,7 @@ import { ScanQueueMessageSchema, type ScanQueueMessage } from '../schemas/tenant
 import { streamScanResult } from '../lib/hooks/analytics-stream';
 import { resolveTenant, type ResolverEnv, type TenantDbHandle } from './tenant-resolver';
 import { resolveAccumulatorShardModeFromEnv } from '../lib/profile-accumulator';
-import type { CheckResult, Finding } from '../lib/scoring';
+import type { Finding } from '../lib/scoring';
 
 /** Wall-clock budget for one message — covers handleToolsCall + the D1 inserts. */
 export const QUEUE_MESSAGE_TIMEOUT_MS = 20_000;
@@ -185,11 +186,11 @@ async function writeDlqRow(
 async function persistScan(
 	tenantDb: TenantDbHandle,
 	msg: ScanQueueMessage,
-	captured: CheckResult | null,
+	captured: CapturedScanResult | null,
 ): Promise<void> {
 	const scanId = newRowId();
 	const score = captured?.score ?? null;
-	const grade = (captured as unknown as { grade?: string } | null)?.grade ?? null;
+	const grade = captured?.grade ?? null;
 	const findingCount = captured?.findings?.length ?? 0;
 	await tenantDb
 		.prepare(SCANS_INSERT_SQL)
@@ -304,7 +305,7 @@ export async function processScanMessage(
 		secondaryDoh: env.BV_DOH_ENDPOINT ? { endpoint: env.BV_DOH_ENDPOINT, token: env.BV_DOH_TOKEN } : undefined,
 	};
 
-	let captured: CheckResult | null = null;
+	let captured: CapturedScanResult | null = null;
 	try {
 		// Phase 6: Fingerprint pre-flight
 		if (!parsed.force_refresh) {
@@ -333,7 +334,7 @@ export async function processScanMessage(
 							// to keep the cycle consistent with the skip logic.
 							// But wait, the cycle alert sweep needs a scan row for THIS cycle_id
 							// to find the findings. So we DO need to persist it.
-							captured = JSON.parse(lastScan.result_json) as CheckResult;
+							captured = JSON.parse(lastScan.result_json) as CapturedScanResult;
 						}
 					}
 				}
@@ -349,8 +350,11 @@ export async function processScanMessage(
 					env.SCAN_CACHE,
 					{
 						...runtimeOptions,
+						// Narrowed rather than assigned blind: `resultCapture` is typed as the
+						// CheckResult | CapturedScanResult union, and only the scan aggregate
+						// carries the score/grade this row persists.
 						resultCapture: (r) => {
-							captured = r;
+							if (isCapturedScanResult(r)) captured = r;
 						},
 					},
 				),
@@ -376,11 +380,11 @@ export async function processScanMessage(
 	}
 
 	try {
-		await persistScan(tenantDb, parsed, captured as CheckResult | null);
+		await persistScan(tenantDb, parsed, captured as CapturedScanResult | null);
 		ctx.waitUntil(streamScanResult(env, {
 			domain: parsed.domain,
-			grade: (captured as unknown as { grade?: string } | null)?.grade ?? null,
-			score: captured?.score ?? null,
+			grade: (captured as CapturedScanResult | null)?.grade ?? null,
+			score: (captured as CapturedScanResult | null)?.score ?? null,
 			sub_tenant_id: parsed.sub_tenant_id,
 			cycle_id: parsed.cycle_id
 		}));

--- a/src/tenants/routes.ts
+++ b/src/tenants/routes.ts
@@ -18,6 +18,7 @@ import { Hono } from 'hono';
 import { drizzle } from 'drizzle-orm/d1';
 import { ZodError } from 'zod';
 import { handleToolsCall } from '../handlers/tools';
+import { isCapturedScanResult, type CapturedScanResult } from '../lib/captured-result';
 import { createAnalyticsClient, hashForAnalytics, hashIpForAnalytics } from '../lib/analytics';
 import { resolveClientIpFromHeaderGetter } from '../lib/client-ip';
 import { parseScoringConfigCached } from '../lib/scoring-config';
@@ -816,7 +817,7 @@ tenantRoutes.post('/scan', async (c) => {
 							if (isRecent) {
 								const fp = await computeFingerprint(domain);
 								if (fp.kind === 'ok' && !fingerprintsDiffer(fp.fingerprint, domainRow?.fingerprint ?? null)) {
-									const captured = JSON.parse(lastScan.result_json) as CheckResult;
+									const captured = JSON.parse(lastScan.result_json) as CapturedScanResult;
 									// Return the cached result as if it were a fresh scan, but skip handleToolsCall
 									return { domain, result: { isError: false }, captured, skippedByFingerprint: true };
 								}
@@ -827,18 +828,21 @@ tenantRoutes.post('/scan', async (c) => {
 					}
 				}
 
-				let captured: CheckResult | null = null;
+				let captured: CapturedScanResult | null = null;
 				const result = await handleToolsCall(
 					{ name: 'scan_domain', arguments: { domain } },
 					c.env.SCAN_CACHE,
 					{
 						...runtimeBase,
+						// Narrowed rather than assigned blind: `resultCapture` is typed as the
+						// CheckResult | CapturedScanResult union, and only the scan aggregate
+						// carries the score/grade this row persists.
 						resultCapture: (r) => {
-							captured = r;
+							if (isCapturedScanResult(r)) captured = r;
 						},
 					},
 				);
-				return { domain, result, captured: captured as CheckResult | null, skippedByFingerprint: false };
+				return { domain, result, captured: captured as CapturedScanResult | null, skippedByFingerprint: false };
 			}),
 		);
 
@@ -847,7 +851,7 @@ tenantRoutes.post('/scan', async (c) => {
 				errored += 1;
 				continue;
 			}
-			const { domain, result, captured, skippedByFingerprint } = s.value as { domain: string; result: { isError: boolean }; captured: CheckResult | null; skippedByFingerprint: boolean };
+			const { domain, result, captured, skippedByFingerprint } = s.value as { domain: string; result: { isError: boolean }; captured: CapturedScanResult | null; skippedByFingerprint: boolean };
 			if (result.isError) {
 				errored += 1;
 				continue;
@@ -863,7 +867,7 @@ tenantRoutes.post('/scan', async (c) => {
 			try {
 				const scanId = newRowId();
 				const score = captured?.score ?? null;
-				const grade = (captured as unknown as { grade?: string } | null)?.grade ?? null;
+				const grade = captured?.grade ?? null;
 				const findingCount = captured?.findings?.length ?? 0;
 				await tenantDb
 					.prepare(SCANS_INSERT_SQL)

--- a/test/chaos/tenant-queue.chaos.test.ts
+++ b/test/chaos/tenant-queue.chaos.test.ts
@@ -164,9 +164,14 @@ describe('Tenant queue consumer chaos: handleScanQueue wrapper resilience', () =
 			}
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
 			opts?.resultCapture?.({
-				category: 'spf',
-				passed: true,
+				domain: 'example.com',
 				score: 90,
+				grade: 'A',
+				passed: true,
+				// `categoryScores` is what marks this as scan_domain's aggregate payload
+				// (CapturedScanResult) rather than a per-category CheckResult. The tenant
+				// path only ever calls scan_domain, so that is the shape it really receives.
+				categoryScores: { spf: 90 },
 				findings: [],
 			});
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
@@ -213,9 +218,14 @@ describe('Tenant queue consumer chaos: handleScanQueue wrapper resilience', () =
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
 			opts?.resultCapture?.({
-				category: 'spf',
-				passed: true,
+				domain: 'example.com',
 				score: 90,
+				grade: 'A',
+				passed: true,
+				// `categoryScores` is what marks this as scan_domain's aggregate payload
+				// (CapturedScanResult) rather than a per-category CheckResult. The tenant
+				// path only ever calls scan_domain, so that is the shape it really receives.
+				categoryScores: { spf: 90 },
 				findings: [],
 			});
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -856,6 +856,59 @@ describe('handleToolsCall - resultCapture', () => {
 		expect((captured as Record<string, unknown>).category).toBe('spf');
 		expect(typeof (captured as Record<string, unknown>).score).toBe('number');
 	});
+
+	// Regression: scan_domain is dispatched from the `switch`, not TOOL_REGISTRY, so it
+	// never reached the registry path's resultCapture call. The callback silently never
+	// fired and every tenant scan row persisted score/grade null.
+	it('invokes resultCapture with the aggregate scan result for scan_domain', async () => {
+		mockAllChecks();
+		let fired = false;
+		let captured: unknown = null;
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const result = await handleToolsCall({ name: 'scan_domain', arguments: { domain: 'example.com' } }, undefined, {
+			resultCapture: (r) => {
+				fired = true;
+				captured = r;
+			},
+		});
+		expect(result.isError).toBeUndefined();
+		expect(fired).toBe(true);
+
+		const payload = captured as Record<string, unknown>;
+		// A real, persistable score/grade — not the null that reached D1 before.
+		expect(typeof payload.score).toBe('number');
+		expect(payload.score).toBeGreaterThan(0);
+		expect(typeof payload.grade).toBe('string');
+		expect(payload.grade).not.toBe('');
+		expect(payload.domain).toBe('example.com');
+		// Findings are flattened off the per-category checks so tenant rows can persist them.
+		expect(Array.isArray(payload.findings)).toBe(true);
+	});
+
+	it('captures a payload scan consumers can narrow with isCapturedScanResult', async () => {
+		mockAllChecks();
+		mockTxtRecords(['v=spf1 -all']);
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		const { isCapturedScanResult } = await import('../src/lib/captured-result');
+
+		let scanCapture: unknown = null;
+		await handleToolsCall({ name: 'scan_domain', arguments: { domain: 'example.com' } }, undefined, {
+			resultCapture: (r) => {
+				if (isCapturedScanResult(r)) scanCapture = r;
+			},
+		});
+		expect(scanCapture).not.toBeNull();
+
+		// The guard must NOT swallow a per-category CheckResult as a scan aggregate —
+		// internal.ts relies on that distinction to keep its structured contract stable.
+		let checkCapture: unknown = null;
+		await handleToolsCall({ name: 'check_spf', arguments: { domain: 'example.com' } }, undefined, {
+			resultCapture: (r) => {
+				if (isCapturedScanResult(r)) checkCapture = r;
+			},
+		});
+		expect(checkCapture).toBeNull();
+	});
 });
 
 // -- tool routing for additional registry tools --

--- a/test/tenants/findings-batch.spec.ts
+++ b/test/tenants/findings-batch.spec.ts
@@ -147,7 +147,7 @@ describe('queue-consumer persistScan — findings batching (T3)', () => {
 		const n = 25;
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
-			opts?.resultCapture?.({ category: 'spf', passed: true, score: 80, findings: makeFindings(n) });
+			opts?.resultCapture?.({ domain: 'example.com', score: 80, grade: 'A', passed: true, categoryScores: { spf: 80 }, findings: makeFindings(n) });
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
 		});
 		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
@@ -172,7 +172,7 @@ describe('queue-consumer persistScan — findings batching (T3)', () => {
 		const n = 12;
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
-			opts?.resultCapture?.({ category: 'spf', passed: true, score: 80, findings: makeFindings(n) });
+			opts?.resultCapture?.({ domain: 'example.com', score: 80, grade: 'A', passed: true, categoryScores: { spf: 80 }, findings: makeFindings(n) });
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
 		});
 		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
@@ -190,7 +190,7 @@ describe('queue-consumer persistScan — findings batching (T3)', () => {
 	it('writes no findings INSERT when the scan has zero findings', async () => {
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
-			opts?.resultCapture?.({ category: 'spf', passed: true, score: 100, findings: [] });
+			opts?.resultCapture?.({ domain: 'example.com', score: 100, grade: 'A', passed: true, categoryScores: { spf: 100 }, findings: [] });
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
 		});
 		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
@@ -224,7 +224,7 @@ describe('routes POST /internal/tenants/scan — findings batching (T3)', () => 
 		const n = 25;
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
-			opts?.resultCapture?.({ category: 'spf', passed: true, score: 80, findings: makeFindings(n) });
+			opts?.resultCapture?.({ domain: 'example.com', score: 80, grade: 'A', passed: true, categoryScores: { spf: 80 }, findings: makeFindings(n) });
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
 		});
 		const worker = (await import('../../src')).default;

--- a/test/tenants/queue-consumer.integration.test.ts
+++ b/test/tenants/queue-consumer.integration.test.ts
@@ -158,9 +158,14 @@ describe('processScanMessage', () => {
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
 			opts?.resultCapture?.({
-				category: 'spf',
-				passed: true,
+				domain: 'example.com',
 				score: 90,
+				grade: 'A',
+				passed: true,
+				// `categoryScores` is what marks this as scan_domain's aggregate payload
+				// (CapturedScanResult) rather than a per-category CheckResult. The tenant
+				// path only ever calls scan_domain, so that is the shape it really receives.
+				categoryScores: { spf: 90 },
 				findings: [
 					{ category: 'spf', severity: 'info', title: 'spf_ok', detail: 'looks good' },
 					{ category: 'spf', severity: 'low', title: 'spf_pct', detail: 'pct=100' },
@@ -242,9 +247,14 @@ describe('processScanMessage', () => {
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
 			opts?.resultCapture?.({
-				category: 'spf',
-				passed: true,
+				domain: 'example.com',
 				score: 90,
+				grade: 'A',
+				passed: true,
+				// `categoryScores` is what marks this as scan_domain's aggregate payload
+				// (CapturedScanResult) rather than a per-category CheckResult. The tenant
+				// path only ever calls scan_domain, so that is the shape it really receives.
+				categoryScores: { spf: 90 },
 				findings: [{ category: 'spf', severity: 'info', title: 'spf_ok', detail: 'looks good' }],
 			});
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
@@ -321,9 +331,14 @@ describe('processScanMessage', () => {
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
 			opts?.resultCapture?.({
-				category: 'spf',
-				passed: true,
+				domain: 'example.com',
 				score: 90,
+				grade: 'A',
+				passed: true,
+				// `categoryScores` is what marks this as scan_domain's aggregate payload
+				// (CapturedScanResult) rather than a per-category CheckResult. The tenant
+				// path only ever calls scan_domain, so that is the shape it really receives.
+				categoryScores: { spf: 90 },
 				findings: [],
 			});
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
@@ -391,9 +406,14 @@ describe('handleScanQueue', () => {
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			const opts = runtimeOptions as { resultCapture?: (r: unknown) => void } | undefined;
 			opts?.resultCapture?.({
-				category: 'spf',
-				passed: true,
+				domain: 'example.com',
 				score: 90,
+				grade: 'A',
+				passed: true,
+				// `categoryScores` is what marks this as scan_domain's aggregate payload
+				// (CapturedScanResult) rather than a per-category CheckResult. The tenant
+				// path only ever calls scan_domain, so that is the shape it really receives.
+				categoryScores: { spf: 90 },
 				findings: [],
 			});
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };

--- a/test/tenants/scan-persistence.integration.test.ts
+++ b/test/tenants/scan-persistence.integration.test.ts
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * End-to-end regression tests for tenant scan persistence.
+ *
+ * These deliberately do NOT `vi.mock('../../src/handlers/tools')`. Every other
+ * tenant suite mocks `handleToolsCall` and fires `resultCapture` itself, so they
+ * all passed while production captured nothing: `resultCapture` was only invoked
+ * on the `TOOL_REGISTRY` dispatch path, and `scan_domain` is dispatched from the
+ * `switch` in `handlers/tools.ts` instead. Every tenant scan row therefore
+ * persisted `score: null, grade: null` with zero findings, which made the
+ * `/report/:cycle_id` `mean_score` and `grade_dist` aggregates meaningless.
+ *
+ * Driving the REAL `handleToolsCall` (with DNS mocked at the fetch layer) is the
+ * only way to catch that wiring gap, so these tests assert on the values actually
+ * bound to the `scans` INSERT.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { resetTenantResolverCache } from '../../src/tenants/tenant-resolver';
+import { setupFetchMock, createDohResponse, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse } from '../helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => {
+	restore();
+	resetTenantResolverCache();
+});
+
+const TEST_TENANT_ID = 'tenant-1';
+const TEST_TENANT_BINDING = 'TENANT_DB_TENANT_1';
+const TEST_INTERNAL_KEY = 'tenant-orchestrator-internal-key';
+const TEST_DOMAIN = 'example.com';
+const REGISTRY_LOOKUP_SQL = 'SELECT id, super_tenant_id, d1_db_id, routing_mode, active FROM sub_tenants WHERE id = ? LIMIT 1';
+const SCANS_INSERT_SQL =
+	'INSERT INTO scans (id, domain, scan_at, score, grade, maturity_stage, finding_count, result_json, cycle_id) ' +
+	'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
+
+/** Bind positions of the `scans` INSERT above. */
+const SCORE_BIND = 3;
+const GRADE_BIND = 4;
+const FINDING_COUNT_BIND = 6;
+const RESULT_JSON_BIND = 7;
+
+/** A scan-wide DNS/HTTP mock: enough signal that the domain scores above zero. */
+function mockScannableDomain() {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+		if (url.includes('cloudflare-dns.com')) {
+			if (url.includes('type=TXT') || url.includes('type=16')) {
+				if (url.includes('_dmarc.')) return Promise.resolve(txtResponse(`_dmarc.${TEST_DOMAIN}`, ['v=DMARC1; p=reject']));
+				if (url.includes('_domainkey.')) return Promise.resolve(txtResponse(`default._domainkey.${TEST_DOMAIN}`, ['v=DKIM1; k=rsa; p=MIGf']));
+				return Promise.resolve(txtResponse(TEST_DOMAIN, ['v=spf1 include:_spf.google.com -all']));
+			}
+			if (url.includes('type=NS') || url.includes('type=2')) {
+				return Promise.resolve(nsResponse(TEST_DOMAIN, ['ns1.example.com.', 'ns2.example.com.']));
+			}
+			if (url.includes('type=CAA') || url.includes('type=257')) {
+				return Promise.resolve(caaResponse(TEST_DOMAIN, ['0 issue "letsencrypt.org"']));
+			}
+			if (url.includes('type=A') || url.includes('type=1')) {
+				return Promise.resolve(dnssecResponse(TEST_DOMAIN, true));
+			}
+			return Promise.resolve(createDohResponse([], []));
+		}
+
+		if (url.startsWith('https://')) return Promise.resolve({ ...httpResponse('OK'), url });
+		return Promise.resolve(httpResponse('OK'));
+	});
+}
+
+type RecordedCall = { sql: string; binds: unknown[] };
+
+function makeMockD1(rowsBySql: Record<string, unknown[]> = {}) {
+	const calls: RecordedCall[] = [];
+	const db: D1Database = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					return stmt;
+				},
+				async first<T = unknown>(): Promise<T | null> {
+					calls.push({ sql, binds });
+					return ((rowsBySql[sql] ?? [])[0] as T | undefined) ?? null;
+				},
+				async all<T = unknown>() {
+					calls.push({ sql, binds });
+					return { results: (rowsBySql[sql] ?? []) as T[], success: true, meta: {} } as unknown as D1Result<T>;
+				},
+				async run() {
+					calls.push({ sql, binds });
+					return {
+						success: true,
+						meta: { changes: 1, last_row_id: 0, duration: 0, rows_read: 0, rows_written: 1, size_after: 0 },
+					} as unknown as D1Response;
+				},
+				async raw() {
+					calls.push({ sql, binds });
+					return [] as unknown[];
+				},
+			};
+			return stmt as unknown as D1PreparedStatement;
+		},
+		async batch<T = unknown>(stmts: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+			const out: D1Result<T>[] = [];
+			for (const s of stmts) out.push((await (s as unknown as { run: () => Promise<unknown> }).run()) as D1Result<T>);
+			return out;
+		},
+		async exec() {
+			return { count: 0, duration: 0 } as unknown as D1ExecResult;
+		},
+		dump() {
+			throw new Error('not implemented');
+		},
+		withSession() {
+			throw new Error('not implemented');
+		},
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+function buildEnv(rowsBySql: Record<string, unknown[]> = {}) {
+	const registry = makeMockD1({
+		[REGISTRY_LOOKUP_SQL]: [{ id: TEST_TENANT_ID, super_tenant_id: 'super-tenant-1', d1_db_id: 'fake-d1-uuid', active: 1 }],
+	});
+	const tenant = makeMockD1(rowsBySql);
+	const customEnv = {
+		...env,
+		BV_WEB_INTERNAL_KEY: TEST_INTERNAL_KEY,
+		REQUIRE_INTERNAL_AUTH: 'true',
+		TENANT_REGISTRY_DB: registry.db,
+		[TEST_TENANT_BINDING]: tenant.db,
+	} as typeof env & Record<string, unknown>;
+	return { customEnv, tenantCalls: tenant.calls };
+}
+
+/** Assert a `scans` row carries a genuine score/grade rather than the nulls production wrote. */
+function expectRealScoreRow(binds: unknown[]) {
+	expect(typeof binds[SCORE_BIND]).toBe('number');
+	expect(binds[SCORE_BIND]).toBeGreaterThan(0);
+	expect(typeof binds[GRADE_BIND]).toBe('string');
+	expect(binds[GRADE_BIND]).not.toBe('');
+	// result_json must round-trip the aggregate the fingerprint pre-flight re-reads.
+	expect(typeof binds[RESULT_JSON_BIND]).toBe('string');
+	const parsed = JSON.parse(binds[RESULT_JSON_BIND] as string) as { score?: unknown; grade?: unknown; domain?: unknown };
+	expect(parsed.score).toBe(binds[SCORE_BIND]);
+	expect(parsed.grade).toBe(binds[GRADE_BIND]);
+	expect(parsed.domain).toBe(TEST_DOMAIN);
+}
+
+describe('tenant scan persistence (real handleToolsCall)', () => {
+	it('persists a real score and grade via the queue consumer', async () => {
+		mockScannableDomain();
+		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
+		const { customEnv, tenantCalls } = buildEnv();
+		const ctx = createExecutionContext();
+
+		const outcome = await processScanMessage(
+			{ cycle_id: 'cycle_persist_q', sub_tenant_id: TEST_TENANT_ID, domain: TEST_DOMAIN },
+			1,
+			customEnv,
+			{ waitUntil: (p: Promise<unknown>) => ctx.waitUntil(p) },
+		);
+		await waitOnExecutionContext(ctx);
+		expect(outcome).toBe('ack');
+
+		const scanInserts = tenantCalls.filter((c) => c.sql === SCANS_INSERT_SQL);
+		expect(scanInserts.length).toBe(1);
+		expectRealScoreRow(scanInserts[0]!.binds);
+	});
+
+	it('persists a real score and grade via the sync POST /internal/tenants/scan route', async () => {
+		mockScannableDomain();
+		const worker = (await import('../../src')).default;
+		const { customEnv, tenantCalls } = buildEnv();
+
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tenants/scan', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${TEST_INTERNAL_KEY}`,
+				'X-Tenant': TEST_TENANT_ID,
+			},
+			body: JSON.stringify({ domains: [TEST_DOMAIN] }),
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, customEnv, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(res.status).toBe(200);
+
+		const scanInserts = tenantCalls.filter((c) => c.sql === SCANS_INSERT_SQL);
+		expect(scanInserts.length).toBe(1);
+		expectRealScoreRow(scanInserts[0]!.binds);
+	});
+
+	it('persists the scan findings so finding_count is not stuck at zero', async () => {
+		mockScannableDomain();
+		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
+		const { customEnv, tenantCalls } = buildEnv();
+		const ctx = createExecutionContext();
+
+		await processScanMessage(
+			{ cycle_id: 'cycle_persist_findings', sub_tenant_id: TEST_TENANT_ID, domain: TEST_DOMAIN },
+			1,
+			customEnv,
+			{ waitUntil: (p: Promise<unknown>) => ctx.waitUntil(p) },
+		);
+		await waitOnExecutionContext(ctx);
+
+		const scanInsert = tenantCalls.find((c) => c.sql === SCANS_INSERT_SQL);
+		const findingCount = scanInsert!.binds[FINDING_COUNT_BIND] as number;
+		expect(findingCount).toBeGreaterThan(0);
+
+		// A non-zero finding_count must be matched by actual findings rows, or the
+		// cycle alert sweep (which reads the findings table) sees an empty scan.
+		const findingInserts = tenantCalls.filter((c) => c.sql.startsWith('INSERT INTO findings'));
+		expect(findingInserts.length).toBeGreaterThan(0);
+		const persistedFindings = findingInserts.reduce((n, c) => n + c.binds.length / 8, 0);
+		expect(persistedFindings).toBe(findingCount);
+	});
+
+	it('reports a non-zero mean_score once rows carry real scores', async () => {
+		const worker = (await import('../../src')).default;
+		// Rows shaped like the ones the fixed persistence path now writes.
+		const { customEnv } = buildEnv({
+			'SELECT score, grade FROM scans WHERE cycle_id = ?': [
+				{ score: 80, grade: 'B' },
+				{ score: 90, grade: 'A' },
+			],
+		});
+
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tenants/report/cycle_persist_q', {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${TEST_INTERNAL_KEY}`, 'X-Tenant': TEST_TENANT_ID },
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, customEnv, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(res.status).toBe(200);
+
+		const body = (await res.json()) as { summary: { mean_score: number; grade_dist: Record<string, number> } };
+		expect(body.summary.mean_score).toBe(85);
+		// Before the fix every row was null → grade_dist was always `{ unknown: N }`.
+		expect(body.summary.grade_dist).toEqual({ B: 1, A: 1 });
+		expect(body.summary.grade_dist.unknown).toBeUndefined();
+	});
+});


### PR DESCRIPTION
## Summary

Fixes a critical bug where tenant scan rows persisted `score: null`, `grade: null`, `finding_count: 0`, and no findings data. The root cause: `scan_domain` is dispatched from the `switch` statement in `handlers/tools.ts`, not from the `TOOL_REGISTRY` path, so the `resultCapture` callback that tenant scan paths pass was never invoked. This made all historical tenant scan aggregates meaningless and broke the `/report/:cycle_id` `mean_score` and `grade_dist` calculations.

## Changes

### Core fix
- **`src/handlers/tools.ts`**: Invoke `resultCapture` for `scan_domain` results (previously only fired for registry tools). Updated `ToolRuntimeOptions.resultCapture` signature from `(result: CheckResult)` to `(result: CapturedToolResult)` to accurately reflect that `scan_domain` emits a different shape.

### Type safety
- **`src/lib/captured-result.ts`** (new): Defines `CapturedScanResult` (scan aggregate with flattened findings), `CapturedToolResult` union, and `isCapturedScanResult()` type guard. Placed in its own module to avoid import issues when `handlers/tools` is mocked in tests.
- **`src/handlers/tools.ts`**: Re-exports the new types for backward compatibility.

### Consumer updates
- **`src/tenants/queue-consumer.ts`**: Use `isCapturedScanResult()` to narrow the captured result; remove unsafe `as unknown as { grade?: string }` cast. Type now correctly reflects that `grade` is a string, not optional.
- **`src/tenants/routes.ts`**: Same narrowing and type fixes for the sync scan endpoint.
- **`src/internal.ts`**: Filter out `scan_domain` aggregates from `resultCapture` (via `isCapturedScanResult()`) to preserve the existing `/tools/call` structured response contract — `scan_domain` is not a registry tool and already surfaces its report via `result.structuredContent`.

### Test updates
- **`test/handlers-tools.spec.ts`**: Added regression tests verifying `resultCapture` fires for `scan_domain` with a real score/grade, and that `isCapturedScanResult()` correctly discriminates scan aggregates from per-category `CheckResult`s.
- **`test/tenants/scan-persistence.integration.test.ts`** (new): End-to-end regression suite driving the real `handleToolsCall` (with DNS mocked at fetch layer) to verify tenant scan rows persist genuine scores, grades, and findings — not nulls.
- **`test/tenants/queue-consumer.integration.test.ts`**, **`test/chaos/tenant-queue.chaos.test.ts`**, **`test/tenants/findings-batch.spec.ts`**: Updated mock `resultCapture` payloads to match the new `CapturedScanResult` shape (includes `domain`, `grade`, `categoryScores`).

### Documentation
- **`docs/tenant-ops-runbook.md`**: Added "Legacy `scans` rows with a null score" section documenting the pre-fix data state, why rows cannot be backfilled, and recommended handling (flag rather than fabricate, exclude from aggregates, re-scan forward).
- **`CHANGELOG.md`**: Documented the fix.

## Security impact

None. This fixes a data integrity bug; no auth, validation, or error handling changes.

## Test plan

- ✅ New integration test suite (`test/tenants/scan-persistence.integration.test.ts`) verifies real scores/grades persist via both queue and sync endpoints
- ✅ New regression tests in `test/handlers-tools.spec.ts` confirm `resultCapture` fires for `scan_domain`
- ✅ Updated mock payloads in existing tenant tests to match corrected shape
- ✅ `npm test` passes; `npm run typecheck` passes

## Checklist

- [x] Changes follow existing code conventions
- [x] No secrets, credentials, or internal references included
- [x] Error

https://claude.ai/code/session_01NhdyKEuiF8ByfHC44D2tes