### PR TITLE
chore: bump version to 3.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.35.0] - 2026-07-26
+
+Three "silently empty" defects of one shape — a consumer reading a field or hook the producer never populates, with tests that fabricated the missing shape and so passed while production returned nothing. Plus the dependency work that unblocked the `contract` CI gate, red on `main` since 2026-07-23.
+
+Production dependencies moved: `hono` 4.12.30 → 4.12.32 (includes the honojs/hono#5161 prototype-pollution hardening; verified against our usage — we do not use `streamSSE`, `secureHeaders`, or `parseBody`) and `tldts` 7.4.8 → 7.4.9 (Public Suffix List refresh, which feeds `resolveZoneApex` and the PSL-bounded NS walk). No scoring-model or tool-surface change; `@blackveil/dns-checks` stays at 1.5.2.
+
 ### Fixed
 
 - **`/internal/tools/batch?format=structured` returned the MCP frame instead of the payload for custom-shape tools.** The batch door only unwrapped results captured through `resultCapture` (the `check_*` cohort) and fell through to the MCP-framed tool result for everything else, so a batched `scan_domain` / `explain_finding` / `compare_baseline` / `get_benchmark` yielded `{ content, structuredContent }` under `result` while a batched `check_*` yielded a bare payload. One `payload.result` read could not serve both. The batch door now falls back to `structuredContent` exactly as the single-call door does, so `result` is the payload for every tool on both doors. **Response-shape change** for structured batch callers of those four tools: `result` is now the report itself rather than a wrapper around it (`result.structuredContent` → `result`); `check_*` batch results are unchanged. `test/internal.spec.ts` gains a cross-door parity test asserting the two doors agree on the payload shape for the same tool. Also corrects the stale claim in `docs/design/agent-chat-tool-allowlist.md` that these tools fall through to MCP-framed content under `format=structured` — untrue for the single-call door since its fallback landed, and now untrue for the batch door too.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.34.1",
+	"version": "3.35.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.34.1",
+			"version": "3.35.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.34.1",
+	"version": "3.35.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "com.blackveilsecurity/dns",
-  "description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
-  "repository": {
-    "url": "https://github.com/MadaBurns/bv-mcp",
-    "source": "github"
-  },
-  "version": "3.34.1",
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://dns-mcp.blackveilsecurity.com/mcp"
-    }
-  ]
+	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+	"name": "com.blackveilsecurity/dns",
+	"description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"repository": {
+		"url": "https://github.com/MadaBurns/bv-mcp",
+		"source": "github"
+	},
+	"version": "3.35.0",
+	"remotes": [
+		{
+			"type": "streamable-http",
+			"url": "https://dns-mcp.blackveilsecurity.com/mcp"
+		}
+	]
 }


### PR DESCRIPTION
## Summary

Release bump for **3.35.0**, pre-bumped locally before tagging so `publish.yml`'s version-sync step becomes a no-op — that job's `git push origin HEAD:main` is rejected by branch protection, which is exactly the failure mode CLAUDE.md's "Release workflow" section documents.

Version surfaces synced (all four):

| Surface | Value |
| --- | --- |
| `package.json` | 3.35.0 |
| `package-lock.json` (root + `packages[""]`) | 3.35.0 |
| `server.json` top-level `version` | 3.35.0 |
| `CHANGELOG.md` heading | `## [3.35.0] - 2026-07-26` |

`SERVER_VERSION` is not hand-edited — it auto-derives from `pkg.version` via `src/lib/server-version.ts`. `server.json` is remotes-only, so there is no `packages[0].version` to sync.

**`@blackveil/dns-checks` stays at 1.5.2.** No scoring-model change in this release, so `PARITY_CORPUS_VERSION` is untouched and the version-lock contract holds.

### Why minor, not patch

The release carries a documented **response-shape change** to `/internal/tools/batch?format=structured` for the four `NON_CHECK_RESULT_TOOLS` (`result.structuredContent` → `result`). Shipping that under a patch bump would understate it for internal consumers. The rest is bug fixes plus dependency work.

### What's in 3.35.0

Three "silently empty" defects of one shape — a consumer reading a field or hook the producer never populates, with tests that fabricated the missing shape and so passed while production returned nothing:

- Registrar-complement deep-scan read `envelope.structured`, a field `handleToolsCall` never emits (#551)
- Tenant scan paths collected `scan_domain` via `resultCapture`, which that orchestrator never invokes — every `scans` row persisted null score/grade/`result_json` (#551)
- The internal batch door returned the MCP frame instead of the payload for custom-shape tools (#556)

Plus the dependency work that unblocked the `contract` gate (red on `main` since 2026-07-23), and two production dependency bumps: `hono` 4.12.30 → 4.12.32 and `tldts` 7.4.8 → 7.4.9.

## Type of change

- [x] Refactor / cleanup
- [x] CI / tooling

## Security impact

None from this commit — it changes only version strings and the changelog. The release it tags does include the `npm audit --audit-level=high` remediation (0 vulnerabilities, down from 5 high) and hono's honojs/hono#5161 prototype-pollution hardening, both already reviewed and merged.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm audit --audit-level=high` → 0 vulnerabilities
- [x] Version-sync-adjacent audits pass: `server-json-tool-count`, `deploy-pipeline`, `npm-publish-surface`, `workflow-secret-check` (14 tests)
- [x] `npm ci` + dns-checks package build clean on the merged tree
- [ ] Full suite — running against merged `main` at time of opening; **the tag will not be pushed until it comes back clean**

The full-suite run matters here beyond routine: `main` is a combination no individual PR's CI exercised — hono 4.12.32 + tldts 7.4.9 + workers-types 5.20260726.1 + the batch-door change, each verified against a different base, two of them production dependencies that ship in the Worker.

## Checklist

- [x] Changes follow existing code conventions
- [x] No secrets, credentials, or internal references included
- [x] Error messages follow the safe-prefix convention — n/a
- [x] New tool? Followed the "Adding a New Tool" checklist — n/a, tool surface unchanged

### Note on tagging

Pushing `v3.35.0` triggers **both** `publish.yml` (npm publish with provenance → Cloudflare deploy → MCP Registry → GitHub Release) and `deploy-prod.yml`. Both are gated on the `production` GitHub Environment reviewer, so they will wait for approval rather than shipping unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxVFp4AMEQCpCCk4SPWQEJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UxVFp4AMEQCpCCk4SPWQEJ)_