### PR TITLE
fix(dns-checks): close non-apex zone edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.35.1] - 2026-07-26
+
+Patch release for honest handling of unmeasured tenant results and non-apex DNS zone-resolution edge cases. `@blackveil/dns-checks` moves from 1.5.2 to 1.5.3 with the parity corpus version kept in lockstep.
+
 ### Fixed
 
 - **DLQ rows were scored `0`, dragging every cycle's `mean_score` down.** `writeDlqRow` (`src/tenants/queue-consumer.ts`) persisted a hardcoded `score: 0` for a domain that timed out or exhausted its retries. That domain was never measured, so `0` reported it as a genuinely catastrophic score — and because `0` is not null, it also survived any null-skipping filter downstream. DLQ rows now write a null score, matching every other unmeasured row. The domain still appears in the cycle via its `queue_dlq` finding and its `grade_dist` `unknown` bucket.
 - **`/report/:cycle_id` counted unmeasured domains as zeros.** The cycle mean was `scanRows.reduce((acc, r) => acc + (r.score ?? 0), 0) / scanRows.length`, so any row without a score (a DLQ row, or one written before the `scanResultCapture` fix) was averaged in as a 0 rather than excluded. `mean_score` is now computed over measured rows only, and the summary gains **`measured_domains`** so the denominator is visible instead of inferred. **Response-shape change for consumers:** `mean_score` is now `number | null` — it is `null` when no row in the cycle carried a score, because `0` would be a fabricated result for a cycle that measured nothing.
