### PR TITLE
fix(spf): worker-layer trust-surface post-processor recognizes Mailjet + counts unrecognized ESPs (#566)

### DIFF
--- a/src/tools/check-spf.ts
+++ b/src/tools/check-spf.ts
@@ -9,7 +9,8 @@ import { checkSPF } from '@blackveil/dns-checks';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { buildDnsErrorResult } from '../lib/dns-error-result';
-import type { CheckResult } from '../lib/scoring';
+import type { CheckResult, Finding } from '../lib/scoring';
+import { analyzeTrustSurface, type TrustSurfaceContext } from './spf-trust-surface';
 
 /**
  * Check SPF records for a domain.
@@ -23,8 +24,83 @@ import type { CheckResult } from '../lib/scoring';
  */
 export async function checkSpf(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
 	try {
-		return (await checkSPF(domain, makeQueryDNS(dnsOptions), { timeout: dnsOptions?.timeoutMs ?? 5000 })) as CheckResult;
+		const core = (await checkSPF(domain, makeQueryDNS(dnsOptions), {
+			timeout: dnsOptions?.timeoutMs ?? 5000,
+		})) as CheckResult;
+		return await augmentTrustSurface(core, domain, dnsOptions);
 	} catch (err) {
 		return buildDnsErrorResult('spf', 'SPF', err);
+	}
+}
+
+/**
+ * Worker-layer trust-surface post-processor (issue #566).
+ *
+ * The core `checkSPF` produces trust-surface findings ("SPF delegates to shared
+ * platform: …" + an "N shared platforms" summary) from its OWN parity-locked ESP
+ * catalog, which misses some multi-tenant senders (e.g. Mailjet) and counts only
+ * cataloged platforms. We cannot edit the vendored core, so this re-derives the trust
+ * surface in the worker with a broader recognizer and REPLACES the core-produced
+ * trust-surface findings.
+ *
+ * SCORE IS NEVER RECOMPUTED: `core.score`, `passed`, `checkStatus`, `partial`, and every
+ * non-trust-surface finding are passed through unchanged — this only rewrites the
+ * informational trust-surface findings. Fail-soft: any error returns `core` untouched.
+ */
+async function augmentTrustSurface(
+	core: CheckResult,
+	domain: string,
+	dnsOptions?: QueryDnsOptions,
+): Promise<CheckResult> {
+	try {
+		// A failed/transient check has unreliable findings — never post-process it.
+		if (core.checkStatus === 'error' || core.checkStatus === 'timeout') {
+			return core;
+		}
+
+		const coreTrustFindings = core.findings.filter((f) => f.metadata?.trustSurface === true);
+
+		// Re-fetch the SPF record: the include list is not reliably exposed on the core
+		// result (a clean `-all` record with only cataloged includes carries no
+		// includeDomains-bearing finding), so we parse it ourselves.
+		const txtRecords = await makeQueryDNS(dnsOptions)(domain, 'TXT');
+		const spf = txtRecords.find((record) => /^v=spf1(\s|$)/i.test(record.trim()));
+		if (!spf) {
+			return core; // No SPF record to analyze — leave core as-is.
+		}
+
+		// Reconstruct the DMARC context the core used from its own trust-surface finding
+		// metadata so worker severities match the core's (info vs medium/high). When the
+		// core recognized nothing, default to no-corroboration (conservative info).
+		const ctxSource = coreTrustFindings[0]?.metadata;
+		const context: TrustSurfaceContext = ctxSource
+			? {
+					corroboratedByWeakDmarc: ctxSource.dmarcCorroborated === true,
+					...(typeof ctxSource.dmarcPolicy === 'string' ? { dmarcPolicy: ctxSource.dmarcPolicy } : {}),
+					...(typeof ctxSource.dmarcAlignmentMode === 'string'
+						? { dmarcAlignmentMode: ctxSource.dmarcAlignmentMode }
+						: {}),
+				}
+			: {};
+
+		const workerTrustFindings = analyzeTrustSurface(spf, context);
+
+		// Replace core trust-surface findings with the corrected worker ones; preserve all
+		// other findings in their original relative order.
+		const nonTrustFindings: Finding[] = core.findings.filter((f) => f.metadata?.trustSurface !== true);
+
+		// Mirror the core suppression rule: the "SPF record configured" info finding is only
+		// valid when no non-informational trust-surface finding remains. If the broadened
+		// worker analysis surfaced a real (non-info) trust finding, drop a now-stale
+		// "configured" finding so output stays self-consistent (does NOT affect score).
+		const hasNonInfoTrust = workerTrustFindings.some((f) => f.severity !== 'info');
+		const mergedNonTrust = hasNonInfoTrust
+			? nonTrustFindings.filter((f) => f.title !== 'SPF record configured')
+			: nonTrustFindings;
+
+		return { ...core, findings: [...mergedNonTrust, ...workerTrustFindings] };
+	} catch {
+		// Fail-soft: never worsen the core result on any post-processing error.
+		return core;
 	}
 }

--- a/src/tools/spf-trust-surface.ts
+++ b/src/tools/spf-trust-surface.ts
@@ -4,6 +4,16 @@
  * SPF Trust Surface Analysis.
  * Identifies when SPF include: or redirect= directives delegate sending
  * authority to multi-tenant SaaS platforms, expanding the domain's trust surface.
+ *
+ * WORKER-LAYER AUGMENTATION (issue #566): this module is intentionally NOT dead code.
+ * The `check_spf` tool delegates scoring/findings to the parity-locked core package
+ * `@blackveil/dns-checks`, whose own trust-surface recognizer omits some ESP includes
+ * (e.g. Mailjet) and counts only cataloged platforms. This worker copy carries a
+ * broader catalog PLUS a generic "unrecognized shared sender" heuristic so the
+ * `check_spf` OUTPUT reflects the full delegated trust surface. `check-spf.ts` runs it
+ * as a post-processor that REPLACES the core-produced trust-surface findings while
+ * leaving the score untouched. When the core catalog is updated + re-vendored, this
+ * augmentation can be retired.
  */
 
 import type { Finding } from '../lib/scoring';
@@ -43,7 +53,23 @@ const MULTI_TENANT_PLATFORMS: ReadonlyMap<string, PlatformInfo> = new Map([
 	['spf.messagelabs.com', { name: 'Symantec/Broadcom', risk: 'Shared sending infrastructure' }],
 	['_spf.atlassian.net', { name: 'Atlassian', risk: 'Any Atlassian customer can send as your domain' }],
 	['xero.com', { name: 'Xero', risk: 'Any Xero customer can send as your domain' }],
+	// #566: Mailjet — multi-tenant ESP the core catalog misses. Registrable key so
+	// `spf.mailjet.com` and any Mailjet sub-host match via the endsWith('.'+key) rule.
+	['mailjet.com', { name: 'Mailjet', risk: 'Any Mailjet customer can send as your domain' }],
 ]);
+
+/**
+ * Heuristic for an UNRECOGNIZED but broad multi-tenant sending host (issue #566):
+ * a hostname carrying an `spf` / `_spf` / `spfNN` label is an SPF-delegation endpoint
+ * for a shared platform, even when the specific provider is not in the catalog above.
+ * First-party includes like `mail.mycompany.com` deliberately do NOT match, so they
+ * are never flagged as shared senders.
+ */
+const GENERIC_SHARED_SENDER_RE = /(^|\.)_?spf\d*\./i;
+
+function isGenericSharedSender(domain: string): boolean {
+	return GENERIC_SHARED_SENDER_RE.test(domain.toLowerCase());
+}
 
 /**
  * Check whether a domain matches or is a subdomain of a known multi-tenant platform.
@@ -83,7 +109,7 @@ function extractIncludeAndRedirectDomains(spfRecord: string): string[] {
 export function analyzeTrustSurface(spfRecord: string, context: TrustSurfaceContext = {}): Finding[] {
 	const findings: Finding[] = [];
 	const domains = extractIncludeAndRedirectDomains(spfRecord);
-	const matchedPlatforms: { name: string; includeDomain: string }[] = [];
+	const delegated: { name: string; includeDomain: string; recognized: boolean }[] = [];
 	const corroboratedByWeakDmarc = context.corroboratedByWeakDmarc === true;
 	const findingSeverity = corroboratedByWeakDmarc ? 'medium' : 'info';
 	const summarySeverity = corroboratedByWeakDmarc ? 'high' : 'info';
@@ -94,7 +120,7 @@ export function analyzeTrustSurface(spfRecord: string, context: TrustSurfaceCont
 	for (const domain of domains) {
 		const result = matchPlatform(domain);
 		if (result) {
-			matchedPlatforms.push({ name: result.info.name, includeDomain: domain });
+			delegated.push({ name: result.info.name, includeDomain: domain, recognized: true });
 			findings.push(
 				createFinding(
 					'spf',
@@ -111,20 +137,43 @@ export function analyzeTrustSurface(spfRecord: string, context: TrustSurfaceCont
 					},
 				),
 			);
+		} else if (isGenericSharedSender(domain)) {
+			// #566: broaden the trust surface to unrecognized-but-broad shared senders so
+			// an ESP the catalog misses still counts. Named as the include host, not a brand.
+			delegated.push({ name: 'unrecognized shared sender', includeDomain: domain, recognized: false });
+			findings.push(
+				createFinding(
+					'spf',
+					`SPF delegates to shared sending platform (unrecognized): ${domain}`,
+					findingSeverity,
+					`SPF include:${domain} delegates sending to an external multi-tenant-style platform that is not in the recognized ESP catalog. It still widens your trust surface even though the specific provider is not named. ${detailSuffix}`,
+					{
+						trustSurface: true,
+						platform: 'unrecognized shared sender',
+						includeDomain: domain,
+						recognized: false,
+						dmarcCorroborated: corroboratedByWeakDmarc,
+						...(context.dmarcPolicy ? { dmarcPolicy: context.dmarcPolicy } : {}),
+						...(context.dmarcAlignmentMode ? { dmarcAlignmentMode: context.dmarcAlignmentMode } : {}),
+					},
+				),
+			);
 		}
 	}
 
-	if (matchedPlatforms.length > 1) {
-		const platformNames = matchedPlatforms.map((p) => p.name).join(', ');
+	if (delegated.length > 1) {
+		const platformNames = delegated
+			.map((p) => (p.recognized ? p.name : `${p.includeDomain} (unrecognized)`))
+			.join(', ');
 		findings.push(
 			createFinding(
 				'spf',
-				`SPF trust surface: ${matchedPlatforms.length} shared platforms`,
+				`SPF trust surface: ${delegated.length} shared platforms`,
 				summarySeverity,
-				`SPF record delegates sending authority to ${matchedPlatforms.length} multi-tenant platforms (${platformNames}). Audit each include to confirm it is still needed, configure provider-specific DKIM, and keep DMARC enforcement and alignment strong across every authorized sender.`,
+				`SPF record delegates sending authority to ${delegated.length} multi-tenant platforms (${platformNames}). Audit each include to confirm it is still needed, configure provider-specific DKIM, and keep DMARC enforcement and alignment strong across every authorized sender.`,
 				{
 					trustSurface: true,
-					platformCount: matchedPlatforms.length,
+					platformCount: delegated.length,
 					platforms: platformNames,
 					dmarcCorroborated: corroboratedByWeakDmarc,
 					...(context.dmarcPolicy ? { dmarcPolicy: context.dmarcPolicy } : {}),

--- a/test/check-spf-trust-surface-worker.spec.ts
+++ b/test/check-spf-trust-surface-worker.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/**
+ * Mock TXT responses for a map of name -> records.
+ * Mirrors the helper in check-spf.spec.ts so this suite exercises the real DoH path.
+ */
+function mockMultiDomainTxt(domainRecords: Record<string, string[]>) {
+	globalThis.fetch = vi.fn().mockImplementation((url: string | URL) => {
+		const u = new URL(typeof url === 'string' ? url : url.toString());
+		const name = u.searchParams.get('name') ?? '';
+		const records = domainRecords[name] ?? [];
+		const answers = records.map((data) => ({ name, type: 16, TTL: 300, data: `"${data}"` }));
+		return Promise.resolve(createDohResponse([{ name, type: 16 }], answers));
+	});
+}
+
+/**
+ * Regression coverage for issue #566: the worker-layer trust-surface post-processor
+ * must recognize ESP includes the core catalog misses (Mailjet) and count every
+ * delegated shared-sender include, WITHOUT changing the SPF score.
+ */
+describe('check_spf worker-layer trust-surface post-processor (#566)', () => {
+	const SPOTTO =
+		'v=spf1 include:spf.mailjet.com include:spf.protection.outlook.com include:441725607.spf01.hubspotemail.net -all';
+
+	function baseMock(spf: string) {
+		mockMultiDomainTxt({
+			'spotto.ai': [spf],
+			// includes resolve to simple terminal SPF records (no extra lookups / noise)
+			'spf.mailjet.com': ['v=spf1 -all'],
+			'spf.protection.outlook.com': ['v=spf1 -all'],
+			'441725607.spf01.hubspotemail.net': ['v=spf1 -all'],
+			'_spf.google.com': ['v=spf1 -all'],
+			'sendgrid.net': ['v=spf1 -all'],
+		});
+	}
+
+	it('recognizes all THREE delegated platforms including Mailjet (was 2)', async () => {
+		baseMock(SPOTTO);
+		const { checkSpf } = await import('../src/tools/check-spf');
+		const result = await checkSpf('spotto.ai');
+
+		const perInclude = result.findings.filter(
+			(f) => f.metadata?.trustSurface === true && /delegates to/i.test(f.title),
+		);
+		const names = perInclude.map((f) => f.title);
+		expect(names.some((t) => /Mailjet/i.test(t))).toBe(true);
+		expect(names.some((t) => /Microsoft 365/i.test(t))).toBe(true);
+		expect(names.some((t) => /HubSpot/i.test(t))).toBe(true);
+
+		const summary = result.findings.find((f) => f.metadata?.platformCount != null);
+		expect(summary).toBeDefined();
+		expect(summary!.metadata?.platformCount).toBe(3);
+		expect(summary!.title).toContain('3 shared platforms');
+	});
+
+	it('still reports exactly 2 for a two-recognized-include record', async () => {
+		const spf = 'v=spf1 include:spf.protection.outlook.com include:441725607.spf01.hubspotemail.net -all';
+		baseMock(spf);
+		const { checkSpf } = await import('../src/tools/check-spf');
+		const result = await checkSpf('spotto.ai');
+
+		const summary = result.findings.find((f) => f.metadata?.platformCount != null);
+		expect(summary).toBeDefined();
+		expect(summary!.metadata?.platformCount).toBe(2);
+		expect(summary!.title).toContain('2 shared platforms');
+	});
+
+	it('counts an unrecognized broad shared sender toward the trust surface total', async () => {
+		// _spf.google.com is recognized; spf.unknownesp.io is an unrecognized broad ESP-style host.
+		const spf = 'v=spf1 include:_spf.google.com include:spf.unknownesp.io -all';
+		mockMultiDomainTxt({
+			'spotto.ai': [spf],
+			'_spf.google.com': ['v=spf1 -all'],
+			'spf.unknownesp.io': ['v=spf1 -all'],
+		});
+		const { checkSpf } = await import('../src/tools/check-spf');
+		const result = await checkSpf('spotto.ai');
+
+		const summary = result.findings.find((f) => f.metadata?.platformCount != null);
+		expect(summary).toBeDefined();
+		expect(summary!.metadata?.platformCount).toBe(2);
+	});
+
+	it('leaves the SPF score byte-identical to the core checkSPF result', async () => {
+		baseMock(SPOTTO);
+		const { checkSPF } = await import('@blackveil/dns-checks');
+		const { makeQueryDNS } = await import('../src/lib/dns-query-adapter');
+		const core = await checkSPF('spotto.ai', makeQueryDNS());
+
+		baseMock(SPOTTO);
+		const { checkSpf } = await import('../src/tools/check-spf');
+		const worker = await checkSpf('spotto.ai');
+
+		expect(worker.score).toBe(core.score);
+		expect(worker.passed).toBe(core.passed);
+		expect(worker.checkStatus).toBe(core.checkStatus);
+	});
+});


### PR DESCRIPTION
Fixes #566.

**Root cause:** the trust-surface finding + "N shared platforms" count come from the parity-locked core `packages/dns-checks` catalog (no Mailjet). Per operator decision this is fixed in the **worker layer** (core left byte-untouched, no publish/re-vendor).

**Fix:** revived the (previously dead) worker `spf-trust-surface.ts` — added Mailjet + an `isGenericSharedSender` heuristic so unrecognized broad ESP includes still count — and wired it into `checkSpf` as a fail-soft post-processor that REPLACES only the trust-surface findings. `score`/`passed`/`checkStatus` and all other findings pass through from core unchanged. Reaches `scan_domain`, `assess_spoofability`, `simulate_attack_paths`, `validate_fix` (all import the worker `checkSpf`).

**Note:** bv-web-prod consumes the core `checkSPF` directly, so its scan SPF surface stays gapped until a separate core catalog fix + re-vendor.
**Scope:** `src/tools/check-spf.ts`, `src/tools/spf-trust-surface.ts` + new spec. No `packages/dns-checks` change.
**Tests:** 34/34 green; `worker.score === core.score` asserted.