### PR TITLE
fix(scanner): 4 scanner bugs (composite scoring, shadow-domain registration, CT outage, deep-discovery lifecycle) + dns-checks 1.5.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5189,7 +5189,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.5.3",
+			"version": "1.5.4",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.5.3",
+	"version": "1.5.4",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
@@ -99,14 +99,13 @@ export function defineScoringEngineSuite(s: ScoringModule): void {
 				]),
 			]);
 
-			// Protective tier: subdomain_takeover gets a penalty (score=60, weight=4 out of 20 total protective)
-			// Core: all absent → 100% → 70 points
-			// Protective earned: (60/100)*4 + (100/100)*16 = 2.4+16 = 18.4/20 = 0.92 → 0.92*20 = 18.4
-			// Hardening: 0 (no hardening results)
-			// Base: 70 + 18.4 + 0 = 88.4 → 88
-			// Then -15 for verified critical penalty = 73
-			expect(scan.overall).toBeLessThanOrEqual(75);
-			expect(scan.overall).toBeGreaterThanOrEqual(70);
+			// Core: all never-run → excluded (empty tier renormalizes to 100%) → 70 points.
+			// Protective: ONLY subdomain_takeover ran (score=60, weight=4); every other protective
+			// category is never-run and excluded (NOT padded to 100 — that was the masking bug), so
+			// protective renormalizes over the single measured category: (60/100)*4 / 4 = 0.6 → 12.
+			// Base: 70 + 12 + 0 = 82; no email bonus (spf/dmarc absent); then -15 verified-critical = 67.
+			expect(scan.overall).toBeLessThanOrEqual(70);
+			expect(scan.overall).toBeGreaterThanOrEqual(64);
 		});
 
 		it('IMPORTANCE_WEIGHTS covers every CheckCategory value', () => {
@@ -115,12 +114,16 @@ export function defineScoringEngineSuite(s: ScoringModule): void {
 			expect(importanceKeys).toEqual(displayKeys);
 		});
 
-		it('computeScanScore initialises all category scores even without results', () => {
+		it('computeScanScore reports NO category scores when nothing ran (never a phantom 100)', () => {
+			// A category that produced no result was not measured — it must be absent from
+			// categoryScores, never seeded to a misleading perfect 100 (which read as "clean" and
+			// silently earned full weight). With zero results, the map is empty.
 			const scan = computeScanScore([]);
 			const categories: CheckCategory[] = Object.keys(CATEGORY_DISPLAY_WEIGHTS) as CheckCategory[];
 			for (const cat of categories) {
-				expect(scan.categoryScores[cat]).toBe(100);
+				expect(scan.categoryScores[cat]).toBeUndefined();
 			}
+			expect(Object.keys(scan.categoryScores)).toHaveLength(0);
 		});
 
 		it('exports CORE_WEIGHTS and PROTECTIVE_WEIGHTS', () => {
@@ -236,6 +239,57 @@ export function defineScoringEngineSuite(s: ScoringModule): void {
 				const httpBad: CheckResult = { ...buildCheckResult('http_security', [createFinding('http_security', 'No CSP', 'medium', 'missing')]), score: 0, passed: false };
 				// Genuinely measured 0 (no transient status) must still drag the score down.
 				expect(computeScanScore([...passingCore(), httpBad]).overall).toBeLessThan(baseline.overall);
+			});
+		});
+
+		describe('never-run categories are excluded, not scored 100', () => {
+			// scan_domain runs a FIXED roster that excludes some scored categories entirely —
+			// notably `lookalikes` and `shadow_domains` (protective weight 2 each), which are
+			// surfaced only by the dedicated deep-scan tools. Historically the engine seeded
+			// EVERY category to 100, so a never-run category surfaced as a perfect 100 in
+			// categoryScores AND was silently awarded full protective weight — masking the real
+			// brand-abuse findings the dedicated tools return. A never-run scored category must
+			// be treated like an inconclusive one: absent from categoryScores and excluded from
+			// the weighted tier (renormalized), never a phantom 100.
+			const passingCore = (): CheckResult[] => [
+				{ ...buildCheckResult('spf', []), score: 100, passed: true },
+				{ ...buildCheckResult('dmarc', []), score: 100, passed: true },
+				{ ...buildCheckResult('dkim', []), score: 100, passed: true },
+				{ ...buildCheckResult('dnssec', []), score: 100, passed: true },
+				{ ...buildCheckResult('ssl', []), score: 100, passed: true },
+			];
+			const takeoverFail = (): CheckResult => ({
+				...buildCheckResult('subdomain_takeover', [
+					createFinding('subdomain_takeover', 'Dangling delegation', 'high', 'takeover risk'),
+				]),
+				score: 0,
+				passed: false,
+			});
+
+			it('a never-run scored category is absent from categoryScores (never a phantom 100)', () => {
+				const scan = computeScanScore([...passingCore(), takeoverFail()]);
+				expect(scan.categoryScores.lookalikes).toBeUndefined();
+				expect(scan.categoryScores.shadow_domains).toBeUndefined();
+				// Only categories that actually produced a result appear — categoryScores can never
+				// list a category with no corresponding checkStatus.
+				expect(Object.keys(scan.categoryScores).sort()).toEqual(
+					['dkim', 'dmarc', 'dnssec', 'spf', 'ssl', 'subdomain_takeover'],
+				);
+			});
+
+			it('a never-run protective category does NOT inflate the overall (excluded + renormalized)', () => {
+				const measured = [...passingCore(), takeoverFail()];
+				const excluded = computeScanScore(measured).overall;
+				// Actually MEASURING lookalikes+shadow_domains as perfect can only hold or raise the
+				// overall — never lower it. Pre-fix the two un-run categories were auto-padded to 100,
+				// making these identical; that padding IS the masking bug, so the fixed engine must
+				// score the excluded case strictly lower when a real protective failure is present.
+				const withPerfectExtras = computeScanScore([
+					...measured,
+					{ ...buildCheckResult('lookalikes', []), score: 100, passed: true },
+					{ ...buildCheckResult('shadow_domains', []), score: 100, passed: true },
+				]).overall;
+				expect(excluded).toBeLessThan(withPerfectExtras);
 			});
 		});
 	});

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.5.3';
+export const PARITY_CORPUS_VERSION = '1.5.4';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import {
-	CATEGORY_DISPLAY_WEIGHTS,
 	CATEGORY_TIERS,
 	type CheckCategory,
 	type CheckResult,
@@ -181,6 +180,21 @@ function buildGenericContext(
 		}
 	}
 
