### PR TITLE
fix(http-security): relabel edge-challenged 401 as artifact, not auth-required (#567)

### DIFF
--- a/src/lib/waf-detection.ts
+++ b/src/lib/waf-detection.ts
@@ -19,8 +19,16 @@
 import { createFinding } from './scoring';
 import type { CheckCategory, Finding } from './scoring';
 
-/** A detected WAF interception — either an interstitial challenge or a terminal block. */
-export type WafEvent = { provider: 'cloudflare' | 'akamai'; kind: 'challenge' | 'block' };
+/**
+ * A detected WAF interception:
+ * - `challenge` — an interstitial JS/interactive challenge page.
+ * - `block` — a terminal access-block page.
+ * - `edge-artifact` — the edge answered the automated probe with an HTTP 401 while a normal
+ *   client gets a different (public) response. This is edge fingerprinting/challenge, NOT an
+ *   origin auth requirement, so the "requires authentication" label would be misleading
+ *   (issue #567, same class as the #455 403-challenge false positive).
+ */
+export type WafEvent = { provider: 'cloudflare' | 'akamai'; kind: 'challenge' | 'block' | 'edge-artifact' };
 
 /** Cloudflare access-block body signatures (distinct from the "Just a moment" JS challenge). */
 const CF_BLOCK_BODY = /sorry, you have been blocked|attention required|error 10(09|10|12|13|15|20)/i;
@@ -50,6 +58,17 @@ export function looksLikeWaf(headers: Headers): boolean {
  * The Akamai branch mirrors the same rigor: a bare `Server: AkamaiGHost` header is present on
  * ordinary responses, so a block requires a 4xx PLUS an Akamai access-denied body signature —
  * a genuine origin 403/404/500 behind Akamai is NOT mis-attributed to a WAF block.
+ *
+ * HTTP 401 special case (issue #567): a Cloudflare-fronted origin frequently answers an
+ * automated probe with `401` (edge fingerprinting/challenge) while a normal client gets a
+ * public `200` at the same URL. Unlike the 403 block path this carries NO block-body signature —
+ * the returned page is often the real (or a generic) page — so the 401 status ITSELF, combined
+ * with a Cloudflare edge signal, is the discriminator. It is classified as `edge-artifact` so the
+ * caller can label it "challenged/blocked at the edge" instead of the misleading "endpoint
+ * requires authentication". A 401 with NO Cloudflare signal (a genuine auth-gated origin) is left
+ * untouched → `null` → the caller keeps the honest auth-required finding. The challenge and block
+ * classifications are still checked FIRST, so a 401 that IS a "Just a moment" challenge or a
+ * block-body page keeps its more specific kind.
  */
 export function detectWafEvent(headers: Headers, body: string | undefined, status: number): WafEvent | null {
 	const server = (headers.get('server') ?? '').toLowerCase();
@@ -60,6 +79,7 @@ export function detectWafEvent(headers: Headers, body: string | undefined, statu
 	if (cfRay || cfMitigated || server.includes('cloudflare')) {
 		if (/just a moment/i.test(b) || cfMitigated === 'challenge') return { provider: 'cloudflare', kind: 'challenge' };
 		if (status >= 400 && (CF_BLOCK_BODY.test(b) || !!cfMitigated)) return { provider: 'cloudflare', kind: 'block' };
+		if (status === 401) return { provider: 'cloudflare', kind: 'edge-artifact' };
 	}
 	if (server.includes('akamaighost') && status >= 400 && AKAMAI_BLOCK_BODY.test(b)) {
 		return { provider: 'akamai', kind: 'block' };

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -417,12 +417,24 @@ async function checkHttpSecurityInner(domain: string, callerSignal?: AbortSignal
 		const event = detectWafEvent(headersForWaf, body, dualResult.status);
 		if (event) {
 			const provider = event.provider.charAt(0).toUpperCase() + event.provider.slice(1);
-			const title =
-				event.kind === 'block' ? `${provider} WAF blocked external header inspection` : `${provider} WAF challenge intercepted`;
-			const detail =
-				event.kind === 'block'
-					? `https://${domain} returned an HTTP ${dualResult.status} ${provider} block page, not the site. Security headers cannot be inspected externally.`
-					: `The fetched response appears to be a ${provider} challenge page, not the real site. Header analysis is inconclusive.`;
+			let title: string;
+			let detail: string;
+			if (event.kind === 'block') {
+				title = `${provider} WAF blocked external header inspection`;
+				detail = `https://${domain} returned an HTTP ${dualResult.status} ${provider} block page, not the site. Security headers cannot be inspected externally.`;
+			} else if (event.kind === 'edge-artifact') {
+				// An HTTP 401 to the scanner that a normal client does not see (issue #567). The
+				// request was challenged/blocked at the edge — NOT an origin auth requirement, so we
+				// deliberately avoid the misleading "requires authentication" wording.
+				title = `${provider} edge challenged the HTTP security probe`;
+				detail =
+					`https://${domain} returned HTTP ${dualResult.status} to the scanner while presenting ${provider} edge signals; ` +
+					`the request was challenged/blocked at the edge, not authenticated at the origin. A normal client may receive a different ` +
+					`response at this URL, so security headers are not externally verifiable here.`;
+			} else {
+				title = `${provider} WAF challenge intercepted`;
+				detail = `The fetched response appears to be a ${provider} challenge page, not the real site. Header analysis is inconclusive.`;
+			}
 			const finding = buildWafFinding('http_security', event, dualResult.status, { title, detail });
 			const base = buildCheckResult('http_security', [finding]);
 			return { ...base, score: 0, passed: false, checkStatus: 'error' };

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -239,6 +239,39 @@ describe('checkHttpSecurity', () => {
 		expect(result.passed).toBe(false);
 	});
 
+	it('relabels a Cloudflare-fronted 401 (edge signals) as an edge-challenge artifact, not auth-required (#567)', async () => {
+		// Live repro (api-au.spotto.ai): the scanner is fingerprinted/challenged at the edge and
+		// gets HTTP 401 while curl/browser get HTTP 200 for a public page. Must NOT read as
+		// "endpoint requires authentication".
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: false,
+			status: 401,
+			headers: new Headers({ 'cf-ray': '91xyz4567-SYD', server: 'cloudflare' }),
+			text: async () => '<html><head><title>Spotto API Documentation</title></head><body>Public docs</body></html>',
+		} as unknown as Response);
+		const result = await run('api-au.spotto.ai');
+		// Graceful inconclusive is preserved.
+		expect(result.checkStatus).toBe('error');
+		expect(result.score).toBe(0);
+		expect(result.passed).toBe(false);
+		// Attributed to the edge (Cloudflare), not to origin auth.
+		const ev = result.findings.find((f) => f.metadata?.wafEvent === 'cloudflare');
+		expect(ev).toBeDefined();
+		expect(ev!.metadata?.wafKind).toBe('edge-artifact');
+		expect(ev!.metadata?.inconclusive).toBe(true);
+		// The misleading "requires authentication" label must be gone.
+		expect(result.findings.some((f) => f.title === 'HTTP check requires authentication')).toBe(false);
+		expect(result.findings.every((f) => !/requires authentication/i.test(f.detail ?? ''))).toBe(true);
+	});
+
+	it('still labels a genuine 401 with NO edge signals as auth-required (#567 guard)', async () => {
+		globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401, headers: new Headers() });
+		const result = await run();
+		expect(result.findings).toHaveLength(1);
+		expect(result.findings[0].title).toBe('HTTP check requires authentication');
+		expect(result.findings[0].severity).toBe('info');
+	});
+
 	it('should return rejected finding for other 4xx responses', async () => {
 		globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 429, headers: new Headers() });
 		const result = await run();

--- a/test/waf-detection.spec.ts
+++ b/test/waf-detection.spec.ts
@@ -70,6 +70,43 @@ describe('detectWafEvent — Cloudflare branch (unchanged)', () => {
 	});
 });
 
+describe('detectWafEvent — edge-challenged 401 (#567)', () => {
+	it('classifies a 401 carrying Cloudflare edge signals as an edge-artifact (not a real auth gate)', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		// Live repro (api-au.spotto.ai): the scanner receives HTTP 401 from a Cloudflare-fronted
+		// origin while a normal client gets HTTP 200 for a fully public page. The 401 is an edge
+		// fingerprinting/challenge artifact, not an origin auth requirement.
+		expect(
+			detectWafEvent(
+				headers({ 'cf-ray': '91xyz4567-SYD', server: 'cloudflare' }),
+				'<html><head><title>Spotto API Documentation</title></head><body>Public docs</body></html>',
+				401,
+			),
+		).toEqual({ provider: 'cloudflare', kind: 'edge-artifact' });
+	});
+
+	it('classifies a 401 with cf-ray only (no block/challenge body) as an edge-artifact', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ 'cf-ray': '91xyz4567-SYD' }), '', 401)).toEqual({
+			provider: 'cloudflare',
+			kind: 'edge-artifact',
+		});
+	});
+
+	it('returns null for a genuine 401 with NO edge signals (a real auth-gated origin)', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({}), '', 401)).toBeNull();
+	});
+
+	it('still prefers the challenge classification over edge-artifact for a "Just a moment" 401', async () => {
+		const { detectWafEvent } = await import('../src/lib/waf-detection');
+		expect(detectWafEvent(headers({ 'cf-ray': '91xyz4567-SYD', server: 'cloudflare' }), 'Just a moment...', 401)).toEqual({
+			provider: 'cloudflare',
+			kind: 'challenge',
+		});
+	});
+});
+
 describe('buildWafFinding — canonical inconclusive WAF info-finding', () => {
 	it('builds an info-severity finding with the canonical metadata contract', async () => {
 		const { buildWafFinding } = await import('../src/lib/waf-detection');


### PR DESCRIPTION
Fixes #567.

**Root cause:** a Cloudflare-fronted origin answers the scanner with 401 (edge fingerprinting) while normal clients get 200; the vendored `checkHTTPSecurity` labelled it "requires authentication". The #455 WAF detector missed it because its CF block branch needs a block-body signature a 401 doesn't carry.

**Fix:** new `edge-artifact` kind in `detectWafEvent` (401 + CF signal), checked AFTER challenge/block so a "Just a moment"/block-body 401 keeps its specific kind. `check-http-security.ts` relabels it ("edge challenged the probe … not authenticated at origin"), keeping the graceful inconclusive. A signalless 401 (real auth-gated origin) still reads auth-required.

**Scope:** `src/lib/waf-detection.ts`, `src/tools/check-http-security.ts` + specs. No `packages/dns-checks` change.
**Tests:** 63/63 green (red-first); mta-sts consumer regression check 23/23.