### PR TITLE
fix: correctness-defect campaign — slices 4 & 5 (ownership attribution + success-shaped zeros)

### DIFF
--- a/src/lib/brand-evidence.ts
+++ b/src/lib/brand-evidence.ts
@@ -58,12 +58,7 @@ const STRONG_SIGNALS: ReadonlySet<BrandEvidenceSignal> = new Set([
 	'bounty_scope',
 ]);
 
-const MEDIUM_SIGNALS: ReadonlySet<BrandEvidenceSignal> = new Set([
-	'ns',
-	'dmarc_rua',
-	'mx_overlap',
-	'san',
-]);
+const MEDIUM_SIGNALS: ReadonlySet<BrandEvidenceSignal> = new Set(['dmarc_rua', 'mx_overlap', 'san']);
 
 const WEAK_SIGNALS: ReadonlySet<BrandEvidenceSignal> = new Set([
 	'markov_gen',
@@ -90,6 +85,14 @@ export function evidenceTier(signal: BrandEvidenceSignal, metadata?: Record<stri
 	if (signal === 'mx_platform') {
 		const sharedMxPlatform = normalizedMetadataValue(metadata, 'sharedMxPlatform');
 		return sharedMxPlatform && BROAD_MX_PLATFORMS.has(sharedMxPlatform) ? 'weak' : 'medium';
+	}
+	if (signal === 'ns') {
+		// D6.3 (2026-07-26 correctness-defects design) — an in-bailiwick NS match
+		// (the candidate's own nameservers delegated under the seed's apex) is
+		// near-deterministic ownership evidence, unlike a plain NS-set overlap
+		// (which can land on a shared provider and needs corroboration).
+		const matchType = normalizedMetadataValue(metadata, 'matchType');
+		return matchType === 'in_bailiwick' ? 'strong' : 'medium';
 	}
 	if (STRONG_SIGNALS.has(signal)) return 'strong';
 	if (MEDIUM_SIGNALS.has(signal)) return 'medium';

--- a/src/lib/category-interactions.ts
+++ b/src/lib/category-interactions.ts
@@ -77,22 +77,28 @@ export const INTERACTION_RULES: InteractionRule[] = [
 		// gate below fails and neither mechanism fires.
 		id: 'impersonation_weak_dmarc',
 		conditions: [
-			// F3(a) (2026-07-27 fix round 2): corrected — this used to claim
-			// "lookalikes score drops below 100 only when a calibrated
-			// medium/high lookalike is found". That stopped being true once the
-			// D4 ownership-attribution gate (check-lookalikes.ts) shipped: every
-			// `lookalikes` finding — owned_by_seed or ownership-demoted third
-			// party alike — is now emitted at `info` severity, so the category
-			// score is always 100 and this `maxScore: 85` condition cannot
-			// currently be satisfied. Its sibling predicate,
-			// `hasActiveImpersonation()` in scan/post-processing.ts, checks for
-			// the same medium/high/critical severities and is equally
-			// unreachable today. Both are effectively dead code as a direct
-			// consequence of the D4 gate — the same defect the reviewer's Major
-			// finding on Task 7 flagged (escalated to the design owner
-			// separately; NOT fixed here, per explicit instruction not to
-			// change the gate or the cap in this round). Left in place and
-			// documented honestly pending that decision.
+			// REACHABLE AGAIN as of Task 7b (2026-07-27). History, because this
+			// comment has now been wrong in both directions:
+			//   - Originally: "lookalikes drops below 100 only when a calibrated
+			//     medium/high lookalike is found" — true pre-D4.
+			//   - F3(a) (fix round 2): corrected to "unreachable", because the D4
+			//     ownership gate capped EVERY `lookalikes` finding at `info`, so
+			//     the category always scored 100 and `maxScore: 85` could never
+			//     be satisfied. That was the honest state at the time and the
+			//     defect the reviewer's Major finding on Task 7 flagged.
+			//   - Task 7b: the design owner ruled the two axes apart. A non-owned
+			//     candidate now carries BOTH an `info` ATTRIBUTION finding (the
+			//     ownership claim, still capped) and a separate
+			//     THREAT-OBSERVATION finding at the #264-calibrated severity
+			//     (`metadata.findingAxis === 'threat_observation'`). A live
+			//     typosquat with mail infrastructure therefore drops the
+			//     `lookalikes` category well below 85 again, and this condition
+			//     is satisfiable exactly as originally intended. Its sibling
+			//     predicate, `hasActiveImpersonation()` in
+			//     scan/post-processing.ts, is reachable again on the same signal.
+			// Owned-by-seed candidates still emit ONLY an `info` attribution
+			// finding, so a customer's own defensive registration can never
+			// trigger this rule.
 			{ category: 'lookalikes', maxScore: 85 },
 			// Weak/absent DMARC, as left by the escalation pass (see above).
 			{ category: 'dmarc', maxScore: 60 },

--- a/src/lib/category-interactions.ts
+++ b/src/lib/category-interactions.ts
@@ -77,28 +77,33 @@ export const INTERACTION_RULES: InteractionRule[] = [
 		// gate below fails and neither mechanism fires.
 		id: 'impersonation_weak_dmarc',
 		conditions: [
-			// REACHABLE AGAIN as of Task 7b (2026-07-27). History, because this
-			// comment has now been wrong in both directions:
-			//   - Originally: "lookalikes drops below 100 only when a calibrated
-			//     medium/high lookalike is found" — true pre-D4.
-			//   - F3(a) (fix round 2): corrected to "unreachable", because the D4
-			//     ownership gate capped EVERY `lookalikes` finding at `info`, so
-			//     the category always scored 100 and `maxScore: 85` could never
-			//     be satisfied. That was the honest state at the time and the
-			//     defect the reviewer's Major finding on Task 7 flagged.
-			//   - Task 7b: the design owner ruled the two axes apart. A non-owned
-			//     candidate now carries BOTH an `info` ATTRIBUTION finding (the
-			//     ownership claim, still capped) and a separate
-			//     THREAT-OBSERVATION finding at the #264-calibrated severity
-			//     (`metadata.findingAxis === 'threat_observation'`). A live
-			//     typosquat with mail infrastructure therefore drops the
-			//     `lookalikes` category well below 85 again, and this condition
-			//     is satisfiable exactly as originally intended. Its sibling
-			//     predicate, `hasActiveImpersonation()` in
-			//     scan/post-processing.ts, is reachable again on the same signal.
-			// Owned-by-seed candidates still emit ONLY an `info` attribution
-			// finding, so a customer's own defensive registration can never
-			// trigger this rule.
+			// Task 7b (2026-07-27) — what satisfies this condition today, stated
+			// precisely, because two earlier revisions of this comment were wrong.
+			//
+			// The `lookalikes` category drops to/below 85 when the check emits a
+			// finding above `info`. Since Task 7b that happens on the
+			// THREAT-OBSERVATION axis (`metadata.findingAxis ===
+			// 'threat_observation'`): a #264-calibrated observation about a
+			// confusable domain's infrastructure (e.g. live MX on a disposable
+			// provider), plus the aggregate HIGH summary. ATTRIBUTION-axis findings
+			// (`'attribution'`) are capped at `info` for every non-`owned_by_seed`
+			// verdict and cannot move the score.
+			//
+			// CORRECTION (fix round 1, F3): the previous revision claimed that under
+			// Task 7 "every lookalikes finding was capped at info", so this rule was
+			// dead code. That was FALSE. The recon CT-corroboration finding in
+			// check-lookalikes.ts emits `'medium'` and has never been routed through
+			// the ownership gate, so on an operator deploy with the BV_RECON binding
+			// this condition was satisfiable throughout — the earlier revision
+			// before THAT one, claiming it fired whenever a calibrated medium/high
+			// lookalike was found, was the one closer to the truth. What Task 7
+			// actually broke was the DNS-derived path (per-candidate and summary
+			// findings), which is what 7b restored. Nor is it true, as that revision
+			// also claimed, that an owned-by-seed candidate "can never trigger this
+			// rule": the recon finding is scoped to the SCANNED domain and fires
+			// independently of any candidate's ownership verdict. What IS true: no
+			// finding this rule keys on makes an ownership claim about a third
+			// party's domain.
 			{ category: 'lookalikes', maxScore: 85 },
 			// Weak/absent DMARC, as left by the escalation pass (see above).
 			{ category: 'dmarc', maxScore: 60 },

--- a/src/lib/category-interactions.ts
+++ b/src/lib/category-interactions.ts
@@ -77,11 +77,22 @@ export const INTERACTION_RULES: InteractionRule[] = [
 		// gate below fails and neither mechanism fires.
 		id: 'impersonation_weak_dmarc',
 		conditions: [
-			// lookalikes score drops below 100 only when a calibrated medium/high
-			// lookalike is found (defensive registrations / shared-NS matches stay
-			// info-severity and don't move the score). <= 85 == "at least one
-			// medium-or-higher active impersonation domain" — the same predicate
-			// hasActiveImpersonation() uses on the label side.
+			// F3(a) (2026-07-27 fix round 2): corrected — this used to claim
+			// "lookalikes score drops below 100 only when a calibrated
+			// medium/high lookalike is found". That stopped being true once the
+			// D4 ownership-attribution gate (check-lookalikes.ts) shipped: every
+			// `lookalikes` finding — owned_by_seed or ownership-demoted third
+			// party alike — is now emitted at `info` severity, so the category
+			// score is always 100 and this `maxScore: 85` condition cannot
+			// currently be satisfied. Its sibling predicate,
+			// `hasActiveImpersonation()` in scan/post-processing.ts, checks for
+			// the same medium/high/critical severities and is equally
+			// unreachable today. Both are effectively dead code as a direct
+			// consequence of the D4 gate — the same defect the reviewer's Major
+			// finding on Task 7 flagged (escalated to the design owner
+			// separately; NOT fixed here, per explicit instruction not to
+			// change the gate or the cap in this round). Left in place and
+			// documented honestly pending that decision.
 			{ category: 'lookalikes', maxScore: 85 },
 			// Weak/absent DMARC, as left by the escalation pass (see above).
 			{ category: 'dmarc', maxScore: 60 },

--- a/src/lib/dns-error-result.ts
+++ b/src/lib/dns-error-result.ts
@@ -29,10 +29,24 @@
  * generate-records). An errored check did not pass.
  */
 
-import { buildCheckResult, createFinding, type CheckCategory, type CheckResult } from './scoring';
+import { buildCheckResult, createFinding, type CheckCategory, type CheckResult, type Finding } from './scoring';
 
 // Mirrors safeCheck()'s allowlist so the surfaced detail stays bounded/safe.
 const SAFE_PREFIXES = ['DNS query', 'Check timed out', 'Check failed', 'Connection', 'timeout'];
+
+/**
+ * True for the synthetic "check error" finding this module builds — a transient
+ * DNS/network failure, not a measurement of the customer's posture. Consumers that
+ * derive remediation actions, compliance verdicts, or priced upsells from findings
+ * MUST exclude these: there is nothing to remediate and nothing to sell against a
+ * category that was never actually observed. The single spelling of the
+ * `errorKind` marker check, so every consumer filters on the exact same predicate
+ * rather than re-deriving `severity === 'high'` (which would also swallow genuine
+ * high-severity findings) or comparing detail/title prose.
+ */
+export function isDnsErrorFinding(f: Pick<Finding, 'metadata'>): boolean {
+	return f.metadata?.errorKind === 'dns_error';
+}
 
 /**
  * Build a transient-failure CheckResult for a caught DNS error. `label` is the

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -4,9 +4,9 @@
  * Ownership-attribution primitive (P2, 2026-07-26 correctness-defects design §4).
  *
  * Classifies a registered candidate domain's ownership relative to a seed
- * domain. This is the single gate that decides whether a shadow-domain or
- * lookalike finding may exceed `info` severity — see
- * `docs/superpowers/specs/2026-07-26-bv-mcp-correctness-defects-design.md`
+ * domain. `capAttributionSeverity()` below is the single gate that decides
+ * whether a shadow-domain or lookalike finding may exceed `info` severity —
+ * see `docs/superpowers/specs/2026-07-26-bv-mcp-correctness-defects-design.md`
  * §4 (P2) and §5 (D4).
  *
  * Pure function, no DNS I/O: callers gather NS records and registration
@@ -22,32 +22,48 @@
  * severity gating keys ONLY on `verdict === 'owned_by_seed'` vs everything
  * else. The `third_party` / `unattributed` distinction changes report
  * wording, never severity — a misclassification between those two can never
- * produce a false high-severity finding. `capAttributionSeverity()` below
- * enforces this: it treats `third_party` and `unattributed` identically.
+ * produce a false high-severity finding. `capAttributionSeverity()` enforces
+ * this and takes `verdict` ALONE — no other input can move the ceiling.
  *
  * DEMOTE, NEVER DELETE (controller amendment 1, binding ruling from the
- * human partner): `passesAttributionGuard()` is a CLASSIFIER of corroboration
- * confidence, not a suppressor. The campaign's own seed brand in this slice's
- * fixture corpus (`bnz`) is 3 characters — the same length class as the
- * impersonator the guard was sized against (`hnz`) — so a guard that OMITS
- * findings on failure would delete real measurements about the customer's
- * OWN assets, which is worse than the false-positive it exists to prevent.
- * `capAttributionSeverity()` is the safe API surface for callers: it always
- * returns a concrete, truthy value (a `Severity` or the `'unbounded'`
- * sentinel) — there is no `null`/`undefined` return that a caller could
- * mistake for "omit this finding". A real measurement must never be
+ * human partner): `attributionConfidence()` is a CLASSIFIER of wording
+ * confidence, not a severity gate and not a suppressor — see fix-round F1/F3
+ * below for why it must never be consulted for the severity ceiling.
+ * `capAttributionSeverity()` is the ONLY exported severity-decision surface:
+ * it always returns a concrete, truthy value (a `Severity` or the
+ * `'unbounded'` sentinel) — there is no `null`/`undefined` return a caller
+ * could mistake for "omit this finding". A real measurement must never be
  * suppressed; only its severity is capped and its wording kept neutral.
+ *
+ * FIX ROUND 1 (2026-07-27, post-review): the first implementation had
+ * `capAttributionSeverity()` consult the D4 label-length/corroboration guard
+ * BEFORE the ownership verdict, so any non-owned candidate with a brand
+ * label >= `MIN_ATTRIBUTION_LABEL_LENGTH` characters (e.g. `westpac`, a
+ * competing bank) came back `'unbounded'` — the exact defect this slice
+ * exists to fix, on the safety-critical function. Corrected:
+ * `capAttributionSeverity()` now takes ONLY `verdict` and gates on ownership
+ * FIRST. The label-length/corroboration guard (`attributionConfidence()`,
+ * renamed from `passesAttributionGuard()`) still exists but now governs
+ * WORDING/CONFIDENCE prose only — it is never consulted for severity, and
+ * its non-boolean `'corroborated' | 'uncorroborated'` return shape (renamed
+ * from a raw boolean) makes it read as a confidence classifier rather than
+ * a permission gate a caller might branch into a suppression.
  */
 
 import type { Severity } from '@blackveil/dns-checks/scoring';
 import { getRegistrableDomain } from './public-suffix';
-import type { RegistrationState } from './registration-state';
-import { UNKNOWN_REASON_PHRASES } from './registration-state';
+import { UNKNOWN_REASON_PHRASES, type RegistrationState } from './registration-state';
 
 /** Final attribution verdict. */
 export type OwnershipVerdict = 'owned_by_seed' | 'third_party' | 'unattributed';
 
-export type OwnershipStrength = 'strong' | 'medium' | 'weak' | 'none';
+/**
+ * `classifyOwnership()` only ever returns `'strong'`, `'medium'`, or
+ * `'none'` — there is no rule in the current precedence table that yields
+ * `'weak'`. Kept out of the union rather than left as a dead member so a
+ * caller `switch` can be exhaustive.
+ */
+export type OwnershipStrength = 'strong' | 'medium' | 'none';
 
 export type OwnershipSignal =
 	| 'ns_in_bailiwick'
@@ -83,6 +99,23 @@ export interface ClassifyOwnershipInput {
 	 * (neither tool parses SPF `include:` targets, SOA RNAME, or HTTP
 	 * redirect targets today) — accepted here so a future slice can wire a
 	 * real probe without touching this function's precedence logic again.
+	 *
+	 * SECURITY — CALLER OBLIGATION (flagged in fix-round F4, mapping change
+	 * itself is UNRESOLVED — do not treat this comment as having fixed it):
+	 * all three of `soaInBailiwick`, `spfIncludesSeedApex`, and
+	 * `httpRedirectToSeedApex` are attacker-influenceable. Unlike
+	 * `ns_in_bailiwick` (which requires the candidate to control its own
+	 * delegated zone), an attacker who registers `evilbnz.co.nz` can
+	 * unilaterally publish an SPF `include:` pointing at the seed apex or an
+	 * HTTP redirect to it, with NO cooperation from the seed's owner. As
+	 * currently wired, ANY ONE of these three flags alone is sufficient for
+	 * `classifyOwnership()` to return `owned_by_seed`/`strong` — the inverse
+	 * of the false-attribution defect this slice fixes. A future caller that
+	 * wires a real probe for any of these MUST NOT let it alone produce
+	 * `owned_by_seed`; it should require corroboration from an
+	 * owner-controlled signal (NS delegation) or be demoted to a weaker
+	 * verdict/strength. This file does not change the verdict mapping —
+	 * that call belongs to the design owner, not to this fix.
 	 */
 	soaInBailiwick?: boolean;
 	spfIncludesSeedApex?: boolean;
@@ -94,7 +127,7 @@ const DEDICATED_NS_MATCH_RATIO = 0.5;
 /** Minimum absolute count of dedicated shared NS hosts, alongside the ratio above. */
 const DEDICATED_NS_MATCH_MIN_COUNT = 2;
 
-/** Minimum brand-label length below which a non-owned candidate needs corroboration to be scored at full confidence (D4). */
+/** Minimum brand-label length below which a non-owned candidate needs corroboration to be worded with full confidence (D4). Governs WORDING ONLY — see `attributionConfidence()`. */
 export const MIN_ATTRIBUTION_LABEL_LENGTH = 5;
 
 function normHost(h: string): string {
@@ -134,6 +167,11 @@ export function isInBailiwick(nsHost: string, seedApex: string): boolean {
  *     operational plumbing, not ownership evidence).
  *  8. Registered with its own resolvable NS, no ownership signal → `third_party`.
  *  9. Everything else (no NS info at all) → `unattributed`.
+ *
+ * Steps 3-4 accept attacker-influenceable evidence — see the caller-
+ * obligation note on `ClassifyOwnershipInput`'s `soaInBailiwick` /
+ * `spfIncludesSeedApex` / `httpRedirectToSeedApex` fields. That mapping is
+ * unchanged and unresolved by this fix round; flagged, not altered.
  */
 export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAssessment {
 	const { registration, candidateDomain } = input;
@@ -159,7 +197,8 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
-	const seedApex = getRegistrableDomain(input.seedDomain) ?? normHost(input.seedDomain);
+	const normalisedSeedDomain = normHost(input.seedDomain);
+	const seedApex = getRegistrableDomain(normalisedSeedDomain) ?? normalisedSeedDomain;
 	const candidateNs = registration.ns.map(normHost).filter(Boolean);
 	const seedNs = input.seedNs.map(normHost).filter(Boolean);
 
@@ -173,6 +212,12 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
+	// SECURITY: soaInBailiwick / spfIncludesSeedApex / httpRedirectToSeedApex
+	// are attacker-influenceable (see the ClassifyOwnershipInput caller-
+	// obligation note above) — unlike ns_in_bailiwick, none of these require
+	// the candidate to control its own delegated zone. Not gathered by any
+	// caller in this slice; the mapping below is unresolved, flagged for the
+	// design owner, and intentionally NOT altered by this fix round.
 	if (input.soaInBailiwick) {
 		return {
 			verdict: 'owned_by_seed',
@@ -237,11 +282,20 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 	};
 }
 
+/** {@link attributionConfidence} return type — deliberately not a boolean; see its JSDoc for why. */
+export type AttributionConfidence = 'corroborated' | 'uncorroborated';
+
 /**
- * D4 corroboration classifier: does a non-owned candidate's brand-label
- * match meet the confidence bar to stand on its own?
+ * D4 WORDING/CONFIDENCE classifier: does a non-owned candidate's brand-label
+ * match meet the bar to be worded with full confidence in a report, versus
+ * hedged/neutral wording? THIS FUNCTION MUST NEVER BE CONSULTED FOR
+ * SEVERITY — that is `capAttributionSeverity()`'s job, and it takes
+ * `verdict` alone. (Renamed from `passesAttributionGuard()` in fix round 1:
+ * the original boolean-returning name/shape invited exactly the misuse this
+ * rename and the `'corroborated' | 'uncorroborated'` return type resist —
+ * see F3 in the fix-round report.)
  *
- * `owned_by_seed` always passes — it is the strongest available
+ * `owned_by_seed` is always `'corroborated'` — it is the strongest available
  * corroborating brand signal by construction. Any other verdict needs
  * EITHER a brand label at least `MIN_ATTRIBUTION_LABEL_LENGTH` characters
  * long, OR an explicit corroborating signal supplied by the caller
@@ -250,39 +304,31 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
  * fetches them today). Below the threshold with no corroboration, a short
  * brand label (e.g. `bnz`, 3 characters) collides with too much unrelated
  * global DNS for a bare label match to mean anything on its own — see spec
- * §5 D4.
- *
- * THIS FUNCTION IS A CLASSIFIER, NOT A SUPPRESSION GATE. A caller MUST NOT
- * branch a `false` result into omitting a finding — do that and a real
- * measurement about the customer's own short-labelled brand (this
- * campaign's seed, `bnz`, is itself 3 characters) silently vanishes from the
- * report. Use `capAttributionSeverity()` instead: its return type has no
- * value that means "no finding", only a severity ceiling.
+ * §5 D4. This is a WORDING signal only: whatever it returns, the finding is
+ * still emitted, at the severity `capAttributionSeverity()` computed.
  */
-export function passesAttributionGuard(verdict: OwnershipVerdict, brandLabel: string, corroborated: boolean): boolean {
-	if (verdict === 'owned_by_seed') return true;
-	return brandLabel.length >= MIN_ATTRIBUTION_LABEL_LENGTH || corroborated;
+export function attributionConfidence(verdict: OwnershipVerdict, brandLabel: string, corroborated: boolean): AttributionConfidence {
+	if (verdict === 'owned_by_seed') return 'corroborated';
+	return brandLabel.length >= MIN_ATTRIBUTION_LABEL_LENGTH || corroborated ? 'corroborated' : 'uncorroborated';
 }
 
 /**
- * Severity ceiling a non-owned candidate's finding may not exceed —
- * `'unbounded'` when no cap applies, or the literal `Severity` value
- * (currently always `'info'`) the caller must clamp down to otherwise.
+ * THE single exported severity-decision surface (fix-round F1/F3). Every
+ * non-owned candidate is capped at `'info'` — full stop, regardless of
+ * brand-label length or corroboration. Those factors govern report WORDING
+ * only, via `attributionConfidence()` above; they must never move the
+ * severity ceiling. `owned_by_seed` is the only verdict exempt.
  *
- * DEMOTE, NEVER DELETE: unlike a boolean gate, this type has no falsy /
- * null / undefined member, so there is no value a caller could mistake for
- * "omit this finding" — every return is a concrete instruction to either
- * leave the computed severity alone (`'unbounded'`) or clamp it
- * (`'info'`). The finding itself is ALWAYS emitted by the caller; only its
- * severity and wording change. See the file-header note on controller
- * amendment 1 for the incident this fixes (a length-5 guard, sized against
- * the impersonator `hnz`, would otherwise have deleted findings about this
- * campaign's own 3-character seed brand `bnz`).
+ * DEMOTE, NEVER DELETE: this type has no falsy / null / undefined member,
+ * so there is no value a caller could mistake for "omit this finding" —
+ * every return is a concrete instruction to either leave the computed
+ * severity alone (`'unbounded'`) or clamp it (`'info'`). The finding itself
+ * is ALWAYS emitted by the caller; only its severity and wording change.
  *
- * Per the load-bearing safety property (amendment 2), `third_party` and
- * `unattributed` are treated identically here — only `owned_by_seed` is
- * ever exempt from the cap.
+ * Per the load-bearing safety property (controller amendment 2), `third_party`
+ * and `unattributed` are capped identically — only `owned_by_seed` is ever
+ * exempt.
  */
-export function capAttributionSeverity(verdict: OwnershipVerdict, brandLabel: string, corroborated: boolean): Severity | 'unbounded' {
-	return passesAttributionGuard(verdict, brandLabel, corroborated) ? 'unbounded' : 'info';
+export function capAttributionSeverity(verdict: OwnershipVerdict): Severity | 'unbounded' {
+	return verdict === 'owned_by_seed' ? 'unbounded' : 'info';
 }

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -1,0 +1,288 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Ownership-attribution primitive (P2, 2026-07-26 correctness-defects design §4).
+ *
+ * Classifies a registered candidate domain's ownership relative to a seed
+ * domain. This is the single gate that decides whether a shadow-domain or
+ * lookalike finding may exceed `info` severity — see
+ * `docs/superpowers/specs/2026-07-26-bv-mcp-correctness-defects-design.md`
+ * §4 (P2) and §5 (D4).
+ *
+ * Pure function, no DNS I/O: callers gather NS records and registration
+ * state themselves (via `resolveRegistration()` from `./registration-state`,
+ * or an existing NS probe) and pass them in — mirroring the injectable-
+ * dependency pattern already used by `correlateNs`
+ * (`src/tenants/discovery/ns-correlator.ts`'s `NsCorrelationOptions.dnsQuery`).
+ * This keeps `src/lib/` free of a dependency on `src/tenants/discovery/`:
+ * the shared-NS-apex predicate is passed in as `isSharedNsHost` rather than
+ * imported directly.
+ *
+ * LOAD-BEARING SAFETY PROPERTY (controller amendment 2, do not weaken):
+ * severity gating keys ONLY on `verdict === 'owned_by_seed'` vs everything
+ * else. The `third_party` / `unattributed` distinction changes report
+ * wording, never severity — a misclassification between those two can never
+ * produce a false high-severity finding. `capAttributionSeverity()` below
+ * enforces this: it treats `third_party` and `unattributed` identically.
+ *
+ * DEMOTE, NEVER DELETE (controller amendment 1, binding ruling from the
+ * human partner): `passesAttributionGuard()` is a CLASSIFIER of corroboration
+ * confidence, not a suppressor. The campaign's own seed brand in this slice's
+ * fixture corpus (`bnz`) is 3 characters — the same length class as the
+ * impersonator the guard was sized against (`hnz`) — so a guard that OMITS
+ * findings on failure would delete real measurements about the customer's
+ * OWN assets, which is worse than the false-positive it exists to prevent.
+ * `capAttributionSeverity()` is the safe API surface for callers: it always
+ * returns a concrete, truthy value (a `Severity` or the `'unbounded'`
+ * sentinel) — there is no `null`/`undefined` return that a caller could
+ * mistake for "omit this finding". A real measurement must never be
+ * suppressed; only its severity is capped and its wording kept neutral.
+ */
+
+import type { Severity } from '@blackveil/dns-checks/scoring';
+import { getRegistrableDomain } from './public-suffix';
+import type { RegistrationState } from './registration-state';
+import { UNKNOWN_REASON_PHRASES } from './registration-state';
+
+/** Final attribution verdict. */
+export type OwnershipVerdict = 'owned_by_seed' | 'third_party' | 'unattributed';
+
+export type OwnershipStrength = 'strong' | 'medium' | 'weak' | 'none';
+
+export type OwnershipSignal =
+	| 'ns_in_bailiwick'
+	| 'ns_set_match'
+	| 'ns_shared_provider_complete'
+	| 'soa_in_bailiwick'
+	| 'spf_include_seed'
+	| 'http_redirect_seed'
+	| 'distinct_infrastructure';
+
+export interface OwnershipAssessment {
+	verdict: OwnershipVerdict;
+	strength: OwnershipStrength;
+	signals: OwnershipSignal[];
+	/** Human-readable, safe to surface in a report — never implies ownership beyond `verdict`. */
+	rationale: string;
+}
+
+export interface ClassifyOwnershipInput {
+	seedDomain: string;
+	/** The seed's own NS hostnames. */
+	seedNs: string[];
+	candidateDomain: string;
+	registration: RegistrationState;
+	/**
+	 * Injected shared-NS-apex predicate (`isSharedNsHost` from
+	 * `src/tenants/discovery/shared-ns-hosts.ts`). Required so this module
+	 * never imports from `src/tenants/discovery/` (see file header).
+	 */
+	isSharedNsHost: (nsHost: string) => boolean;
+	/**
+	 * Additional strong signals. Not gathered by any caller in this slice
+	 * (neither tool parses SPF `include:` targets, SOA RNAME, or HTTP
+	 * redirect targets today) — accepted here so a future slice can wire a
+	 * real probe without touching this function's precedence logic again.
+	 */
+	soaInBailiwick?: boolean;
+	spfIncludesSeedApex?: boolean;
+	httpRedirectToSeedApex?: boolean;
+}
+
+/** Minimum ratio of dedicated (non-shared-provider) NS hosts shared with the seed to count as strong evidence. */
+const DEDICATED_NS_MATCH_RATIO = 0.5;
+/** Minimum absolute count of dedicated shared NS hosts, alongside the ratio above. */
+const DEDICATED_NS_MATCH_MIN_COUNT = 2;
+
+/** Minimum brand-label length below which a non-owned candidate needs corroboration to be scored at full confidence (D4). */
+export const MIN_ATTRIBUTION_LABEL_LENGTH = 5;
+
+function normHost(h: string): string {
+	return h.trim().toLowerCase().replace(/\.$/, '');
+}
+
+/**
+ * True when `nsHost` is the seed apex itself or a subdomain of it.
+ *
+ * The dot-boundary check on the `endsWith` branch is load-bearing: without
+ * it, a lookalike like `evilbnz.co.nz` (or an NS host under it,
+ * `ns1.evilbnz.co.nz`) would satisfy a bare `hostname.endsWith(seedApex)`
+ * check against seed `bnz.co.nz`, because the substring `bnz.co.nz` appears
+ * inside `evilbnz.co.nz` with no label separator in front of it. Requiring
+ * the character immediately before the apex to be `.` (or an exact match)
+ * closes that off.
+ */
+export function isInBailiwick(nsHost: string, seedApex: string): boolean {
+	const host = normHost(nsHost);
+	const apex = normHost(seedApex);
+	if (!host || !apex) return false;
+	return host === apex || host.endsWith('.' + apex);
+}
+
+/**
+ * Classify a candidate's ownership relative to a seed domain.
+ *
+ * Precedence (design doc §4 P2, corrected per §3.3):
+ *  1. Non-registered / registration-unknown → `unattributed` (attribution is moot).
+ *  2. NS in-bailiwick to the seed apex → `owned_by_seed`, strong.
+ *  3. SOA RNAME in-bailiwick (caller-supplied) → `owned_by_seed`, strong.
+ *  4. SPF include / HTTP redirect to seed apex (caller-supplied) → `owned_by_seed`, strong.
+ *  5. NS set match on hosts NOT flagged shared, >=50% AND >=2 shared → `owned_by_seed`, strong.
+ *  6. Complete (100%) NS set match where every shared host is on a SHARED provider → `owned_by_seed`, medium.
+ *  7. Partial overlap confined to shared-provider hosts → not evidence (falls through silently —
+ *     this is the ANZ/Westpac 1/6-Akamai trap: a single shared-provider NS host in common is
+ *     operational plumbing, not ownership evidence).
+ *  8. Registered with its own resolvable NS, no ownership signal → `third_party`.
+ *  9. Everything else (no NS info at all) → `unattributed`.
+ */
+export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAssessment {
+	const { registration, candidateDomain } = input;
+
+	if (registration.state === 'unregistered') {
+		return {
+			verdict: 'unattributed',
+			strength: 'none',
+			signals: [],
+			rationale: `${candidateDomain} is not registered — there is nothing to attribute.`,
+		};
+	}
+	if (registration.state === 'unknown') {
+		// Amendment (3): render the human-readable phrase from
+		// UNKNOWN_REASON_PHRASES, never the raw UnknownReason token — internal
+		// enum values like 'empty_noerror' are meaningless in a customer-facing
+		// report about a named organisation.
+		return {
+			verdict: 'unattributed',
+			strength: 'none',
+			signals: [],
+			rationale: `${candidateDomain}'s registration status could not be determined — ${UNKNOWN_REASON_PHRASES[registration.reason]}.`,
+		};
+	}
+
+	const seedApex = getRegistrableDomain(input.seedDomain) ?? normHost(input.seedDomain);
+	const candidateNs = registration.ns.map(normHost).filter(Boolean);
+	const seedNs = input.seedNs.map(normHost).filter(Boolean);
+
+	const inBailiwickNs = candidateNs.filter((ns) => isInBailiwick(ns, seedApex));
+	if (inBailiwickNs.length > 0) {
+		return {
+			verdict: 'owned_by_seed',
+			strength: 'strong',
+			signals: ['ns_in_bailiwick'],
+			rationale: `${candidateDomain}'s nameserver(s) ${inBailiwickNs.join(', ')} are delegated under ${seedApex}.`,
+		};
+	}
+
+	if (input.soaInBailiwick) {
+		return {
+			verdict: 'owned_by_seed',
+			strength: 'strong',
+			signals: ['soa_in_bailiwick'],
+			rationale: `${candidateDomain}'s SOA responsible party is in-bailiwick to ${seedApex}.`,
+		};
+	}
+	if (input.spfIncludesSeedApex || input.httpRedirectToSeedApex) {
+		const signal: OwnershipSignal = input.spfIncludesSeedApex ? 'spf_include_seed' : 'http_redirect_seed';
+		return {
+			verdict: 'owned_by_seed',
+			strength: 'strong',
+			signals: [signal],
+			rationale:
+				signal === 'spf_include_seed'
+					? `${candidateDomain}'s SPF record includes a policy rooted at ${seedApex}.`
+					: `${candidateDomain}'s HTTP root redirects to ${seedApex}.`,
+		};
+	}
+
+	const sharedNs = candidateNs.filter((ns) => seedNs.includes(ns));
+	const dedicatedShared = sharedNs.filter((ns) => !input.isSharedNsHost(ns));
+	const seedTotal = seedNs.length;
+
+	if (
+		seedTotal > 0 &&
+		dedicatedShared.length >= DEDICATED_NS_MATCH_MIN_COUNT &&
+		dedicatedShared.length / seedTotal >= DEDICATED_NS_MATCH_RATIO
+	) {
+		return {
+			verdict: 'owned_by_seed',
+			strength: 'strong',
+			signals: ['ns_set_match'],
+			rationale: `${candidateDomain} shares ${dedicatedShared.length}/${seedTotal} dedicated nameservers with ${seedApex}.`,
+		};
+	}
+
+	if (seedTotal > 0 && sharedNs.length === seedTotal && sharedNs.every((ns) => input.isSharedNsHost(ns))) {
+		return {
+			verdict: 'owned_by_seed',
+			strength: 'medium',
+			signals: ['ns_shared_provider_complete'],
+			rationale: `${candidateDomain} matches the complete ${seedTotal}/${seedTotal} nameserver set on a shared provider. A full match is evidence; a partial match on the same provider would not be.`,
+		};
+	}
+
+	if (candidateNs.length > 0) {
+		return {
+			verdict: 'third_party',
+			strength: 'none',
+			signals: ['distinct_infrastructure'],
+			rationale: `${candidateDomain} is registered with its own nameservers, distinct from ${seedApex} — no ownership signal links it to this organisation.`,
+		};
+	}
+
+	return {
+		verdict: 'unattributed',
+		strength: 'none',
+		signals: [],
+		rationale: `No ownership or third-party signal could be established for ${candidateDomain}.`,
+	};
+}
+
+/**
+ * D4 corroboration classifier: does a non-owned candidate's brand-label
+ * match meet the confidence bar to stand on its own?
+ *
+ * `owned_by_seed` always passes — it is the strongest available
+ * corroborating brand signal by construction. Any other verdict needs
+ * EITHER a brand label at least `MIN_ATTRIBUTION_LABEL_LENGTH` characters
+ * long, OR an explicit corroborating signal supplied by the caller
+ * (MX/SPF overlap with the primary domain is the one wired in this slice —
+ * cert-SAN and page-content corroboration are not, since neither tool
+ * fetches them today). Below the threshold with no corroboration, a short
+ * brand label (e.g. `bnz`, 3 characters) collides with too much unrelated
+ * global DNS for a bare label match to mean anything on its own — see spec
+ * §5 D4.
+ *
+ * THIS FUNCTION IS A CLASSIFIER, NOT A SUPPRESSION GATE. A caller MUST NOT
+ * branch a `false` result into omitting a finding — do that and a real
+ * measurement about the customer's own short-labelled brand (this
+ * campaign's seed, `bnz`, is itself 3 characters) silently vanishes from the
+ * report. Use `capAttributionSeverity()` instead: its return type has no
+ * value that means "no finding", only a severity ceiling.
+ */
+export function passesAttributionGuard(verdict: OwnershipVerdict, brandLabel: string, corroborated: boolean): boolean {
+	if (verdict === 'owned_by_seed') return true;
+	return brandLabel.length >= MIN_ATTRIBUTION_LABEL_LENGTH || corroborated;
+}
+
+/**
+ * Severity ceiling a non-owned candidate's finding may not exceed —
+ * `'unbounded'` when no cap applies, or the literal `Severity` value
+ * (currently always `'info'`) the caller must clamp down to otherwise.
+ *
+ * DEMOTE, NEVER DELETE: unlike a boolean gate, this type has no falsy /
+ * null / undefined member, so there is no value a caller could mistake for
+ * "omit this finding" — every return is a concrete instruction to either
+ * leave the computed severity alone (`'unbounded'`) or clamp it
+ * (`'info'`). The finding itself is ALWAYS emitted by the caller; only its
+ * severity and wording change. See the file-header note on controller
+ * amendment 1 for the incident this fixes (a length-5 guard, sized against
+ * the impersonator `hnz`, would otherwise have deleted findings about this
+ * campaign's own 3-character seed brand `bnz`).
+ *
+ * Per the load-bearing safety property (amendment 2), `third_party` and
+ * `unattributed` are treated identically here — only `owned_by_seed` is
+ * ever exempt from the cap.
+ */
+export function capAttributionSeverity(verdict: OwnershipVerdict, brandLabel: string, corroborated: boolean): Severity | 'unbounded' {
+	return passesAttributionGuard(verdict, brandLabel, corroborated) ? 'unbounded' : 'info';
+}

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -48,6 +48,16 @@
  * its non-boolean `'corroborated' | 'uncorroborated'` return shape (renamed
  * from a raw boolean) makes it read as a confidence classifier rather than
  * a permission gate a caller might branch into a suppression.
+ *
+ * TASK 7c (2026-07-27, two rulings amending the P2 signal table — see
+ * `.superpowers/sdd/2026-07-26-slice4-ownership-attribution/task-7c-brief.md`):
+ * Ruling A — the candidate-side signals (`soaInBailiwick`,
+ * `spfIncludesSeedApex`, `httpRedirectToSeedApex`) are attacker-influenceable
+ * and NEVER independently verdict-bearing; see the OWNERSHIP RULE note on
+ * `ClassifyOwnershipInput`. Ruling B — an in-bailiwick NS observation is
+ * ownership-bearing only when it comes from an actually-resolved NS answer
+ * set; see `classifyOwnership()`'s precedence-table JSDoc and
+ * `resolveRegistrationUncached()` in `./registration-state`.
  */
 
 import type { CheckCategory, Finding, Severity } from '@blackveil/dns-checks/scoring';
@@ -96,27 +106,32 @@ export interface ClassifyOwnershipInput {
 	 */
 	isSharedNsHost: (nsHost: string) => boolean;
 	/**
-	 * Additional strong signals. Not gathered by any caller in this slice
-	 * (neither tool parses SPF `include:` targets, SOA RNAME, or HTTP
+	 * Candidate-side corroboration inputs. Not gathered by any caller in this
+	 * slice (neither tool parses SPF `include:` targets, SOA RNAME, or HTTP
 	 * redirect targets today) — accepted here so a future slice can wire a
 	 * real probe without touching this function's precedence logic again.
 	 *
-	 * SECURITY — CALLER OBLIGATION (flagged in fix-round F4, mapping change
-	 * itself is UNRESOLVED — do not treat this comment as having fixed it):
-	 * all three of `soaInBailiwick`, `spfIncludesSeedApex`, and
-	 * `httpRedirectToSeedApex` are attacker-influenceable. Unlike
-	 * `ns_in_bailiwick` (which requires the candidate to control its own
-	 * delegated zone), an attacker who registers `evilbnz.co.nz` can
-	 * unilaterally publish an SPF `include:` pointing at the seed apex or an
-	 * HTTP redirect to it, with NO cooperation from the seed's owner. As
-	 * currently wired, ANY ONE of these three flags alone is sufficient for
-	 * `classifyOwnership()` to return `owned_by_seed`/`strong` — the inverse
-	 * of the false-attribution defect this slice fixes. A future caller that
-	 * wires a real probe for any of these MUST NOT let it alone produce
-	 * `owned_by_seed`; it should require corroboration from an
-	 * owner-controlled signal (NS delegation) or be demoted to a weaker
-	 * verdict/strength. This file does not change the verdict mapping —
-	 * that call belongs to the design owner, not to this fix.
+	 * OWNERSHIP RULE (Ruling A, 2026-07-27 task-7c — supersedes the prior F4
+	 * "flagged, not fixed" note): all three of `soaInBailiwick`,
+	 * `spfIncludesSeedApex`, and `httpRedirectToSeedApex` are
+	 * attacker-influenceable. Unlike `ns_in_bailiwick` / `ns_set_match` /
+	 * `ns_shared_provider_complete` (which all require the CANDIDATE's own
+	 * resolved NS records to actually nest under or match the seed's — i.e.
+	 * seed-side control), an attacker who registers `evilbnz.co.nz` can
+	 * unilaterally publish an SPF `include:` pointing at the seed apex, an
+	 * HTTP redirect to it, or an in-bailiwick SOA RNAME, with NO cooperation
+	 * from the seed's owner. Ownership verdicts therefore require a seed-side
+	 * signal. These three fields:
+	 *  - may RAISE `strength`/wording confidence on a verdict ALREADY earned
+	 *    by a seed-side signal (steps 2-4 in `classifyOwnership()`'s
+	 *    precedence table);
+	 *  - may serve as CORROBORATION for `attributionConfidence()`'s wording
+	 *    channel;
+	 *  - must NEVER, alone or in any combination with each other, produce
+	 *    `owned_by_seed` — `classifyOwnership()` does not consult them at all
+	 *    for the verdict.
+	 * A future caller that wires a real probe for any of these MUST NOT let
+	 * it alone (or all three together) produce `owned_by_seed`.
 	 */
 	soaInBailiwick?: boolean;
 	spfIncludesSeedApex?: boolean;
@@ -156,23 +171,35 @@ export function isInBailiwick(nsHost: string, seedApex: string): boolean {
 /**
  * Classify a candidate's ownership relative to a seed domain.
  *
- * Precedence (design doc §4 P2, corrected per §3.3):
+ * Precedence (design doc §4 P2, corrected per §3.3, and per Ruling A
+ * 2026-07-27 task-7c — see the OWNERSHIP RULE note on
+ * `ClassifyOwnershipInput`'s candidate-side fields):
  *  1. Non-registered / registration-unknown → `unattributed` (attribution is moot).
- *  2. NS in-bailiwick to the seed apex → `owned_by_seed`, strong.
- *  3. SOA RNAME in-bailiwick (caller-supplied) → `owned_by_seed`, strong.
- *  4. SPF include / HTTP redirect to seed apex (caller-supplied) → `owned_by_seed`, strong.
- *  5. NS set match on hosts NOT flagged shared, >=50% AND >=2 shared → `owned_by_seed`, strong.
- *  6. Complete (100%) NS set match where every shared host is on a SHARED provider → `owned_by_seed`, medium.
- *  7. Partial overlap confined to shared-provider hosts → not evidence (falls through silently —
+ *     RegistrationState is a discriminated union: only the `registered` arm
+ *     carries an `ns` field at all, so an in-bailiwick match is structurally
+ *     unreachable for `unregistered`/`unknown` (Ruling B) — this precedence
+ *     step returns before `registration.ns` is ever read.
+ *  2. NS in-bailiwick to the seed apex → `owned_by_seed`, strong. Because
+ *     `registration.ns` is only ever populated from an ACTUALLY-RESOLVED NS
+ *     answer set (see `resolveRegistrationUncached()` in
+ *     `./registration-state`), a lame delegation — attacker sets NS =
+ *     `ns1.bnz.co.nz` in the candidate's own parent-zone delegation, but the
+ *     seed's server never actually serves that zone — SERVFAILs at
+ *     resolution and never reaches this arm with a matching host (Ruling B:
+ *     "in-bailiwick NS requires resolution evidence").
+ *  3. NS set match on hosts NOT flagged shared, >=50% AND >=2 shared → `owned_by_seed`, strong.
+ *  4. Complete (100%) NS set match where every shared host is on a SHARED provider → `owned_by_seed`, medium.
+ *  5. Partial overlap confined to shared-provider hosts → not evidence (falls through silently —
  *     this is the ANZ/Westpac 1/6-Akamai trap: a single shared-provider NS host in common is
  *     operational plumbing, not ownership evidence).
- *  8. Registered with its own resolvable NS, no ownership signal → `third_party`.
- *  9. Everything else (no NS info at all) → `unattributed`.
+ *  6. Registered with its own resolvable NS, no ownership signal → `third_party`.
+ *  7. Everything else (no NS info at all) → `unattributed`.
  *
- * Steps 3-4 accept attacker-influenceable evidence — see the caller-
- * obligation note on `ClassifyOwnershipInput`'s `soaInBailiwick` /
- * `spfIncludesSeedApex` / `httpRedirectToSeedApex` fields. That mapping is
- * unchanged and unresolved by this fix round; flagged, not altered.
+ * `soaInBailiwick` / `spfIncludesSeedApex` / `httpRedirectToSeedApex`
+ * (Ruling A) are candidate-side, attacker-influenceable signals and play NO
+ * role in this precedence table — they can never independently (or combined)
+ * produce `owned_by_seed`; see the OWNERSHIP RULE note on
+ * `ClassifyOwnershipInput` for what a future caller may use them for.
  */
 export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAssessment {
 	const { registration, candidateDomain } = input;
@@ -213,32 +240,12 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
-	// SECURITY: soaInBailiwick / spfIncludesSeedApex / httpRedirectToSeedApex
-	// are attacker-influenceable (see the ClassifyOwnershipInput caller-
-	// obligation note above) — unlike ns_in_bailiwick, none of these require
-	// the candidate to control its own delegated zone. Not gathered by any
-	// caller in this slice; the mapping below is unresolved, flagged for the
-	// design owner, and intentionally NOT altered by this fix round.
-	if (input.soaInBailiwick) {
-		return {
-			verdict: 'owned_by_seed',
-			strength: 'strong',
-			signals: ['soa_in_bailiwick'],
-			rationale: `${candidateDomain}'s SOA responsible party is in-bailiwick to ${seedApex}.`,
-		};
-	}
-	if (input.spfIncludesSeedApex || input.httpRedirectToSeedApex) {
-		const signal: OwnershipSignal = input.spfIncludesSeedApex ? 'spf_include_seed' : 'http_redirect_seed';
-		return {
-			verdict: 'owned_by_seed',
-			strength: 'strong',
-			signals: [signal],
-			rationale:
-				signal === 'spf_include_seed'
-					? `${candidateDomain}'s SPF record includes a policy rooted at ${seedApex}.`
-					: `${candidateDomain}'s HTTP root redirects to ${seedApex}.`,
-		};
-	}
+	// Ruling A (2026-07-27, task-7c): soaInBailiwick / spfIncludesSeedApex /
+	// httpRedirectToSeedApex are candidate-side, attacker-influenceable
+	// signals (see the OWNERSHIP RULE note on `ClassifyOwnershipInput`) and
+	// are DELIBERATELY not consulted here — they can never independently (or
+	// combined) establish `owned_by_seed`. Only seed-side signals (this arm
+	// and the two below) may do that.
 
 	const sharedNs = candidateNs.filter((ns) => seedNs.includes(ns));
 	const dedicatedShared = sharedNs.filter((ns) => !input.isSharedNsHost(ns));

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -50,7 +50,8 @@
  * a permission gate a caller might branch into a suppression.
  */
 
-import type { Severity } from '@blackveil/dns-checks/scoring';
+import type { CheckCategory, Finding, Severity } from '@blackveil/dns-checks/scoring';
+import { createFinding } from '@blackveil/dns-checks/scoring';
 import { getRegistrableDomain } from './public-suffix';
 import { UNKNOWN_REASON_PHRASES, type RegistrationState } from './registration-state';
 
@@ -331,4 +332,98 @@ export function attributionConfidence(verdict: OwnershipVerdict, brandLabel: str
  */
 export function capAttributionSeverity(verdict: OwnershipVerdict): Severity | 'unbounded' {
 	return verdict === 'owned_by_seed' ? 'unbounded' : 'info';
+}
+
+/**
+ * Metadata shape every ownership-gated finding carries, owned or not.
+ * Extracted (fix round 2, F1) after `check-lookalikes.ts` and
+ * `check-shadow-domains.ts` each hand-built this same four-field object and
+ * drifted apart within a single slice — see {@link buildNonOwnedGateFinding}.
+ */
+export function buildOwnershipGateMetadata(
+	finding: Finding,
+	ownership: OwnershipAssessment,
+	confidence: AttributionConfidence,
+): Record<string, unknown> {
+	return {
+		...finding.metadata,
+		ownershipVerdict: ownership.verdict,
+		ownershipRationale: ownership.rationale,
+		attributionConfidence: confidence,
+		severityCappedBy: 'ownership_attribution',
+	};
+}
+
+/**
+ * Per-tool knobs for {@link buildNonOwnedGateFinding}. Everything ELSE about
+ * the neutral non-owned rewrite — the title template, the hedge sentence,
+ * the metadata shape — is shared and must stay byte-identical across
+ * callers; these three fields are the only legitimate axis of variation.
+ */
+export interface NonOwnedGateOptions {
+	/** Check category the rewritten finding belongs to (e.g. `'lookalikes'`, `'shadow_domains'`). */
+	category: CheckCategory;
+	/** `finding.metadata` key that carries this finding's own domain/variant string. */
+	domainMetadataKey: string;
+	/**
+	 * Noun phrase describing what's being reported on (e.g. `'DNS/mail
+	 * posture'`). Callers MUST pass the same value so the hedge sentence
+	 * reads identically regardless of which tool emitted it — see F1
+	 * (2026-07-27 fix round 2): `check-lookalikes.ts` and
+	 * `check-shadow-domains.ts` had already drifted to `'DNS/mail posture'`
+	 * vs `'mail posture'` within a single slice before this was noticed.
+	 */
+	postureNoun: string;
+}
+
+/**
+ * Build the shared neutral, severity-capped finding for a NON-OWNED
+ * (`third_party`/`unattributed`) candidate whose raw calibrated severity was
+ * ABOVE `info`. THE single place that sentence and its metadata shape are
+ * assembled — `check-lookalikes.ts` and `check-shadow-domains.ts` each used
+ * to hand-roll their own copy of this text and had already drifted apart
+ * (F1, fix round 2): `check-lookalikes.ts` said "Its DNS/mail posture" and
+ * never quoted the brand label, `check-shadow-domains.ts` said "Its mail
+ * posture" and quoted `"${brand}"`. Both tools now call this function with
+ * the same `postureNoun`, so they emit byte-identical wording for the same
+ * verdict — verified by `test/ownership-attribution.spec.ts`'s cross-tool
+ * parity test.
+ *
+ * Callers are responsible for the `ceiling === 'unbounded'` passthrough (an
+ * `owned_by_seed` finding is returned unchanged, never routed here) and, for
+ * tools whose raw finding CAN be `'info'`-severity already (unlike
+ * `check-lookalikes.ts`, where `calibrateLookalikeSeverity()` never returns
+ * `'info'`), for their own local info-severity branch — see
+ * `check-shadow-domains.ts`'s `NEUTRAL_INFO_TITLES` handling, which stays
+ * tool-local by design (only the shared sentence and metadata shape moved
+ * here, per the fix-round instruction).
+ */
+export function buildNonOwnedGateFinding(
+	finding: Finding,
+	ownership: OwnershipAssessment,
+	brand: string,
+	corroborated: boolean,
+	ceiling: Severity,
+	options: NonOwnedGateOptions,
+): Finding {
+	const confidence = attributionConfidence(ownership.verdict, brand, corroborated);
+	const domainValue = finding.metadata?.[options.domainMetadataKey];
+	const domain = typeof domainValue === 'string' ? domainValue : 'This domain';
+	const metadata = buildOwnershipGateMetadata(finding, ownership, confidence);
+
+	const relation =
+		ownership.verdict === 'third_party'
+			? 'is registered to a different organisation'
+			: 'could not be attributed to the scanned organisation';
+	const hedge =
+		confidence === 'uncorroborated'
+			? ` The shared label is under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters and nothing else corroborates a link, so the name similarity alone means little.`
+			: '';
+	return createFinding(
+		options.category,
+		`Unrelated domain, confusable label: ${domain}`,
+		ceiling,
+		`${domain} shares the "${brand}" label with the scanned domain but ${relation}. ${ownership.rationale} Its ${options.postureNoun} is reported for awareness only: no action by the scanned organisation is implied, and this finding asserts no control over ${domain}.${hedge}`,
+		metadata,
+	);
 }

--- a/src/lib/ungraded-display.ts
+++ b/src/lib/ungraded-display.ts
@@ -7,8 +7,8 @@
  * A deliberately tiny leaf module (no imports) so every formatter in `src/tools/`
  * can depend on it without an import cycle through the scan orchestrator.
  *
- * `isCompletedCheck`/`hasCompletedEvidence` below are the SSOT for "did this
- * check/scan produce usable evidence" on the `src/` side only —
+ * `isCompletedCheck`/`hasCompletedEvidence`/`normalizeCheckStatus` below are the
+ * SSOT for "did this check/scan produce usable evidence" on the `src/` side only —
  * `test/audits/completed-evidence-predicate-ssot.audit.test.ts` bans any other
  * `src/` module from re-deriving the same check. `packages/dns-checks/src/scoring/evidence.ts`
  * (`computeScanEvidence`'s per-result completed/attempted accounting) is a
@@ -136,4 +136,20 @@ export function hasCompletedEvidence(checks: readonly CheckStatusBearer[]): bool
  */
 export function isCompletedCheck(check: CheckStatusBearer): boolean {
 	return check.checkStatus === undefined || check.checkStatus === 'completed';
+}
+
+/**
+ * The VALUE-normalizing twin of `isCompletedCheck`'s BOOLEAN question — same
+ * `undefined → 'completed'` rule, spelled for a caller that needs the concrete
+ * status string rather than yes/no. The only known consumer is
+ * `StructuredScanResult.checkStatuses` (`format-report.ts`), which is
+ * customer-facing and contractually typed `Record<string, 'completed' | 'timeout' | 'error'>`
+ * — it cannot carry `undefined`, so an absent `checkStatus` must be normalized
+ * to a concrete member before it can go on the wire. Sharing this rule with
+ * `isCompletedCheck` (rather than re-deriving `?? 'completed'` at the call
+ * site) is what keeps the two in lockstep if a new `CheckStatus` member is
+ * ever added.
+ */
+export function normalizeCheckStatus(checkStatus: 'completed' | 'timeout' | 'error' | undefined): 'completed' | 'timeout' | 'error' {
+	return checkStatus ?? 'completed';
 }

--- a/src/lib/ungraded-display.ts
+++ b/src/lib/ungraded-display.ts
@@ -6,6 +6,19 @@
  *
  * A deliberately tiny leaf module (no imports) so every formatter in `src/tools/`
  * can depend on it without an import cycle through the scan orchestrator.
+ *
+ * `isCompletedCheck`/`hasCompletedEvidence` below are the SSOT for "did this
+ * check/scan produce usable evidence" on the `src/` side only —
+ * `test/audits/completed-evidence-predicate-ssot.audit.test.ts` bans any other
+ * `src/` module from re-deriving the same check. `packages/dns-checks/src/scoring/evidence.ts`
+ * (`computeScanEvidence`'s per-result completed/attempted accounting) is a
+ * DELIBERATE, KNOWN twin on the other side of the package boundary — it is a
+ * published SSOT vendored by another repo and frozen for this campaign, so it
+ * cannot import from `src/`, and this module cannot be vendored into it
+ * without inverting the dependency direction (`src/` already depends on
+ * `@blackveil/dns-checks`, not the other way around). The two are kept in
+ * semantic lockstep by hand, not by a shared import; a change to what
+ * "completed" means must be applied to BOTH deliberately.
  */
 
 /**
@@ -99,5 +112,28 @@ interface CheckStatusBearer {
  * `evidenceInsufficient` rather than by switching predicates.
  */
 export function hasCompletedEvidence(checks: readonly CheckStatusBearer[]): boolean {
-	return checks.some((c) => c.checkStatus === undefined || c.checkStatus === 'completed');
+	return checks.some(isCompletedCheck);
+}
+
+/**
+ * The per-check half of {@link hasCompletedEvidence} — "did THIS check produce
+ * usable evidence" (`checkStatus` absent/`'completed'`) rather than "did ANY
+ * check in a collection". Exported so a caller that needs the individual
+ * check-level partition (e.g. `matchedResults.filter(isCompletedCheck)` to
+ * separate completed evidence from transient noise within one control's
+ * matched categories) shares the exact same predicate `hasCompletedEvidence`
+ * uses internally, instead of re-deriving it — see `test/audits/*evidence*`
+ * for the ban on re-spelling this check.
+ *
+ * Deliberately an ALLOWLIST (`undefined | 'completed'` counts as completed),
+ * not a denylist (`!== 'timeout' && !== 'error'`). Both forms agree today
+ * because `CheckStatus` is a closed 3-member union, but they diverge the
+ * moment a new member is added: a denylist silently treats an unrecognized
+ * future status as "completed" (wrong — an incomplete measurement must never
+ * read as confident evidence, the campaign invariant this whole module
+ * exists to protect), while this allowlist correctly treats it as NOT
+ * completed until a maintainer deliberately adds it here.
+ */
+export function isCompletedCheck(check: CheckStatusBearer): boolean {
+	return check.checkStatus === undefined || check.checkStatus === 'completed';
 }

--- a/src/tenants/discovery/ns-correlator.ts
+++ b/src/tenants/discovery/ns-correlator.ts
@@ -18,6 +18,8 @@
 
 import { queryDns } from '../../lib/dns-transport';
 import type { DohResponse, RecordTypeName } from '../../lib/dns-types';
+import { isInBailiwick } from '../../lib/ownership-attribution';
+import { getRegistrableDomain } from '../../lib/public-suffix';
 import { mapConcurrent } from '../../lib/map-concurrent';
 import { validateDomain } from '../../lib/sanitize';
 import { isSharedNsHost } from './shared-ns-hosts';
@@ -40,10 +42,12 @@ export interface NsCorrelationOptions {
 export interface NsCoOwnedCandidate {
 	/** Lowercase, trailing-dot-stripped candidate domain. */
 	domain: string;
-	/** Lowercase nameserver hostnames shared with the seed. */
+	/** Lowercase nameserver hostnames shared with the seed, or (for in-bailiwick matches) the candidate's own in-bailiwick NS hosts. */
 	sharedNs: string[];
-	/** |intersection| / |seed_NS_set|, rounded to 2 decimals. 1.0 = full overlap. */
+	/** |intersection| / |seed_NS_set|, rounded to 2 decimals. 1.0 = full overlap or an in-bailiwick match. */
 	confidence: number;
+	/** `in_bailiwick` — candidate's own NS delegated under the seed apex (D6.1). `set_overlap` — shares NS hostnames with the seed (pre-existing logic). */
+	matchType: 'in_bailiwick' | 'set_overlap';
 }
 
 export interface NsCorrelationResult {
@@ -117,6 +121,7 @@ export async function correlateNs(
 	}
 	const seedNsSet = seedOutcome.set;
 	const seedNs = Array.from(seedNsSet).sort();
+	const seedApex = getRegistrableDomain(seedLower) ?? seedLower;
 
 	const candidates = options.candidateDomains ?? [];
 	if (candidates.length === 0) {
@@ -134,6 +139,23 @@ export async function correlateNs(
 		if (candidateOutcome.kind === 'error') {
 			return { candidate: null, failed: true };
 		}
+		// D6.1 (2026-07-26 correctness-defects design §3.4) — in-bailiwick match.
+		// A candidate whose OWN nameservers are delegated under the seed's apex
+		// (e.g. ns2.bnz.co.nz under bnz.co.nz) is ownership-bearing regardless
+		// of whether it shares any NS *hostname* with the seed — set
+		// intersection alone misses this whenever the seed itself sits on
+		// different (often shared-provider) infrastructure, as bnz.co.nz's
+		// Akamai delegation does relative to its self-hosted NS variants.
+		const inBailiwick = Array.from(candidateOutcome.set)
+			.filter((ns) => isInBailiwick(ns, seedApex))
+			.sort();
+		if (inBailiwick.length > 0) {
+			return {
+				candidate: { domain: candidate, sharedNs: inBailiwick, confidence: 1, matchType: 'in_bailiwick' },
+				failed: false,
+			};
+		}
+
 		const shared: string[] = [];
 		for (const ns of candidateOutcome.set) {
 			if (seedNsSet.has(ns)) shared.push(ns);
@@ -154,6 +176,7 @@ export async function correlateNs(
 				domain: candidate,
 				sharedNs: shared.sort(),
 				confidence: round2(ownershipBearingShared.length / seedNsSet.size),
+				matchType: 'set_overlap',
 			},
 			failed: false,
 		};

--- a/src/tenants/discovery/shared-ns-hosts.ts
+++ b/src/tenants/discovery/shared-ns-hosts.ts
@@ -51,6 +51,13 @@ export const SHARED_NS_APEXES: ReadonlySet<string> = new Set([
 	'secureserver.net',
 	// Namecheap registrar-default
 	'registrar-servers.com',
+	// Akamai — assigns NS hostnames from a shared pool reused across unrelated
+	// customer zones (2026-07-26 correctness-defects design §3.3, verified
+	// live: bnz.co.nz shares a9-65.akam.net with anz.co.nz and a3-67.akam.net
+	// with westpac.co.nz). Overlap on an Akamai hostname alone is NOT
+	// ownership evidence; only a complete NS-set match is (see
+	// `classifyOwnership()` in `src/lib/ownership-attribution.ts`).
+	'akam.net',
 ]);
 
 /**

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -18,10 +18,9 @@ import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
 import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg } from './check-rdap-lookup';
 import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSignals } from './lookalike-severity';
 import {
-	attributionConfidence,
+	buildNonOwnedGateFinding,
 	capAttributionSeverity,
 	classifyOwnership,
-	MIN_ATTRIBUTION_LABEL_LENGTH,
 	type OwnershipAssessment,
 } from '../lib/ownership-attribution';
 import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
@@ -222,7 +221,11 @@ async function queryPrimaryMx(domain: string): Promise<Set<string>> {
  * D4 severity ceiling for a lookalike finding, mirroring `applyOwnershipGate()`
  * in `check-shadow-domains.ts` — see that file's JSDoc for the full rationale;
  * this is the same pattern reused for a second tool so the two stay
- * consistent for downstream consumers.
+ * consistent for downstream consumers. The neutral-wording sentence and
+ * metadata shape live in `buildNonOwnedGateFinding()`
+ * (`src/lib/ownership-attribution.ts`), shared with `check-shadow-domains.ts`
+ * (fix round 2, F1) — the two tools had already drifted apart within this
+ * slice when each hand-rolled its own copy.
  *
  * `owned_by_seed` findings pass through unclamped — `checkLookalikesCore`'s
  * main loop already emits its own dedicated "likely owned by same entity"
@@ -242,31 +245,16 @@ function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, br
 	const ceiling = capAttributionSeverity(ownership.verdict);
 	if (ceiling === 'unbounded') return finding;
 
-	const confidence = attributionConfidence(ownership.verdict, brand, corroborated);
-	const lookalikeDomain = typeof finding.metadata?.lookalikeDomain === 'string' ? finding.metadata.lookalikeDomain : 'This domain';
-	const metadata = {
-		...finding.metadata,
-		ownershipVerdict: ownership.verdict,
-		ownershipRationale: ownership.rationale,
-		attributionConfidence: confidence,
-		severityCappedBy: 'ownership_attribution',
-	};
-
-	const relation =
-		ownership.verdict === 'third_party'
-			? 'is registered to a different organisation'
-			: 'could not be attributed to the scanned organisation';
-	const hedge =
-		confidence === 'uncorroborated'
-			? ` The shared label is under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters and nothing else corroborates a link, so the name similarity alone means little.`
-			: '';
-	return createFinding(
-		'lookalikes',
-		`Unrelated domain, confusable label: ${lookalikeDomain}`,
-		ceiling,
-		`${lookalikeDomain} shares a similar label with the scanned domain but ${relation}. ${ownership.rationale} Its DNS/mail posture is reported for awareness only: no action by the scanned organisation is implied, and this finding asserts no control over ${lookalikeDomain}.${hedge}`,
-		metadata,
-	);
+	// `calibrateLookalikeSeverity()` never returns `'info'`, so unlike
+	// `check-shadow-domains.ts` there is no local info-severity branch here —
+	// every candidate reaching this point goes through the shared non-owned
+	// rewrite. `postureNoun` MUST match `check-shadow-domains.ts`'s value
+	// byte-for-byte (parity pinned by `test/ownership-attribution.spec.ts`).
+	return buildNonOwnedGateFinding(finding, ownership, brand, corroborated, ceiling, {
+		category: 'lookalikes',
+		domainMetadataKey: 'lookalikeDomain',
+		postureNoun: 'DNS/mail posture',
+	});
 }
 
 /**
@@ -528,19 +516,44 @@ async function checkLookalikesCore(
 
 		// Same-entity correlation (issue #263): the calibrated severity is a
 		// threat tier (low/medium/high), but if this lookalike's RDAP registrant
-		// org matches the scan domain's, it's the org's own defensive / regional
-		// registration. Downgrade to an info finding instead of a threat. Only
-		// medium/high candidates are eligible (see computeSameEntityCandidates);
-		// LOW web-only matches stay as-is (cheap, low-noise, not worth the fetch).
+		// org matches the scan domain's, it's PLAUSIBLY the org's own defensive /
+		// regional registration. Downgrade to an info finding instead of a
+		// threat. Only medium/high candidates are eligible (see
+		// computeSameEntityCandidates); LOW web-only matches stay as-is (cheap,
+		// low-noise, not worth the fetch).
+		//
+		// F2 (2026-07-27 fix round 2): a RDAP registrant-org match is
+		// DELIBERATELY NOT fed into `classifyOwnership()` as an ownership
+		// signal — the org field is self-declared and unverified by most
+		// registries (the same attacker-influenceable class flagged for
+		// `soaInBailiwick`/`spfIncludesSeedApex`/`httpRedirectToSeedApex` in
+		// `ClassifyOwnershipInput`'s JSDoc), so it must never be able to
+		// silently produce an `owned_by_seed` verdict. Every candidate reaching
+		// this branch therefore still carries the STRUCTURAL verdict computed
+		// earlier (`third_party` here — `sameOwner` above already filtered out
+		// `owned_by_seed`), and the verdict now travels on this finding too
+		// (`ownershipVerdict` in metadata) per the same "verdict travels on
+		// EVERY classified finding" invariant `check-shadow-domains.ts` states
+		// for its own emission sites. The title/prose no longer asserts common
+		// ownership outright — it's reworded to state plainly that this is a
+		// registrant-organisation SIGNAL, distinct from (and weaker than) the
+		// structural NS-based evidence, whose own finding is quoted verbatim.
 		const matchedOrg = sameEntityMatches.get(result.domain);
 		if (matchedOrg !== undefined) {
 			findings.push(
 				createFinding(
 					'lookalikes',
-					`Lookalike domain likely owned by same entity: ${result.domain}`,
+					`Lookalike domain shares registrant organisation with scanned domain: ${result.domain}`,
 					'info',
-					`The domain ${result.domain} shares the same RDAP registrant organisation as ${domain} ("${matchedOrg}"), indicating it is likely a defensive registration or regional presence by the same owner rather than a third-party lookalike.${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
-					{ lookalikeDomain: result.domain, hasA: result.hasA, hasMX: result.hasMX, sharedRegistrantOrg: matchedOrg },
+					`The domain ${result.domain} shares the same RDAP registrant organisation as ${domain} ("${matchedOrg}"), which may indicate a defensive registration or regional presence by the same owner. This is a registrant-organisation signal, not structural ownership evidence — RDAP registrant fields are self-declared and not independently verified. Nameserver-based evidence: ${ownership.rationale}${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
+					{
+						lookalikeDomain: result.domain,
+						hasA: result.hasA,
+						hasMX: result.hasMX,
+						sharedRegistrantOrg: matchedOrg,
+						ownershipVerdict: ownership.verdict,
+						ownershipRationale: ownership.rationale,
+					},
 				),
 			);
 			continue;

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -16,7 +16,7 @@ import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
 import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg } from './check-rdap-lookup';
-import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSignals } from './lookalike-severity';
+import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
 import {
 	buildNonOwnedGateFinding,
 	capAttributionSeverity,
@@ -25,6 +25,34 @@ import {
 } from '../lib/ownership-attribution';
 import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 import { extractBrandName } from '../lib/public-suffix';
+
+/**
+ * TASK 7B TWO-AXIS SPLIT (human-partner ruling, 2026-07-27).
+ *
+ * This tool reports on TWO independent axes, and every finding it emits
+ * declares which one it belongs to via `metadata.findingAxis`:
+ *
+ *  - `'attribution'` — WHO owns the candidate. Governed by
+ *    `classifyOwnership()` + `capAttributionSeverity()`: every non-
+ *    `owned_by_seed` verdict is capped at `info` with neutral wording
+ *    (D4's load-bearing safety property — the scanner never claims someone
+ *    else's domain is the customer's, and never demands the customer act on
+ *    a domain it does not control). UNCHANGED by this task.
+ *
+ *  - `'threat_observation'` — WHAT the candidate is doing. Carries the #264
+ *    calibrated severity from `calibrateLookalikeSeverity()`. Task 7 computed
+ *    that severity and then capped it away, which made `highCount`, the HIGH
+ *    summary finding, and every sub-100 `lookalikes` category score
+ *    unreachable — a live typosquat with active MX on a disposable provider
+ *    scored 100/passed. These findings assert NOTHING about ownership (they
+ *    say explicitly that the domain does not appear to belong to the scanned
+ *    organisation) and demand no action ON that domain; only defensive
+ *    options on the scanned organisation's own side are suggested.
+ *
+ * The axis marker is STRUCTURAL, not prose: downstream consumers (and Task
+ * 8's cross-cutting audit) key on the exact literals, never on wording.
+ */
+export type LookalikeFindingAxis = 'attribution' | 'threat_observation';
 
 /** Default and minimum batch sizes for adaptive batching */
 export const INITIAL_BATCH_SIZE = 10;
@@ -218,6 +246,13 @@ async function queryPrimaryMx(domain: string): Promise<Set<string>> {
 }
 
 /**
+ * AXIS 1 (attribution) ONLY — Task 7b. This caps what the report may CLAIM
+ * about ownership; it does not and must not cap what the report may say was
+ * OBSERVED. The observed-threat severity now travels on a separate finding
+ * built by {@link buildThreatObservationFinding}, so capping here no longer
+ * makes `highCount`, the HIGH summary finding, and every sub-100 `lookalikes`
+ * category score unreachable (the defect the opus review found in Task 7).
+ *
  * D4 severity ceiling for a lookalike finding, mirroring `applyOwnershipGate()`
  * in `check-shadow-domains.ts` — see that file's JSDoc for the full rationale;
  * this is the same pattern reused for a second tool so the two stay
@@ -255,6 +290,62 @@ function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, br
 		domainMetadataKey: 'lookalikeDomain',
 		postureNoun: 'DNS/mail posture',
 	});
+}
+
+/**
+ * AXIS 2 — build the observed-threat finding for a NON-OWNED candidate
+ * (Task 7b). Carries the #264 calibrated severity verbatim; the attribution
+ * finding built by {@link applyOwnershipGate} carries the `info` cap.
+ *
+ * WORDING CONTRACT (customer-facing, legal-sensitive — BlackVeil names real
+ * third-party organisations in reports). The text:
+ *  - states only what was OBSERVED (MX/A presence, registration recency,
+ *    disposable MX, absent web content) — no claim of intent.
+ *    "Impersonation-shaped" / "consistent with pre-phishing staging" is the
+ *    ceiling; the words "malicious"/"attacker" are deliberately absent;
+ *  - says EXPLICITLY that the domain does not appear to belong to the scanned
+ *    organisation, so no reader can mistake this for an ownership claim;
+ *  - never uses "your", "shadow domain", or any ownership/control framing;
+ *  - demands no action ON the observed domain. Only defensive options that
+ *    need no access to it (monitor, block at the gateway, report for
+ *    takedown) are offered.
+ *
+ * Pinned by `test/check-lookalikes.spec.ts`'s Task 7b block, which asserts
+ * both the positive wording and the banned-framing negatives on title AND
+ * detail (a split surface — right severity, ownership-framed prose — is the
+ * failure mode that bit Task 6's first review pass).
+ */
+function buildThreatObservationFinding(
+	candidateDomain: string,
+	seedDomain: string,
+	severity: LookalikeSeverity,
+	signals: LookalikeSignals,
+	ownership: OwnershipAssessment,
+	corroboratorReasons: string,
+): Finding {
+	const infraPhrase = signals.hasMX
+		? `active mail infrastructure (MX records), so it is capable of sending mail that resembles ${seedDomain}`
+		: 'web infrastructure (A records) and no active mail infrastructure';
+	const observed = corroboratorReasons ? `${infraPhrase}; also observed: ${corroboratorReasons}` : infraPhrase;
+	return createFinding(
+		'lookalikes',
+		`Impersonation-shaped ${signals.hasMX ? 'infrastructure' : 'web infrastructure'} observed: ${candidateDomain}`,
+		severity,
+		`${candidateDomain} is a confusable variant of ${seedDomain} and was observed with ${observed}. This is an infrastructure observation only: ${candidateDomain} does not appear to belong to the scanned organisation, this finding claims no control over it, and no change to it is requested. Defensive options that need no access to ${candidateDomain}: monitor it, block or quarantine mail bearing that name at the gateway, and report it to its registrar or a takedown provider.`,
+		{
+			lookalikeDomain: candidateDomain,
+			hasA: signals.hasA,
+			hasMX: signals.hasMX,
+			registrationDays: signals.registrationDays,
+			mxOnDisposable: signals.mxOnDisposable,
+			hasWebContent: signals.hasWebContent,
+			findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+			// The verdict travels on EVERY classified finding, threat axis
+			// included, so a consumer can read "high observed threat, NOT owned by
+			// the customer" off a single object rather than correlating two.
+			ownershipVerdict: ownership.verdict,
+		},
+	);
 }
 
 /**
@@ -311,6 +402,7 @@ export async function checkLookalikes(
 				'Lookalike check incomplete',
 				'info',
 				'Lookalike check did not complete within the time limit. Results may be incomplete — try again shortly.',
+				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
 			),
 		]);
 		// Mark as partial so callers can skip caching
@@ -337,6 +429,7 @@ async function checkLookalikesCore(
 				'No active lookalike domains detected',
 				'info',
 				`No lookalike domain permutations could be generated for ${domain}.`,
+				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
 			),
 		);
 		return buildCheckResult('lookalikes', findings);
@@ -392,6 +485,7 @@ async function checkLookalikesCore(
 				'No active lookalike domains detected',
 				'info',
 				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations detected.`,
+				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
 			),
 		);
 		return buildCheckResult('lookalikes', findings);
@@ -469,9 +563,16 @@ async function checkLookalikesCore(
 		}
 	}
 
-	// Classify results — route the ownership verdict computed above through
-	// the D4 gate so a shared-provider/no-signal candidate can never surface
-	// above info (see classifyOwnership()'s JSDoc in ../lib/ownership-attribution).
+	// Classify results on BOTH axes (Task 7b). The ownership verdict computed
+	// above routes through the D4 gate so an ATTRIBUTION claim about a
+	// shared-provider/no-signal candidate can never surface above info (see
+	// classifyOwnership()'s JSDoc in ../lib/ownership-attribution); the
+	// #264-calibrated OBSERVED-threat severity rides a separate finding that
+	// asserts nothing about ownership.
+	//
+	// `highCount` is reachable again as of Task 7b: it counts threat-OBSERVATION
+	// highs, which the ownership cap no longer touches. Under Task 7 it could
+	// never increment and the summary finding below was dead code.
 	let highCount = 0;
 	for (const result of results) {
 		const ownership: OwnershipAssessment = ownershipByDomain.get(result.domain) ?? {
@@ -490,9 +591,21 @@ async function checkLookalikesCore(
 					`Lookalike domain likely owned by same entity: ${result.domain}`,
 					'info',
 					`The domain ${result.domain} is owned by the same organisation as ${domain} (${ownership.rationale}).${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
-					{ lookalikeDomain: result.domain, hasA: result.hasA, hasMX: result.hasMX, ownershipVerdict: ownership.verdict },
+					{
+						lookalikeDomain: result.domain,
+						hasA: result.hasA,
+						hasMX: result.hasMX,
+						ownershipVerdict: ownership.verdict,
+						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+					},
 				),
 			);
+			// Task 7b requirement 5: an `owned_by_seed` candidate gets NO
+			// threat-observation finding — the customer's own domain is not an
+			// impersonation threat to itself. This `continue` (together with the
+			// enrichment skip above) is the only thing enforcing that, so the 6(c)
+			// test pins it against a disposable-MX fixture that would otherwise
+			// calibrate to HIGH.
 			continue;
 		}
 
@@ -553,13 +666,21 @@ async function checkLookalikesCore(
 						sharedRegistrantOrg: matchedOrg,
 						ownershipVerdict: ownership.verdict,
 						ownershipRationale: ownership.rationale,
+						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
 					},
 				),
 			);
+			// Task 7b: no threat-observation finding either. DELIBERATE, and
+			// asymmetric with the plain third_party path below — a registrant-org
+			// MATCH is AFFIRMATIVE evidence of a benign explanation (the org's own
+			// defensive/regional registration, issue #263), which is a different
+			// thing from the mere ABSENCE of ownership evidence that Task 7 wrongly
+			// treated as grounds for suppression. Flagged for the design owner and
+			// pinned by a dedicated test so it can only be reversed on purpose.
 			continue;
 		}
 
-		// D4 — the ownership verdict caps the calibrated severity: a candidate
+		// AXIS 1 — the ownership verdict caps the ATTRIBUTION finding's severity: a candidate
 		// with no ownership signal linking it to the scanned organisation can
 		// never surface above info, regardless of how threatening its raw
 		// infrastructure signals look. `attributionConfidence()` (fed the
@@ -579,6 +700,7 @@ async function checkLookalikesCore(
 						registrationDays: signals.registrationDays,
 						mxOnDisposable: signals.mxOnDisposable,
 						hasWebContent: signals.hasWebContent,
+						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
 					},
 				)
 			: createFinding(
@@ -593,24 +715,35 @@ async function checkLookalikesCore(
 						registrationDays: signals.registrationDays,
 						mxOnDisposable: signals.mxOnDisposable,
 						hasWebContent: signals.hasWebContent,
+						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
 					},
 				);
 
-		const gatedFinding = applyOwnershipGate(rawFinding, ownership, brand, mxOverlapsPrimary);
-		if (result.hasMX && gatedFinding.severity === 'high') highCount++;
-		findings.push(gatedFinding);
+		// AXIS 1 — attribution, capped at info with neutral wording. Pushed FIRST
+		// so a consumer scanning for the ownership statement about a candidate
+		// finds it ahead of the threat observation.
+		findings.push(applyOwnershipGate(rawFinding, ownership, brand, mxOverlapsPrimary));
+
+		// AXIS 2 — the observed threat, at the severity the #264 matrix already
+		// computed and Task 7 used to discard. Emitted only for non-owned
+		// candidates (the `sameOwner` branch above `continue`s), and only when the
+		// #263 same-entity RDAP correlation did NOT supply an affirmative benign
+		// explanation (that branch `continue`s too — see its comment).
+		findings.push(buildThreatObservationFinding(result.domain, domain, severity, signals, ownership, corroboratorReasons));
+		if (result.hasMX && severity === 'high') highCount++;
 	}
 
-	// Summary finding for high-severity lookalikes. Only fires when at least one
-	// candidate reached HIGH under the issue #264 matrix (mail-infra + corroborator).
+	// Summary finding for high-severity lookalikes (AXIS 2). Only fires when at
+	// least one NON-OWNED candidate reached HIGH under the issue #264 matrix
+	// (mail-infra + corroborator). Owned candidates never reach here.
 	if (highCount > 0) {
 		findings.push(
 			createFinding(
 				'lookalikes',
 				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} with mail capability detected`,
 				'high',
-				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating phishing signals. Consider monitoring these domains and implementing DMARC with p=reject to protect your brand.`,
-				{ lookalikeDomainCount: highCount },
+				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging. ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
+				{ lookalikeDomainCount: highCount, findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
 			),
 		);
 	}
@@ -623,6 +756,7 @@ async function checkLookalikesCore(
 				'No active lookalike domains detected',
 				'info',
 				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations with DNS or mail infrastructure detected.`,
+				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
 			),
 		);
 	}
@@ -645,7 +779,7 @@ async function checkLookalikesCore(
 					'CT-observed lookalike corroboration',
 					'medium',
 					reconResult.details ?? `Threat intelligence corroborates CT-observed lookalike signal for ${domain}.`,
-					{ domain, reconEnriched: true },
+					{ domain, reconEnriched: true, findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
 				),
 			);
 		}

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -62,10 +62,12 @@ import { extractBrandName } from '../lib/public-suffix';
  *   3. no `'threat_observation'` finding carries `ownershipVerdict ===
  *      'owned_by_seed'` — a threat observation is never about a domain the
  *      scanned organisation owns;
- *   4. every `'threat_observation'` finding names what it observed in metadata:
- *      `lookalikeDomain` (per candidate), `lookalikeDomains` (the aggregate
- *      summary), or `domain` (the recon CT corroboration, which is scoped to
- *      the scanned domain rather than to one candidate).
+ *   4. every `'threat_observation'` finding names the candidate it observed via
+ *      `lookalikeDomain` (per candidate, INCLUDING the named-candidate recon CT
+ *      corroboration) or `lookalikeDomains` (the aggregate summary). Bare
+ *      `domain` metadata (scoped to the scanned domain, not a candidate) only
+ *      ever appears on the demoted `'scan_status'` finding emitted when recon
+ *      names no specific candidate — never on a `'threat_observation'` finding.
  *
  * The axis marker is STRUCTURAL, not prose: downstream consumers (and Task
  * 8's cross-cutting audit) key on the exact literals, never on wording.

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -11,7 +11,7 @@ import { queryDnsRecords, queryMxRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { callReconScan, isReconHit } from '../lib/recon-binding';
 import { safeFetch } from '../lib/safe-fetch';
-import type { ReconBinding, BindingDegradationSink } from '../lib/recon-binding';
+import type { ReconBinding, BindingDegradationSink, ReconScanResult } from '../lib/recon-binding';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
@@ -415,6 +415,26 @@ async function probeWithAdaptiveBatching(permutations: string[]): Promise<Promis
  * Generates domain permutations and checks for active registrations using adaptive batching.
  * Filters out false positives from wildcard DNS on parent domains and null MX records.
  */
+/**
+ * Extract a specific candidate domain bv-recon's CT_LOOKALIKE hit names, if
+ * any (fix round 1, F1). The check response schema's only extension point
+ * for this is the passthrough `metadata` bag (`ReconScanResponseSchema` in
+ * `../lib/recon-binding`); a `matchedDomain` string there is treated as the
+ * named candidate. Defensively normalised (trim/lowercase/strip trailing
+ * dot); rejected outright — returns `null` rather than the seed — when it is
+ * empty or equal to the SEED domain itself, so a recon response that merely
+ * echoes the query target can never satisfy the threat-observation naming
+ * invariant without actually naming a distinct candidate.
+ */
+export function extractReconMatchedDomain(reconResult: ReconScanResult, seedDomain: string): string | null {
+	const raw = reconResult.metadata?.matchedDomain;
+	if (typeof raw !== 'string') return null;
+	const normalized = raw.trim().toLowerCase().replace(/\.$/, '');
+	const seedNormalized = seedDomain.trim().toLowerCase().replace(/\.$/, '');
+	if (normalized === '' || normalized === seedNormalized) return null;
+	return normalized;
+}
+
 export async function checkLookalikes(
 	domain: string,
 	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
@@ -803,7 +823,16 @@ async function checkLookalikesCore(
 		);
 	}
 
-	// Recon enrichment: additive-only, fail-soft
+	// Recon enrichment: additive-only, fail-soft.
+	//
+	// FIX ROUND 1, F1 (2026-07-27, post-review): this block used to emit a
+	// `medium`-severity `threat_observation` with NO `ownershipVerdict` and
+	// `domain: domain` (the SEED, not any candidate) — a live violation of
+	// this slice's own load-bearing safety property, caught by the Task 8
+	// audit's adversarial review (`ownership-severity-gate.audit.test.ts`).
+	// bv-recon's CT_LOOKALIKE check is scoped to the seed's own CT-log
+	// neighbourhood; it does not always name a specific confusable domain, so
+	// `extractReconMatchedDomain()` below may legitimately return null.
 	if (reconOptions.reconBinding) {
 		const reconResult = await callReconScan(
 			reconOptions.reconBinding,
@@ -814,16 +843,51 @@ async function checkLookalikesCore(
 			reconOptions.onBindingDegradation,
 		);
 		const hit = reconResult && isReconHit(reconResult.status);
-		if (hit) {
-			findings.push(
-				createFinding(
-					'lookalikes',
-					'CT-observed lookalike corroboration',
-					'medium',
-					reconResult.details ?? `Threat intelligence corroborates CT-observed lookalike signal for ${domain}.`,
-					{ domain, reconEnriched: true, findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
-				),
-			);
+		if (hit && reconResult) {
+			const matchedDomain = extractReconMatchedDomain(reconResult, domain);
+			const detail = reconResult.details ?? `Threat intelligence corroborates CT-observed lookalike signal for ${domain}.`;
+
+			if (matchedDomain) {
+				// A named candidate — reuse the SAME ownership assessment the local
+				// classification loop above computed when we also generated/probed
+				// this permutation ourselves. When bv-recon names a domain outside
+				// our own generated permutation set, default to `unattributed`
+				// (never `owned_by_seed` — an externally-sourced, unverified match
+				// is never sufficient to claim the candidate is the customer's own).
+				const reconOwnership: OwnershipAssessment = ownershipByDomain.get(matchedDomain) ?? {
+					verdict: 'unattributed',
+					strength: 'none',
+					signals: [],
+					rationale: `No ownership signal is available for ${matchedDomain}.`,
+				};
+				// Task 7b requirement 5: a candidate already known to be the
+				// customer's own domain gets no threat_observation finding — this
+				// enrichment is additive-only and adds nothing new for one.
+				if (reconOwnership.verdict !== 'owned_by_seed') {
+					findings.push(
+						createFinding('lookalikes', 'CT-observed lookalike corroboration', 'medium', detail, {
+							lookalikeDomain: matchedDomain,
+							reconEnriched: true,
+							findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+							ownershipVerdict: reconOwnership.verdict,
+						}),
+					);
+				}
+			} else {
+				// No specific candidate nameable — never fabricate one. A
+				// scan-level notice about the run's own CT signal, not a
+				// per-candidate threat claim, so it stays `info`/`scan_status`
+				// (DEMOTE, NEVER DELETE: the real signal is still surfaced).
+				findings.push(
+					createFinding(
+						'lookalikes',
+						'CT-observed lookalike corroboration (no specific candidate identified)',
+						'info',
+						`${detail} No specific confusable domain was identified by this signal, so no candidate-level claim is made.`,
+						{ domain, reconEnriched: true, findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
+					),
+				);
+			}
 		}
 	}
 

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -860,8 +860,29 @@ interface LookalikeCorroborators {
  * A surviving match is still only a WEAK, unverified signal: it earns a
  * sentence in the report, never a severity discount. The threat-observation
  * finding is emitted at its full calibrated severity regardless.
+ *
+ * EQUALITY-MATCHING INVARIANT — READ BEFORE CHANGING THE COMPARISON (fix round
+ * 2, re-review residual). The final test is STRICT EQUALITY, and
+ * `isRedactedRegistrantOrg()` is a pure function of its string. Therefore
+ * whenever the two orgs are equal the predicate returns the SAME verdict for
+ * both, and checking one side is currently EXACTLY equivalent to checking both.
+ * That was verified by execution: mutating this function to gate the candidate
+ * side only left the entire suite green, and no end-to-end fixture can
+ * discriminate — for a one-sided gate to wrongly match, the two strings would
+ * have to differ in redaction status while still being equal, which equality
+ * matching makes impossible.
+ *
+ * The both-sides form is kept as DEFENCE IN DEPTH for the day that comparison
+ * stops being equality. ANY change to fuzzy/containment/token-overlap/edit-
+ * distance matching MUST (a) keep the gate on BOTH sides — under fuzzy matching
+ * a redacted string can match a non-redacted one, so a one-sided gate becomes a
+ * real hole — and (b) ship a fixture that discriminates one-sided from
+ * two-sided, which only becomes constructible once equality is gone. Until
+ * then the semantics are pinned directly by the unit tests on this function in
+ * `test/check-lookalikes.spec.ts` (exported for exactly that purpose), not by
+ * an end-to-end fixture that cannot tell the two implementations apart.
  */
-function isSameEntityOrgMatch(primaryOrg: string | null, candidateOrg: string | null): boolean {
+export function isSameEntityOrgMatch(primaryOrg: string | null, candidateOrg: string | null): boolean {
 	if (primaryOrg === null || candidateOrg === null) return false;
 	if (isRedactedRegistrantOrg(primaryOrg) || isRedactedRegistrantOrg(candidateOrg)) return false;
 	return primaryOrg === candidateOrg;

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -7,7 +7,7 @@
  * Standalone check — not included in scan_domain due to query volume.
  */
 
-import { queryDnsRecords } from '../lib/dns';
+import { queryDnsRecords, queryMxRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { callReconScan, isReconHit } from '../lib/recon-binding';
 import { safeFetch } from '../lib/safe-fetch';
@@ -17,6 +17,15 @@ import { buildCheckResult, createFinding } from '../lib/scoring';
 import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
 import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg } from './check-rdap-lookup';
 import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSignals } from './lookalike-severity';
+import {
+	attributionConfidence,
+	capAttributionSeverity,
+	classifyOwnership,
+	MIN_ATTRIBUTION_LABEL_LENGTH,
+	type OwnershipAssessment,
+} from '../lib/ownership-attribution';
+import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
+import { extractBrandName } from '../lib/public-suffix';
 
 /** Default and minimum batch sizes for adaptive batching */
 export const INITIAL_BATCH_SIZE = 10;
@@ -48,9 +57,6 @@ interface LookalikeResult {
 /** Budgets for the Defect L enrichment probes. Both are intentionally tight so 12 candidates × (RDAP + HEAD) stays under LOOKALIKE_TIMEOUT_MS. */
 const RDAP_PROBE_TIMEOUT_MS = 2500;
 const WEB_PROBE_TIMEOUT_MS = 2500;
-
-/** Minimum number of NS records that must overlap to consider domains as sharing nameservers. */
-const SHARED_NS_THRESHOLD = 1;
 
 /**
  * Cap on the number of medium/high-severity lookalikes for which we attempt
@@ -185,21 +191,6 @@ function normalizeNsSet(nsRecords: string[]): Set<string> {
 }
 
 /**
- * Check whether two NS sets share at least SHARED_NS_THRESHOLD nameservers.
- * Shared nameservers are a strong signal that both domains are controlled by the same entity.
- */
-function sharesNameservers(primaryNs: Set<string>, lookalikeNs: Set<string>): boolean {
-	let overlap = 0;
-	for (const ns of lookalikeNs) {
-		if (primaryNs.has(ns)) {
-			overlap++;
-			if (overlap >= SHARED_NS_THRESHOLD) return true;
-		}
-	}
-	return false;
-}
-
-/**
  * Query NS records for the primary domain to use for ownership comparison.
  * Returns an empty set if the query fails.
  */
@@ -210,6 +201,72 @@ async function queryPrimaryNs(domain: string): Promise<Set<string>> {
 	} catch {
 		return new Set<string>();
 	}
+}
+
+/**
+ * Query MX records for the primary domain — the D4 (2026-07-26
+ * correctness-defects design) MX-overlap corroboration signal for
+ * `attributionConfidence()`. Fail-soft: an empty set just means the guard
+ * falls back to "no corroboration" rather than throwing.
+ */
+async function queryPrimaryMx(domain: string): Promise<Set<string>> {
+	try {
+		const mx = await queryMxRecords(domain, PHASE1_DNS_OPTS);
+		return new Set(mx.map((r) => r.exchange.toLowerCase().replace(/\.$/, '')));
+	} catch {
+		return new Set<string>();
+	}
+}
+
+/**
+ * D4 severity ceiling for a lookalike finding, mirroring `applyOwnershipGate()`
+ * in `check-shadow-domains.ts` — see that file's JSDoc for the full rationale;
+ * this is the same pattern reused for a second tool so the two stay
+ * consistent for downstream consumers.
+ *
+ * `owned_by_seed` findings pass through unclamped — `checkLookalikesCore`'s
+ * main loop already emits its own dedicated "likely owned by same entity"
+ * finding for that verdict before this function is ever reached, so in
+ * practice every call here receives a non-owned verdict. The passthrough
+ * branch exists anyway so the invariant is explicit and enforced at this
+ * chokepoint rather than merely assumed by the caller.
+ *
+ * DEMOTE, NEVER DELETE (binding ruling): this returns a `Finding`, never
+ * `null`/`undefined` — a real measurement (an active registration with
+ * MX/A records) is never suppressed, only its severity capped and its
+ * wording made neutral. `attributionConfidence()` governs WORDING/CONFIDENCE
+ * ONLY; it can never move the ceiling, which `capAttributionSeverity()`
+ * derives from `ownership.verdict` alone.
+ */
+function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, brand: string, corroborated: boolean): Finding {
+	const ceiling = capAttributionSeverity(ownership.verdict);
+	if (ceiling === 'unbounded') return finding;
+
+	const confidence = attributionConfidence(ownership.verdict, brand, corroborated);
+	const lookalikeDomain = typeof finding.metadata?.lookalikeDomain === 'string' ? finding.metadata.lookalikeDomain : 'This domain';
+	const metadata = {
+		...finding.metadata,
+		ownershipVerdict: ownership.verdict,
+		ownershipRationale: ownership.rationale,
+		attributionConfidence: confidence,
+		severityCappedBy: 'ownership_attribution',
+	};
+
+	const relation =
+		ownership.verdict === 'third_party'
+			? 'is registered to a different organisation'
+			: 'could not be attributed to the scanned organisation';
+	const hedge =
+		confidence === 'uncorroborated'
+			? ` The shared label is under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters and nothing else corroborates a link, so the name similarity alone means little.`
+			: '';
+	return createFinding(
+		'lookalikes',
+		`Unrelated domain, confusable label: ${lookalikeDomain}`,
+		ceiling,
+		`${lookalikeDomain} shares a similar label with the scanned domain but ${relation}. ${ownership.rationale} Its DNS/mail posture is reported for awareness only: no action by the scanned organisation is implied, and this finding asserts no control over ${lookalikeDomain}.${hedge}`,
+		metadata,
+	);
 }
 
 /**
@@ -329,9 +386,15 @@ async function checkLookalikesCore(
 
 	const permsToProbe = [...nonDotInsertionPerms, ...filteredDotInsertionPerms];
 
-	// Phase 1: Fast NS existence check — filter out unregistered domains
-	// Also query the primary domain's NS for ownership comparison
-	const [nsResult, primaryNs] = await Promise.all([filterByNsExistence(permsToProbe), queryPrimaryNs(domain)]);
+	// Phase 1: Fast NS existence check — filter out unregistered domains.
+	// Also query the primary domain's NS + MX for ownership comparison: NS for
+	// the ownership verdict itself, MX for the D4 MX-overlap corroboration
+	// signal consulted by `attributionConfidence()` (wording only).
+	const [nsResult, primaryNs, primaryMx] = await Promise.all([
+		filterByNsExistence(permsToProbe),
+		queryPrimaryNs(domain),
+		queryPrimaryMx(domain),
+	]);
 	const { registered: registeredPerms, nsMap: lookalikeNsMap } = nsResult;
 
 	if (registeredPerms.length === 0) {
@@ -346,6 +409,33 @@ async function checkLookalikesCore(
 		return buildCheckResult('lookalikes', findings);
 	}
 
+	// D4 (2026-07-26 correctness-defects design) — classify every registered
+	// candidate's ownership ONCE, up front, reused across all three same-owner
+	// decision points below (the enrichment filter, the main classification
+	// loop, and the same-entity RDAP-eligibility filter). Replaces
+	// sharesNameservers() (SHARED_NS_THRESHOLD = 1 — a single shared NS host,
+	// e.g. a pooled Akamai hostname, was already enough to mark two unrelated
+	// organisations as the same owner — an even weaker version of the
+	// shadow-domains bug this design also fixes). Every registered candidate
+	// here was proven registered via NS (filterByNsExistence only returns
+	// domains with NS records), so `registration.ns` is always non-empty.
+	const primaryNsList = Array.from(primaryNs);
+	const brand = extractBrandName(domain) ?? '';
+	const ownershipByDomain = new Map<string, OwnershipAssessment>();
+	for (const perm of registeredPerms) {
+		const candidateNs = Array.from(lookalikeNsMap.get(perm) ?? []);
+		ownershipByDomain.set(
+			perm,
+			classifyOwnership({
+				seedDomain: domain,
+				seedNs: primaryNsList,
+				candidateDomain: perm,
+				registration: { state: 'registered', ns: candidateNs, evidence: candidateNs.length > 0 ? ['ns'] : ['a'] },
+				isSharedNsHost,
+			}),
+		);
+	}
+
 	// Phase 2: Detail probe only registered domains
 	const probeResults = await probeWithAdaptiveBatching(registeredPerms);
 	const results: LookalikeResult[] = [];
@@ -357,12 +447,12 @@ async function checkLookalikesCore(
 
 	// Enrichment (Defect L / issue #264): for each non-defensively-registered
 	// lookalike with mail or web infrastructure, gather corroborating signals
-	// so the calibrator can pick the right severity tier. Lookalikes that
-	// share nameservers with the primary domain skip enrichment entirely (they
-	// short-circuit to info-severity defensive-registration findings).
+	// so the calibrator can pick the right severity tier. Lookalikes the
+	// ownership verdict already attributes to the same organisation skip
+	// enrichment entirely (they short-circuit to info-severity
+	// defensive-registration findings in the main loop below).
 	const candidatesToEnrich: LookalikeResult[] = results.filter((r) => {
-		const lookalikeNs = lookalikeNsMap.get(r.domain);
-		const sameOwner = primaryNs.size > 0 && lookalikeNs !== undefined && sharesNameservers(primaryNs, lookalikeNs);
+		const sameOwner = ownershipByDomain.get(r.domain)?.verdict === 'owned_by_seed';
 		return !sameOwner && (r.hasMX || r.hasA);
 	});
 	const enrichment = await enrichLookalikes(candidatesToEnrich);
@@ -370,7 +460,7 @@ async function checkLookalikesCore(
 	// Same-entity correlation (issue #263): a flagged lookalike that shares the
 	// scan domain's RDAP registrant org is almost certainly the org's own
 	// defensive registration / regional subsidiary (e.g. a vendor's regional
-	// presence on a DIFFERENT DNS provider, which the shared-NS pass above
+	// presence on a DIFFERENT DNS provider, which the ownership verdict above
 	// misses). We only fetch the primary's registrant org — and only apply the
 	// correlation — when at least one enriched candidate would surface at
 	// medium/high severity, so a clean scan pays no RDAP cost. The candidates'
@@ -380,7 +470,7 @@ async function checkLookalikesCore(
 	// SAME_ENTITY_RDAP_CAP, highest-severity first. Fail-soft: if the primary
 	// RDAP org is unknown, NO downgrade happens (a real threat is never
 	// suppressed because RDAP was unavailable).
-	const sameEntityCandidates = computeSameEntityCandidates(results, lookalikeNsMap, primaryNs, enrichment);
+	const sameEntityCandidates = computeSameEntityCandidates(results, ownershipByDomain, enrichment);
 	const primaryRegistrantOrg = sameEntityCandidates.length > 0 ? await probePrimaryRegistrantOrg(domain) : null;
 	const sameEntityMatches = new Map<string, string>();
 	if (primaryRegistrantOrg !== null) {
@@ -391,21 +481,28 @@ async function checkLookalikesCore(
 		}
 	}
 
-	// Classify results — check for shared nameservers with primary domain to detect defensive registrations
+	// Classify results — route the ownership verdict computed above through
+	// the D4 gate so a shared-provider/no-signal candidate can never surface
+	// above info (see classifyOwnership()'s JSDoc in ../lib/ownership-attribution).
 	let highCount = 0;
 	for (const result of results) {
-		const lookalikeNs = lookalikeNsMap.get(result.domain);
-		const sameOwner = primaryNs.size > 0 && lookalikeNs !== undefined && sharesNameservers(primaryNs, lookalikeNs);
+		const ownership: OwnershipAssessment = ownershipByDomain.get(result.domain) ?? {
+			verdict: 'unattributed',
+			strength: 'none',
+			signals: [],
+			rationale: `No ownership signal is available for ${result.domain}.`,
+		};
+		const sameOwner = ownership.verdict === 'owned_by_seed';
 
 		if (sameOwner) {
-			// Shared nameservers — likely a defensive registration by the same entity
+			// Structurally owned by the seed — the customer's own domain.
 			findings.push(
 				createFinding(
 					'lookalikes',
 					`Lookalike domain likely owned by same entity: ${result.domain}`,
 					'info',
-					`The domain ${result.domain} shares nameservers with ${domain}, indicating it is likely a defensive registration by the same owner.${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
-					{ lookalikeDomain: result.domain, hasA: result.hasA, hasMX: result.hasMX, sharedNs: true },
+					`The domain ${result.domain} is owned by the same organisation as ${domain} (${ownership.rationale}).${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
+					{ lookalikeDomain: result.domain, hasA: result.hasA, hasMX: result.hasMX, ownershipVerdict: ownership.verdict },
 				),
 			);
 			continue;
@@ -449,10 +546,15 @@ async function checkLookalikesCore(
 			continue;
 		}
 
-		if (result.hasMX) {
-			if (severity === 'high') highCount++;
-			findings.push(
-				createFinding(
+		// D4 — the ownership verdict caps the calibrated severity: a candidate
+		// with no ownership signal linking it to the scanned organisation can
+		// never surface above info, regardless of how threatening its raw
+		// infrastructure signals look. `attributionConfidence()` (fed the
+		// MX-overlap corroboration signal below) governs WORDING/CONFIDENCE
+		// only — see `applyOwnershipGate()`'s JSDoc.
+		const mxOverlapsPrimary = result.mxExchanges.some((ex) => primaryMx.has(ex));
+		const rawFinding = result.hasMX
+			? createFinding(
 					'lookalikes',
 					`Lookalike domain with mail infrastructure: ${result.domain}`,
 					severity,
@@ -465,12 +567,8 @@ async function checkLookalikesCore(
 						mxOnDisposable: signals.mxOnDisposable,
 						hasWebContent: signals.hasWebContent,
 					},
-				),
-			);
-		} else {
-			// Web-only
-			findings.push(
-				createFinding(
+				)
+			: createFinding(
 					'lookalikes',
 					`Lookalike domain registered: ${result.domain}`,
 					severity,
@@ -483,9 +581,11 @@ async function checkLookalikesCore(
 						mxOnDisposable: signals.mxOnDisposable,
 						hasWebContent: signals.hasWebContent,
 					},
-				),
-			);
-		}
+				);
+
+		const gatedFinding = applyOwnershipGate(rawFinding, ownership, brand, mxOverlapsPrimary);
+		if (result.hasMX && gatedFinding.severity === 'high') highCount++;
+		findings.push(gatedFinding);
 	}
 
 	// Summary finding for high-severity lookalikes. Only fires when at least one
@@ -559,22 +659,22 @@ interface LookalikeCorroborators {
  * Determine which lookalike candidates are eligible for the issue #263
  * same-entity (shared-registrant) downgrade. Eligibility mirrors the
  * classification loop's decision so we never fetch the primary's registrant
- * org speculatively: a candidate qualifies only when it is NOT already a
- * shared-NS same-owner hit, has mail/web infra, AND its calibrated severity is
- * medium or high (low web-only matches aren't worth the RDAP cost). The result
+ * org speculatively: a candidate qualifies only when `ownershipByDomain`
+ * does NOT already attribute it to the seed (`owned_by_seed` — CALL SITE 3
+ * of the D4 2026-07-26 correctness-defects design's ownership gate), has
+ * mail/web infra, AND its calibrated severity is medium or high (low
+ * web-only matches aren't worth the RDAP cost). The result
  * is sorted high-before-medium and capped at {@link SAME_ENTITY_RDAP_CAP} so a
  * permutation explosion can't widen the RDAP fan-out unbounded.
  */
 function computeSameEntityCandidates(
 	results: LookalikeResult[],
-	lookalikeNsMap: Map<string, Set<string>>,
-	primaryNs: Set<string>,
+	ownershipByDomain: Map<string, OwnershipAssessment>,
 	enrichment: Map<string, LookalikeCorroborators>,
 ): string[] {
 	const eligible: Array<{ domain: string; severity: 'medium' | 'high' }> = [];
 	for (const result of results) {
-		const lookalikeNs = lookalikeNsMap.get(result.domain);
-		const sameOwner = primaryNs.size > 0 && lookalikeNs !== undefined && sharesNameservers(primaryNs, lookalikeNs);
+		const sameOwner = ownershipByDomain.get(result.domain)?.verdict === 'owned_by_seed';
 		if (sameOwner) continue;
 		if (!result.hasMX && !result.hasA) continue;
 		const corroborators = enrichment.get(result.domain);

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -15,13 +15,14 @@ import type { ReconBinding, BindingDegradationSink } from '../lib/recon-binding'
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
-import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg } from './check-rdap-lookup';
+import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg, isRedactedRegistrantOrg } from './check-rdap-lookup';
 import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
 import {
 	buildNonOwnedGateFinding,
 	capAttributionSeverity,
 	classifyOwnership,
 	type OwnershipAssessment,
+	type OwnershipVerdict,
 } from '../lib/ownership-attribution';
 import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 import { extractBrandName } from '../lib/public-suffix';
@@ -49,10 +50,27 @@ import { extractBrandName } from '../lib/public-suffix';
  *    organisation) and demand no action ON that domain; only defensive
  *    options on the scanned organisation's own side are suggested.
  *
+ *  - `'scan_status'` — the RUN itself, not any candidate: the "no active
+ *    lookalike domains detected" notices and the timeout notice. Always
+ *    `info`. Split out in fix round 1 (F2) because forcing these into
+ *    `'threat_observation'` made the threat-axis invariants below unstateable.
+ *
+ * INVARIANTS (true of this file, pinned by `test/check-lookalikes.spec.ts`, and
+ * what Task 8's cross-cutting audit will key on):
+ *   1. every finding carries one of the three literals;
+ *   2. every `'scan_status'` finding is `info`;
+ *   3. no `'threat_observation'` finding carries `ownershipVerdict ===
+ *      'owned_by_seed'` — a threat observation is never about a domain the
+ *      scanned organisation owns;
+ *   4. every `'threat_observation'` finding names what it observed in metadata:
+ *      `lookalikeDomain` (per candidate), `lookalikeDomains` (the aggregate
+ *      summary), or `domain` (the recon CT corroboration, which is scoped to
+ *      the scanned domain rather than to one candidate).
+ *
  * The axis marker is STRUCTURAL, not prose: downstream consumers (and Task
  * 8's cross-cutting audit) key on the exact literals, never on wording.
  */
-export type LookalikeFindingAxis = 'attribution' | 'threat_observation';
+export type LookalikeFindingAxis = 'attribution' | 'threat_observation' | 'scan_status';
 
 /** Default and minimum batch sizes for adaptive batching */
 export const INITIAL_BATCH_SIZE = 10;
@@ -322,16 +340,24 @@ function buildThreatObservationFinding(
 	signals: LookalikeSignals,
 	ownership: OwnershipAssessment,
 	corroboratorReasons: string,
+	sharedRegistrantOrg: string | undefined,
 ): Finding {
 	const infraPhrase = signals.hasMX
 		? `active mail infrastructure (MX records), so it is capable of sending mail that resembles ${seedDomain}`
 		: 'web infrastructure (A records) and no active mail infrastructure';
 	const observed = corroboratorReasons ? `${infraPhrase}; also observed: ${corroboratorReasons}` : infraPhrase;
+	// FIX ROUND 1 (F1): when the #263 correlation found a shared registrant-org
+	// string, it is RECORDED here — as an unverified observation — but it does
+	// NOT reduce the severity and does not suppress this finding. An org string
+	// anyone can type into a registrar form earns a sentence, not a discount.
+	const registrantNote = sharedRegistrantOrg
+		? ` Its RDAP registrant-organisation string matches the one published for ${seedDomain} ("${sharedRegistrantOrg}"); that field is self-declared, unverified by the registry, and frequently a shared privacy-service placeholder, so it is recorded but does not reduce what was observed here.`
+		: '';
 	return createFinding(
 		'lookalikes',
 		`Impersonation-shaped ${signals.hasMX ? 'infrastructure' : 'web infrastructure'} observed: ${candidateDomain}`,
 		severity,
-		`${candidateDomain} is a confusable variant of ${seedDomain} and was observed with ${observed}. This is an infrastructure observation only: ${candidateDomain} does not appear to belong to the scanned organisation, this finding claims no control over it, and no change to it is requested. Defensive options that need no access to ${candidateDomain}: monitor it, block or quarantine mail bearing that name at the gateway, and report it to its registrar or a takedown provider.`,
+		`${candidateDomain} is a confusable variant of ${seedDomain} and was observed with ${observed}. This is an infrastructure observation only: ${candidateDomain} does not appear to belong to the scanned organisation, this finding claims no control over it, and no change to it is requested.${registrantNote} Defensive options that need no access to ${candidateDomain}: monitor it, block or quarantine mail bearing that name at the gateway, and report it to its registrar or a takedown provider.`,
 		{
 			lookalikeDomain: candidateDomain,
 			hasA: signals.hasA,
@@ -344,6 +370,7 @@ function buildThreatObservationFinding(
 			// included, so a consumer can read "high observed threat, NOT owned by
 			// the customer" off a single object rather than correlating two.
 			ownershipVerdict: ownership.verdict,
+			...(sharedRegistrantOrg ? { sharedRegistrantOrg } : {}),
 		},
 	);
 }
@@ -402,7 +429,7 @@ export async function checkLookalikes(
 				'Lookalike check incomplete',
 				'info',
 				'Lookalike check did not complete within the time limit. Results may be incomplete — try again shortly.',
-				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
+				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
 			),
 		]);
 		// Mark as partial so callers can skip caching
@@ -429,7 +456,7 @@ async function checkLookalikesCore(
 				'No active lookalike domains detected',
 				'info',
 				`No lookalike domain permutations could be generated for ${domain}.`,
-				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
+				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
 			),
 		);
 		return buildCheckResult('lookalikes', findings);
@@ -485,7 +512,7 @@ async function checkLookalikesCore(
 				'No active lookalike domains detected',
 				'info',
 				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations detected.`,
-				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
+				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
 			),
 		);
 		return buildCheckResult('lookalikes', findings);
@@ -550,16 +577,19 @@ async function checkLookalikesCore(
 	// fetch as registrationDays), so this adds exactly ONE extra RDAP fetch (the
 	// primary), not one-per-candidate. The eligible set is capped at
 	// SAME_ENTITY_RDAP_CAP, highest-severity first. Fail-soft: if the primary
-	// RDAP org is unknown, NO downgrade happens (a real threat is never
-	// suppressed because RDAP was unavailable).
+	// RDAP org is unknown, NO correlation happens.
+	//
+	// FIX ROUND 1 (review finding F1): a match here NO LONGER suppresses the
+	// threat axis — see the emission site below — and every use of it is gated
+	// by `isSameEntityOrgMatch()`, which rejects privacy-proxy / redacted /
+	// generic strings on BOTH sides.
 	const sameEntityCandidates = computeSameEntityCandidates(results, ownershipByDomain, enrichment);
 	const primaryRegistrantOrg = sameEntityCandidates.length > 0 ? await probePrimaryRegistrantOrg(domain) : null;
 	const sameEntityMatches = new Map<string, string>();
-	if (primaryRegistrantOrg !== null) {
-		for (const candidateDomain of sameEntityCandidates) {
-			if (enrichment.get(candidateDomain)?.registrantOrg === primaryRegistrantOrg) {
-				sameEntityMatches.set(candidateDomain, primaryRegistrantOrg);
-			}
+	for (const candidateDomain of sameEntityCandidates) {
+		const candidateOrg = enrichment.get(candidateDomain)?.registrantOrg ?? null;
+		if (candidateOrg !== null && isSameEntityOrgMatch(primaryRegistrantOrg, candidateOrg)) {
+			sameEntityMatches.set(candidateDomain, candidateOrg);
 		}
 	}
 
@@ -574,6 +604,10 @@ async function checkLookalikesCore(
 	// highs, which the ownership cap no longer touches. Under Task 7 it could
 	// never increment and the summary finding below was dead code.
 	let highCount = 0;
+	/** The counted candidates, so the aggregate summary can name what it counted (invariant 4). */
+	const highDomains: string[] = [];
+	/** Their ownership verdicts — always non-owned, since owned candidates never reach the counter. */
+	const highVerdicts = new Set<OwnershipVerdict>();
 	for (const result of results) {
 		const ownership: OwnershipAssessment = ownershipByDomain.get(result.domain) ?? {
 			verdict: 'unattributed',
@@ -653,6 +687,9 @@ async function checkLookalikesCore(
 		// structural NS-based evidence, whose own finding is quoted verbatim.
 		const matchedOrg = sameEntityMatches.get(result.domain);
 		if (matchedOrg !== undefined) {
+			// AXIS 1 — the registrant-org observation REPLACES the neutral D4 gate
+			// template for this candidate (it is strictly more informative), but it
+			// is still an attribution statement capped at info.
 			findings.push(
 				createFinding(
 					'lookalikes',
@@ -670,67 +707,63 @@ async function checkLookalikesCore(
 					},
 				),
 			);
-			// Task 7b: no threat-observation finding either. DELIBERATE, and
-			// asymmetric with the plain third_party path below — a registrant-org
-			// MATCH is AFFIRMATIVE evidence of a benign explanation (the org's own
-			// defensive/regional registration, issue #263), which is a different
-			// thing from the mere ABSENCE of ownership evidence that Task 7 wrongly
-			// treated as grounds for suppression. Flagged for the design owner and
-			// pinned by a dedicated test so it can only be reversed on purpose.
-			continue;
+		} else {
+			// AXIS 1 — the ownership verdict caps the ATTRIBUTION finding's severity: a candidate
+			// with no ownership signal linking it to the scanned organisation can
+			// never surface above info, regardless of how threatening its raw
+			// infrastructure signals look. `attributionConfidence()` (fed the
+			// MX-overlap corroboration signal below) governs WORDING/CONFIDENCE
+			// only — see `applyOwnershipGate()`'s JSDoc.
+			const mxOverlapsPrimary = result.mxExchanges.some((ex) => primaryMx.has(ex));
+			const rawFinding = result.hasMX
+				? createFinding(
+						'lookalikes',
+						`Lookalike domain with mail infrastructure: ${result.domain}`,
+						severity,
+						`The domain ${result.domain} is registered with active mail servers (MX records), which could be used for phishing or email spoofing targeting ${domain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
+						{
+							lookalikeDomain: result.domain,
+							hasA: result.hasA,
+							hasMX: result.hasMX,
+							registrationDays: signals.registrationDays,
+							mxOnDisposable: signals.mxOnDisposable,
+							hasWebContent: signals.hasWebContent,
+							findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+						},
+					)
+				: createFinding(
+						'lookalikes',
+						`Lookalike domain registered: ${result.domain}`,
+						severity,
+						`The domain ${result.domain} is registered (has web presence) but no mail infrastructure detected. It could still be used for phishing websites targeting ${domain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
+						{
+							lookalikeDomain: result.domain,
+							hasA: result.hasA,
+							hasMX: result.hasMX,
+							registrationDays: signals.registrationDays,
+							mxOnDisposable: signals.mxOnDisposable,
+							hasWebContent: signals.hasWebContent,
+							findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+						},
+					);
+
+			// Attribution pushed FIRST so a consumer scanning for the ownership
+			// statement about a candidate finds it ahead of the threat observation.
+			findings.push(applyOwnershipGate(rawFinding, ownership, brand, mxOverlapsPrimary));
 		}
 
-		// AXIS 1 — the ownership verdict caps the ATTRIBUTION finding's severity: a candidate
-		// with no ownership signal linking it to the scanned organisation can
-		// never surface above info, regardless of how threatening its raw
-		// infrastructure signals look. `attributionConfidence()` (fed the
-		// MX-overlap corroboration signal below) governs WORDING/CONFIDENCE
-		// only — see `applyOwnershipGate()`'s JSDoc.
-		const mxOverlapsPrimary = result.mxExchanges.some((ex) => primaryMx.has(ex));
-		const rawFinding = result.hasMX
-			? createFinding(
-					'lookalikes',
-					`Lookalike domain with mail infrastructure: ${result.domain}`,
-					severity,
-					`The domain ${result.domain} is registered with active mail servers (MX records), which could be used for phishing or email spoofing targeting ${domain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
-					{
-						lookalikeDomain: result.domain,
-						hasA: result.hasA,
-						hasMX: result.hasMX,
-						registrationDays: signals.registrationDays,
-						mxOnDisposable: signals.mxOnDisposable,
-						hasWebContent: signals.hasWebContent,
-						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
-					},
-				)
-			: createFinding(
-					'lookalikes',
-					`Lookalike domain registered: ${result.domain}`,
-					severity,
-					`The domain ${result.domain} is registered (has web presence) but no mail infrastructure detected. It could still be used for phishing websites targeting ${domain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
-					{
-						lookalikeDomain: result.domain,
-						hasA: result.hasA,
-						hasMX: result.hasMX,
-						registrationDays: signals.registrationDays,
-						mxOnDisposable: signals.mxOnDisposable,
-						hasWebContent: signals.hasWebContent,
-						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
-					},
-				);
-
-		// AXIS 1 — attribution, capped at info with neutral wording. Pushed FIRST
-		// so a consumer scanning for the ownership statement about a candidate
-		// finds it ahead of the threat observation.
-		findings.push(applyOwnershipGate(rawFinding, ownership, brand, mxOverlapsPrimary));
-
-		// AXIS 2 — the observed threat, at the severity the #264 matrix already
-		// computed and Task 7 used to discard. Emitted only for non-owned
-		// candidates (the `sameOwner` branch above `continue`s), and only when the
-		// #263 same-entity RDAP correlation did NOT supply an affirmative benign
-		// explanation (that branch `continue`s too — see its comment).
-		findings.push(buildThreatObservationFinding(result.domain, domain, severity, signals, ownership, corroboratorReasons));
-		if (result.hasMX && severity === 'high') highCount++;
+		// AXIS 2 — the observed threat, at the severity the #264 matrix computed
+		// and Task 7 used to discard. Emitted for EVERY non-owned candidate,
+		// including one whose RDAP registrant org matched the seed's (fix round 1,
+		// F1: that string is unverified and collision-prone, so it may annotate the
+		// observation but must never switch the axis off). Only `owned_by_seed`
+		// candidates are exempt — they `continue` above.
+		findings.push(buildThreatObservationFinding(result.domain, domain, severity, signals, ownership, corroboratorReasons, matchedOrg));
+		if (result.hasMX && severity === 'high') {
+			highCount++;
+			highDomains.push(result.domain);
+			highVerdicts.add(ownership.verdict);
+		}
 	}
 
 	// Summary finding for high-severity lookalikes (AXIS 2). Only fires when at
@@ -743,7 +776,16 @@ async function checkLookalikesCore(
 				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} with mail capability detected`,
 				'high',
 				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging. ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
-				{ lookalikeDomainCount: highCount, findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
+				{
+					lookalikeDomainCount: highCount,
+					lookalikeDomains: highDomains,
+					// Present whenever the counted set shares one verdict (the realistic
+					// case — a non-owned registered candidate is always `third_party`).
+					// Omitted rather than fabricated for a mixed set; either way it can
+					// never be `owned_by_seed`, since owned candidates never reach here.
+					...(highVerdicts.size === 1 ? { ownershipVerdict: [...highVerdicts][0] } : {}),
+					findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+				},
 			),
 		);
 	}
@@ -756,7 +798,7 @@ async function checkLookalikesCore(
 				'No active lookalike domains detected',
 				'info',
 				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations with DNS or mail infrastructure detected.`,
-				{ findingAxis: 'threat_observation' satisfies LookalikeFindingAxis },
+				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
 			),
 		);
 	}
@@ -800,6 +842,29 @@ interface LookalikeCorroborators {
 	 * stands; a real threat is never suppressed on missing RDAP).
 	 */
 	registrantOrg: string | null;
+}
+
+/**
+ * THE single predicate deciding whether two RDAP registrant-org strings may be
+ * treated as the same entity (issue #263). Added in Task 7b fix round 1 for
+ * review finding F1.
+ *
+ * The org field is free text the registrant TYPES and RDAP does not verify it.
+ * Raw string equality was therefore both forgeable (one registrar form field)
+ * and — far more damaging — trivially collision-prone: seed and candidate
+ * sitting behind the SAME privacy service normalise equal for reasons that
+ * carry zero identity information. Both sides are gated through
+ * `isRedactedRegistrantOrg()`, so a redacted / proxy / generic value can never
+ * produce a match.
+ *
+ * A surviving match is still only a WEAK, unverified signal: it earns a
+ * sentence in the report, never a severity discount. The threat-observation
+ * finding is emitted at its full calibrated severity regardless.
+ */
+function isSameEntityOrgMatch(primaryOrg: string | null, candidateOrg: string | null): boolean {
+	if (primaryOrg === null || candidateOrg === null) return false;
+	if (isRedactedRegistrantOrg(primaryOrg) || isRedactedRegistrantOrg(candidateOrg)) return false;
+	return primaryOrg === candidateOrg;
 }
 
 /**

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -38,9 +38,7 @@ export interface LockPosture {
  */
 export function deriveLockPosture(eppStatus: readonly string[]): LockPosture {
 	const norm = new Set(
-		(Array.isArray(eppStatus) ? eppStatus : [])
-			.map((s) => String(s).toLowerCase().replace(/\s+/g, ''))
-			.filter((s) => s.length > 0),
+		(Array.isArray(eppStatus) ? eppStatus : []).map((s) => String(s).toLowerCase().replace(/\s+/g, '')).filter((s) => s.length > 0),
 	);
 	const has = (code: string) => norm.has(code);
 
@@ -333,6 +331,95 @@ export function normalizeRegistrantOrg(value: string | null | undefined): string
 	return normalized.length > 0 ? normalized : null;
 }
 
+/**
+ * Substrings that, when present in a NORMALISED registrant-org string, mean the
+ * field carries no identity information — a privacy/proxy service placeholder,
+ * a redaction marker, or a generic filler.
+ *
+ * WHY THIS EXISTS (Task 7b fix round 1, review finding F1). The registrant org
+ * is free text the registrant TYPES; RDAP does not verify it, and no part of
+ * the parse path (`extractVcardName` → `normalizeRegistrantOrg`) filters
+ * redaction. Two consequences make it unsafe to treat equality as an identity
+ * signal:
+ *   (a) FORGERY — anyone can type the target's org name into one registrar form
+ *       field and manufacture a "match";
+ *   (b) COLLISION (the bigger problem, and zero-effort) — a large fraction of
+ *       real registrations sit behind the same handful of privacy services, so
+ *       seed and candidate normalise EQUAL for reasons that say nothing about
+ *       who owns either domain.
+ *
+ * Matching is substring-on-normalised (already lowercased and
+ * whitespace-collapsed by {@link normalizeRegistrantOrg}). The generic tokens
+ * subsume the named services listed after them — the named entries are kept for
+ * documentation value, so a reader can see which real-world strings motivated
+ * the list.
+ */
+export const REDACTED_REGISTRANT_ORG_TOKENS: readonly string[] = [
+	// Generic redaction / privacy-proxy vocabulary.
+	'redacted',
+	'privacy',
+	'whois',
+	'proxy',
+	'withheld',
+	'not disclosed',
+	'non-public',
+	'data protected',
+	'gdpr',
+	'masked',
+	'masking',
+	'anonym',
+	'identity protect',
+	'registration private',
+	// Named services (redundant with the tokens above; retained as documentation).
+	'domains by proxy',
+	'perfect privacy',
+	'contact privacy',
+	'withheld for privacy',
+	'privacyguardian',
+	'namecheap inc', // resells "WhoisGuard"-style masking under its own name
+];
+
+/**
+ * Normalised registrant-org strings that are present but carry no identity —
+ * filler a registrar or registrant left in the field. Exact-match (not
+ * substring) so a real organisation whose name merely CONTAINS one of these
+ * words is unaffected.
+ */
+const GENERIC_REGISTRANT_ORG_VALUES: ReadonlySet<string> = new Set([
+	'',
+	'-',
+	'.',
+	'n/a',
+	'na',
+	'none',
+	'null',
+	'nil',
+	'unknown',
+	'not applicable',
+	'not available',
+	'private',
+	'registrant',
+	'domain administrator',
+	'domain admin',
+	'individual',
+	'personal',
+]);
+
+/**
+ * True when a normalised registrant-org string must NOT be used as a
+ * same-entity signal — it is absent, a privacy-proxy/redaction placeholder, or
+ * generic filler. See {@link REDACTED_REGISTRANT_ORG_TOKENS} for the rationale.
+ *
+ * Callers MUST gate every use of a registrant-org match behind this predicate,
+ * on BOTH sides of the comparison.
+ */
+export function isRedactedRegistrantOrg(normalizedOrg: string | null | undefined): boolean {
+	if (typeof normalizedOrg !== 'string') return true;
+	const value = normalizedOrg.trim().toLowerCase().replace(/\s+/g, ' ');
+	if (GENERIC_REGISTRANT_ORG_VALUES.has(value)) return true;
+	return REDACTED_REGISTRANT_ORG_TOKENS.some((token) => value.includes(token));
+}
+
 /** Extract country from a vCard adr property. */
 function extractVcardCountry(entity: RdapEntity): string | null {
 	if (!entity.vcardArray || entity.vcardArray[0] !== 'vcard') return null;
@@ -410,9 +497,7 @@ function parseRetryAfterMs(value: string | null, remainingBudgetMs?: number): nu
 	if (typeof remainingBudgetMs === 'number' && remainingBudgetMs <= 0) return 0;
 
 	const ceiling =
-		typeof remainingBudgetMs === 'number'
-			? Math.max(0, Math.min(RDAP_RETRY_MAX_DELAY_MS, remainingBudgetMs))
-			: RDAP_RETRY_MAX_DELAY_MS;
+		typeof remainingBudgetMs === 'number' ? Math.max(0, Math.min(RDAP_RETRY_MAX_DELAY_MS, remainingBudgetMs)) : RDAP_RETRY_MAX_DELAY_MS;
 
 	if (!value) return Math.min(RDAP_RETRY_DEFAULT_DELAY_MS, ceiling);
 	const seconds = Number(value);
@@ -697,8 +782,7 @@ export interface RdapCheckOptions {
  * (the fetch returns immediately, the caller handles it as `caller_aborted`).
  */
 function composeFetchSignal(callerSignal: AbortSignal | undefined, remainingBudgetMs?: number): AbortSignal {
-	const perRequestMs =
-		typeof remainingBudgetMs === 'number' ? Math.max(0, Math.min(RDAP_TIMEOUT_MS, remainingBudgetMs)) : RDAP_TIMEOUT_MS;
+	const perRequestMs = typeof remainingBudgetMs === 'number' ? Math.max(0, Math.min(RDAP_TIMEOUT_MS, remainingBudgetMs)) : RDAP_TIMEOUT_MS;
 	const timeoutSignal = AbortSignal.timeout(perRequestMs);
 	if (!callerSignal) return timeoutSignal;
 	return AbortSignal.any([timeoutSignal, callerSignal]);

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -19,6 +19,14 @@ import {
 	type RegistrationEvidence,
 	type UnknownReason,
 } from '../lib/registration-state';
+import {
+	attributionConfidence,
+	capAttributionSeverity,
+	classifyOwnership,
+	MIN_ATTRIBUTION_LABEL_LENGTH,
+	type OwnershipAssessment,
+} from '../lib/ownership-attribution';
+import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 
 /** Wall-clock timeout for the entire shadow domain check (ms). */
 const SHADOW_TIMEOUT_MS = 20_000;
@@ -232,18 +240,6 @@ function isSameMxInfra(variantMx: string[], primaryMx: string[]): boolean {
 }
 
 /**
- * Check whether a variant's NS records overlap with the primary domain's NS records.
- * Compares normalized (lowercased, trailing-dot-stripped) nameserver hostnames.
- * Returns true when at least 2 nameservers are shared (typical NS pair).
- */
-function sharesNsWithPrimary(variantNs: string[], primaryNs: string[]): boolean {
-	if (variantNs.length === 0 || primaryNs.length === 0) return false;
-	const primarySet = new Set(primaryNs.map((n) => n.toLowerCase().replace(/\.$/, '')));
-	const shared = variantNs.filter((n) => primarySet.has(n.toLowerCase().replace(/\.$/, '')));
-	return shared.length >= 2;
-}
-
-/**
  * RFC 7505 null MX detection. After `queryMxRecords`'s trailing-dot strip, the canonical
  * null-MX target (`MX 0 .`) appears as an empty exchange; the older `MX 0 localhost.`
  * convention used by some operators for the same intent appears as `'localhost'`. Both
@@ -274,17 +270,40 @@ export function canClaimUnregistered(observed: { ns: string[]; mx: string[]; has
 
 /**
  * Classify a probed variant into a finding based on risk.
- * When the variant shares nameservers with the primary domain (indicating common ownership),
- * email-auth findings are downgraded one severity level.
+ * When the variant is owned by the seed organisation, email-auth findings are
+ * downgraded one severity level (it is the customer's own domain to fix, not a
+ * hostile shadow).
+ *
+ * D4 (2026-07-26 correctness-defects design §5) — same-owner detection is
+ * driven by `classifyOwnership()`'s structural verdict, replacing the naive
+ * `sharesNsWithPrimary()` >=2-shared-hostname set-overlap heuristic. That
+ * heuristic was actively dangerous on shared-NS providers (§3.3): two unrelated
+ * banks pooled onto Akamai could reach its threshold by luck and have a genuine
+ * third party's finding softened, while a customer's own domain delegated
+ * in-bailiwick (`ns1.<seed>`) scored zero overlap and was reported to them as a
+ * hostile CRITICAL. The severity CEILING is applied separately, by
+ * {@link applyOwnershipGate}; this function only computes the unclamped ladder.
  */
-function classifyVariant(probe: VariantProbeResult, primaryMx: string[], primaryNs: string[]): Finding {
+function classifyVariant(probe: VariantProbeResult, primaryMx: string[], ownership: OwnershipAssessment): Finding {
 	const { variant, ns, mx, hasSpf, dmarcPolicy } = probe;
 	const hasNullMxOnly = mx.length > 0 && mx.every(isNullMxExchange);
 	const hasMx = mx.length > 0 && !hasNullMxOnly;
 	const hasNs = ns.length > 0;
-	const sameOwner = sharesNsWithPrimary(ns, primaryNs);
-	const meta = { variant, ns, mx, hasSpf, dmarcPolicy };
-	const ownerNote = ' Likely same owner based on shared nameservers — still recommended to add DMARC.';
+	const sameOwner = ownership.verdict === 'owned_by_seed';
+	// The verdict travels on EVERY classified finding, owned or not, so the
+	// structured payload carries the same attribution the prose does.
+	const meta = {
+		variant,
+		ns,
+		mx,
+		hasSpf,
+		dmarcPolicy,
+		ownershipVerdict: ownership.verdict,
+		ownershipRationale: ownership.rationale,
+	};
+	// States the evidence that actually produced the verdict rather than a fixed
+	// "shared nameservers" sentence, which is wrong for the in-bailiwick case.
+	const ownerNote = ` Likely same owner (${ownership.rationale}) — still recommended to add DMARC.`;
 
 	// RFC 7505 explicit non-mail posture — the domain is doing the right thing for a
 	// non-mail name. Don't pretend it's spoofable.
@@ -336,7 +355,9 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], primary
 		if (dmarcPolicy === 'quarantine' || dmarcPolicy === 'reject') {
 			if (!isSameMxInfra(mx, primaryMx)) {
 				// Divergent MX infrastructure → medium
-				const divergentNote = sameOwner ? ` Shared nameservers suggest common ownership despite different mail servers.` : '';
+				const divergentNote = sameOwner
+					? ` Nameserver evidence indicates common ownership (${ownership.rationale}) despite the different mail servers.`
+					: '';
 				return createFinding(
 					'shadow_domains',
 					'Shadow domain divergent mail infrastructure',
@@ -413,6 +434,92 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], primary
 			: `${variant} is registered but no nameserver, mail or SPF records were observed during this scan.`,
 		{ ...meta, registrationState: 'registered', confidence: 'heuristic' },
 	);
+}
+
+/**
+ * D4 severity ceiling. `owned_by_seed` findings pass through untouched —
+ * `classifyVariant`'s ladder already applies to a domain the customer controls.
+ * Every other verdict is clamped to `info` with wording that never implies the
+ * scanned organisation controls the domain or owes it any action.
+ *
+ * DEMOTE, NEVER DELETE (binding ruling): this returns a `Finding`, never
+ * `null`/`undefined`. A real measurement is never suppressed — an unrelated
+ * organisation's domain is still reported, just neutrally and at `info`.
+ * `attributionConfidence()` is consulted for WORDING ONLY; it can never move
+ * the ceiling, which `capAttributionSeverity()` derives from the verdict alone.
+ *
+ * Findings whose unclamped severity is above `info` carry the risk-ladder prose
+ * ("Shadow domain fully spoofable", "well-managed"), which reads as a statement
+ * about a domain the customer owns — title AND detail are replaced. The
+ * `info`-level titles are already bare registration observations, so they keep
+ * their wording and merely gain the attribution sentence.
+ */
+function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, brand: string, corroborated: boolean): Finding {
+	const ceiling = capAttributionSeverity(ownership.verdict);
+	if (ceiling === 'unbounded') return finding;
+
+	const confidence = attributionConfidence(ownership.verdict, brand, corroborated);
+	const variant = typeof finding.metadata?.variant === 'string' ? finding.metadata.variant : 'This domain';
+	const metadata = {
+		...finding.metadata,
+		ownershipVerdict: ownership.verdict,
+		ownershipRationale: ownership.rationale,
+		attributionConfidence: confidence,
+		severityCappedBy: 'ownership_attribution',
+	};
+
+	if (finding.severity === 'info') {
+		return createFinding('shadow_domains', finding.title, ceiling, `${finding.detail} ${ownership.rationale}`, metadata);
+	}
+
+	const relation =
+		ownership.verdict === 'third_party'
+			? 'is registered to a different organisation'
+			: 'could not be attributed to the scanned organisation';
+	const hedge =
+		confidence === 'uncorroborated'
+			? ` The shared label is under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters and nothing else corroborates a link, so the name similarity alone means little.`
+			: '';
+	return createFinding(
+		'shadow_domains',
+		`Unrelated domain, confusable label: ${variant}`,
+		ceiling,
+		`${variant} shares the "${brand}" label with the scanned domain but ${relation}. ${ownership.rationale} Its mail posture is reported for awareness only: no action by the scanned organisation is implied, and this finding asserts no control over ${variant}.${hedge}`,
+		metadata,
+	);
+}
+
+/**
+ * Assess ownership for one probed variant and emit its GATED finding.
+ *
+ * The single chokepoint through which every `classifyVariant` result reaches
+ * `findings` — used by BOTH emission sites (the unknown-bucket re-probe and the
+ * Phase-2 completed-probe loop). Wiring the gate at only one of them left the
+ * other emitting ungated `critical`/`high` findings with no ownership verdict
+ * at all, so the decision is centralised here rather than duplicated per site.
+ *
+ * `classifyOwnership()` is pure and does no DNS I/O: it is fed from what the
+ * probe already resolved.
+ */
+function classifyAndGate(probe: VariantProbeResult, seedDomain: string, seedNs: string[], primaryMx: string[], brand: string): Finding {
+	// Evidence is recorded for honesty only — `classifyOwnership()` reads
+	// `state` and `ns`. A probe proven registered by MX/SPF alone legitimately
+	// contributes no NS/SOA/A evidence.
+	const evidence: RegistrationEvidence[] = [];
+	if (probe.ns.length > 0) evidence.push('ns');
+	if (probe.hasA) evidence.push('a');
+
+	const ownership = classifyOwnership({
+		seedDomain,
+		seedNs,
+		candidateDomain: probe.variant,
+		registration: { state: 'registered', ns: probe.ns, evidence },
+		isSharedNsHost,
+	});
+
+	// Shared mail infrastructure with the primary is the one corroborating
+	// signal available here (neither cert SANs nor page content are fetched).
+	return applyOwnershipGate(classifyVariant(probe, primaryMx, ownership), ownership, brand, isSameMxInfra(probe.mx, primaryMx));
 }
 
 /**
@@ -678,7 +785,10 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 				// in Phase 1 by `resolveRegistration`, remains the sole path to an
 				// "unregistered" claim.
 				const hasEvidence = probe.ns.length > 0 || probe.hasA || probe.mx.length > 0 || probe.hasSpf || probe.dmarcPolicy !== null;
-				if (hasEvidence) findings.push(classifyVariant(probe, primaryMx, primaryNs));
+				//
+				// CALL SITE 1 of 2 for `classifyAndGate` — this path is as capable of
+				// emitting a `critical` as Phase 2 is, so it is gated identically.
+				if (hasEvidence) findings.push(classifyAndGate(probe, domain, primaryNs, primaryMx, brand));
 				else pushUnknownFinding(variant, reason, probe);
 			}
 
@@ -754,9 +864,10 @@ export async function checkShadowDomains(domain: string, dnsOptions?: QueryDnsOp
 		cursor += size;
 	}
 
-	// Classify each completed probe
+	// Classify each completed probe.
+	// CALL SITE 2 of 2 for `classifyAndGate`.
 	for (const probe of completedProbes) {
-		findings.push(classifyVariant(probe, primaryMx, primaryNs));
+		findings.push(classifyAndGate(probe, domain, primaryNs, primaryMx, brand));
 	}
 
 	// Detect shared NS pairs

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -231,9 +231,19 @@ async function bucketVariantsByRegistration(
 
 /**
  * Check whether the variant MX set is a subset of the primary MX set.
- * Compares sorted exchange hostnames (case-insensitive).
+ * Compares exchange hostnames case-insensitively, tolerating a trailing root
+ * dot on either side.
+ *
+ * EXPORTED FOR TEST (fix round 1, F3): the trailing-dot normalisation is
+ * unobservable through `checkShadowDomains`, because `queryMxRecords` already
+ * strips the root dot before either side reaches here — deleting both
+ * `.replace(/\.$/, '')` calls leaves every integration test green. The
+ * normalisation is still a real part of this predicate's contract for any
+ * caller that passes unnormalised hostnames, so it is pinned by a direct unit
+ * test instead of by an integration test that cannot see it. Mirrors the
+ * existing `canClaimUnregistered` export precedent below.
  */
-function isSameMxInfra(variantMx: string[], primaryMx: string[]): boolean {
+export function isSameMxInfra(variantMx: string[], primaryMx: string[]): boolean {
 	if (variantMx.length === 0) return false;
 	const primarySet = new Set(primaryMx.map((h) => h.toLowerCase().replace(/\.$/, '')));
 	return variantMx.every((h) => primarySet.has(h.toLowerCase().replace(/\.$/, '')));
@@ -318,34 +328,45 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], ownersh
 	}
 
 	if (hasMx) {
+		// LADDER ARMS ARE OWNED-ONLY BY CONSTRUCTION (fix round 1, F2). Each rung
+		// below used to read `sameOwner ? X : Y`, where the `Y` (non-owned) arm
+		// carried the harsher severity — `'critical'` on the rung immediately
+		// below. Those arms are now UNREACHABLE in output: `sameOwner` is exactly
+		// `verdict === 'owned_by_seed'`, so `Y` is only ever computed for a finding
+		// `applyOwnershipGate()` immediately clamps to `info` and re-words. Leaving
+		// a live `'critical'` literal here was a latent trap — any future
+		// relaxation of the gate would silently resurrect a critical
+		// shadow-domain finding about a third party's mail hygiene. The arms are
+		// collapsed to the owned-domain severity so the dead arm cannot be reached
+		// by construction; the rung itself is still named by the finding title.
 		if (!hasSpf && dmarcPolicy === null) {
-			// MX present, no SPF AND no DMARC → critical (or high if same owner)
+			// MX present, no SPF AND no DMARC → the top rung, on the seed's own domain.
 			return createFinding(
 				'shadow_domains',
 				'Shadow domain fully spoofable',
-				sameOwner ? 'high' : 'critical',
+				'high',
 				`${variant} has mail servers but no SPF or DMARC records. Any sender can forge email from this domain.${sameOwner ? ownerNote : ''}`,
 				meta,
 			);
 		}
 
 		if (hasSpf && dmarcPolicy === null) {
-			// MX present, SPF but no DMARC → high (or medium if same owner)
+			// MX present, SPF but no DMARC.
 			return createFinding(
 				'shadow_domains',
 				'Shadow domain lacks DMARC',
-				sameOwner ? 'medium' : 'high',
+				'medium',
 				`${variant} has mail servers and SPF but no DMARC record. Without DMARC, SPF alone cannot prevent spoofing.${sameOwner ? ownerNote : ''}`,
 				meta,
 			);
 		}
 
 		if (dmarcPolicy === 'none') {
-			// MX present, DMARC p=none → high (or medium if same owner)
+			// MX present, DMARC p=none.
 			return createFinding(
 				'shadow_domains',
 				'Shadow domain DMARC not enforcing',
-				sameOwner ? 'medium' : 'high',
+				'medium',
 				`${variant} has mail servers with DMARC policy set to "none" — spoofed emails are monitored but not blocked.${sameOwner ? ownerNote.replace('add DMARC', 'enforce DMARC') : ''}`,
 				meta,
 			);
@@ -437,6 +458,34 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], ownersh
 }
 
 /**
+ * Neutral replacements for the `info`-severity titles that use ownership
+ * framing. "Shadow domain" is a possessive noun phrase: it files the name into
+ * the SCANNED organisation's inventory. Applied only to non-owned candidates —
+ * an `owned_by_seed` variant genuinely IS a shadow domain of the seed and keeps
+ * the original wording.
+ */
+const NEUTRAL_INFO_TITLES: Record<string, string> = {
+	'Shadow domain explicit non-mail (RFC 7505)': 'Confusable domain declares no mail (RFC 7505)',
+	'Shadow domain registered, no mail': 'Confusable domain registered, no mail',
+};
+
+/**
+ * KNOWN RESIDUAL, verified by execution (not by reading): the third
+ * ownership-framed `info` title, `'Shadow domain registered, records not
+ * observed'` (the Phase-2 fallthrough), is NOT in the map above because
+ * `test/audits/registration-invariant.audit.test.ts:163` filters
+ * `result.findings` on that exact title literal, and that audit is a slice-3
+ * safety net that may not be edited from here. Adding the entry was tried and
+ * fails it with `expected 0 to be greater than 0`. The clean fix belongs in a
+ * task permitted to touch the audit: re-pin its assertion on
+ * `metadata.registrationState === 'registered'` + `confidence === 'heuristic'`
+ * instead of the title string, then add the third entry here. Tracked by
+ * {@link AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE}, which the D4 title-framing
+ * guard carves out explicitly rather than silently.
+ */
+export const AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE = 'Shadow domain registered, records not observed';
+
+/**
  * D4 severity ceiling. `owned_by_seed` findings pass through untouched —
  * `classifyVariant`'s ladder already applies to a domain the customer controls.
  * Every other verdict is clamped to `info` with wording that never implies the
@@ -448,11 +497,19 @@ function classifyVariant(probe: VariantProbeResult, primaryMx: string[], ownersh
  * `attributionConfidence()` is consulted for WORDING ONLY; it can never move
  * the ceiling, which `capAttributionSeverity()` derives from the verdict alone.
  *
- * Findings whose unclamped severity is above `info` carry the risk-ladder prose
- * ("Shadow domain fully spoofable", "well-managed"), which reads as a statement
- * about a domain the customer owns — title AND detail are replaced. The
- * `info`-level titles are already bare registration observations, so they keep
- * their wording and merely gain the attribution sentence.
+ * WORDING, not just severity. "Shadow domain X" files a name into the
+ * CUSTOMER's inventory; on a domain that is demonstrably not theirs, that is
+ * the same false attribution the severity cap exists to prevent, just spelled
+ * in the title. So:
+ *   - above `info`: the risk-ladder title AND detail are replaced outright —
+ *     they assert a spoofing posture the customer supposedly owns and owes
+ *     action on;
+ *   - at `info`: the detail is a bare observation and is kept (plus the
+ *     attribution sentence), but the TITLE is still remapped through
+ *     {@link NEUTRAL_INFO_TITLES} when it uses ownership framing. An earlier
+ *     revision claimed info-level titles "are already bare registration
+ *     observations"; that was false — two of the three begin with the
+ *     ownership noun.
  */
 function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, brand: string, corroborated: boolean): Finding {
 	const ceiling = capAttributionSeverity(ownership.verdict);
@@ -469,7 +526,13 @@ function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, br
 	};
 
 	if (finding.severity === 'info') {
-		return createFinding('shadow_domains', finding.title, ceiling, `${finding.detail} ${ownership.rationale}`, metadata);
+		return createFinding(
+			'shadow_domains',
+			NEUTRAL_INFO_TITLES[finding.title] ?? finding.title,
+			ceiling,
+			`${finding.detail} ${ownership.rationale}`,
+			metadata,
+		);
 	}
 
 	const relation =

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -21,9 +21,10 @@ import {
 } from '../lib/registration-state';
 import {
 	attributionConfidence,
+	buildNonOwnedGateFinding,
+	buildOwnershipGateMetadata,
 	capAttributionSeverity,
 	classifyOwnership,
-	MIN_ATTRIBUTION_LABEL_LENGTH,
 	type OwnershipAssessment,
 } from '../lib/ownership-attribution';
 import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
@@ -510,46 +511,40 @@ export const AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE = 'Shadow domain registered, re
  *     revision claimed info-level titles "are already bare registration
  *     observations"; that was false — two of the three begin with the
  *     ownership noun.
+ *
+ * The neutral-wording sentence and metadata shape for the ABOVE-`info` case
+ * live in `buildNonOwnedGateFinding()` (`src/lib/ownership-attribution.ts`),
+ * shared with `check-lookalikes.ts` (fix round 2, F1) — the two tools had
+ * already drifted apart within this slice ("Its mail posture" + quoted
+ * `"${brand}"` here vs "Its DNS/mail posture" + no brand quote there) before
+ * this was noticed. The `'info'`-severity branch below stays LOCAL to this
+ * file per the fix-round instruction — `check-lookalikes.ts` never reaches
+ * it (`calibrateLookalikeSeverity()` never returns `'info'`), so there is no
+ * shared behaviour to extract there, only the four-field metadata shape
+ * (`buildOwnershipGateMetadata()`).
  */
 function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, brand: string, corroborated: boolean): Finding {
 	const ceiling = capAttributionSeverity(ownership.verdict);
 	if (ceiling === 'unbounded') return finding;
 
-	const confidence = attributionConfidence(ownership.verdict, brand, corroborated);
-	const variant = typeof finding.metadata?.variant === 'string' ? finding.metadata.variant : 'This domain';
-	const metadata = {
-		...finding.metadata,
-		ownershipVerdict: ownership.verdict,
-		ownershipRationale: ownership.rationale,
-		attributionConfidence: confidence,
-		severityCappedBy: 'ownership_attribution',
-	};
-
 	if (finding.severity === 'info') {
+		const confidence = attributionConfidence(ownership.verdict, brand, corroborated);
 		return createFinding(
 			'shadow_domains',
 			NEUTRAL_INFO_TITLES[finding.title] ?? finding.title,
 			ceiling,
 			`${finding.detail} ${ownership.rationale}`,
-			metadata,
+			buildOwnershipGateMetadata(finding, ownership, confidence),
 		);
 	}
 
-	const relation =
-		ownership.verdict === 'third_party'
-			? 'is registered to a different organisation'
-			: 'could not be attributed to the scanned organisation';
-	const hedge =
-		confidence === 'uncorroborated'
-			? ` The shared label is under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters and nothing else corroborates a link, so the name similarity alone means little.`
-			: '';
-	return createFinding(
-		'shadow_domains',
-		`Unrelated domain, confusable label: ${variant}`,
-		ceiling,
-		`${variant} shares the "${brand}" label with the scanned domain but ${relation}. ${ownership.rationale} Its mail posture is reported for awareness only: no action by the scanned organisation is implied, and this finding asserts no control over ${variant}.${hedge}`,
-		metadata,
-	);
+	// `postureNoun` MUST match `check-lookalikes.ts`'s value byte-for-byte
+	// (parity pinned by `test/ownership-attribution.spec.ts`).
+	return buildNonOwnedGateFinding(finding, ownership, brand, corroborated, ceiling, {
+		category: 'shadow_domains',
+		domainMetadataKey: 'variant',
+		postureNoun: 'DNS/mail posture',
+	});
 }
 
 /**

--- a/src/tools/check-spf.ts
+++ b/src/tools/check-spf.ts
@@ -9,6 +9,7 @@ import { checkSPF } from '@blackveil/dns-checks';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { buildDnsErrorResult } from '../lib/dns-error-result';
+import { isCompletedCheck } from '../lib/ungraded-display';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { analyzeTrustSurface, type TrustSurfaceContext } from './spf-trust-surface';
 
@@ -47,14 +48,10 @@ export async function checkSpf(domain: string, dnsOptions?: QueryDnsOptions): Pr
  * non-trust-surface finding are passed through unchanged — this only rewrites the
  * informational trust-surface findings. Fail-soft: any error returns `core` untouched.
  */
-async function augmentTrustSurface(
-	core: CheckResult,
-	domain: string,
-	dnsOptions?: QueryDnsOptions,
-): Promise<CheckResult> {
+async function augmentTrustSurface(core: CheckResult, domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
 	try {
 		// A failed/transient check has unreliable findings — never post-process it.
-		if (core.checkStatus === 'error' || core.checkStatus === 'timeout') {
+		if (!isCompletedCheck(core)) {
 			return core;
 		}
 
@@ -77,9 +74,7 @@ async function augmentTrustSurface(
 			? {
 					corroboratedByWeakDmarc: ctxSource.dmarcCorroborated === true,
 					...(typeof ctxSource.dmarcPolicy === 'string' ? { dmarcPolicy: ctxSource.dmarcPolicy } : {}),
-					...(typeof ctxSource.dmarcAlignmentMode === 'string'
-						? { dmarcAlignmentMode: ctxSource.dmarcAlignmentMode }
-						: {}),
+					...(typeof ctxSource.dmarcAlignmentMode === 'string' ? { dmarcAlignmentMode: ctxSource.dmarcAlignmentMode } : {}),
 				}
 			: {};
 
@@ -94,9 +89,7 @@ async function augmentTrustSurface(
 		// worker analysis surfaced a real (non-info) trust finding, drop a now-stale
 		// "configured" finding so output stays self-consistent (does NOT affect score).
 		const hasNonInfoTrust = workerTrustFindings.some((f) => f.severity !== 'info');
-		const mergedNonTrust = hasNonInfoTrust
-			? nonTrustFindings.filter((f) => f.title !== 'SPF record configured')
-			: nonTrustFindings;
+		const mergedNonTrust = hasNonInfoTrust ? nonTrustFindings.filter((f) => f.title !== 'SPF record configured') : nonTrustFindings;
 
 		return { ...core, findings: [...mergedNonTrust, ...workerTrustFindings] };
 	} catch {

--- a/src/tools/discover-brand-domains.ts
+++ b/src/tools/discover-brand-domains.ts
@@ -68,6 +68,8 @@ import { checkLookalikes as defaultCheckLookalikes } from './check-lookalikes';
 import { clearsOwnershipGate, type BrandEvidenceObservation } from '../lib/brand-evidence';
 import { detectAppLinks } from '../tenants/discovery/app-links-detector';
 import { detectBountyScope, type BountyPlatform } from '../tenants/discovery/bounty-scope-detector';
+import { generateVariants } from './check-shadow-domains';
+import { extractBrandName, getEffectiveTld } from '../lib/public-suffix';
 import type { Tier0Result } from '../lib/brand-tier0-enterprise';
 import type { Tier1Result } from '../lib/brand-tier1-graph';
 import type { Tier2Result } from '../lib/brand-tier2-evidence';
@@ -229,6 +231,7 @@ export interface DiscoverBrandDomainsDeps {
 	generateMarkovLookalikes: typeof generateMarkovLookalikes;
 	checkLookalikes: typeof defaultCheckLookalikes;
 	domainLabelSimilarity: typeof defaultDomainLabelSimilarity;
+	generateVariants: typeof generateVariants;
 	createDnsContext?: typeof createDiscoveryDnsContext;
 	/** Tier 0 lookup (tenant-declared portfolio via bv-enterprise). Tiered mode only. */
 	tier0Lookup?: (domain: string) => Promise<Tier0Result>;
@@ -369,6 +372,7 @@ function defaultDeps(): DiscoverBrandDomainsDeps {
 		generateMarkovLookalikes: generateMarkovLookalikes,
 		checkLookalikes: defaultCheckLookalikes,
 		domainLabelSimilarity: defaultDomainLabelSimilarity,
+		generateVariants: generateVariants,
 	};
 }
 
@@ -1116,7 +1120,22 @@ export async function discoverBrandDomains(
 		jobs.push({
 			name: 'ns',
 			run: async () => {
-				const nsCandidates = recordCandidateSignalProbes('ns', candidatesForSignal('ns'));
+				// D6.2 (2026-07-26 correctness-defects design §3.4) — NS becomes a
+				// discovery signal, not only a confirmation signal. TLD variants of
+				// the seed's own brand (the same generator check_shadow_domains
+				// uses) are probed directly, additive to whatever candidates other
+				// signals already proposed — so this signal can find an owned
+				// domain no other signal happened to generate. Additive (unioned in
+				// after candidatesForSignal), so these precision candidates are
+				// never crowded out by planner caps competing with markov_gen noise
+				// (D6.4).
+				const brand = extractBrandName(seedDomain);
+				const effectiveTld = getEffectiveTld(seedDomain);
+				const tldVariantCandidates = brand && effectiveTld ? d.generateVariants(brand, effectiveTld, seedDomain) : [];
+				const nsCandidates = recordCandidateSignalProbes(
+					'ns',
+					Array.from(new Set([...candidatesForSignal('ns'), ...tldVariantCandidates])),
+				);
 				const out = await runTrackedSignal<NsCorrelationResult>(
 					'ns',
 					() => d.correlateNs(seedDomain, { candidateDomains: nsCandidates, dnsContext }),
@@ -1132,6 +1151,7 @@ export async function discoverBrandDomains(
 					addObservation(aggregator, c.domain, 'ns', c.confidence, {
 						sharedNs: c.sharedNs,
 						nsConfidence: c.confidence,
+						matchType: c.matchType,
 					});
 				}
 			},
@@ -1611,12 +1631,21 @@ export async function discoverBrandDomains(
 		tieredState.tier3Count = tier3Count;
 	}
 
+	// D6.5 (2026-07-26 correctness-defects design) — name every degraded signal
+	// in the human-readable summary text, so "1 candidate" is never read as
+	// "this brand owns exactly one other domain" when a precision signal
+	// (ns, http_redirect, ...) actually failed or ran out of budget.
+	const DEGRADED_STATUSES = new Set(['partial', 'budget_exceeded', 'timeout', 'failed']);
+	const degradedSignals = signals.filter((s) => DEGRADED_STATUSES.has(signalStatus[s]?.status ?? ''));
+	const degradedNote =
+		degradedSignals.length > 0 ? ` degraded=[${degradedSignals.map((s) => `${s}:${signalStatus[s]?.status}`).join(', ')}]` : '';
+
 	// Always emit a summary finding so the formatter has something to print.
 	const summary = createFinding(
 		'brand_discovery',
 		`Brand-domain discovery: ${candidateFindings.length} candidate(s) at confidence ≥ ${minConfidence}`,
 		'info',
-		`Seed=${seedDomain.trim().toLowerCase()} signals=[${signals.join(', ')}] aggregated_total=${aggregator.size} surfaced=${candidateFindings.length}`,
+		`Seed=${seedDomain.trim().toLowerCase()} signals=[${signals.join(', ')}] aggregated_total=${aggregator.size} surfaced=${candidateFindings.length}${degradedNote}`,
 		{
 			summary: true,
 			signals,

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -1026,7 +1026,7 @@ export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, forma
 		// comes back through the zero branch.
 		return result.stale
 			? `${staleBanner(result)}\n\nSubdomain Discovery: ${result.domain} — the cached enumeration contains no subdomains; this is NOT a confirmed empty result.`
-			: `Subdomain Discovery: ${result.domain} — no subdomains found in Certificate Transparency logs`;
+			: `Subdomain Discovery: ${result.domain} — no subdomains found in Certificate Transparency logs (unconfirmed: CT logs only capture certificate issuance, so this is not a verified absence)`;
 	}
 
 	const body = format === 'compact' ? formatCompact(result) : formatFull(result);

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -156,7 +156,7 @@ export interface DiscoveredSubdomain {
 
 /** An issue detected during subdomain discovery. */
 export interface SubdomainIssue {
-	type: 'expired_subdomain' | 'wildcard_exposure' | 'many_issuers' | 'recent_issuance' | 'shadow_subdomain';
+	type: 'expired_subdomain' | 'wildcard_exposure' | 'many_issuers' | 'recent_issuance' | 'shadow_subdomain' | 'unconfirmed_zero';
 	severity: 'high' | 'medium' | 'low' | 'info';
 	detail: string;
 }
@@ -622,22 +622,38 @@ function delayWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
 
 /**
  * Query the direct public CT sources with per-source health logging and deadline
- * gating. Stops at the FIRST source that responds authoritatively:
- *   - `ok`    → real data; return it.
- *   - `empty` → a genuine "no subdomains" answer; return available-but-empty.
+ * gating.
+ *
+ *   - `ok`    → real data; return it immediately (a later empty answer never
+ *               overrides real data already in hand).
+ *   - `empty` → NOT authoritative on its own. crt.sh (or Certspotter) can be
+ *               behind on indexing a domain even when it is up, so a single
+ *               source's "nothing here" is corroborated by trying the next
+ *               source before it is trusted — an uncorroborated single-source
+ *               empty is exactly the success-shaped-zero this tool must not
+ *               produce. Only once a full pass over every source completes
+ *               without any `ok` do we report `available:true` with an empty
+ *               set (the caller routes this through `emptyResult()`, which
+ *               always carries the `unconfirmed_zero` issue regardless of how
+ *               many sources agreed — CT-log absence is never positive proof).
  *
  * Ordering is **failover-first, retry-second**: pass 1 tries every source once
  * (crt.sh → Certspotter) before any source is retried. Re-asking a source that
  * just timed out is the worst use of a tight budget — it costs another full
- * timeout and delays the source that would actually rescue the caller. Only when
- * every source has failed and budget remains do we spend it on a retry pass.
+ * timeout and delays the source that would actually rescue the caller. A pass
+ * that ends with at least one authoritative `empty` and no `ok` stops there
+ * (that is real information, not a gap to paper over with a retry pass); a
+ * pass that ends with ONLY failures (http_error / timeout / error — no source
+ * answered at all) spends a retry pass chasing what is presumed transient.
  *
- * `available:false` means every source failed — the caller then decides between
- * last-known-good and an explicit outage error.
+ * `available:false` means no source ever answered authoritatively — the
+ * caller then decides between last-known-good and an explicit outage error.
  *
- * NOTE: sequential first-authoritative-wins, not a fan-out+merge. Under the ~24s
- * synchronous budget, querying every source to merge results would blow the
- * deadline; failing over to the first responder is what the budget allows.
+ * NOTE: sequential first-authoritative-wins on `ok`, not a fan-out+merge.
+ * Under the ~24s synchronous budget, querying every source to merge results
+ * on every call would blow the deadline; failing over to the first
+ * `ok` responder is what the budget allows. `empty` is the one outcome that
+ * deliberately keeps trying rather than winning immediately.
  */
 async function queryDirectSources(
 	domain: string,
@@ -651,15 +667,24 @@ async function queryDirectSources(
 		{ name: 'certspotter', timeoutMs: CERTSPOTTER_TIMEOUT_MS, fetch: fetchCertspotterEntries },
 	];
 
+	// True once ANY source has returned an authoritative "no subdomains"
+	// answer. Tracked across sources (and, if reached, retry passes) so a
+	// first-source empty is never reported until at least one other source
+	// has had a chance to corroborate it or supersede it with real data.
+	let sawEmpty = false;
+
 	for (let pass = 0; pass <= CT_SOURCE_MAX_RETRIES; pass++) {
 		// Backoff applies BETWEEN passes, not between sources — failover should be
 		// immediate, only a repeat attempt at the same source needs to back off.
 		if (pass > 0) await delayWithSignal(CT_SOURCE_RETRY_BACKOFF_MS, options?.signal);
 
 		for (const source of sources) {
-			// Never start an attempt we can't finish inside the budget.
+			// Never start an attempt we can't finish inside the budget. An empty
+			// answer already gathered from an earlier source in this loop is real
+			// information — surface it rather than downgrading to a bare outage
+			// just because we ran out of budget to corroborate further.
 			if (deadlineExceeded(options) || !hasBudgetFor(options, source.timeoutMs)) {
-				return { available: false, entries: [] };
+				return sawEmpty ? { available: true, entries: [] } : { available: false, entries: [] };
 			}
 			const composed = composeAbortSignal(source.timeoutMs, options?.signal);
 			let res: SourceResult;
@@ -670,8 +695,16 @@ async function queryDirectSources(
 			}
 			logCtSource(domain, source.name, res.outcome);
 			if (res.outcome === 'ok') return { available: true, entries: res.entries };
-			if (res.outcome === 'empty') return { available: true, entries: [] };
+			if (res.outcome === 'empty') sawEmpty = true;
+			// empty / http_error / timeout / error all fall through to try the
+			// next source instead of short-circuiting.
 		}
+
+		// A full pass completed without any source returning real data. An
+		// authoritative empty from at least one source is a real (if
+		// unconfirmed) answer — report it rather than burning a retry pass
+		// chasing a source that merely failed to respond.
+		if (sawEmpty) return { available: true, entries: [] };
 	}
 	return { available: false, entries: [] };
 }
@@ -737,6 +770,16 @@ async function readLastKnownGood(domain: string, options?: DiscoverSubdomainsOpt
  * check the optional deadline; if tripped, we either return the enumerate
  * result tagged `partial:true` (when it had data) or signal the orchestrator
  * to skip remaining stages by returning a partial empty result.
+ *
+ * `timedOut` handling (mirrors `attemptCertstreamSans` in
+ * `src/tenants/discovery/san-correlator.ts`): the worker itself hit ITS
+ * upstream timeout mid-query. A `timedOut:true` response with data is a real,
+ * if incomplete, measurement — returned marked `partial:true` rather than
+ * discarded. A `timedOut:true` response with NO data carries no signal at
+ * all (we don't know whether there truly are zero subdomains, or whether the
+ * timeout hit before anything could be found) — that is treated like a
+ * failure so the caller falls through to the next stage instead of accepting
+ * an incomplete measurement as a confident zero.
  */
 async function queryCertstream(
 	domain: string,
@@ -748,12 +791,24 @@ async function queryCertstream(
 		return emptyResult(domain, true, true);
 	}
 
-	const enumerate = await queryCertstreamEndpoint<CertstreamEnumerateResponse>('enumerate', domain, certstream, certstreamAuthToken, options);
-	const enumerateResult =
-		enumerate && !enumerate.error && Array.isArray(enumerate.subdomains)
-			? buildCertstreamResult(domain, enumerate.subdomains, enumerate.certificateCount)
-			: null;
-	if (enumerateResult) return enumerateResult;
+	const enumerate = await queryCertstreamEndpoint<CertstreamEnumerateResponse>(
+		'enumerate',
+		domain,
+		certstream,
+		certstreamAuthToken,
+		options,
+	);
+	const enumerateOk = Boolean(enumerate) && !enumerate?.error && Array.isArray(enumerate?.subdomains);
+	if (enumerateOk && enumerate) {
+		if (!enumerate.timedOut) {
+			return buildCertstreamResult(domain, enumerate.subdomains, enumerate.certificateCount);
+		}
+		if (enumerate.subdomains.length > 0) {
+			return { ...buildCertstreamResult(domain, enumerate.subdomains, enumerate.certificateCount), partial: true };
+		}
+		// timedOut:true with an empty list — fall through to /sans below rather
+		// than accepting an incomplete measurement as a confident zero.
+	}
 
 	// Deadline gate: if we already burned the budget on /enumerate, skip /sans
 	// and let the orchestrator decide whether to fall through to crt.sh.
@@ -762,7 +817,18 @@ async function queryCertstream(
 	}
 
 	const sans = await queryCertstreamEndpoint<CertstreamSansResponse>('sans', domain, certstream, certstreamAuthToken, options);
-	return sans && !sans.error && Array.isArray(sans.names) ? buildCertstreamResult(domain, sans.names, sans.certificateCount) : null;
+	const sansOk = Boolean(sans) && !sans?.error && Array.isArray(sans?.names);
+	if (!sansOk || !sans) return null;
+	if (!sans.timedOut) {
+		return buildCertstreamResult(domain, sans.names, sans.certificateCount);
+	}
+	if (sans.names.length > 0) {
+		return { ...buildCertstreamResult(domain, sans.names, sans.certificateCount), partial: true };
+	}
+	// timedOut:true with an empty list — return null so the orchestrator falls
+	// through to the direct public sources (crt.sh → Certspotter) instead of
+	// treating this as a confident zero.
+	return null;
 }
 
 async function queryCertstreamEndpoint<T>(
@@ -915,6 +981,16 @@ function buildCertstreamResult(domain: string, names: string[], certificateCount
  * Build an empty result. `sourceUnavailable` distinguishes a CT lookup failure
  * (crt.sh non-OK / network error) from a successful query that found nothing.
  * `partial` indicates the deadline tripped before a stage could run.
+ *
+ * Every call carries a `high`-severity `unconfirmed_zero` issue: `isError`
+ * (set by the handler for `sourceUnavailable`) is dropped by structured
+ * consumers that read `issues[]` directly, so a bare `totalSubdomains: 0` +
+ * `issues: []` reads as a confidently-verified absence of subdomains — the
+ * success-shaped-zero this tool must never produce. CT logs are indirect
+ * evidence at best (a subdomain with no certificate never appears in them),
+ * so even a query that ran to completion cannot *positively* confirm zero
+ * subdomains — it can only report that no certificate-issuance evidence was
+ * found.
  */
 function emptyResult(domain: string, sourceUnavailable = false, partial = false): SubdomainDiscoveryResult {
 	return {
@@ -925,7 +1001,15 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false)
 		wildcardCerts: 0,
 		expiredCerts: 0,
 		uniqueIssuers: [],
-		issues: [],
+		issues: [
+			{
+				type: 'unconfirmed_zero',
+				severity: 'high',
+				detail: sourceUnavailable
+					? `Certificate Transparency enumeration for ${domain} did not complete — this zero-subdomain result reflects a lookup failure, not a confirmed absence of subdomains.`
+					: `No Certificate Transparency source has positively confirmed ${domain} has zero subdomains — CT logs only capture certificate issuance, so this is an unconfirmed measurement, not a verified absence.`,
+			},
+		],
 		sourceUnavailable,
 		...(partial ? { partial: true } : {}),
 	};
@@ -946,14 +1030,29 @@ export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, forma
 	}
 
 	const body = format === 'compact' ? formatCompact(result) : formatFull(result);
-	return result.stale ? `${staleBanner(result)}\n\n${body}` : body;
+	const banners: string[] = [];
+	if (result.stale) banners.push(staleBanner(result));
+	// Distinct from `stale` (served from the last-known-good cache): `partial`
+	// here means a live source answered but timed out mid-query, so the data
+	// shown is real but the enumeration may be incomplete. Skip when `stale`
+	// already fired for this result — the stale banner already says the data
+	// may not be current, and the two flags are not expected to co-occur from
+	// the paths that set `partial:true` with real subdomain data.
+	if (result.partial && !result.stale) banners.push(partialBanner());
+	return banners.length > 0 ? `${banners.join('\n\n')}\n\n${body}` : body;
 }
 
 /** Staleness notice prepended when a result came from the last-known-good cache. */
 function staleBanner(result: SubdomainDiscoveryResult): string {
 	const age = result.cacheAgeMinutes ?? 0;
-	const ageText = age < 60 ? `${age} minute${age === 1 ? '' : 's'}` : `${Math.floor(age / 60)} hour${Math.floor(age / 60) === 1 ? '' : 's'}`;
+	const ageText =
+		age < 60 ? `${age} minute${age === 1 ? '' : 's'}` : `${Math.floor(age / 60)} hour${Math.floor(age / 60) === 1 ? '' : 's'}`;
 	return `⚠️ STALE RESULT (cached ${ageText} ago): every live Certificate Transparency source is currently unreachable, so this is the last known good enumeration — not a fresh one. Newly-issued certificates may be missing.`;
+}
+
+/** Partial notice prepended when a live source answered but timed out mid-query. */
+function partialBanner(): string {
+	return `⚠️ PARTIAL RESULT: the Certificate Transparency source timed out before finishing this enumeration — the subdomains below are real, but there may be more that were not found in time.`;
 }
 
 /** Compact format: concise one-line-per-subdomain output. */

--- a/src/tools/generate-fix-plan.ts
+++ b/src/tools/generate-fix-plan.ts
@@ -15,6 +15,7 @@ import { IMPORTANCE_WEIGHTS, isGraded } from '@blackveil/dns-checks/scoring';
 import { scanDomain } from './scan-domain';
 import type { ScanRuntimeOptions } from './scan/post-processing';
 import { formatScoreGrade, hasCompletedEvidence, UNGRADED_DISPLAY } from '../lib/ungraded-display';
+import { isDnsErrorFinding } from '../lib/dns-error-result';
 
 /** A single remediation action in a fix plan. */
 export interface FixAction {
@@ -52,6 +53,17 @@ export interface FixPlanResult {
 	assessed: boolean;
 	/** Populated only when `assessed` is false; `null` otherwise. */
 	caveat: string | null;
+	/**
+	 * Categories whose OWN check failed transiently (`checkStatus: 'error' |
+	 * 'timeout'`) and were therefore excluded from `actions` — filtering out a
+	 * transient error's synthetic "check error" finding must not silently read
+	 * as "nothing to fix" for that category (that is a fabricated clean bill of
+	 * health, not a real one). `[]` when nothing was excluded this way, INCLUDING
+	 * the whole-scan-unassessed case (`assessed: false`) — that failure mode is
+	 * already fully covered by `caveat`, so listing every category here too would
+	 * duplicate the same fact in two places with two different wordings.
+	 */
+	transientCategories: CheckCategory[];
 }
 
 /**
@@ -148,16 +160,17 @@ function findingToAction(finding: Finding): string {
 }
 
 /**
- * Generate a prioritized fix plan for a domain.
- *
- * @param domain - Validated, sanitized domain
- * @param kv - Optional KV namespace for caching
- * @param runtimeOptions - Scan runtime options
- * @returns Prioritized fix plan
+ * Evaluate a fix plan from check results (pure function).
+ * Exported for direct unit testing without needing to mock scanDomain.
+ * Modeled on `evaluateCompliance`/`evaluateCscProducts`.
  */
-export async function generateFixPlan(domain: string, kv?: KVNamespace, runtimeOptions?: ScanRuntimeOptions): Promise<FixPlanResult> {
-	const scanResult = await scanDomain(domain, kv, runtimeOptions);
-
+export function evaluateFixPlan(
+	checkResults: CheckResult[],
+	domain: string,
+	score: number | null,
+	grade: string | null,
+	maturityStage: number | null,
+): FixPlanResult {
 	// `isMeasured` (`checks.length > 0`) cannot tell "19 healthy checks" apart
 	// from "19 checks that all timed out" — both are truthy. A total
 	// DoH/network outage where every attempted check carries a transient
@@ -168,9 +181,17 @@ export async function generateFixPlan(domain: string, kv?: KVNamespace, runtimeO
 	// `hasCompletedEvidence` requires at least one check to have actually
 	// COMPLETED, so an all-transient outage abstains the same way a
 	// zero-check scan does.
-	const hasEvidence = hasCompletedEvidence(scanResult.checks);
+	const hasEvidence = hasCompletedEvidence(checkResults);
+	// Even when SOME categories completed (`hasEvidence: true`), an individual
+	// category's OWN check can still have failed transiently — its CheckResult
+	// carries only the synthetic "check error" finding `isDnsErrorFinding`
+	// marks (see `dns-error-result.ts`). That finding is the ABSENCE of a
+	// measurement, not a customer's real posture, so it must never become a
+	// remediation action ("Fix DMARC: DMARC check error — ..."). Filtering it
+	// out here — rather than dropping it silently — pairs with
+	// `transientCategories` below so the exclusion still reaches the customer.
 	const actionableFindings = hasEvidence
-		? scanResult.checks.flatMap((check: CheckResult) => check.findings).filter((f: Finding) => f.severity !== 'info')
+		? checkResults.flatMap((check: CheckResult) => check.findings).filter((f: Finding) => f.severity !== 'info' && !isDnsErrorFinding(f))
 		: [];
 
 	const actions: FixAction[] = actionableFindings.map((finding: Finding) => {
@@ -202,20 +223,60 @@ export async function generateFixPlan(domain: string, kv?: KVNamespace, runtimeO
 	const assessed = hasEvidence;
 	const caveat = assessed
 		? null
-		: scanResult.checks.length === 0
+		: checkResults.length === 0
 			? UNASSESSED_FIX_PLAN_CAVEAT
-			: buildAllTransientFixPlanCaveat(scanResult.checks.length);
+			: buildAllTransientFixPlanCaveat(checkResults.length);
+
+	// The categories excluded from `actionableFindings` above because their OWN
+	// check never completed. Only computed when `assessed` is true — the
+	// all-transient/never-ran case is already fully represented by `caveat`,
+	// and listing every category here too would just restate the same fact in
+	// a second vocabulary.
+	const transientCategories: CheckCategory[] = assessed
+		? checkResults.filter((c) => c.checkStatus === 'error' || c.checkStatus === 'timeout').map((c) => c.category)
+		: [];
 
 	return {
 		domain,
-		score: scanResult.score.overall,
-		grade: scanResult.score.grade,
-		maturityStage: isGraded(scanResult.score) ? scanResult.maturity.stage : null,
+		score,
+		grade,
+		maturityStage,
 		totalActions: actions.length,
 		actions,
 		assessed,
 		caveat,
+		transientCategories,
 	};
+}
+
+/**
+ * Generate a prioritized fix plan for a domain.
+ *
+ * @param domain - Validated, sanitized domain
+ * @param kv - Optional KV namespace for caching
+ * @param runtimeOptions - Scan runtime options
+ * @returns Prioritized fix plan
+ */
+export async function generateFixPlan(domain: string, kv?: KVNamespace, runtimeOptions?: ScanRuntimeOptions): Promise<FixPlanResult> {
+	const scanResult = await scanDomain(domain, kv, runtimeOptions);
+
+	return evaluateFixPlan(
+		scanResult.checks,
+		domain,
+		scanResult.score.overall,
+		scanResult.score.grade,
+		isGraded(scanResult.score) ? scanResult.maturity.stage : null,
+	);
+}
+
+/**
+ * Note for categories excluded from `actions` because their own check failed
+ * transiently (see `FixPlanResult.transientCategories`). Shared by both format
+ * modes so the two surfaces cannot describe the same exclusion two ways.
+ */
+function transientCategoriesNote(categories: CheckCategory[]): string {
+	const n = categories.length;
+	return `${n} categor${n === 1 ? 'y' : 'ies'} could not be assessed (transient check failure, not a clean result): ${categories.join(', ')}.`;
 }
 
 /** Format a fix plan as a human-readable text report. */
@@ -233,7 +294,16 @@ export function formatFixPlan(plan: FixPlanResult, format: OutputFormat = 'full'
 			// a somehow-unset `caveat` would render the never-ran-specific text
 			// even for an all-transient state. The only genuinely safe fallback
 			// here makes no specific claim.
-			lines.push(plan.assessed ? 'No actionable findings.' : (plan.caveat ?? 'This domain could not be assessed.'));
+			if (!plan.assessed) {
+				lines.push(plan.caveat ?? 'This domain could not be assessed.');
+			} else if (plan.transientCategories.length > 0) {
+				// Zero actions here does NOT mean a clean bill of health — some
+				// category was never actually measured. Say so instead of reading
+				// as "No actionable findings" (see the full-mode branch below).
+				lines.push(transientCategoriesNote(plan.transientCategories));
+			} else {
+				lines.push('No actionable findings.');
+			}
 			return lines.join('\n');
 		}
 		const maxShow = 5;
@@ -244,6 +314,9 @@ export function formatFixPlan(plan: FixPlanResult, format: OutputFormat = 'full'
 		}
 		if (plan.actions.length > maxShow) {
 			lines.push(`... and ${plan.actions.length - maxShow} more`);
+		}
+		if (plan.transientCategories.length > 0) {
+			lines.push(transientCategoriesNote(plan.transientCategories));
 		}
 		return lines.join('\n');
 	}
@@ -258,9 +331,13 @@ export function formatFixPlan(plan: FixPlanResult, format: OutputFormat = 'full'
 		// Zero actions is only good news when something was actually examined.
 		// See the compact-mode fallback above for why this does NOT fall back to
 		// `UNASSESSED_FIX_PLAN_CAVEAT` specifically.
-		lines.push(
-			plan.assessed ? 'No actionable findings. Domain security posture is strong.' : (plan.caveat ?? 'This domain could not be assessed.'),
-		);
+		if (!plan.assessed) {
+			lines.push(plan.caveat ?? 'This domain could not be assessed.');
+		} else if (plan.transientCategories.length > 0) {
+			lines.push(transientCategoriesNote(plan.transientCategories));
+		} else {
+			lines.push('No actionable findings. Domain security posture is strong.');
+		}
 		return lines.join('\n');
 	}
 
@@ -274,6 +351,10 @@ export function formatFixPlan(plan: FixPlanResult, format: OutputFormat = 'full'
 			lines.push(`Dependencies: ${action.dependencies.join('; ')}`);
 		}
 		lines.push('');
+	}
+
+	if (plan.transientCategories.length > 0) {
+		lines.push(transientCategoriesNote(plan.transientCategories));
 	}
 
 	return lines.join('\n');

--- a/src/tools/generate-fix-plan.ts
+++ b/src/tools/generate-fix-plan.ts
@@ -14,7 +14,7 @@ import type { CheckResult, Finding, Severity, CheckCategory } from '@blackveil/d
 import { IMPORTANCE_WEIGHTS, isGraded } from '@blackveil/dns-checks/scoring';
 import { scanDomain } from './scan-domain';
 import type { ScanRuntimeOptions } from './scan/post-processing';
-import { formatScoreGrade, hasCompletedEvidence, UNGRADED_DISPLAY } from '../lib/ungraded-display';
+import { formatScoreGrade, hasCompletedEvidence, isCompletedCheck, UNGRADED_DISPLAY } from '../lib/ungraded-display';
 import { isDnsErrorFinding } from '../lib/dns-error-result';
 
 /** A single remediation action in a fix plan. */
@@ -212,7 +212,7 @@ export function evaluateFixPlan(
 	// fix action, so both filters stay in force.
 	const actionableFindings = hasEvidence
 		? checkResults
-				.filter((c) => c.checkStatus !== 'error' && c.checkStatus !== 'timeout')
+				.filter(isCompletedCheck)
 				.flatMap((check: CheckResult) => check.findings)
 				.filter((f: Finding) => f.severity !== 'info' && !isDnsErrorFinding(f))
 		: [];
@@ -255,9 +255,7 @@ export function evaluateFixPlan(
 	// all-transient/never-ran case is already fully represented by `caveat`,
 	// and listing every category here too would just restate the same fact in
 	// a second vocabulary.
-	const transientCategories: CheckCategory[] = assessed
-		? checkResults.filter((c) => c.checkStatus === 'error' || c.checkStatus === 'timeout').map((c) => c.category)
-		: [];
+	const transientCategories: CheckCategory[] = assessed ? checkResults.filter((c) => !isCompletedCheck(c)).map((c) => c.category) : [];
 
 	return {
 		domain,

--- a/src/tools/generate-fix-plan.ts
+++ b/src/tools/generate-fix-plan.ts
@@ -205,12 +205,20 @@ export function evaluateFixPlan(
 	// The `isDnsErrorFinding` filter is kept as a SECOND, independent guard —
 	// not redundant with the checkStatus filter above. A check can COMPLETE
 	// (`checkStatus` absent/'completed') and still attach an errorKind-tagged
-	// finding for a narrower reason than a full check failure — e.g.
-	// `discover-brand-domains.ts`'s "Brand-domain discovery could not
-	// complete" finding, emitted when every discovery SIGNAL failed but the
-	// check itself ran to completion. That finding would survive the
-	// checkStatus filter (the check completed) but must still never become a
-	// fix action, so both filters stay in force.
+	// finding for a narrower reason than a full check failure. NOT via
+	// `discover-brand-domains.ts`'s `brand_discovery` category in production:
+	// `brand_discovery` is a `CheckCategory` but is absent from `scan-domain.ts`'s
+	// `CHECK_DISPATCH`/`SCAN_CATEGORIES`, so `scanDomain()` never produces one
+	// and `generateFixPlan` (which feeds `evaluateFixPlan` exclusively from
+	// `scanResult.checks`) can never see it. This function is exported and
+	// callable directly with an arbitrary `checkResults` array, though — that
+	// is the actual reason the guard earns its keep: a caller of the pure
+	// `evaluateFixPlan` entry point is not restricted to `scan_domain`'s
+	// dispatched categories, so a completed check carrying an errorKind-tagged
+	// finding from ANY category (a future scored category, a hand-built test
+	// fixture, or a direct non-scan caller) must still never become a fix
+	// action. Both filters stay in force as defence-in-depth for that entry
+	// point, not because of a reachable production path today.
 	const actionableFindings = hasEvidence
 		? checkResults
 				.filter(isCompletedCheck)

--- a/src/tools/generate-fix-plan.ts
+++ b/src/tools/generate-fix-plan.ts
@@ -183,15 +183,38 @@ export function evaluateFixPlan(
 	// zero-check scan does.
 	const hasEvidence = hasCompletedEvidence(checkResults);
 	// Even when SOME categories completed (`hasEvidence: true`), an individual
-	// category's OWN check can still have failed transiently — its CheckResult
-	// carries only the synthetic "check error" finding `isDnsErrorFinding`
-	// marks (see `dns-error-result.ts`). That finding is the ABSENCE of a
-	// measurement, not a customer's real posture, so it must never become a
-	// remediation action ("Fix DMARC: DMARC check error — ..."). Filtering it
-	// out here — rather than dropping it silently — pairs with
-	// `transientCategories` below so the exclusion still reaches the customer.
+	// category's OWN check can still have failed transiently. There are TWO
+	// distinct producers of that shape, and only one of them tags the finding:
+	// `buildDnsErrorResult` (used by tools with their own top-level DNS-error
+	// handling, e.g. check-dmarc.ts) sets BOTH `checkStatus: 'error'` AND
+	// `metadata.errorKind: 'dns_error'`. `safeCheck` — scan_domain's OWN
+	// orchestrator-level catch, `src/tools/scan-domain.ts`'s `safeCheck()`,
+	// which is what actually runs during a real production scan for any check
+	// that doesn't have its own internal DNS-error handling — sets
+	// `checkStatus: 'error' | 'timeout'` but NEVER `errorKind`. A per-finding
+	// `errorKind` filter alone therefore misses every safeCheck-produced
+	// transient: `checkStatus: 'timeout'` would render as an action
+	// ("Fix DMARC: DMARC check timed out — ...") in the SAME plan that also
+	// lists that category under `transientCategories` — self-contradictory
+	// output. Filtering on `checkStatus` at the CHECK level first (mirrors
+	// `map_compliance`'s `completed` filter and this file's own
+	// `transientCategories` below) catches BOTH producers regardless of
+	// whether the errorKind marker was set.
+	//
+	// The `isDnsErrorFinding` filter is kept as a SECOND, independent guard —
+	// not redundant with the checkStatus filter above. A check can COMPLETE
+	// (`checkStatus` absent/'completed') and still attach an errorKind-tagged
+	// finding for a narrower reason than a full check failure — e.g.
+	// `discover-brand-domains.ts`'s "Brand-domain discovery could not
+	// complete" finding, emitted when every discovery SIGNAL failed but the
+	// check itself ran to completion. That finding would survive the
+	// checkStatus filter (the check completed) but must still never become a
+	// fix action, so both filters stay in force.
 	const actionableFindings = hasEvidence
-		? checkResults.flatMap((check: CheckResult) => check.findings).filter((f: Finding) => f.severity !== 'info' && !isDnsErrorFinding(f))
+		? checkResults
+				.filter((c) => c.checkStatus !== 'error' && c.checkStatus !== 'timeout')
+				.flatMap((check: CheckResult) => check.findings)
+				.filter((f: Finding) => f.severity !== 'info' && !isDnsErrorFinding(f))
 		: [];
 
 	const actions: FixAction[] = actionableFindings.map((finding: Finding) => {

--- a/src/tools/generate-fix-plan.ts
+++ b/src/tools/generate-fix-plan.ts
@@ -196,10 +196,11 @@ export function evaluateFixPlan(
 	// transient: `checkStatus: 'timeout'` would render as an action
 	// ("Fix DMARC: DMARC check timed out — ...") in the SAME plan that also
 	// lists that category under `transientCategories` — self-contradictory
-	// output. Filtering on `checkStatus` at the CHECK level first (mirrors
-	// `map_compliance`'s `completed` filter and this file's own
-	// `transientCategories` below) catches BOTH producers regardless of
-	// whether the errorKind marker was set.
+	// output. Filtering on `checkStatus` at the CHECK level first (shares
+	// `isCompletedCheck` with `map_compliance`'s `completed` filter and this
+	// file's own `transientCategories` below — by import, not duplication)
+	// catches BOTH producers regardless of whether the errorKind marker was
+	// set.
 	//
 	// The `isDnsErrorFinding` filter is kept as a SECOND, independent guard —
 	// not redundant with the checkStatus filter above. A check can COMPLETE

--- a/src/tools/map-compliance.ts
+++ b/src/tools/map-compliance.ts
@@ -11,7 +11,7 @@ import { scanDomain } from './scan-domain';
 import type { ScanRuntimeOptions } from './scan/post-processing';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
-import { formatScoreGrade, UNGRADED_DISPLAY } from '../lib/ungraded-display';
+import { formatScoreGrade, hasCompletedEvidence, isCompletedCheck, UNGRADED_DISPLAY } from '../lib/ungraded-display';
 
 export type ComplianceFramework = 'nist_800_177' | 'pci_dss_4' | 'soc2' | 'cis_controls';
 
@@ -267,9 +267,10 @@ export function evaluateCompliance(
 			// A matched result whose check never COMPLETED (checkStatus 'timeout'/'error')
 			// is not evidence either way — `buildDnsErrorResult`/`safeCheck` return those
 			// as `passed: false`, indistinguishable from a genuine failure unless we
-			// partition on `checkStatus` here. Absent or 'completed' means the check ran
-			// normally (mirrors profiles.ts's `measuredChecks` predicate).
-			const completed = matchedResults.filter((r) => r.checkStatus !== 'timeout' && r.checkStatus !== 'error');
+			// partition on `checkStatus` here. `isCompletedCheck` is the single SSOT
+			// spelling of "absent or 'completed' means the check ran normally" — see
+			// `test/audits/*evidence*` for the ban on re-deriving this locally.
+			const completed = matchedResults.filter(isCompletedCheck);
 
 			if (completed.length === 0) {
 				// Every matched category was measured-AT but never measured — one slow
@@ -364,8 +365,7 @@ export function evaluateCompliance(
 	// that all timed out", which is exactly the dishonesty this closes. The two failure
 	// modes get DISTINCT caveat wording (different remediation: nothing to retry vs.
 	// retry once the transient condition clears), even though both report `assessed: false`.
-	const hasCompletedEvidence = checkResults.some((r) => r.checkStatus !== 'timeout' && r.checkStatus !== 'error');
-	const assessed = hasCompletedEvidence;
+	const assessed = hasCompletedEvidence(checkResults);
 	const caveat = assessed ? null : checkResults.length === 0 ? UNASSESSED_COMPLIANCE_CAVEAT : buildAllTransientCaveat(checkResults.length);
 	return { domain, score, grade, assessed, caveat, frameworks };
 }

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -42,6 +42,20 @@ export interface CscProductRecommendation {
 	priority: CscPriority;
 	justifyingGap: string;
 	relatedFindings: string[];
+	/**
+	 * `false` exactly for a product built by {@link unassessedScanProduct} — the
+	 * category (or the whole scan) was never actually observed. Every OTHER
+	 * construction site (`evalMultiLock`, `evalScanProduct`'s pass/fail/absent
+	 * branches) sets this `true`. This is the render-time discriminant
+	 * `formatCscProducts` MUST use to keep an unassessed product visually
+	 * distinct from a genuine clean pass — before this field existed, both
+	 * states shared `recommended: false` and rendered byte-identical
+	 * (`✓ Managed DMARC` / `➖ Managed DMARC — OK`) in both format modes, so a
+	 * transient DMARC failure was indistinguishable from a passing DMARC check
+	 * on the surface most interactive clients see (compact is auto-selected
+	 * for them).
+	 */
+	assessed: boolean;
 }
 
 export interface CscProductReport {
@@ -149,9 +163,21 @@ function nonInfoTitles(result: CheckResult | undefined): string[] {
 	return result.findings.filter((f) => f.severity !== 'info' && !isDnsErrorFinding(f)).map((f) => f.title);
 }
 
-/** MultiLock recommendation — reads the booleans, not `level` alone (Spec A handoff). */
+/**
+ * MultiLock recommendation — reads the booleans, not `level` alone (Spec A handoff).
+ * Always `assessed: true`: MultiLock reads RDAP independently of the scan (see
+ * `evaluateCscProducts`'s doc on why it is never gated on `assessed`), including
+ * the "unobservable" branch — RDAP genuinely returning nothing is itself a
+ * definitive lookup outcome, not a transient scan failure. Out of scope for this
+ * fix round.
+ */
 function evalMultiLock(lockPosture: LockPosture | null): CscProductRecommendation {
-	const base = { product: 'csc_multilock' as const, productName: CSC_PRODUCT_NAMES.csc_multilock, relatedFindings: [] as string[] };
+	const base = {
+		product: 'csc_multilock' as const,
+		productName: CSC_PRODUCT_NAMES.csc_multilock,
+		relatedFindings: [] as string[],
+		assessed: true as const,
+	};
 	if (lockPosture == null || lockPosture.level === 'unknown') {
 		return { ...base, recommended: false, priority: 'none', justifyingGap: 'Lock posture unobservable (RDAP unavailable/redacted)' };
 	}
@@ -186,12 +212,19 @@ function evalScanProduct(
 	gaps: { passing: string; failing: string; absent: string },
 	concern: string,
 ): CscProductRecommendation {
-	const base = { product, productName: CSC_PRODUCT_NAMES[product] };
+	const base = { product, productName: CSC_PRODUCT_NAMES[product], assessed: true as const };
 	if (result === undefined) {
 		return { ...base, recommended: true, priority: 'low', justifyingGap: gaps.absent, relatedFindings: [] };
 	}
 	if (result.checkStatus === 'error' || result.checkStatus === 'timeout') {
-		return unassessedScanProduct(product, concern, 'all_transient');
+		// This ONE category's own check failed transiently — other categories in
+		// this scan (the ones NOT reaching this branch) may well have completed,
+		// which is why `'category_transient'` gets its own wording distinct from
+		// the whole-report `'all_transient'` case (see `unassessedScanProduct`'s
+		// doc): "checks attempted, none completed" would be a false claim about
+		// this scan when it is specifically this category, not every category,
+		// that never completed.
+		return unassessedScanProduct(product, concern, 'category_transient');
 	}
 	if (result.passed) {
 		return { ...base, recommended: false, priority: 'none', justifyingGap: gaps.passing, relatedFindings: [] };
@@ -202,7 +235,23 @@ function evalScanProduct(
 }
 
 /**
- * The scan-driven product line for a domain with no COMPLETED check evidence.
+ * The three reasons a product can go unassessed. `never_ran`/`all_transient`
+ * mirror {@link CaveatKind} exactly (the WHOLE-REPORT states — every category
+ * failed, or nothing ran at all). `category_transient` is a THIRD, narrower
+ * state introduced by `evalScanProduct`'s `checkStatus` branch: THIS category's
+ * own check failed transiently while the rest of the scan may well have
+ * completed normally — `CaveatKind` deliberately does NOT gain this value
+ * (it is a per-report field consumed elsewhere, e.g. `prioritize_csc_leads`'
+ * `isNeverRanKind`, which is not written to expect a third state), so this is
+ * a local, wider type instead of a change to the exported `CaveatKind` union.
+ */
+type UnassessedReason = CaveatKind | 'category_transient';
+
+/**
+ * The scan-driven product line for a domain with no COMPLETED check evidence —
+ * either the WHOLE report (`caveatKind`/`'never_ran'`/`'all_transient'`, via
+ * `evaluateCscProducts`) or a SINGLE category within an otherwise-assessed scan
+ * (`'category_transient'`, via `evalScanProduct`'s `checkStatus` branch).
  *
  * `evalScanProduct`'s `absent` branch ("DMARC not observed") means "we looked and
  * found nothing" — a real, sellable gap. With no completed evidence nobody
@@ -210,27 +259,35 @@ function evalScanProduct(
  * strength of non-observation. This states the absence of evidence instead of
  * pricing it.
  *
- * `caveatKind` (the STRUCTURAL discriminant carried on `CscProductReport.caveatKind`
- * — see its type doc) picks the wording: "no checks ran" is false — and this exact
- * text, ending up on the `recommendations[].justifyingGap` WIRE field even though
- * `formatCscProducts` never prints it to prose — for a total-outage scan where N
- * checks WERE attempted. Classifying on `caveatKind` rather than comparing the
- * `caveat` STRING means a renamed/edited caveat wording cannot silently flip which
- * branch this takes. Exported for direct unit testing of that decoupling — see
- * the round-6c pin test in `test/map-csc-products.spec.ts`.
+ * `reason` (the STRUCTURAL discriminant, {@link UnassessedReason}) picks the
+ * wording: "no checks ran" is false — and this exact text, ending up on the
+ * `recommendations[].justifyingGap` WIRE field even though `formatCscProducts`
+ * never prints it to prose — for a total-outage scan where N checks WERE
+ * attempted; "checks attempted, none completed" is equally false when it is
+ * ONE category, not the whole scan, that never completed. Classifying on
+ * `reason` rather than comparing the `caveat` STRING means a renamed/edited
+ * caveat wording cannot silently flip which branch this takes. Exported for
+ * direct unit testing of that decoupling — see the round-6c pin test in
+ * `test/map-csc-products.spec.ts`.
  */
 export function unassessedScanProduct(
 	product: Exclude<CscProductKey, 'csc_multilock'>,
 	concern: string,
-	caveatKind: CaveatKind | null,
+	reason: UnassessedReason | null,
 ): CscProductRecommendation {
-	const reason = caveatKind === 'all_transient' ? 'checks attempted, none completed' : 'no checks ran';
+	const reasonText =
+		reason === 'category_transient'
+			? "this category's check failed transiently — other categories in this scan may have completed normally"
+			: reason === 'all_transient'
+				? 'checks attempted, none completed'
+				: 'no checks ran';
 	return {
 		product,
 		productName: CSC_PRODUCT_NAMES[product],
 		recommended: false,
 		priority: 'none',
-		justifyingGap: `${concern} not assessed — ${reason}`,
+		assessed: false,
+		justifyingGap: `${concern} not assessed — ${reasonText}`,
 		relatedFindings: [],
 	};
 }
@@ -369,8 +426,19 @@ export function formatCscProducts(report: CscProductReport, format: OutputFormat
 		lines.push(`CSC products: ${sanitizeOutputText(report.domain, 253)} — ${formatScoreGrade(report.score, report.grade)}${countSegment}`);
 		if (!report.assessed) lines.push(caveat);
 		for (const r of shown) {
-			const icon = r.recommended ? ' →' : ' ✓';
-			const suffix = r.recommended ? ` [${r.priority}] ${sanitizeOutputText(r.justifyingGap, 80)}` : '';
+			// `!r.assessed` (F1, review round 1): a product `unassessedScanProduct`
+			// built — the category itself (or the whole scan) was never observed —
+			// MUST NOT render as `✓`, the SAME icon a genuine clean pass gets. Before
+			// this branch, both states shared `recommended: false` and rendered
+			// byte-identical in compact mode (`✓ Managed DMARC`, no gap text at all)
+			// — the silent drop this task exists to close, on the format every
+			// interactive LLM client auto-selects.
+			const icon = !r.assessed ? ' ?' : r.recommended ? ' →' : ' ✓';
+			const suffix = !r.assessed
+				? ` ${sanitizeOutputText(r.justifyingGap, 80)}`
+				: r.recommended
+					? ` [${r.priority}] ${sanitizeOutputText(r.justifyingGap, 80)}`
+					: '';
 			lines.push(`${icon} ${sanitizeOutputText(r.productName, 40)}${suffix}`);
 		}
 	} else {
@@ -380,8 +448,12 @@ export function formatCscProducts(report: CscProductReport, format: OutputFormat
 		if (!report.assessed) lines.push(caveat);
 		lines.push('');
 		for (const r of shown) {
-			const icon = r.recommended ? '✅' : '➖';
-			const tag = r.recommended ? ` — ${r.priority.toUpperCase()}` : ' — OK';
+			// Same F1 fix as compact mode above: an unassessed product must not tag
+			// as `— OK` (indistinguishable from a genuine clean pass) even though the
+			// gap line below already names it correctly — the TAG line is what a
+			// skimming reader sees first.
+			const icon = !r.assessed ? '❓' : r.recommended ? '✅' : '➖';
+			const tag = !r.assessed ? ' — NOT ASSESSED' : r.recommended ? ` — ${r.priority.toUpperCase()}` : ' — OK';
 			lines.push(`${icon} **${sanitizeOutputText(r.productName, 40)}**${tag}`);
 			lines.push(`  - ${sanitizeOutputText(r.justifyingGap, 160)}`);
 			for (const f of r.relatedFindings) lines.push(`  - ${sanitizeOutputText(f, 120)}`);

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -165,30 +165,72 @@ function nonInfoTitles(result: CheckResult | undefined): string[] {
 
 /**
  * MultiLock recommendation — reads the booleans, not `level` alone (Spec A handoff).
- * Always `assessed: true`: MultiLock reads RDAP independently of the scan (see
- * `evaluateCscProducts`'s doc on why it is never gated on `assessed`), including
- * the "unobservable" branch — RDAP genuinely returning nothing is itself a
- * definitive lookup outcome, not a transient scan failure. Out of scope for this
- * fix round.
+ * MultiLock reads RDAP independently of the scan (see `evaluateCscProducts`'s doc
+ * on why it is never gated on the report-level `assessed`), but it has its OWN
+ * two-way assessed split — distinct from `evalScanProduct`'s transient-check
+ * split — because `lockPosture == null` and `lockPosture.level === 'unknown'` are
+ * NOT the same fact:
+ *   - `lockPosture === null` — RDAP was never actually reached: no RDAP server
+ *     resolved for the TLD, a non-OK HTTP status, or a fetch/parse failure (see
+ *     `checkRdapLookup`'s failure branches — none of them populate
+ *     `metadata.lockPosture`, which is what `extractLockPosture` needs to
+ *     produce a non-null value). Nothing was observed, so `assessed: false`.
+ *   - `lockPosture.level === 'unknown'` — RDAP WAS reached and answered (a 200
+ *     with a parsed response); the record just carries no EPP status codes. An
+ *     empty status array is itself an answer, not a missing one, so this is a
+ *     real observation and stays `assessed: true`.
+ * A prior version of this function set `assessed: true` on BOTH branches, and its
+ * doc claimed "RDAP genuinely returning nothing is itself a definitive lookup
+ * outcome" — that was wrong for the null case: an unreachable RDAP server is an
+ * INCOMPLETE measurement, not a definitive one, and rendering it identically to a
+ * clean pass (`✓`/`➖ … — OK`, no disclosure) is exactly the defect this campaign
+ * exists to close. The doc also conflated "unavailable" with "redacted"; the two
+ * branches above are the actual, distinguishable causes.
  */
 function evalMultiLock(lockPosture: LockPosture | null): CscProductRecommendation {
 	const base = {
 		product: 'csc_multilock' as const,
 		productName: CSC_PRODUCT_NAMES.csc_multilock,
 		relatedFindings: [] as string[],
-		assessed: true as const,
 	};
-	if (lockPosture == null || lockPosture.level === 'unknown') {
-		return { ...base, recommended: false, priority: 'none', justifyingGap: 'Lock posture unobservable (RDAP unavailable/redacted)' };
+	if (lockPosture == null) {
+		return {
+			...base,
+			recommended: false,
+			priority: 'none',
+			assessed: false,
+			justifyingGap: 'Lock posture unobservable — RDAP was unreachable for this domain',
+		};
+	}
+	if (lockPosture.level === 'unknown') {
+		return {
+			...base,
+			recommended: false,
+			priority: 'none',
+			assessed: true,
+			justifyingGap: 'Lock posture unobservable — RDAP responded but reported no EPP status codes',
+		};
 	}
 	if (lockPosture.registryLevel === true) {
-		return { ...base, recommended: false, priority: 'none', justifyingGap: 'Registry lock already in effect' };
+		return { ...base, recommended: false, priority: 'none', assessed: true, justifyingGap: 'Registry lock already in effect' };
 	}
 	if (lockPosture.transferLocked === false) {
-		return { ...base, recommended: true, priority: 'high', justifyingGap: 'Domain transfer not locked — no registry or registrar lock' };
+		return {
+			...base,
+			recommended: true,
+			priority: 'high',
+			assessed: true,
+			justifyingGap: 'Domain transfer not locked — no registry or registrar lock',
+		};
 	}
 	// registrarLevel true (or defensive fallback): registrar lock only, no server lock.
-	return { ...base, recommended: true, priority: 'medium', justifyingGap: 'Registrar lock only — no registry-level (server) lock' };
+	return {
+		...base,
+		recommended: true,
+		priority: 'medium',
+		assessed: true,
+		justifyingGap: 'Registrar lock only — no registry-level (server) lock',
+	};
 }
 
 /**

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -198,8 +198,9 @@ function evalMultiLock(lockPosture: LockPosture | null): CscProductRecommendatio
  * "not assessed" wording {@link unassessedScanProduct} uses for a whole-report
  * outage — see its doc for why a category whose OWN check never completed must not
  * be priced as a gap even when `assessed` is `true` overall (other categories DID
- * complete). Checking `checkStatus` here (mirrors `map_compliance`'s `completed`
- * filter) is necessary in addition to the `isDnsErrorFinding` filter in
+ * complete). Checking `checkStatus` via `isCompletedCheck` here (shares the same
+ * predicate as `map_compliance`'s `completed` filter, by import) is necessary
+ * in addition to the `isDnsErrorFinding` filter in
  * `nonInfoTitles`/below: after that filter a transient result's `findings` and
  * `titles` are both empty, but `result.passed` is still `false` (set explicitly by
  * `buildDnsErrorResult`), so without this branch the code below would still fall

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -16,6 +16,7 @@ import type { ScanRuntimeOptions } from './scan/post-processing';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import { formatScoreGrade, hasCompletedEvidence } from '../lib/ungraded-display';
+import { isDnsErrorFinding } from '../lib/dns-error-result';
 
 export type CscProductKey = 'csc_multilock' | 'managed_dmarc' | 'digital_certificates' | 'dnssec_management';
 
@@ -136,10 +137,16 @@ const CSC_PRODUCT_NAMES: Record<CscProductKey, string> = {
 	dnssec_management: 'DNSSEC management',
 };
 
-/** Non-info finding titles from a failing CheckResult (mirrors map-compliance). */
+/**
+ * Non-info finding titles from a failing CheckResult (mirrors map-compliance).
+ * Also excludes the synthetic "check error" finding a transient DNS/network
+ * failure produces (`isDnsErrorFinding`) — that finding is the ABSENCE of a
+ * measurement, not a sellable gap, and must never surface as a
+ * `relatedFinding` justifying an upsell.
+ */
 function nonInfoTitles(result: CheckResult | undefined): string[] {
 	if (!result) return [];
-	return result.findings.filter((f) => f.severity !== 'info').map((f) => f.title);
+	return result.findings.filter((f) => f.severity !== 'info' && !isDnsErrorFinding(f)).map((f) => f.title);
 }
 
 /** MultiLock recommendation — reads the booleans, not `level` alone (Spec A handoff). */
@@ -158,21 +165,39 @@ function evalMultiLock(lockPosture: LockPosture | null): CscProductRecommendatio
 	return { ...base, recommended: true, priority: 'medium', justifyingGap: 'Registrar lock only — no registry-level (server) lock' };
 }
 
-/** Scan-driven product (dmarc/ssl/dnssec). Missing category → low-priority "not observed" lead. */
+/**
+ * Scan-driven product (dmarc/ssl/dnssec). Missing category → low-priority "not observed" lead.
+ *
+ * `concern` (e.g. 'DMARC') is only used on the transient branch, to build the same
+ * "not assessed" wording {@link unassessedScanProduct} uses for a whole-report
+ * outage — see its doc for why a category whose OWN check never completed must not
+ * be priced as a gap even when `assessed` is `true` overall (other categories DID
+ * complete). Checking `checkStatus` here (mirrors `map_compliance`'s `completed`
+ * filter) is necessary in addition to the `isDnsErrorFinding` filter in
+ * `nonInfoTitles`/below: after that filter a transient result's `findings` and
+ * `titles` are both empty, but `result.passed` is still `false` (set explicitly by
+ * `buildDnsErrorResult`), so without this branch the code below would still fall
+ * through to `recommended: true, priority: 'medium'` — an upsell justified by
+ * nothing, for a category nobody actually measured.
+ */
 function evalScanProduct(
 	product: Exclude<CscProductKey, 'csc_multilock'>,
 	result: CheckResult | undefined,
 	gaps: { passing: string; failing: string; absent: string },
+	concern: string,
 ): CscProductRecommendation {
 	const base = { product, productName: CSC_PRODUCT_NAMES[product] };
 	if (result === undefined) {
 		return { ...base, recommended: true, priority: 'low', justifyingGap: gaps.absent, relatedFindings: [] };
 	}
+	if (result.checkStatus === 'error' || result.checkStatus === 'timeout') {
+		return unassessedScanProduct(product, concern, 'all_transient');
+	}
 	if (result.passed) {
 		return { ...base, recommended: false, priority: 'none', justifyingGap: gaps.passing, relatedFindings: [] };
 	}
 	const titles = nonInfoTitles(result);
-	const hasSevere = result.findings.some((f) => f.severity === 'critical' || f.severity === 'high');
+	const hasSevere = result.findings.some((f) => (f.severity === 'critical' || f.severity === 'high') && !isDnsErrorFinding(f));
 	return { ...base, recommended: true, priority: hasSevere ? 'high' : 'medium', justifyingGap: gaps.failing, relatedFindings: titles };
 }
 
@@ -241,25 +266,40 @@ export function evaluateCscProducts(
 	const recommendations: CscProductRecommendation[] = [
 		evalMultiLock(lockPosture),
 		assessed
-			? evalScanProduct('managed_dmarc', byCategory.get('dmarc'), {
-					passing: 'DMARC policy in effect',
-					failing: 'DMARC present but not passing',
-					absent: 'DMARC not observed',
-				})
+			? evalScanProduct(
+					'managed_dmarc',
+					byCategory.get('dmarc'),
+					{
+						passing: 'DMARC policy in effect',
+						failing: 'DMARC present but not passing',
+						absent: 'DMARC not observed',
+					},
+					'DMARC',
+				)
 			: unassessedScanProduct('managed_dmarc', 'DMARC', caveatKind),
 		assessed
-			? evalScanProduct('digital_certificates', byCategory.get('ssl'), {
-					passing: 'TLS/SSL configuration healthy',
-					failing: 'TLS/SSL issues detected',
-					absent: 'TLS/SSL not observed',
-				})
+			? evalScanProduct(
+					'digital_certificates',
+					byCategory.get('ssl'),
+					{
+						passing: 'TLS/SSL configuration healthy',
+						failing: 'TLS/SSL issues detected',
+						absent: 'TLS/SSL not observed',
+					},
+					'TLS/SSL',
+				)
 			: unassessedScanProduct('digital_certificates', 'TLS/SSL', caveatKind),
 		assessed
-			? evalScanProduct('dnssec_management', byCategory.get('dnssec'), {
-					passing: 'DNSSEC enabled',
-					failing: 'DNSSEC not enabled',
-					absent: 'DNSSEC not observed',
-				})
+			? evalScanProduct(
+					'dnssec_management',
+					byCategory.get('dnssec'),
+					{
+						passing: 'DNSSEC enabled',
+						failing: 'DNSSEC not enabled',
+						absent: 'DNSSEC not observed',
+					},
+					'DNSSEC',
+				)
 			: unassessedScanProduct('dnssec_management', 'DNSSEC', caveatKind),
 	];
 

--- a/src/tools/map-csc-products.ts
+++ b/src/tools/map-csc-products.ts
@@ -15,7 +15,7 @@ import { scanDomain } from './scan-domain';
 import type { ScanRuntimeOptions } from './scan/post-processing';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
-import { formatScoreGrade, hasCompletedEvidence } from '../lib/ungraded-display';
+import { formatScoreGrade, hasCompletedEvidence, isCompletedCheck } from '../lib/ungraded-display';
 import { isDnsErrorFinding } from '../lib/dns-error-result';
 
 export type CscProductKey = 'csc_multilock' | 'managed_dmarc' | 'digital_certificates' | 'dnssec_management';
@@ -216,7 +216,7 @@ function evalScanProduct(
 	if (result === undefined) {
 		return { ...base, recommended: true, priority: 'low', justifyingGap: gaps.absent, relatedFindings: [] };
 	}
-	if (result.checkStatus === 'error' || result.checkStatus === 'timeout') {
+	if (!isCompletedCheck(result)) {
 		// This ONE category's own check failed transiently — other categories in
 		// this scan (the ones NOT reaching this branch) may well have completed,
 		// which is why `'category_transient'` gets its own wording distinct from

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -7,7 +7,7 @@ import type { OutputFormat } from '../../handlers/tool-args';
 import { sanitizeOutputText } from '../../lib/output-sanitize';
 import { resolveImpactNarrative } from '../explain-finding';
 import { SCORING_MODEL_VERSION, computeScoringConfigHash } from '../../lib/scoring-version';
-import { formatScoreGrade, isMeasured, UNGRADED_DISPLAY } from '../../lib/ungraded-display';
+import { formatScoreGrade, isCompletedCheck, isMeasured, normalizeCheckStatus, UNGRADED_DISPLAY } from '../../lib/ungraded-display';
 
 // All three live in a tiny leaf module so every formatter in src/tools/ can share
 // them without importing the scan orchestrator. Re-exported here because this is
@@ -245,7 +245,7 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 	// checkStatuses
 	const checkStatuses: Record<string, 'completed' | 'timeout' | 'error'> = {};
 	for (const check of result.checks) {
-		checkStatuses[check.category] = check.checkStatus ?? 'completed';
+		checkStatuses[check.category] = normalizeCheckStatus(check.checkStatus);
 	}
 
 	// dnssecSource
@@ -269,7 +269,7 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		const dnssecDeficient = dnssecCheck.findings.some(
 			(f) => f.title === 'DNSSEC not enabled' || f.title === 'DNSSEC chain of trust incomplete' || f.title === 'DNSSEC validation failing',
 		);
-		if (dnssecSource === null && dnssecCheck.passed && !dnssecDeficient && (checkStatuses['dnssec'] ?? 'completed') === 'completed') {
+		if (dnssecSource === null && dnssecCheck.passed && !dnssecDeficient && isCompletedCheck(dnssecCheck)) {
 			dnssecSource = 'domain_configured';
 		}
 	}
@@ -309,14 +309,15 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		const rawScore: number | undefined = Object.prototype.hasOwnProperty.call(sourceCategoryScores, category)
 			? sourceCategoryScores[category]
 			: undefined;
-		const status = check?.checkStatus;
 
 		// INCONCLUSIVE — the check timed out or threw, so we could not measure it. This is
 		// checked FIRST and returns early, because it must win over any profile-based
 		// applicability rule: a check that never ran cannot be declared inapplicable on the
 		// strength of the profile it would have been judged under. Disjoint from
-		// `notApplicableCategories`; the score is null in both cases.
-		if (status === 'timeout' || status === 'error') {
+		// `notApplicableCategories`; the score is null in both cases. A category with no
+		// `CheckResult` at all (`check === undefined`) is never inconclusive by this rule —
+		// `isCompletedCheck` only answers the question for a check that actually ran.
+		if (check !== undefined && !isCompletedCheck(check)) {
 			inconclusiveCategories.push(category);
 			categoryScores[category] = null;
 			continue;

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -501,18 +501,23 @@ function adjustBimiForNonMailDomain(results: CheckResult[]): CheckResult[] {
  * finding (a calibrated lookalike/typosquat with real infrastructure). Info-level
  * findings — defensive registrations, shared-NS matches — are deliberately excluded.
  *
- * TASK 7B (2026-07-27) — what a medium-or-higher `lookalikes` finding now MEANS.
- * Under the D4 ownership gate (Task 7) this predicate was unreachable: every
- * `lookalikes` finding was capped at `info`, so no scan could signal
- * impersonation. Task 7b split the axes, and the severities this predicate sees
- * come exclusively from the THREAT-OBSERVATION axis
- * (`metadata.findingAxis === 'threat_observation'` — a #264-calibrated
- * observation about infrastructure, e.g. a confusable domain with live MX on a
- * disposable provider). ATTRIBUTION-axis findings (`'attribution'`) stay capped
- * at `info` for every non-`owned_by_seed` verdict and can never trip this, and
- * an `owned_by_seed` candidate emits no threat finding at all — so escalating
- * DMARC to critical here is keyed on OBSERVED impersonation-shaped
- * infrastructure, never on an ownership claim about a third party's domain.
+ * TASK 7B (2026-07-27) — what a medium-or-higher `lookalikes` finding MEANS.
+ * The severities this predicate sees come from the THREAT-OBSERVATION axis
+ * (`metadata.findingAxis === 'threat_observation'`): the #264-calibrated
+ * per-candidate observations about infrastructure (e.g. a confusable domain
+ * with live MX on a disposable provider), the aggregate HIGH summary, and — on
+ * an operator deploy with the BV_RECON binding — the `'medium'` CT-corroboration
+ * finding. ATTRIBUTION-axis findings (`'attribution'`) are capped at `info` for
+ * every non-`owned_by_seed` verdict and can never trip this, and an
+ * `owned_by_seed` candidate emits no threat finding at all — so the DMARC
+ * escalation is keyed on OBSERVED impersonation-shaped infrastructure, never on
+ * an ownership claim about a third party's domain.
+ *
+ * CORRECTION (fix round 1, F3): an earlier revision of this note claimed the
+ * predicate was "unreachable" under Task 7 because every `lookalikes` finding
+ * was capped at `info`. That was FALSE — the recon CT-corroboration finding has
+ * never been routed through the ownership gate and emits `'medium'` regardless.
+ * The Task 7 gate broke the DNS-derived path only; 7b restored it.
  *
  * This keys on `lookalikes` ONLY, deliberately matching the `impersonation_weak_dmarc`
  * interaction rule in `category-interactions.ts`, which scores `lookalikes <= 85`

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -501,6 +501,19 @@ function adjustBimiForNonMailDomain(results: CheckResult[]): CheckResult[] {
  * finding (a calibrated lookalike/typosquat with real infrastructure). Info-level
  * findings — defensive registrations, shared-NS matches — are deliberately excluded.
  *
+ * TASK 7B (2026-07-27) — what a medium-or-higher `lookalikes` finding now MEANS.
+ * Under the D4 ownership gate (Task 7) this predicate was unreachable: every
+ * `lookalikes` finding was capped at `info`, so no scan could signal
+ * impersonation. Task 7b split the axes, and the severities this predicate sees
+ * come exclusively from the THREAT-OBSERVATION axis
+ * (`metadata.findingAxis === 'threat_observation'` — a #264-calibrated
+ * observation about infrastructure, e.g. a confusable domain with live MX on a
+ * disposable provider). ATTRIBUTION-axis findings (`'attribution'`) stay capped
+ * at `info` for every non-`owned_by_seed` verdict and can never trip this, and
+ * an `owned_by_seed` candidate emits no threat finding at all — so escalating
+ * DMARC to critical here is keyed on OBSERVED impersonation-shaped
+ * infrastructure, never on an ownership claim about a third party's domain.
+ *
  * This keys on `lookalikes` ONLY, deliberately matching the `impersonation_weak_dmarc`
  * interaction rule in `category-interactions.ts`, which scores `lookalikes <= 85`
  * (≈ "at least one medium-or-higher finding"). Keeping the label-escalation here and

--- a/test/audits/completed-evidence-predicate-ssot.audit.test.ts
+++ b/test/audits/completed-evidence-predicate-ssot.audit.test.ts
@@ -44,6 +44,27 @@
  * of this same audit (see FORBIDDEN_SHAPES doc for the specific evasions this
  * closes, and for the one judged infeasible to add without an unacceptable
  * false-positive rate).
+ *
+ * ROUND 2: an independent review found the shapes above were still anchored
+ * to the literal token `checkStatus`, so two more evasions slipped past: (E1)
+ * `new Set(['timeout','error']).has(checkStatus)` / a hoisted
+ * `const X = ['timeout','error']; ... X.includes(checkStatus)` — the same
+ * NOT-COMPLETED question spelled via Set/collection membership instead of
+ * `.includes`/`||`; and (E2) a locally renamed identifier, e.g.
+ * `const { checkStatus: cs } = check; cs !== 'timeout' && cs !== 'error'`,
+ * which no `checkStatus`-anchored regex can see. E1 is closed the same way
+ * as M5a/M5b (new shapes below). E2 is closed by PROVENANCE tracking, not
+ * blind identifier-agnostic matching: `findCheckStatusAliases()` traces a
+ * local name back to `checkStatus` via a destructuring rename
+ * (`const { checkStatus: X } = ...`) or a direct initializer
+ * (`const X = obj.checkStatus;`), and only THOSE traced names — never an
+ * arbitrary identifier — are folded into the shape regexes alongside the
+ * literal `checkStatus` token. A blind "any identifier compared against both
+ * literals" version was tried first and rejected: it flagged genuine
+ * unrelated code (e.g. `src/lib/brand-audit-depth.ts` and
+ * `src/tools/discover-brand-domains.ts`, both branching on an unrelated
+ * `status` variable that was never derived from `checkStatus`) — see
+ * `findCheckStatusAliases`'s doc for the exact boundary this leaves.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -110,11 +131,72 @@ const SSOT_PATH = '../../src/lib/ungraded-display.ts';
 const KNOWN_DIFFERENT_PURPOSE = new Set(['../../src/tools/scan-domain.ts', '../../src/tools/check-http-security.ts']);
 
 /**
+ * Traces a local identifier back to `checkStatus` via one of the two shapes
+ * a developer actually reaches for when renaming/aliasing it (round 2, E2):
+ *
+ *   - a destructuring rename: `const { checkStatus: cs } = check;` — matched
+ *     ONLY when the `{ ... } =` braces open directly after `const`/`let`/`var`
+ *     (i.e. it's really the LHS of a destructuring assignment), not when
+ *     `checkStatus: someVar` appears as a plain object-literal property on
+ *     the RHS of an assignment (e.g. `return { ...base, checkStatus: status }`
+ *     in `scan-domain.ts` — the OPPOSITE direction, writing INTO a
+ *     `checkStatus` field, not reading a local alias OUT of one; conflating
+ *     the two was tried and produced a false alias there).
+ *   - a direct initializer: `const cs = checkStatus;` or
+ *     `const cs = result.checkStatus;` — matched only when the initializer is
+ *     JUST that reference (immediately followed by `;`/`,`/`)`/newline), not
+ *     an arbitrary expression that merely mentions `checkStatus` (e.g.
+ *     `const isUnanalyzable = result.checkStatus === 'error' || ...` in
+ *     `check-http-security.ts` is deliberately NOT treated as an alias of
+ *     `checkStatus` — `isUnanalyzable` is a derived boolean, not the status
+ *     value itself, so tracing it would be both wrong and, worse, a source
+ *     of false positives on unrelated later comparisons of that name).
+ *
+ * This is PROVENANCE tracking, not blind identifier-agnostic matching — the
+ * distinction matters. An earlier version of this function returned any
+ * identifier ever compared against BOTH `'timeout'` and `'error'`, with no
+ * requirement that it be traceable to `checkStatus` at all; run against the
+ * full `src/` corpus that flagged two genuine false positives —
+ * `src/lib/brand-audit-depth.ts` and `src/tools/discover-brand-domains.ts`,
+ * both branching on an unrelated `status` value with its own `'timeout'`/
+ * `'error'`/`'failed'` members that were never derived from `checkStatus`.
+ * Anchoring to provable provenance instead of the name closes the E2 evasion
+ * (`cs` is caught because it demonstrably came FROM `checkStatus`) without
+ * that false-positive rate — verified empirically: zero offenders across the
+ * corpus below with this version, vs. two with the blind version.
+ *
+ * Known remaining gap (undetectable by a text scanner, same class as the
+ * "NOT attempted" note further down): an alias assigned outside its
+ * declaration (`let cs; cs = checkStatus;`) or threaded through an
+ * intermediate function call (`const cs = pick(checkStatus);`) is NOT traced
+ * — review-time concern, not this audit's job.
+ */
+function findCheckStatusAliases(source: string): string[] {
+	const aliases = new Set<string>();
+	for (const m of source.matchAll(/\b(?:const|let|var)\s*\{[^{}]{0,200}?checkStatus\s*:\s*(\w+)[^{}]{0,200}?\}\s*=/g)) {
+		if (m[1] !== 'checkStatus') aliases.add(m[1]);
+	}
+	for (const m of source.matchAll(/\b(?:const|let)\s+(\w+)\s*=\s*(?:\w+\.)?checkStatus\s*[;,)\n]/g)) {
+		if (m[1] !== 'checkStatus') aliases.add(m[1]);
+	}
+	return [...aliases];
+}
+
+/** `checkStatus`, or an alternation of it plus every traced alias in this file — see `findCheckStatusAliases`. */
+function identifierPattern(aliases: string[]): string {
+	return `\\b(?:${['checkStatus', ...aliases].join('|')})\\b`;
+}
+
+/**
  * Every shape (both comparison orders, where applicable) known to re-derive
- * the completed/not-completed question outside the SSOT. Matched against
- * COMMENT-STRIPPED source (see `stripComments`) with a modest gap that only
- * needs to bridge whitespace/arrow-function syntax now that comments can no
- * longer pad it out:
+ * the completed/not-completed question outside the SSOT, parameterized on
+ * `idPat` — `identifierPattern(findCheckStatusAliases(source))` for the file
+ * under test, so each shape matches `checkStatus` OR any alias PROVABLY
+ * traced back to it in that same file (round 2, E2 — see
+ * `findCheckStatusAliases` doc). Matched against COMMENT-STRIPPED source
+ * (see `stripComments`) with a modest gap that only needs to bridge
+ * whitespace/arrow-function syntax now that comments can no longer pad it
+ * out:
  *
  *   - DENYLIST-AND: `!== 'timeout' && ... !== 'error'` (found in the local
  *     shadow, the inline copy inside `map_compliance`, and the fix-plan
@@ -133,6 +215,14 @@ const KNOWN_DIFFERENT_PURPOSE = new Set(['../../src/tools/scan-domain.ts', '../.
  *     and `case 'error':` fall through together (either order) — the same
  *     grouping of the two transient members into one bucket, spelled as
  *     control flow instead of a boolean expression.
+ *   - SET-MEMBERSHIP (round 2, E1): `new Set(['timeout','error']).has(checkStatus)`,
+ *     either literal order — the same NOT-COMPLETED question spelled via
+ *     `Set#has` instead of `Array#includes`/`||`.
+ *   - HOISTED-COLLECTION (round 2, E1): the denylist array/Set held in a
+ *     NAMED const declared earlier (`const TRANSIENT = ['timeout','error'] as
+ *     const;` … `TRANSIENT.includes(checkStatus)`), rather than inlined right
+ *     before `.includes`/`.has` — a backreference (`\1`) ties the later call
+ *     back to the SAME hoisted name, either literal order.
  *
  * Comparison operators are `!==?`/`===?` (an optional second `=`) rather
  * than a hard-coded `!==`/`===`, so a re-spelling that loosens to `!=`/`==`
@@ -143,27 +233,41 @@ const KNOWN_DIFFERENT_PURPOSE = new Set(['../../src/tools/scan-domain.ts', '../.
  * NOT attempted: a fully abstracted local re-implementation under a novel
  * name with no textual relationship to `checkStatus`/`timeout`/`error`/
  * `completed` at all (e.g. a bitmask, a lookup table keyed on something
- * else, or a helper imported from a brand-new, unreviewed module). No text
- * scanner can catch an arbitrary rename with an arbitrary algorithm without
- * either becoming a full type-aware linter or producing unworkable false
- * positives on unrelated code — that class of evasion needs code review to
- * catch, not an audit. This is a judgement call, not a silent gap: it is why
- * this audit is a SUPPLEMENT to review, not a replacement for it.
+ * else, or a helper imported from a brand-new, unreviewed module), NOR an
+ * alias whose provenance can't be traced back to `checkStatus` by
+ * `findCheckStatusAliases` (see that function's "known remaining gap" note).
+ * No text scanner can catch an arbitrary rename with an arbitrary algorithm
+ * without either becoming a full type-aware linter or producing unworkable
+ * false positives on unrelated code — that class of evasion needs code
+ * review to catch, not an audit. This is a judgement call, not a silent gap:
+ * it is why this audit is a SUPPLEMENT to review, not a replacement for it.
  */
-const FORBIDDEN_SHAPES: RegExp[] = [
-	/checkStatus\s*!==?\s*'timeout'[\s\S]{0,100}?checkStatus\s*!==?\s*'error'/,
-	/checkStatus\s*!==?\s*'error'[\s\S]{0,100}?checkStatus\s*!==?\s*'timeout'/,
-	/checkStatus\s*===?\s*undefined[\s\S]{0,100}?checkStatus\s*===?\s*'completed'/,
-	/checkStatus\s*===?\s*'completed'[\s\S]{0,100}?checkStatus\s*===?\s*undefined/,
-	/checkStatus\s*===?\s*'error'[\s\S]{0,100}?checkStatus\s*===?\s*'timeout'/,
-	/checkStatus\s*===?\s*'timeout'[\s\S]{0,100}?checkStatus\s*===?\s*'error'/,
-	// M5a — array-membership form, either literal order.
-	/\[\s*'timeout'\s*,\s*'error'\s*\][\s\S]{0,60}?\.includes\([^)]*checkStatus[^)]*\)/,
-	/\[\s*'error'\s*,\s*'timeout'\s*\][\s\S]{0,60}?\.includes\([^)]*checkStatus[^)]*\)/,
-	// M5b — switch/case fall-through form, either case order.
-	/switch\s*\([^)]*checkStatus[^)]*\)[\s\S]{0,200}?case\s*'timeout'\s*:[\s\S]{0,80}?case\s*'error'\s*:/,
-	/switch\s*\([^)]*checkStatus[^)]*\)[\s\S]{0,200}?case\s*'error'\s*:[\s\S]{0,80}?case\s*'timeout'\s*:/,
-];
+function buildForbiddenShapes(idPat: string): RegExp[] {
+	return [
+		new RegExp(`${idPat}\\s*!==?\\s*'timeout'[\\s\\S]{0,100}?${idPat}\\s*!==?\\s*'error'`),
+		new RegExp(`${idPat}\\s*!==?\\s*'error'[\\s\\S]{0,100}?${idPat}\\s*!==?\\s*'timeout'`),
+		new RegExp(`${idPat}\\s*===?\\s*undefined[\\s\\S]{0,100}?${idPat}\\s*===?\\s*'completed'`),
+		new RegExp(`${idPat}\\s*===?\\s*'completed'[\\s\\S]{0,100}?${idPat}\\s*===?\\s*undefined`),
+		new RegExp(`${idPat}\\s*===?\\s*'error'[\\s\\S]{0,100}?${idPat}\\s*===?\\s*'timeout'`),
+		new RegExp(`${idPat}\\s*===?\\s*'timeout'[\\s\\S]{0,100}?${idPat}\\s*===?\\s*'error'`),
+		// M5a — array-membership form, either literal order.
+		new RegExp(`\\[\\s*'timeout'\\s*,\\s*'error'\\s*\\][\\s\\S]{0,60}?\\.includes\\([^)]*${idPat}[^)]*\\)`),
+		new RegExp(`\\[\\s*'error'\\s*,\\s*'timeout'\\s*\\][\\s\\S]{0,60}?\\.includes\\([^)]*${idPat}[^)]*\\)`),
+		// M5b — switch/case fall-through form, either case order.
+		new RegExp(`switch\\s*\\([^)]*${idPat}[^)]*\\)[\\s\\S]{0,200}?case\\s*'timeout'\\s*:[\\s\\S]{0,80}?case\\s*'error'\\s*:`),
+		new RegExp(`switch\\s*\\([^)]*${idPat}[^)]*\\)[\\s\\S]{0,200}?case\\s*'error'\\s*:[\\s\\S]{0,80}?case\\s*'timeout'\\s*:`),
+		// Round 2, E1 — Set-membership form, either literal order.
+		new RegExp(`new\\s+Set\\(\\s*\\[\\s*'timeout'\\s*,\\s*'error'\\s*\\]\\s*\\)[\\s\\S]{0,60}?\\.has\\([^)]*${idPat}[^)]*\\)`),
+		new RegExp(`new\\s+Set\\(\\s*\\[\\s*'error'\\s*,\\s*'timeout'\\s*\\]\\s*\\)[\\s\\S]{0,60}?\\.has\\([^)]*${idPat}[^)]*\\)`),
+		// Round 2, E1 — hoisted array/Set held in a named const, either literal order.
+		new RegExp(
+			`\\bconst\\s+(\\w+)\\s*(?::\\s*[^=]+)?=\\s*(?:new\\s+Set\\()?\\[\\s*'timeout'\\s*,\\s*'error'\\s*\\](?:\\s*as\\s*const)?\\)?[\\s\\S]{0,400}?\\1\\.(?:includes|has)\\([^)]*${idPat}[^)]*\\)`,
+		),
+		new RegExp(
+			`\\bconst\\s+(\\w+)\\s*(?::\\s*[^=]+)?=\\s*(?:new\\s+Set\\()?\\[\\s*'error'\\s*,\\s*'timeout'\\s*\\](?:\\s*as\\s*const)?\\)?[\\s\\S]{0,400}?\\1\\.(?:includes|has)\\([^)]*${idPat}[^)]*\\)`,
+		),
+	];
+}
 
 /** A local re-declaration of the SSOT's own exported names, anywhere outside the SSOT file. */
 const REDECLARATION_SHAPES: RegExp[] = [
@@ -172,10 +276,10 @@ const REDECLARATION_SHAPES: RegExp[] = [
 	/\b(?:export\s+)?(?:const|let|var|function)\s+normalizeCheckStatus\b/,
 ];
 
-/** Total forbidden-shape matches (all shapes, each counted with a global flag) in one file's stripped source. */
+/** Total forbidden-shape matches (all shapes for THIS file's traced identifier set, each counted with a global flag) in one file's stripped source. */
 function countForbiddenShapeMatches(source: string): number {
 	let total = 0;
-	for (const shape of FORBIDDEN_SHAPES) {
+	for (const shape of buildForbiddenShapes(identifierPattern(findCheckStatusAliases(source)))) {
 		const global = new RegExp(shape.source, 'g');
 		total += source.match(global)?.length ?? 0;
 	}
@@ -219,13 +323,16 @@ describe('completed-evidence predicate SSOT (src/ only)', () => {
 		expect(source).toMatch(/checks\.some\(isCompletedCheck\)/);
 	});
 
-	it('has no OTHER src/ module re-deriving the completed/not-completed check inline (copy-paste OR rewritten)', () => {
+	it('has no OTHER src/ module re-deriving the completed/not-completed check inline (copy-paste OR rewritten, incl. renamed/aliased identifiers)', () => {
 		const offenders: Array<{ path: string; shape: string }> = [];
 		for (const path of shippedSourcePaths()) {
 			if (path === SSOT_PATH) continue;
 			if (KNOWN_DIFFERENT_PURPOSE.has(path)) continue;
 			const source = STRIPPED[path];
-			for (const shape of FORBIDDEN_SHAPES) {
+			// Per-file: checkStatus plus any alias PROVABLY traced back to it in
+			// THIS file — see findCheckStatusAliases doc for why this is not a
+			// blind "any identifier" match.
+			for (const shape of buildForbiddenShapes(identifierPattern(findCheckStatusAliases(source)))) {
 				if (shape.test(source)) offenders.push({ path, shape: shape.source });
 			}
 		}

--- a/test/audits/completed-evidence-predicate-ssot.audit.test.ts
+++ b/test/audits/completed-evidence-predicate-ssot.audit.test.ts
@@ -65,6 +65,36 @@
  * `src/tools/discover-brand-domains.ts`, both branching on an unrelated
  * `status` variable that was never derived from `checkStatus`) — see
  * `findCheckStatusAliases`'s doc for the exact boundary this leaves.
+ *
+ * ROUND 3: the final-wave reviewer found two more evasions of the round-2
+ * machinery, both closed:
+ *   (b) a cast/parenthesis wedged between a HOISTED collection name and its
+ *       `.includes`/`.has` call — `(TRANSIENT as readonly string[]).includes(cs)`
+ *       — defeated the backreference in the M5a/E1 hoisted-collection shapes,
+ *       which required `\1` immediately followed by `.includes`/`.has` with no
+ *       gap. The plain, uncast `TRANSIENT.includes(cs)` was already caught.
+ *       Fixed by allowing an optional `(… as …)` wrapper around the
+ *       backreference in those two shapes.
+ *   (N3) `const cs = check.checkStatus ?? 'completed';` — the direct-initializer
+ *       alias regex in `findCheckStatusAliases` required the initializer to be
+ *       JUST `checkStatus`/`x.checkStatus`, terminated immediately by
+ *       `[;,)\n]`, so a `?? 'completed'` tail (this repo's OWN pre-3813f07c
+ *       value-normalization spelling — see `normalizeCheckStatus`'s body in
+ *       the SSOT file) fell through untraced. Fixed by allowing that exact
+ *       optional tail before the terminator.
+ * Two classes remain KNOWN-OPEN, deliberately not chased (a text scanner
+ * cannot close them without an unacceptable false-positive rate — see
+ * `findCheckStatusAliases`'s doc for the full boundary):
+ *   (N1) a TWO-HOP alias chain — `const a = check.checkStatus; const b = a;`
+ *       — `a` is traced (RHS is literally `checkStatus`), but `b`'s RHS is
+ *       the identifier `a`, not the literal `checkStatus` token, so the
+ *       direct-initializer regex does not extend the chain to `b`.
+ *   (N2) `check.checkStatus` passed directly into a helper function's
+ *       parameter — `someHelper(check.checkStatus)` — the parameter name
+ *       inside the helper is never traced back to the call-site expression at
+ *       all; this is the same "threaded through an intermediate function
+ *       call" gap already noted below, restated here for the doc-vs-code
+ *       parity the final review round asked for.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -143,9 +173,14 @@ const KNOWN_DIFFERENT_PURPOSE = new Set(['../../src/tools/scan-domain.ts', '../.
  *     `checkStatus` field, not reading a local alias OUT of one; conflating
  *     the two was tried and produced a false alias there).
  *   - a direct initializer: `const cs = checkStatus;` or
- *     `const cs = result.checkStatus;` — matched only when the initializer is
- *     JUST that reference (immediately followed by `;`/`,`/`)`/newline), not
- *     an arbitrary expression that merely mentions `checkStatus` (e.g.
+ *     `const cs = result.checkStatus;`, OPTIONALLY followed by the SSOT's
+ *     own `?? 'completed'` value-normalization tail (round 3, N3 — e.g.
+ *     `const cs = check.checkStatus ?? 'completed';`, this repo's OWN
+ *     pre-3813f07c spelling, matching `normalizeCheckStatus`'s own body) —
+ *     matched only when the initializer is JUST that reference (plus the
+ *     optional `?? 'completed'` tail), immediately followed by
+ *     `;`/`,`/`)`/newline, not an arbitrary expression that merely mentions
+ *     `checkStatus` (e.g.
  *     `const isUnanalyzable = result.checkStatus === 'error' || ...` in
  *     `check-http-security.ts` is deliberately NOT treated as an alias of
  *     `checkStatus` — `isUnanalyzable` is a derived boolean, not the status
@@ -165,18 +200,29 @@ const KNOWN_DIFFERENT_PURPOSE = new Set(['../../src/tools/scan-domain.ts', '../.
  * that false-positive rate — verified empirically: zero offenders across the
  * corpus below with this version, vs. two with the blind version.
  *
- * Known remaining gap (undetectable by a text scanner, same class as the
- * "NOT attempted" note further down): an alias assigned outside its
- * declaration (`let cs; cs = checkStatus;`) or threaded through an
- * intermediate function call (`const cs = pick(checkStatus);`) is NOT traced
- * — review-time concern, not this audit's job.
+ * Known remaining gaps (undetectable by a text scanner, same class as the
+ * "NOT attempted" note further down; round 3 named these explicitly as
+ * N1/N2 so the doc's claimed coverage never runs ahead of the code):
+ *   (N1) a TWO-HOP alias chain — `const a = check.checkStatus; const b = a;`
+ *       — `a` is traced (its initializer is literally `checkStatus`), but
+ *       `b`'s initializer is the identifier `a`, not the literal
+ *       `checkStatus` token, so the chain does not extend to `b`.
+ *   (N2) `check.checkStatus` passed directly into a helper function's
+ *       parameter — `someHelper(check.checkStatus)` — the parameter name
+ *       inside the helper has no textual link back to `checkStatus` at the
+ *       call site, so it can never be traced. (This is the same class as
+ *       the `const cs = pick(checkStatus);` intermediate-function-call gap
+ *       below, restated under its round-3 name.)
+ * An alias assigned outside its declaration (`let cs; cs = checkStatus;`)
+ * is the same undetectable shape as N1/N2 — review-time concern, not this
+ * audit's job.
  */
 function findCheckStatusAliases(source: string): string[] {
 	const aliases = new Set<string>();
 	for (const m of source.matchAll(/\b(?:const|let|var)\s*\{[^{}]{0,200}?checkStatus\s*:\s*(\w+)[^{}]{0,200}?\}\s*=/g)) {
 		if (m[1] !== 'checkStatus') aliases.add(m[1]);
 	}
-	for (const m of source.matchAll(/\b(?:const|let)\s+(\w+)\s*=\s*(?:\w+\.)?checkStatus\s*[;,)\n]/g)) {
+	for (const m of source.matchAll(/\b(?:const|let)\s+(\w+)\s*=\s*(?:\w+\.)?checkStatus\s*(?:\?\?\s*['"]completed['"]\s*)?[;,)\n]/g)) {
 		if (m[1] !== 'checkStatus') aliases.add(m[1]);
 	}
 	return [...aliases];
@@ -218,11 +264,16 @@ function identifierPattern(aliases: string[]): string {
  *   - SET-MEMBERSHIP (round 2, E1): `new Set(['timeout','error']).has(checkStatus)`,
  *     either literal order — the same NOT-COMPLETED question spelled via
  *     `Set#has` instead of `Array#includes`/`||`.
- *   - HOISTED-COLLECTION (round 2, E1): the denylist array/Set held in a
- *     NAMED const declared earlier (`const TRANSIENT = ['timeout','error'] as
- *     const;` … `TRANSIENT.includes(checkStatus)`), rather than inlined right
- *     before `.includes`/`.has` — a backreference (`\1`) ties the later call
- *     back to the SAME hoisted name, either literal order.
+ *   - HOISTED-COLLECTION (round 2, E1; cast-tolerant since round 3, (b)): the
+ *     denylist array/Set held in a NAMED const declared earlier
+ *     (`const TRANSIENT = ['timeout','error'] as const;` …
+ *     `TRANSIENT.includes(checkStatus)`), rather than inlined right before
+ *     `.includes`/`.has` — a backreference (`\1`) ties the later call back to
+ *     the SAME hoisted name, either literal order. The backreference tolerates
+ *     an optional `(NAME as SomeType)` cast/parenthesis wedged between the
+ *     name and the call — `(TRANSIENT as readonly string[]).includes(cs)` —
+ *     which round 3's (b) found defeated a version that required `\1`
+ *     immediately followed by `.includes`/`.has` with no gap.
  *
  * Comparison operators are `!==?`/`===?` (an optional second `=`) rather
  * than a hard-coded `!==`/`===`, so a re-spelling that loosens to `!=`/`==`
@@ -259,12 +310,16 @@ function buildForbiddenShapes(idPat: string): RegExp[] {
 		// Round 2, E1 — Set-membership form, either literal order.
 		new RegExp(`new\\s+Set\\(\\s*\\[\\s*'timeout'\\s*,\\s*'error'\\s*\\]\\s*\\)[\\s\\S]{0,60}?\\.has\\([^)]*${idPat}[^)]*\\)`),
 		new RegExp(`new\\s+Set\\(\\s*\\[\\s*'error'\\s*,\\s*'timeout'\\s*\\]\\s*\\)[\\s\\S]{0,60}?\\.has\\([^)]*${idPat}[^)]*\\)`),
-		// Round 2, E1 — hoisted array/Set held in a named const, either literal order.
+		// Round 2, E1 — hoisted array/Set held in a named const, either literal
+		// order. Round 3, (b): the backreference tolerates an optional
+		// `(NAME as SomeType)` cast/parenthesis between the hoisted name and the
+		// `.includes`/`.has` call — a bare `\1\.(?:includes|has)\(` (no gap
+		// allowed) let a cast defeat the backreference entirely.
 		new RegExp(
-			`\\bconst\\s+(\\w+)\\s*(?::\\s*[^=]+)?=\\s*(?:new\\s+Set\\()?\\[\\s*'timeout'\\s*,\\s*'error'\\s*\\](?:\\s*as\\s*const)?\\)?[\\s\\S]{0,400}?\\1\\.(?:includes|has)\\([^)]*${idPat}[^)]*\\)`,
+			`\\bconst\\s+(\\w+)\\s*(?::\\s*[^=]+)?=\\s*(?:new\\s+Set\\()?\\[\\s*'timeout'\\s*,\\s*'error'\\s*\\](?:\\s*as\\s*const)?\\)?[\\s\\S]{0,400}?\\(?\\s*\\1(?:\\s+as\\s+[^()]*)?\\s*\\)?\\s*\\.(?:includes|has)\\([^)]*${idPat}[^)]*\\)`,
 		),
 		new RegExp(
-			`\\bconst\\s+(\\w+)\\s*(?::\\s*[^=]+)?=\\s*(?:new\\s+Set\\()?\\[\\s*'error'\\s*,\\s*'timeout'\\s*\\](?:\\s*as\\s*const)?\\)?[\\s\\S]{0,400}?\\1\\.(?:includes|has)\\([^)]*${idPat}[^)]*\\)`,
+			`\\bconst\\s+(\\w+)\\s*(?::\\s*[^=]+)?=\\s*(?:new\\s+Set\\()?\\[\\s*'error'\\s*,\\s*'timeout'\\s*\\](?:\\s*as\\s*const)?\\)?[\\s\\S]{0,400}?\\(?\\s*\\1(?:\\s+as\\s+[^()]*)?\\s*\\)?\\s*\\.(?:includes|has)\\([^)]*${idPat}[^)]*\\)`,
 		),
 	];
 }

--- a/test/audits/completed-evidence-predicate-ssot.audit.test.ts
+++ b/test/audits/completed-evidence-predicate-ssot.audit.test.ts
@@ -1,0 +1,168 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * "Does this check/scan carry completed evidence" must be spelled in exactly
+ * ONE place on the `src/` side: `isCompletedCheck`/`hasCompletedEvidence` in
+ * `src/lib/ungraded-display.ts`.
+ *
+ * Before this audit the same question was answered FOUR different ways: the
+ * SSOT export itself; a local `const hasCompletedEvidence` re-declared inside
+ * `map_compliance`'s `evaluateCompliance` instead of importing the primitive;
+ * an inline arrow-function copy of the same per-check test inside that same
+ * function's per-control partition; and (found while collapsing the above,
+ * so folded into this same guard) two more inline copies inside
+ * `generate_fix_plan` and `map_csc_products`. A future change to what
+ * "completed" means — e.g. a new `CheckStatus` member — would then only
+ * reach the ONE spelling a maintainer remembered to update, silently
+ * reintroducing this campaign's own defect class on whichever surfaces were
+ * missed: a scan with incomplete evidence rendering a confident verdict.
+ * This audit fails if any of those spellings reappears anywhere in `src/`.
+ *
+ * SCOPE: `src/` only. `packages/dns-checks/src/scoring/evidence.ts` carries
+ * its own DELIBERATE twin (`computeScanEvidence`'s per-result
+ * completed/attempted accounting) — that package is a published SSOT
+ * vendored by another repo and is frozen for this campaign (see
+ * `src/lib/ungraded-display.ts`'s file-level doc for the cross-package
+ * pointer). This audit does not, and must not, reach into
+ * `packages/dns-checks`; it exists solely to stop the `src/`-side surfaces
+ * from drifting from EACH OTHER and from their own SSOT.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// Vitest's Workers pool has no `fs`; the source corpus is inlined at build
+// time by import.meta.glob (eager, raw) so this audit runs inside workerd.
+// `src/` ONLY — packages/dns-checks is out of scope by design, see file doc.
+const SOURCES = import.meta.glob(['../../src/**/*.ts'], {
+	eager: true,
+	query: '?raw',
+	import: 'default',
+}) as Record<string, string>;
+
+/** Shipped source only — never this audit's own siblings. */
+function shippedSources(): Array<[string, string]> {
+	return Object.entries(SOURCES).filter(([path]) => !path.endsWith('.spec.ts') && !path.endsWith('.test.ts'));
+}
+
+const SSOT_PATH = '../../src/lib/ungraded-display.ts';
+
+/**
+ * Files that legitimately branch on the CONCRETE `'error' | 'timeout'` value
+ * rather than asking the completed/not-completed BOOLEAN question, so the
+ * three-way-OR shape below is expected and already reviewed there — it is
+ * not a re-spelling of the SSOT predicate:
+ *
+ * - `scan-domain.ts` records the concrete status into a
+ *   `Map<CheckCategory, 'error' | 'timeout'>` for re-application after
+ *   post-processing strips `checkStatus`. It needs the VALUE, not a
+ *   boolean — routing it through `isCompletedCheck` would just move the
+ *   same type-narrowing problem to an unsafe cast at the call site, with
+ *   no SSOT benefit.
+ * - `check-http-security.ts` gates a CDN-annotation enrichment on a
+ *   THREE-way OR (`checkStatus` transient OR a `missingControl` finding) —
+ *   a narrower, single-check, single-purpose gate, not the "does this scan
+ *   have usable evidence" question the SSOT answers.
+ */
+const KNOWN_DIFFERENT_PURPOSE = new Set(['../../src/tools/scan-domain.ts', '../../src/tools/check-http-security.ts']);
+
+/**
+ * Every shape (both comparison orders) this collapse found duplicated:
+ *   - DENYLIST-AND: `!== 'timeout' && ... !== 'error'` — the local shadow
+ *     and the inline copy inside `map_compliance`, and the fix-plan
+ *     `actionableFindings` filter.
+ *   - ALLOWLIST-OR (manually spelled): `=== undefined || ... === 'completed'`
+ *     — a hand-written restatement of `isCompletedCheck`'s own body.
+ *   - NOT-COMPLETED-OR: `=== 'error' || ... === 'timeout'` — the complement
+ *     form used by the fix-plan `transientCategories` filter and
+ *     `map_csc_products`' single-result gate.
+ * A `[\s\S]{0,80}` gap tolerates the arrow-function/whitespace between the
+ * two comparisons without reaching across unrelated code far apart in the
+ * same file.
+ */
+const FORBIDDEN_SHAPES: RegExp[] = [
+	/checkStatus\s*!==\s*'timeout'[\s\S]{0,80}?checkStatus\s*!==\s*'error'/,
+	/checkStatus\s*!==\s*'error'[\s\S]{0,80}?checkStatus\s*!==\s*'timeout'/,
+	/checkStatus\s*===\s*undefined[\s\S]{0,80}?checkStatus\s*===\s*'completed'/,
+	/checkStatus\s*===\s*'completed'[\s\S]{0,80}?checkStatus\s*===\s*undefined/,
+	/checkStatus\s*===\s*'error'[\s\S]{0,80}?checkStatus\s*===\s*'timeout'/,
+	/checkStatus\s*===\s*'timeout'[\s\S]{0,80}?checkStatus\s*===\s*'error'/,
+];
+
+/** A local re-declaration of the SSOT's own exported names, anywhere outside the SSOT file. */
+const REDECLARATION_SHAPES: RegExp[] = [
+	/\b(?:export\s+)?(?:const|let|var|function)\s+hasCompletedEvidence\b/,
+	/\b(?:export\s+)?(?:const|let|var|function)\s+isCompletedCheck\b/,
+];
+
+describe('completed-evidence predicate SSOT (src/ only)', () => {
+	it('scanned a non-trivial src/ corpus, including the SSOT file and a known consumer', () => {
+		// Anti-vacuous guard: an empty/near-empty glob would make every assertion
+		// below pass trivially and protect nothing — this campaign caught exactly
+		// that failure mode (a vacuous-green sweep) in an earlier slice.
+		const files = shippedSources();
+		expect(files.length).toBeGreaterThan(200);
+		expect(Object.keys(SOURCES)).toContain(SSOT_PATH);
+		expect(Object.keys(SOURCES)).toContain('../../src/tools/map-compliance.ts');
+		expect(Object.keys(SOURCES)).toContain('../../src/tools/generate-fix-plan.ts');
+		expect(Object.keys(SOURCES)).toContain('../../src/tools/map-csc-products.ts');
+	});
+
+	it('declares hasCompletedEvidence / isCompletedCheck exactly once each, both in the SSOT file', () => {
+		for (const name of ['hasCompletedEvidence', 'isCompletedCheck']) {
+			const declPattern = new RegExp(`\\bexport function ${name}\\b`, 'g');
+			const declaredIn: string[] = [];
+			for (const [path, source] of shippedSources()) {
+				const matches = source.match(declPattern);
+				if (matches) {
+					for (const _m of matches) declaredIn.push(path);
+				}
+			}
+			expect(declaredIn, `${name} must be declared exactly once, in ${SSOT_PATH}`).toEqual([SSOT_PATH]);
+		}
+	});
+
+	it('hasCompletedEvidence delegates to isCompletedCheck rather than re-deriving it inline', () => {
+		const source = SOURCES[SSOT_PATH];
+		expect(source).toBeDefined();
+		expect(source).toMatch(/checks\.some\(isCompletedCheck\)/);
+	});
+
+	it('has no OTHER src/ module re-deriving the completed/not-completed check inline', () => {
+		const offenders: Array<{ path: string; shape: string }> = [];
+		for (const [path, source] of shippedSources()) {
+			if (path === SSOT_PATH) continue;
+			if (KNOWN_DIFFERENT_PURPOSE.has(path)) continue;
+			for (const shape of FORBIDDEN_SHAPES) {
+				if (shape.test(source)) offenders.push({ path, shape: shape.source });
+			}
+		}
+		expect(offenders, 'import isCompletedCheck/hasCompletedEvidence from src/lib/ungraded-display.ts instead').toEqual([]);
+	});
+
+	it('has no OTHER src/ module re-declaring hasCompletedEvidence/isCompletedCheck as a local binding', () => {
+		const offenders: Array<{ path: string; shape: string }> = [];
+		for (const [path, source] of shippedSources()) {
+			if (path === SSOT_PATH) continue;
+			for (const shape of REDECLARATION_SHAPES) {
+				if (shape.test(source)) offenders.push({ path, shape: shape.source });
+			}
+		}
+		expect(offenders).toEqual([]);
+	});
+
+	it('the KNOWN_DIFFERENT_PURPOSE exclusions still exist and still only contain the reviewed shape', () => {
+		// If either file were renamed/removed this exclusion set would silently
+		// stop meaning anything; if either one grows a SECOND, unreviewed
+		// instance of the forbidden shape elsewhere in the same file, the
+		// non-emptiness check for offenders in the previous test only skips a
+		// whole PATH — so this test independently pins that the ONE reviewed
+		// occurrence is still exactly what was reviewed, not a superset.
+		for (const path of KNOWN_DIFFERENT_PURPOSE) {
+			expect(Object.keys(SOURCES), `${path} must exist for this exclusion to mean anything`).toContain(path);
+		}
+		expect(SOURCES['../../src/tools/scan-domain.ts']).toMatch(/r\.checkStatus === 'error' \|\| r\.checkStatus === 'timeout'/);
+		expect(SOURCES['../../src/tools/check-http-security.ts']).toMatch(
+			/result\.checkStatus === 'error' \|\| result\.checkStatus === 'timeout'/,
+		);
+	});
+});

--- a/test/audits/completed-evidence-predicate-ssot.audit.test.ts
+++ b/test/audits/completed-evidence-predicate-ssot.audit.test.ts
@@ -2,21 +2,29 @@
 
 /**
  * "Does this check/scan carry completed evidence" must be spelled in exactly
- * ONE place on the `src/` side: `isCompletedCheck`/`hasCompletedEvidence` in
- * `src/lib/ungraded-display.ts`.
+ * ONE place on the `src/` side: `isCompletedCheck`/`hasCompletedEvidence`/
+ * `normalizeCheckStatus` in `src/lib/ungraded-display.ts`.
  *
- * Before this audit the same question was answered FOUR different ways: the
- * SSOT export itself; a local `const hasCompletedEvidence` re-declared inside
- * `map_compliance`'s `evaluateCompliance` instead of importing the primitive;
- * an inline arrow-function copy of the same per-check test inside that same
- * function's per-control partition; and (found while collapsing the above,
- * so folded into this same guard) two more inline copies inside
- * `generate_fix_plan` and `map_csc_products`. A future change to what
- * "completed" means — e.g. a new `CheckStatus` member — would then only
- * reach the ONE spelling a maintainer remembered to update, silently
- * reintroducing this campaign's own defect class on whichever surfaces were
- * missed: a scan with incomplete evidence rendering a confident verdict.
- * This audit fails if any of those spellings reappears anywhere in `src/`.
+ * Before this audit the same question was answered independently, by hand, at
+ * least SEVEN times: the SSOT export itself; a local `const hasCompletedEvidence`
+ * re-declared inside `map_compliance`'s `evaluateCompliance` instead of
+ * importing the primitive; an inline arrow-function copy of the same per-check
+ * test inside that same function's per-control partition; two more inline
+ * copies inside `generate_fix_plan` and `map_csc_products` (both explicitly
+ * commented as "mirrors map_compliance's completed filter" — a comment that
+ * correctly diagnosed the duplication without fixing it); and, in
+ * `format-report.ts`'s customer-facing `buildStructuredScanResult`, a
+ * `checkStatus ?? 'completed'` value-normalization (used twice) plus a THIRD
+ * inline copy (`status === 'timeout' || status === 'error'`, hidden from a
+ * naive `checkStatus`-only text search by a locally renamed variable). A
+ * future change to what "completed" means — e.g. a new `CheckStatus` member —
+ * would then only reach the ONE spelling a maintainer remembered to update,
+ * silently reintroducing this campaign's own defect class on whichever
+ * surfaces were missed: a scan with incomplete evidence rendering a confident
+ * verdict. This audit fails if any of those spellings reappears anywhere in
+ * `src/`, INCLUDING syntactic rewrites of the same logic (array-membership,
+ * switch/case, loose (`!=`/`==`) comparison, or a comment wedged between the
+ * two halves of a split comparison) — see FORBIDDEN_SHAPES below.
  *
  * SCOPE: `src/` only. `packages/dns-checks/src/scoring/evidence.ts` carries
  * its own DELIBERATE twin (`computeScanEvidence`'s per-result
@@ -26,6 +34,16 @@
  * pointer). This audit does not, and must not, reach into
  * `packages/dns-checks`; it exists solely to stop the `src/`-side surfaces
  * from drifting from EACH OTHER and from their own SSOT.
+ *
+ * This is a TEXT scanner, not a parser — it cannot catch every conceivable
+ * rewrite (a fully abstracted local helper with a made-up name, a computed
+ * property lookup, a re-implementation via a completely different algorithm
+ * that happens to be extensionally equal). It targets the syntactic shapes a
+ * human actually reaches for when re-deriving "is this checkStatus
+ * completed" by hand, discovered by adversarial review of an earlier version
+ * of this same audit (see FORBIDDEN_SHAPES doc for the specific evasions this
+ * closes, and for the one judged infeasible to add without an unacceptable
+ * false-positive rate).
  */
 
 import { describe, it, expect } from 'vitest';
@@ -40,9 +58,35 @@ const SOURCES = import.meta.glob(['../../src/**/*.ts'], {
 }) as Record<string, string>;
 
 /** Shipped source only — never this audit's own siblings. */
-function shippedSources(): Array<[string, string]> {
-	return Object.entries(SOURCES).filter(([path]) => !path.endsWith('.spec.ts') && !path.endsWith('.test.ts'));
+function shippedSourcePaths(): string[] {
+	return Object.keys(SOURCES).filter((path) => !path.endsWith('.spec.ts') && !path.endsWith('.test.ts'));
 }
+
+/**
+ * Strip comments before shape-matching, so a re-spelling can't hide by
+ * wedging an arbitrarily long explanatory comment between the two halves of
+ * a split comparison (the M5c evasion an earlier version of this audit
+ * missed — see FORBIDDEN_SHAPES doc). Matches, in priority order: a
+ * string/template literal (kept VERBATIM, so a `//` or `/*` inside a URL or
+ * prose string is never mistaken for a comment start) OR a block comment OR
+ * a line comment (both replaced with a single space, so tokens on either
+ * side of a removed comment don't get accidentally glued together). This is
+ * a text heuristic, not a real lexer — nested template-literal
+ * interpolations containing comment-like sequences are the known edge case
+ * it does not handle, judged acceptable because none of the `checkStatus`
+ * shapes this audit polices occur inside a template-literal expression
+ * anywhere in the current corpus (verified by the non-vacuity test below
+ * still finding real files, and the corpus-wide "no offenders" test staying
+ * green).
+ */
+function stripComments(source: string): string {
+	return source.replace(/"(?:\\.|[^"\\])*"|'(?:\\.|[^'\\])*'|`(?:\\.|[^`\\])*`|\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, (match) =>
+		match.startsWith('/*') || match.startsWith('//') ? ' ' : match,
+	);
+}
+
+/** `path -> comment-stripped source`, computed once. Shape-matching ALWAYS runs against this, never raw SOURCES. */
+const STRIPPED: Record<string, string> = Object.fromEntries(shippedSourcePaths().map((path) => [path, stripComments(SOURCES[path])]));
 
 const SSOT_PATH = '../../src/lib/ungraded-display.ts';
 
@@ -66,53 +110,101 @@ const SSOT_PATH = '../../src/lib/ungraded-display.ts';
 const KNOWN_DIFFERENT_PURPOSE = new Set(['../../src/tools/scan-domain.ts', '../../src/tools/check-http-security.ts']);
 
 /**
- * Every shape (both comparison orders) this collapse found duplicated:
- *   - DENYLIST-AND: `!== 'timeout' && ... !== 'error'` — the local shadow
- *     and the inline copy inside `map_compliance`, and the fix-plan
- *     `actionableFindings` filter.
+ * Every shape (both comparison orders, where applicable) known to re-derive
+ * the completed/not-completed question outside the SSOT. Matched against
+ * COMMENT-STRIPPED source (see `stripComments`) with a modest gap that only
+ * needs to bridge whitespace/arrow-function syntax now that comments can no
+ * longer pad it out:
+ *
+ *   - DENYLIST-AND: `!== 'timeout' && ... !== 'error'` (found in the local
+ *     shadow, the inline copy inside `map_compliance`, and the fix-plan
+ *     `actionableFindings` filter).
  *   - ALLOWLIST-OR (manually spelled): `=== undefined || ... === 'completed'`
  *     — a hand-written restatement of `isCompletedCheck`'s own body.
- *   - NOT-COMPLETED-OR: `=== 'error' || ... === 'timeout'` — the complement
- *     form used by the fix-plan `transientCategories` filter and
- *     `map_csc_products`' single-result gate.
- * A `[\s\S]{0,80}` gap tolerates the arrow-function/whitespace between the
- * two comparisons without reaching across unrelated code far apart in the
- * same file.
+ *   - NOT-COMPLETED-OR: `=== 'error' || ... === 'timeout'` (the complement
+ *     form used by the fix-plan `transientCategories` filter,
+ *     `map_csc_products`' single-result gate, and — before this collapse —
+ *     `format-report.ts`'s `inconclusiveCategories` partition).
+ *   - ARRAY-MEMBERSHIP (M5a): `['timeout','error'].includes(checkStatus)`,
+ *     either literal order, optionally parenthesised/`as const`-cast and
+ *     negated — the same NOT-COMPLETED question spelled via `Array#includes`
+ *     instead of `||`.
+ *   - SWITCH/CASE (M5b): a `switch (…checkStatus…)` whose `case 'timeout':`
+ *     and `case 'error':` fall through together (either order) — the same
+ *     grouping of the two transient members into one bucket, spelled as
+ *     control flow instead of a boolean expression.
+ *
+ * Comparison operators are `!==?`/`===?` (an optional second `=`) rather
+ * than a hard-coded `!==`/`===`, so a re-spelling that loosens to `!=`/`==`
+ * (M5d — behaviourally identical for these string-literal comparisons, so a
+ * developer "simplifying" the operator would still slip the exact same
+ * defect past a strict-only regex) is caught too.
+ *
+ * NOT attempted: a fully abstracted local re-implementation under a novel
+ * name with no textual relationship to `checkStatus`/`timeout`/`error`/
+ * `completed` at all (e.g. a bitmask, a lookup table keyed on something
+ * else, or a helper imported from a brand-new, unreviewed module). No text
+ * scanner can catch an arbitrary rename with an arbitrary algorithm without
+ * either becoming a full type-aware linter or producing unworkable false
+ * positives on unrelated code — that class of evasion needs code review to
+ * catch, not an audit. This is a judgement call, not a silent gap: it is why
+ * this audit is a SUPPLEMENT to review, not a replacement for it.
  */
 const FORBIDDEN_SHAPES: RegExp[] = [
-	/checkStatus\s*!==\s*'timeout'[\s\S]{0,80}?checkStatus\s*!==\s*'error'/,
-	/checkStatus\s*!==\s*'error'[\s\S]{0,80}?checkStatus\s*!==\s*'timeout'/,
-	/checkStatus\s*===\s*undefined[\s\S]{0,80}?checkStatus\s*===\s*'completed'/,
-	/checkStatus\s*===\s*'completed'[\s\S]{0,80}?checkStatus\s*===\s*undefined/,
-	/checkStatus\s*===\s*'error'[\s\S]{0,80}?checkStatus\s*===\s*'timeout'/,
-	/checkStatus\s*===\s*'timeout'[\s\S]{0,80}?checkStatus\s*===\s*'error'/,
+	/checkStatus\s*!==?\s*'timeout'[\s\S]{0,100}?checkStatus\s*!==?\s*'error'/,
+	/checkStatus\s*!==?\s*'error'[\s\S]{0,100}?checkStatus\s*!==?\s*'timeout'/,
+	/checkStatus\s*===?\s*undefined[\s\S]{0,100}?checkStatus\s*===?\s*'completed'/,
+	/checkStatus\s*===?\s*'completed'[\s\S]{0,100}?checkStatus\s*===?\s*undefined/,
+	/checkStatus\s*===?\s*'error'[\s\S]{0,100}?checkStatus\s*===?\s*'timeout'/,
+	/checkStatus\s*===?\s*'timeout'[\s\S]{0,100}?checkStatus\s*===?\s*'error'/,
+	// M5a — array-membership form, either literal order.
+	/\[\s*'timeout'\s*,\s*'error'\s*\][\s\S]{0,60}?\.includes\([^)]*checkStatus[^)]*\)/,
+	/\[\s*'error'\s*,\s*'timeout'\s*\][\s\S]{0,60}?\.includes\([^)]*checkStatus[^)]*\)/,
+	// M5b — switch/case fall-through form, either case order.
+	/switch\s*\([^)]*checkStatus[^)]*\)[\s\S]{0,200}?case\s*'timeout'\s*:[\s\S]{0,80}?case\s*'error'\s*:/,
+	/switch\s*\([^)]*checkStatus[^)]*\)[\s\S]{0,200}?case\s*'error'\s*:[\s\S]{0,80}?case\s*'timeout'\s*:/,
 ];
 
 /** A local re-declaration of the SSOT's own exported names, anywhere outside the SSOT file. */
 const REDECLARATION_SHAPES: RegExp[] = [
 	/\b(?:export\s+)?(?:const|let|var|function)\s+hasCompletedEvidence\b/,
 	/\b(?:export\s+)?(?:const|let|var|function)\s+isCompletedCheck\b/,
+	/\b(?:export\s+)?(?:const|let|var|function)\s+normalizeCheckStatus\b/,
 ];
 
+/** Total forbidden-shape matches (all shapes, each counted with a global flag) in one file's stripped source. */
+function countForbiddenShapeMatches(source: string): number {
+	let total = 0;
+	for (const shape of FORBIDDEN_SHAPES) {
+		const global = new RegExp(shape.source, 'g');
+		total += source.match(global)?.length ?? 0;
+	}
+	return total;
+}
+
 describe('completed-evidence predicate SSOT (src/ only)', () => {
-	it('scanned a non-trivial src/ corpus, including the SSOT file and a known consumer', () => {
+	it('scanned a non-trivial src/ corpus, including the SSOT file and known consumers', () => {
 		// Anti-vacuous guard: an empty/near-empty glob would make every assertion
 		// below pass trivially and protect nothing — this campaign caught exactly
 		// that failure mode (a vacuous-green sweep) in an earlier slice.
-		const files = shippedSources();
-		expect(files.length).toBeGreaterThan(200);
-		expect(Object.keys(SOURCES)).toContain(SSOT_PATH);
-		expect(Object.keys(SOURCES)).toContain('../../src/tools/map-compliance.ts');
-		expect(Object.keys(SOURCES)).toContain('../../src/tools/generate-fix-plan.ts');
-		expect(Object.keys(SOURCES)).toContain('../../src/tools/map-csc-products.ts');
+		const paths = shippedSourcePaths();
+		expect(paths.length).toBeGreaterThan(200);
+		expect(paths).toContain(SSOT_PATH);
+		expect(paths).toContain('../../src/tools/map-compliance.ts');
+		expect(paths).toContain('../../src/tools/generate-fix-plan.ts');
+		expect(paths).toContain('../../src/tools/map-csc-products.ts');
+		expect(paths).toContain('../../src/tools/scan/format-report.ts');
+		// The comment-stripping preprocessor must actually remove something on a
+		// real file, not silently no-op (which would make the M5c defense vacuous).
+		expect(STRIPPED[SSOT_PATH].length).toBeLessThan(SOURCES[SSOT_PATH].length);
 	});
 
-	it('declares hasCompletedEvidence / isCompletedCheck exactly once each, both in the SSOT file', () => {
-		for (const name of ['hasCompletedEvidence', 'isCompletedCheck']) {
+	it('declares hasCompletedEvidence / isCompletedCheck / normalizeCheckStatus exactly once each, all in the SSOT file', () => {
+		for (const name of ['hasCompletedEvidence', 'isCompletedCheck', 'normalizeCheckStatus']) {
 			const declPattern = new RegExp(`\\bexport function ${name}\\b`, 'g');
 			const declaredIn: string[] = [];
-			for (const [path, source] of shippedSources()) {
-				const matches = source.match(declPattern);
+			for (const path of shippedSourcePaths()) {
+				const matches = STRIPPED[path].match(declPattern);
 				if (matches) {
 					for (const _m of matches) declaredIn.push(path);
 				}
@@ -122,27 +214,31 @@ describe('completed-evidence predicate SSOT (src/ only)', () => {
 	});
 
 	it('hasCompletedEvidence delegates to isCompletedCheck rather than re-deriving it inline', () => {
-		const source = SOURCES[SSOT_PATH];
+		const source = STRIPPED[SSOT_PATH];
 		expect(source).toBeDefined();
 		expect(source).toMatch(/checks\.some\(isCompletedCheck\)/);
 	});
 
-	it('has no OTHER src/ module re-deriving the completed/not-completed check inline', () => {
+	it('has no OTHER src/ module re-deriving the completed/not-completed check inline (copy-paste OR rewritten)', () => {
 		const offenders: Array<{ path: string; shape: string }> = [];
-		for (const [path, source] of shippedSources()) {
+		for (const path of shippedSourcePaths()) {
 			if (path === SSOT_PATH) continue;
 			if (KNOWN_DIFFERENT_PURPOSE.has(path)) continue;
+			const source = STRIPPED[path];
 			for (const shape of FORBIDDEN_SHAPES) {
 				if (shape.test(source)) offenders.push({ path, shape: shape.source });
 			}
 		}
-		expect(offenders, 'import isCompletedCheck/hasCompletedEvidence from src/lib/ungraded-display.ts instead').toEqual([]);
+		expect(offenders, 'import isCompletedCheck/hasCompletedEvidence/normalizeCheckStatus from src/lib/ungraded-display.ts instead').toEqual(
+			[],
+		);
 	});
 
-	it('has no OTHER src/ module re-declaring hasCompletedEvidence/isCompletedCheck as a local binding', () => {
+	it('has no OTHER src/ module re-declaring hasCompletedEvidence/isCompletedCheck/normalizeCheckStatus as a local binding', () => {
 		const offenders: Array<{ path: string; shape: string }> = [];
-		for (const [path, source] of shippedSources()) {
+		for (const path of shippedSourcePaths()) {
 			if (path === SSOT_PATH) continue;
+			const source = STRIPPED[path];
 			for (const shape of REDECLARATION_SHAPES) {
 				if (shape.test(source)) offenders.push({ path, shape: shape.source });
 			}
@@ -150,19 +246,18 @@ describe('completed-evidence predicate SSOT (src/ only)', () => {
 		expect(offenders).toEqual([]);
 	});
 
-	it('the KNOWN_DIFFERENT_PURPOSE exclusions still exist and still only contain the reviewed shape', () => {
-		// If either file were renamed/removed this exclusion set would silently
-		// stop meaning anything; if either one grows a SECOND, unreviewed
-		// instance of the forbidden shape elsewhere in the same file, the
-		// non-emptiness check for offenders in the previous test only skips a
-		// whole PATH — so this test independently pins that the ONE reviewed
-		// occurrence is still exactly what was reviewed, not a superset.
+	it('the KNOWN_DIFFERENT_PURPOSE exclusions carry EXACTLY ONE reviewed occurrence each, not a superset', () => {
+		// F3: `toMatch`/presence-only would let a SECOND, unreviewed re-spelling
+		// hide in an excluded file forever (both excluded files are among the
+		// largest, most-churned in src/tools/). Count every forbidden-shape match
+		// in each excluded file's stripped source and require exactly 1 — the one
+		// shape reviewed and named in KNOWN_DIFFERENT_PURPOSE's doc above. Zero
+		// would mean the exclusion no longer protects anything real (dead
+		// exclusion); two or more means an unreviewed second instance was added.
 		for (const path of KNOWN_DIFFERENT_PURPOSE) {
 			expect(Object.keys(SOURCES), `${path} must exist for this exclusion to mean anything`).toContain(path);
+			const count = countForbiddenShapeMatches(STRIPPED[path]);
+			expect(count, `${path} must contain exactly the one reviewed forbidden-shape occurrence, found ${count}`).toBe(1);
 		}
-		expect(SOURCES['../../src/tools/scan-domain.ts']).toMatch(/r\.checkStatus === 'error' \|\| r\.checkStatus === 'timeout'/);
-		expect(SOURCES['../../src/tools/check-http-security.ts']).toMatch(
-			/result\.checkStatus === 'error' \|\| result\.checkStatus === 'timeout'/,
-		);
 	});
 });

--- a/test/audits/ownership-severity-gate.audit.test.ts
+++ b/test/audits/ownership-severity-gate.audit.test.ts
@@ -1,0 +1,444 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Cross-cutting structural-invariant audit — Task 8 (2026-07-26 correctness-
+ * defects design, slice 4 "ownership attribution").
+ *
+ * THE LOAD-BEARING SAFETY PROPERTY THIS AUDIT LOCKS: a finding may exceed
+ * `info` severity ONLY when it is justified by ownership — `owned_by_seed` —
+ * or is an explicitly-named threat OBSERVATION about a candidate that is NOT
+ * the scanned organisation's own domain. Nothing else above `info` is
+ * permitted to slip through `checkShadowDomains()` / `checkLookalikes()`.
+ *
+ * CONTROLLER AMENDMENTS TO THE ORIGINAL TASK-8 BRIEF (binding, see
+ * `.superpowers/sdd/2026-07-26-slice4-ownership-attribution/task-8-brief.md`
+ * for the superseded text):
+ *
+ *  (1) POSITIVE-ASSERTION FORM. The brief's audit inspected only findings
+ *      that already CARRY `ownershipVerdict` — a finding that omits the
+ *      verdict entirely escaped it. This audit instead sweeps EVERY finding
+ *      both tools emit (`assertSeverityJustified` below) and requires each
+ *      one above `info` to affirmatively justify itself:
+ *        (`ownershipVerdict === 'owned_by_seed'`) OR
+ *        (`findingAxis === 'threat_observation'` AND `ownershipVerdict` is
+ *         present and `!== 'owned_by_seed'` AND a candidate domain is named
+ *         in metadata).
+ *      A finding with NEITHER above `info` is an AUDIT FAILURE, full stop.
+ *
+ *  (2) THE AXIS MODEL (lookalikes only — `check-shadow-domains.ts` has no
+ *      `findingAxis` field by design ruling, so its invariant is simply
+ *      "nothing above info without `ownershipVerdict === 'owned_by_seed'`",
+ *      which (1) above already covers). For `checkLookalikes`:
+ *        - every finding carries one of `'attribution' | 'threat_observation'
+ *          | 'scan_status'`;
+ *        - every `'scan_status'` finding is `info`;
+ *        - every `'threat_observation'` finding carries `ownershipVerdict
+ *          !== 'owned_by_seed'` and names a candidate;
+ *        - every `'attribution'` finding for a non-owned candidate is `info`
+ *          AND carries no ownership-framed prose ("shadow domain", "your",
+ *          "owned by same entity") in its title or detail.
+ *      `check-shadow-domains.ts` carries a SEPARATE, single carve-out for
+ *      this same framing rule — `AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE` (the
+ *      Phase-2 "records not observed" fallthrough keeps its ownership-framed
+ *      title because `registration-invariant.audit.test.ts` — byte-frozen —
+ *      pins that exact title literal). This audit asserts that carve-out is
+ *      EXACTLY one title and EXACTLY the known string, so it cannot silently
+ *      widen to swallow other framed titles.
+ *
+ *  (3) THE PRIMITIVE-LEVEL INVARIANT (task 7c). The three candidate-side
+ *      signals (`soaInBailiwick`, `spfIncludesSeedApex`, `httpRedirectToSeedApex`)
+ *      must never — alone or combined — produce `owned_by_seed` from
+ *      `classifyOwnership()` directly. Pinned once more here (unit tests
+ *      already pin it) so a future "optimisation" of those unit tests can't
+ *      silently drop the property from BOTH places at once.
+ *
+ * METHOD NOTE: every clause below was proven to go RED by a real source
+ * mutation (ungating a call site, retagging a `scan_status` finding, undoing
+ * Ruling A, widening the framed-title carve-out, forcing an empty findings
+ * array) — see `.superpowers/sdd/2026-07-26-slice4-ownership-attribution/
+ * task-8-report.md` for the mutation-by-mutation evidence. The mutations
+ * themselves are not preserved in this file; only their proof they were run.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import type { Finding } from '../../src/lib/scoring';
+import { setupFetchMock, createDohResponse } from '../helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+// ---------------------------------------------------------------------------
+// DoH mock plumbing (mirrors test/check-shadow-domains.spec.ts and
+// test/check-lookalikes.spec.ts's own local helpers).
+// ---------------------------------------------------------------------------
+
+function parseDohQuery(input: string | URL | Request): { name: string; type: string } | null {
+	const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+	try {
+		const parsed = new URL(url);
+		return { name: parsed.searchParams.get('name') ?? '', type: parsed.searchParams.get('type') ?? '' };
+	} catch {
+		return null;
+	}
+}
+
+function empty() {
+	return createDohResponse([], []);
+}
+function nsRecords(domain: string, nameservers: string[]) {
+	return createDohResponse(
+		[{ name: domain, type: 2 }],
+		nameservers.map((ns) => ({ name: domain, type: 2, TTL: 300, data: ns })),
+	);
+}
+function aRecords(domain: string, ips: string[]) {
+	return createDohResponse(
+		[{ name: domain, type: 1 }],
+		ips.map((ip) => ({ name: domain, type: 1, TTL: 300, data: ip })),
+	);
+}
+function mxRecords(domain: string, records: string[]) {
+	return createDohResponse(
+		[{ name: domain, type: 15 }],
+		records.map((data) => ({ name: domain, type: 15, TTL: 300, data })),
+	);
+}
+function servfail(domain: string, type: number) {
+	return createDohResponse([{ name: domain, type }], [], { status: 2 });
+}
+
+/** Real bnz.co.nz-style Akamai NS pool (2026-07-26 correctness-defects design §3.3). */
+const SEED_AKAMAI_NS = ['a1-97.akam.net.', 'a3-67.akam.net.', 'a8-66.akam.net.', 'a9-65.akam.net.', 'a16-65.akam.net.', 'a24-64.akam.net.'];
+
+// ---------------------------------------------------------------------------
+// Shared invariant assertions (the actual "gate" this audit locks).
+// ---------------------------------------------------------------------------
+
+interface Violation {
+	tool: string;
+	title: string;
+	severity: string;
+	reason: string;
+}
+
+/**
+ * Amendment (1) — THE positive-assertion rule. Returns violations rather than
+ * throwing immediately so a single sweep can report every offender at once
+ * (and so the "exactly one framed title" check elsewhere can reuse it).
+ */
+function findSeverityViolations(tool: string, findings: readonly Finding[]): Violation[] {
+	const violations: Violation[] = [];
+	for (const f of findings) {
+		if (f.severity === 'info') continue;
+		const meta = f.metadata as Record<string, unknown> | undefined;
+		const verdict = meta?.ownershipVerdict;
+		if (verdict === 'owned_by_seed') continue;
+
+		const axis = meta?.findingAxis;
+		if (axis === 'threat_observation' && verdict !== undefined && verdict !== 'owned_by_seed') {
+			const named =
+				typeof meta?.lookalikeDomain === 'string' ||
+				(Array.isArray(meta?.lookalikeDomains) && (meta.lookalikeDomains as unknown[]).length > 0) ||
+				typeof meta?.domain === 'string';
+			if (named) continue;
+			violations.push({ tool, title: f.title, severity: f.severity, reason: 'threat_observation above info names no candidate domain' });
+			continue;
+		}
+
+		violations.push({
+			tool,
+			title: f.title,
+			severity: f.severity,
+			reason: `above-info with no ownership justification (verdict=${JSON.stringify(verdict)}, axis=${JSON.stringify(axis)})`,
+		});
+	}
+	return violations;
+}
+
+/** Vacuous-green guard: a sweep over zero findings would trivially "pass". Call before every sweep. */
+function assertNonEmpty(tool: string, findings: readonly Finding[]) {
+	expect(findings.length, `${tool}: fixture produced zero findings — the sweep below would be vacuously green`).toBeGreaterThan(0);
+}
+
+function assertSeverityJustified(tool: string, findings: readonly Finding[]) {
+	assertNonEmpty(tool, findings);
+	const violations = findSeverityViolations(tool, findings);
+	expect(violations, `${tool}: unjustified above-info findings:\n${JSON.stringify(violations, null, 2)}`).toEqual([]);
+}
+
+const BANNED_FRAMING = [/shadow domain/i, /\byour\b/i, /owned by same entity/i];
+
+function framingViolations(title: string, detail: string): string[] {
+	return BANNED_FRAMING.filter((re) => re.test(title) || re.test(detail)).map((re) => re.source);
+}
+
+// =============================================================================
+// Fixture A — checkShadowDomains, one combined scan carrying every required
+// scenario: owned (in-bailiwick), third-party with active-MX threat signals,
+// the shared-provider (Akamai) partial-overlap trap, and the "registered,
+// records not observed" unattributed carve-out branch.
+// =============================================================================
+
+async function runShadowDomainsFixture() {
+	const seed = 'bnz.co.nz';
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const q = parseDohQuery(input);
+		if (!q) return Promise.resolve(empty());
+		const { name, type } = q;
+
+		if (name === seed) {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(seed, SEED_AKAMAI_NS));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(seed, ['10 mail.bnz.co.nz.']));
+		}
+
+		// OWNED — in-bailiwick NS, fully spoofable shape. Must stay unclamped:
+		// it is the seed's own domain, above-info is correct here.
+		if (name === 'bnz.com') {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.bnz.co.nz.']));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mx.bnz.com.']));
+		}
+
+		// THIRD-PARTY THREAT — distinct NS, fully spoofable shape. Must be
+		// capped to info via the D4 gate.
+		if (name === 'bnz.de') {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.attacker-dns.com.']));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mx.bnz.de.']));
+		}
+
+		// SHARED-PROVIDER (AKAMAI) PARTIAL-OVERLAP TRAP — shares exactly ONE
+		// Akamai NS host with the seed, otherwise distinct, ALSO fully
+		// spoofable shape. Must be capped to info (1/6 shared-provider overlap
+		// is not ownership evidence).
+		if (name === 'bnz.eu') {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, [SEED_AKAMAI_NS[0], 'ns2.unrelated-registrar.com.']));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mx.bnz.eu.']));
+		}
+
+		// RECORDS-NOT-OBSERVED / UNATTRIBUTED carve-out — NS empty, A resolves,
+		// no MX, no SPF. classifyOwnership() falls all the way through to
+		// 'unattributed' (candidateNs is empty — no NS evidence at all).
+		if (name === 'bnz.ca') {
+			if (type === 'NS' || type === '2') return Promise.resolve(empty());
+			if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.50']));
+		}
+
+		// SERVFAIL-ish — resolver-broken delegation, stays 'unknown' end to
+		// end (info-only, no ownershipVerdict at all).
+		if (name === 'bnz.nl' && (type === 'NS' || type === '2')) return Promise.resolve(servfail(name, 2));
+
+		// THIRD-PARTY, REGISTERED WITH NO MAIL — exercises the OTHER
+		// NEUTRAL_INFO_TITLES entry ("Shadow domain registered, no mail" →
+		// "Confusable domain registered, no mail") end to end, so the
+		// exactly-one-carve-out check below has more than one candidate title
+		// to actually discriminate against.
+		if (name === 'bnz.jp' && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(name, ['ns1.attacker-dns.com.']));
+
+		return Promise.resolve(empty());
+	});
+
+	const { checkShadowDomains } = await import('../../src/tools/check-shadow-domains');
+	return checkShadowDomains(seed);
+}
+
+/** A fully clean scan: nothing registered anywhere. Sanity + vacuous-green guard target. */
+async function runShadowDomainsCleanFixture() {
+	globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(empty()));
+	const { checkShadowDomains } = await import('../../src/tools/check-shadow-domains');
+	return checkShadowDomains('cleanbrand9182.com');
+}
+
+// =============================================================================
+// Fixture B — checkLookalikes, one combined scan: owned (in-bailiwick,
+// disposable MX to prove owned candidates get no threat axis at all),
+// third-party with an active disposable-MX threat (the #264 HIGH tier), and
+// the shared-provider (Akamai) partial-overlap trap.
+// =============================================================================
+
+async function runLookalikesFixture() {
+	const seed = 'testco.com';
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const q = parseDohQuery(input);
+		if (!q) return Promise.resolve(empty());
+		const { name, type } = q;
+
+		if (name === seed && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(seed, SEED_AKAMAI_NS));
+
+		// OWNED (in-bailiwick) — even with a disposable-MX shape, an owned
+		// candidate must get NO threat_observation finding at all (Task 7b
+		// requirement 5 — a domain is not an impersonation threat to itself).
+		if (name === 'testc0.com') {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.testco.com.']));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mx.mailgun.org.']));
+		}
+
+		// THIRD-PARTY THREAT — distinct NS, live mail on a disposable provider:
+		// the #264 HIGH tier. Attribution axis capped at info; threat axis
+		// carries the real HIGH, verdict !== owned_by_seed, candidate named.
+		if (name === 'twstco.com') {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.unrelated-dns.com.']));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mx.mailgun.org.']));
+		}
+
+		// SHARED-PROVIDER (AKAMAI) TRAP — shares exactly ONE Akamai host with
+		// the seed, otherwise distinct, with plain (non-disposable) mail infra
+		// — the #264 MEDIUM tier. Attribution axis still capped at info.
+		if (name === 'trstco.com') {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, [SEED_AKAMAI_NS[0], 'ns2.other-registrar.com.']));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mx.trstco.com.']));
+		}
+
+		return Promise.resolve(empty());
+	});
+
+	const { checkLookalikes } = await import('../../src/tools/check-lookalikes');
+	return checkLookalikes(seed);
+}
+
+/** A fully clean scan: nothing registered anywhere. Sanity + vacuous-green guard target. */
+async function runLookalikesCleanFixture() {
+	globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(empty()));
+	const { checkLookalikes } = await import('../../src/tools/check-lookalikes');
+	return checkLookalikes('nomatch918273brand.com');
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('ownership severity gate (audit) — load-bearing safety property', () => {
+	it('checkShadowDomains: no above-info finding without ownership justification (positive-assertion sweep, exhaustive)', async () => {
+		const result = await runShadowDomainsFixture();
+		assertSeverityJustified('checkShadowDomains', result.findings);
+
+		// Sanity the fixture actually exercised both directions, not just a
+		// uniformly-info result that would make the sweep trivially green.
+		expect(result.findings.some((f) => f.severity !== 'info')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+	});
+
+	it('checkShadowDomains: clean scan sweeps green and is never vacuously empty', async () => {
+		const result = await runShadowDomainsCleanFixture();
+		assertSeverityJustified('checkShadowDomains (clean)', result.findings);
+		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
+	});
+
+	it('checkShadowDomains: ownership framing absent from non-owned findings, except the exactly-one audit-pinned carve-out', async () => {
+		const { AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE } = await import('../../src/tools/check-shadow-domains');
+		expect(AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE).toBe('Shadow domain registered, records not observed');
+
+		const result = await runShadowDomainsFixture();
+		const nonOwned = result.findings.filter((f) => {
+			const v = f.metadata?.ownershipVerdict;
+			return v !== undefined && v !== 'owned_by_seed';
+		});
+		expect(nonOwned.length).toBeGreaterThan(0);
+
+		const framedTitles = new Set<string>();
+		for (const f of nonOwned) {
+			if (f.title === AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE) continue; // the one sanctioned carve-out
+			const hits = framingViolations(f.title, f.detail);
+			if (hits.length > 0) framedTitles.add(f.title);
+		}
+		expect([...framedTitles]).toEqual([]);
+
+		// The carve-out itself must actually have been exercised by this
+		// fixture (bnz.ca) — otherwise "exactly one" is an unverified claim.
+		expect(result.findings.some((f) => f.title === AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE)).toBe(true);
+	});
+
+	it('checkLookalikes: no above-info finding without ownership justification (positive-assertion sweep, exhaustive)', async () => {
+		const result = await runLookalikesFixture();
+		assertSeverityJustified('checkLookalikes', result.findings);
+
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+	});
+
+	it('checkLookalikes: clean scan sweeps green and is never vacuously empty', async () => {
+		const result = await runLookalikesCleanFixture();
+		assertSeverityJustified('checkLookalikes (clean)', result.findings);
+		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
+	});
+
+	it('checkLookalikes: every finding carries a findingAxis, and axis-specific invariants hold (Task 7b axis model)', async () => {
+		const mainResult = await runLookalikesFixture();
+		const cleanResult = await runLookalikesCleanFixture();
+		// Merge both fixtures so the scan_status clause is genuinely exercised
+		// (the main fixture has no unregistered/empty path — scan_status only
+		// appears in the clean scan's "no active lookalikes" notice).
+		const result = { findings: [...mainResult.findings, ...cleanResult.findings] };
+		assertNonEmpty('checkLookalikes (axis)', result.findings);
+
+		for (const f of result.findings) {
+			expect(['attribution', 'threat_observation', 'scan_status']).toContain(f.metadata?.findingAxis);
+		}
+		// All three axes actually represented — a degenerate "everything is
+		// attribution" world would otherwise satisfy the loop above.
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'attribution')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'scan_status')).toBe(true);
+
+		for (const f of result.findings) {
+			if (f.metadata?.findingAxis !== 'scan_status') continue;
+			expect(f.severity, `scan_status finding "${f.title}" is not info`).toBe('info');
+		}
+
+		for (const f of result.findings) {
+			if (f.metadata?.findingAxis !== 'threat_observation') continue;
+			expect(f.metadata?.ownershipVerdict, `threat_observation "${f.title}" carries no ownershipVerdict`).toBeDefined();
+			expect(f.metadata?.ownershipVerdict, `threat_observation "${f.title}" carries owned_by_seed`).not.toBe('owned_by_seed');
+			const named =
+				typeof f.metadata?.lookalikeDomain === 'string' ||
+				(Array.isArray(f.metadata?.lookalikeDomains) && (f.metadata.lookalikeDomains as unknown[]).length > 0) ||
+				typeof f.metadata?.domain === 'string';
+			expect(named, `threat_observation "${f.title}" names no candidate`).toBe(true);
+		}
+
+		for (const f of result.findings) {
+			if (f.metadata?.findingAxis !== 'attribution') continue;
+			const verdict = f.metadata?.ownershipVerdict;
+			if (verdict === undefined || verdict === 'owned_by_seed') continue;
+			expect(f.severity, `non-owned attribution finding "${f.title}" is above info`).toBe('info');
+			const hits = framingViolations(f.title, f.detail);
+			expect(hits, `non-owned attribution finding "${f.title}" carries ownership-framed prose: ${hits.join(', ')}`).toEqual([]);
+		}
+	});
+
+	it('checkLookalikes: an owned_by_seed candidate gets no threat_observation finding at all', async () => {
+		const result = await runLookalikesFixture();
+		const ownedThreat = result.findings.filter(
+			(f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === 'testc0.com',
+		);
+		expect(ownedThreat).toEqual([]);
+	});
+
+	it('classifyOwnership(): candidate-side signals — soaInBailiwick, spfIncludesSeedApex, httpRedirectToSeedApex — never independently or combined produce owned_by_seed (Ruling A, task 7c)', async () => {
+		const { classifyOwnership } = await import('../../src/lib/ownership-attribution');
+		const { isSharedNsHost } = await import('../../src/tenants/discovery/shared-ns-hosts');
+
+		const base = {
+			seedDomain: 'bnz.co.nz',
+			seedNs: ['ns-cloud1.googledomains.com'],
+			candidateDomain: 'evilbnz.co.nz',
+			registration: { state: 'registered' as const, ns: ['ns1.attacker-dns.com'], evidence: ['ns' as const] },
+			isSharedNsHost,
+		};
+
+		// Each signal alone.
+		expect(classifyOwnership({ ...base, soaInBailiwick: true }).verdict).not.toBe('owned_by_seed');
+		expect(classifyOwnership({ ...base, spfIncludesSeedApex: true }).verdict).not.toBe('owned_by_seed');
+		expect(classifyOwnership({ ...base, httpRedirectToSeedApex: true }).verdict).not.toBe('owned_by_seed');
+
+		// All three combined.
+		const combined = classifyOwnership({
+			...base,
+			soaInBailiwick: true,
+			spfIncludesSeedApex: true,
+			httpRedirectToSeedApex: true,
+		});
+		expect(combined.verdict).not.toBe('owned_by_seed');
+		expect(combined.verdict).toBe('third_party');
+	});
+});

--- a/test/audits/ownership-severity-gate.audit.test.ts
+++ b/test/audits/ownership-severity-gate.audit.test.ts
@@ -9,6 +9,10 @@
  * or is an explicitly-named threat OBSERVATION about a candidate that is NOT
  * the scanned organisation's own domain. Nothing else above `info` is
  * permitted to slip through `checkShadowDomains()` / `checkLookalikes()`.
+ * Ownership framing in prose ("shadow domain", "your", "owned by same
+ * entity") is likewise never permitted on a non-owned finding, on EITHER
+ * axis — a threat observation describes the CANDIDATE's behaviour, never
+ * the scanned organisation's ownership of it.
  *
  * CONTROLLER AMENDMENTS TO THE ORIGINAL TASK-8 BRIEF (binding, see
  * `.superpowers/sdd/2026-07-26-slice4-ownership-attribution/task-8-brief.md`
@@ -22,7 +26,12 @@
  *        (`ownershipVerdict === 'owned_by_seed'`) OR
  *        (`findingAxis === 'threat_observation'` AND `ownershipVerdict` is
  *         present and `!== 'owned_by_seed'` AND a candidate domain is named
- *         in metadata).
+ *         in metadata that is DISTINCT FROM THE SCANNED SEED — `lookalikeDomain`
+ *         preferred; `lookalikeDomains`/`domain` accepted only as a fallback,
+ *         and only when the value is not the seed itself (fix round 1, F4 —
+ *         the predicate used to accept a bare `meta.domain` unconditionally,
+ *         which is exactly what the recon-corroboration emission site in
+ *         `check-lookalikes.ts` used to set to the SEED, not a candidate)).
  *      A finding with NEITHER above `info` is an AUDIT FAILURE, full stop.
  *
  *  (2) THE AXIS MODEL (lookalikes only — `check-shadow-domains.ts` has no
@@ -33,17 +42,22 @@
  *          | 'scan_status'`;
  *        - every `'scan_status'` finding is `info`;
  *        - every `'threat_observation'` finding carries `ownershipVerdict
- *          !== 'owned_by_seed'` and names a candidate;
- *        - every `'attribution'` finding for a non-owned candidate is `info`
- *          AND carries no ownership-framed prose ("shadow domain", "your",
- *          "owned by same entity") in its title or detail.
+ *          !== 'owned_by_seed'` and names a candidate (per the tightened
+ *          predicate in (1));
+ *        - every finding of ANY axis for a non-owned candidate carries NO
+ *          ownership-framed prose ("shadow domain", "your", "owned by same
+ *          entity") in its title or detail (fix round 1, F2 — the original
+ *          version of this audit only framing-checked the `attribution` axis,
+ *          leaving a `critical` `threat_observation` titled e.g. "Your shadow
+ *          domain portfolio is exposed" undetected).
  *      `check-shadow-domains.ts` carries a SEPARATE, single carve-out for
  *      this same framing rule — `AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE` (the
  *      Phase-2 "records not observed" fallthrough keeps its ownership-framed
  *      title because `registration-invariant.audit.test.ts` — byte-frozen —
  *      pins that exact title literal). This audit asserts that carve-out is
  *      EXACTLY one title and EXACTLY the known string, so it cannot silently
- *      widen to swallow other framed titles.
+ *      widen to swallow other framed titles. `checkLookalikes` has NO such
+ *      carve-out — the framing sweep against it is unconditional.
  *
  *  (3) THE PRIMITIVE-LEVEL INVARIANT (task 7c). The three candidate-side
  *      signals (`soaInBailiwick`, `spfIncludesSeedApex`, `httpRedirectToSeedApex`)
@@ -52,12 +66,33 @@
  *      already pin it) so a future "optimisation" of those unit tests can't
  *      silently drop the property from BOTH places at once.
  *
+ *  (4) FIX ROUND 1 (2026-07-27, adversarial re-review). Four findings, all
+ *      addressed:
+ *        F1 — LIVE VIOLATION. `check-lookalikes.ts`'s recon-corroboration
+ *             emission site (`CT_LOOKALIKE`) emitted a `medium`
+ *             `threat_observation` with NO `ownershipVerdict` and
+ *             `domain: <the seed>` — a real production bug this audit's
+ *             ORIGINAL fixture set never exercised (no recon-binding
+ *             fixture existed). Fixed at the SOURCE (see
+ *             `extractReconMatchedDomain()` + the emission site in
+ *             `check-lookalikes.ts`) and now covered by
+ *             `runLookalikesReconFixture()` below, permanently inside the
+ *             sweep.
+ *        F2 — the framing sweep now covers every axis, not just `attribution`
+ *             (see amendment (2) above).
+ *        F3 — an EXPECTED-VERDICT map (`assertExpectedVerdicts` below) pins
+ *             each fixture's candidates to their REQUIRED stamped verdict, so
+ *             a mutation that stamps `owned_by_seed` everywhere (which would
+ *             trivially satisfy the severity-justification sweep AND exit the
+ *             framing filter simultaneously) is still caught.
+ *        F4 — the named-candidate predicate tightened (see amendment (1)).
+ *
  * METHOD NOTE: every clause below was proven to go RED by a real source
- * mutation (ungating a call site, retagging a `scan_status` finding, undoing
- * Ruling A, widening the framed-title carve-out, forcing an empty findings
- * array) — see `.superpowers/sdd/2026-07-26-slice4-ownership-attribution/
- * task-8-report.md` for the mutation-by-mutation evidence. The mutations
- * themselves are not preserved in this file; only their proof they were run.
+ * mutation — see `.superpowers/sdd/2026-07-26-slice4-ownership-attribution/
+ * task-8-report.md` (fix round 1 addendum) for the mutation-by-mutation
+ * evidence, including the F1 live-violation fix, the A5/A8b/A8c re-runs. The
+ * mutations themselves are not preserved in this file; only their proof they
+ * were run.
  */
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
@@ -121,12 +156,44 @@ interface Violation {
 	reason: string;
 }
 
+function normalizeDomain(d: string): string {
+	return d.trim().toLowerCase().replace(/\.$/, '');
+}
+
+/**
+ * F4 (fix round 1): the named-candidate predicate. `lookalikeDomain` is
+ * PREFERRED and authoritative when present — it is never overridden by a
+ * fallback field even if it happens to equal the seed (in which case this
+ * correctly returns false rather than silently trying `domain` next).
+ * `lookalikeDomains` (the aggregate summary) and `domain` (the shadow-domains
+ * "variant" field lives under a different key entirely — see
+ * `assertExpectedVerdicts`'s `domainKeys` param — this predicate is scoped to
+ * the fields `checkLookalikes` actually emits) are accepted as fallbacks, and
+ * ONLY when the named value is not the seed itself.
+ */
+function namesNonSeedCandidate(meta: Record<string, unknown> | undefined, seedNorm: string): boolean {
+	if (typeof meta?.lookalikeDomain === 'string') {
+		const v = meta.lookalikeDomain.trim();
+		return v !== '' && normalizeDomain(v) !== seedNorm;
+	}
+	if (Array.isArray(meta?.lookalikeDomains) && meta.lookalikeDomains.length > 0) {
+		return meta.lookalikeDomains.some((d) => typeof d === 'string' && d.trim() !== '' && normalizeDomain(d) !== seedNorm);
+	}
+	if (typeof meta?.domain === 'string') {
+		const v = meta.domain.trim();
+		return v !== '' && normalizeDomain(v) !== seedNorm;
+	}
+	return false;
+}
+
 /**
  * Amendment (1) — THE positive-assertion rule. Returns violations rather than
- * throwing immediately so a single sweep can report every offender at once
- * (and so the "exactly one framed title" check elsewhere can reuse it).
+ * throwing immediately so a single sweep can report every offender at once.
+ * `seedDomain` is required (F4) so the named-candidate check can reject a
+ * self-referential match.
  */
-function findSeverityViolations(tool: string, findings: readonly Finding[]): Violation[] {
+function findSeverityViolations(tool: string, seedDomain: string, findings: readonly Finding[]): Violation[] {
+	const seedNorm = normalizeDomain(seedDomain);
 	const violations: Violation[] = [];
 	for (const f of findings) {
 		if (f.severity === 'info') continue;
@@ -136,12 +203,13 @@ function findSeverityViolations(tool: string, findings: readonly Finding[]): Vio
 
 		const axis = meta?.findingAxis;
 		if (axis === 'threat_observation' && verdict !== undefined && verdict !== 'owned_by_seed') {
-			const named =
-				typeof meta?.lookalikeDomain === 'string' ||
-				(Array.isArray(meta?.lookalikeDomains) && (meta.lookalikeDomains as unknown[]).length > 0) ||
-				typeof meta?.domain === 'string';
-			if (named) continue;
-			violations.push({ tool, title: f.title, severity: f.severity, reason: 'threat_observation above info names no candidate domain' });
+			if (namesNonSeedCandidate(meta, seedNorm)) continue;
+			violations.push({
+				tool,
+				title: f.title,
+				severity: f.severity,
+				reason: 'threat_observation above info names no candidate domain distinct from the seed',
+			});
 			continue;
 		}
 
@@ -160,9 +228,9 @@ function assertNonEmpty(tool: string, findings: readonly Finding[]) {
 	expect(findings.length, `${tool}: fixture produced zero findings — the sweep below would be vacuously green`).toBeGreaterThan(0);
 }
 
-function assertSeverityJustified(tool: string, findings: readonly Finding[]) {
+function assertSeverityJustified(tool: string, seedDomain: string, findings: readonly Finding[]) {
 	assertNonEmpty(tool, findings);
-	const violations = findSeverityViolations(tool, findings);
+	const violations = findSeverityViolations(tool, seedDomain, findings);
 	expect(violations, `${tool}: unjustified above-info findings:\n${JSON.stringify(violations, null, 2)}`).toEqual([]);
 }
 
@@ -172,6 +240,67 @@ function framingViolations(title: string, detail: string): string[] {
 	return BANNED_FRAMING.filter((re) => re.test(title) || re.test(detail)).map((re) => re.source);
 }
 
+/**
+ * F2 (fix round 1) — framing sweep across EVERY finding whose stamped
+ * verdict is present and `!== 'owned_by_seed'`, regardless of `findingAxis`.
+ * `carveOutTitle`, when supplied, exempts exactly one title
+ * (`check-shadow-domains.ts`'s `AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE`) — never
+ * a pattern, never a prefix, so it cannot silently widen.
+ */
+function findFramingViolations(tool: string, findings: readonly Finding[], carveOutTitle?: string): Violation[] {
+	const violations: Violation[] = [];
+	for (const f of findings) {
+		const verdict = (f.metadata as Record<string, unknown> | undefined)?.ownershipVerdict;
+		if (verdict === undefined || verdict === 'owned_by_seed') continue;
+		if (carveOutTitle !== undefined && f.title === carveOutTitle) continue;
+		const hits = framingViolations(f.title, f.detail);
+		if (hits.length > 0) {
+			violations.push({ tool, title: f.title, severity: f.severity, reason: `ownership-framed prose: ${hits.join(', ')}` });
+		}
+	}
+	return violations;
+}
+
+/**
+ * F3 (fix round 1) — EXPECTED-VERDICT map. Asserts every finding that names a
+ * fixture-known candidate (via one of `domainKeys`, checked in priority
+ * order) carries the REQUIRED stamped verdict for that candidate. This is
+ * the check that survives a mutation stamping `owned_by_seed` on every
+ * finding: such a mutation trivially satisfies `findSeverityViolations` (the
+ * exemption fires) AND `findFramingViolations` (the framing filter exits
+ * early on `owned_by_seed`) simultaneously — only a check that TRUSTS NOTHING
+ * about the stamped verdict and instead compares it against an independently
+ * declared expectation can catch it.
+ */
+function assertExpectedVerdicts(
+	tool: string,
+	findings: readonly Finding[],
+	domainKeys: readonly string[],
+	mustBeOwned: ReadonlySet<string>,
+	mustNotBeOwned: ReadonlySet<string>,
+) {
+	for (const f of findings) {
+		const meta = f.metadata as Record<string, unknown> | undefined;
+		let candidate: string | undefined;
+		for (const key of domainKeys) {
+			const v = meta?.[key];
+			if (typeof v === 'string' && v.trim() !== '') {
+				candidate = v;
+				break;
+			}
+		}
+		if (candidate === undefined) continue;
+		const norm = normalizeDomain(candidate);
+		const verdict = meta?.ownershipVerdict;
+		if (mustBeOwned.has(norm)) {
+			expect(verdict, `${tool}: "${f.title}" for ${candidate} must be stamped owned_by_seed`).toBe('owned_by_seed');
+		}
+		if (mustNotBeOwned.has(norm)) {
+			expect(verdict, `${tool}: "${f.title}" for ${candidate} must NOT be stamped owned_by_seed`).not.toBe('owned_by_seed');
+		}
+	}
+}
+
 // =============================================================================
 // Fixture A — checkShadowDomains, one combined scan carrying every required
 // scenario: owned (in-bailiwick), third-party with active-MX threat signals,
@@ -179,16 +308,19 @@ function framingViolations(title: string, detail: string): string[] {
 // records not observed" unattributed carve-out branch.
 // =============================================================================
 
+const SHADOW_SEED = 'bnz.co.nz';
+const SHADOW_MUST_BE_OWNED = new Set(['bnz.com']);
+const SHADOW_MUST_NOT_BE_OWNED = new Set(['bnz.de', 'bnz.eu', 'bnz.ca', 'bnz.jp']);
+
 async function runShadowDomainsFixture() {
-	const seed = 'bnz.co.nz';
 	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 		const q = parseDohQuery(input);
 		if (!q) return Promise.resolve(empty());
 		const { name, type } = q;
 
-		if (name === seed) {
-			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(seed, SEED_AKAMAI_NS));
-			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(seed, ['10 mail.bnz.co.nz.']));
+		if (name === SHADOW_SEED) {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(SHADOW_SEED, SEED_AKAMAI_NS));
+			if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(SHADOW_SEED, ['10 mail.bnz.co.nz.']));
 		}
 
 		// OWNED — in-bailiwick NS, fully spoofable shape. Must stay unclamped:
@@ -237,7 +369,7 @@ async function runShadowDomainsFixture() {
 	});
 
 	const { checkShadowDomains } = await import('../../src/tools/check-shadow-domains');
-	return checkShadowDomains(seed);
+	return checkShadowDomains(SHADOW_SEED);
 }
 
 /** A fully clean scan: nothing registered anywhere. Sanity + vacuous-green guard target. */
@@ -254,14 +386,18 @@ async function runShadowDomainsCleanFixture() {
 // the shared-provider (Akamai) partial-overlap trap.
 // =============================================================================
 
-async function runLookalikesFixture() {
-	const seed = 'testco.com';
+const LOOKALIKES_SEED = 'testco.com';
+const LOOKALIKES_MUST_BE_OWNED = new Set(['testc0.com']);
+const LOOKALIKES_MUST_NOT_BE_OWNED = new Set(['twstco.com', 'trstco.com']);
+
+/** DNS mock shared by every checkLookalikes fixture below (recon options vary per caller). */
+function mockLookalikesFixtureDns() {
 	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 		const q = parseDohQuery(input);
 		if (!q) return Promise.resolve(empty());
 		const { name, type } = q;
 
-		if (name === seed && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(seed, SEED_AKAMAI_NS));
+		if (name === LOOKALIKES_SEED && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(LOOKALIKES_SEED, SEED_AKAMAI_NS));
 
 		// OWNED (in-bailiwick) — even with a disposable-MX shape, an owned
 		// candidate must get NO threat_observation finding at all (Task 7b
@@ -289,9 +425,12 @@ async function runLookalikesFixture() {
 
 		return Promise.resolve(empty());
 	});
+}
 
+async function runLookalikesFixture() {
+	mockLookalikesFixtureDns();
 	const { checkLookalikes } = await import('../../src/tools/check-lookalikes');
-	return checkLookalikes(seed);
+	return checkLookalikes(LOOKALIKES_SEED);
 }
 
 /** A fully clean scan: nothing registered anywhere. Sanity + vacuous-green guard target. */
@@ -301,6 +440,59 @@ async function runLookalikesCleanFixture() {
 	return checkLookalikes('nomatch918273brand.com');
 }
 
+/**
+ * F1 (fix round 1) — the recon-binding fixture. Stubs `BV_RECON` (the
+ * operator-deploy-only enrichment binding — this code path ships in prod)
+ * returning a CT_LOOKALIKE hit naming `twstco.com` as `metadata.matchedDomain`
+ * — a candidate ALSO generated/probed locally by this same scan (so
+ * `ownershipByDomain` genuinely resolves it, exercising the "reuse the local
+ * assessment" branch of the source fix, not just its null-fallback branch).
+ * This keeps the recon emission site permanently INSIDE the sweep.
+ */
+async function runLookalikesReconFixture() {
+	mockLookalikesFixtureDns();
+	const reconBinding = {
+		fetch: vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						checkType: 'CT_LOOKALIKE',
+						status: 'warning',
+						details: 'Certificate transparency logs show lookalike activity for twstco.com',
+						metadata: { matchedDomain: 'twstco.com' },
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } },
+				),
+		),
+	};
+	const { checkLookalikes } = await import('../../src/tools/check-lookalikes');
+	return checkLookalikes(LOOKALIKES_SEED, { reconBinding, reconAuthToken: 'tok' });
+}
+
+/**
+ * A5 re-run target — the post-loop `if (findings.length === 0)` scan_status
+ * notice (`check-lookalikes.ts` ~line 793) is reachable ONLY when at least
+ * one permutation is registered (so the tool doesn't early-return before
+ * reaching the main classification loop) AND every registered permutation
+ * has neither an A nor an MX record (so the loop's
+ * `if (!result.hasMX && !result.hasA) continue;` guard skips it, pushing
+ * NOTHING). `tstco.com` here is registered (NS only) with no A/MX — the
+ * ONLY registered permutation in this fixture — so `findings` is genuinely
+ * empty when the loop exits.
+ */
+async function runLookalikesPostLoopScanStatusFixture() {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const q = parseDohQuery(input);
+		if (!q) return Promise.resolve(empty());
+		const { name, type } = q;
+		if (name === LOOKALIKES_SEED && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(LOOKALIKES_SEED, SEED_AKAMAI_NS));
+		if (name === 'tstco.com' && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+		return Promise.resolve(empty());
+	});
+	const { checkLookalikes } = await import('../../src/tools/check-lookalikes');
+	return checkLookalikes(LOOKALIKES_SEED);
+}
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -308,7 +500,8 @@ async function runLookalikesCleanFixture() {
 describe('ownership severity gate (audit) — load-bearing safety property', () => {
 	it('checkShadowDomains: no above-info finding without ownership justification (positive-assertion sweep, exhaustive)', async () => {
 		const result = await runShadowDomainsFixture();
-		assertSeverityJustified('checkShadowDomains', result.findings);
+		assertSeverityJustified('checkShadowDomains', SHADOW_SEED, result.findings);
+		assertExpectedVerdicts('checkShadowDomains', result.findings, ['variant'], SHADOW_MUST_BE_OWNED, SHADOW_MUST_NOT_BE_OWNED);
 
 		// Sanity the fixture actually exercised both directions, not just a
 		// uniformly-info result that would make the sweep trivially green.
@@ -319,28 +512,23 @@ describe('ownership severity gate (audit) — load-bearing safety property', () 
 
 	it('checkShadowDomains: clean scan sweeps green and is never vacuously empty', async () => {
 		const result = await runShadowDomainsCleanFixture();
-		assertSeverityJustified('checkShadowDomains (clean)', result.findings);
+		assertSeverityJustified('checkShadowDomains (clean)', 'cleanbrand9182.com', result.findings);
 		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
 	});
 
-	it('checkShadowDomains: ownership framing absent from non-owned findings, except the exactly-one audit-pinned carve-out', async () => {
+	it('checkShadowDomains: ownership framing absent from non-owned findings (all axes — shadow-domains has none — so this is unconditional), except the exactly-one audit-pinned carve-out', async () => {
 		const { AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE } = await import('../../src/tools/check-shadow-domains');
 		expect(AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE).toBe('Shadow domain registered, records not observed');
 
 		const result = await runShadowDomainsFixture();
-		const nonOwned = result.findings.filter((f) => {
+		const nonOwnedCount = result.findings.filter((f) => {
 			const v = f.metadata?.ownershipVerdict;
 			return v !== undefined && v !== 'owned_by_seed';
-		});
-		expect(nonOwned.length).toBeGreaterThan(0);
+		}).length;
+		expect(nonOwnedCount).toBeGreaterThan(0);
 
-		const framedTitles = new Set<string>();
-		for (const f of nonOwned) {
-			if (f.title === AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE) continue; // the one sanctioned carve-out
-			const hits = framingViolations(f.title, f.detail);
-			if (hits.length > 0) framedTitles.add(f.title);
-		}
-		expect([...framedTitles]).toEqual([]);
+		const violations = findFramingViolations('checkShadowDomains', result.findings, AUDIT_PINNED_OWNERSHIP_FRAMED_TITLE);
+		expect(violations, `framed titles: ${JSON.stringify(violations, null, 2)}`).toEqual([]);
 
 		// The carve-out itself must actually have been exercised by this
 		// fixture (bnz.ca) — otherwise "exactly one" is an unverified claim.
@@ -349,7 +537,8 @@ describe('ownership severity gate (audit) — load-bearing safety property', () 
 
 	it('checkLookalikes: no above-info finding without ownership justification (positive-assertion sweep, exhaustive)', async () => {
 		const result = await runLookalikesFixture();
-		assertSeverityJustified('checkLookalikes', result.findings);
+		assertSeverityJustified('checkLookalikes', LOOKALIKES_SEED, result.findings);
+		assertExpectedVerdicts('checkLookalikes', result.findings, ['lookalikeDomain'], LOOKALIKES_MUST_BE_OWNED, LOOKALIKES_MUST_NOT_BE_OWNED);
 
 		expect(result.findings.some((f) => f.severity === 'high')).toBe(true);
 		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
@@ -358,7 +547,7 @@ describe('ownership severity gate (audit) — load-bearing safety property', () 
 
 	it('checkLookalikes: clean scan sweeps green and is never vacuously empty', async () => {
 		const result = await runLookalikesCleanFixture();
-		assertSeverityJustified('checkLookalikes (clean)', result.findings);
+		assertSeverityJustified('checkLookalikes (clean)', 'nomatch918273brand.com', result.findings);
 		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
 	});
 
@@ -389,21 +578,16 @@ describe('ownership severity gate (audit) — load-bearing safety property', () 
 			if (f.metadata?.findingAxis !== 'threat_observation') continue;
 			expect(f.metadata?.ownershipVerdict, `threat_observation "${f.title}" carries no ownershipVerdict`).toBeDefined();
 			expect(f.metadata?.ownershipVerdict, `threat_observation "${f.title}" carries owned_by_seed`).not.toBe('owned_by_seed');
-			const named =
-				typeof f.metadata?.lookalikeDomain === 'string' ||
-				(Array.isArray(f.metadata?.lookalikeDomains) && (f.metadata.lookalikeDomains as unknown[]).length > 0) ||
-				typeof f.metadata?.domain === 'string';
-			expect(named, `threat_observation "${f.title}" names no candidate`).toBe(true);
+			expect(
+				namesNonSeedCandidate(f.metadata as Record<string, unknown> | undefined, normalizeDomain(LOOKALIKES_SEED)),
+				`threat_observation "${f.title}" names no candidate distinct from the seed`,
+			).toBe(true);
 		}
 
-		for (const f of result.findings) {
-			if (f.metadata?.findingAxis !== 'attribution') continue;
-			const verdict = f.metadata?.ownershipVerdict;
-			if (verdict === undefined || verdict === 'owned_by_seed') continue;
-			expect(f.severity, `non-owned attribution finding "${f.title}" is above info`).toBe('info');
-			const hits = framingViolations(f.title, f.detail);
-			expect(hits, `non-owned attribution finding "${f.title}" carries ownership-framed prose: ${hits.join(', ')}`).toEqual([]);
-		}
+		// F2: framing sweep across EVERY axis for this fixture set — not just
+		// 'attribution'. checkLookalikes carries no carve-out.
+		const violations = findFramingViolations('checkLookalikes', result.findings);
+		expect(violations, `framed findings: ${JSON.stringify(violations, null, 2)}`).toEqual([]);
 	});
 
 	it('checkLookalikes: an owned_by_seed candidate gets no threat_observation finding at all', async () => {
@@ -412,6 +596,49 @@ describe('ownership severity gate (audit) — load-bearing safety property', () 
 			(f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === 'testc0.com',
 		);
 		expect(ownedThreat).toEqual([]);
+	});
+
+	// F1 (fix round 1) — the recon-corroboration emission site, permanently
+	// inside the sweep. Runs the FULL invariant battery (severity
+	// justification, expected-verdict map, and framing) against a fixture
+	// whose ONLY new finding relative to `runLookalikesFixture()` is the
+	// recon-corroboration one, so a regression at that specific emission
+	// site cannot hide behind the other candidates' correct output.
+	it('checkLookalikes: the recon-corroboration finding (CT_LOOKALIKE) carries a real ownershipVerdict and names the matched candidate, not the seed', async () => {
+		const result = await runLookalikesReconFixture();
+		assertSeverityJustified('checkLookalikes (recon)', LOOKALIKES_SEED, result.findings);
+		assertExpectedVerdicts(
+			'checkLookalikes (recon)',
+			result.findings,
+			['lookalikeDomain'],
+			LOOKALIKES_MUST_BE_OWNED,
+			LOOKALIKES_MUST_NOT_BE_OWNED,
+		);
+		const framingHits = findFramingViolations('checkLookalikes (recon)', result.findings);
+		expect(framingHits).toEqual([]);
+
+		const reconFindings = result.findings.filter((f) => f.metadata?.reconEnriched === true);
+		expect(reconFindings).toHaveLength(1);
+		const reconFinding = reconFindings[0];
+		expect(reconFinding.severity).toBe('medium');
+		expect(reconFinding.metadata?.findingAxis).toBe('threat_observation');
+		expect(reconFinding.metadata?.lookalikeDomain).toBe('twstco.com');
+		expect(reconFinding.metadata?.domain).toBeUndefined();
+		expect(reconFinding.metadata?.ownershipVerdict).toBe('third_party');
+	});
+
+	// A5 re-run (fix round 1) — this branch was UNREACHABLE by either the
+	// main or clean fixture before this dedicated fixture was added (the main
+	// fixture always has findings before reaching it; the clean fixture
+	// early-returns before it). Proves it is now reachable AND swept.
+	it('checkLookalikes: the previously-unreachable post-loop scan_status notice fires and is swept', async () => {
+		const result = await runLookalikesPostLoopScanStatusFixture();
+		assertNonEmpty('checkLookalikes (post-loop scan_status)', result.findings);
+		const notice = result.findings.find((f) => f.title === 'No active lookalike domains detected');
+		expect(notice, 'the post-loop scan_status notice did not fire — the fixture no longer reaches it').toBeDefined();
+		expect(notice!.metadata?.findingAxis).toBe('scan_status');
+		expect(notice!.severity).toBe('info');
+		assertSeverityJustified('checkLookalikes (post-loop scan_status)', LOOKALIKES_SEED, result.findings);
 	});
 
 	it('classifyOwnership(): candidate-side signals — soaInBailiwick, spfIncludesSeedApex, httpRedirectToSeedApex — never independently or combined produce owned_by_seed (Ruling A, task 7c)', async () => {

--- a/test/audits/shared-ns-hosts.audit.test.ts
+++ b/test/audits/shared-ns-hosts.audit.test.ts
@@ -31,6 +31,11 @@ const SHARED_NS_MUST_MATCH: ReadonlyArray<readonly [string, string]> = [
 	['ns1.secureserver.net', 'GoDaddy secureserver'],
 	// Namecheap registrar default
 	['dns1.registrar-servers.com', 'Namecheap registrar-default NS'],
+	// Akamai — hostnames are shared across unrelated customers (2026-07-26
+	// correctness-defects design §3.3: bnz.co.nz shares a9-65.akam.net with
+	// anz.co.nz and a3-67.akam.net with westpac.co.nz — three competing banks).
+	['a1-97.akam.net', 'Akamai — shared across unrelated customer zones'],
+	['a9-65.akam.net', 'Akamai — shared across unrelated customer zones'],
 ];
 
 const SHARED_NS_MUST_NOT_MATCH: ReadonlyArray<readonly [string, string]> = [

--- a/test/audits/ungraded-representation.audit.test.ts
+++ b/test/audits/ungraded-representation.audit.test.ts
@@ -351,6 +351,7 @@ describe('ungraded representation', () => {
 			actions: [],
 			assessed: false,
 			caveat: buildAllTransientFixPlanCaveat(allTransient.length),
+			transientCategories: [],
 		};
 
 		const surfaces = [

--- a/test/brand-evidence.test.ts
+++ b/test/brand-evidence.test.ts
@@ -9,6 +9,17 @@ describe('brand evidence tier policy', () => {
 		expect(evidenceTier('mx_platform', { sharedMxPlatform: 'google_workspace' })).toBe('weak');
 	});
 
+	it('treats an in-bailiwick NS match as strong evidence, clearing ownership alone', () => {
+		expect(evidenceTier('ns', { matchType: 'in_bailiwick' })).toBe('strong');
+		expect(clearsOwnershipGate([{ signal: 'ns', confidence: 1, metadata: { matchType: 'in_bailiwick' } }])).toBe(true);
+	});
+
+	it('keeps a plain NS set-overlap match at medium — needs a second signal to clear ownership', () => {
+		expect(evidenceTier('ns', { matchType: 'set_overlap' })).toBe('medium');
+		expect(evidenceTier('ns')).toBe('medium');
+		expect(clearsOwnershipGate([{ signal: 'ns', confidence: 0.5, metadata: { matchType: 'set_overlap' } }])).toBe(false);
+	});
+
 	it('does not let markov generation plus broad MX platform clear ownership', () => {
 		expect(
 			clearsOwnershipGate(

--- a/test/check-lookalikes-recon-enrichment.integration.test.ts
+++ b/test/check-lookalikes-recon-enrichment.integration.test.ts
@@ -26,19 +26,13 @@ function buildLookalikeFetchMock() {
 		// One lookalike (tst.com) has NS + MX + A records → reaches main return
 		if (name === 'tst.com' || name === 'tes.com') {
 			if (type === 'NS' || type === '2') {
-				return Promise.resolve(
-					createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }]),
-				);
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }]));
 			}
 			if (type === 'MX' || type === '15') {
-				return Promise.resolve(
-					createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.example.com.' }]),
-				);
+				return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.example.com.' }]));
 			}
 			if (type === 'A' || type === '1') {
-				return Promise.resolve(
-					createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]),
-				);
+				return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
 			}
 		}
 		return Promise.resolve(createDohResponse([], []));
@@ -49,15 +43,32 @@ function buildLookalikeFetchMock() {
 // Recon binding mock helper
 // ---------------------------------------------------------------------------
 
-function makeReconHitBinding(detail: string) {
+function makeReconHitBinding(detail: string, matchedDomain?: string) {
 	return {
-		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'CT_LOOKALIKE', status: 'warning', details: detail }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+		fetch: vi.fn(
+			async () =>
+				new Response(
+					JSON.stringify({
+						checkType: 'CT_LOOKALIKE',
+						status: 'warning',
+						details: detail,
+						...(matchedDomain !== undefined ? { metadata: { matchedDomain } } : {}),
+					}),
+					{ status: 200, headers: { 'Content-Type': 'application/json' } },
+				),
+		),
 	};
 }
 
 function makeReconBenignBinding() {
 	return {
-		fetch: vi.fn(async () => new Response(JSON.stringify({ checkType: 'CT_LOOKALIKE', status: 'info', details: 'nothing serious' }), { status: 200, headers: { 'Content-Type': 'application/json' } })),
+		fetch: vi.fn(
+			async () =>
+				new Response(JSON.stringify({ checkType: 'CT_LOOKALIKE', status: 'info', details: 'nothing serious' }), {
+					status: 200,
+					headers: { 'Content-Type': 'application/json' },
+				}),
+		),
 	};
 }
 
@@ -76,7 +87,18 @@ describe('checkLookalikes recon enrichment', () => {
 		expect(enriched).toHaveLength(0);
 	});
 
-	it('enriched: adds corroboration finding when recon returns a hit status', async () => {
+	// FIX ROUND 1, F1 (2026-07-27, post-review): bv-recon's CT_LOOKALIKE check
+	// is scoped to the SEED domain's CT-log neighbourhood and does not always
+	// name a specific confusable domain. When it doesn't (this test's stub —
+	// no `metadata.matchedDomain`), the old behaviour was a live violation of
+	// the ownership-severity-gate invariant: a `medium` `threat_observation`
+	// with NO `ownershipVerdict` and `domain: <the seed>` metadata (not any
+	// candidate). The fix demotes an unnamed-candidate hit to `info` +
+	// `scan_status` instead of fabricating a candidate name or verdict —
+	// this is the CORRECTED expectation, not a relaxation: the underlying
+	// signal is still surfaced (DEMOTE, NEVER DELETE), just never claims a
+	// severity-bearing statement about an unnamed target.
+	it('enriched, no specific candidate named: demotes to an info scan_status notice, never a nameless threat_observation', async () => {
 		buildLookalikeFetchMock();
 
 		const reconBinding = makeReconHitBinding('Certificate transparency logs show lookalike activity for test.com');
@@ -86,9 +108,52 @@ describe('checkLookalikes recon enrichment', () => {
 
 		const enriched = result.findings.filter((f) => f.metadata?.reconEnriched === true);
 		expect(enriched).toHaveLength(1);
-		expect(enriched[0].severity).toBe('medium');
-		expect(enriched[0].title).toBe('CT-observed lookalike corroboration');
+		expect(enriched[0].severity).toBe('info');
+		expect(enriched[0].metadata?.findingAxis).toBe('scan_status');
+		expect(enriched[0].title).toBe('CT-observed lookalike corroboration (no specific candidate identified)');
 		expect(enriched[0].detail).toContain('Certificate transparency logs show lookalike activity');
+		// Never fabricates an ownershipVerdict for an unnamed target.
+		expect(enriched[0].metadata?.ownershipVerdict).toBeUndefined();
+	});
+
+	// The corrected, named-candidate path: bv-recon's metadata.matchedDomain
+	// resolves to a permutation this scan ALSO generated/probed locally
+	// (`tst.com`, registered on `ns1.registrar.com.` — no seed NS overlap,
+	// so `third_party`). The corroboration finding must reuse that SAME
+	// ownership assessment rather than omitting it.
+	it('enriched, named candidate resolves via ownershipByDomain: carries the real ownershipVerdict and names the candidate, not the seed', async () => {
+		buildLookalikeFetchMock();
+
+		const reconBinding = makeReconHitBinding('Certificate transparency logs show lookalike activity for tst.com', 'tst.com');
+
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('test.com', { reconBinding, reconAuthToken: 'tok' });
+
+		const enriched = result.findings.filter((f) => f.metadata?.reconEnriched === true);
+		expect(enriched).toHaveLength(1);
+		expect(enriched[0].severity).toBe('medium');
+		expect(enriched[0].metadata?.findingAxis).toBe('threat_observation');
+		expect(enriched[0].title).toBe('CT-observed lookalike corroboration');
+		expect(enriched[0].metadata?.lookalikeDomain).toBe('tst.com');
+		expect(enriched[0].metadata?.domain).toBeUndefined();
+		expect(enriched[0].metadata?.ownershipVerdict).toBe('third_party');
+	});
+
+	// F4 hardening: a recon response that merely echoes the SEED as
+	// `matchedDomain` must be treated identically to "no candidate named" —
+	// never let a self-referential match masquerade as a real one.
+	it('enriched, matchedDomain equal to the seed itself: treated as no candidate named (F4)', async () => {
+		buildLookalikeFetchMock();
+
+		const reconBinding = makeReconHitBinding('echoes the seed', 'test.com');
+
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('test.com', { reconBinding, reconAuthToken: 'tok' });
+
+		const enriched = result.findings.filter((f) => f.metadata?.reconEnriched === true);
+		expect(enriched).toHaveLength(1);
+		expect(enriched[0].severity).toBe('info');
+		expect(enriched[0].metadata?.findingAxis).toBe('scan_status');
 	});
 
 	it('enriched: no corroboration finding when recon returns a benign status', async () => {
@@ -106,7 +171,11 @@ describe('checkLookalikes recon enrichment', () => {
 	it('enriched: no corroboration finding when recon binding fetch fails (fail-soft)', async () => {
 		buildLookalikeFetchMock();
 
-		const reconBinding = { fetch: vi.fn(async () => { throw new Error('network error'); }) };
+		const reconBinding = {
+			fetch: vi.fn(async () => {
+				throw new Error('network error');
+			}),
+		};
 
 		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
 		const result = await checkLookalikes('test.com', { reconBinding, reconAuthToken: 'tok' });

--- a/test/check-lookalikes-recon-enrichment.integration.test.ts
+++ b/test/check-lookalikes-recon-enrichment.integration.test.ts
@@ -156,6 +156,38 @@ describe('checkLookalikes recon enrichment', () => {
 		expect(enriched[0].metadata?.findingAxis).toBe('scan_status');
 	});
 
+	// FIX WAVE (2026-07-27, final-review mutation gap): the reviewer proved by
+	// mutation that flipping the `ownershipByDomain.get(matchedDomain) ?? {...}`
+	// fallback verdict at check-lookalikes.ts:857-866 from `'unattributed'` to
+	// `'owned_by_seed'` — which SILENTLY SUPPRESSES the threat finding, since
+	// the emission site skips any candidate resolved as `owned_by_seed` — left
+	// every test in this file (and the other 79 relevant tests) green. Both
+	// prior fixtures above name `tst.com`, a candidate this scan ALSO
+	// generated/probed locally (present in `ownershipByDomain`), so the
+	// fallback branch itself was never exercised. This fixture's
+	// `matchedDomain` is a domain bv-recon names that this scan's own
+	// permutation generator never produced, so it is guaranteed absent from
+	// `ownershipByDomain` and must hit the fallback.
+	it('enriched, named candidate OUTSIDE the locally probed/permutation set: falls back to unattributed, threat finding still fires (guards the fallback verdict)', async () => {
+		buildLookalikeFetchMock();
+
+		const reconBinding = makeReconHitBinding(
+			'Certificate transparency logs show lookalike activity for an externally-sourced candidate',
+			'external-not-probed-locally.example',
+		);
+
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('test.com', { reconBinding, reconAuthToken: 'tok' });
+
+		const enriched = result.findings.filter((f) => f.metadata?.reconEnriched === true);
+		expect(enriched).toHaveLength(1);
+		expect(enriched[0].severity).toBe('medium');
+		expect(enriched[0].metadata?.findingAxis).toBe('threat_observation');
+		expect(enriched[0].metadata?.lookalikeDomain).toBe('external-not-probed-locally.example');
+		expect(enriched[0].metadata?.domain).toBeUndefined();
+		expect(enriched[0].metadata?.ownershipVerdict).toBe('unattributed');
+	});
+
 	it('enriched: no corroboration finding when recon returns a benign status', async () => {
 		buildLookalikeFetchMock();
 

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -1542,6 +1542,10 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 		expect(bnzComFindings.length).toBeGreaterThan(0);
 		expect(bnzComFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(true);
 		expect(bnzComFindings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
+		// F3(b) (2026-07-27 fix round 2): the assertion the `:1516` comment
+		// promised but this test never actually made — pins the native
+		// same-owner finding's hardcoded 'info' severity explicitly.
+		expect(bnzComFindings.every((f) => f.severity === 'info')).toBe(true);
 		// Call site 1: an owned candidate must never trigger the RDAP enrichment
 		// probe (the old exact-hostname-overlap check would have missed the
 		// in-bailiwick relationship and enriched it anyway).

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -34,9 +34,16 @@ describe('checkLookalikes', () => {
 		expect(info!.severity).toBe('info');
 	});
 
-	it('should return medium finding for lookalike with mail-infra but no corroborator (issue #264 matrix)', async () => {
-		// Updated for issue #264: mail-infra alone is MEDIUM, not HIGH.
-		// HIGH requires a corroborator (recent registration, disposable MX, or no web content).
+	// D4 fixture repair (2026-07-26 correctness-defects design): these
+	// candidates' NS ('ns1.registrar.com.') carries no ownership signal —
+	// third_party under classifyOwnership() — so the calibrated #264
+	// mail-infra-alone MEDIUM is now capped to info by the ownership gate
+	// (a third_party verdict can never exceed info). The #264 calibration
+	// still runs internally (it drives wording/metadata), it just no longer
+	// surfaces as an elevated `.severity` for a domain the scanner cannot
+	// attribute to the scanned organisation. The `describeCorroborators`
+	// hedge stays observable in `.detail`.
+	it('caps mail-infra-alone lookalikes with no ownership signal at info, never elevates them (issue #264 matrix, D4-capped)', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
 
@@ -55,18 +62,14 @@ describe('checkLookalikes', () => {
 			return Promise.resolve(createDohResponse([], []));
 		});
 		const result = await run('test.com');
-		const mediumFindings = result.findings.filter((f) => f.severity === 'medium');
-		expect(mediumFindings.length).toBeGreaterThan(0);
-		const mxFinding = mediumFindings.find((f) => /mail infrastructure/i.test(f.title));
-		expect(mxFinding).toBeDefined();
-		// And no HIGH should be emitted (no corroborating signal)
-		const highFindings = result.findings.filter((f) => f.severity === 'high');
-		expect(highFindings.length).toBe(0);
+		// No MEDIUM or HIGH is emitted for any non-owned candidate.
+		expect(result.findings.some((f) => f.severity === 'medium' || f.severity === 'high')).toBe(false);
+		const gated = result.findings.filter((f) => f.metadata?.ownershipVerdict === 'third_party');
+		expect(gated.length).toBeGreaterThan(0);
+		expect(gated.every((f) => f.severity === 'info')).toBe(true);
 	});
 
-	it('should return low finding for lookalike with A but no MX (web-only, no corroborator)', async () => {
-		// Updated for issue #264: web-only lookalikes default to LOW.
-		// MEDIUM is reserved for web-only + recent registration (<90d).
+	it('caps web-only lookalikes with no ownership signal at info (web-only, no corroborator, D4-capped)', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
 
@@ -82,17 +85,19 @@ describe('checkLookalikes', () => {
 			return Promise.resolve(createDohResponse([], []));
 		});
 		const result = await run('test.com');
-		const lowFindings = result.findings.filter((f) => f.severity === 'low');
-		expect(lowFindings.length).toBeGreaterThan(0);
-		const registeredFinding = lowFindings.find((f) => /Lookalike domain registered/i.test(f.title));
-		expect(registeredFinding).toBeDefined();
+		expect(result.findings.some((f) => f.severity === 'low')).toBe(false);
+		const gated = result.findings.filter((f) => f.metadata?.ownershipVerdict === 'third_party' && f.metadata?.hasMX === false);
+		expect(gated.length).toBeGreaterThan(0);
+		expect(gated.every((f) => f.severity === 'info')).toBe(true);
 	});
 
-	it('surfaces a registered combosquat (brand + lure affix) that edit-distance generation misses', async () => {
+	it('surfaces a registered combosquat (brand + lure affix) that edit-distance generation misses, capped at info (no ownership signal)', async () => {
 		// `paypal-login.com` is a combosquat of `paypal.com`: generateLookalikes
 		// (edit-distance mutators) never produces it — generateCombosquats does.
-		// Give it mail infrastructure so it surfaces at MEDIUM per the #264 matrix,
-		// proving Part 3 generation feeds the same severity pipeline.
+		// It has mail infrastructure and would calibrate to MEDIUM per the #264
+		// matrix, but carries no ownership signal (third_party) so the D4 gate
+		// caps it at info — proving Part 3 generation still feeds the same
+		// ownership-gated pipeline as every other detection path.
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
 			if (name === 'paypal-login.com') {
@@ -109,8 +114,9 @@ describe('checkLookalikes', () => {
 			return Promise.resolve(createDohResponse([], []));
 		});
 		const result = await run('paypal.com');
-		const surfaced = result.findings.filter((f) => f.severity === 'medium' || f.severity === 'high');
+		const surfaced = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'paypal-login.com');
 		expect(surfaced.length).toBeGreaterThan(0);
+		expect(surfaced.every((f) => f.severity === 'info')).toBe(true);
 		expect(JSON.stringify(result.findings)).toContain('paypal-login.com');
 	});
 
@@ -198,7 +204,10 @@ describe('checkLookalikes', () => {
 		const result = await run('test.com');
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('low');
+		// D4-capped: no ownership signal (ns1.registrar.com) → third_party → info,
+		// not the raw web-only LOW the #264 calibrator computes internally.
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
 	});
 });
 
@@ -228,13 +237,15 @@ describe('checkLookalikes - null MX filtering', () => {
 		});
 		const result = await run('test.com');
 
-		// Should NOT have any high findings (null MX is not real mail infra)
-		const mxFindings = result.findings.filter((f) => /mail infrastructure/i.test(f.title));
-		expect(mxFindings.length).toBe(0);
-
-		// Should have low findings (A record present, but no real MX → web-only LOW under #264)
-		const lowFindings = result.findings.filter((f) => f.severity === 'low');
-		expect(lowFindings.length).toBeGreaterThan(0);
+		// D4-capped: no ownership signal, so severity is 'info' regardless — the
+		// title-based "mail infrastructure" check no longer discriminates null-MX
+		// filtering (every capped finding is retitled "Unrelated domain,
+		// confusable label: X"). The actual point — null MX must NOT register as
+		// real mail infra — is now pinned on the preserved `hasMX` metadata.
+		const gated = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com' || f.metadata?.lookalikeDomain === 'tes.com');
+		expect(gated.length).toBeGreaterThan(0);
+		expect(gated.every((f) => f.metadata?.hasMX === false)).toBe(true);
+		expect(gated.every((f) => f.severity === 'info')).toBe(true);
 	});
 
 	it('should not flag legacy null MX (0 localhost.) as mail infrastructure', async () => {
@@ -257,8 +268,13 @@ describe('checkLookalikes - null MX filtering', () => {
 			return Promise.resolve(createDohResponse([], []));
 		});
 		const result = await run('test.com');
-		const mxFindings = result.findings.filter((f) => /mail infrastructure/i.test(f.title));
-		expect(mxFindings.length).toBe(0);
+		// D4-capped (third_party, no ownership signal): title no longer carries
+		// "mail infrastructure" wording for ANY capped finding, so the actual
+		// point — legacy null MX must not register as real mail infra — is
+		// pinned on the preserved `hasMX` metadata instead.
+		const gated = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com' || f.metadata?.lookalikeDomain === 'tes.com');
+		expect(gated.length).toBeGreaterThan(0);
+		expect(gated.every((f) => f.metadata?.hasMX === false)).toBe(true);
 	});
 
 	it('should flag real MX but ignore null MX in mixed responses', async () => {
@@ -293,20 +309,24 @@ describe('checkLookalikes - null MX filtering', () => {
 		});
 		const result = await run('test.com');
 
-		// testt.com has real MX but no corroborating signal → MEDIUM under #264 matrix
-		const testtMedium = result.findings.find((f) => f.severity === 'medium' && f.title.includes('testt.com'));
-		expect(testtMedium).toBeDefined();
+		// D4-capped (neither has an ownership signal — third_party): the raw
+		// #264 calibration (testt.com → MEDIUM mail-infra, tes.com → LOW
+		// web-only) still runs internally but is capped to info. What this test
+		// actually still needs to prove — real MX registers, null MX does not —
+		// is pinned on the `hasMX` metadata rather than the severity/title.
+		const testtFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'testt.com');
+		expect(testtFinding).toBeDefined();
+		expect(testtFinding!.metadata?.hasMX).toBe(true);
+		expect(testtFinding!.severity).toBe('info');
 
-		// tes.com has only A record (web-only, no MX) — LOW under #264 matrix.
-		// (Previously MEDIUM; the calibrator now reserves MEDIUM for web-only + recent registration.)
-		const tesLow = result.findings.find((f) => f.severity === 'low' && f.title.includes('tes.com'));
-		expect(tesLow).toBeDefined();
+		const tesFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tes.com');
+		expect(tesFinding).toBeDefined();
+		expect(tesFinding!.metadata?.hasMX).toBe(false);
+		expect(tesFinding!.severity).toBe('info');
 
-		// Neither should be HIGH
-		const tesHigh = result.findings.find((f) => f.severity === 'high' && f.title.includes('tes.com'));
-		expect(tesHigh).toBeUndefined();
-		const testtHigh = result.findings.find((f) => f.severity === 'high' && f.title.includes('testt.com'));
-		expect(testtHigh).toBeUndefined();
+		// Neither should be HIGH or MEDIUM regardless (ownership cap, not just
+		// the null-MX distinction).
+		expect(result.findings.some((f) => f.severity === 'high' || f.severity === 'medium')).toBe(false);
 	});
 });
 
@@ -362,7 +382,9 @@ describe('checkLookalikes - wildcard DNS filtering', () => {
 		// te.st.com should remain because st.com has no wildcard
 		const teStFinding = result.findings.find((f) => f.title.includes('te.st.com'));
 		expect(teStFinding).toBeDefined();
-		expect(teStFinding!.severity).toBe('low'); // web-only baseline (#264)
+		// D4-capped: no ownership signal → third_party → info (the web-only LOW
+		// baseline still computes internally but is capped at the tool boundary).
+		expect(teStFinding!.severity).toBe('info');
 	});
 
 	it('should not affect non-dot-insertion permutations regardless of wildcard', async () => {
@@ -386,7 +408,8 @@ describe('checkLookalikes - wildcard DNS filtering', () => {
 		// tst.com is a same-label-count permutation (char omission), not dot-insertion — should be kept
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('low'); // web-only baseline (#264)
+		// D4-capped: no ownership signal → third_party → info.
+		expect(tstFinding!.severity).toBe('info');
 	});
 
 	it('exports WILDCARD_CANARY_LABEL constant', async () => {
@@ -445,21 +468,30 @@ describe('checkLookalikes - shared nameserver detection', () => {
 
 		const result = await run('test.com');
 
-		// tst.com should be info (shared NS = likely same owner), NOT high
+		// tst.com should be info (2/2 dedicated NS match = owned_by_seed under
+		// classifyOwnership), NOT high.
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
 		expect(tstFinding!.severity).toBe('info');
 		expect(tstFinding!.title).toContain('likely owned by same entity');
-		expect(tstFinding!.detail).toContain('shares nameservers');
+		expect(tstFinding!.detail).toContain('dedicated nameservers');
 		expect(tstFinding!.detail).toContain('mail infrastructure');
-		expect(tstFinding!.metadata?.sharedNs).toBe(true);
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('owned_by_seed');
 
 		// Should NOT appear in the high count summary
 		const highSummary = result.findings.find((f) => /mail capability detected/i.test(f.title));
 		expect(highSummary).toBeUndefined();
 	});
 
-	it('should keep high severity when lookalike has different nameservers', async () => {
+	// D4-capped (2026-07-26 correctness-defects design): tst.com's NS
+	// ('ns1.attacker-dns.com.') carries no ownership signal against the
+	// primary — third_party. What USED to be described as "keep high
+	// severity" is now capped at info by the ownership gate: a domain the
+	// scanner cannot attribute to the scanned organisation can never surface
+	// above info, regardless of how threatening its raw MX signal looks. The
+	// underlying #264 calibration (MX-alone → medium) still runs internally,
+	// preserved in `hasMX` metadata, but the visible severity is capped.
+	it('caps a lookalike with different (unrelated) nameservers at info despite active MX (D4 ownership cap)', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
 
@@ -468,7 +500,8 @@ describe('checkLookalikes - shared nameserver detection', () => {
 				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.cloudflare.com.' }]));
 			}
 
-			// tst.com has DIFFERENT nameservers + MX → should remain HIGH
+			// tst.com has DIFFERENT (unrelated) nameservers + MX — no ownership
+			// signal against the primary.
 			if (name === 'tst.com') {
 				if (type === 'NS' || type === '2') {
 					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.attacker-dns.com.' }]));
@@ -488,24 +521,47 @@ describe('checkLookalikes - shared nameserver detection', () => {
 
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
-		// MX present but no corroborator → MEDIUM under issue #264 matrix.
-		expect(tstFinding!.severity).toBe('medium');
-		expect(tstFinding!.title).toContain('mail infrastructure');
+		// D4-capped: third_party (unrelated NS) — capped at info regardless of
+		// the raw #264 MX-alone MEDIUM the calibrator computes internally.
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
+		expect(tstFinding!.metadata?.hasMX).toBe(true);
 	});
 
-	it('should downgrade medium to info when lookalike with A record shares NS', async () => {
+	// D4 fixture repair: classifyOwnership()'s dedicated NS-set-match rule
+	// (rule 5) requires >= 2 matching dedicated hosts, not a single host — a
+	// SINGLE arbitrary hostname match is exactly the naive threshold=1
+	// coincidence this design closes off (§3.3). Two dedicated hosts here
+	// keeps the scenario genuinely owned_by_seed.
+	it('should downgrade medium to info when lookalike with A record shares a 2-host dedicated NS pair', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
 
 			// Primary domain NS
 			if (name === 'test.com' && (type === 'NS' || type === '2')) {
-				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.example-dns.com.' }]));
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type: 2 }],
+						[
+							{ name, type: 2, TTL: 300, data: 'ns1.example-dns.com.' },
+							{ name, type: 2, TTL: 300, data: 'ns2.example-dns.com.' },
+						],
+					),
+				);
 			}
 
-			// tst.com shares NS, has A record but no MX
+			// tst.com shares the same 2-host dedicated NS pair, has an A record but no MX
 			if (name === 'tst.com') {
 				if (type === 'NS' || type === '2') {
-					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.example-dns.com.' }]));
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[
+								{ name, type: 2, TTL: 300, data: 'ns1.example-dns.com.' },
+								{ name, type: 2, TTL: 300, data: 'ns2.example-dns.com.' },
+							],
+						),
+					);
 				}
 				if (type === 'A' || type === '1') {
 					return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
@@ -523,21 +579,43 @@ describe('checkLookalikes - shared nameserver detection', () => {
 		expect(tstFinding!.severity).toBe('info');
 		expect(tstFinding!.title).toContain('likely owned by same entity');
 		expect(tstFinding!.detail).toContain('web presence');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('owned_by_seed');
 	});
 
+	// D4 fixture repair: same 2-host minimum as above — a single normalized
+	// hostname match doesn't clear classifyOwnership()'s rule-5 threshold, so
+	// a second host is added to both sides. Casing/trailing-dot variation is
+	// kept on one host pair to still exercise the normalization this test is
+	// actually about.
 	it('should handle NS comparison case-insensitively and strip trailing dots', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
 
 			// Primary domain NS with trailing dot and mixed case
 			if (name === 'test.com' && (type === 'NS' || type === '2')) {
-				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'NS1.CloudFlare.COM.' }]));
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type: 2 }],
+						[
+							{ name, type: 2, TTL: 300, data: 'NS1.CloudFlare.COM.' },
+							{ name, type: 2, TTL: 300, data: 'NS2.CloudFlare.COM.' },
+						],
+					),
+				);
 			}
 
-			// tst.com has same NS but different casing/trailing dot
+			// tst.com has the same NS but different casing/trailing dot
 			if (name === 'tst.com') {
 				if (type === 'NS' || type === '2') {
-					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.cloudflare.com' }]));
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							[
+								{ name, type: 2, TTL: 300, data: 'ns1.cloudflare.com' },
+								{ name, type: 2, TTL: 300, data: 'ns2.cloudflare.com' },
+							],
+						),
+					);
 				}
 				if (type === 'A' || type === '1') {
 					return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
@@ -582,13 +660,15 @@ describe('checkLookalikes - shared nameserver detection', () => {
 
 		const result = await run('test.com');
 
-		// Primary NS unknown (empty set — can't compare). Mail-infra present without
-		// corroborator → MEDIUM under issue #264 matrix. The shared-NS gate is
-		// independent of the severity calibration.
+		// Primary NS unknown (empty set — can't compare) → third_party (no
+		// ownership signal at all) → D4-capped at info, same numeric outcome as
+		// an explicit ownership downgrade would produce, but via the "no
+		// evidence" path rather than a same-owner claim.
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('medium');
-		// And must NOT be downgraded to info (no shared NS detected)
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
+		// And must NOT carry the same-owner claim (no shared NS detected).
 		expect(tstFinding!.title).not.toContain('likely owned by same entity');
 	});
 
@@ -648,17 +728,20 @@ describe('checkLookalikes - shared nameserver detection', () => {
 
 		const result = await run('test.com');
 
-		// tst.com should be info (shared NS)
+		// tst.com should be info (2/2 dedicated NS match = owned_by_seed)
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
 		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('owned_by_seed');
 
-		// testt.com has different NS + MX but no corroborator → MEDIUM under #264 matrix
-		// (was HIGH under the old "any MX → high" rule).
-		const testtFinding = result.findings.find((f) => f.severity === 'medium' && f.title.includes('testt.com'));
+		// testt.com has different (unrelated) NS + MX — third_party — D4-capped
+		// at info regardless of the raw #264 MX-alone MEDIUM computed internally.
+		const testtFinding = result.findings.find((f) => f.title.includes('testt.com'));
 		expect(testtFinding).toBeDefined();
+		expect(testtFinding!.severity).toBe('info');
+		expect(testtFinding!.metadata?.ownershipVerdict).toBe('third_party');
 
-		// No HIGH summary fires because no lookalike scored HIGH under the new matrix.
+		// No HIGH summary fires because nothing surfaces above info.
 		const summary = result.findings.find((f) => /mail capability detected/i.test(f.title));
 		expect(summary).toBeUndefined();
 	});
@@ -709,12 +792,7 @@ describe('checkLookalikes - issue #264 severity calibration wiring', () => {
 	 * to ok:true (fail-soft → hasWebContent=true) unless the test overrides
 	 * the URL to be parked/refused.
 	 */
-	function mockWithRdap(opts: {
-		mailDomain: string;
-		mxExchange?: string;
-		registrationDaysAgo?: number | null;
-		hasWebContent?: boolean;
-	}) {
+	function mockWithRdap(opts: { mailDomain: string; mxExchange?: string; registrationDaysAgo?: number | null; hasWebContent?: boolean }) {
 		const { mailDomain, mxExchange = 'mail.example.com.', registrationDaysAgo, hasWebContent = true } = opts;
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
@@ -754,46 +832,66 @@ describe('checkLookalikes - issue #264 severity calibration wiring', () => {
 				if (!hasWebContent) {
 					return Promise.reject(new Error('connection refused'));
 				}
-				return Promise.resolve({ ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve(''), json: () => Promise.resolve({}) } as unknown as Response);
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					headers: new Headers(),
+					text: () => Promise.resolve(''),
+					json: () => Promise.resolve({}),
+				} as unknown as Response);
 			}
 
 			return Promise.resolve(createDohResponse([], []));
 		});
 	}
 
-	it('elevates mail-infra + recent registration to HIGH', async () => {
+	// D4-capped (2026-07-26 correctness-defects design): 'ns1.registrar.com.'
+	// carries no ownership signal against the (unmocked, empty) primary NS —
+	// third_party. Every RDAP-driven elevation in this describe block still
+	// runs internally (it is what produces the `registrationDays`/
+	// `mxOnDisposable`/`hasWebContent` metadata pinned below, proving the
+	// wiring is intact), but the OUTPUT severity is now capped at info for a
+	// domain the scanner cannot attribute to the scanned organisation — a
+	// domain that genuinely calibrates to HIGH under #264 is exactly the
+	// riskiest case for a false-attribution claim, so it is not exempted.
+	it('caps mail-infra + recent registration at info despite calibrating internally to HIGH', async () => {
 		mockWithRdap({ mailDomain: 'tst.com', registrationDaysAgo: 30 });
 		const result = await run('test.com');
-		const tstFinding = result.findings.find((f) => f.title.includes('tst.com') && /mail infrastructure/i.test(f.title));
+		const tstFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tst.com');
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('high');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
+		expect(tstFinding!.metadata?.registrationDays).toBe(30);
 	});
 
-	it('keeps mail-infra at MEDIUM when registration is old (≥90d)', async () => {
+	it('caps mail-infra at info when registration is old (≥90d) — internal calibration stays MEDIUM-shaped in metadata', async () => {
 		mockWithRdap({ mailDomain: 'tst.com', registrationDaysAgo: 1500 });
 		const result = await run('test.com');
-		const tstFinding = result.findings.find((f) => f.title.includes('tst.com') && /mail infrastructure/i.test(f.title));
+		const tstFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tst.com');
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('medium');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.registrationDays).toBe(1500);
 	});
 
-	it('elevates mail-infra + disposable MX to HIGH', async () => {
+	it('caps mail-infra + disposable MX at info despite calibrating internally to HIGH', async () => {
 		mockWithRdap({ mailDomain: 'tst.com', mxExchange: 'smtp.mailgun.org.', registrationDaysAgo: null });
 		const result = await run('test.com');
-		const tstFinding = result.findings.find((f) => f.title.includes('tst.com') && /mail infrastructure/i.test(f.title));
+		const tstFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tst.com');
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('high');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.mxOnDisposable).toBe(true);
 	});
 
-	it('elevates mail-infra + no web content (parked/refused) to HIGH', async () => {
+	it('caps mail-infra + no web content (parked/refused) at info despite calibrating internally to HIGH', async () => {
 		mockWithRdap({ mailDomain: 'tst.com', registrationDaysAgo: null, hasWebContent: false });
 		const result = await run('test.com');
-		const tstFinding = result.findings.find((f) => f.title.includes('tst.com') && /mail infrastructure/i.test(f.title));
+		const tstFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tst.com');
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('high');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.hasWebContent).toBe(false);
 	});
 
-	it('elevates web-only + recent registration to MEDIUM', async () => {
+	it('caps web-only + recent registration at info despite calibrating internally to MEDIUM', async () => {
 		// Build a slightly different mock — no MX, A only, recent registration.
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
@@ -818,14 +916,22 @@ describe('checkLookalikes - issue #264 severity calibration wiring', () => {
 				} as unknown as Response);
 			}
 			if (url.startsWith('https://') || url.startsWith('http://')) {
-				return Promise.resolve({ ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve(''), json: () => Promise.resolve({}) } as unknown as Response);
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					headers: new Headers(),
+					text: () => Promise.resolve(''),
+					json: () => Promise.resolve({}),
+				} as unknown as Response);
 			}
 			return Promise.resolve(createDohResponse([], []));
 		});
 		const result = await run('test.com');
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('medium');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
+		expect(tstFinding!.metadata?.registrationDays).toBe(30);
 	});
 });
 
@@ -848,9 +954,15 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 						{
 							objectClassName: 'entity',
 							roles: ['registrant'],
-							vcardArray: ['vcard', [['version', {}, 'text', '4.0'], ['org', {}, 'text', org]]],
+							vcardArray: [
+								'vcard',
+								[
+									['version', {}, 'text', '4.0'],
+									['org', {}, 'text', org],
+								],
+							],
 						},
-				  ];
+					];
 		return { events, entities };
 	}
 
@@ -905,7 +1017,13 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 
 			// HEAD probe — reachable web content (fail-soft true)
 			if (url.startsWith('https://') || url.startsWith('http://')) {
-				return Promise.resolve({ ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve(''), json: () => Promise.resolve({}) } as unknown as Response);
+				return Promise.resolve({
+					ok: true,
+					status: 200,
+					headers: new Headers(),
+					text: () => Promise.resolve(''),
+					json: () => Promise.resolve({}),
+				} as unknown as Response);
 			}
 			return Promise.resolve(createDohResponse([], []));
 		});
@@ -935,21 +1053,30 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 		expect(summary).toBeUndefined();
 	});
 
-	it('keeps the calibrated threat severity when the registrant org differs (real third-party lookalike preserved)', async () => {
+	// D4-capped: tst.com's NS ('ns1.other-dns.com.', deliberately distinct
+	// from the primary's 'ns1.primary-dns.com.' per mockSameEntity) carries no
+	// ownership signal — third_party — so even a genuine "Phishing Co"
+	// registrant with a recent-registration HIGH calibration is capped at
+	// info. This is the deliberately conservative D4 trade-off: the tool no
+	// longer distinguishes a real phishing lookalike's threat tier in
+	// `.severity` once ownership can't be established, but it is still
+	// reported (never suppressed) with the calibration preserved in metadata.
+	it('caps a real third-party phishing lookalike at info even when its RDAP registrant org differs (D4 ownership cap)', async () => {
 		mockSameEntity({
 			lookalike: 'tst.com',
-			lookalikeRdap: rdapWithRegistrant('Phishing Co', 30), // recent reg + mail-infra → HIGH
+			lookalikeRdap: rdapWithRegistrant('Phishing Co', 30), // recent reg + mail-infra → HIGH internally
 			primaryRdap: rdapWithRegistrant('<Vendor> Limited'),
 		});
 		const result = await run('test.com');
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('high');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
 		expect(tstFinding!.title).not.toContain('likely owned by same entity');
-		expect(tstFinding!.title).toContain('mail infrastructure');
+		expect(tstFinding!.metadata?.registrationDays).toBe(30);
 	});
 
-	it('falls back to the threat severity when RDAP fails for the lookalike (fail-soft, never suppresses)', async () => {
+	it('caps at info when RDAP fails for the lookalike, never suppresses (fail-soft)', async () => {
 		mockSameEntity({
 			lookalike: 'tst.com',
 			lookalikeRdap: { fail: true }, // RDAP unavailable → registrantOrg unknown
@@ -958,13 +1085,22 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 		const result = await run('test.com');
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
-		// Mail-infra, no corroborator, RDAP age unknown → MEDIUM (issue #264 default). NOT downgraded to info.
-		expect(tstFinding!.severity).toBe('medium');
+		// Mail-infra, no corroborator, RDAP age unknown → MEDIUM internally
+		// (issue #264 default), but third_party → D4-capped at info. Present,
+		// not suppressed, and not carrying the same-owner claim.
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
 		expect(tstFinding!.title).not.toContain('likely owned by same entity');
 	});
 
-	it('detects a shared-NS same-entity lookalike WITHOUT issuing any RDAP fetch (cheap path preserved)', async () => {
-		const sharedNs = 'ns1.shared-dns.com.';
+	// D4 fixture repair: a SINGLE shared NS host (not flagged as a shared
+	// provider) no longer clears classifyOwnership()'s rule-5 threshold
+	// (>= 2 dedicated hosts) — that single-host coincidence is exactly the
+	// naive threshold=1 bug this design closes. A second shared host is added
+	// so the scenario is genuinely owned_by_seed, keeping this test's actual
+	// subject (the cheap shared-NS path skips RDAP entirely) observable.
+	it('detects a 2-host dedicated-NS same-entity lookalike WITHOUT issuing any RDAP fetch (cheap path preserved)', async () => {
+		const sharedNs = ['ns1.shared-dns.com.', 'ns2.shared-dns.com.'];
 		const rdapCalls: string[] = [];
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
@@ -972,11 +1108,21 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 			if (url.includes('cloudflare-dns.com')) {
 				const { name, type } = parseDohQuery(input);
 				if (name === 'test.com' && (type === 'NS' || type === '2')) {
-					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: sharedNs }]));
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							sharedNs.map((d) => ({ name, type: 2, TTL: 300, data: d })),
+						),
+					);
 				}
 				if (name === 'tst.com') {
 					if (type === 'NS' || type === '2') {
-						return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: sharedNs }]));
+						return Promise.resolve(
+							createDohResponse(
+								[{ name, type: 2 }],
+								sharedNs.map((d) => ({ name, type: 2, TTL: 300, data: d })),
+							),
+						);
 					}
 					if (type === 'MX' || type === '15') {
 						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.tst.com.' }]));
@@ -994,7 +1140,7 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 		expect(tstFinding).toBeDefined();
 		expect(tstFinding!.severity).toBe('info');
 		expect(tstFinding!.title).toContain('likely owned by same entity');
-		expect(tstFinding!.detail).toContain('shares nameservers');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('owned_by_seed');
 		// The cheaper shared-NS path must short-circuit BEFORE any RDAP call.
 		expect(rdapCalls.length).toBe(0);
 	});
@@ -1106,7 +1252,13 @@ describe('checkLookalikes - probeRdap routes through safeFetch (SSRF parity, P3 
 				return Promise.resolve(createDohResponse([], []));
 			}
 			// HEAD web-content probe — reachable (fail-soft true).
-			return Promise.resolve({ ok: true, status: 200, headers: new Headers(), text: () => Promise.resolve(''), json: () => Promise.resolve({}) } as unknown as Response);
+			return Promise.resolve({
+				ok: true,
+				status: 200,
+				headers: new Headers(),
+				text: () => Promise.resolve(''),
+				json: () => Promise.resolve({}),
+			} as unknown as Response);
 		};
 	}
 
@@ -1143,10 +1295,15 @@ describe('checkLookalikes - probeRdap routes through safeFetch (SSRF parity, P3 
 		// the validated URL is the hardcoded public RDAP host — proves it passes validateOutboundUrl
 		expect(rdapUrls.some((u) => u.startsWith('https://rdap.verisign.com/'))).toBe(true);
 
-		// (2) the legitimate RDAP response still parses → recent registration elevates to HIGH
-		const tstFinding = result.findings.find((f) => f.title.includes('tst.com') && /mail infrastructure/i.test(f.title));
+		// (2) the legitimate RDAP response still parses → recent registration is
+		// captured in metadata (registrationDays). Severity itself is D4-capped
+		// at info: 'ns1.registrar.com.' carries no ownership signal
+		// (third_party), so even the internally-HIGH calibration this recent
+		// registration would produce is capped.
+		const tstFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tst.com');
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('high');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.registrationDays).toBe(30);
 	});
 
 	it('degrades fail-soft (no throw, registration unknown) when safeFetch blocks the RDAP host', async () => {
@@ -1167,9 +1324,283 @@ describe('checkLookalikes - probeRdap routes through safeFetch (SSRF parity, P3 
 		// Must not throw out of the tool — the probe's try/catch absorbs the block.
 		const result = await checkLookalikes('test.com');
 
-		// Registration age is unknown (probe blocked) → mail-infra stays MEDIUM, not HIGH.
-		const tstFinding = result.findings.find((f) => f.title.includes('tst.com') && /mail infrastructure/i.test(f.title));
+		// Registration age is unknown (probe blocked) → mail-infra stays
+		// MEDIUM-shaped internally, not HIGH — and third_party (no ownership
+		// signal) caps the OUTPUT severity at info regardless.
+		const tstFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tst.com');
 		expect(tstFinding).toBeDefined();
-		expect(tstFinding!.severity).toBe('medium');
+		expect(tstFinding!.severity).toBe('info');
+		expect(tstFinding!.metadata?.registrationDays).toBeNull();
+	});
+});
+
+describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-defects design)', () => {
+	async function run(domain = 'example.com') {
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		return checkLookalikes(domain);
+	}
+
+	// CALL SITE 2 (main classification loop). Old sharesNameservers()/
+	// SHARED_NS_THRESHOLD=1 fired on a SINGLE shared Akamai host and would
+	// have relabelled this "likely owned by same entity" at info. Under
+	// classifyOwnership(), a partial overlap confined to a shared-provider
+	// host (a1-97.akam.net) is explicitly NOT ownership evidence (§3.3), so
+	// the verdict is third_party. DEMOTE, NEVER DELETE: the finding must
+	// still be present (a real measurement, never suppressed) but capped at
+	// info with neutral wording — never the ownership-framed title.
+	it('does not mark a lookalike as same-owner off a single shared Akamai NS host — demotes to info, never suppresses', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'testco.com' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type: 2 }],
+						['a1-97.akam.net.', 'a3-67.akam.net.'].map((d) => ({ name, type: 2, TTL: 300, data: d })),
+					),
+				);
+			}
+			if (name === 'twstco.com') {
+				if (type === 'NS' || type === '2') {
+					// Shares exactly ONE Akamai host (a1-97) with the primary — the
+					// old SHARED_NS_THRESHOLD=1 bug would call this "same owner".
+					return Promise.resolve(
+						createDohResponse(
+							[{ name, type: 2 }],
+							['a1-97.akam.net.', 'a99-99.akam.net.'].map((d) => ({ name, type: 2, TTL: 300, data: d })),
+						),
+					);
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.example.com.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+
+		const result = await run('testco.com');
+		const twstFindings = result.findings.filter((f) => f.detail.includes('twstco.com'));
+		// DEMOTE, NEVER DELETE: a real, positively-probed candidate (has MX) is
+		// always present in the output.
+		expect(twstFindings.length).toBeGreaterThan(0);
+		expect(twstFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(false);
+		// Capped at info, not left at the mail-infra medium/high the calibrator
+		// would otherwise assign.
+		expect(twstFindings.every((f) => f.severity === 'info')).toBe(true);
+		const gated = twstFindings.find((f) => f.metadata?.ownershipVerdict !== undefined);
+		expect(gated).toBeDefined();
+		expect(gated!.metadata?.ownershipVerdict).toBe('third_party');
+		expect(gated!.metadata?.severityCappedBy).toBe('ownership_attribution');
+	});
+
+	// CALL SITE 2 + the load-bearing safety property: severity gates on the
+	// VERDICT alone, never on attributionConfidence/label length/
+	// corroboration. Brand label here is 7 chars (>= MIN_ATTRIBUTION_LABEL_LENGTH)
+	// AND the candidate's MX exchange overlaps the primary's — both signals
+	// that would make attributionConfidence() return 'corroborated'. If
+	// severity were (wrongly) gated on attributionConfidence instead of
+	// capAttributionSeverity(verdict), a 'third_party' + 'corroborated'
+	// candidate would be treated as unbounded and surface above info. It
+	// must not: third_party is capped at info regardless of corroboration.
+	it('caps a third_party verdict at info even with a long brand label AND MX-overlap corroboration (verdict-only gate)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'contoso.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.shared-mx.com.' }]));
+				}
+			}
+			if (name === 'contos0.com') {
+				if (type === 'NS' || type === '2') {
+					// Completely distinct NS from the primary — no ownership signal.
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.attacker-dns.com.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					// Same MX exchange as the primary — a genuine MX-overlap
+					// corroboration signal, wired for WORDING only.
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.shared-mx.com.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+
+		const result = await run('contoso.com');
+		const findings = result.findings.filter((f) => f.detail.includes('contos0.com'));
+		expect(findings.length).toBeGreaterThan(0);
+		expect(findings.every((f) => f.severity === 'info')).toBe(true);
+		const gated = findings.find((f) => f.metadata?.ownershipVerdict === 'third_party');
+		expect(gated).toBeDefined();
+		// Corroboration affects wording (confidence), never the ceiling.
+		expect(gated!.metadata?.attributionConfidence).toBe('corroborated');
+	});
+
+	// CALL SITE 2 (the demoted rung must be neutrally worded, not just
+	// numerically capped). A split-surface bug (severity right, title still
+	// ownership-framed) is exactly what bit Task 6's first review pass.
+	it('never uses ownership-implying prose ("owned", "your domain") for a non-owned candidate at the capped severity', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'testco.com' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+			}
+			if (name === 'twstco.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.attacker-dns.com.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.evil.com.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+
+		const result = await run('testco.com');
+		const gated = result.findings.find((f) => f.metadata?.ownershipVerdict === 'third_party' && f.detail.includes('twstco.com'));
+		expect(gated).toBeDefined();
+		expect(gated!.severity).toBe('info');
+		expect(gated!.title).not.toMatch(/owned by same entity/i);
+		expect(gated!.detail).not.toMatch(/is owned by the same organisation/i);
+	});
+
+	// CALL SITE 1 (the enrichment gate) AND CALL SITE 2 together, on the
+	// OPPOSITE direction from the Akamai test: an in-bailiwick NS delegation
+	// is ownership evidence with ZERO literal hostname overlap against the
+	// primary's own NS set, so the OLD sharesNameservers()/threshold=1 check
+	// (exact-hostname set intersection) would see NO overlap and treat this
+	// as a third party — while classifyOwnership() correctly recognises
+	// in-bailiwick delegation as owned_by_seed. This is the discriminator for
+	// call site 1: with the old code, this candidate would NOT be excluded
+	// from enrichment (an RDAP fetch would fire); with the fix, ownership is
+	// resolved from the NS verdict alone and RDAP is never consulted for an
+	// owned candidate. The finding must surface UNCLAMPED (medium/high, not
+	// capped to info) since verdict is owned_by_seed.
+	it('recognises in-bailiwick NS delegation as owned_by_seed with zero literal NS-hostname overlap, skips RDAP enrichment, and leaves severity unclamped', async () => {
+		const rdapCalls: string[] = [];
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('rdap')) rdapCalls.push(url);
+			const { name, type } = parseDohQuery(input);
+			// Primary's own NS is a totally distinct hostname from the candidate's.
+			if (name === 'bnz.co.nz' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns-cloud1.googledomains.com.' }]));
+			}
+			if (name === 'bnz.com') {
+				if (type === 'NS' || type === '2') {
+					// In-bailiwick to the seed apex bnz.co.nz — zero literal overlap
+					// with the primary's own NS hostname above.
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.bnz.co.nz.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.bnz.co.nz.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+
+		const result = await run('bnz.co.nz');
+		const bnzComFindings = result.findings.filter((f) => f.detail.includes('bnz.com') || f.metadata?.lookalikeDomain === 'bnz.com');
+		expect(bnzComFindings.length).toBeGreaterThan(0);
+		expect(bnzComFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(true);
+		expect(bnzComFindings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
+		// Call site 1: an owned candidate must never trigger the RDAP enrichment
+		// probe (the old exact-hostname-overlap check would have missed the
+		// in-bailiwick relationship and enriched it anyway).
+		expect(rdapCalls.length).toBe(0);
+	});
+
+	// CALL SITE 3 (computeSameEntityCandidates' RDAP-eligibility filter). Seed
+	// TLD is deliberately .com (FALLBACK_RDAP_SERVERS has an entry — unlike
+	// .nz, used elsewhere in this block, which has none and would make a
+	// "no primary RDAP fetch" assertion pass trivially regardless of gating).
+	// The ONLY candidate with mail infrastructure in this scan is the
+	// in-bailiwick owned combosquat 'mail-contoso.com'; if call site 3 is left
+	// on the old exact-hostname-overlap check it would (wrongly) treat this
+	// owned candidate as eligible for the same-entity RDAP correlation and
+	// fetch the PRIMARY's own registrant org even though nothing needs
+	// correlating — an unnecessary RDAP fetch this test catches directly by
+	// asserting no RDAP call for the primary domain occurs.
+	it('excludes an owned_by_seed candidate from the same-entity RDAP-eligibility set (no primary RDAP fetch)', async () => {
+		const primaryRdapCalls: string[] = [];
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('rdap') && url.includes('/domain/contoso.com')) primaryRdapCalls.push(url);
+			const { name, type } = parseDohQuery(input);
+			if (name === 'contoso.com' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+			}
+			// mail-contoso.com — a combosquat, delegated in-bailiwick to the seed
+			// apex contoso.com — owned_by_seed with zero literal NS-hostname
+			// overlap against the primary's own NS above.
+			if (name === 'mail-contoso.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.contoso.com.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.contoso.com.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+
+		await run('contoso.com');
+		expect(primaryRdapCalls.length).toBe(0);
+	});
+
+	// D4 spec row for this tool, BOTH directions pinned together (a test that
+	// proves only one direction does not discriminate): a short (3-char)
+	// brand label with a third_party verdict and no corroboration is
+	// suppressed FROM ELEVATION (present at info, neutral wording) while a
+	// short (3-char) brand label with an owned_by_seed verdict (NS in
+	// bailiwick — the strongest corroborating signal by construction) still
+	// surfaces at full computed severity.
+	it('D4 short-label pin: third-party short label capped at info; owned_by_seed short label surfaces unclamped', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'bnz.co.nz' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns-cloud1.googledomains.com.' }]));
+			}
+			// hnz.co.nz — a homoglyph of bnz.co.nz (b -> h), registered on its own
+			// unrelated NS. Brand label 'bnz' is 3 chars, below
+			// MIN_ATTRIBUTION_LABEL_LENGTH, and there is no MX overlap with the
+			// primary — third_party, uncorroborated.
+			if (name === 'hnz.co.nz') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(
+						createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-registrar.com.' }]),
+					);
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.hnz.co.nz.' }]));
+				}
+			}
+			// bnz.com — a TLD-swap variant delegated in-bailiwick to bnz.co.nz.
+			// Same 3-char brand label, but owned_by_seed via NS in-bailiwick.
+			if (name === 'bnz.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.bnz.co.nz.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.bnz.co.nz.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+
+		const result = await run('bnz.co.nz');
+
+		// third-party direction: hnz.co.nz present, capped at info, neutral title.
+		const hnzFindings = result.findings.filter((f) => f.detail.includes('hnz.co.nz') || f.metadata?.lookalikeDomain === 'hnz.co.nz');
+		expect(hnzFindings.length).toBeGreaterThan(0);
+		expect(hnzFindings.every((f) => f.severity === 'info')).toBe(true);
+		expect(hnzFindings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+		expect(hnzFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(false);
+
+		// owned_by_seed direction: bnz.com present, unclamped, ownership title.
+		const bnzComFindings = result.findings.filter((f) => f.detail.includes('bnz.com') || f.metadata?.lookalikeDomain === 'bnz.com');
+		expect(bnzComFindings.length).toBeGreaterThan(0);
+		expect(bnzComFindings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
+		expect(bnzComFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(true);
 	});
 });

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -2095,3 +2095,87 @@ describe('checkLookalikes - Task 7b fix round 1 (RDAP org gating + scan_status a
 		expect(summary!.metadata?.ownershipVerdict).toBe('third_party');
 	});
 });
+
+// ---------------------------------------------------------------------------
+// Task 7b FIX ROUND 2 — residual: the both-sides redaction gate was UNPINNED.
+//
+// The re-reviewer mutated `isSameEntityOrgMatch` to check `isRedactedRegistrantOrg`
+// on the CANDIDATE side only and the whole suite stayed green. Analysis, confirmed
+// by re-running that mutation: NO fixture can discriminate. The final comparison is
+// strict equality (`primaryOrg === candidateOrg`), and `isRedactedRegistrantOrg` is a
+// pure function of its string, so whenever the two orgs are equal the predicate
+// returns the SAME verdict for both — a one-sided check is currently EXACTLY
+// equivalent to a two-sided one. For a one-sided check to wrongly match, the two
+// strings would have to differ in redaction status while still being equal, which is
+// impossible under equality matching.
+//
+// The correct pins are therefore semantic rather than fixture-based:
+//   (a) these direct unit tests on `isSameEntityOrgMatch` (exported for the purpose),
+//       which DO die when the redaction gate is removed altogether; and
+//   (b) the equality-matching invariant recorded on the function's JSDoc, obliging any
+//       future fuzzy/containment matcher to re-establish both-sides gating WITH a
+//       discriminating test — at which point a fixture becomes constructible.
+// ---------------------------------------------------------------------------
+describe('isSameEntityOrgMatch - fix round 2 residual (direct semantic pin)', () => {
+	async function load() {
+		const [{ isSameEntityOrgMatch }, { isRedactedRegistrantOrg }] = await Promise.all([
+			import('../src/tools/check-lookalikes'),
+			import('../src/tools/check-rdap-lookup'),
+		]);
+		return { isSameEntityOrgMatch, isRedactedRegistrantOrg };
+	}
+
+	it('rejects an IDENTICAL redacted string on both sides (the privacy-proxy collision, pinned at the predicate)', async () => {
+		const { isSameEntityOrgMatch } = await load();
+		expect(isSameEntityOrgMatch('redacted for privacy', 'redacted for privacy')).toBe(false);
+		expect(isSameEntityOrgMatch('domains by proxy, llc', 'domains by proxy, llc')).toBe(false);
+		expect(
+			isSameEntityOrgMatch('privacy service provided by withheld for privacy ehf', 'privacy service provided by withheld for privacy ehf'),
+		).toBe(false);
+	});
+
+	it('accepts an identical GENUINE org string — the gate suppresses redaction, not correlation', async () => {
+		const { isSameEntityOrgMatch } = await load();
+		expect(isSameEntityOrgMatch('contoso limited', 'contoso limited')).toBe(true);
+	});
+
+	it('rejects a null on either side, and rejects two different genuine orgs', async () => {
+		const { isSameEntityOrgMatch } = await load();
+		expect(isSameEntityOrgMatch(null, 'contoso limited')).toBe(false);
+		expect(isSameEntityOrgMatch('contoso limited', null)).toBe(false);
+		expect(isSameEntityOrgMatch(null, null)).toBe(false);
+		expect(isSameEntityOrgMatch('contoso limited', 'fabrikam limited')).toBe(false);
+	});
+
+	/**
+	 * THE invariant that makes a one-sided check equivalent TODAY, asserted rather
+	 * than assumed. If a future change makes matching fuzzy (containment, token
+	 * overlap, edit distance), this test keeps passing while the equivalence it
+	 * documents silently stops holding — which is exactly why the JSDoc on
+	 * `isSameEntityOrgMatch` obliges that change to re-establish both-sides gating
+	 * with its own discriminating fixture.
+	 */
+	it('equality invariant: for any org string, a self-match is allowed iff the string is not redacted', async () => {
+		const { isSameEntityOrgMatch, isRedactedRegistrantOrg } = await load();
+		const corpus = [
+			'contoso limited',
+			'fabrikam nz limited',
+			'redacted for privacy',
+			'domains by proxy, llc',
+			'whois privacy corp.',
+			'withheld for privacy ehf',
+			'gdpr masked',
+			'n/a',
+			'unknown',
+			'private',
+			'',
+		];
+		// The corpus must exercise BOTH outcomes, else the biconditional below is
+		// satisfiable by a predicate that always returns one value.
+		expect(corpus.some((org) => isRedactedRegistrantOrg(org))).toBe(true);
+		expect(corpus.some((org) => !isRedactedRegistrantOrg(org))).toBe(true);
+		for (const org of corpus) {
+			expect(isSameEntityOrgMatch(org, org)).toBe(!isRedactedRegistrantOrg(org));
+		}
+	});
+});

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -70,7 +70,7 @@ describe('checkLookalikes', () => {
 		expect(attribution.every((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
 		// Axis 2 (threat observation) carries the #264 mail-infra-alone MEDIUM
 		// that Task 7 used to discard.
-		const threat = result.findings.filter((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain);
+		const threat = result.findings.filter((f) => f.metadata?.findingAxis === 'threat_observation');
 		expect(threat.length).toBeGreaterThan(0);
 		expect(threat.every((f) => f.severity === 'medium')).toBe(true);
 		// Still no HIGH: mail infrastructure alone, with no corroborator.
@@ -101,7 +101,7 @@ describe('checkLookalikes', () => {
 		expect(attribution.every((f) => f.severity === 'info')).toBe(true);
 		// Axis 2 — web-only with no corroborator is the matrix's LOW tier, and
 		// never more than that.
-		const threat = result.findings.filter((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain);
+		const threat = result.findings.filter((f) => f.metadata?.findingAxis === 'threat_observation');
 		expect(threat.length).toBeGreaterThan(0);
 		expect(threat.every((f) => f.severity === 'low')).toBe(true);
 		expect(result.findings.some((f) => f.severity === 'medium' || f.severity === 'high')).toBe(false);
@@ -1858,12 +1858,12 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
 	});
 
-	it('2. every finding this tool emits carries a findingAxis marker with one of the two exact literals', async () => {
+	it('2. every finding this tool emits carries a findingAxis marker with one of the three exact literals', async () => {
 		mockPrePhishingFixture();
 		const result = await run('testco.com');
 		expect(result.findings.length).toBeGreaterThan(0);
 		for (const finding of result.findings) {
-			expect(['attribution', 'threat_observation']).toContain(finding.metadata?.findingAxis);
+			expect(['attribution', 'threat_observation', 'scan_status']).toContain(finding.metadata?.findingAxis);
 		}
 		// Both axes are actually represented (a non-discriminating "all axes are
 		// 'attribution'" world would otherwise satisfy the loop above).
@@ -1871,18 +1871,63 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
 	});
 
+	it('the scan-level "no active lookalikes" notice is tagged scan_status, not threat_observation', async () => {
+		globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createDohResponse([], [])));
+		const result = await run('test.com');
+		const notice = result.findings.find((f) => /No active lookalike/i.test(f.title));
+		expect(notice).toBeDefined();
+		expect(notice!.metadata?.findingAxis).toBe('scan_status');
+		expect(notice!.severity).toBe('info');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Task 7b FIX ROUND 1 (review findings F1/F2).
+//   F1 — the issue #263 RDAP registrant-org match must NOT suppress the threat
+//        axis, and every use of that match must be gated behind a
+//        privacy-proxy / redaction filter (the string is free text the
+//        registrant types, is unverified, and collides trivially).
+//   F2 — a third axis literal, `scan_status`, plus the two invariants Task 8
+//        will audit: scan_status findings are always `info`; threat_observation
+//        findings never carry `owned_by_seed` and always name a domain.
+// ---------------------------------------------------------------------------
+describe('checkLookalikes - Task 7b fix round 1 (RDAP org gating + scan_status axis)', () => {
+	async function run(domain = 'example.com') {
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		return checkLookalikes(domain);
+	}
+
 	/**
-	 * DELIBERATE ASYMMETRY, flagged for the design owner: the issue #263
-	 * same-entity RDAP correlation branch emits an attribution finding and
-	 * `continue`s, so it produces NO threat observation either. This is NOT the
-	 * Task-7 defect resurfacing: a registrant-org MATCH is AFFIRMATIVE evidence
-	 * of a benign explanation (the org's own defensive/regional registration),
-	 * which is a different thing from the mere ABSENCE of ownership evidence
-	 * that Task 7 wrongly treated as a reason to suppress. Pinned here so the
-	 * choice is visible and can be reversed intentionally rather than by drift.
+	 * The axis invariants Task 8's cross-cutting audit will key on. Applied to
+	 * every fixture in this block, clean scans included — a check that only ever
+	 * ran against candidate-bearing scans would pass vacuously on exactly the
+	 * finding shapes (status notices with no domain in metadata) the invariants
+	 * exist to keep off the threat axis.
 	 */
-	it('the #263 same-entity RDAP branch emits no threat-observation finding (affirmative benign explanation, not absence of evidence)', async () => {
-		const rdap = {
+	function assertAxisInvariants(findings: Awaited<ReturnType<typeof run>>['findings']): void {
+		expect(findings.length).toBeGreaterThan(0);
+		for (const finding of findings) {
+			expect(['attribution', 'threat_observation', 'scan_status']).toContain(finding.metadata?.findingAxis);
+			if (finding.metadata?.findingAxis === 'scan_status') {
+				expect(finding.severity).toBe('info');
+			}
+			if (finding.metadata?.findingAxis === 'threat_observation') {
+				// Never about a domain the scanned organisation owns.
+				expect(finding.metadata?.ownershipVerdict).not.toBe('owned_by_seed');
+				// Always names what it observed: a single candidate, the aggregate
+				// candidate list, or (recon corroboration) the scanned domain.
+				const named =
+					finding.metadata?.lookalikeDomain ??
+					(finding.metadata?.lookalikeDomains as string[] | undefined)?.[0] ??
+					finding.metadata?.domain;
+				expect(named).toBeTruthy();
+			}
+		}
+	}
+
+	/** RDAP payload with a registrant vCard `org` of the caller's choosing. */
+	function rdapOrg(org: string) {
+		return {
 			events: [{ eventAction: 'registration', eventDate: new Date(Date.now() - 1500 * 86400_000).toISOString() }],
 			entities: [
 				{
@@ -1892,12 +1937,22 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 						'vcard',
 						[
 							['version', {}, 'text', '4.0'],
-							['org', {}, 'text', 'Contoso Limited'],
+							['org', {}, 'text', org],
 						],
 					],
 				},
 			],
 		};
+	}
+
+	/**
+	 * Seed `test.com` on its own NS; candidate `tst.com` on UNRELATED NS with
+	 * live MX (third_party, #264 mail-infra-alone MEDIUM). Both domains' RDAP
+	 * returns `org` — same string on both sides, so the #263 same-entity
+	 * correlation fires whenever the string survives the redaction filter.
+	 */
+	function mockSharedOrg(org: string): void {
+		const payload = rdapOrg(org);
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 			if (url.includes('cloudflare-dns.com')) {
@@ -1916,25 +1971,127 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 				return Promise.resolve(createDohResponse([], []));
 			}
 			if (url.includes('rdap')) {
-				return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(rdap) } as unknown as Response);
+				return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(payload) } as unknown as Response);
 			}
 			return Promise.resolve(createDohResponse([], []));
 		});
+	}
+
+	/**
+	 * F1(1) — a GENUINE shared registrant org still produces the #263
+	 * observation, but it may no longer switch the threat axis off. An
+	 * unverified string earns a sentence, not a severity discount.
+	 */
+	it('F1: a genuine shared registrant org keeps the #263 observation AND still emits the threat finding at the full calibrated severity', async () => {
+		mockSharedOrg('Contoso Limited');
 		const result = await run('test.com');
-		const tst = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com');
-		expect(tst.length).toBe(1);
-		expect(tst[0].metadata?.sharedRegistrantOrg).toBe('contoso limited');
-		expect(tst[0].metadata?.findingAxis).toBe('attribution');
-		expect(tst[0].severity).toBe('info');
-		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain)).toBe(false);
+
+		const attribution = result.findings.filter(
+			(f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.lookalikeDomain === 'tst.com',
+		);
+		expect(attribution.length).toBe(1);
+		expect(attribution[0].title).toMatch(/shares registrant organisation/i);
+		expect(attribution[0].metadata?.sharedRegistrantOrg).toBe('contoso limited');
+		expect(attribution[0].severity).toBe('info');
+
+		const threat = result.findings.filter(
+			(f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === 'tst.com',
+		);
+		expect(threat.length).toBe(1);
+		// NOT tiered down for the org match — mail-infra-alone is MEDIUM.
+		expect(threat[0].severity).toBe('medium');
+		// The observation is noted in the detail, flagged as unverified.
+		expect(threat[0].detail).toMatch(/registrant/i);
+		expect(threat[0].detail).toMatch(/self-declared|unverified/i);
+		expect(threat[0].metadata?.sharedRegistrantOrg).toBe('contoso limited');
+		assertAxisInvariants(result.findings);
 	});
 
-	it('the scan-level "no active lookalikes" finding also carries an axis marker', async () => {
+	/**
+	 * F1(2)/(3) — the ZERO-EFFORT collision. Both domains sit behind the same
+	 * privacy service, so their normalised registrant strings are equal for
+	 * reasons that carry no identity information at all. No same-entity
+	 * observation may be produced, and the threat axis must be untouched.
+	 */
+	it.each(['REDACTED FOR PRIVACY', 'Domains By Proxy, LLC', 'Privacy service provided by Withheld for Privacy ehf', 'Whois Privacy Corp.'])(
+		'F1: privacy-proxy collision (%s) produces NO same-entity observation and still emits the threat finding',
+		async (org) => {
+			mockSharedOrg(org);
+			const result = await run('test.com');
+
+			// No same-entity observation anywhere — neither the title nor the metadata.
+			expect(result.findings.some((f) => /shares registrant organisation/i.test(f.title))).toBe(false);
+			expect(result.findings.some((f) => f.metadata?.sharedRegistrantOrg !== undefined)).toBe(false);
+
+			// The attribution finding falls back to the neutral D4 gate template.
+			const attribution = result.findings.filter(
+				(f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.lookalikeDomain === 'tst.com',
+			);
+			expect(attribution.length).toBe(1);
+			expect(attribution[0].severity).toBe('info');
+			expect(attribution[0].metadata?.severityCappedBy).toBe('ownership_attribution');
+
+			// The threat axis is unaffected by the collision.
+			const threat = result.findings.filter(
+				(f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === 'tst.com',
+			);
+			expect(threat.length).toBe(1);
+			expect(threat[0].severity).toBe('medium');
+			assertAxisInvariants(result.findings);
+		},
+	);
+
+	/** F2 — the scan-status axis, and both Task 8 invariants, on a clean scan. */
+	it('F2: a clean scan emits only scan_status findings, all at info', async () => {
 		globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createDohResponse([], [])));
 		const result = await run('test.com');
+		// Invariants first: a mis-tagged status notice must be reported as the
+		// invariant violation it is (a threat finding naming no domain), not
+		// merely as "this scan isn't all scan_status".
+		assertAxisInvariants(result.findings);
 		expect(result.findings.length).toBeGreaterThan(0);
-		for (const finding of result.findings) {
-			expect(['attribution', 'threat_observation']).toContain(finding.metadata?.findingAxis);
-		}
+		expect(result.findings.every((f) => f.metadata?.findingAxis === 'scan_status')).toBe(true);
+		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
+	});
+
+	/**
+	 * F2 — the two invariants Task 8's cross-cutting audit will key on, asserted
+	 * on a scan that emits ALL THREE axes' shapes at once (per-candidate
+	 * attribution + per-candidate threat + the aggregate HIGH summary).
+	 */
+	it('F2: axis invariants — scan_status is always info; threat_observation never carries owned_by_seed and always names a domain', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'testco.com' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+			}
+			if (name === 'twstco.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mx.mailgun.org.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('testco.com');
+
+		const axes = result.findings.map((f) => f.metadata?.findingAxis);
+		expect(axes.every((a) => a === 'attribution' || a === 'threat_observation' || a === 'scan_status')).toBe(true);
+		// The fixture really does exercise both non-status axes, including the
+		// aggregate summary (which names no single candidate) — otherwise the
+		// invariant loops below would pass vacuously.
+		expect(axes.filter((a) => a === 'attribution').length).toBe(1);
+		expect(axes.filter((a) => a === 'threat_observation').length).toBe(2);
+
+		assertAxisInvariants(result.findings);
+
+		// The aggregate summary specifically: it names the counted candidates and
+		// declares their (non-owned) verdict rather than leaving both blank.
+		const summary = result.findings.find((f) => /with mail capability detected/i.test(f.title));
+		expect(summary).toBeDefined();
+		expect(summary!.metadata?.lookalikeDomains).toEqual(['twstco.com']);
+		expect(summary!.metadata?.ownershipVerdict).toBe('third_party');
 	});
 });

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -62,11 +62,19 @@ describe('checkLookalikes', () => {
 			return Promise.resolve(createDohResponse([], []));
 		});
 		const result = await run('test.com');
-		// No MEDIUM or HIGH is emitted for any non-owned candidate.
-		expect(result.findings.some((f) => f.severity === 'medium' || f.severity === 'high')).toBe(false);
-		const gated = result.findings.filter((f) => f.metadata?.ownershipVerdict === 'third_party');
-		expect(gated.length).toBeGreaterThan(0);
-		expect(gated.every((f) => f.severity === 'info')).toBe(true);
+		// Task 7b: the two axes are pinned SEPARATELY. Axis 1 (attribution) is
+		// still capped at info for every non-owned candidate — D4 unchanged.
+		const attribution = result.findings.filter((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution.length).toBeGreaterThan(0);
+		expect(attribution.every((f) => f.severity === 'info')).toBe(true);
+		expect(attribution.every((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+		// Axis 2 (threat observation) carries the #264 mail-infra-alone MEDIUM
+		// that Task 7 used to discard.
+		const threat = result.findings.filter((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain);
+		expect(threat.length).toBeGreaterThan(0);
+		expect(threat.every((f) => f.severity === 'medium')).toBe(true);
+		// Still no HIGH: mail infrastructure alone, with no corroborator.
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
 	});
 
 	it('caps web-only lookalikes with no ownership signal at info (web-only, no corroborator, D4-capped)', async () => {
@@ -85,10 +93,18 @@ describe('checkLookalikes', () => {
 			return Promise.resolve(createDohResponse([], []));
 		});
 		const result = await run('test.com');
-		expect(result.findings.some((f) => f.severity === 'low')).toBe(false);
-		const gated = result.findings.filter((f) => f.metadata?.ownershipVerdict === 'third_party' && f.metadata?.hasMX === false);
-		expect(gated.length).toBeGreaterThan(0);
-		expect(gated.every((f) => f.severity === 'info')).toBe(true);
+		// Axis 1 — attribution capped at info.
+		const attribution = result.findings.filter(
+			(f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.ownershipVerdict === 'third_party' && f.metadata?.hasMX === false,
+		);
+		expect(attribution.length).toBeGreaterThan(0);
+		expect(attribution.every((f) => f.severity === 'info')).toBe(true);
+		// Axis 2 — web-only with no corroborator is the matrix's LOW tier, and
+		// never more than that.
+		const threat = result.findings.filter((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain);
+		expect(threat.length).toBeGreaterThan(0);
+		expect(threat.every((f) => f.severity === 'low')).toBe(true);
+		expect(result.findings.some((f) => f.severity === 'medium' || f.severity === 'high')).toBe(false);
 	});
 
 	it('surfaces a registered combosquat (brand + lure affix) that edit-distance generation misses, capped at info (no ownership signal)', async () => {
@@ -116,7 +132,10 @@ describe('checkLookalikes', () => {
 		const result = await run('paypal.com');
 		const surfaced = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'paypal-login.com');
 		expect(surfaced.length).toBeGreaterThan(0);
-		expect(surfaced.every((f) => f.severity === 'info')).toBe(true);
+		// Task 7b: attribution capped at info; the #264 mail-infra MEDIUM now
+		// surfaces on the threat axis instead of being discarded.
+		expect(surfaced.filter((f) => f.metadata?.findingAxis === 'attribution').every((f) => f.severity === 'info')).toBe(true);
+		expect(surfaced.filter((f) => f.metadata?.findingAxis === 'threat_observation').every((f) => f.severity === 'medium')).toBe(true);
 		expect(JSON.stringify(result.findings)).toContain('paypal-login.com');
 	});
 
@@ -245,7 +264,11 @@ describe('checkLookalikes - null MX filtering', () => {
 		const gated = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com' || f.metadata?.lookalikeDomain === 'tes.com');
 		expect(gated.length).toBeGreaterThan(0);
 		expect(gated.every((f) => f.metadata?.hasMX === false)).toBe(true);
-		expect(gated.every((f) => f.severity === 'info')).toBe(true);
+		// Task 7b: severity is axis-scoped — attribution stays info; the threat
+		// axis reports the web-only LOW tier (NOT a mail-infra MEDIUM/HIGH,
+		// which is the null-MX point this test exists for).
+		expect(gated.filter((f) => f.metadata?.findingAxis === 'attribution').every((f) => f.severity === 'info')).toBe(true);
+		expect(gated.filter((f) => f.metadata?.findingAxis === 'threat_observation').every((f) => f.severity === 'low')).toBe(true);
 	});
 
 	it('should not flag legacy null MX (0 localhost.) as mail infrastructure', async () => {
@@ -314,19 +337,26 @@ describe('checkLookalikes - null MX filtering', () => {
 		// web-only) still runs internally but is capped to info. What this test
 		// actually still needs to prove — real MX registers, null MX does not —
 		// is pinned on the `hasMX` metadata rather than the severity/title.
-		const testtFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'testt.com');
+		const testtFinding = result.findings.find(
+			(f) => f.metadata?.lookalikeDomain === 'testt.com' && f.metadata?.findingAxis === 'attribution',
+		);
 		expect(testtFinding).toBeDefined();
 		expect(testtFinding!.metadata?.hasMX).toBe(true);
 		expect(testtFinding!.severity).toBe('info');
 
-		const tesFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tes.com');
+		const tesFinding = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tes.com' && f.metadata?.findingAxis === 'attribution');
 		expect(tesFinding).toBeDefined();
 		expect(tesFinding!.metadata?.hasMX).toBe(false);
 		expect(tesFinding!.severity).toBe('info');
 
-		// Neither should be HIGH or MEDIUM regardless (ownership cap, not just
-		// the null-MX distinction).
-		expect(result.findings.some((f) => f.severity === 'high' || f.severity === 'medium')).toBe(false);
+		// Task 7b: the threat axis is where the null-MX distinction now shows up
+		// numerically — real MX → mail-infra MEDIUM, null MX → web-only LOW.
+		// Neither reaches HIGH (no corroborator on either).
+		const threatFor = (d: string) =>
+			result.findings.find((f) => f.metadata?.lookalikeDomain === d && f.metadata?.findingAxis === 'threat_observation');
+		expect(threatFor('testt.com')!.severity).toBe('medium');
+		expect(threatFor('tes.com')!.severity).toBe('low');
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
 	});
 });
 
@@ -1412,10 +1442,11 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 		// always present in the output.
 		expect(twstFindings.length).toBeGreaterThan(0);
 		expect(twstFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(false);
-		// Capped at info, not left at the mail-infra medium/high the calibrator
-		// would otherwise assign.
-		expect(twstFindings.every((f) => f.severity === 'info')).toBe(true);
-		const gated = twstFindings.find((f) => f.metadata?.ownershipVerdict !== undefined);
+		// Task 7b: the ATTRIBUTION axis is capped at info (D4 unchanged). The
+		// mail-infra MEDIUM the calibrator assigns now rides the threat axis.
+		expect(twstFindings.filter((f) => f.metadata?.findingAxis === 'attribution').every((f) => f.severity === 'info')).toBe(true);
+		expect(twstFindings.filter((f) => f.metadata?.findingAxis === 'threat_observation').every((f) => f.severity === 'medium')).toBe(true);
+		const gated = twstFindings.find((f) => f.metadata?.severityCappedBy !== undefined);
 		expect(gated).toBeDefined();
 		expect(gated!.metadata?.ownershipVerdict).toBe('third_party');
 		expect(gated!.metadata?.severityCappedBy).toBe('ownership_attribution');
@@ -1458,8 +1489,11 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 		const result = await run('contoso.com');
 		const findings = result.findings.filter((f) => f.detail.includes('contos0.com'));
 		expect(findings.length).toBeGreaterThan(0);
-		expect(findings.every((f) => f.severity === 'info')).toBe(true);
-		const gated = findings.find((f) => f.metadata?.ownershipVerdict === 'third_party');
+		// Task 7b: the verdict-only cap applies to the ATTRIBUTION axis. A long
+		// brand label plus MX-overlap corroboration must still not lift the
+		// attribution finding above info.
+		expect(findings.filter((f) => f.metadata?.findingAxis === 'attribution').every((f) => f.severity === 'info')).toBe(true);
+		const gated = findings.find((f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.ownershipVerdict === 'third_party');
 		expect(gated).toBeDefined();
 		// Corroboration affects wording (confidence), never the ceiling.
 		expect(gated!.metadata?.attributionConfidence).toBe('corroborated');
@@ -1643,7 +1677,8 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 		// third-party direction: hnz.co.nz present, capped at info, neutral title.
 		const hnzFindings = result.findings.filter((f) => f.detail.includes('hnz.co.nz') || f.metadata?.lookalikeDomain === 'hnz.co.nz');
 		expect(hnzFindings.length).toBeGreaterThan(0);
-		expect(hnzFindings.every((f) => f.severity === 'info')).toBe(true);
+		// Task 7b: axis-scoped — attribution info, threat axis free to calibrate.
+		expect(hnzFindings.filter((f) => f.metadata?.findingAxis === 'attribution').every((f) => f.severity === 'info')).toBe(true);
 		expect(hnzFindings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
 		expect(hnzFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(false);
 
@@ -1657,5 +1692,249 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 		// finding is NOT routed through the D4 demotion template. Pin the actual
 		// contract explicitly rather than leaving it implied by the title check.
 		expect(bnzComFindings.every((f) => f.severity === 'info')).toBe(true);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Task 7b (human-partner ruling 2026-07-27): the two axes are SPLIT.
+//   Axis 1 — attribution confidence (WHO owns it): still capped at `info` with
+//            neutral wording for every non-`owned_by_seed` verdict (D4).
+//   Axis 2 — observed-threat severity (WHAT it is doing): a NEW finding at the
+//            already-computed #264 calibrated severity, asserting nothing about
+//            ownership and demanding nothing of the customer on that domain.
+// Both axes are machine-discriminable via `metadata.findingAxis`.
+// ---------------------------------------------------------------------------
+describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observation)', () => {
+	async function run(domain = 'example.com') {
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		return checkLookalikes(domain);
+	}
+
+	/**
+	 * The textbook pre-phishing setup the opus review proved Task 7 had made
+	 * invisible: a confusable label on unrelated nameservers (third_party) with
+	 * LIVE mail infrastructure on a disposable provider — the #264 matrix's HIGH
+	 * tier. `mailgun.org` is in DISPOSABLE_MX_PROVIDERS, so the HIGH is reached
+	 * without needing an RDAP registration-age mock.
+	 */
+	function mockPrePhishingFixture(): void {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'testco.com' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+			}
+			if (name === 'twstco.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mx.mailgun.org.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+	}
+
+	it('6(a) emits BOTH axes for a live third-party typosquat: attribution capped at info, threat at the calibrated HIGH', async () => {
+		mockPrePhishingFixture();
+		const result = await run('testco.com');
+
+		const attribution = result.findings.filter(
+			(f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.lookalikeDomain === 'twstco.com',
+		);
+		expect(attribution.length).toBe(1);
+		// Axis 1 unchanged — D4's safety property preserved verbatim.
+		expect(attribution[0].severity).toBe('info');
+		expect(attribution[0].metadata?.ownershipVerdict).toBe('third_party');
+		expect(attribution[0].metadata?.severityCappedBy).toBe('ownership_attribution');
+
+		// Axis 2 — the observed threat, at the severity the #264 matrix computed.
+		const threat = result.findings.filter(
+			(f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === 'twstco.com',
+		);
+		expect(threat.length).toBe(1);
+		expect(threat[0].severity).toBe('high');
+		// The verdict travels on EVERY classified finding — a consumer must be
+		// able to read "high threat, NOT owned by the customer" off one object.
+		expect(threat[0].metadata?.ownershipVerdict).toBe('third_party');
+	});
+
+	it('6(a) un-deadens scoring: the lookalikes category no longer scores 100/passed on a live typosquat', async () => {
+		mockPrePhishingFixture();
+		const result = await run('testco.com');
+		expect(result.score).toBeLessThan(100);
+		// A HIGH threat observation is a -25 penalty; the summary finding adds
+		// another. Pin the direction, not a brittle exact number.
+		expect(result.score).toBeLessThanOrEqual(75);
+	});
+
+	it('un-deadens the summary path: the previously-unreachable HIGH "mail capability" summary finding fires again', async () => {
+		mockPrePhishingFixture();
+		const result = await run('testco.com');
+		const summary = result.findings.find((f) => /lookalike domains? with mail capability detected/i.test(f.title));
+		expect(summary).toBeDefined();
+		expect(summary!.severity).toBe('high');
+		expect(summary!.metadata?.findingAxis).toBe('threat_observation');
+		expect(summary!.metadata?.lookalikeDomainCount).toBe(1);
+	});
+
+	it('3. the threat finding states what was OBSERVED and uses no ownership/control framing', async () => {
+		mockPrePhishingFixture();
+		const result = await run('testco.com');
+		const threat = result.findings.find(
+			(f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === 'twstco.com',
+		);
+		expect(threat).toBeDefined();
+		// States the observation.
+		expect(threat!.title).toMatch(/^Impersonation-shaped .*observed: twstco\.com$/);
+		expect(threat!.detail).toMatch(/mail infrastructure/i);
+		expect(threat!.detail).toMatch(/disposable MX provider/i);
+		// Explicitly disclaims ownership, per the ruling.
+		expect(threat!.detail).toMatch(/does not appear to belong to the scanned organisation/i);
+		// Banned framing — title AND detail (a split surface where the prose
+		// contradicts the axis marker is the failure mode this pins).
+		for (const text of [threat!.title, threat!.detail]) {
+			expect(text).not.toMatch(/\byour\b/i);
+			expect(text).not.toMatch(/shadow domain/i);
+			expect(text).not.toMatch(/\bowned by\b/i);
+			expect(text).not.toMatch(/\bmalicious\b/i);
+			expect(text).not.toMatch(/\battacker\b/i);
+		}
+	});
+
+	it('6(b) a benign parked third-party lookalike (web only, no MX) yields NO high/medium threat finding', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'testco.com' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+			}
+			if (name === 'twstco.com') {
+				if (type === 'NS' || type === '2') {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]));
+				}
+				if (type === 'A' || type === '1') {
+					return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('testco.com');
+		expect(result.findings.some((f) => f.severity === 'high' || f.severity === 'medium')).toBe(false);
+		const threat = result.findings.find(
+			(f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === 'twstco.com',
+		);
+		expect(threat).toBeDefined();
+		// Matrix LOW tier — web-only, no corroborator.
+		expect(threat!.severity).toBe('low');
+	});
+
+	it('6(c) an owned_by_seed candidate gets NO threat-observation finding (a domain is not an impersonation threat to itself)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'bnz.co.nz' && (type === 'NS' || type === '2')) {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns-cloud1.googledomains.com.' }]));
+			}
+			if (name === 'bnz.com') {
+				if (type === 'NS' || type === '2') {
+					// In-bailiwick to the seed apex — owned_by_seed.
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.bnz.co.nz.' }]));
+				}
+				if (type === 'MX' || type === '15') {
+					// Live mail infra on a DISPOSABLE provider — the #264 HIGH tier.
+					// If ownership were ignored on the threat axis this would surface
+					// as a HIGH against the customer's own domain.
+					return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mx.mailgun.org.' }]));
+				}
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('bnz.co.nz');
+		const owned = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'bnz.com');
+		expect(owned.length).toBe(1);
+		expect(owned[0].metadata?.ownershipVerdict).toBe('owned_by_seed');
+		expect(owned[0].metadata?.findingAxis).toBe('attribution');
+		// No threat axis anywhere in this scan — including no HIGH summary.
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(false);
+		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
+	});
+
+	it('2. every finding this tool emits carries a findingAxis marker with one of the two exact literals', async () => {
+		mockPrePhishingFixture();
+		const result = await run('testco.com');
+		expect(result.findings.length).toBeGreaterThan(0);
+		for (const finding of result.findings) {
+			expect(['attribution', 'threat_observation']).toContain(finding.metadata?.findingAxis);
+		}
+		// Both axes are actually represented (a non-discriminating "all axes are
+		// 'attribution'" world would otherwise satisfy the loop above).
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'attribution')).toBe(true);
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
+	});
+
+	/**
+	 * DELIBERATE ASYMMETRY, flagged for the design owner: the issue #263
+	 * same-entity RDAP correlation branch emits an attribution finding and
+	 * `continue`s, so it produces NO threat observation either. This is NOT the
+	 * Task-7 defect resurfacing: a registrant-org MATCH is AFFIRMATIVE evidence
+	 * of a benign explanation (the org's own defensive/regional registration),
+	 * which is a different thing from the mere ABSENCE of ownership evidence
+	 * that Task 7 wrongly treated as a reason to suppress. Pinned here so the
+	 * choice is visible and can be reversed intentionally rather than by drift.
+	 */
+	it('the #263 same-entity RDAP branch emits no threat-observation finding (affirmative benign explanation, not absence of evidence)', async () => {
+		const rdap = {
+			events: [{ eventAction: 'registration', eventDate: new Date(Date.now() - 1500 * 86400_000).toISOString() }],
+			entities: [
+				{
+					objectClassName: 'entity',
+					roles: ['registrant'],
+					vcardArray: [
+						'vcard',
+						[
+							['version', {}, 'text', '4.0'],
+							['org', {}, 'text', 'Contoso Limited'],
+						],
+					],
+				},
+			],
+		};
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				const { name, type } = parseDohQuery(input);
+				if (name === 'test.com' && (type === 'NS' || type === '2')) {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
+				}
+				if (name === 'tst.com') {
+					if (type === 'NS' || type === '2') {
+						return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.other-dns.com.' }]));
+					}
+					if (type === 'MX' || type === '15') {
+						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.example.com.' }]));
+					}
+				}
+				return Promise.resolve(createDohResponse([], []));
+			}
+			if (url.includes('rdap')) {
+				return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(rdap) } as unknown as Response);
+			}
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const result = await run('test.com');
+		const tst = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com');
+		expect(tst.length).toBe(1);
+		expect(tst[0].metadata?.sharedRegistrantOrg).toBe('contoso limited');
+		expect(tst[0].metadata?.findingAxis).toBe('attribution');
+		expect(tst[0].severity).toBe('info');
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain)).toBe(false);
+	});
+
+	it('the scan-level "no active lookalikes" finding also carries an axis marker', async () => {
+		globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(createDohResponse([], [])));
+		const result = await run('test.com');
+		expect(result.findings.length).toBeGreaterThan(0);
+		for (const finding of result.findings) {
+			expect(['attribution', 'threat_observation']).toContain(finding.metadata?.findingAxis);
+		}
 	});
 });

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -1041,8 +1041,16 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
 		expect(tstFinding!.severity).toBe('info');
-		expect(tstFinding!.title).toContain('likely owned by same entity');
+		// F2 (2026-07-27 fix round 2): retitled from "likely owned by same
+		// entity" — the structural verdict at this branch is always
+		// third_party (RDAP registrant-org matching is deliberately NOT fed
+		// into classifyOwnership()), so the title no longer claims ownership
+		// outright, and the verdict now travels in metadata alongside it.
+		expect(tstFinding!.title).toContain('shares registrant organisation');
+		expect(tstFinding!.title).not.toContain('likely owned by same entity');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
 		expect(tstFinding!.detail).toContain('registrant organisation');
+		expect(tstFinding!.detail).toContain('not structural ownership evidence');
 		// `createFinding` now sanitizes metadata strings at the chokepoint (F7 / issue
 		// #389): the `< >` in the placeholder org are neutralized to spaces. The match
 		// logic itself runs pre-sanitize on the raw RDAP value, so the same-entity
@@ -1155,8 +1163,29 @@ describe('checkLookalikes - issue #263 same-entity RDAP registrant correlation',
 		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
 		expect(tstFinding).toBeDefined();
 		expect(tstFinding!.severity).toBe('info');
-		expect(tstFinding!.title).toContain('likely owned by same entity');
+		expect(tstFinding!.title).toContain('shares registrant organisation');
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
 		expect(tstFinding!.metadata?.sharedRegistrantOrg).toBe('xero limited');
+	});
+
+	// F2 pin (2026-07-27 fix round 2): the reviewer's exact defect — a
+	// third_party structural verdict must not be titled as owned-by-same-
+	// entity without the metadata saying so. Proves BOTH halves of the fix
+	// together: the verdict travels in metadata, AND the title no longer
+	// overclaims common ownership from an unverified RDAP org-name match
+	// alone.
+	it('F2: carries the third_party ownershipVerdict on the RDAP same-entity finding and does not title it as owned-by-same-entity', async () => {
+		mockSameEntity({
+			lookalike: 'tst.com',
+			lookalikeRdap: rdapWithRegistrant('<Vendor> Limited'),
+			primaryRdap: rdapWithRegistrant('<Vendor> Limited'),
+		});
+		const result = await run('test.com');
+		const tstFinding = result.findings.find((f) => f.title.includes('tst.com'));
+		expect(tstFinding).toBeDefined();
+		expect(tstFinding!.metadata?.ownershipVerdict).toBe('third_party');
+		expect(tstFinding!.metadata?.sharedRegistrantOrg).toBe('vendor limited');
+		expect(tstFinding!.title).not.toContain('likely owned by same entity');
 	});
 });
 
@@ -1474,9 +1503,18 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 	// call site 1: with the old code, this candidate would NOT be excluded
 	// from enrichment (an RDAP fetch would fire); with the fix, ownership is
 	// resolved from the NS verdict alone and RDAP is never consulted for an
-	// owned candidate. The finding must surface UNCLAMPED (medium/high, not
-	// capped to info) since verdict is owned_by_seed.
-	it('recognises in-bailiwick NS delegation as owned_by_seed with zero literal NS-hostname overlap, skips RDAP enrichment, and leaves severity unclamped', async () => {
+	// owned candidate.
+	//
+	// F3(b) (2026-07-27 fix round 2): renamed from "...and leaves severity
+	// unclamped" — that name overstated the assertions. The `sameOwner`
+	// branch in check-lookalikes.ts (`:485`) hardcodes severity to `'info'`
+	// unconditionally; there is no medium/high value it is ever "unclamped"
+	// from. What this test actually discriminates is that an owned_by_seed
+	// candidate keeps its NATIVE same-owner finding (title + rationale-based
+	// detail) rather than being routed through the D4 gate's non-owned
+	// demotion template (`buildNonOwnedGateFinding`) — pinned below via the
+	// explicit `severity === 'info'` assertion plus the title/verdict checks.
+	it('recognises in-bailiwick NS delegation as owned_by_seed with zero literal NS-hostname overlap, skips RDAP enrichment, and keeps the native same-owner info finding (not the D4 demotion template)', async () => {
 		const rdapCalls: string[] = [];
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
@@ -1551,11 +1589,19 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 	// D4 spec row for this tool, BOTH directions pinned together (a test that
 	// proves only one direction does not discriminate): a short (3-char)
 	// brand label with a third_party verdict and no corroboration is
-	// suppressed FROM ELEVATION (present at info, neutral wording) while a
-	// short (3-char) brand label with an owned_by_seed verdict (NS in
-	// bailiwick — the strongest corroborating signal by construction) still
-	// surfaces at full computed severity.
-	it('D4 short-label pin: third-party short label capped at info; owned_by_seed short label surfaces unclamped', async () => {
+	// demoted to the neutral info template (`buildNonOwnedGateFinding`),
+	// while a short (3-char) brand label with an owned_by_seed verdict (NS in
+	// bailiwick — the strongest corroborating signal by construction) keeps
+	// its native same-owner info finding instead.
+	//
+	// F3(b) (2026-07-27 fix round 2): renamed from "...owned_by_seed short
+	// label surfaces unclamped" — both directions are 'info' by construction
+	// (calibrateLookalikeSeverity never runs for the sameOwner branch), so
+	// "unclamped" never meant medium/high. What differs is WHICH template
+	// produced the info finding — the demotion template (neutral wording, no
+	// ownership title) vs. the native same-owner finding (ownership title,
+	// rationale-based detail). Both severities are now pinned explicitly.
+	it('D4 short-label pin: third-party short label demoted to the neutral info template; owned_by_seed short label keeps its native same-owner info finding', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
 			if (name === 'bnz.co.nz' && (type === 'NS' || type === '2')) {
@@ -1602,5 +1648,10 @@ describe('checkLookalikes - D4 ownership-gated severity (2026-07-26 correctness-
 		expect(bnzComFindings.length).toBeGreaterThan(0);
 		expect(bnzComFindings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
 		expect(bnzComFindings.some((f) => f.title.includes('likely owned by same entity'))).toBe(true);
+		// F3(b): the promised severity assertion — 'unclamped' does not mean
+		// medium/high here (the sameOwner branch hardcodes 'info'); it means the
+		// finding is NOT routed through the D4 demotion template. Pin the actual
+		// contract explicitly rather than leaving it implied by the title check.
+		expect(bnzComFindings.every((f) => f.severity === 'info')).toBe(true);
 	});
 });

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -779,9 +779,22 @@ describe('checkShadowDomains — classification edge cases', () => {
 		expect((notEnforcing!.metadata as { dmarcPolicy?: string | null }).dmarcPolicy).toBe('none');
 	});
 
-	// D4 fixture repair: the subject is trailing-dot normalisation in the
-	// MX-infrastructure comparison, only observable on an owned variant.
-	it('should normalize trailing dot on MX hostname for comparison', async () => {
+	// HONEST SCOPE (fix round 1, F3 — corrects an overclaim in the round-0
+	// report). This test does NOT observe trailing-dot normalisation. The DoH
+	// fixture carries a root dot on the primary's MX and none on the variant's,
+	// but `queryMxRecords` strips the root dot upstream, so both sides reach
+	// `isSameMxInfra` already normalised — deleting BOTH `.replace(/\.$/, '')`
+	// calls from that predicate leaves this test GREEN (verified by executing
+	// that mutation). What this test actually covers is the end-to-end
+	// same-MX-infrastructure path producing the well-managed rung rather than
+	// the divergent one. The normalisation itself is pinned by the
+	// `isSameMxInfra (unit)` describe at the bottom of this file, which passes
+	// unnormalised inputs and DOES go red under that mutation.
+	//
+	// The D4 fixture repair here (variant moved onto the primary's own NS pair)
+	// is still required: without it the variant is `third_party` and the gate
+	// caps the finding at info, hiding the well-managed/divergent distinction.
+	it('matches MX infrastructure end-to-end despite a trailing dot in the wire data', async () => {
 		const target = 'example.com';
 		const ownNs = ['ns1.example-dns.net.', 'ns2.example-dns.net.'];
 
@@ -1662,5 +1675,246 @@ describe('checkShadowDomains — D4 ownership-gated severity', () => {
 		expect(reclassified!.severity).toBe('info');
 		expect(/lacks DMARC/i.test(reclassified!.title)).toBe(false);
 		for (const f of netFindings) expect(f.severity).toBe('info');
+	});
+});
+
+describe('checkShadowDomains — D4 wording: no ownership framing on a non-owned candidate', () => {
+	async function run(domain: string) {
+		const { checkShadowDomains } = await import('../src/tools/check-shadow-domains');
+		return checkShadowDomains(domain);
+	}
+
+	/**
+	 * The single ownership-framed title still reachable on a non-owned candidate.
+	 * `test/audits/registration-invariant.audit.test.ts:163` filters findings on
+	 * this exact literal and may not be edited from this task, so the Phase-2
+	 * fallthrough title cannot be neutralised yet. Carved out EXPLICITLY here so
+	 * the guard is honest about its one hole rather than quietly matching a
+	 * looser pattern. Verified by execution: adding it to NEUTRAL_INFO_TITLES
+	 * fails that audit with `expected 0 to be greater than 0`.
+	 */
+	const AUDIT_PINNED = 'Shadow domain registered, records not observed';
+
+	/** Nouns that file a domain into the SCANNED organisation's inventory. */
+	function hasOwnershipFraming(title: string): boolean {
+		return /shadow domain/i.test(title);
+	}
+
+	it('never titles a non-owned variant as the customer’s "shadow domain" — registered, no mail', async () => {
+		// example.net is registered on an unrelated registrar's nameservers with no
+		// mail => third_party, and the `info` rung 'Shadow domain registered, no
+		// mail'. The severity was already correct; the TITLE still filed a
+		// competitor's domain into the customer's shadow-domain inventory while
+		// the detail disclaimed exactly that. Split surface, prose half.
+		const target = 'example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.unrelated-registrar.net.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = result.findings.filter((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFindings.length).toBeGreaterThan(0);
+		expect((netFindings[0].metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('third_party');
+		for (const f of netFindings) {
+			expect(hasOwnershipFraming(f.title)).toBe(false);
+		}
+	});
+
+	it('never titles a non-owned variant as the customer’s "shadow domain" — RFC 7505 null MX', async () => {
+		// The null-MX rung: 'Shadow domain explicit non-mail (RFC 7505)'.
+		const target = 'example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.unrelated-registrar.net.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['0 .']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = result.findings.filter((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFindings.length).toBeGreaterThan(0);
+		expect((netFindings[0].metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('third_party');
+		expect(netFindings.some((f) => /RFC 7505/i.test(f.title))).toBe(true);
+		for (const f of netFindings) {
+			expect(hasOwnershipFraming(f.title)).toBe(false);
+		}
+	});
+
+	it('keeps "shadow domain" framing for a variant the seed genuinely owns', async () => {
+		// The gate must not sand the language off a REAL shadow domain: the
+		// framing is accurate when the customer owns the name, and stripping it
+		// everywhere would be an equal-and-opposite defect.
+		const target = 'example.com';
+		const ownNs = ['ns1.example-dns.net.', 'ns2.example-dns.net.'];
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = result.findings.filter((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFindings.length).toBeGreaterThan(0);
+		expect((netFindings[0].metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
+		expect(netFindings.some((f) => hasOwnershipFraming(f.title))).toBe(true);
+	});
+
+	it('sweeps a whole scan: the ONLY ownership-framed title on a non-owned variant is the audit-pinned one', async () => {
+		// Whole-result sweep rather than a single hand-picked finding, so a NEW
+		// ownership-framed title added to classifyVariant later cannot slip past
+		// by simply not being one of the cases above.
+		const target = 'example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			// A spread of non-owned shapes across several variants at once.
+			if (name === 'example.net' || name === 'example.org' || name === 'example.io') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.unrelated-registrar.net.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				if (name === 'example.org' && (type === 'MX' || type === '15')) return Promise.resolve(mxRecords(name, ['10 mail.elsewhere.net.']));
+				if (name === 'example.io' && (type === 'MX' || type === '15')) return Promise.resolve(mxRecords(name, ['0 .']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const nonOwned = result.findings.filter(
+			(f) => (f.metadata as { ownershipVerdict?: string } | undefined)?.ownershipVerdict === 'third_party',
+		);
+		expect(nonOwned.length).toBeGreaterThanOrEqual(3);
+		const offenders = nonOwned.filter((f) => hasOwnershipFraming(f.title) && f.title !== AUDIT_PINNED);
+		expect(offenders.map((f) => f.title)).toEqual([]);
+	});
+});
+
+describe('checkShadowDomains — unattributed is never treated as ownership', () => {
+	async function run(domain: string) {
+		const { checkShadowDomains } = await import('../src/tools/check-shadow-domains');
+		return checkShadowDomains(domain);
+	}
+
+	it('caps a Phase-2 variant registered via SOA/A with no NS observed', async () => {
+		// Registration is PROVEN (SOA answers) but no NS is ever observed, so
+		// classifyOwnership() has no NS evidence either way => `unattributed`.
+		// "We could not tell" must be treated as NOT-owned: a verdict of
+		// `unattributed` returning 'unbounded' would let a full ladder rung
+		// through on a domain nothing links to the customer.
+		const target = 'example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			if (name === 'example.net') {
+				// NS never answers; SOA proves the name exists; MX + no SPF/DMARC is
+				// the top ladder rung.
+				if (type === 'SOA' || type === '6') return Promise.resolve(soaRecords(name));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.elsewhere.net.']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = result.findings.filter((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFindings.length).toBeGreaterThan(0);
+		const gated = netFindings[0];
+		expect((gated.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('unattributed');
+		expect(gated.severity).toBe('info');
+		expect(gated.title).not.toMatch(/fully spoofable/i);
+		// Neutral wording must be the unattributed variant, not the third-party one.
+		expect(gated.detail).toMatch(/could not be attributed to the scanned organisation/i);
+		expect(gated.detail).not.toMatch(/registered to a different organisation/i);
+	});
+
+	it('caps a null-MX variant whose registration is proven without NS', async () => {
+		// A second unattributed shape on a different classifyVariant branch, so
+		// the `unattributed` arm is not pinned by one code path alone.
+		const target = 'example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			if (name === 'example.net') {
+				if (type === 'SOA' || type === '6') return Promise.resolve(soaRecords(name));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['0 .']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = result.findings.filter((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFindings.length).toBeGreaterThan(0);
+		for (const f of netFindings) {
+			expect((f.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('unattributed');
+			expect(f.severity).toBe('info');
+			expect(/shadow domain/i.test(f.title)).toBe(false);
+		}
+	});
+});
+
+describe('isSameMxInfra (unit)', () => {
+	// F3: this predicate's trailing-dot normalisation is UNOBSERVABLE through
+	// checkShadowDomains — queryMxRecords strips the root dot upstream, so both
+	// sides arrive already normalised and deleting the .replace() calls leaves
+	// every integration test green. Pinned directly here instead, with inputs
+	// that are NOT pre-normalised.
+	it('matches hostnames that differ only by a trailing root dot', async () => {
+		const { isSameMxInfra } = await import('../src/tools/check-shadow-domains');
+		expect(isSameMxInfra(['mail.example.com'], ['mail.example.com.'])).toBe(true);
+		expect(isSameMxInfra(['mail.example.com.'], ['mail.example.com'])).toBe(true);
+		expect(isSameMxInfra(['mail.example.com.'], ['mail.example.com.'])).toBe(true);
+	});
+
+	it('matches case-insensitively', async () => {
+		const { isSameMxInfra } = await import('../src/tools/check-shadow-domains');
+		expect(isSameMxInfra(['MAIL.Example.COM.'], ['mail.example.com'])).toBe(true);
+	});
+
+	it('requires the variant set to be a subset, and rejects an empty variant set', async () => {
+		const { isSameMxInfra } = await import('../src/tools/check-shadow-domains');
+		expect(isSameMxInfra(['mail.example.com', 'mail2.other.net'], ['mail.example.com.'])).toBe(false);
+		expect(isSameMxInfra([], ['mail.example.com.'])).toBe(false);
+		expect(isSameMxInfra(['mail.elsewhere.net'], ['mail.example.com.'])).toBe(false);
 	});
 });

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -65,7 +65,15 @@ describe('checkShadowDomains', () => {
 		return checkShadowDomains(domain);
 	}
 
-	it('should return critical finding when variant has MX but no SPF and no DMARC', async () => {
+	// D4 (2026-07-26): `example.net` here is delegated to `ns1.registrar.com` while
+	// the primary answers no NS at all — no in-bailiwick delegation, no NS-set
+	// overlap, so `classifyOwnership()` returns `third_party`. The fully-spoofable
+	// record shape is real and still reported, but its severity is now capped at
+	// `info`: the scanner has no evidence the scanned organisation controls this
+	// domain, and a CRITICAL "shadow domain" finding in the customer's name about
+	// an unrelated organisation's domain is the defect this slice removes. The
+	// unclamped ladder is covered by the owned-variant cases below.
+	it('reports a third-party variant with MX but no SPF and no DMARC at info, not critical', async () => {
 		const target = 'example.com';
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
@@ -94,12 +102,16 @@ describe('checkShadowDomains', () => {
 
 		const result = await run(target);
 		expect(result.category).toBe('shadow_domains');
-		const critical = result.findings.find((f) => f.severity === 'critical' && f.detail.includes('example.net'));
-		expect(critical).toBeDefined();
-		expect(critical!.title).toMatch(/fully spoofable/i);
+		const netFinding = result.findings.find((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFinding).toBeDefined();
+		expect(netFinding!.severity).toBe('info');
+		expect((netFinding!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('third_party');
+		expect(result.findings.some((f) => f.severity === 'critical')).toBe(false);
 	});
 
-	it('should return high finding when variant has MX + SPF but no DMARC', async () => {
+	// D4: same third-party fixture (`ns1.registrar.com`, no seed NS overlap) —
+	// the lacks-DMARC rung is computed but capped at info for a non-owned domain.
+	it('reports a third-party variant with MX + SPF but no DMARC at info, not high', async () => {
 		const target = 'example.com';
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
@@ -125,11 +137,17 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
-		expect(high).toBeDefined();
+		const netFinding = result.findings.find((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFinding).toBeDefined();
+		expect(netFinding!.severity).toBe('info');
+		expect((netFinding!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('third_party');
+		expect((netFinding!.metadata as { hasSpf?: boolean }).hasSpf).toBe(true);
+		expect((netFinding!.metadata as { dmarcPolicy?: string | null }).dmarcPolicy).toBeNull();
 	});
 
-	it('should return high finding when variant has MX + DMARC p=none', async () => {
+	// D4: as above — the DMARC-not-enforcing rung is capped at info for a
+	// non-owned domain. `dmarcPolicy` in metadata still pins the parsed policy.
+	it('reports a third-party variant with MX + DMARC p=none at info, not high', async () => {
 		const target = 'example.com';
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
@@ -155,8 +173,11 @@ describe('checkShadowDomains', () => {
 		});
 
 		const result = await run(target);
-		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title));
-		expect(high).toBeDefined();
+		const netFinding = result.findings.find((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFinding).toBeDefined();
+		expect(netFinding!.severity).toBe('info');
+		expect((netFinding!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('third_party');
+		expect((netFinding!.metadata as { dmarcPolicy?: string | null }).dmarcPolicy).toBe('none');
 	});
 
 	it('should return info finding for unregistered variant (defensive registration opportunity)', async () => {
@@ -242,22 +263,31 @@ describe('checkShadowDomains', () => {
 		expect(primaryFinding).toBeUndefined();
 	});
 
+	// D4 fixture repair: this case's subject is the MX-infrastructure match, not
+	// ownership. The old fixture gave the variant an unrelated registrar's NS, so
+	// under the ownership gate it would now cap at `info` and the well-managed
+	// rung would never be observable. The primary and the variant now share a
+	// dedicated NS pair (`owned_by_seed`), which is the only configuration in
+	// which the ladder legitimately runs unclamped — keeping the test on its
+	// actual subject.
 	it('should return low finding for well-managed shadow with matching MX and enforcing DMARC', async () => {
 		const target = 'example.com';
+		const ownNs = ['ns1.example-dns.net.', 'ns2.example-dns.net.'];
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const q = parseDohQuery(input);
 			if (!q) return Promise.resolve(emptyResponse());
 			const { name, type } = q;
 
-			// Primary domain MX
-			if (name === target && (type === 'MX' || type === '15')) {
-				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			// Primary domain NS + MX
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
 			}
 
-			// example.org: same MX infra, SPF, enforcing DMARC
+			// example.org: same NS (same owner), same MX infra, SPF, enforcing DMARC
 			if (name === 'example.org') {
-				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
 				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
 				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
 				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 include:spf.provider.com -all']));
@@ -272,24 +302,30 @@ describe('checkShadowDomains', () => {
 		const result = await run(target);
 		const low = result.findings.find((f) => f.severity === 'low' && f.detail.includes('example.org') && /well-managed/i.test(f.title));
 		expect(low).toBeDefined();
+		expect((low!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 
+	// D4 fixture repair, same rationale as the well-managed case above: the
+	// subject is divergent MX infrastructure, which is only observable on a
+	// domain the seed actually owns.
 	it('should return medium finding for divergent MX with enforcing DMARC', async () => {
 		const target = 'example.com';
+		const ownNs = ['ns1.example-dns.net.', 'ns2.example-dns.net.'];
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const q = parseDohQuery(input);
 			if (!q) return Promise.resolve(emptyResponse());
 			const { name, type } = q;
 
-			// Primary domain MX
-			if (name === target && (type === 'MX' || type === '15')) {
-				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			// Primary domain NS + MX
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
 			}
 
-			// example.org: different MX infra, SPF, enforcing DMARC
+			// example.org: same NS (same owner), different MX infra, SPF, enforcing DMARC
 			if (name === 'example.org') {
-				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
 				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
 				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.other-provider.com.']));
 				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 include:spf.provider.com -all']));
@@ -304,6 +340,7 @@ describe('checkShadowDomains', () => {
 		const result = await run(target);
 		const medium = result.findings.find((f) => f.severity === 'medium' && f.detail.includes('example.org') && /divergent/i.test(f.title));
 		expect(medium).toBeDefined();
+		expect((medium!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 
 	it('should detect shared NS across multiple variants', async () => {
@@ -701,20 +738,26 @@ describe('checkShadowDomains — classification edge cases', () => {
 		expect(wrongHigh).toBeUndefined();
 	});
 
-	it('should treat DMARC with no p= tag as p=none (high severity)', async () => {
+	// D4 fixture repair: the subject is DMARC parsing (a missing `p=` tag defaults
+	// to `p=none`), not ownership. The variant now shares the primary's dedicated
+	// NS pair so the not-enforcing rung stays observable; the parsed policy is
+	// additionally pinned directly in metadata, which no ownership gate can mask.
+	it('should treat DMARC with no p= tag as p=none', async () => {
 		const target = 'example.com';
+		const ownNs = ['ns1.example-dns.net.', 'ns2.example-dns.net.'];
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const q = parseDohQuery(input);
 			if (!q) return Promise.resolve(emptyResponse());
 			const { name, type } = q;
 
-			if (name === target && (type === 'MX' || type === '15')) {
-				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
 			}
 
 			if (name === 'example.net') {
-				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
 				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
 				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.shadow.com.']));
 				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 include:spf.provider.com -all']));
@@ -728,27 +771,34 @@ describe('checkShadowDomains — classification edge cases', () => {
 		});
 
 		const result = await run(target);
-		// Missing p= tag should default to p=none, classified as high
-		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /not enforcing/i.test(f.title));
-		expect(high).toBeDefined();
+		// Missing p= tag defaults to p=none: the not-enforcing rung, softened one
+		// step to medium because the variant is the seed's own domain.
+		const notEnforcing = result.findings.find((f) => f.detail.includes('example.net') && /not enforcing/i.test(f.title));
+		expect(notEnforcing).toBeDefined();
+		expect(notEnforcing!.severity).toBe('medium');
+		expect((notEnforcing!.metadata as { dmarcPolicy?: string | null }).dmarcPolicy).toBe('none');
 	});
 
+	// D4 fixture repair: the subject is trailing-dot normalisation in the
+	// MX-infrastructure comparison, only observable on an owned variant.
 	it('should normalize trailing dot on MX hostname for comparison', async () => {
 		const target = 'example.com';
+		const ownNs = ['ns1.example-dns.net.', 'ns2.example-dns.net.'];
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const q = parseDohQuery(input);
 			if (!q) return Promise.resolve(emptyResponse());
 			const { name, type } = q;
 
-			// Primary MX with trailing dot
-			if (name === target && (type === 'MX' || type === '15')) {
-				return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
+			// Primary NS + MX with trailing dot
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(target, ['10 mail.example.com.']));
 			}
 
-			// Variant with same MX but without trailing dot
+			// Variant with same NS (same owner) and same MX but without trailing dot
 			if (name === 'example.org') {
-				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ownNs));
 				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
 				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com'])); // no trailing dot
 				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 -all']));
@@ -815,7 +865,8 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /fully spoofable/i.test(f.title));
 		expect(high).toBeDefined();
-		expect(high!.detail).toContain('shared nameservers');
+		expect(high!.detail).toContain('shares 2/2 dedicated nameservers');
+		expect((high!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 
 	it('should downgrade "lacks DMARC" from high to medium when variant shares NS with primary', async () => {
@@ -852,7 +903,8 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 		const medium = result.findings.find((f) => f.severity === 'medium' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
 		expect(medium).toBeDefined();
-		expect(medium!.detail).toContain('shared nameservers');
+		expect(medium!.detail).toContain('shares 2/2 dedicated nameservers');
+		expect((medium!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 
 	it('should downgrade "DMARC not enforcing" from high to medium when variant shares NS with primary', async () => {
@@ -890,7 +942,8 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 			(f) => f.severity === 'medium' && f.detail.includes('example.net') && /not enforcing/i.test(f.title),
 		);
 		expect(medium).toBeDefined();
-		expect(medium!.detail).toContain('shared nameservers');
+		expect(medium!.detail).toContain('shares 2/2 dedicated nameservers');
+		expect((medium!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 
 	it('should annotate divergent MX finding when variant shares NS with primary', async () => {
@@ -928,7 +981,13 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 		expect(divergent!.detail).toContain('common ownership');
 	});
 
-	it('should NOT downgrade when variant has different NS from primary', async () => {
+	// D4: the pre-fix contract here was "different NS => no same-owner softening,
+	// so the lacks-DMARC rung stays HIGH". That is the liability defect stated as
+	// a requirement: a variant on `ns1.other-registrar.com` is not the customer's
+	// domain, so a HIGH finding about it in the customer's report is exactly what
+	// this slice removes. Different NS now means `third_party`, which caps at
+	// info — the finding is still emitted, and the same-owner note stays absent.
+	it('treats a variant with different NS as third-party: capped at info, no same-owner note', async () => {
 		const target = 'example.com';
 
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
@@ -958,10 +1017,12 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 		});
 
 		const result = await run(target);
-		// Should remain high (not downgraded)
-		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
-		expect(high).toBeDefined();
-		expect(high!.detail).not.toContain('shared nameservers');
+		const netFinding = result.findings.find((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'example.net');
+		expect(netFinding).toBeDefined();
+		expect(netFinding!.severity).toBe('info');
+		expect((netFinding!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('third_party');
+		// The same-owner softening note must not appear on a non-owned domain.
+		expect(netFinding!.detail).not.toContain('Likely same owner');
 	});
 });
 
@@ -1406,5 +1467,200 @@ describe('registration-state correctness', () => {
 		expect((spoofable!.metadata as { ns?: string[] }).ns).toEqual(SHARED_NS);
 		// Shared nameservers => same owner => downgraded from critical to high.
 		expect(spoofable!.severity).toBe('high');
+	});
+});
+
+describe('checkShadowDomains — D4 ownership-gated severity', () => {
+	async function run(domain: string) {
+		const { checkShadowDomains } = await import('../src/tools/check-shadow-domains');
+		return checkShadowDomains(domain);
+	}
+
+	/** All findings this scan made about one named variant, via metadata (never prose matching). */
+	function forVariant(findings: Array<{ metadata?: Record<string, unknown> }>, variant: string) {
+		return findings.filter((f) => (f.metadata as { variant?: string } | undefined)?.variant === variant);
+	}
+
+	it('caps a third-party variant at info instead of critical — and still EMITS it', async () => {
+		// example.net is registered on its own unrelated registrar's nameservers:
+		// no in-bailiwick NS, no NS-set overlap with the primary, no shared-provider
+		// full match => classifyOwnership() returns `third_party`. Its record shape
+		// (MX, no SPF, no DMARC) is the fully-spoofable ladder's top rung, so the
+		// pre-fix classifier reported CRITICAL "Shadow domain fully spoofable" about
+		// a domain the scanned organisation demonstrably does not control.
+		//
+		// The brand label here is `example` — 7 characters, comfortably past
+		// MIN_ATTRIBUTION_LABEL_LENGTH — so this case ALSO pins that the ceiling is
+		// gated on the ownership VERDICT and not on attributionConfidence(): a
+		// confidence-gated implementation would read 'corroborated' here and let the
+		// critical through.
+		const target = 'example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			if (name === 'example.net') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.unrelated-registrar.net.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.somewhere-else.net.']));
+				if (type === 'TXT' || type === '16') return Promise.resolve(emptyResponse());
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = forVariant(result.findings, 'example.net');
+
+		// DEMOTE, NEVER DELETE: the measurement is still reported.
+		expect(netFindings.length).toBeGreaterThan(0);
+		for (const f of netFindings) expect(f.severity).toBe('info');
+
+		// Prose surface: no title may assert a spoofing posture the customer owns.
+		expect(netFindings.some((f) => /fully spoofable|lacks DMARC|not enforcing|well-managed/i.test(f.title))).toBe(false);
+
+		// Structured surface: the verdict is recorded, not merely implied by the severity.
+		const gated = netFindings[0];
+		expect((gated.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('third_party');
+		expect(String((gated.metadata as { ownershipRationale?: string }).ownershipRationale)).toContain('example.net');
+		// Wording must not imply the scanned organisation controls or must act on it.
+		expect(gated.detail).toMatch(/no action .*is implied/i);
+	});
+
+	it('never attributes an Akamai-hosted variant to the seed on a 1/6 partial NS overlap', async () => {
+		// The ANZ/Westpac trap from the design doc §3.3: bnz.co.nz and an unrelated
+		// bank both sit on Akamai's shared NS pool, so one hostname in common is
+		// operational plumbing, not ownership. `akam.net` is in SHARED_NS_APEXES
+		// (Task 1), so the overlap contributes no dedicated-NS evidence and the
+		// set match is 1/6, not complete => third_party.
+		const target = 'bnz.co.nz';
+		const seedNs = ['a1-97.akam.net.', 'a3-67.akam.net.', 'a8-66.akam.net.', 'a9-65.akam.net.', 'a16-65.akam.net.', 'a24-64.akam.net.'];
+		const variantNs = ['a1-6.akam.net.', 'a3-66.akam.net.', 'a6-65.akam.net.', 'a9-65.akam.net.', 'a12-66.akam.net.', 'a28-67.akam.net.'];
+
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, seedNs));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.bnz.co.nz.']));
+			}
+			if (name === 'bnz.de') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, variantNs));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.somewhere-else.net.']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const deFindings = forVariant(result.findings, 'bnz.de');
+		expect(deFindings.length).toBeGreaterThan(0);
+		for (const f of deFindings) {
+			expect(f.severity).toBe('info');
+			expect((f.metadata as { ownershipVerdict?: string }).ownershipVerdict).not.toBe('owned_by_seed');
+		}
+	});
+
+	it('keeps a short brand label’s uncorroborated match at info WITHOUT suppressing it', async () => {
+		// `bnz` is 3 characters — below MIN_ATTRIBUTION_LABEL_LENGTH — and the
+		// variant's mail infrastructure does not overlap the primary's, so
+		// attributionConfidence() reports 'uncorroborated'. That governs WORDING
+		// only: the finding is still emitted, at info. A guard that SUPPRESSED it
+		// would fail the first assertion here (and the registration-invariant audit).
+		const target = 'bnz.co.nz';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.bnz.co.nz.']));
+			}
+			if (name === 'bnz.de') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.unrelated-registrar.net.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.somewhere-else.net.']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const deFindings = forVariant(result.findings, 'bnz.de');
+		expect(deFindings.length).toBeGreaterThan(0);
+		const gated = deFindings[0];
+		expect(gated.severity).toBe('info');
+		expect((gated.metadata as { attributionConfidence?: string }).attributionConfidence).toBe('uncorroborated');
+		expect(gated.detail).toMatch(/name similarity alone/i);
+	});
+
+	it('still surfaces the customer-owned in-bailiwick variant above info', async () => {
+		// bnz.nz delegates to nameservers UNDER the seed apex — the one signal an
+		// attacker cannot forge without controlling the seed's own zone. Ownership
+		// is established, so classifyVariant's ladder applies unclamped (critical,
+		// softened one rung to high by the same-owner note).
+		const target = 'bnz.co.nz';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['a1-97.akam.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.bnz.co.nz.']));
+			}
+			if (name === 'bnz.nz') {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.bnz.co.nz.', 'ns2.bnz.co.nz.']));
+				if (type === 'A' || type === '1') return Promise.resolve(aRecords(name, ['192.0.2.1']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.evil-shadow.net.']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const owned = forVariant(result.findings, 'bnz.nz');
+		expect(owned.length).toBeGreaterThan(0);
+		const spoofable = owned.find((f) => /fully spoofable/i.test(f.title));
+		expect(spoofable).toBeDefined();
+		expect(spoofable!.severity).toBe('high');
+		expect((spoofable!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
+	});
+
+	it('gates the UNKNOWN-BUCKET RE-PROBE call site, not just the Phase-2 loop', async () => {
+		// SECOND CALL SITE. example.net answers NOERROR-empty for NS, SOA and A, so
+		// Phase 1 buckets it `unknown` — it never reaches the Phase-2 completed-probe
+		// loop. The unknown re-probe then finds MX + SPF, proving registration, and
+		// classifies it from its real records ('Shadow domain lacks DMARC', high).
+		// Wiring only the Phase-2 site leaves this path emitting an ungated `high`
+		// with no ownership verdict at all — the defect through the back door.
+		const target = 'example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const q = parseDohQuery(input);
+			if (!q) return Promise.resolve(emptyResponse());
+			const { name, type } = q;
+			if (name === target) {
+				if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.primary-dns.net.', 'ns2.primary-dns.net.']));
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.example.com.']));
+			}
+			if (name === 'example.net') {
+				// NS / SOA / A all NOERROR-empty => Phase 1 verdict `unknown`.
+				if (type === 'MX' || type === '15') return Promise.resolve(mxRecords(name, ['10 mail.attacker.net.']));
+				if (type === 'TXT' || type === '16') return Promise.resolve(txtRecords(name, ['v=spf1 include:sendgrid.net ~all']));
+			}
+			return Promise.resolve(emptyResponse());
+		});
+
+		const result = await run(target);
+		const netFindings = forVariant(result.findings, 'example.net');
+		// The re-probe path must have run and reclassified it (not left it "unknown").
+		const reclassified = netFindings.find((f) => (f.metadata as { hasSpf?: boolean }).hasSpf === true);
+		expect(reclassified).toBeDefined();
+		// …and it must carry an ownership verdict and be capped, exactly like Phase 2.
+		expect((reclassified!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('unattributed');
+		expect(reclassified!.severity).toBe('info');
+		expect(/lacks DMARC/i.test(reclassified!.title)).toBe(false);
+		for (const f of netFindings) expect(f.severity).toBe('info');
 	});
 });

--- a/test/discover-brand-domains.spec.ts
+++ b/test/discover-brand-domains.spec.ts
@@ -98,6 +98,7 @@ function makeDeps(overrides: Partial<DiscoverBrandDomainsDeps> = {}): DiscoverBr
 			findings: [],
 		}),
 		domainLabelSimilarity: vi.fn().mockReturnValue(0),
+		generateVariants: vi.fn().mockReturnValue([]),
 		...overrides,
 	};
 }
@@ -1225,5 +1226,70 @@ describe('discoverBrandDomains — discovery_mode=tiered', () => {
 			.filter((f) => f.metadata?.candidate)
 			.map((f) => f.metadata?.candidate as string);
 		expect(surfaced).not.toContain('opted-out.example.net');
+	});
+});
+
+describe('D6 — NS as a discovery signal (2026-07-26 correctness-defects design)', () => {
+	it('probes TLD variants of the seed brand for NS, not just candidates other signals proposed', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const { generateVariants } = await import('../src/tools/check-shadow-domains');
+		// IMPORTANT: 'bnz.nz' is NOT a valid discriminator here — the pre-existing
+		// `buildBrandCandidateUniverse()` tld_sweep (src/lib/brand-candidate-universe.ts)
+		// already seeds `${brand}.nz` on every standard-depth run (`.nz` is in its
+		// own STANDARD_TLDS list), completely independent of this task's NS
+		// TLD-variant union. A candidate that already reaches `candidatesForSignal`
+		// through that unrelated path would make this assertion pass even with
+		// the union deleted (verified: this was the actual failure mode hit while
+		// writing this test — see task-5-report.md). `.kiwi` is unique to
+		// `generateVariants`'s NZ_REGIONAL set and is NOT in tld_sweep's TLD list,
+		// so 'bnz.kiwi' only reaches the NS probe via the D6.2 union.
+		const correlateNs = vi.fn().mockImplementation(async (_seed: string, opts: { candidateDomains?: string[] }) => ({
+			seedDomain: 'bnz.co.nz',
+			seedNs: ['a1-97.akam.net'],
+			coOwnedDomains: (opts.candidateDomains ?? []).includes('bnz.kiwi')
+				? [{ domain: 'bnz.kiwi', sharedNs: ['ns1.bnz.co.nz'], confidence: 1, matchType: 'in_bailiwick' as const }]
+				: [],
+			queryStatus: 'ok' as const,
+		}));
+		// Wire the REAL generateVariants (not the default empty-array stub) so this
+		// test exercises the actual production generator end to end.
+		const deps = makeDeps({ correlateNs, generateVariants });
+
+		const result = await discoverBrandDomains('bnz.co.nz', { signals: ['ns'] }, deps);
+
+		expect(correlateNs).toHaveBeenCalledTimes(1);
+		const [, callOptions] = correlateNs.mock.calls[0] as [string, { candidateDomains: string[] }];
+		expect(callOptions.candidateDomains).toEqual(expect.arrayContaining(['bnz.kiwi']));
+
+		const bnzKiwiFinding = result.findings.find((f) => f.metadata?.candidate === 'bnz.kiwi');
+		expect(bnzKiwiFinding).toBeDefined();
+		expect((bnzKiwiFinding!.metadata?.sources as Record<string, unknown>)?.ns).toMatchObject({ matchType: 'in_bailiwick' });
+	});
+
+	it('names every non-completed signal in the summary finding text', async () => {
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const deps = makeDeps({
+			correlateNs: vi.fn().mockResolvedValue({
+				seedDomain: 'example.com',
+				seedNs: [],
+				coOwnedDomains: [],
+				queryStatus: 'partial' as const,
+			}),
+		});
+
+		const result = await discoverBrandDomains('example.com', { signals: ['ns', 'san'] }, deps);
+
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary).toBeDefined();
+		// NOTE: createFinding() (@blackveil/dns-checks/scoring, a vendored SSOT we
+		// cannot modify) auto-sanitizes `detail` and strips `[`/`]` as markdown-
+		// injection characters (same as it already does to the pre-existing
+		// `signals=[...]` segment above). The brief's literal `degraded=\[...\]`
+		// regex can therefore never match real output — assert on the
+		// bracket-stripped text instead, which still discriminates: it requires
+		// both the `degraded=` marker AND the `ns:partial` status pair to be
+		// present, so it goes RED if the degraded list is omitted from the
+		// summary OR if `partial` is dropped from the degraded-status set.
+		expect(summary!.detail).toMatch(/degraded=.*ns:partial/);
 	});
 });

--- a/test/discover-subdomains.spec.ts
+++ b/test/discover-subdomains.spec.ts
@@ -371,6 +371,174 @@ describe('discoverSubdomains', () => {
 	});
 });
 
+describe('discoverSubdomains — honest zero (D5 residual gaps: R1/R2/R3)', () => {
+	async function run(domain = 'example.com') {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		return discoverSubdomains(domain);
+	}
+
+	// R1: emptyResult() must never surface a bare `issues: []` — structured
+	// consumers read `issues[]` directly and drop `isError` (a handler-layer
+	// concern), so an empty issues array on a zero-subdomain result is a
+	// success-shaped zero indistinguishable from a genuinely verified absence.
+	it('R1: a corroborated-empty direct-source result still carries a high-severity unconfirmed_zero issue', async () => {
+		mockCrtSh([]); // crt.sh: outcome 'empty'. Certspotter falls to mockCrtSh's
+		// generic non-Response fallback, which throws inside fetchCertspotterEntries
+		// and is caught as outcome 'error' — so this exercises "one source spoke
+		// (empty), the other never confirmed" exactly as R3 requires.
+		const result = await run();
+
+		expect(result.totalSubdomains).toBe(0);
+		expect(result.sourceUnavailable).toBeFalsy();
+		const issue = result.issues.find((i) => i.type === 'unconfirmed_zero');
+		expect(issue).toBeDefined();
+		expect(issue?.severity).toBe('high');
+	});
+
+	it('R1: a total-outage emptyResult also carries the unconfirmed_zero issue (belt-and-braces with isError)', async () => {
+		globalThis.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+		const result = await run();
+
+		expect(result.sourceUnavailable).toBe(true);
+		const issue = result.issues.find((i) => i.type === 'unconfirmed_zero');
+		expect(issue).toBeDefined();
+		expect(issue?.severity).toBe('high');
+	});
+
+	// R2: CertstreamEnumerateResponse.timedOut / CertstreamSansResponse.timedOut
+	// are declared but were never read — a `{subdomains: [], timedOut: true}`
+	// response was accepted as a confident zero.
+	it('R2: a timed-out /enumerate response with an EMPTY list is not accepted as a confident zero — falls through to /sans', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const certstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === 'https://certstream/enumerate?domain=example.com') {
+				return Response.json({ domain: 'example.com', subdomains: [], certificateCount: 0, timedOut: true, cached: false });
+			}
+			if (url === 'https://certstream/sans?domain=example.com') {
+				return Response.json({
+					domain: 'example.com',
+					names: ['api.example.com'],
+					certificateCount: 1,
+					timedOut: false,
+					truncated: false,
+					cached: false,
+				});
+			}
+			throw new Error(`unexpected certstream URL: ${url}`);
+		});
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('crt.sh fallback should not be used');
+		});
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch }, 'shared-internal-key');
+
+		// The enumerate timeout must not have been treated as a final answer —
+		// /sans had to be consulted.
+		expect(certstreamFetch).toHaveBeenCalledTimes(2);
+		expect(result.totalSubdomains).toBe(1);
+		expect(result.subdomains.map((s) => s.subdomain)).toEqual(['api.example.com']);
+		expect(result.sourceUnavailable).toBeFalsy();
+	});
+
+	it('R2: a timed-out /enumerate response WITH data is kept and marked partial, not suppressed', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const certstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === 'https://certstream/enumerate?domain=example.com') {
+				return Response.json({
+					domain: 'example.com',
+					subdomains: ['api.example.com'],
+					certificateCount: 1,
+					timedOut: true,
+					cached: false,
+				});
+			}
+			throw new Error(`unexpected certstream URL: ${url} (should not reach /sans — enumerate already had data)`);
+		});
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('crt.sh fallback should not be used');
+		});
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch }, 'shared-internal-key');
+
+		expect(certstreamFetch).toHaveBeenCalledTimes(1);
+		expect(result.totalSubdomains).toBe(1);
+		expect(result.subdomains.map((s) => s.subdomain)).toEqual(['api.example.com']);
+		expect(result.partial).toBe(true);
+		expect(result.sourceUnavailable).toBeFalsy();
+	});
+
+	it('R2: a timed-out /sans response with an empty list falls through to the direct public sources', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const certstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+			if (url === 'https://certstream/enumerate?domain=example.com') {
+				return new Response(JSON.stringify({ error: 'upstream transient' }), {
+					status: 502,
+					headers: { 'Content-Type': 'application/json' },
+				});
+			}
+			if (url === 'https://certstream/sans?domain=example.com') {
+				return Response.json({ domain: 'example.com', names: [], certificateCount: 0, timedOut: true, truncated: false, cached: false });
+			}
+			throw new Error(`unexpected certstream URL: ${url}`);
+		});
+		mockCrtSh([{ name_value: 'fromcrtsh.example.com', issuer_name: 'CN=R3', not_before: '2026-01-01', not_after: '2026-04-01' }]);
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch }, 'shared-internal-key');
+
+		expect(result.subdomains.map((s) => s.subdomain)).toContain('fromcrtsh.example.com');
+		expect(result.sourceUnavailable).toBeFalsy();
+	});
+
+	// R3: a first-source (crt.sh) HTTP-200 `[]` was treated as available:true
+	// and short-circuited before Certspotter (the #562 cross-check) ever ran.
+	it('R3: a first-source empty does not short-circuit — falls through to corroborate with the second source', async () => {
+		let certspotterCalled = false;
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([], { status: 200 }); // empty
+			if (s.includes('certspotter.com')) {
+				certspotterCalled = true;
+				return Response.json(
+					[
+						{
+							dns_names: ['found.example.com'],
+							issuer: { name: "C=US, O=Let's Encrypt, CN=R3" },
+							not_before: '2026-01-01',
+							not_after: '2026-04-01',
+						},
+					],
+					{ status: 200 },
+				);
+			}
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await run();
+
+		expect(certspotterCalled).toBe(true);
+		expect(result.subdomains.map((s) => s.subdomain)).toContain('found.example.com');
+		expect(result.sourceUnavailable).toBeFalsy();
+	});
+
+	it('R3: an empty confirmed by BOTH direct sources is still reported unconfirmed (issues[] carries the caution), not a clean 0', async () => {
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([], { status: 200 });
+			if (s.includes('certspotter.com')) return Response.json([], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await run();
+
+		expect(result.totalSubdomains).toBe(0);
+		expect(result.sourceUnavailable).toBeFalsy();
+		expect(result.issues.some((i) => i.type === 'unconfirmed_zero')).toBe(true);
+	});
+});
+
 describe('formatSubdomainDiscovery', () => {
 	async function getFormatter() {
 		const { formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
@@ -519,6 +687,29 @@ describe('formatSubdomainDiscovery', () => {
 
 		const fullOutput = formatSubdomainDiscovery(result, 'full');
 		expect(fullOutput).toContain('50 more subdomains not shown');
+	});
+
+	it('formats a partial (timed-out-but-productive) result with a partial banner, distinct from stale', async () => {
+		const formatSubdomainDiscovery = await getFormatter();
+
+		const result = {
+			domain: 'example.com',
+			totalSubdomains: 1,
+			totalCertificates: 1,
+			subdomains: [
+				{ subdomain: 'api.example.com', firstSeen: '', lastSeen: '', issuer: '', certCount: 1, isWildcard: false, isExpired: false },
+			],
+			wildcardCerts: 0,
+			expiredCerts: 0,
+			uniqueIssuers: [],
+			issues: [],
+			partial: true,
+		};
+
+		const output = formatSubdomainDiscovery(result, 'compact');
+		expect(output).toMatch(/partial/i);
+		expect(output).not.toMatch(/stale/i);
+		expect(output).toContain('api.example.com');
 	});
 });
 

--- a/test/discover-subdomains.spec.ts
+++ b/test/discover-subdomains.spec.ts
@@ -660,6 +660,42 @@ describe('formatSubdomainDiscovery', () => {
 		expect(output).toContain('no subdomains found');
 	});
 
+	/**
+	 * Final review round, item 2: `emptyResult` always attaches a high-severity
+	 * `unconfirmed_zero` issue — CT logs are indirect evidence, so even a
+	 * completed query cannot positively confirm zero subdomains (see
+	 * `emptyResult`'s doc). The prose zero-branch used to render the bare "no
+	 * subdomains found" sentence with no disclosure of that caveat — a
+	 * confident prose surface next to an honest structured one, the exact
+	 * split-surface defect this campaign closes elsewhere. The prose must now
+	 * say the zero is unconfirmed, in wording consistent with the issue detail.
+	 */
+	it('R4 (final review, item 2): the zero-branch prose discloses the zero is unconfirmed, matching the structured unconfirmed_zero issue', async () => {
+		const formatSubdomainDiscovery = await getFormatter();
+
+		const result = {
+			domain: 'example.com',
+			totalSubdomains: 0,
+			totalCertificates: 0,
+			subdomains: [],
+			wildcardCerts: 0,
+			expiredCerts: 0,
+			uniqueIssuers: [],
+			issues: [
+				{
+					type: 'unconfirmed_zero' as const,
+					severity: 'high' as const,
+					detail:
+						'No Certificate Transparency source has positively confirmed example.com has zero subdomains — CT logs only capture certificate issuance, so this is an unconfirmed measurement, not a verified absence.',
+				},
+			],
+		};
+
+		const output = formatSubdomainDiscovery(result, 'compact');
+		expect(output).toContain('no subdomains found');
+		expect(output.toLowerCase()).toContain('unconfirmed');
+	});
+
 	it('should show overflow count when subdomains are truncated', async () => {
 		const formatSubdomainDiscovery = await getFormatter();
 

--- a/test/format-report.spec.ts
+++ b/test/format-report.spec.ts
@@ -124,6 +124,24 @@ describe('buildStructuredScanResult', () => {
 		expect(s.dnssecSource).toBeNull();
 	});
 
+	/**
+	 * The `'timeout'` case above and this `'error'` case are DELIBERATELY separate
+	 * tests, not one parameterized over both values: `dnssecSource`'s completed-gate
+	 * (`isCompletedCheck(dnssecCheck)`, `format-report.ts`) is a boolean over the
+	 * FULL three-member `CheckStatus` union, and a mutation that widens the gate to
+	 * also accept ONE of the two transient values (e.g. treating 'error' as
+	 * completed while still excluding 'timeout') would slip past a suite that only
+	 * ever exercised 'timeout' here. Pins the collapse onto `isCompletedCheck`
+	 * independently for BOTH transient members.
+	 */
+	it('sets dnssecSource to null when dnssec check errored (even if passed=true)', () => {
+		const result = makeMockScanResult({
+			checks: [{ category: 'dnssec', passed: true, score: 100, findings: [], checkStatus: 'error' }] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.dnssecSource).toBeNull();
+	});
+
 	it('derives cdnProvider from http_security finding metadata', () => {
 		const result = makeMockScanResult({
 			checks: [

--- a/test/generate-fix-plan.spec.ts
+++ b/test/generate-fix-plan.spec.ts
@@ -52,22 +52,23 @@ function mockScanResponses(options: { hasSpf?: boolean; hasDmarc?: boolean; hasD
 			}
 			// MX records
 			if (type === 15) {
-				return Promise.resolve(createDohResponse([{ name, type }], [
-					{ name, type: 15, TTL: 300, data: '10 mail.example.com.' },
-				]));
+				return Promise.resolve(createDohResponse([{ name, type }], [{ name, type: 15, TTL: 300, data: '10 mail.example.com.' }]));
 			}
 			// NS records
 			if (type === 2) {
-				return Promise.resolve(createDohResponse([{ name, type }], [
-					{ name, type: 2, TTL: 300, data: 'ns1.example.com.' },
-					{ name, type: 2, TTL: 300, data: 'ns2.example.com.' },
-				]));
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type }],
+						[
+							{ name, type: 2, TTL: 300, data: 'ns1.example.com.' },
+							{ name, type: 2, TTL: 300, data: 'ns2.example.com.' },
+						],
+					),
+				);
 			}
 			// A records
 			if (type === 1) {
-				return Promise.resolve(createDohResponse([{ name, type }], [
-					{ name, type: 1, TTL: 300, data: '93.184.216.34' },
-				]));
+				return Promise.resolve(createDohResponse([{ name, type }], [{ name, type: 1, TTL: 300, data: '93.184.216.34' }]));
 			}
 			// AAAA
 			if (type === 28) {
@@ -95,9 +96,12 @@ function mockScanResponses(options: { hasSpf?: boolean; hasDmarc?: boolean; hasD
 			}
 			// SOA
 			if (type === 6) {
-				return Promise.resolve(createDohResponse([{ name, type }], [
-					{ name, type: 6, TTL: 300, data: 'ns1.example.com. admin.example.com. 2024010101 3600 900 604800 86400' },
-				]));
+				return Promise.resolve(
+					createDohResponse(
+						[{ name, type }],
+						[{ name, type: 6, TTL: 300, data: 'ns1.example.com. admin.example.com. 2024010101 3600 900 604800 86400' }],
+					),
+				);
 			}
 			// SRV
 			if (type === 33) {
@@ -193,6 +197,7 @@ describe('formatFixPlan', () => {
 			actions: [],
 			assessed: true,
 			caveat: null,
+			transientCategories: [],
 		});
 		expect(text).toContain('No actionable findings');
 		expect(text).toContain('posture is strong');
@@ -208,7 +213,17 @@ describe('formatFixPlan', () => {
 			impact: 'high' as const,
 			dependencies: ['dep'],
 		}));
-		const plan = { domain: 'test.com', score: 30, grade: 'F', maturityStage: 0, totalActions: 7, actions, assessed: true, caveat: null };
+		const plan = {
+			domain: 'test.com',
+			score: 30,
+			grade: 'F',
+			maturityStage: 0,
+			totalActions: 7,
+			actions,
+			assessed: true,
+			caveat: null,
+			transientCategories: [],
+		};
 		const compact = formatFixPlan(plan, 'compact');
 		const full = formatFixPlan(plan, 'full');
 		expect(compact.length).toBeLessThan(full.length);
@@ -242,6 +257,7 @@ describe('formatFixPlan — a domain that was never measured', () => {
 			actions: [],
 			assessed: false,
 			caveat: UNASSESSED_FIX_PLAN_CAVEAT,
+			transientCategories: [],
 		};
 	}
 
@@ -269,7 +285,17 @@ describe('formatFixPlan — a domain that was never measured', () => {
 		// Without this control the assertions above would hold under a formatter that
 		// abstained unconditionally.
 		const text = formatFixPlan(
-			{ domain: 'clean.example', score: 95, grade: 'A+', maturityStage: 4, totalActions: 0, actions: [], assessed: true, caveat: null },
+			{
+				domain: 'clean.example',
+				score: 95,
+				grade: 'A+',
+				maturityStage: 4,
+				totalActions: 0,
+				actions: [],
+				assessed: true,
+				caveat: null,
+				transientCategories: [],
+			},
 			'full',
 		);
 
@@ -292,5 +318,88 @@ describe('formatFixPlan — a domain that was never measured', () => {
 		const comment = result.content.map((c) => c.text).find((t) => t.includes('STRUCTURED_RESULT'));
 		expect(comment).toBeDefined();
 		expect(comment).toContain('"maturityStage":null');
+	});
+});
+
+/**
+ * Task R4 (residual of the correctness-defect campaign): a transient DNS/network
+ * failure for ONE category (e.g. DMARC) must not turn into a remediation action
+ * just because OTHER categories completed normally (`assessed: true`). The
+ * synthetic "check error" finding `buildDnsErrorResult` attaches carries
+ * `metadata.errorKind: 'dns_error'` — that finding is the ABSENCE of a
+ * measurement, not a customer gap to fix. Mirrors the equivalent
+ * `map_compliance`/`map_csc_products` fix (see `src/lib/map-compliance.ts:272`
+ * for the reference implementation this is modeled on).
+ */
+describe('evaluateFixPlan: a category that failed transiently is not turned into a remediation action', () => {
+	async function buildFixtures() {
+		const { buildCheckResult, createFinding } = await import('@blackveil/dns-checks/scoring');
+		const transientDmarc = {
+			...buildCheckResult('dmarc', [
+				createFinding('dmarc', 'DMARC check error', 'high', 'Check failed: DNS query failed', { errorKind: 'dns_error' }),
+			]),
+			score: 0,
+			passed: false,
+			checkStatus: 'error' as const,
+			partial: true,
+		};
+		// A genuine, non-transient high-severity finding on a DIFFERENT category —
+		// this one MUST survive. A wrong implementation that filters on
+		// `severity === 'high'` instead of the errorKind marker would drop this too,
+		// which is exactly what this fixture is designed to catch.
+		const genuineSsl = {
+			...buildCheckResult('ssl', [createFinding('ssl', 'Certificate expired', 'high', 'The TLS certificate expired 3 days ago')]),
+			score: 0,
+			passed: false,
+		};
+		const cleanDnssec = { ...buildCheckResult('dnssec', []), score: 100, passed: true };
+		return { transientDmarc, genuineSsl, cleanDnssec };
+	}
+
+	it('the transient "check error" finding never becomes a fix action, but a genuine finding on another category still does (discriminates errorKind from severity)', async () => {
+		const { evaluateFixPlan } = await import('../src/tools/generate-fix-plan');
+		const { transientDmarc, genuineSsl, cleanDnssec } = await buildFixtures();
+
+		const plan = evaluateFixPlan([transientDmarc, genuineSsl, cleanDnssec], 'partial-outage.example', 40, 'F', 1);
+
+		expect(plan.assessed).toBe(true); // ssl + dnssec completed
+		expect(plan.caveat).toBeNull();
+
+		const titles = plan.actions.map((a) => a.findingTitle);
+		expect(titles).not.toContain('DMARC check error');
+		expect(titles).toContain('Certificate expired');
+		expect(plan.actions.some((a) => a.category === 'dmarc')).toBe(false);
+		expect(plan.actions.some((a) => a.category === 'ssl')).toBe(true);
+	});
+
+	it('the excluded category is represented in transientCategories, not silently dropped', async () => {
+		const { evaluateFixPlan } = await import('../src/tools/generate-fix-plan');
+		const { transientDmarc, cleanDnssec } = await buildFixtures();
+		const { buildCheckResult } = await import('@blackveil/dns-checks/scoring');
+		const cleanSsl = { ...buildCheckResult('ssl', []), score: 100, passed: true };
+
+		const plan = evaluateFixPlan([transientDmarc, cleanSsl, cleanDnssec], 'quiet-outage.example', 90, 'A', 4);
+
+		// ssl/dnssec are clean and DMARC's only evidence was transient — zero real
+		// actions — but this must NOT read as a clean bill of health: DMARC was
+		// never actually measured.
+		expect(plan.totalActions).toBe(0);
+		expect(plan.assessed).toBe(true);
+		expect(plan.transientCategories).toEqual(['dmarc']);
+	});
+
+	it('formatFixPlan surfaces the transient category instead of claiming a clean bill of health', async () => {
+		const { evaluateFixPlan, formatFixPlan } = await import('../src/tools/generate-fix-plan');
+		const { transientDmarc, cleanDnssec } = await buildFixtures();
+		const { buildCheckResult } = await import('@blackveil/dns-checks/scoring');
+		const cleanSsl = { ...buildCheckResult('ssl', []), score: 100, passed: true };
+
+		const plan = evaluateFixPlan([transientDmarc, cleanSsl, cleanDnssec], 'quiet-outage.example', 90, 'A', 4);
+
+		for (const text of [formatFixPlan(plan, 'full'), formatFixPlan(plan, 'compact')]) {
+			expect(text.toLowerCase()).not.toContain('posture is strong');
+			expect(text.toLowerCase()).toContain('dmarc');
+			expect(text.toLowerCase()).toMatch(/not assess|could not be assessed|transient/);
+		}
 	});
 });

--- a/test/generate-fix-plan.spec.ts
+++ b/test/generate-fix-plan.spec.ts
@@ -328,7 +328,7 @@ describe('formatFixPlan — a domain that was never measured', () => {
  * synthetic "check error" finding `buildDnsErrorResult` attaches carries
  * `metadata.errorKind: 'dns_error'` — that finding is the ABSENCE of a
  * measurement, not a customer gap to fix. Mirrors the equivalent
- * `map_compliance`/`map_csc_products` fix (see `src/lib/map-compliance.ts:272`
+ * `map_compliance`/`map_csc_products` fix (see `src/tools/map-compliance.ts:272`
  * for the reference implementation this is modeled on).
  */
 describe('evaluateFixPlan: a category that failed transiently is not turned into a remediation action', () => {
@@ -401,5 +401,108 @@ describe('evaluateFixPlan: a category that failed transiently is not turned into
 			expect(text.toLowerCase()).toContain('dmarc');
 			expect(text.toLowerCase()).toMatch(/not assess|could not be assessed|transient/);
 		}
+	});
+
+	/**
+	 * F2 (review round 1): `buildFixtures()` above uses `buildDnsErrorResult`-shaped
+	 * transients (`metadata.errorKind: 'dns_error'`). But the ORCHESTRATOR's own
+	 * transient producer — `safeCheck()` in `src/tools/scan-domain.ts`, which is
+	 * what actually runs for any check with no top-level internal DNS-error
+	 * handling of its own — sets `checkStatus: 'error' | 'timeout'` and NEVER sets
+	 * `errorKind`. A fix gated only on `errorKind` would miss every
+	 * safeCheck-produced transient: a `checkStatus: 'timeout'` result would render
+	 * BOTH as a fix action ("Fix DMARC: DMARC check timed out — ...") AND, in the
+	 * SAME plan, as a `transientCategories` entry — self-contradictory output.
+	 * `evaluateFixPlan` gates on `checkStatus` (not `errorKind`) for exactly this
+	 * reason; these fixtures are built the way `safeCheck` actually produces
+	 * results to prove that gate is what is doing the work, covering both
+	 * `checkStatus` values `safeCheck` can produce.
+	 */
+	describe('a safeCheck-shaped transient (no errorKind metadata) is still excluded — covers both checkStatus values', () => {
+		async function safeCheckShapedFixtures() {
+			const { buildCheckResult, createFinding } = await import('@blackveil/dns-checks/scoring');
+			// No `metadata` argument at all — matches safeCheck()'s own
+			// `createFinding(category, title, severity, detail)` call exactly.
+			const timedOutDmarc = {
+				...buildCheckResult('dmarc', [
+					createFinding('dmarc', 'DMARC check timed out', 'low', 'Check did not complete within the 8s limit'),
+				]),
+				score: 0,
+				checkStatus: 'timeout' as const,
+				partial: true,
+			};
+			const erroredMx = {
+				...buildCheckResult('mx', [createFinding('mx', 'MX check error', 'high', 'Check failed: DNS query failed')]),
+				score: 0,
+				passed: false,
+				checkStatus: 'error' as const,
+				partial: true,
+			};
+			const cleanSsl = { ...buildCheckResult('ssl', []), score: 100, passed: true };
+			return { timedOutDmarc, erroredMx, cleanSsl };
+		}
+
+		it('neither the timeout- nor the error-shaped safeCheck transient becomes a fix action, and both are represented in transientCategories', async () => {
+			const { evaluateFixPlan } = await import('../src/tools/generate-fix-plan');
+			const { timedOutDmarc, erroredMx, cleanSsl } = await safeCheckShapedFixtures();
+
+			const plan = evaluateFixPlan([timedOutDmarc, erroredMx, cleanSsl], 'safecheck-outage.example', 90, 'A', 4);
+
+			expect(plan.assessed).toBe(true); // ssl completed
+			expect(plan.totalActions).toBe(0);
+			const titles = plan.actions.map((a) => a.findingTitle);
+			expect(titles).not.toContain('DMARC check timed out');
+			expect(titles).not.toContain('MX check error');
+			expect(plan.transientCategories.sort()).toEqual(['dmarc', 'mx']);
+		});
+
+		it('formatFixPlan never emits a self-contradictory plan (an action for a category ALSO listed as not-assessed)', async () => {
+			const { evaluateFixPlan, formatFixPlan } = await import('../src/tools/generate-fix-plan');
+			const { timedOutDmarc, erroredMx, cleanSsl } = await safeCheckShapedFixtures();
+
+			const plan = evaluateFixPlan([timedOutDmarc, erroredMx, cleanSsl], 'safecheck-outage.example', 90, 'A', 4);
+
+			for (const text of [formatFixPlan(plan, 'full'), formatFixPlan(plan, 'compact')]) {
+				expect(text).not.toContain('DMARC check timed out');
+				expect(text).not.toContain('MX check error');
+				expect(text.toLowerCase()).toMatch(/not|transient/);
+			}
+		});
+	});
+
+	/**
+	 * Proves the `isDnsErrorFinding` per-finding filter is NOT dead code in this
+	 * file (contrast with map-csc-products.ts, where the reviewer's M2a proved
+	 * the equivalent per-finding filters ARE dead once the `checkStatus` guard
+	 * exists). A check can COMPLETE (`checkStatus` absent/'completed') and still
+	 * attach its OWN errorKind-tagged finding for a narrower reason than a full
+	 * check failure — e.g. `discover-brand-domains.ts`'s "Brand-domain discovery
+	 * could not complete" finding, emitted when every discovery signal failed
+	 * but the check itself ran to completion. The `checkStatus`-level filter
+	 * (F2's fix) cannot see this state at all — `checkStatus` is never
+	 * `'error'`/`'timeout'` here — so only the per-finding filter catches it.
+	 */
+	it('a COMPLETED check whose own finding is errorKind-tagged still never becomes a fix action (proves the per-finding filter is load-bearing here)', async () => {
+		const { evaluateFixPlan } = await import('../src/tools/generate-fix-plan');
+		const { buildCheckResult, createFinding } = await import('@blackveil/dns-checks/scoring');
+
+		// checkStatus intentionally ABSENT — the check itself completed normally;
+		// only its own finding is errorKind-tagged.
+		const inconclusiveBrandDiscovery = buildCheckResult('brand_discovery', [
+			createFinding('brand_discovery', 'Brand-domain discovery could not complete', 'high', 'All signals failed', {
+				errorKind: 'dns_error',
+				missingControl: true,
+			}),
+		]);
+		const cleanSsl = { ...buildCheckResult('ssl', []), score: 100, passed: true };
+
+		const plan = evaluateFixPlan([inconclusiveBrandDiscovery, cleanSsl], 'inconclusive.example', 90, 'A', 4);
+
+		expect(plan.assessed).toBe(true);
+		expect(plan.actions.some((a) => a.category === 'brand_discovery')).toBe(false);
+		// Not in transientCategories either — its checkStatus was never
+		// 'error'/'timeout', so this state is invisible to that channel; it is
+		// caught SOLELY by the per-finding errorKind filter.
+		expect(plan.transientCategories).not.toContain('brand_discovery');
 	});
 });

--- a/test/map-csc-products.spec.ts
+++ b/test/map-csc-products.spec.ts
@@ -101,6 +101,57 @@ describe('evaluateCscProducts — CSC MultiLock (reads booleans, not level)', ()
 		const m = recFor(r, 'csc_multilock');
 		expect(m.recommended).toBe(false);
 	});
+
+	/**
+	 * Final review round, item 1: `lockPosture === null` (RDAP never reached —
+	 * no server for the TLD, a non-OK HTTP status, or a fetch/parse failure)
+	 * and `lockPosture.level === 'unknown'` (RDAP DID answer, the record just
+	 * carries no EPP status codes) used to share `assessed: true` and one
+	 * "unavailable/redacted" gap sentence. That let an unreachable RDAP lookup
+	 * render byte-identical to a genuine clean pass (`✓ CSC MultiLock`, no
+	 * disclosure) — an incomplete measurement presented with full confidence.
+	 * `assessed` must now distinguish the two: null is NOT an observation,
+	 * `level: 'unknown'` (non-null) IS one.
+	 */
+	it('null posture (RDAP unreachable) → assessed: false — an incomplete measurement, not a clean pass', () => {
+		const r = evaluateCscProducts(allPassing(), null, 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.assessed).toBe(false);
+	});
+
+	it('level=unknown but posture object present (RDAP answered, no EPP status) → assessed: true — a real observation (control)', () => {
+		const r = evaluateCscProducts(allPassing(), lp({ level: 'unknown' }), 'a.com', 90, 'A');
+		const m = recFor(r, 'csc_multilock');
+		expect(m.assessed).toBe(true);
+	});
+});
+
+/**
+ * Final review round, item 1 (render side): `formatCscProducts` must use the
+ * per-recommendation `assessed` discriminant for MultiLock exactly like it
+ * already does for the three scan-driven products — a not-assessed MultiLock
+ * must never render the same icon/tag a genuine clean pass gets, in EITHER
+ * format.
+ */
+describe('formatCscProducts — an unassessed MultiLock (null lock posture) renders distinct from a clean pass', () => {
+	function unreachableRdapReport() {
+		return evaluateCscProducts(allPassing(), null, 'rdap-unreachable.com', 90, 'A');
+	}
+
+	it('compact: shows "?" and the unobservable gap text, never the clean-pass "✓" with no disclosure', () => {
+		const compact = formatCscProducts(unreachableRdapReport(), 'compact');
+		const line = compact.split('\n').find((l) => l.includes('CSC MultiLock'));
+		expect(line).toBeDefined();
+		expect(line).not.toContain('✓');
+		expect(line).toContain('?');
+		expect(line!.toLowerCase()).toContain('unobservable');
+	});
+
+	it('full: shows the ❓ / NOT ASSESSED tag, never "➖ … — OK"', () => {
+		const full = formatCscProducts(unreachableRdapReport(), 'full');
+		expect(full).toContain('❓ **CSC MultiLock** — NOT ASSESSED');
+		expect(full).not.toContain('➖ **CSC MultiLock** — OK');
+	});
 });
 
 describe('evaluateCscProducts — scan-driven products', () => {

--- a/test/map-csc-products.spec.ts
+++ b/test/map-csc-products.spec.ts
@@ -42,7 +42,13 @@ function recFor(report: CscProductReport, key: CscProductRecommendation['product
 
 describe('evaluateCscProducts — CSC MultiLock (reads booleans, not level)', () => {
 	it('registry-lock posture (registryLevel true) → not recommended, none', () => {
-		const r = evaluateCscProducts(allPassing(), lp({ level: 'registry-lock', registryLevel: true, transferLocked: true }), 'a.com', 90, 'A');
+		const r = evaluateCscProducts(
+			allPassing(),
+			lp({ level: 'registry-lock', registryLevel: true, transferLocked: true }),
+			'a.com',
+			90,
+			'A',
+		);
 		const m = recFor(r, 'csc_multilock');
 		expect(m.recommended).toBe(false);
 		expect(m.priority).toBe('none');
@@ -57,7 +63,13 @@ describe('evaluateCscProducts — CSC MultiLock (reads booleans, not level)', ()
 	});
 
 	it('registrar-lock posture (registrarLevel true, registryLevel false) → recommended medium', () => {
-		const r = evaluateCscProducts(allPassing(), lp({ level: 'registrar-lock', registrarLevel: true, transferLocked: true }), 'a.com', 90, 'A');
+		const r = evaluateCscProducts(
+			allPassing(),
+			lp({ level: 'registrar-lock', registrarLevel: true, transferLocked: true }),
+			'a.com',
+			90,
+			'A',
+		);
 		const m = recFor(r, 'csc_multilock');
 		expect(m.recommended).toBe(true);
 		expect(m.priority).toBe('medium');
@@ -79,7 +91,13 @@ describe('evaluateCscProducts — CSC MultiLock (reads booleans, not level)', ()
 	});
 
 	it('BOOLEANS guard: level=unlocked but registryLevel=true (server delete lock, no transfer lock) → NOT recommended', () => {
-		const r = evaluateCscProducts(allPassing(), lp({ level: 'unlocked', registryLevel: true, transferLocked: false, deleteLocked: true }), 'a.com', 90, 'A');
+		const r = evaluateCscProducts(
+			allPassing(),
+			lp({ level: 'unlocked', registryLevel: true, transferLocked: false, deleteLocked: true }),
+			'a.com',
+			90,
+			'A',
+		);
 		const m = recFor(r, 'csc_multilock');
 		expect(m.recommended).toBe(false);
 	});
@@ -92,7 +110,11 @@ describe('evaluateCscProducts — scan-driven products', () => {
 	});
 
 	it('dmarc failing with a high finding → recommended high, relatedFindings carries title', () => {
-		const checks = [makeCheck('dmarc', false, [{ title: 'No DMARC record', severity: 'high' }]), makeCheck('ssl', true), makeCheck('dnssec', true)];
+		const checks = [
+			makeCheck('dmarc', false, [{ title: 'No DMARC record', severity: 'high' }]),
+			makeCheck('ssl', true),
+			makeCheck('dnssec', true),
+		];
 		const m = recFor(evaluateCscProducts(checks, null, 'a.com', 50, 'F'), 'managed_dmarc');
 		expect(m.recommended).toBe(true);
 		expect(m.priority).toBe('high');
@@ -100,7 +122,11 @@ describe('evaluateCscProducts — scan-driven products', () => {
 	});
 
 	it('dmarc failing with only medium findings → priority medium', () => {
-		const checks = [makeCheck('dmarc', false, [{ title: 'Weak DMARC policy', severity: 'medium' }]), makeCheck('ssl', true), makeCheck('dnssec', true)];
+		const checks = [
+			makeCheck('dmarc', false, [{ title: 'Weak DMARC policy', severity: 'medium' }]),
+			makeCheck('ssl', true),
+			makeCheck('dnssec', true),
+		];
 		expect(recFor(evaluateCscProducts(checks, null, 'a.com', 60, 'D'), 'managed_dmarc').priority).toBe('medium');
 	});
 
@@ -113,20 +139,35 @@ describe('evaluateCscProducts — scan-driven products', () => {
 	});
 
 	it('ssl failing → digital_certificates recommended; ssl passing → not', () => {
-		const fail = [makeCheck('dmarc', true), makeCheck('ssl', false, [{ title: 'Certificate expired', severity: 'high' }]), makeCheck('dnssec', true)];
+		const fail = [
+			makeCheck('dmarc', true),
+			makeCheck('ssl', false, [{ title: 'Certificate expired', severity: 'high' }]),
+			makeCheck('dnssec', true),
+		];
 		expect(recFor(evaluateCscProducts(fail, null, 'a.com', 60, 'D'), 'digital_certificates').recommended).toBe(true);
 		expect(recFor(evaluateCscProducts(allPassing(), null, 'a.com', 90, 'A'), 'digital_certificates').recommended).toBe(false);
 	});
 
 	it('dnssec failing → dnssec_management medium; absent → low', () => {
-		const fail = [makeCheck('dmarc', true), makeCheck('ssl', true), makeCheck('dnssec', false, [{ title: 'DNSSEC not enabled', severity: 'medium' }])];
+		const fail = [
+			makeCheck('dmarc', true),
+			makeCheck('ssl', true),
+			makeCheck('dnssec', false, [{ title: 'DNSSEC not enabled', severity: 'medium' }]),
+		];
 		expect(recFor(evaluateCscProducts(fail, null, 'a.com', 70, 'C'), 'dnssec_management').priority).toBe('medium');
 		const absent = [makeCheck('dmarc', true), makeCheck('ssl', true)];
 		expect(recFor(evaluateCscProducts(absent, null, 'a.com', 70, 'C'), 'dnssec_management').priority).toBe('low');
 	});
 
 	it('relatedFindings excludes info-severity findings', () => {
-		const checks = [makeCheck('dmarc', false, [{ title: 'Real gap', severity: 'high' }, { title: 'Just info', severity: 'info' }]), makeCheck('ssl', true), makeCheck('dnssec', true)];
+		const checks = [
+			makeCheck('dmarc', false, [
+				{ title: 'Real gap', severity: 'high' },
+				{ title: 'Just info', severity: 'info' },
+			]),
+			makeCheck('ssl', true),
+			makeCheck('dnssec', true),
+		];
 		const m = recFor(evaluateCscProducts(checks, null, 'a.com', 50, 'F'), 'managed_dmarc');
 		expect(m.relatedFindings).toContain('Real gap');
 		expect(m.relatedFindings).not.toContain('Just info');
@@ -136,8 +177,19 @@ describe('evaluateCscProducts — scan-driven products', () => {
 describe('evaluateCscProducts — report shape', () => {
 	it('exactly 4 recommendations in fixed order; recommendedCount matches; passthrough fields', () => {
 		const posture = lp({ level: 'unlocked', transferLocked: false });
-		const r = evaluateCscProducts([makeCheck('dmarc', false, [{ title: 'x', severity: 'high' }]), makeCheck('ssl', true), makeCheck('dnssec', true)], posture, 'shape.com', 42, 'F');
-		expect(r.recommendations.map((x) => x.product)).toEqual(['csc_multilock', 'managed_dmarc', 'digital_certificates', 'dnssec_management']);
+		const r = evaluateCscProducts(
+			[makeCheck('dmarc', false, [{ title: 'x', severity: 'high' }]), makeCheck('ssl', true), makeCheck('dnssec', true)],
+			posture,
+			'shape.com',
+			42,
+			'F',
+		);
+		expect(r.recommendations.map((x) => x.product)).toEqual([
+			'csc_multilock',
+			'managed_dmarc',
+			'digital_certificates',
+			'dnssec_management',
+		]);
 		expect(r.recommendedCount).toBe(r.recommendations.filter((x) => x.recommended).length);
 		expect(r.recommendedCount).toBe(2); // multilock high + dmarc high
 		expect(r.lockPosture).toEqual(posture);
@@ -147,7 +199,13 @@ describe('evaluateCscProducts — report shape', () => {
 	});
 
 	it('all-clean: all-pass checks + registry-lock posture → recommendedCount 0, every priority none', () => {
-		const r = evaluateCscProducts(allPassing(), lp({ level: 'registry-lock', registryLevel: true, transferLocked: true }), 'clean.com', 98, 'A+');
+		const r = evaluateCscProducts(
+			allPassing(),
+			lp({ level: 'registry-lock', registryLevel: true, transferLocked: true }),
+			'clean.com',
+			98,
+			'A+',
+		);
 		expect(r.recommendedCount).toBe(0);
 		expect(r.recommendations.every((x) => x.priority === 'none')).toBe(true);
 		expect(r.recommendations.every((x) => x.recommended === false)).toBe(true);
@@ -171,7 +229,9 @@ describe('extractLockPosture', () => {
 			category: 'rdap',
 			passed: false,
 			score: 0,
-			findings: [{ category: 'rdap', title: 'RDAP lookup failed', severity: 'low', detail: '', metadata: { registrarSource: 'lookup_failed' } }],
+			findings: [
+				{ category: 'rdap', title: 'RDAP lookup failed', severity: 'low', detail: '', metadata: { registrarSource: 'lookup_failed' } },
+			],
 		} as unknown as CheckResult;
 		expect(extractLockPosture(rdap)).toBeNull();
 	});
@@ -405,6 +465,87 @@ describe('evaluateCscProducts: a total outage (all checks attempted, none comple
 		const dmarc = report.recommendations.find((r) => r.product === 'managed_dmarc')!;
 		expect(dmarc.recommended).toBe(true);
 		expect(dmarc.priority).toBe('high');
+	});
+});
+
+/**
+ * Task R4 (residual of the correctness-defect campaign): the PRICED category's
+ * OWN check can be the one that failed transiently, while OTHER categories
+ * completed normally (`assessed: true` overall). Before this fix,
+ * `evalScanProduct` read the transient CheckResult's `passed: false` and its
+ * synthetic "check error" finding (severity `high`, no real content) as a
+ * genuine DMARC gap, pricing an upsell — "DMARC present but not passing" —
+ * against a category nobody actually measured. Mirrors the equivalent
+ * `map_compliance`/`generate_fix_plan` fix (see `src/lib/map-compliance.ts:272`
+ * for the reference implementation this is modeled on).
+ */
+describe('evaluateCscProducts: the priced category itself failed transiently (not the whole scan)', () => {
+	async function buildFixtures() {
+		const { buildCheckResult, createFinding } = await import('@blackveil/dns-checks/scoring');
+		const transientDmarc = {
+			...buildCheckResult('dmarc', [
+				createFinding('dmarc', 'DMARC check error', 'high', 'Check failed: DNS query failed', { errorKind: 'dns_error' }),
+			]),
+			score: 0,
+			passed: false,
+			checkStatus: 'error' as const,
+			partial: true,
+		};
+		// A genuine, non-transient high-severity finding on a DIFFERENT category —
+		// this one MUST still be priced. A wrong implementation that filters on
+		// `severity === 'high'` instead of the errorKind marker would swallow this
+		// too, which is exactly what this fixture is designed to catch.
+		const genuineSsl = {
+			...buildCheckResult('ssl', [createFinding('ssl', 'Certificate expired', 'high', 'The TLS certificate expired 3 days ago')]),
+			score: 0,
+			passed: false,
+		};
+		return { transientDmarc, genuineSsl };
+	}
+
+	it('managed_dmarc is NOT priced as an upsell when DMARC itself is the transient category, but digital_certificates IS priced from the genuine ssl finding', async () => {
+		const { evaluateCscProducts: evaluate } = await import('../src/tools/map-csc-products');
+		const { transientDmarc, genuineSsl } = await buildFixtures();
+
+		const report = evaluate([transientDmarc, genuineSsl], null, 'partial-transient.example', 55, 'D');
+
+		expect(report.assessed).toBe(true); // ssl completed
+		expect(report.caveat).toBeNull();
+
+		const dmarc = report.recommendations.find((r) => r.product === 'managed_dmarc')!;
+		expect(dmarc.recommended).toBe(false);
+		expect(dmarc.priority).toBe('none');
+		expect(dmarc.relatedFindings).not.toContain('DMARC check error');
+
+		const ssl = report.recommendations.find((r) => r.product === 'digital_certificates')!;
+		expect(ssl.recommended).toBe(true);
+		expect(ssl.priority).toBe('high');
+		expect(ssl.relatedFindings).toContain('Certificate expired');
+	});
+
+	it('the transient category is REPRESENTED (not assessed), not silently dropped from the recommendation list', async () => {
+		const { evaluateCscProducts: evaluate } = await import('../src/tools/map-csc-products');
+		const { transientDmarc, genuineSsl } = await buildFixtures();
+
+		const report = evaluate([transientDmarc, genuineSsl], null, 'partial-transient.example', 55, 'D');
+		const dmarc = report.recommendations.find((r) => r.product === 'managed_dmarc')!;
+
+		// Not "DMARC policy in effect" (a false pass) and not "DMARC present but not
+		// passing" (a phantom gap) — a distinct, honest "not assessed" wording.
+		expect(dmarc.justifyingGap.toLowerCase()).toContain('not assessed');
+		expect(dmarc.justifyingGap.toLowerCase()).not.toContain('policy in effect');
+	});
+
+	it('formatCscProducts renders the transient category as not-assessed prose, not a silent omission', async () => {
+		const { evaluateCscProducts: evaluate, formatCscProducts } = await import('../src/tools/map-csc-products');
+		const { transientDmarc, genuineSsl } = await buildFixtures();
+
+		const report = evaluate([transientDmarc, genuineSsl], null, 'partial-transient.example', 55, 'D');
+
+		for (const text of [formatCscProducts(report, 'full'), formatCscProducts(report, 'compact')]) {
+			expect(text.toLowerCase()).toContain('dmarc');
+			expect(text.toLowerCase()).not.toContain('dmarc check error');
+		}
 	});
 });
 

--- a/test/map-csc-products.spec.ts
+++ b/test/map-csc-products.spec.ts
@@ -476,7 +476,7 @@ describe('evaluateCscProducts: a total outage (all checks attempted, none comple
  * synthetic "check error" finding (severity `high`, no real content) as a
  * genuine DMARC gap, pricing an upsell — "DMARC present but not passing" —
  * against a category nobody actually measured. Mirrors the equivalent
- * `map_compliance`/`generate_fix_plan` fix (see `src/lib/map-compliance.ts:272`
+ * `map_compliance`/`generate_fix_plan` fix (see `src/tools/map-compliance.ts:272`
  * for the reference implementation this is modeled on).
  */
 describe('evaluateCscProducts: the priced category itself failed transiently (not the whole scan)', () => {
@@ -515,11 +515,13 @@ describe('evaluateCscProducts: the priced category itself failed transiently (no
 		const dmarc = report.recommendations.find((r) => r.product === 'managed_dmarc')!;
 		expect(dmarc.recommended).toBe(false);
 		expect(dmarc.priority).toBe('none');
+		expect(dmarc.assessed).toBe(false);
 		expect(dmarc.relatedFindings).not.toContain('DMARC check error');
 
 		const ssl = report.recommendations.find((r) => r.product === 'digital_certificates')!;
 		expect(ssl.recommended).toBe(true);
 		expect(ssl.priority).toBe('high');
+		expect(ssl.assessed).toBe(true);
 		expect(ssl.relatedFindings).toContain('Certificate expired');
 	});
 
@@ -536,15 +538,67 @@ describe('evaluateCscProducts: the priced category itself failed transiently (no
 		expect(dmarc.justifyingGap.toLowerCase()).not.toContain('policy in effect');
 	});
 
-	it('formatCscProducts renders the transient category as not-assessed prose, not a silent omission', async () => {
-		const { evaluateCscProducts: evaluate, formatCscProducts } = await import('../src/tools/map-csc-products');
+	/**
+	 * F6 (review round 1): `unassessedScanProduct`'s "checks attempted, none
+	 * completed" wording is TRUE for the whole-report `'all_transient'` case
+	 * (every category failed) but was, before this fix, ALSO used verbatim for
+	 * THIS per-category case — where digital_certificates (`genuineSsl`)
+	 * completed in the very same scan. "none completed" is a false statement
+	 * about a scan where a sibling category plainly did complete.
+	 */
+	it('the per-category transient wording does not falsely claim the whole scan failed to complete (F6)', async () => {
+		const { evaluateCscProducts: evaluate } = await import('../src/tools/map-csc-products');
 		const { transientDmarc, genuineSsl } = await buildFixtures();
 
 		const report = evaluate([transientDmarc, genuineSsl], null, 'partial-transient.example', 55, 'D');
+		const dmarc = report.recommendations.find((r) => r.product === 'managed_dmarc')!;
 
-		for (const text of [formatCscProducts(report, 'full'), formatCscProducts(report, 'compact')]) {
-			expect(text.toLowerCase()).toContain('dmarc');
-			expect(text.toLowerCase()).not.toContain('dmarc check error');
+		expect(dmarc.justifyingGap.toLowerCase()).not.toContain('none completed');
+		expect(dmarc.justifyingGap.toLowerCase()).toMatch(/this category/);
+
+		// Control: the WHOLE-report all-transient case genuinely has nothing that
+		// completed, so "none completed" IS true there and must still render.
+		const { unassessedScanProduct } = await import('../src/tools/map-csc-products');
+		const wholeReport = unassessedScanProduct('managed_dmarc', 'DMARC', 'all_transient');
+		expect(wholeReport.justifyingGap.toLowerCase()).toContain('none completed');
+	});
+
+	/**
+	 * F3 (review round 1): the original version of this test only asserted
+	 * `toContain('dmarc')` (satisfied by the ever-present product name "Managed
+	 * DMARC") and `not.toContain('dmarc check error')` (satisfied by an EMPTY
+	 * `relatedFindings`, regardless of how the row otherwise rendered) — both
+	 * stayed GREEN under a full silent-drop mutation (compact mode rendering
+	 * `✓ Managed DMARC` with no gap text at all, identical to a clean pass), so
+	 * neither assertion was actually testing what the title claimed. Rewritten
+	 * to directly compare the TRANSIENT render against a CLEAN-PASS render of
+	 * the same product and assert they differ — the property F1 exists to
+	 * guarantee — instead of grepping for a substring a silent drop can still
+	 * satisfy.
+	 */
+	it('formatCscProducts renders an unassessed transient product as visually DISTINCT from a genuine clean pass — not a silent omission', async () => {
+		const { evaluateCscProducts: evaluate, formatCscProducts } = await import('../src/tools/map-csc-products');
+		const { buildCheckResult } = await import('@blackveil/dns-checks/scoring');
+		const { transientDmarc, genuineSsl } = await buildFixtures();
+		const cleanDmarc = { ...buildCheckResult('dmarc', []), score: 100, passed: true };
+
+		const transientReport = evaluate([transientDmarc, genuineSsl], null, 'partial-transient.example', 55, 'D');
+		const cleanReport = evaluate([cleanDmarc, genuineSsl], null, 'partial-transient.example', 55, 'D');
+
+		const dmarcLine = (text: string) => text.split('\n').find((l) => l.includes('Managed DMARC'))!;
+
+		for (const format of ['full', 'compact'] as const) {
+			const transientLine = dmarcLine(formatCscProducts(transientReport, format));
+			const cleanLine = dmarcLine(formatCscProducts(cleanReport, format));
+
+			// The core F1 property: the two states must never render identically.
+			expect(transientLine).not.toBe(cleanLine);
+			// And specifically via the markers a clean pass uses in each mode —
+			// the transient render must use NEITHER.
+			expect(transientLine).not.toContain('✓');
+			expect(transientLine).not.toContain('➖');
+			expect(transientLine.toLowerCase()).not.toContain('— ok');
+			expect(transientLine.toLowerCase()).toMatch(/not assessed/);
 		}
 	});
 });

--- a/test/ownership-attribution.spec.ts
+++ b/test/ownership-attribution.spec.ts
@@ -65,7 +65,7 @@ describe('classifyOwnership — §4 fixture corpus (2026-07-26 correctness-defec
 		expect(result.signals).toContain('ns_shared_provider_complete');
 	});
 
-	it('does NOT attribute anz.co.nz or westpac.co.nz to the seed — the 1/6 Akamai trap', async () => {
+	it('does NOT attribute anz.co.nz or westpac.co.nz to the seed — the 1/6 Akamai trap (F5: tightened to exact verdict)', async () => {
 		const { classifyOwnership } = await loadModule();
 		const anzResult = classifyOwnership({
 			seedDomain: SEED,
@@ -81,7 +81,7 @@ describe('classifyOwnership — §4 fixture corpus (2026-07-26 correctness-defec
 			]),
 			isSharedNsHost,
 		});
-		expect(anzResult.verdict).not.toBe('owned_by_seed');
+		expect(anzResult.verdict).toBe('third_party');
 
 		const westpacResult = classifyOwnership({
 			seedDomain: SEED,
@@ -97,7 +97,7 @@ describe('classifyOwnership — §4 fixture corpus (2026-07-26 correctness-defec
 			]),
 			isSharedNsHost,
 		});
-		expect(westpacResult.verdict).not.toBe('owned_by_seed');
+		expect(westpacResult.verdict).toBe('third_party');
 	});
 
 	it('a 3-of-6 overlap confined entirely to shared-provider NS hosts is NOT treated as dedicated-NS evidence', async () => {
@@ -117,7 +117,6 @@ describe('classifyOwnership — §4 fixture corpus (2026-07-26 correctness-defec
 			registration: registered([SEED_NS[0], SEED_NS[1], SEED_NS[2], 'x1-1.akam.net', 'x2-2.akam.net', 'x3-3.akam.net']),
 			isSharedNsHost,
 		});
-		expect(result.verdict).not.toBe('owned_by_seed');
 		expect(result.verdict).toBe('third_party');
 	});
 
@@ -142,7 +141,6 @@ describe('classifyOwnership — §4 fixture corpus (2026-07-26 correctness-defec
 			]),
 			isSharedNsHost,
 		});
-		expect(result.verdict).not.toBe('owned_by_seed');
 		expect(result.verdict).toBe('third_party');
 	});
 
@@ -237,63 +235,112 @@ describe('isInBailiwick', () => {
 			registration: registered(['ns1.evilbnz.co.nz', 'ns2.evilbnz.co.nz']),
 			isSharedNsHost,
 		});
-		expect(result.verdict).not.toBe('owned_by_seed');
 		expect(result.verdict).toBe('third_party');
 	});
 });
 
-describe('passesAttributionGuard — D4 minimum label length (CLASSIFIER, not a suppressor)', () => {
-	it('always passes for owned_by_seed regardless of label length', async () => {
-		const { passesAttributionGuard } = await loadModule();
-		expect(passesAttributionGuard('owned_by_seed', 'bnz', false)).toBe(true);
+describe('F4 (security, flagged not fixed): attacker-influenceable evidence branches — pinning CURRENT behaviour', () => {
+	// These three flags are NOT gathered by any caller in this slice, but the
+	// branches exist and were previously untested. Per the reviewer's F4
+	// instruction, the verdict mapping itself is NOT being changed here (that
+	// call belongs to the design owner) — these tests only pin what the
+	// current code does, so a future change to the mapping is a deliberate,
+	// visible diff here rather than a silent behaviour change.
+	it('soaInBailiwick ALONE (no NS evidence at all) currently produces owned_by_seed/strong', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'evilbnz.co.nz',
+			registration: registered(['ns1.totally-unrelated-registrar.example']),
+			isSharedNsHost,
+			soaInBailiwick: true,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('strong');
+		expect(result.signals).toContain('soa_in_bailiwick');
 	});
 
-	it('does not pass a short-label non-owned candidate with no corroboration', async () => {
-		const { passesAttributionGuard } = await loadModule();
-		expect(passesAttributionGuard('third_party', 'hnz', false)).toBe(false);
+	it('spfIncludesSeedApex ALONE currently produces owned_by_seed/strong — attacker-controllable, unresolved', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'evilbnz.co.nz',
+			registration: registered(['ns1.totally-unrelated-registrar.example']),
+			isSharedNsHost,
+			spfIncludesSeedApex: true,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('strong');
+		expect(result.signals).toContain('spf_include_seed');
 	});
 
-	it('passes a short-label non-owned candidate when corroborated', async () => {
-		const { passesAttributionGuard } = await loadModule();
-		expect(passesAttributionGuard('third_party', 'hnz', true)).toBe(true);
-	});
-
-	it('passes a non-owned candidate at or above the minimum length with no corroboration needed', async () => {
-		const { passesAttributionGuard } = await loadModule();
-		expect(passesAttributionGuard('third_party', 'bankof', false)).toBe(true);
+	it('httpRedirectToSeedApex ALONE currently produces owned_by_seed/strong — attacker-controllable, unresolved', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'evilbnz.co.nz',
+			registration: registered(['ns1.totally-unrelated-registrar.example']),
+			isSharedNsHost,
+			httpRedirectToSeedApex: true,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('strong');
+		expect(result.signals).toContain('http_redirect_seed');
 	});
 });
 
-describe('capAttributionSeverity — DEMOTE NEVER DELETE (controller amendment 1)', () => {
-	it('never caps owned_by_seed, regardless of label length or corroboration', async () => {
-		const { capAttributionSeverity } = await loadModule();
-		expect(capAttributionSeverity('owned_by_seed', 'bnz', false)).toBe('unbounded');
-		expect(capAttributionSeverity('owned_by_seed', 'x', false)).toBe('unbounded');
+describe('attributionConfidence — D4 minimum label length (WORDING classifier, renamed from passesAttributionGuard, never a severity gate)', () => {
+	it('always corroborated for owned_by_seed regardless of label length', async () => {
+		const { attributionConfidence } = await loadModule();
+		expect(attributionConfidence('owned_by_seed', 'bnz', false)).toBe('corroborated');
 	});
 
-	it("caps a short-label, non-corroborated non-owned candidate at 'info' — but the type offers no way to omit the finding", async () => {
-		const { capAttributionSeverity } = await loadModule();
-		// bnz is the campaign's own seed brand and is 3 characters — this is
-		// EXACTLY the case the human partner's "demote never delete" ruling
-		// exists to protect: it must be capped, never dropped.
-		expect(capAttributionSeverity('third_party', 'bnz', false)).toBe('info');
-		expect(capAttributionSeverity('unattributed', 'hnz', false)).toBe('info');
+	it('uncorroborated for a short-label non-owned candidate with no corroboration', async () => {
+		const { attributionConfidence } = await loadModule();
+		expect(attributionConfidence('third_party', 'hnz', false)).toBe('uncorroborated');
 	});
 
-	it('does not cap a short-label non-owned candidate when corroborated', async () => {
-		const { capAttributionSeverity } = await loadModule();
-		expect(capAttributionSeverity('third_party', 'hnz', true)).toBe('unbounded');
+	it('corroborated for a short-label non-owned candidate when the caller supplies corroboration', async () => {
+		const { attributionConfidence } = await loadModule();
+		expect(attributionConfidence('third_party', 'hnz', true)).toBe('corroborated');
 	});
 
-	it('does not cap a non-owned candidate at/above the minimum label length', async () => {
+	it('corroborated for a non-owned candidate at or above the minimum length with no corroboration needed', async () => {
+		const { attributionConfidence } = await loadModule();
+		expect(attributionConfidence('third_party', 'bankof', false)).toBe('corroborated');
+	});
+});
+
+describe('capAttributionSeverity — F1 FIX: severity gates on ownership FIRST, never on label length/corroboration', () => {
+	it('never caps owned_by_seed', async () => {
 		const { capAttributionSeverity } = await loadModule();
-		expect(capAttributionSeverity('third_party', 'bankof', false)).toBe('unbounded');
+		expect(capAttributionSeverity('owned_by_seed')).toBe('unbounded');
+	});
+
+	it("caps a SHORT-label non-owned candidate at 'info' (bnz is the campaign's own seed brand, 3 chars — demote never delete)", async () => {
+		const { capAttributionSeverity } = await loadModule();
+		expect(capAttributionSeverity('third_party')).toBe('info');
+		expect(capAttributionSeverity('unattributed')).toBe('info');
+	});
+
+	it("F1 REGRESSION PIN: caps a LONG-label (>= MIN_ATTRIBUTION_LABEL_LENGTH) non-owned candidate at 'info' too — e.g. a competing bank like westpac must NEVER come back unbounded merely because its label is long enough to pass the D4 wording guard", async () => {
+		// This is the exact defect F1 flagged: the first implementation
+		// consulted attributionConfidence('third_party', 'westpac', false) —
+		// which is 'corroborated' because 'westpac'.length (7) >=
+		// MIN_ATTRIBUTION_LABEL_LENGTH (5) — and returned 'unbounded'. Label
+		// length must NEVER be able to lift the ceiling off a non-owned verdict.
+		const { capAttributionSeverity, MIN_ATTRIBUTION_LABEL_LENGTH } = await loadModule();
+		expect('westpac'.length).toBeGreaterThanOrEqual(MIN_ATTRIBUTION_LABEL_LENGTH);
+		expect(capAttributionSeverity('third_party')).toBe('info');
 	});
 
 	it('the return type structurally cannot represent "no finding" — only a Severity or the unbounded sentinel', async () => {
 		const { capAttributionSeverity } = await loadModule();
-		const capped = capAttributionSeverity('third_party', 'hnz', false);
-		const uncapped = capAttributionSeverity('third_party', 'bankof', false);
+		const capped = capAttributionSeverity('third_party');
+		const uncapped = capAttributionSeverity('owned_by_seed');
 		// Both are truthy, non-null strings — a caller cannot `if (!cap) continue`
 		// their way into suppressing a finding, because there is no falsy value
 		// this function can ever return.
@@ -307,8 +354,8 @@ describe('capAttributionSeverity — DEMOTE NEVER DELETE (controller amendment 1
 describe('load-bearing safety property (controller amendment 2): severity gates ONLY on owned_by_seed vs everything else', () => {
 	it('third_party and unattributed are equally non-owned for capping purposes — the distinction is wording-only', async () => {
 		const { capAttributionSeverity } = await loadModule();
-		const thirdPartyCap = capAttributionSeverity('third_party', 'x', false);
-		const unattributedCap = capAttributionSeverity('unattributed', 'x', false);
+		const thirdPartyCap = capAttributionSeverity('third_party');
+		const unattributedCap = capAttributionSeverity('unattributed');
 		expect(thirdPartyCap).toBe(unattributedCap);
 		expect(thirdPartyCap).toBe('info');
 	});

--- a/test/ownership-attribution.spec.ts
+++ b/test/ownership-attribution.spec.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: BUSL-1.1
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
 import { isSharedNsHost } from '../src/tenants/discovery/shared-ns-hosts';
 import { UNKNOWN_REASON_PHRASES } from '../src/lib/registration-state';
 import type { RegistrationState } from '../src/lib/registration-state';
@@ -358,5 +358,151 @@ describe('load-bearing safety property (controller amendment 2): severity gates 
 		const unattributedCap = capAttributionSeverity('unattributed');
 		expect(thirdPartyCap).toBe(unattributedCap);
 		expect(thirdPartyCap).toBe('info');
+	});
+});
+
+describe('buildNonOwnedGateFinding — cross-tool wording parity (F1, 2026-07-27 fix round 2)', () => {
+	let restoreAfterThisTest: (() => void) | undefined;
+	afterEach(() => {
+		restoreAfterThisTest?.();
+		restoreAfterThisTest = undefined;
+	});
+
+	/**
+	 * F1: check-lookalikes.ts and check-shadow-domains.ts each used to
+	 * hand-roll their own copy of the non-owned hedge sentence and had
+	 * already drifted apart within a single slice ("Its DNS/mail posture" +
+	 * no brand quote in lookalikes vs "Its mail posture" + quoted `"${brand}"`
+	 * in shadow-domains) before review caught it. Both now call the SAME
+	 * `buildNonOwnedGateFinding()` (`src/lib/ownership-attribution.ts`) with
+	 * the same `postureNoun`. This is a UNIT-level pin on the shared function
+	 * itself: if the two call sites ever again pass different `postureNoun`
+	 * values, this test does not catch that (it can't see call-site source —
+	 * see the end-to-end pin below for that). What it pins is that the shared
+	 * function, given the SAME inputs, produces byte-identical output
+	 * regardless of category/domain-key — i.e. there is no per-tool special
+	 * casing hiding inside the shared function that could reintroduce drift.
+	 */
+	it('produces byte-identical hedge wording for two different (category, domainMetadataKey) callers given the same postureNoun', async () => {
+		const { buildNonOwnedGateFinding, classifyOwnership } = await loadModule();
+		const ownership = classifyOwnership({
+			seedDomain: 'contoso.com',
+			seedNs: ['ns1.primary-dns.com'],
+			candidateDomain: 'contos0.com',
+			registration: registered(['ns1.attacker-dns.com']),
+			isSharedNsHost,
+		});
+		expect(ownership.verdict).toBe('third_party');
+
+		const rawFinding = {
+			category: 'lookalikes' as const,
+			title: 'raw',
+			severity: 'medium' as const,
+			detail: 'raw detail',
+			metadata: { lookalikeDomain: 'contos0.com' },
+		};
+		const lookalikeStyle = buildNonOwnedGateFinding(rawFinding, ownership, 'contoso', false, 'info', {
+			category: 'lookalikes',
+			domainMetadataKey: 'lookalikeDomain',
+			postureNoun: 'DNS/mail posture',
+		});
+
+		const shadowStyleRaw = { ...rawFinding, category: 'shadow_domains' as const, metadata: { variant: 'contos0.com' } };
+		const shadowStyle = buildNonOwnedGateFinding(shadowStyleRaw, ownership, 'contoso', false, 'info', {
+			category: 'shadow_domains',
+			domainMetadataKey: 'variant',
+			postureNoun: 'DNS/mail posture',
+		});
+
+		// Only the finding category differs (each tool's own CheckCategory) —
+		// the title and detail (the customer-facing legal-hedge sentence) are
+		// byte-for-byte identical, since both resolve to the same candidate
+		// domain string and the same postureNoun.
+		expect(lookalikeStyle.title).toBe(shadowStyle.title);
+		expect(lookalikeStyle.detail).toBe(shadowStyle.detail);
+		expect(lookalikeStyle.category).toBe('lookalikes');
+		expect(shadowStyle.category).toBe('shadow_domains');
+	});
+
+	/**
+	 * End-to-end pin (proves the REAL call sites, not just the shared
+	 * function, agree): runs both `checkLookalikes` and `checkShadowDomains`
+	 * against a third_party MX-having candidate and asserts their emitted
+	 * findings share the exact fixed frame around the posture noun. This is
+	 * what catches a FUTURE regression where one tool's call site is edited
+	 * to pass a different `postureNoun` while the other is not — the unit
+	 * test above cannot see that (it calls the shared function directly with
+	 * matched arguments), but this test exercises the actual production call
+	 * sites in `check-lookalikes.ts` and `check-shadow-domains.ts`.
+	 */
+	it('check-lookalikes.ts and check-shadow-domains.ts emit the same fixed posture-noun frame end-to-end', async () => {
+		const { setupFetchMock, createDohResponse } = await import('./helpers/dns-mock');
+		const { restore } = setupFetchMock();
+		restoreAfterThisTest = restore;
+		{
+			function parseDohQuery(input: string | URL | Request): { name: string; type: string } {
+				const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+				const parsed = new URL(url);
+				return { name: parsed.searchParams.get('name') ?? '', type: parsed.searchParams.get('type') ?? '' };
+			}
+
+			// --- check_lookalikes: seed contoso.com, third-party candidate with MX ---
+			globalThis.fetch = (async (input: string | URL | Request) => {
+				const { name, type } = parseDohQuery(input);
+				if (name === 'contoso.com') {
+					if (type === 'NS' || type === '2') {
+						return createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]);
+					}
+				}
+				if (name === 'contos0.com') {
+					if (type === 'NS' || type === '2') {
+						return createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.attacker-dns.com.' }]);
+					}
+					if (type === 'MX' || type === '15') {
+						return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.evil.com.' }]);
+					}
+				}
+				return createDohResponse([], []);
+			}) as unknown as typeof fetch;
+			const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+			const lookalikeResult = await checkLookalikes('contoso.com');
+			const lookalikeFinding = lookalikeResult.findings.find((f) => f.metadata?.ownershipVerdict === 'third_party');
+			expect(lookalikeFinding).toBeDefined();
+
+			// --- check_shadow_domains: seed example.com, third-party variant with MX, no SPF/DMARC ---
+			globalThis.fetch = (async (input: string | URL | Request) => {
+				const { name, type } = parseDohQuery(input);
+				if (name === 'example.com' && (type === 'MX' || type === '15')) {
+					return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.example.com.' }]);
+				}
+				if (name === 'example.net') {
+					if (type === 'NS' || type === '2') {
+						return createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.registrar.com.' }]);
+					}
+					if (type === 'A' || type === '1') {
+						return createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]);
+					}
+					if (type === 'MX' || type === '15') {
+						return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.shadow.com.' }]);
+					}
+				}
+				return createDohResponse([], []);
+			}) as unknown as typeof fetch;
+			const { checkShadowDomains } = await import('../src/tools/check-shadow-domains');
+			const shadowResult = await checkShadowDomains('example.com');
+			const shadowFinding = shadowResult.findings.find(
+				(f) =>
+					(f.metadata as { variant?: string } | undefined)?.variant === 'example.net' && f.metadata?.ownershipVerdict === 'third_party',
+			);
+			expect(shadowFinding).toBeDefined();
+
+			// The fixed frame around the posture noun — everything except the
+			// noun itself and the candidate-domain substitutions — must be
+			// byte-identical between the two tools.
+			const FRAME =
+				'is reported for awareness only: no action by the scanned organisation is implied, and this finding asserts no control over';
+			expect(lookalikeFinding!.detail).toContain(`DNS/mail posture ${FRAME}`);
+			expect(shadowFinding!.detail).toContain(`DNS/mail posture ${FRAME}`);
+		}
 	});
 });

--- a/test/ownership-attribution.spec.ts
+++ b/test/ownership-attribution.spec.ts
@@ -1,0 +1,315 @@
+// SPDX-License-Identifier: BUSL-1.1
+import { describe, it, expect } from 'vitest';
+import { isSharedNsHost } from '../src/tenants/discovery/shared-ns-hosts';
+import { UNKNOWN_REASON_PHRASES } from '../src/lib/registration-state';
+import type { RegistrationState } from '../src/lib/registration-state';
+
+function registered(ns: string[]): RegistrationState {
+	return { state: 'registered', ns, evidence: ['ns'] };
+}
+const unregistered: RegistrationState = { state: 'unregistered' };
+function unknown(reason: RegistrationState extends { state: 'unknown'; reason: infer R } ? R : never): RegistrationState {
+	return { state: 'unknown', reason } as RegistrationState;
+}
+
+const SEED = 'bnz.co.nz';
+const SEED_NS = ['a1-97.akam.net', 'a3-67.akam.net', 'a8-66.akam.net', 'a9-65.akam.net', 'a16-65.akam.net', 'a24-64.akam.net'];
+const BNZ_APEX_NS = ['ns1.bnz.co.nz', 'ns2.bnz.co.nz', 'ns3.bnz.co.nz', 'ns4.bnz.co.nz'];
+
+async function loadModule() {
+	return import('../src/lib/ownership-attribution');
+}
+
+describe('classifyOwnership — §4 fixture corpus (2026-07-26 correctness-defects design)', () => {
+	it('classifies in-bailiwick NZ/global variants as owned_by_seed (strong)', async () => {
+		const { classifyOwnership } = await loadModule();
+		for (const domain of ['bnz.nz', 'bnz.co', 'bnz.org.nz', 'bnz.net.nz', 'bnz.sg']) {
+			const result = classifyOwnership({
+				seedDomain: SEED,
+				seedNs: SEED_NS,
+				candidateDomain: domain,
+				registration: registered(BNZ_APEX_NS),
+				isSharedNsHost,
+			});
+			expect(result.verdict).toBe('owned_by_seed');
+			expect(result.strength).toBe('strong');
+			expect(result.signals).toContain('ns_in_bailiwick');
+		}
+	});
+
+	it('classifies bankofnewzealand.co.nz / .com as owned_by_seed via in-bailiwick NS', async () => {
+		const { classifyOwnership } = await loadModule();
+		for (const domain of ['bankofnewzealand.co.nz', 'bankofnewzealand.com']) {
+			const result = classifyOwnership({
+				seedDomain: SEED,
+				seedNs: SEED_NS,
+				candidateDomain: domain,
+				registration: registered(BNZ_APEX_NS),
+				isSharedNsHost,
+			});
+			expect(result.verdict).toBe('owned_by_seed');
+		}
+	});
+
+	it('classifies bnzpartners.co.nz as owned_by_seed via a complete (6/6) shared-provider match — medium strength', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'bnzpartners.co.nz',
+			registration: registered(SEED_NS.slice()),
+			isSharedNsHost,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('medium');
+		expect(result.signals).toContain('ns_shared_provider_complete');
+	});
+
+	it('does NOT attribute anz.co.nz or westpac.co.nz to the seed — the 1/6 Akamai trap', async () => {
+		const { classifyOwnership } = await loadModule();
+		const anzResult = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'anz.co.nz',
+			registration: registered([
+				'a1-6.akam.net',
+				'a3-66.akam.net',
+				'a6-65.akam.net',
+				'a9-65.akam.net',
+				'a12-66.akam.net',
+				'a28-67.akam.net',
+			]),
+			isSharedNsHost,
+		});
+		expect(anzResult.verdict).not.toBe('owned_by_seed');
+
+		const westpacResult = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'westpac.co.nz',
+			registration: registered([
+				'a1-55.akam.net',
+				'a3-67.akam.net',
+				'a6-65.akam.net',
+				'a7-64.akam.net',
+				'a14-65.akam.net',
+				'a28-64.akam.net',
+			]),
+			isSharedNsHost,
+		});
+		expect(westpacResult.verdict).not.toBe('owned_by_seed');
+	});
+
+	it('a 3-of-6 overlap confined entirely to shared-provider NS hosts is NOT treated as dedicated-NS evidence', async () => {
+		// Isolates the shared-host EXCLUSION step from the count/ratio threshold:
+		// 3 shared hosts clears both DEDICATED_NS_MATCH_MIN_COUNT (>=2) and
+		// DEDICATED_NS_MATCH_RATIO (3/6 = 0.5 >= 0.5), so if the implementation
+		// ever computed "dedicated" overlap from the raw shared-NS set instead of
+		// the set with shared-provider hosts excluded, this would wrongly flip to
+		// owned_by_seed. The ANZ/Westpac fixtures (1/6) cannot catch this
+		// specific defect because they never clear the count/ratio threshold in
+		// the first place, regardless of exclusion.
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'shared-akamai-only.co.nz',
+			registration: registered([SEED_NS[0], SEED_NS[1], SEED_NS[2], 'x1-1.akam.net', 'x2-2.akam.net', 'x3-3.akam.net']),
+			isSharedNsHost,
+		});
+		expect(result.verdict).not.toBe('owned_by_seed');
+		expect(result.verdict).toBe('third_party');
+	});
+
+	it('a 1-of-4 overlap on DEDICATED (non-shared-provider) nameservers is below the >=50%-AND->=2 threshold and stays third_party', async () => {
+		// Isolates the count/ratio threshold itself, using hosts that are NOT on
+		// a SHARED_NS_APEXES provider (so the exclusion step in the previous
+		// test cannot be what's protecting this one — only the
+		// DEDICATED_NS_MATCH_MIN_COUNT/DEDICATED_NS_MATCH_RATIO check can). A
+		// threshold weakened from ">=2 AND >=50%" down to a bare ">=1" would
+		// wrongly flip this to owned_by_seed.
+		const { classifyOwnership } = await loadModule();
+		const dedicatedSeedNs = ['ns1.bnzcorp-dns.example', 'ns2.bnzcorp-dns.example', 'ns3.bnzcorp-dns.example', 'ns4.bnzcorp-dns.example'];
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: dedicatedSeedNs,
+			candidateDomain: 'unrelated-dedicated-overlap.co.nz',
+			registration: registered([
+				'ns1.bnzcorp-dns.example',
+				'ns1.someothercompany.example',
+				'ns2.someothercompany.example',
+				'ns3.someothercompany.example',
+			]),
+			isSharedNsHost,
+		});
+		expect(result.verdict).not.toBe('owned_by_seed');
+		expect(result.verdict).toBe('third_party');
+	});
+
+	it('classifies distinctly-hosted lookalikes as third_party', async () => {
+		const { classifyOwnership } = await loadModule();
+		for (const domain of ['bnz.de', 'bnz.jp', 'bnz.ca', 'bnz.ac.nz', 'hnz.co.nz', 'bbnz.co.nz']) {
+			const result = classifyOwnership({
+				seedDomain: SEED,
+				seedNs: SEED_NS,
+				candidateDomain: domain,
+				registration: registered(['ns1.unrelated-registrar.example', 'ns2.unrelated-registrar.example']),
+				isSharedNsHost,
+			});
+			expect(result.verdict).toBe('third_party');
+		}
+	});
+
+	it('classifies an unregistered candidate as unattributed, with a distinguishing rationale', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'bnz.kiwi',
+			registration: unregistered,
+			isSharedNsHost,
+		});
+		expect(result.verdict).toBe('unattributed');
+		expect(result.rationale).toMatch(/not registered/i);
+	});
+
+	it('classifies a registration-unknown (SERVFAIL) candidate as unattributed, rendering the human-readable phrase (not the raw enum token)', async () => {
+		const { classifyOwnership } = await loadModule();
+		for (const domain of ['bnz.com', 'bnz.net']) {
+			const result = classifyOwnership({
+				seedDomain: SEED,
+				seedNs: SEED_NS,
+				candidateDomain: domain,
+				registration: unknown('servfail'),
+				isSharedNsHost,
+			});
+			expect(result.verdict).toBe('unattributed');
+			expect(result.rationale).toMatch(/could not be determined/i);
+			// Amendment (3): must render UNKNOWN_REASON_PHRASES.servfail verbatim,
+			// not the bare internal token 'servfail' in parentheses. A prose sentence
+			// containing ONLY the raw enum (e.g. "(servfail)") would satisfy the
+			// /could not be determined/i check above but leak an internal token into
+			// customer-facing text — this assertion is what actually discriminates.
+			expect(result.rationale).toContain(UNKNOWN_REASON_PHRASES.servfail);
+			expect(result.rationale).not.toMatch(/\(servfail\)/);
+		}
+	});
+
+	it('renders the distinct phrase for a different UnknownReason (refused), proving the map is consulted per-reason and not hardcoded to servfail', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'bnz.info',
+			registration: unknown('refused'),
+			isSharedNsHost,
+		});
+		expect(result.verdict).toBe('unattributed');
+		expect(result.rationale).toContain(UNKNOWN_REASON_PHRASES.refused);
+		expect(result.rationale).not.toContain(UNKNOWN_REASON_PHRASES.servfail);
+	});
+});
+
+describe('isInBailiwick', () => {
+	it('matches the apex itself and any subdomain', async () => {
+		const { isInBailiwick } = await loadModule();
+		expect(isInBailiwick('bnz.co.nz', 'bnz.co.nz')).toBe(true);
+		expect(isInBailiwick('ns1.bnz.co.nz', 'bnz.co.nz')).toBe(true);
+		expect(isInBailiwick('ns1.notbnz.co.nz', 'bnz.co.nz')).toBe(false);
+		expect(isInBailiwick('bnz.co.nz.evil.example', 'bnz.co.nz')).toBe(false);
+	});
+
+	it('SECURITY PIN: does not match a lookalike label that merely ends with the seed apex as a substring (no dot boundary)', async () => {
+		const { isInBailiwick } = await loadModule();
+		// The real-world shape this guards: an attacker registers evilbnz.co.nz
+		// and delegates ns1.evilbnz.co.nz. A bare `.endsWith(seedApex)` (no dot
+		// prefix) would wrongly treat that as "under bnz.co.nz".
+		expect(isInBailiwick('evilbnz.co.nz', 'bnz.co.nz')).toBe(false);
+		expect(isInBailiwick('ns1.evilbnz.co.nz', 'bnz.co.nz')).toBe(false);
+	});
+
+	it('a malicious NS host shaped like the seed-apex-as-suffix does not flip classifyOwnership to owned_by_seed', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'evilbnz.co.nz',
+			registration: registered(['ns1.evilbnz.co.nz', 'ns2.evilbnz.co.nz']),
+			isSharedNsHost,
+		});
+		expect(result.verdict).not.toBe('owned_by_seed');
+		expect(result.verdict).toBe('third_party');
+	});
+});
+
+describe('passesAttributionGuard — D4 minimum label length (CLASSIFIER, not a suppressor)', () => {
+	it('always passes for owned_by_seed regardless of label length', async () => {
+		const { passesAttributionGuard } = await loadModule();
+		expect(passesAttributionGuard('owned_by_seed', 'bnz', false)).toBe(true);
+	});
+
+	it('does not pass a short-label non-owned candidate with no corroboration', async () => {
+		const { passesAttributionGuard } = await loadModule();
+		expect(passesAttributionGuard('third_party', 'hnz', false)).toBe(false);
+	});
+
+	it('passes a short-label non-owned candidate when corroborated', async () => {
+		const { passesAttributionGuard } = await loadModule();
+		expect(passesAttributionGuard('third_party', 'hnz', true)).toBe(true);
+	});
+
+	it('passes a non-owned candidate at or above the minimum length with no corroboration needed', async () => {
+		const { passesAttributionGuard } = await loadModule();
+		expect(passesAttributionGuard('third_party', 'bankof', false)).toBe(true);
+	});
+});
+
+describe('capAttributionSeverity — DEMOTE NEVER DELETE (controller amendment 1)', () => {
+	it('never caps owned_by_seed, regardless of label length or corroboration', async () => {
+		const { capAttributionSeverity } = await loadModule();
+		expect(capAttributionSeverity('owned_by_seed', 'bnz', false)).toBe('unbounded');
+		expect(capAttributionSeverity('owned_by_seed', 'x', false)).toBe('unbounded');
+	});
+
+	it("caps a short-label, non-corroborated non-owned candidate at 'info' — but the type offers no way to omit the finding", async () => {
+		const { capAttributionSeverity } = await loadModule();
+		// bnz is the campaign's own seed brand and is 3 characters — this is
+		// EXACTLY the case the human partner's "demote never delete" ruling
+		// exists to protect: it must be capped, never dropped.
+		expect(capAttributionSeverity('third_party', 'bnz', false)).toBe('info');
+		expect(capAttributionSeverity('unattributed', 'hnz', false)).toBe('info');
+	});
+
+	it('does not cap a short-label non-owned candidate when corroborated', async () => {
+		const { capAttributionSeverity } = await loadModule();
+		expect(capAttributionSeverity('third_party', 'hnz', true)).toBe('unbounded');
+	});
+
+	it('does not cap a non-owned candidate at/above the minimum label length', async () => {
+		const { capAttributionSeverity } = await loadModule();
+		expect(capAttributionSeverity('third_party', 'bankof', false)).toBe('unbounded');
+	});
+
+	it('the return type structurally cannot represent "no finding" — only a Severity or the unbounded sentinel', async () => {
+		const { capAttributionSeverity } = await loadModule();
+		const capped = capAttributionSeverity('third_party', 'hnz', false);
+		const uncapped = capAttributionSeverity('third_party', 'bankof', false);
+		// Both are truthy, non-null strings — a caller cannot `if (!cap) continue`
+		// their way into suppressing a finding, because there is no falsy value
+		// this function can ever return.
+		expect(capped).toBeTruthy();
+		expect(uncapped).toBeTruthy();
+		expect(typeof capped).toBe('string');
+		expect(typeof uncapped).toBe('string');
+	});
+});
+
+describe('load-bearing safety property (controller amendment 2): severity gates ONLY on owned_by_seed vs everything else', () => {
+	it('third_party and unattributed are equally non-owned for capping purposes — the distinction is wording-only', async () => {
+		const { capAttributionSeverity } = await loadModule();
+		const thirdPartyCap = capAttributionSeverity('third_party', 'x', false);
+		const unattributedCap = capAttributionSeverity('unattributed', 'x', false);
+		expect(thirdPartyCap).toBe(unattributedCap);
+		expect(thirdPartyCap).toBe('info');
+	});
+});

--- a/test/ownership-attribution.spec.ts
+++ b/test/ownership-attribution.spec.ts
@@ -466,7 +466,12 @@ describe('buildNonOwnedGateFinding — cross-tool wording parity (F1, 2026-07-27
 			}) as unknown as typeof fetch;
 			const { checkLookalikes } = await import('../src/tools/check-lookalikes');
 			const lookalikeResult = await checkLookalikes('contoso.com');
-			const lookalikeFinding = lookalikeResult.findings.find((f) => f.metadata?.ownershipVerdict === 'third_party');
+			// Task 7b fix round 1 (F4): select on the AXIS, not on the verdict. Since
+			// 7b the verdict travels on the threat-observation finding too, so the
+			// old `ownershipVerdict === 'third_party'` selector matched BOTH axes and
+			// landed on the attribution finding only by push order — the parity
+			// contract is about the ATTRIBUTION wording, so say so structurally.
+			const lookalikeFinding = lookalikeResult.findings.find((f) => f.metadata?.findingAxis === 'attribution');
 			expect(lookalikeFinding).toBeDefined();
 
 			// --- check_shadow_domains: seed example.com, third-party variant with MX, no SPF/DMARC ---

--- a/test/ownership-attribution.spec.ts
+++ b/test/ownership-attribution.spec.ts
@@ -239,14 +239,84 @@ describe('isInBailiwick', () => {
 	});
 });
 
-describe('F4 (security, flagged not fixed): attacker-influenceable evidence branches — pinning CURRENT behaviour', () => {
+describe('Ruling B (2026-07-27 task-7c): in-bailiwick NS requires resolution evidence (the lame-delegation trap)', () => {
+	// The attack: an attacker sets NS = ns1.bnz.co.nz in THEIR OWN parent-zone
+	// delegation, but the seed's server never actually serves that zone (a
+	// lame delegation). `RegistrationState` is a discriminated union — only
+	// the `registered` arm carries an `ns` field, and `registered.ns` is
+	// populated ONLY from an actually-resolved NS answer set (see
+	// `resolveRegistrationUncached()` in `src/lib/registration-state.ts`,
+	// which SERVFAILs/returns 'unknown' rather than fabricating `ns` data
+	// when the delegation is broken). So the in-bailiwick verdict is
+	// structurally unreachable without resolution evidence — this is a
+	// PINNING test of that structural guarantee, not a behaviour change.
+	it('the in-bailiwick verdict never fires for an unregistered candidate (no ns field exists on that arm)', async () => {
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'lame-delegation.co.nz',
+			registration: unregistered,
+			isSharedNsHost,
+		});
+		expect(result.verdict).not.toBe('owned_by_seed');
+		expect(result.signals).not.toContain('ns_in_bailiwick');
+	});
+
+	it('the in-bailiwick verdict never fires for a registration-unknown (SERVFAIL) candidate, even if an in-bailiwick NS host is force-attached to the object', async () => {
+		// Simulates the exact regression class the mandatory mutation targets:
+		// something upstream (a bug, or a future refactor) forces NS data onto
+		// an `unknown` registration state. The type system already forbids this
+		// (`{ state: 'unknown'; reason }` has no `ns` member) — the cast below
+		// is the only way to construct the malformed object at all, proving the
+		// guard is the early `state === 'unknown'` return, not the type system
+		// alone protecting runtime callers who bypass it (e.g. via `as any`
+		// from an untyped boundary).
+		const { classifyOwnership } = await loadModule();
+		const forcedUnknownWithNs = {
+			state: 'unknown',
+			reason: 'servfail',
+			ns: ['ns1.bnz.co.nz'],
+		} as unknown as RegistrationState;
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'lame-delegation.co.nz',
+			registration: forcedUnknownWithNs,
+			isSharedNsHost,
+		});
+		expect(result.verdict).toBe('unattributed');
+		expect(result.signals).not.toContain('ns_in_bailiwick');
+	});
+
+	it('a registered candidate whose only positive evidence is an A record (ns: []) cannot in-bailiwick-match, even against a seed apex it would otherwise nest under', async () => {
+		// registration-state.ts's A-record escalation path returns `ns: []`
+		// (evidence: ['a']) precisely because NS/SOA never resolved — this is
+		// the "registered but no NS observed" shape a lame delegation produces
+		// once the A-record fallback succeeds. There is no candidate NS to
+		// filter for bailiwick, so the arm cannot fire.
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'a-only-lame.co.nz',
+			registration: { state: 'registered', ns: [], evidence: ['a'] },
+			isSharedNsHost,
+		});
+		expect(result.verdict).not.toBe('owned_by_seed');
+		expect(result.signals).not.toContain('ns_in_bailiwick');
+	});
+});
+
+describe('Ruling A (2026-07-27 task-7c): candidate-side signals are corroborating-only, NEVER verdict-bearing', () => {
 	// These three flags are NOT gathered by any caller in this slice, but the
-	// branches exist and were previously untested. Per the reviewer's F4
-	// instruction, the verdict mapping itself is NOT being changed here (that
-	// call belongs to the design owner) — these tests only pin what the
-	// current code does, so a future change to the mapping is a deliberate,
-	// visible diff here rather than a silent behaviour change.
-	it('soaInBailiwick ALONE (no NS evidence at all) currently produces owned_by_seed/strong', async () => {
+	// branches exist and are exercised directly here. Task 2's fix round left
+	// them verdict-bearing (flagged, not fixed) — task-7c resolves the
+	// mapping: none of them may establish `owned_by_seed` alone or combined.
+	// With no seed-side NS evidence (a single unrelated registrar host), the
+	// candidate falls through to the "registered with its own NS, no
+	// ownership signal" arm → `third_party`.
+	it('soaInBailiwick ALONE (no seed-side NS evidence) does NOT produce owned_by_seed — falls through to third_party', async () => {
 		const { classifyOwnership } = await loadModule();
 		const result = classifyOwnership({
 			seedDomain: SEED,
@@ -256,12 +326,11 @@ describe('F4 (security, flagged not fixed): attacker-influenceable evidence bran
 			isSharedNsHost,
 			soaInBailiwick: true,
 		});
-		expect(result.verdict).toBe('owned_by_seed');
-		expect(result.strength).toBe('strong');
-		expect(result.signals).toContain('soa_in_bailiwick');
+		expect(result.verdict).toBe('third_party');
+		expect(result.signals).not.toContain('soa_in_bailiwick');
 	});
 
-	it('spfIncludesSeedApex ALONE currently produces owned_by_seed/strong — attacker-controllable, unresolved', async () => {
+	it('spfIncludesSeedApex ALONE (no seed-side NS evidence) does NOT produce owned_by_seed — falls through to third_party', async () => {
 		const { classifyOwnership } = await loadModule();
 		const result = classifyOwnership({
 			seedDomain: SEED,
@@ -271,12 +340,11 @@ describe('F4 (security, flagged not fixed): attacker-influenceable evidence bran
 			isSharedNsHost,
 			spfIncludesSeedApex: true,
 		});
-		expect(result.verdict).toBe('owned_by_seed');
-		expect(result.strength).toBe('strong');
-		expect(result.signals).toContain('spf_include_seed');
+		expect(result.verdict).toBe('third_party');
+		expect(result.signals).not.toContain('spf_include_seed');
 	});
 
-	it('httpRedirectToSeedApex ALONE currently produces owned_by_seed/strong — attacker-controllable, unresolved', async () => {
+	it('httpRedirectToSeedApex ALONE (no seed-side NS evidence) does NOT produce owned_by_seed — falls through to third_party', async () => {
 		const { classifyOwnership } = await loadModule();
 		const result = classifyOwnership({
 			seedDomain: SEED,
@@ -286,9 +354,49 @@ describe('F4 (security, flagged not fixed): attacker-influenceable evidence bran
 			isSharedNsHost,
 			httpRedirectToSeedApex: true,
 		});
-		expect(result.verdict).toBe('owned_by_seed');
-		expect(result.strength).toBe('strong');
-		expect(result.signals).toContain('http_redirect_seed');
+		expect(result.verdict).toBe('third_party');
+		expect(result.signals).not.toContain('http_redirect_seed');
+	});
+
+	it('all THREE candidate-side signals combined, with no seed-side signal, still does NOT produce owned_by_seed', async () => {
+		// The attacker who registers evilbnz.co.nz controls all three of these
+		// simultaneously (SOA RNAME, SPF include, HTTP redirect) — none of them
+		// require cooperation from the seed's owner, so stacking all three must
+		// not add up to ownership either.
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'evilbnz.co.nz',
+			registration: registered(['ns1.totally-unrelated-registrar.example']),
+			isSharedNsHost,
+			soaInBailiwick: true,
+			spfIncludesSeedApex: true,
+			httpRedirectToSeedApex: true,
+		});
+		expect(result.verdict).toBe('third_party');
+		expect(result.signals).not.toContain('soa_in_bailiwick');
+		expect(result.signals).not.toContain('spf_include_seed');
+		expect(result.signals).not.toContain('http_redirect_seed');
+	});
+
+	it('candidate-side signals cannot rescue a candidate that would otherwise be unattributed (no NS at all)', async () => {
+		// A registered-by-A-record-only candidate (RegistrationEvidence 'a', no
+		// NS resolved) has no NS to check bailiwick/set-overlap against at all —
+		// this is the "everything else" unattributed arm, not third_party. The
+		// three candidate-side flags must not be able to flip that either.
+		const { classifyOwnership } = await loadModule();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: SEED_NS,
+			candidateDomain: 'a-only-evilbnz.co.nz',
+			registration: { state: 'registered', ns: [], evidence: ['a'] },
+			isSharedNsHost,
+			soaInBailiwick: true,
+			spfIncludesSeedApex: true,
+			httpRedirectToSeedApex: true,
+		});
+		expect(result.verdict).toBe('unattributed');
 	});
 });
 

--- a/test/reporting-surfaces-unmeasured.integration.test.ts
+++ b/test/reporting-surfaces-unmeasured.integration.test.ts
@@ -230,14 +230,18 @@ describe('generateFixPlan — producer wiring for a total outage (all checks att
 		expect(allTransient.caveat).not.toBe(neverRan.caveat);
 	});
 
-	it('keeps the current behaviour when at least one check completed (guard — no over-abstain)', async () => {
+	it('produces exactly the one real remediation action, not one per transient category (F2/F4, review round 1)', async () => {
 		const { SCAN_CATEGORIES } = await import('../src/tools/scan-domain');
 		const { buildCheckResult, createFinding } = await import('@blackveil/dns-checks/scoring');
 
 		// 1 of N checks completed (dmarc genuinely fails); the rest are
-		// transient. This must produce exactly the one real remediation
-		// action — `hasCompletedEvidence` must not require EVERY check to
-		// complete before the plan is treated as assessed.
+		// safeCheck()-shaped transients — `checkStatus: 'error'`, NO
+		// `metadata.errorKind` (safeCheck's own catch in scan-domain.ts never
+		// sets that marker; only tools with their own internal
+		// buildDnsErrorResult handling do). `hasCompletedEvidence` must not
+		// require EVERY check to complete before the plan is treated as
+		// assessed, and each transient category must NOT read as its own
+		// remediation action.
 		const checks: CheckResult[] = SCAN_CATEGORIES.map((c) => {
 			if (c === 'dmarc') {
 				return {
@@ -267,14 +271,26 @@ describe('generateFixPlan — producer wiring for a total outage (all checks att
 		const { generateFixPlan } = await import('../src/tools/generate-fix-plan');
 		const plan = await generateFixPlan('partial-outage.example');
 
-		// Once ANY check completed, this must behave EXACTLY as it did before this
-		// change — including still surfacing an action per transient "check error"
-		// finding (pre-existing behaviour for a partial outage, out of scope for
-		// this fix, and pinned here so a future change doesn't silently narrow it).
+		// F2/F4 (review round 1): this test used to assert
+		// `plan.totalActions === checks.length` — ONE bogus "Fix X: X check
+		// error" action per transient category, plus the one real DMARC
+		// action — labeled "pre-existing behaviour ... out of scope for this
+		// fix" even though the comment two lines above it already said the
+		// opposite ("must produce exactly the one real remediation action").
+		// That assertion PINNED the bug this task exists to close: it passed
+		// only because these safeCheck-shaped fixtures (no `errorKind`) did
+		// not match the `buildDnsErrorResult`-shaped ones the original filter
+		// checked for. Corrected to match what the surrounding comment always
+		// said should happen.
 		expect(plan.assessed).toBe(true);
 		expect(plan.caveat).toBeNull();
-		expect(plan.totalActions).toBe(checks.length);
+		expect(plan.totalActions).toBe(1);
 		expect(plan.actions.some((a) => a.category === 'dmarc' && a.findingTitle === 'DMARC policy is p=none')).toBe(true);
+		// Every OTHER category's synthetic "check error" finding must be
+		// excluded, not turned into its own fix action.
+		expect(plan.actions.every((a) => a.category === 'dmarc')).toBe(true);
+		expect(plan.transientCategories.length).toBe(checks.length - 1);
+		expect(plan.transientCategories).not.toContain('dmarc');
 	});
 });
 

--- a/test/tenants/discovery/ns-correlator.test.ts
+++ b/test/tenants/discovery/ns-correlator.test.ts
@@ -239,4 +239,61 @@ describe('correlateNs', () => {
 		expect(result.coOwnedDomains).toHaveLength(1);
 		expect(result.coOwnedDomains[0].confidence).toBeCloseTo(1.0, 2);
 	});
+
+	// D6.1 (2026-07-26 correctness-defects design §3.4) — in-bailiwick matching.
+	// A candidate's own NS records being delegated UNDER the seed's apex is
+	// ownership-bearing regardless of whether the candidate shares any NS
+	// *hostname* with the seed. Set-intersection alone misses this whenever
+	// the seed sits on different (often shared-provider) infrastructure —
+	// exactly bnz.co.nz's real situation: seed on Akamai, six of seven owned
+	// variants on ns1-4.bnz.co.nz, zero overlap between the two NS sets.
+
+	it('classifies a candidate whose own NS are in-bailiwick to the seed apex as confidence 1.0, even with zero NS-set overlap', async () => {
+		const dnsQuery = dnsQueryFromMap({
+			'bnz.co.nz': ['a1-97.akam.net.', 'a3-67.akam.net.'],
+			'bnz.nz': ['ns1.bnz.co.nz.', 'ns2.bnz.co.nz.'],
+		});
+		const result = await correlateNs('bnz.co.nz', { dnsQuery, candidateDomains: ['bnz.nz'] });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toHaveLength(1);
+		expect(result.coOwnedDomains[0]).toMatchObject({
+			domain: 'bnz.nz',
+			confidence: 1,
+			matchType: 'in_bailiwick',
+		});
+		expect(result.coOwnedDomains[0].sharedNs).toEqual(['ns1.bnz.co.nz', 'ns2.bnz.co.nz']);
+	});
+
+	it('tags a normal set-overlap match with matchType set_overlap', async () => {
+		const dnsQuery = dnsQueryFromMap({
+			'foo.com': ['ns1.cloudflare.com.', 'ns2.cloudflare.com.'],
+			'bar.com': ['ns1.cloudflare.com.', 'ns2.cloudflare.com.'],
+		});
+		const result = await correlateNs('foo.com', { dnsQuery, candidateDomains: ['bar.com'] });
+		expect(result.coOwnedDomains[0]).toMatchObject({ domain: 'bar.com', matchType: 'set_overlap' });
+	});
+
+	it('does not treat an unrelated candidate as in-bailiwick just because it shares a TLD suffix', async () => {
+		const dnsQuery = dnsQueryFromMap({
+			'bnz.co.nz': ['a1-97.akam.net.'],
+			'notbnz.co.nz': ['ns1.someotherregistrar.example.'],
+		});
+		const result = await correlateNs('bnz.co.nz', { dnsQuery, candidateDomains: ['notbnz.co.nz'] });
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+
+	// Discriminates a bare `hostname.endsWith(seedApex)` regression (no dot
+	// boundary) from the correct `isInBailiwick` dot-boundary check. The
+	// candidate's own NS host `ns.evilbnz.co.nz` contains the seed apex
+	// `bnz.co.nz` as a trailing SUBSTRING but not as a label suffix — a bare
+	// endsWith would wrongly match it in-bailiwick; the dot-boundary check
+	// must not.
+	it('does not in-bailiwick-match a candidate NS host that merely contains the seed apex as a substring, without a dot boundary', async () => {
+		const dnsQuery = dnsQueryFromMap({
+			'bnz.co.nz': ['a1-97.akam.net.'],
+			'evilbnz.co.nz': ['ns.evilbnz.co.nz.'],
+		});
+		const result = await correlateNs('bnz.co.nz', { dnsQuery, candidateDomains: ['evilbnz.co.nz'] });
+		expect(result.coOwnedDomains).toEqual([]);
+	});
 });

--- a/test/tenants/discovery/ns-correlator.test.ts
+++ b/test/tenants/discovery/ns-correlator.test.ts
@@ -223,9 +223,7 @@ describe('correlateNs', () => {
 		expect(result.coOwnedDomains).toHaveLength(1);
 		// Only the cloudflare NS counts toward confidence; sharedNs retained for transparency.
 		expect(result.coOwnedDomains[0].confidence).toBeCloseTo(0.5, 2);
-		expect(result.coOwnedDomains[0].sharedNs).toEqual(
-			['alice.ns.cloudflare.com', 'ns1.sedoparking.com'],
-		);
+		expect(result.coOwnedDomains[0].sharedNs).toEqual(['alice.ns.cloudflare.com', 'ns1.sedoparking.com']);
 	});
 
 	it('keeps a candidate whose shared NS are all genuine hyperscale-DNS hostnames', async () => {
@@ -294,6 +292,51 @@ describe('correlateNs', () => {
 			'evilbnz.co.nz': ['ns.evilbnz.co.nz.'],
 		});
 		const result = await correlateNs('bnz.co.nz', { dnsQuery, candidateDomains: ['evilbnz.co.nz'] });
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+
+	// Ruling B (2026-07-27 task-7c) — in-bailiwick NS requires resolution
+	// evidence (the lame-delegation trap). The attack: an attacker's OWN
+	// parent-zone delegation lists NS = ns1.bnz.co.nz, but the seed's server
+	// never actually serves that zone, so a resolver following the
+	// delegation SERVFAILs rather than returning an NS answer for the
+	// candidate. `fetchNsSet()` builds its NS set purely from `resp.Answer`
+	// (see ns-correlator.ts), which a SERVFAIL response carries none of — so
+	// this is a PINNING test of already-correct behaviour, not a fix.
+	it('a candidate whose NS query SERVFAILs (lame delegation) yields NO in-bailiwick observation, even though the delegated hostname matches the seed apex', async () => {
+		const dnsQuery = vi.fn(async (name: string) => {
+			const key = name.toLowerCase().replace(/\.$/, '');
+			if (key === 'bnz.co.nz') return nsResponse([{ name: 'bnz.co.nz', data: 'a1-97.akam.net.' }]);
+			if (key === 'lame-evilbnz.co.nz') {
+				// SERVFAIL (RCODE 2): the resolver could not obtain an answer —
+				// no Answer records, regardless of what the parent-zone
+				// delegation glue claims the NS hostnames are.
+				return {
+					Status: 2,
+					TC: false,
+					RD: true,
+					RA: true,
+					AD: false,
+					CD: false,
+					Question: [{ name: key, type: 2 }],
+					Answer: [],
+				} satisfies DohResponse;
+			}
+			return emptyDnsResponse();
+		});
+		const result = await correlateNs('bnz.co.nz', { dnsQuery, candidateDomains: ['lame-evilbnz.co.nz'] });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+
+	it('a candidate whose NS query errors/throws (transport failure) yields NO in-bailiwick observation and marks the run partial', async () => {
+		const dnsQuery = vi.fn(async (name: string) => {
+			const key = name.toLowerCase().replace(/\.$/, '');
+			if (key === 'bnz.co.nz') return nsResponse([{ name: 'bnz.co.nz', data: 'a1-97.akam.net.' }]);
+			throw new Error('lame delegation: no response');
+		});
+		const result = await correlateNs('bnz.co.nz', { dnsQuery, candidateDomains: ['lame-evilbnz.co.nz'] });
+		expect(result.queryStatus).toBe('partial');
 		expect(result.coOwnedDomains).toEqual([]);
 	});
 });

--- a/test/ungraded-formatter-rendering.spec.ts
+++ b/test/ungraded-formatter-rendering.spec.ts
@@ -167,6 +167,7 @@ describe('formatFixPlan — ungraded scan', () => {
 			actions: [],
 			assessed,
 			caveat: assessed ? null : 'No checks ran for this domain, so no remediation actions could be planned.',
+			transientCategories: [],
 		};
 	}
 


### PR DESCRIPTION
## Correctness-defect campaign — slices 4 & 5

Continues the campaign merged in #563 (slices 1–3). Governing invariant throughout:

> **An incomplete measurement must never produce a confident output — and a real measurement must never be suppressed.**

Both halves are load-bearing. A fix that silences a genuine signal is as much a defect as one that emits a fabricated confident zero.

`packages/dns-checks/` is **byte-untouched** across all commits (verified by `git diff` against the merge base), as is `test/audits/registration-invariant.audit.test.ts`. No scoring weights, tiers, or grade bands changed.

---

### Slice 4 — ownership attribution

The scanner was asserting *ownership* of domains it had only *observed*. `check_shadow_domains` and `check_lookalikes` could tell a customer "your domain X is misconfigured" about a domain belonging to an unrelated third party — a customer-facing, legally-sensitive claim made on evidence that did not support it.

- **New primitive** `classifyOwnership()` (`src/lib/ownership-attribution.ts`) → `owned_by_seed | third_party | unattributed`, with `capAttributionSeverity(verdict)` as the *sole* severity surface and `attributionConfidence()` for corroboration.
- **Severity gated on the verdict alone**, not on any incidental property of the candidate. Non-owned candidates cap at `info` with neutral wording — no "your", no "shadow domain", no ownership framing.
- **Two-axis split** in `check_lookalikes` (`findingAxis: 'attribution' | 'threat_observation' | 'scan_status'`). Gating attribution alone had silently killed the tool's detection value — a live typosquat with active MX scored the category 100/passed. The threat axis restores the calibrated #264 severity matrix for *observed behaviour*, while the attribution axis stays capped. The threat finding asserts nothing about ownership and demands no action on the third party's domain.
- **Candidate-side signals are never verdict-bearing.** `soaInBailiwick`, `spfIncludesSeedApex`, `httpRedirectToSeedApex` are all written by whoever operates the *candidate* zone — an attacker could point their SPF/redirect/SOA at a customer apex and be attributed into that customer's portfolio. They now corroborate only; verdicts require seed-side control.
- **Lame-delegation trap pinned.** An in-bailiwick NS observation is ownership-bearing only when the zone actually resolves.
- **In-bailiwick NS promoted to strong discovery evidence** (`correlateNs` now matches in-bailiwick, not only set overlap), and `akam.net` added to `SHARED_NS_APEXES` — verified live: `bnz.co.nz` shares `a9-65.akam.net` with `anz.co.nz` and `a3-67.akam.net` with `westpac.co.nz`, so NS-set overlap there is an Akamai artifact, not common ownership.
- **New cross-cutting audit** `test/audits/ownership-severity-gate.audit.test.ts` locks the invariant on every axis.

### Slice 5 — success-shaped zeros and the completed-evidence predicate

Re-scoped against what `main` already shipped (#560, #562 pre-empted ~70% of the original plan, which aimed at the `sourceUnavailable` branch; the zeros that actually survived were on the *success* branches).

- **`discover_subdomains`**: `emptyResult()` now carries a high-severity `unconfirmed_zero` issue; `queryCertstream()` reads `timedOut` on *both* responses; `queryDirectSources()` no longer short-circuits when the first source returns empty.
- **`generate_fix_plan` / `map_registrar_products`**: transient DNS-error categories excluded from fix actions and upsells. The first attempt keyed on `errorKind` — which the orchestrator's own `safeCheck` never sets, so **it did not fire in production**. Regated on `checkStatus`, plus an `assessed` flag with distinct compact/full renders: compact was previously rendering an unmeasured category as `✓ Managed DMARC`, byte-identical to a clean pass.
- **One SSOT for "does this check have completed evidence?"** (`isCompletedCheck` / `hasCompletedEvidence` / `normalizeCheckStatus` in `src/lib/ungraded-display.ts`), replacing five divergent hand-spellings — two of which were an *allowlist* (`{undefined, 'completed'}`) and three a *denylist* (`{!timeout, !error}`). Identical on today's closed three-value union, but `CheckResult`s are re-read from `SCAN_CACHE` KV via `JSON.parse` with no Zod revalidation, so an out-of-union status is reachable at runtime across a version skew — under the denylist it would have rendered as confident evidence. Allowlist semantics chosen deliberately.
- **`test/audits/completed-evidence-predicate-ssot.audit.test.ts`** bans re-spelling the predicate outside the SSOT.

---

### Verification

Every guard in this PR was seen RED by execution before being accepted, and reviewers re-ran the mutation sets themselves rather than reading the reports. Whole-slice adversarial reviews ran on both slices.

<!-- TAIL: fill in suite numbers + open-question list before opening -->