+	// A core/protective category that produced NO result at all was never measured — treat it
+	// exactly like a transient/inconclusive failure: exclude it from the weighted tier so the
+	// score renormalizes over what WAS measured, instead of letting generic.ts's `?? 100`
+	// default award full unearned credit (which masked real findings — e.g. the scan_domain
+	// roster omits lookalikes/shadow_domains, so those never-run protective categories were
+	// silently scored a perfect 100). Hardening is intentionally left alone: its denominator
+	// legitimately counts every hardening category (an unconfigured bonus is an unearned bonus,
+	// handled via hardeningPassed), so a never-run hardening category must NOT be excluded here.
+	for (const cat of Object.keys(CATEGORY_TIERS) as CheckCategory[]) {
+		const tier = CATEGORY_TIERS[cat];
+		if ((tier === 'core' || tier === 'protective') && !resultMap.has(cat)) {
+			transientFailures[cat] = true;
+		}
+	}
+
 	// --- Build hardeningPassed map ---
 	// The original engine iterates ALL hardening categories from CATEGORY_TIERS (not just
 	// those with results). It uses hardeningCount = total hardening categories.
@@ -283,16 +297,15 @@ function buildGenericContext(
  * critical gap categories, and email bonus eligibility instead of defaults.
  */
 export function computeScanScore(results: CheckResult[], context?: DomainContext, config?: ScoringConfig): ScanScore {
-	const partialScores: Partial<Record<CheckCategory, number>> = {};
+	// Only categories that produced a conclusive result appear here. A category that was NEVER
+	// run (absent from `results`) is "not measured", NOT a perfect 100 — seeding it to 100 both
+	// showed a misleading phantom score (a never-run category read as clean) and, via the generic
+	// engine's `?? 100` default, silently awarded it full weight, masking real findings the
+	// dedicated deep-scan tools surface (e.g. lookalikes/shadow_domains are excluded from the
+	// scan_domain roster). Transient (timeout/error) checks are likewise excluded. See
+	// buildGenericContext, which excludes both classes from the weighted overall (renormalized).
+	const categoryScores: Partial<Record<CheckCategory, number>> = {};
 	const allFindings: Finding[] = [];
-
-	// Seed all categories to 100 (default for absent results)
-	for (const category of Object.keys(CATEGORY_DISPLAY_WEIGHTS) as CheckCategory[]) {
-		partialScores[category] = 100;
-	}
-
-	// All CheckCategory keys are populated above — safe to widen from Partial
-	const categoryScores = partialScores as Record<CheckCategory, number>;
 
 	const cfg = config ?? DEFAULT_SCORING_CONFIG;
 
@@ -300,31 +313,28 @@ export function computeScanScore(results: CheckResult[], context?: DomainContext
 		return {
 			overall: 100,
 			grade: scoreToGrade(100, config),
-			categoryScores,
+			categoryScores: categoryScores as Record<CheckCategory, number>,
 			findings: [],
 			summary: `Excellent! No security issues found. Grade: ${scoreToGrade(100, config)}`,
 		};
 	}
 
 	// Populate category scores from actual results. Transient (checkStatus 'timeout'/'error')
-	// checks are INCONCLUSIVE — exclude them from the category-score output (shown as n/a, never
-	// a misleading 0) and from the finding counts; buildGenericContext also excludes them from
-	// the weighted overall score via transientFailures.
-	const transientCategories = new Set<CheckCategory>();
+	// checks are INCONCLUSIVE — omitted from the category-score output (shown as n/a, never a
+	// misleading 0) and from the finding counts; buildGenericContext also excludes them from the
+	// weighted overall score via transientFailures.
 	for (const result of results) {
 		if (result.checkStatus === 'timeout' || result.checkStatus === 'error') {
-			transientCategories.add(result.category);
 			continue;
 		}
 		categoryScores[result.category] = result.score;
 		allFindings.push(...result.findings);
 	}
-	for (const cat of transientCategories) {
-		delete (categoryScores as Partial<Record<CheckCategory, number>>)[cat];
-	}
 
-	// Build the generic context and delegate to the generic engine
-	const genericContext = buildGenericContext(results, categoryScores, allFindings, context, cfg);
+	// Build the generic context and delegate to the generic engine. `categoryScores` is a partial
+	// map (never-run + transient categories are absent); the generic engine treats absent scored
+	// keys via `transientFailures` exclusion, so the widening cast is runtime-safe.
+	const genericContext = buildGenericContext(results, categoryScores as Record<CheckCategory, number>, allFindings, context, cfg);
 	const genericResult = computeGenericScore(genericContext, config);
 
 	// --- Build summary using original logic ---
@@ -347,7 +357,7 @@ export function computeScanScore(results: CheckResult[], context?: DomainContext
 	return {
 		overall: genericResult.overall,
 		grade: genericResult.grade,
-		categoryScores,
+		categoryScores: categoryScores as Record<CheckCategory, number>,
 		findings: allFindings,
 		summary,
 		tierBreakdown: genericResult.tierBreakdown,

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1561,12 +1561,23 @@ export async function handleToolsCall(
 					return buildToolResult(formatSpfChain(result, effectiveFormat), result, effectiveFormat);
 				}
 				case 'discover_subdomains': {
+					const forceRefresh = extractForceRefresh(validatedArgs);
 					const result = await discoverSubdomains(validDomain, runtimeOptions?.certstream, runtimeOptions?.certstreamAuthToken, {
 						signal: AbortSignal.timeout(DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS),
 						deadlineMs: Date.now() + DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS,
+						...(forceRefresh && { forceRefresh }),
 					});
 					logResult = `${result.totalSubdomains} subdomains`;
-					logDetails = { totalSubdomains: result.totalSubdomains, issues: result.issues.length };
+					logDetails = { totalSubdomains: result.totalSubdomains, issues: result.issues.length, sourceUnavailable: result.sourceUnavailable ?? false };
+					// A CT-source outage (sourceUnavailable) is NOT a clean "0 subdomains found" — for a
+					// security tool the two are dangerously indistinguishable. Surface it as a failed/
+					// inconclusive tool call (isError) so a machine consumer cannot read "source down" as
+					// "genuinely no subdomains". The formatted text already explains the outage + suggests
+					// a retry; the structured payload carries sourceUnavailable:true for programmatic checks.
+					if (result.sourceUnavailable) {
+						logToolSuccess({ ...ctx(), status: 'fail', logResult: 'CT source unavailable', logDetails, severity: 'warn' });
+						return { ...buildToolResult(formatSubdomainDiscovery(result, effectiveFormat), result, effectiveFormat), isError: true };
+					}
 					logToolSuccess({ ...ctx(), status: 'pass', logResult, logDetails, severity: 'info' });
 					return buildToolResult(formatSubdomainDiscovery(result, effectiveFormat), result, effectiveFormat);
 				}

--- a/src/lib/registration-evidence.spec.ts
+++ b/src/lib/registration-evidence.spec.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, it, expect } from 'vitest';
+import { hasRegistrationEvidence } from './registration-evidence';
+
+const none = { ns: [] as string[], hasA: false, mx: [] as string[], hasSpf: false, dmarcPolicy: null as string | null };
+
+describe('hasRegistrationEvidence', () => {
+	it('is false only when NO DNS presence exists at all', () => {
+		expect(hasRegistrationEvidence({ ...none })).toBe(false);
+	});
+
+	it('treats a published SPF TXT as proof of registration (the bnz.co contradiction)', () => {
+		// No NS, no A, no MX — but an SPF record cannot exist for an unregistered domain.
+		expect(hasRegistrationEvidence({ ...none, hasSpf: true })).toBe(true);
+	});
+
+	it.each([
+		['NS delegation', { ns: ['ns1.registrar.com.'] }],
+		['A record', { hasA: true }],
+		['MX records', { mx: ['10 mail.example.com.'] }],
+		['DMARC policy', { dmarcPolicy: 'none' }],
+	])('treats %s as proof of registration', (_label, override) => {
+		expect(hasRegistrationEvidence({ ...none, ...override })).toBe(true);
+	});
+});

--- a/src/lib/registration-evidence.ts
+++ b/src/lib/registration-evidence.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DNS-derived evidence that a domain is registered / resolving.
+ *
+ * Only the fields that constitute positive proof of registration are modelled.
+ */
+export interface RegistrationEvidence {
+	/** NS delegation records. */
+	ns: string[];
+	/** Whether an A record resolves. */
+	hasA: boolean;
+	/** MX exchange records (any, including a null MX — a published record is still proof). */
+	mx: string[];
+	/** Whether a `v=spf1` TXT record is published. */
+	hasSpf: boolean;
+	/** Parsed DMARC policy (`null` when no DMARC record). */
+	dmarcPolicy: string | null;
+}
+
+/**
+ * The single source of truth for "is this domain registered?" across the passive
+ * DNS tools (check_shadow_domains, brand discovery).
+ *
+ * A domain is registered/resolving if ANY authoritative DNS presence exists — an NS
+ * delegation, an A record, MX records, a published SPF TXT, or a DMARC policy. None
+ * of those records can exist for an unregistered domain, so inferring registration
+ * from NS presence ALONE wrongly labels a resolving domain "unregistered" — and, worse,
+ * emits an internally contradictory verdict (e.g. `hasSpf: true` alongside "does not
+ * appear to be registered"). Routing every registered/unregistered decision through this
+ * predicate keeps the tools' verdicts from diverging on the same domain.
+ */
+export function hasRegistrationEvidence(e: RegistrationEvidence): boolean {
+	return e.ns.length > 0 || e.hasA || e.mx.length > 0 || e.hasSpf || e.dmarcPolicy !== null;
+}

--- a/src/queue/brand-audit-consumer.ts
+++ b/src/queue/brand-audit-consumer.ts
@@ -43,22 +43,45 @@ import type { Tier1Result } from '../lib/brand-tier1-graph';
 import type { Tier2Result } from '../lib/brand-tier2-evidence';
 
 /**
- * Per-message budget for the orchestrator. The AbortController-driven catch
- * path commits a `failed` row only when the inner orchestrator is well-behaved
- * — the abort `setTimeout` macrotask competes with whatever microtasks the
- * orchestrator generates, and for fan-out-heavy brands (tier-1 portfolios)
- * the microtask queue stays saturated long enough that the worker is
- * killed before any catch UPDATE can flush. Those rows are recovered by the
- * cron reaper (`reapStuckBrandAudits`) ~15 min later — see the 2026-05-19
- * tier-1 investigation for the trace evidence. Until AbortSignal is plumbed
- * through `dns-transport`/`safe-fetch` (so in-flight fetches actually cancel),
- * the reaper is the durability boundary for oversized audits.
- *
- * 300s matches the report-generation runner's per-target poll contract and
- * gives large tier-1 brands enough room for registrar fallback enrichment.
- * Oversized audits still return a controlled failure before the 15-min reaper.
+ * The Cloudflare Workers CPU cap for this consumer, mirrored from `wrangler.jsonc`
+ * `limits.cpu_ms`. The platform KILLS the isolate at this bound — anything past it
+ * (including the AbortController catch that writes the terminal `failed` row) never
+ * runs. **Keep in lockstep with wrangler.jsonc `limits.cpu_ms`.**
  */
-export const BRAND_AUDIT_MESSAGE_TIMEOUT_MS = 300_000;
+export const PLATFORM_CONSUMER_CPU_CAP_MS = 300_000;
+
+/**
+ * Headroom reserved BELOW the platform cap for the abort to unwind + the terminal
+ * D1 write to flush.
+ *
+ * History (the deep-discovery terminal-state bug, Bug #1): the abort budget used to
+ * EQUAL the platform cap (both 300s), leaving zero headroom. A fan-out-heavy `deep`
+ * discovery run consumed the whole budget, so the isolate was killed at the cap
+ * before the AbortController catch could flush its `failed` UPDATE — stranding the
+ * target in `running` until the 7-min read-path/reaper force-failed it (surfacing as
+ * "consumer cap did not flip status"). Standard runs (~27s) never approach the cap,
+ * so they always flip terminal — which is why only deep hung. With the abort now
+ * threaded into `dnsContext` (new probes short-circuit on abort, so in-flight work
+ * drains within a DoH timeout), the ONLY remaining gap was this missing headroom:
+ * the abort must fire strictly before the cap. Since CPU time ≤ wall time, an abort
+ * at `cap - headroom` wall leaves ≥ `headroom` of CPU budget under the cap for the
+ * terminal write. The reaper stays as the last-resort durability boundary, no longer
+ * the normal path for oversized audits.
+ */
+export const BRAND_AUDIT_TERMINAL_WRITE_HEADROOM_MS = 30_000;
+
+/**
+ * Per-message budget for the orchestrator — DERIVED from the platform cap minus the
+ * terminal-write headroom so it can never silently drift back up to the cap. Shared
+ * by the full-audit (`processBrandAuditMessage`) and discovery (`processDiscoverOnlyMessage`)
+ * paths; both get the same terminal-state guarantee. Threaded into the orchestrator
+ * as both the abort `setTimeout` delay and `deadlineMs`, so deadline-aware phases
+ * (e.g. recursive SAN) also skip earlier. Comfortably covers large tier-1 brands +
+ * registrar fallback enrichment; oversized audits return a controlled `failed`
+ * before the cap, not via the cron reaper.
+ */
+export const BRAND_AUDIT_MESSAGE_TIMEOUT_MS =
+	PLATFORM_CONSUMER_CPU_CAP_MS - BRAND_AUDIT_TERMINAL_WRITE_HEADROOM_MS;
 
 /** Wire format for a brand-audit queue message. Validated on the consumer side as defense in depth. */
 export const BrandAuditQueueMessageSchema = z.object({

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -486,18 +486,37 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 		}
 	}
 
-	// Classify truly-unregistered variants (no NS AND no A) as info findings.
-	for (const variant of variants) {
-		if (!registeredVariants.has(variant)) {
-			findings.push(
-				createFinding(
-					'shadow_domains',
-					'Brand variant unregistered',
-					'info',
-					`${variant} does not appear to be registered. Consider defensive registration to prevent brand abuse.`,
-					{ variant, ns: [], mx: [], hasSpf: false, dmarcPolicy: null },
-				),
-			);
+	// Variants that failed BOTH the tight NS (Phase 1) and tight A (Phase 1.5) checks
+	// are NOT yet proven unregistered: a tight-timeout miss on a slow ccTLD server is
+	// not proof of non-registration, and NS/A absence alone ignores a mail-only
+	// registration (MX/SPF/DMARC with no web A record). Re-probe each ONCE with the
+	// full timeout and gate the verdict on the SAME `hasRegistrationEvidence` SSOT
+	// that `classifyVariant` uses (Bug #4 — one verdict, one helper, across both
+	// tools). A variant with ANY registration evidence is classified as registered
+	// with its real metadata; "unregistered" is reserved for a variant with NO
+	// evidence at all, and even then the finding carries the actual probe metadata
+	// (never a hardcoded `hasSpf:false` that could contradict a positive signal).
+	const residualUnregistered = variants.filter((variant) => !registeredVariants.has(variant));
+	if (residualUnregistered.length > 0) {
+		const residualProbes = await Promise.allSettled(residualUnregistered.map((variant) => probeVariant(variant, dnsOpts)));
+		for (let i = 0; i < residualUnregistered.length; i++) {
+			const variant = residualUnregistered[i];
+			const settled = residualProbes[i];
+			const probe: VariantProbeResult =
+				settled.status === 'fulfilled' ? settled.value : { variant, ns: [], hasA: false, mx: [], hasSpf: false, dmarcPolicy: null };
+			if (hasRegistrationEvidence(probe)) {
+				findings.push(classifyVariant(probe, primaryMx, primaryNs));
+			} else {
+				findings.push(
+					createFinding(
+						'shadow_domains',
+						'Brand variant unregistered',
+						'info',
+						`${variant} does not appear to be registered. Consider defensive registration to prevent brand abuse.`,
+						{ variant, ns: probe.ns, mx: probe.mx, hasSpf: probe.hasSpf, dmarcPolicy: probe.dmarcPolicy },
+					),
+				);
+			}
 		}
 	}
 

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -12,6 +12,7 @@ import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { extractBrandName, getEffectiveTld } from '../lib/public-suffix';
 import { validateDomain } from '../lib/sanitize';
+import { hasRegistrationEvidence } from '../lib/registration-evidence';
 
 /** Wall-clock timeout for the entire shadow domain check (ms). */
 const SHADOW_TIMEOUT_MS = 20_000;
@@ -319,7 +320,22 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], primary
 		);
 	}
 
-	// Not registered → info
+	// No NS and no MX, but other authoritative DNS presence (an A record, a published SPF TXT,
+	// or a DMARC policy) still proves the domain is registered and resolving. Emitting
+	// "unregistered" here produced a self-contradictory finding — an "unregistered" verdict
+	// carrying hasSpf:true — and disagreed with brand discovery, which correctly saw the same
+	// domain as live. Route the verdict through the shared registration-evidence SSOT.
+	if (hasRegistrationEvidence(probe)) {
+		return createFinding(
+			'shadow_domains',
+			'Shadow domain registered, no mail',
+			'info',
+			`${variant} is registered (resolves DNS records) but has no mail infrastructure configured.`,
+			meta,
+		);
+	}
+
+	// Truly unregistered — no NS, A, MX, SPF, or DMARC evidence → info.
 	return createFinding(
 		'shadow_domains',
 		'Brand variant unregistered',

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -150,6 +150,12 @@ export interface SubdomainDiscoveryResult {
 export interface DiscoverSubdomainsOptions {
 	signal?: AbortSignal;
 	deadlineMs?: number;
+	/**
+	 * When true, ask the certstream worker to bypass its cache (`force_refresh=true`) so a
+	 * stale cached result — e.g. an empty snapshot captured during a prior CT-source outage —
+	 * is not re-served. The crt.sh fallback is uncached, so this only affects the fast path.
+	 */
+	forceRefresh?: boolean;
 }
 
 /** Extract CN= value from an issuer_name string (e.g. "C=US, O=Let's Encrypt, CN=R3" -> "R3"). */
@@ -451,7 +457,8 @@ async function queryCertstreamEndpoint<T>(
 	const composed = composeAbortSignal(CRT_SH_TIMEOUT_MS, options?.signal);
 
 	try {
-		const response = await certstream.fetch(`https://certstream/${path}?domain=${encodeURIComponent(domain)}`, {
+		const forceRefreshParam = options?.forceRefresh ? '&force_refresh=true' : '';
+		const response = await certstream.fetch(`https://certstream/${path}?domain=${encodeURIComponent(domain)}${forceRefreshParam}`, {
 			...(certstreamAuthToken ? { headers: { Authorization: `Bearer ${certstreamAuthToken}` } } : {}),
 			signal: composed.signal,
 		});

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -364,6 +364,47 @@ describe('checkShadowDomains', () => {
 		);
 		expect(unregistered).toBeDefined();
 	});
+
+	it('does NOT label a mail-only variant "unregistered" when NS+A are absent but MX/SPF exist (Bug #4 residual path)', async () => {
+		const target = 'example.com';
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+
+			if (name === target && (type === 'MX' || type === '15')) {
+				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			}
+
+			// example.net is a MAIL-ONLY registration: no NS (or slow-server NS that
+			// missed the tight window), no web A record — but a real MX + SPF. The old
+			// NS+A-only classifier wrongly emitted "unregistered" with a hardcoded
+			// hasSpf:false. The residual full-timeout probe must find the MX/SPF
+			// evidence and classify it as registered, never unregistered.
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(emptyResponse());
+				if (type === 'A' || type === '1') return Promise.resolve(emptyResponse());
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.attacker.net.']));
+				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 include:sendgrid.net ~all']));
+			}
+			if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
+				return Promise.resolve(emptyResponse());
+			}
+
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = result.findings.filter((f) => f.detail.includes('example.net') || f.metadata?.variant === 'example.net');
+		// No "unregistered" verdict for a variant that publishes MX + SPF.
+		expect(netFindings.some((f) => /unregistered/i.test(f.title))).toBe(false);
+		// And no finding may carry the contradictory positive-SPF + unregistered pair,
+		// nor the old hardcoded hasSpf:false when SPF is actually present.
+		const varFinding = netFindings.find((f) => f.metadata?.variant === 'example.net');
+		expect(varFinding).toBeDefined();
+		expect(varFinding?.metadata?.hasSpf).toBe(true);
+	});
 });
 
 describe('generateVariants', () => {

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -536,6 +536,50 @@ describe('checkShadowDomains — classification edge cases', () => {
 		expect(wronglyUnregistered).toBeUndefined();
 	});
 
+	it('should NOT call a variant unregistered when it publishes SPF but has no NS/MX (bnz.co contradiction)', async () => {
+		// bnz.co resolved an A record + published an SPF TXT (brand discovery independently
+		// surfaced it as a live 0.95 candidate via http_redirect), but its NS query came back
+		// empty and it has no MX. The classifier used NS/MX presence ONLY, so it emitted
+		// "Brand variant unregistered" WHILE its own metadata carried hasSpf:true — an internally
+		// contradictory verdict (an unregistered domain cannot publish SPF). A published SPF/A
+		// record is proof of registration.
+		const target = 'example.com';
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+
+			if (name === target && (type === 'MX' || type === '15')) {
+				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			}
+
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(emptyResponse()); // NS empty (as observed)
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.50'])); // resolves
+				if (type === 'MX' || type === '15') return Promise.resolve(emptyResponse()); // no mail
+				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 -all'])); // SPF published
+			}
+			if (name === '_dmarc.example.net' && (type === 'TXT' || type === '16')) {
+				return Promise.resolve(emptyResponse());
+			}
+
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = result.findings.filter((f) => f.detail.includes('example.net'));
+
+		// It must not be labelled unregistered…
+		expect(netFindings.some((f) => /unregistered|does not appear to be registered/i.test(`${f.title} ${f.detail}`))).toBe(false);
+		// …and NO finding may claim unregistered while its metadata reports positive SPF evidence.
+		expect(
+			netFindings.some(
+				(f) => f.metadata?.hasSpf === true && /unregistered|does not appear to be registered/i.test(`${f.title} ${f.detail}`),
+			),
+		).toBe(false);
+	});
+
 	it('should classify RFC 7505 null MX (MX 0 .) as INFO non-mail, not as spoofable', async () => {
 		const target = 'example.com';
 

--- a/test/discover-subdomains.spec.ts
+++ b/test/discover-subdomains.spec.ts
@@ -521,3 +521,76 @@ describe('formatSubdomainDiscovery', () => {
 		expect(fullOutput).toContain('50 more subdomains not shown');
 	});
 });
+
+describe('discoverSubdomains — force_refresh threading', () => {
+	afterEach(() => restore());
+
+	function certstreamOk(seen: string[]) {
+		return vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			seen.push(url);
+			return new Response(
+				JSON.stringify({ domain: 'example.com', subdomains: ['api.example.com'], certificateCount: 1, timedOut: false, cached: false }),
+				{ status: 200, headers: { 'Content-Type': 'application/json' } },
+			);
+		});
+	}
+
+	it('threads force_refresh to the certstream endpoint so a stale cached result can be bypassed', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const seen: string[] = [];
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('crt.sh should not be used');
+		});
+		await discoverSubdomains('example.com', { fetch: certstreamOk(seen) as unknown as typeof fetch }, 'tok', { forceRefresh: true });
+		expect(seen[0]).toContain('force_refresh=true');
+	});
+
+	it('does NOT add force_refresh when not requested (default cache behaviour)', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const seen: string[] = [];
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('crt.sh should not be used');
+		});
+		await discoverSubdomains('example.com', { fetch: certstreamOk(seen) as unknown as typeof fetch }, 'tok');
+		expect(seen[0]).not.toContain('force_refresh');
+	});
+});
+
+describe('discover_subdomains handler — loud degrade on CT-source outage', () => {
+	afterEach(() => restore());
+
+	it('returns isError:true (NOT a passing empty) when every CT source is unavailable', async () => {
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		// certstream binding 503s → null; crt.sh 500s → sourceUnavailable.
+		const certstreamFetch = vi.fn(async () => new Response('unavailable', { status: 503 }));
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json({}, { status: 500 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		const result = await handleToolsCall(
+			{ name: 'discover_subdomains', arguments: { domain: 'example.com' } },
+			undefined,
+			{ certstream: { fetch: certstreamFetch as unknown as typeof fetch } } as never,
+		);
+		expect(result.isError).toBe(true);
+		expect((result.structuredContent as Record<string, unknown> | undefined)?.sourceUnavailable).toBe(true);
+	});
+
+	it('returns a normal (non-error) result when the source is available but finds nothing', async () => {
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([], { status: 200 }); // available, genuinely empty
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		const result = await handleToolsCall(
+			{ name: 'discover_subdomains', arguments: { domain: 'example.com' } },
+			undefined,
+			undefined,
+		);
+		expect(result.isError).toBeFalsy();
+		expect((result.structuredContent as Record<string, unknown> | undefined)?.sourceUnavailable).toBeFalsy();
+	});
+});

--- a/test/format-report-na-reconciliation.spec.ts
+++ b/test/format-report-na-reconciliation.spec.ts
@@ -224,3 +224,51 @@ describe('Defect H — web_only profile suppresses mail-only categories', () => 
 		expect(s.categoryScores.mta_sts).toBe(60);
 	});
 });
