### PR TITLE
fix(attack-paths): gate email_spoof_direct on evaluated SPF/DMARC (#564)

### DIFF
--- a/src/tools/simulate-attack-paths.ts
+++ b/src/tools/simulate-attack-paths.ts
@@ -84,14 +84,24 @@ function isSpfWeakOrMissing(findings: Finding[]): boolean {
 	});
 }
 
-/** Check if DMARC is missing or has p=none. */
+/** Check if DMARC is missing or set to a non-enforcing policy (p=none). */
 function isDmarcWeakOrMissing(findings: Finding[]): boolean {
 	return hasFindings(findings, (f) => {
 		if (f.category !== 'dmarc') return false;
 		if (f.severity === 'info') return false;
 		const t = f.title.toLowerCase();
 		const d = f.detail.toLowerCase();
-		return t.includes('no dmarc') || t.includes('missing') || d.includes('p=none');
+		// Missing record, missing p= tag, or multiple-records-no-valid-policy.
+		if (t.includes('no dmarc') || t.includes('missing') || t.includes('no valid policy')) return true;
+		// Non-enforcing organizational policy (p=none). Match the policy-none title, and
+		// only a boundary-anchored "p=none" in the detail. Issue #564: the SUBDOMAIN
+		// (sp=none) and non-existent-subdomain (np=none) findings both carry the substring
+		// "p=none", which previously false-tripped this direct-spoof gate on well-protected
+		// domains (SPF -all + DMARC p=quarantine). Those are subdomain risks, handled by the
+		// separate email_spoof_subdomain path — they must NOT imply direct org-domain spoofing.
+		if (t.includes('policy set to none')) return true;
+		if (/(?:^|[^a-z])p=none/.test(d)) return true;
+		return false;
 	});
 }
 
@@ -243,7 +253,12 @@ const ATTACK_PATH_DEFINITIONS: AttackPathDefinition[] = [
 		name: 'Direct Email Spoofing',
 		severity: 'critical',
 		feasibility: 'trivial',
-		condition: (findings) => isSpfWeakOrMissing(findings) || isDmarcWeakOrMissing(findings),
+		// Issue #564: direct exact-domain spoofing is trivial ONLY when SPF is missing/permissive
+		// AND DMARC is missing/p=none — both stated prerequisites must actually hold. A well-protected
+		// domain (SPF -all + DMARC p=quarantine/reject) is NOT trivially spoofable; its residual gap is
+		// subdomain spoofing, covered by the separate email_spoof_subdomain path. This was an OR that
+		// fired critical/trivial on either signal alone, contradicting assess_spoofability.
+		condition: (findings) => isSpfWeakOrMissing(findings) && isDmarcWeakOrMissing(findings),
 		prerequisites: ['SPF missing or permissive', 'DMARC missing or set to p=none'],
 		steps: [
 			'Send email as ceo@domain using any SMTP server',

--- a/test/simulate-attack-paths.spec.ts
+++ b/test/simulate-attack-paths.spec.ts
@@ -648,6 +648,108 @@ function mockNoCaaDomain() {
 	});
 }
 