+- **CAA and DNSSEC could score a false deficiency after an inconclusive non-apex zone walk.** When authoritative-zone discovery returned `delegationStatus: 'unknown'`, CAA could report a missing policy and DNSSEC could evaluate the literal subdomain as unsigned. Both now return the canonical score-excluded `checkStatus: 'error'` shape without issuing follow-on record queries.
+- **The RFC 8659 CAA climb could cross its registrable-domain floor if handed an unnormalized label.** Ancestor traversal now starts from the normalized `ZoneContext.scannedLabel` and stops before any candidate shorter than the registrable floor, so a case or trailing-dot mismatch cannot trigger a bare-TLD query.
+- **Non-apex DNSSEC attribution could carry misleading source metadata.** `dnssecSource: 'domain_configured'` is now attached to an actual DNSSEC verdict or audit finding rather than the leading “posture inherited from zone apex” note, keeping the evaluated apex configuration distinct from the scanned label’s inheritance relationship.
+- **Documented non-apex subrequest overhead for Free-plan self-hosters.** The `scan_domain` operating note now calls out the bounded NS walk, CAA climb, and apex DNSSEC evaluation that can bring deeply nested labels close to the 50-subrequest ceiling.
 
 ## [3.35.0] - 2026-07-26
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,8 @@ Both publish together from `publish.yml` on version tags.
 
 **Subrequest ceiling** (operating constraint, not a bug): a cold-cache `scan_domain` fans out ~20 subrequests/domain (19 categories, mostly DoH + 2 HTTPS); `/internal/tools/batch` can fan out to ~50×19. Cloudflare Workers caps subrequests per invocation at 50 (Free) / 10,000 default on Paid — raisable to 10M via the `limits.subrequests` Wrangler setting (changed 2026-02-11; was 1000). BlackVeil production runs on a paid plan, so this is not a prod concern. BSL self-hosters on the Free plan should keep batch size / scan concurrency modest (cache hits don't count) or upgrade.
 
+A cold non-apex scan can add up to ~20 DNS subrequests for the bounded NS walk, CAA climb, and apex DNSSEC evaluation; deeply nested labels can therefore approach the Free-plan 50-subrequest ceiling.
+
 **Post-processing**:
 
 - Non-mail (no MX): parent DMARC `sp=`/`p=` → downgrade email-auth findings to `info`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.35.0",
+			"version": "3.35.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"
@@ -5189,7 +5189,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.5.2",
+			"version": "1.5.3",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
@@ -2,7 +2,7 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { checkDNSSEC } from '../../checks/check-dnssec';
-import type { DNSQueryFunction, RawDNSQueryFunction } from '../../types';
+import type { DNSQueryFunction, RawDNSQueryFunction, ZoneContext } from '../../types';
 
 function createMockDNS(records: Record<string, string[]>): DNSQueryFunction {
 	return vi.fn(async (domain: string, _type: string) => {
@@ -63,5 +63,30 @@ describe('checkDNSSEC', () => {
 		const rawQueryDNS: RawDNSQueryFunction = vi.fn(async () => ({ AD: true }));
 		const result = await checkDNSSEC('example.com', mockDNS, { rawQueryDNS });
 		expect(result.findings.some((f) => f.title.includes('Deprecated DNSKEY algorithm'))).toBe(true);
+	});
+
+	it('marks a non-apex unknown zone walk inconclusive without querying DNSSEC', async () => {
+		const queryDNS: DNSQueryFunction = vi.fn(async () => ['257 3 13 base64key...']);
+		const rawQueryDNS: RawDNSQueryFunction = vi.fn(async () => ({ AD: true }));
+		const zone: ZoneContext = {
+			scannedLabel: 'app.example.com',
+			registrableDomain: 'example.com',
+			isApex: false,
+			zoneApex: 'example.com',
+			apexNsRecords: [],
+			delegationStatus: 'unknown',
+		};
+
+		const result = await checkDNSSEC('app.example.com', queryDNS, { rawQueryDNS, zone });
+
+		expect(result.checkStatus).toBe('error');
+		expect(result.findings).toEqual([
+			expect.objectContaining({
+				title: 'DNSSEC not assessed',
+				severity: 'info',
+			}),
+		]);
+		expect(queryDNS).not.toHaveBeenCalled();
+		expect(rawQueryDNS).not.toHaveBeenCalled();
 	});
 });

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -13,7 +13,7 @@ import { checkSSL } from '../../checks/check-ssl';
 import { checkHTTPSecurity } from '../../checks/check-http-security';
 import { checkSubdomainTakeover } from '../../checks/check-subdomain-takeover';
 import { checkMTASTS } from '../../checks/check-mta-sts';
-import type { DNSQueryFunction, FetchFunction } from '../../types';
+import type { DNSQueryFunction, FetchFunction, ZoneContext } from '../../types';
 
 function createMockDNS(records: Record<string, string[]>): DNSQueryFunction {
 	return vi.fn(async (domain: string, _type: string) => {
@@ -81,6 +81,50 @@ describe('checkCAA', () => {
 		});
 		const result = await checkCAA('example.com', queryDNS);
 		expect(result.findings.some((f) => f.title === 'CAA properly configured')).toBe(true);
+	});
+
+	it('climbs from the normalized scanned label and never queries below the registrable floor', async () => {
+		const queries: string[] = [];
+		const queryDNS: DNSQueryFunction = vi.fn(async (domain) => {
+			queries.push(domain);
+			return [];
+		});
+		const zone: ZoneContext = {
+			scannedLabel: 'deep.sub.example.com',
+			registrableDomain: 'example.com',
+			isApex: false,
+			zoneApex: 'example.com',
+			apexNsRecords: ['ns1.example.com'],
+			delegationStatus: 'inherited',
+		};
+
+		await checkCAA('DEEP.SUB.EXAMPLE.COM.', queryDNS, { zone });
+
+		expect(queries).toEqual(['DEEP.SUB.EXAMPLE.COM.', 'sub.example.com', 'example.com']);
+		expect(queries).not.toContain('com');
+	});
+
+	it('marks a non-apex unknown zone walk inconclusive without querying CAA', async () => {
+		const queryDNS: DNSQueryFunction = vi.fn(async () => ['0 issue "letsencrypt.org"']);
+		const zone: ZoneContext = {
+			scannedLabel: 'app.example.com',
+			registrableDomain: 'example.com',
+			isApex: false,
+			zoneApex: 'example.com',
+			apexNsRecords: [],
+			delegationStatus: 'unknown',
+		};
+
+		const result = await checkCAA('app.example.com', queryDNS, { zone });
+
+		expect(result.checkStatus).toBe('error');
+		expect(result.findings).toEqual([
+			expect.objectContaining({
+				title: 'CAA records not assessed',
+				severity: 'info',
+			}),
+		]);
+		expect(queryDNS).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/dns-checks/src/checks/check-caa.ts
+++ b/packages/dns-checks/src/checks/check-caa.ts
@@ -20,6 +20,7 @@ function ancestorChainToFloor(label: string, floor: string): string[] {
 	const chain: string[] = [];
 	let current = label;
 	for (let i = 0; i <= MAX_CAA_CLIMB_DEPTH; i += 1) {
+		if (current.length < floor.length) break;
 		chain.push(current);
 		if (current === floor) break;
 		const dot = current.indexOf('.');
@@ -72,6 +73,20 @@ export async function checkCAA(
 	const findings: Finding[] = [];
 	const zone = options?.zone;
 
+	if (zone && !zone.isApex && zone.delegationStatus === 'unknown') {
+		return {
+			...buildCheckResult('caa', [
+				createFinding(
+					'caa',
+					'CAA records not assessed',
+					'info',
+					`Could not determine the authoritative zone for ${zone.scannedLabel} due to a transient DNS failure; CAA inheritance was not assessed.`,
+				),
+			]),
+			checkStatus: 'error',
+		};
+	}
+
 	let rawRecords: string[];
 	try {
 		rawRecords = await queryDNS(domain, 'CAA', { timeout });
@@ -105,7 +120,7 @@ export async function checkCAA(
 		// or no zone) skip this — byte-identical output. Gated strictly on isApex, NOT
 		// delegationStatus: CAA inheritance follows the DNS tree, independent of NS delegation.
 		if (zone && !zone.isApex) {
-			const climbed = await climbForCaa(domain, zone.registrableDomain, queryDNS, timeout);
+			const climbed = await climbForCaa(zone.scannedLabel, zone.registrableDomain, queryDNS, timeout);
 			if (climbed.records.length > 0 && climbed.foundAt) {
 				findings.push(
 					createFinding(

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -33,6 +33,20 @@ export async function checkDNSSEC(
 	const rawQueryDNS = options?.rawQueryDNS;
 	const findings: Finding[] = [];
 
+	if (options?.zone && !options.zone.isApex && options.zone.delegationStatus === 'unknown') {
+		return {
+			...buildCheckResult('dnssec', [
+				createFinding(
+					'dnssec',
+					'DNSSEC not assessed',
+					'info',
+					`Could not determine the authoritative zone for ${options.zone.scannedLabel} due to a transient DNS failure; DNSSEC posture was not assessed.`,
+				),
+			]),
+			checkStatus: 'error',
+		};
+	}
+
 	// A non-apex label with no zone of its own inherits DNSSEC posture from its
 	// signed zone apex (resolved by `resolveZoneApex` upstream) — evaluate the
 	// AD flag / DNSKEY / DS / NSEC3PARAM at the apex instead of the empty

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.5.2';
+export const PARITY_CORPUS_VERSION = '1.5.3';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.35.0",
+	"version": "3.35.1",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/tools/check-dnssec.ts
+++ b/src/tools/check-dnssec.ts
@@ -69,11 +69,17 @@ async function augmentWithSource(domain: string, baseResult: CheckResult, dnsOpt
 		return buildCheckResult('dnssec', [...baseResult.findings, inheritedFinding]);
 	}
 
-	// domain_configured — tag the first non-info finding with the source, or add a carrier finding
-	if (baseResult.findings.length > 0) {
-		const [first, ...rest] = baseResult.findings;
-		const tagged = { ...first, metadata: { ...(first.metadata ?? {}), dnssecSource: 'domain_configured' } };
-		return buildCheckResult('dnssec', [tagged, ...rest]);
+	// domain_configured — never tag the non-apex attribution note: that finding describes
+	// the scanned label's inheritance relationship, while this metadata describes the
+	// evaluated zone apex. Tag the first actual DNSSEC verdict/audit finding instead.
+	const sourceCarrierIndex = baseResult.findings.findIndex((finding) => finding.title !== 'DNSSEC posture inherited from zone apex');
+	if (sourceCarrierIndex >= 0) {
+		const findings = baseResult.findings.map((finding, index) =>
+			index === sourceCarrierIndex
+				? { ...finding, metadata: { ...(finding.metadata ?? {}), dnssecSource: 'domain_configured' } }
+				: finding,
+		);
+		return buildCheckResult('dnssec', findings);
 	}
 
 	const configuredFinding = createFinding(

--- a/test/check-dnssec.spec.ts
+++ b/test/check-dnssec.spec.ts
@@ -143,6 +143,24 @@ describe('checkDnssec — dnssecSource detection', () => {
 		expect(hasDomainConfigured).toBe(true);
 	});
 
+	it('does not tag the inherited-posture attribution finding as domain_configured', async () => {
+		mockDnssecResponses(true, true, true);
+		const { checkDnssec } = await import('../src/tools/check-dnssec');
+		const result = await checkDnssec('app.example.com', undefined, {
+			scannedLabel: 'app.example.com',
+			registrableDomain: 'example.com',
+			isApex: false,
+			zoneApex: 'example.com',
+			apexNsRecords: ['ns1.example.com'],
+			delegationStatus: 'inherited',
+		});
+		const inheritedPosture = result.findings.find((f) => f.title === 'DNSSEC posture inherited from zone apex');
+
+		expect(inheritedPosture).toBeDefined();
+		expect(inheritedPosture?.metadata?.dnssecSource).toBeUndefined();
+		expect(result.findings.some((f) => f !== inheritedPosture && f.metadata?.dnssecSource === 'domain_configured')).toBe(true);
+	});
+
 	it('does not add dnssecSource metadata when DNSSEC is fully absent', async () => {
 		// AD=false, no DNSKEY, no DS — base result will contain 'DNSSEC not enabled'
 		mockDnssecResponses(false, false, false);


### PR DESCRIPTION
## Summary
- make CAA and DNSSEC score-excluded when non-apex zone discovery is inconclusive
- bound the RFC 8659 CAA climb to normalized `ZoneContext.scannedLabel` and the registrable floor
- keep `dnssecSource` off the inherited-posture attribution finding
- document Free-plan non-apex subrequest overhead
- release as Worker v3.35.1 / dns-checks v1.5.3 with lockstep parity metadata

## Issue review
- Closes #544
- Closes #545
- Closes #547
- Closes #546: the original 1.5.0 version-lock/re-vendor gap is already resolved on both repos at 1.5.2; this PR preserves the contract for the new source delta at 1.5.3
- #417 remains an external operator-provisioning item: bv-mcp labeling and envelope contracts are shipped; live Graph reads require the bv-web-prod Entra app credentials and remaining per-tool endpoints

## Verification
- `npm -w packages/dns-checks test` (451 passed)
- `npm test -- test/check-dnssec.spec.ts` (17 passed)
- `CI=true npm test` under Node 22 with generated WASM (563 files passed, 6,040 tests passed, 13 skipped; exit 0; documented Workers-pool teardown errors only)
- `npm run typecheck`
- `npm -w packages/dns-checks run typecheck`
- `npm run lint`
- `npm run build`
- `npm run validate:internal-deps`
- `npm run audit:repo-safety`
- `npm run audit:oss-safety`
- `npm audit --audit-level=high` (0 vulnerabilities)
- `git diff --check`