+
+describe('categoryScores never lists a category that never ran (end-to-end engine → format-report)', () => {
+	// Reproduces the bnz.co.nz symptom: scan_domain runs a fixed roster that OMITS lookalikes/
+	// shadow_domains, yet the composite reported categoryScores.lookalikes = 100 (and
+	// shadow_domains = 100) with NO checkStatuses entry — a never-run brand-abuse dimension
+	// reading "perfect". Runs the REAL engine so a regression of the 100-seed is caught here too.
+	it('a never-run category is absent from categoryScores and every score key has a checkStatus', async () => {
+		const { computeProfileAwareScanScore, buildCheckResult, createFinding } = await import('../src/lib/scoring');
+
+		// A realistic scan_domain-style roster: core + several protective ran; lookalikes and
+		// shadow_domains were NEVER dispatched (not in CHECK_DISPATCH).
+		const ranChecks: CheckResult[] = [
+			{ ...buildCheckResult('spf', []), score: 100, passed: true },
+			{ ...buildCheckResult('dmarc', []), score: 100, passed: true },
+			{ ...buildCheckResult('dkim', []), score: 100, passed: true },
+			{ ...buildCheckResult('dnssec', []), score: 100, passed: true },
+			{ ...buildCheckResult('ssl', []), score: 100, passed: true },
+			{
+				...buildCheckResult('subdomain_takeover', [
+					createFinding('subdomain_takeover', 'Dangling delegation', 'high', 'takeover risk'),
+				]),
+				score: 0,
+				passed: false,
+			},
+			{ ...buildCheckResult('http_security', []), score: 90, passed: true },
+		];
+		const scored = computeProfileAwareScanScore(ranChecks);
+		const result = makeMockScanResult({
+			score: scored.score,
+			context: { ...scored.context },
+			checks: ranChecks,
+		});
+
+		const s = buildStructuredScanResult(result);
+
+		// The never-run brand-abuse categories must NOT surface as a phantom 100.
+		expect(s.categoryScores.lookalikes ?? null).toBeNull();
+		expect(s.categoryScores.shadow_domains ?? null).toBeNull();
+
+		// Acceptance invariant: every category carrying a NON-null numeric score must have run
+		// (i.e. appear in checkStatuses). A score with no execution status is the exact defect.
+		for (const [category, score] of Object.entries(s.categoryScores)) {
+			if (score !== null) {
+				expect(s.checkStatuses).toHaveProperty(category);
+			}
+		}
+	});
+});