+/**
+ * Mock for a well-protected mail domain that is directly spoof-resistant but has a
+ * subdomain gap (issue #564 repro — modelled on spotto.ai):
+ *   SPF = v=spf1 include:... -all   (hard fail — NOT permissive)
+ *   DMARC = v=DMARC1; p=quarantine; sp=none   (quarantine — NOT none/missing)
+ * The direct-spoof path must NOT fire at critical/trivial, but the SUBDOMAIN path
+ * (sp=none) legitimately remains. Everything else is configured correctly.
+ */
+function mockSpoofResistantSubdomainGapDomain() {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+		if (url.includes('cloudflare-dns.com')) {
+			if (url.includes('type=TXT') || url.includes('type=16')) {
+				if (url.includes('_dmarc.')) {
+					// Enforcing org policy (quarantine) but weak subdomain policy (sp=none)
+					return Promise.resolve(
+						txtResponse('_dmarc.example.com', [
+							'v=DMARC1; p=quarantine; sp=none; rua=mailto:dmarc@example.com; adkim=s; aspf=s',
+						]),
+					);
+				}
+				if (url.includes('_domainkey.')) {
+					return Promise.resolve(
+						txtResponse('default._domainkey.example.com', [
+							'v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA',
+						]),
+					);
+				}
+				if (url.includes('_mta-sts.')) {
+					return Promise.resolve(txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']));
+				}
+				if (url.includes('_smtp._tls.')) {
+					return Promise.resolve(
+						txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']),
+					);
+				}
+				// SPF hard fail (-all)
+				return Promise.resolve(txtResponse('example.com', ['v=spf1 include:_spf.google.com -all']));
+			}
+
+			if (url.includes('type=NS') || url.includes('type=2')) {
+				return Promise.resolve(nsResponse('example.com', ['ns1.example.com.', 'ns2.example.com.']));
+			}
+
+			if (url.includes('type=CAA') || url.includes('type=257')) {
+				return Promise.resolve(caaResponse('example.com', ['0 issue "letsencrypt.org"', '0 issuewild ";"']));
+			}
+
+			if (url.includes('type=A') || url.includes('type=1')) {
+				return Promise.resolve(dnssecResponse('example.com', true));
+			}
+
+			if (url.includes('type=MX') || url.includes('type=15')) {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name: 'example.com', type: 15 }],
+						[{ name: 'example.com', type: 15, TTL: 300, data: '10 mx1.example.com.' }],
+					),
+				);
+			}
+
+			if (url.includes('type=TLSA') || url.includes('type=52')) {
+				return Promise.resolve(
+					tlsaResponse('_25._tcp.mx1.example.com', [
+						{ usage: 3, selector: 1, matchingType: 1, certData: 'aabbccddee' },
+					]),
+				);
+			}
+
+			return Promise.resolve(createDohResponse([], []));
+		}
+
+		if (url.includes('mta-sts.') && url.includes('.well-known')) {
+			return Promise.resolve(
+				httpResponse('version: STSv1\nmode: enforce\nmx: *.example.com\nmax_age: 86400'),
+			);
+		}
+
+		if (url.startsWith('https://')) {
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				headers: new Headers({
+					'content-security-policy': "default-src 'self'; script-src 'self'; frame-ancestors 'none'",
+					'x-frame-options': 'DENY',
+					'x-content-type-options': 'nosniff',
+					'permissions-policy': 'camera=(), microphone=()',
+					'referrer-policy': 'strict-origin-when-cross-origin',
+					'cross-origin-resource-policy': 'same-origin',
+					'cross-origin-opener-policy': 'same-origin',
+					'strict-transport-security': 'max-age=31536000; includeSubDomains',
+				}),
+				text: () => Promise.resolve('OK'),
+				json: () => Promise.resolve({}),
+			} as unknown as Response);
+		}
+
+		return Promise.resolve(createDohResponse([], []));
+	});
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -684,6 +786,35 @@ describe('simulateAttackPaths', () => {
 		expect(emailSpoof!.severity).toBe('critical');
 		expect(emailSpoof!.feasibility).toBe('trivial');
 		expect(emailSpoof!.mitigations.length).toBeGreaterThan(0);
+	});
+
+	it('does NOT emit critical/trivial direct email spoofing when SPF hard-fails and DMARC enforces (issue #564)', async () => {
+		// spotto.ai repro: SPF -all + DMARC p=quarantine; sp=none is a well-protected
+		// mail domain — assess_spoofability rates it low. The direct-spoof path must not
+		// be emitted at critical/trivial just because a subdomain (sp=none / np=none)
+		// finding carries the "p=none" substring.
+		mockSpoofResistantSubdomainGapDomain();
+		const result = await run();
+
+		const criticalDirect = result.attackPaths.find(
+			(p) => p.id === 'email_spoof_direct' && (p.severity === 'critical' || p.feasibility === 'trivial'),
+		);
+		expect(criticalDirect).toBeUndefined();
+
+		// The genuine residual — subdomain spoofing via sp=none — must still fire.
+		const subdomainSpoof = result.attackPaths.find((p) => p.id === 'email_spoof_subdomain');
+		expect(subdomainSpoof).toBeDefined();
+		expect(subdomainSpoof!.severity).toBe('high');
+	});
+
+	it('still emits critical/trivial direct email spoofing when SPF and DMARC are both missing (issue #564)', async () => {
+		mockEmailSpoofOnlyDomain();
+		const result = await run();
+
+		const emailSpoof = result.attackPaths.find((p) => p.id === 'email_spoof_direct');
+		expect(emailSpoof).toBeDefined();
+		expect(emailSpoof!.severity).toBe('critical');
+		expect(emailSpoof!.feasibility).toBe('trivial');
 	});
 
 	it('detects DNS hijack path when DNSSEC is disabled (high)', async () => {


### PR DESCRIPTION
Fixes #564.

**Root cause (2 compounding defects, worker layer):**
1. `isDmarcWeakOrMissing` matched `p=none` as a bare substring, so the `sp=none`/`np=none` subdomain findings falsely read as a missing/none org policy.
2. `email_spoof_direct` fired on `spfWeak || dmarcWeak` despite listing both as prerequisites.

So a well-protected domain (SPF `-all` + DMARC `p=quarantine`) tripped critical/trivial, contradicting `assess_spoofability` (23/low).

**Fix:** boundary-anchored `/(?:^|[^a-z])p=none/` + gate changed to `spfWeak && dmarcWeak`. The genuine subdomain gap stays on the separate `email_spoof_subdomain` path (unchanged).

**Scope:** `src/tools/simulate-attack-paths.ts` + spec only. No `packages/dns-checks` change, no version bump.
**Tests:** 15/15 green (red-first confirmed on the pre-fix code).