--- a/test/queue/brand-audit-consumer.chaos.test.ts
+++ b/test/queue/brand-audit-consumer.chaos.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { BRAND_AUDIT_MESSAGE_TIMEOUT_MS } from '../../src/queue/brand-audit-consumer';
+import {
+	BRAND_AUDIT_MESSAGE_TIMEOUT_MS,
+	BRAND_AUDIT_TERMINAL_WRITE_HEADROOM_MS,
+	PLATFORM_CONSUMER_CPU_CAP_MS,
+} from '../../src/queue/brand-audit-consumer';
 
 interface D1Call {
 	sql: string;
@@ -64,8 +68,23 @@ describe('processBrandAuditMessage — budget chaos', () => {
 		vi.useRealTimers();
 	});
 
-	it('keeps the queue budget aligned with the report runner target budget', () => {
-		expect(BRAND_AUDIT_MESSAGE_TIMEOUT_MS).toBe(300_000);
+	it('reserves terminal-write headroom below the platform CPU cap (Bug #1)', () => {
+		// The consumer's abort budget MUST fire strictly before the platform CPU cap
+		// so the AbortController catch has time to flush the terminal `failed` row.
+		// With zero headroom (budget === cap) a fan-out-heavy DEEP run is killed at
+		// the cap before the flush, stranding the target in `running` until the
+		// 7-min read-path/reaper force-fails it — the deep-discovery terminal-state
+		// bug. Standard runs (~27s) never approach the cap, so they always flip.
+		expect(BRAND_AUDIT_TERMINAL_WRITE_HEADROOM_MS).toBeGreaterThan(0);
+		expect(BRAND_AUDIT_MESSAGE_TIMEOUT_MS).toBeLessThan(PLATFORM_CONSUMER_CPU_CAP_MS);
+		expect(BRAND_AUDIT_MESSAGE_TIMEOUT_MS + BRAND_AUDIT_TERMINAL_WRITE_HEADROOM_MS).toBeLessThanOrEqual(
+			PLATFORM_CONSUMER_CPU_CAP_MS,
+		);
+		// The budget is DERIVED from the cap minus headroom — it can't silently drift
+		// back to the cap.
+		expect(BRAND_AUDIT_MESSAGE_TIMEOUT_MS).toBe(
+			PLATFORM_CONSUMER_CPU_CAP_MS - BRAND_AUDIT_TERMINAL_WRITE_HEADROOM_MS,
+		);
 	});
 
 	it('flips the target row to failed from this Worker invocation when the orchestrator exceeds budget', async () => {
@@ -152,5 +171,57 @@ describe('processBrandAuditMessage — budget chaos', () => {
 				(c.binds[0] as string) === 'failed',
 		);
 		expect(failed).toBeUndefined();
+	});
+});
+
+describe('processDiscoverOnlyMessage — deep-discovery budget chaos (Bug #1)', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('flips a wedged DEEP discovery target to failed from this invocation (not the reaper)', async () => {
+		const { processDiscoverOnlyMessage } = await import('../../src/queue/brand-audit-consumer');
+		const { db, calls } = makeMockD1({ status: 'queued', completed_at: null });
+
+		// A deep discovery that never settles until aborted — the fan-out-heavy shape
+		// that used to be killed at the platform cap before the terminal write flushed.
+		const discoverBrandDomains = vi.fn((_target: string, options: { signal?: AbortSignal; deadlineMs?: number }) => {
+			return new Promise<never>((_resolve, reject) => {
+				const onAbort = () => {
+					const reason = (options.signal as (AbortSignal & { reason?: unknown }) | undefined)?.reason;
+					reject(reason instanceof Error ? reason : new Error(typeof reason === 'string' ? reason : 'aborted'));
+				};
+				if (options.signal?.aborted) return onAbort();
+				options.signal?.addEventListener('abort', onAbort, { once: true });
+			});
+		});
+
+		const verdictPromise = processDiscoverOnlyMessage(
+			{ auditId: 'disc-chaos-1', target: 'bnz.co.nz', phase: 'discover_only', depth: 'deep', discovery_mode: 'classic' },
+			{ db, discoverBrandDomains, now: () => 1_750_000_000_000 } as never,
+		);
+
+		// Advance just past the (headroom-reduced) budget so the abort fires — this is
+		// BEFORE the platform cap, leaving room for the terminal write.
+		await vi.advanceTimersByTimeAsync(BRAND_AUDIT_MESSAGE_TIMEOUT_MS + 1_000);
+
+		expect(await verdictPromise).toBe('ack');
+
+		// Deep discovery received the AbortSignal AND a deadlineMs at the reduced budget.
+		const [, opts] = discoverBrandDomains.mock.calls[0]!;
+		expect(opts.signal).toBeInstanceOf(AbortSignal);
+		expect(opts.deadlineMs).toBe(1_750_000_000_000 + BRAND_AUDIT_MESSAGE_TIMEOUT_MS);
+
+		// The target flipped to a TERMINAL `failed` within this invocation, carrying
+		// the budget-exceeded reason — the deep-mode terminal-state guarantee.
+		const failedUpdate = calls.find(
+			(c) => c.sql.includes('UPDATE brand_audit_targets SET status = ?') && (c.binds[0] as string) === 'failed',
+		);
+		expect(failedUpdate).toBeDefined();
+		expect((failedUpdate!.binds[2] as string).toLowerCase()).toContain('budget');
 	});
 });

--- a/test/scoring.spec.ts
+++ b/test/scoring.spec.ts
@@ -87,15 +87,14 @@ describe('scoring', () => {
 		it('computes weighted average from check results', () => {
 			const results: CheckResult[] = [buildCheckResult('spf', [createFinding('spf', 'x', 'critical', 'd')])];
 			const scan = computeScanScore(results);
-			// Three-tier scoring: SPF is core tier (weight 10 out of 60 total core weight).
-			// SPF score 60 → coreEarned = (50*100 + 10*60)/60 = 56.67/60 → corePct ≈ 0.944
-			// Core contributes 70 * 0.944 = 66.1, Protective 20 (all default 100), Hardening 0 (no results).
-			// Base = 86.1 → round = 86. No email bonus (no DKIM/DMARC). Provider mod = 0.
-			// Critical penalty: 'x' + 'd' detail is deterministic → verified? No, it's deterministic.
-			// scoreIndicatesMissingControl: 'd' doesn't match missing pattern, so effectiveScore = 60, not 0.
-			// Critical gap ceiling: SPF has scoreIndicatesMissingControl? title='x', detail='d' → no match.
-			// So no ceiling. Overall = 85.
-			expect(scan.overall).toBe(85);
+			// ONLY spf ran (score 60, core weight 10). Every other core + protective category was
+			// never measured, so it is EXCLUDED (renormalized), NOT padded to a phantom 100 — the
+			// composite must reflect only what it measured.
+			// Core: renormalized over spf alone → 0.6 → 70 * 0.6 = 42pts.
+			// Protective: nothing ran → empty tier renormalizes to 100% → 20pts. Hardening: 0.
+			// Base = 62. No email bonus (no DKIM/DMARC). No verified-critical penalty (deterministic,
+			// not verified). No missing-control ceiling. Overall = 62.
+			expect(scan.overall).toBe(62);
 			expect(scan.categoryScores.spf).toBe(60);
 		});
 
@@ -119,13 +118,15 @@ describe('scoring', () => {
 			const scan = computeScanScore(results);
 			// Three-tier scoring: DMARC missing-control → effectiveScore 0 (core, weight 16).
 			// DNSSEC "ad flag missing" matches MISSING_CONTROL_REGEX + severity high + deterministic → effectiveScore 0.
-			// Core (weights: dmarc=16, dkim=10, spf=10, dnssec=10, ssl=8, max=54):
+			// Core (all 5 ran; weights dmarc=16, dkim=10, spf=10, dnssec=10, ssl=8, max=54):
 			//   earned = 10(spf) + 0(dmarc) + 10(dkim) + 0(dnssec) + 8(ssl) = 28 → corePct=28/54≈0.519 → 36.3pts
-			// Protective: MTA-STS=80(3), NS=100(2), CAA=85(2), rest default 100 → 19.1/20 → 19.1pts
-			// Hardening: 0 passed of 7 → 0pts. Base≈55.4 → round=55.
-			// Critical gap ceiling applies (DMARC missing) → capped at 64, but base 55 < 64.
-			expect(scan.overall).toBe(56);
-			expect(scan.grade).toBe('D+');
+			// Protective: only MTA-STS=80(3), NS=100(2), CAA=85(2) ran; every other protective
+			//   category was never measured and is EXCLUDED (not padded to 100), so protective
+			//   renormalizes over max=7: earned=6.1/7≈0.871 → 17.4pts.
+			// Hardening: 0 passed of 7 → 0pts. Base≈53.7 → round=54.
+			// Critical gap ceiling applies (DMARC missing) → capped at 64, but base 54 < 64.
+			expect(scan.overall).toBe(54);
+			expect(scan.grade).toBe('D');
 		});
 
 		it('applies global critical penalty when critical finding is verified', () => {
@@ -138,12 +139,12 @@ describe('scoring', () => {
 			];
 
 			const scan = computeScanScore(results);
-			// Three-tier: subdomain_takeover is protective tier (weight 4 out of 20 total protective).
-			// Score 60 → protectiveEarned = (16*100 + 4*60)/20 = 19.2/20, protPct = 0.96 → 20*0.96 = 19.2
-			// Core: all default 100 → 70pts. Hardening: 0 (no results). Base = 70 + 19.2 + 0 = 89.2 → round = 89.
-			// No email bonus. Verified critical penalty = 15. Overall = 89 - 15 + 2 (provider mod?) = let's just check.
-			// Actual: 74.
-			expect(scan.overall).toBe(74);
+			// ONLY subdomain_takeover ran (protective, score 60, weight 4). Every other protective
+			// category was never measured and is EXCLUDED (not padded to 100), so protective
+			// renormalizes over that single category: (60/100)*4 / 4 = 0.6 → 20*0.6 = 12pts.
+			// Core: nothing ran → empty tier renormalizes to 100% → 70pts. Hardening: 0.
+			// Base = 82. No email bonus (spf/dmarc absent). Verified critical penalty = 15 → 67.
+			expect(scan.overall).toBe(67);
 		});
 
 		it('includes critical count in summary', () => {


### PR DESCRIPTION
Fixes 4 scanner bugs surfaced during a live scan of bnz.co.nz (2026-07-26). Each is root-caused at source with a regression test at the correct pyramid layer; full suite green (6046 pass; the WebSocket teardown tail is the documented pool-teardown noise).

## Bug #3 (HIGH) — un-run categories scored 100 in the composite
`computeScanScore` seeded every category to 100 and `computeGenericScore` defaulted absent categories to `?? 100`, so `lookalikes`/`shadow_domains` (never in the fixed `scan_domain` roster) surfaced as a perfect 100 **and** were awarded full protective-tier weight — masking the exact findings the dedicated `check_lookalikes`/`check_shadow_domains` tools return. Fix: treat a never-run scored category like an inconclusive one — excluded from `categoryScores` and from the weighted tier (renormalized over what was measured). **This is a composite-scoring change** (per-check parity is unchanged); it needs the 1.5.4 bump for the lockstep re-vendor into bv-web-prod.

## Bug #4 (MEDIUM) — "unregistered" verdict contradicted positive evidence
`check_shadow_domains` inferred "unregistered" from NS-absence alone, ignoring SPF/A/MX. New SSOT `hasRegistrationEvidence()` (NS **or** A **or** MX **or** SPF **or** DMARC = registered); "unregistered" is now reserved for genuine no-evidence.

## Bug #2 (MEDIUM) — CT outage returned empty success
`discover_subdomains` now sets `isError: true` on `sourceUnavailable` and threads `force_refresh` through to bypass cache, so a CT-log outage is an unambiguous inconclusive signal, never a passing empty result.

## Bug #1 (HIGH) — deep discovery hung ~7 min then force-failed
The consumer's in-isolate abort budget equalled the platform `cpu_ms` cap (both 300s) — zero headroom — so a fan-out-heavy deep run was killed at the cap before the AbortController catch could flush its terminal `failed` write (standard mode never approaches the cap). Fix: derive the budget as `cap − 30s` headroom so the abort fires strictly before the cap; both consumer paths get the terminal-state guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5oiYtMZ6wuv2kpFcTCurV
