### PR TITLE
fix(maturity): abstain when a load-bearing check was never measured (fixes #574)

### DIFF
--- a/src/tenants/scan-snapshot.ts
+++ b/src/tenants/scan-snapshot.ts
@@ -53,7 +53,12 @@ export function toTenantScanSnapshot(result: ScanDomainResult): TenantScanSnapsh
 	return {
 		score: result.score.overall,
 		grade: result.score.grade,
-		maturityStage: result.maturity?.stage ?? null,
+		// An INDETERMINATE stage (#574 — a load-bearing check was never measured) is a
+		// placeholder, not a posture measurement. Persisting its 0 into the tenant's
+		// `scans.maturity_stage` column would bake a fabricated "Unprotected" into
+		// history and every trend built off it; `null` is the honest value, and the
+		// column has always been nullable.
+		maturityStage: result.maturity?.indeterminate === true ? null : (result.maturity?.stage ?? null),
 		findings: result.score.findings ?? [],
 	};
 }

--- a/src/tools/generate-fix-plan.ts
+++ b/src/tools/generate-fix-plan.ts
@@ -210,7 +210,11 @@ export async function generateFixPlan(domain: string, kv?: KVNamespace, runtimeO
 		domain,
 		score: scanResult.score.overall,
 		grade: scanResult.score.grade,
-		maturityStage: isGraded(scanResult.score) ? scanResult.maturity.stage : null,
+		// `indeterminate` (#574): a GRADED scan whose maturity ladder abstained because
+		// a load-bearing check was never measured carries a placeholder stage, exactly
+		// like a degraded builder's — so it is withheld here too, or "Maturity Stage:
+		// 0/4" renders a posture verdict nobody measured.
+		maturityStage: isGraded(scanResult.score) && scanResult.maturity.indeterminate !== true ? scanResult.maturity.stage : null,
 		totalActions: actions.length,
 		actions,
 		assessed,

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -363,7 +363,13 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		// stage->label table. Gate on the scan having actually scored, exactly as
 		// generate_fix_plan does one layer up. The LABEL is kept: "Does not resolve"
 		// is information, not a fabricated verdict.
-		maturityStage: isGraded(result.score) ? (result.maturity?.stage ?? null) : null,
+		// The `indeterminate` half is the #574 case, and `isGraded` cannot see it: the
+		// scan IS graded (the affected hosts scored 67 with 17/19 checks completed —
+		// a 0.894 evidence ratio, far over the 0.6 sufficiency threshold), yet the
+		// ladder's one load-bearing input was never measured, so its stage number is
+		// not a measurement either. Same treatment, same reason: withhold the NUMBER,
+		// keep the LABEL.
+		maturityStage: isGraded(result.score) && result.maturity?.indeterminate !== true ? (result.maturity?.stage ?? null) : null,
 		maturityLabel: result.maturity?.label ?? null,
 		categoryScores,
 		findingCounts: {
@@ -445,7 +451,14 @@ export function formatScanReport(result: ScanDomainResult, format: OutputFormat 
 		// withheld, and the ungraded token takes its place so the same state reads the
 		// same way here as everywhere else. A GRADED domain that genuinely sits at
 		// stage 0 still prints "Stage 0"; that zero is a measurement.
-		const stageText = isGraded(result.score) ? `Stage ${result.maturity.stage}` : UNGRADED_DISPLAY;
+		//
+		// #574 adds the second condition: a graded scan whose ladder abstained
+		// (`indeterminate`) also has no stage NUMBER to print, for the same reason —
+		// the number behind it is a placeholder, not a measurement. Its label carries
+		// the state ("Not determined (TLS not measured)") and its description explains
+		// the gap, so the reader loses nothing.
+		const stageText =
+			isGraded(result.score) && result.maturity.indeterminate !== true ? `Stage ${result.maturity.stage}` : UNGRADED_DISPLAY;
 		if (format === 'compact') {
 			lines.push(`Maturity: ${stageText} — ${result.maturity.label}`);
 		} else {

--- a/src/tools/scan/maturity-staging.ts
+++ b/src/tools/scan/maturity-staging.ts
@@ -247,8 +247,14 @@ function computeWebOnlyLadder(byCategory: Map<string, CheckResult>): MaturitySta
 			stage: 0,
 			indeterminate: true,
 			label: 'Not determined (TLS not measured)',
+			// Deliberately states NO cause. `check-ssl.ts` funnels every thrown fetch into
+			// one catch: an edge/WAF block, a network timeout and a plain ECONNREFUSED (no
+			// HTTPS listener at all) are ALL reported as checkStatus 'error'/'timeout' and
+			// are not distinguishable from here. Naming a cause would re-introduce exactly
+			// the unsupported public claim this abstention exists to remove. The retained
+			// connection finding carries the raw probe result for anyone who needs it.
 			description:
-				'The TLS probe for this domain did not complete — it was blocked or timed out at the edge (a CDN or WAF commonly does this to automated clients). This is a measurement gap, NOT a security verdict: no conclusion about this domain’s transport security can be drawn from it, in either direction.',
+				'The TLS probe for this domain did not complete, so its transport security was not measured. A probe can fail because an edge/CDN/WAF blocked the automated request, because the connection timed out, or because no HTTPS service responded at all — these are not distinguishable from the outside. This is a measurement gap, NOT a security verdict: no conclusion can be drawn from it in either direction. See the connection finding for the raw probe result.',
 			nextStep:
 				'Re-scan later, or verify HTTPS directly from an unblocked network (for example `openssl s_client -connect <domain>:443`), before reading anything into this result.',
 		};

--- a/src/tools/scan/maturity-staging.ts
+++ b/src/tools/scan/maturity-staging.ts
@@ -25,6 +25,50 @@ export interface MaturityStage {
 	label: string;
 	description: string;
 	nextStep: string;
+	/**
+	 * ADDITIVE-OPTIONAL (issue #574). `true` when the ladder could not determine a
+	 * stage because a LOAD-BEARING input was never measured (its `checkStatus` is
+	 * `'error'`/`'timeout'`, or the check is absent entirely). The `stage` number
+	 * on such a result is a placeholder with NO measurement behind it, and the
+	 * render layer (`format-report.ts`) withholds it exactly as it withholds the
+	 * stage of an ungraded scan — the LABEL is kept, because "not determined" is
+	 * information.
+	 *
+	 * Optional so every existing producer and consumer is unaffected; absent means
+	 * "the stage is a measurement", which is what every pre-#574 result asserted
+	 * implicitly.
+	 */
+	indeterminate?: true;
+}
+
+/**
+ * Was this check actually MEASURED?
+ *
+ * The ladder used to read `passed` alone — but `scan-domain.ts` forcibly stamps
+ * `score: 0, passed: false` onto every INCONCLUSIVE check (`degradedStatuses`),
+ * so an edge-blocked probe was indistinguishable from a control that is
+ * genuinely absent. That collapsed the two states the rest of the codebase works
+ * hard to separate (`packages/dns-checks/src/scoring/evidence.ts`): INCONCLUSIVE
+ * ("we could not measure it") vs NOT APPLICABLE / ABSENT ("we measured, and the
+ * control is not there").
+ *
+ * `CheckStatus` is exactly `'completed' | 'timeout' | 'error'`, and an ABSENT
+ * status means completed (legacy shape) — so those two values are the complete
+ * set of inconclusive states.
+ */
+function measured(check?: CheckResult): boolean {
+	return check != null && check.checkStatus !== 'error' && check.checkStatus !== 'timeout';
+}
+
+/**
+ * Was this check ATTEMPTED and yet did not complete?
+ *
+ * Narrower than `!measured()`: it excludes a check that is simply absent from the
+ * roster. Used only where an absent entry has a long-standing contracted meaning
+ * that must not change (see the mail ladder's stage-0 abstention).
+ */
+function attemptedButInconclusive(check?: CheckResult): boolean {
+	return check != null && (check.checkStatus === 'error' || check.checkStatus === 'timeout');
 }
 
 /**
@@ -43,6 +87,11 @@ export interface MaturityStage {
  * Stages already at or below the cap are returned unchanged.
  */
 export function capMaturityStage(maturity: MaturityStage, score: number): MaturityStage {
+	// A stage that was never DETERMINED cannot be score-capped — there is no
+	// measurement to lower. Returning it untouched also stops the cap branches
+	// below from dropping the `indeterminate` flag on the way out.
+	if (maturity.indeterminate) return maturity;
+
 	if (score < 50 && maturity.stage > 2) {
 		return {
 			stage: 2,
@@ -74,23 +123,55 @@ export function capMaturityStage(maturity: MaturityStage, score: number): Maturi
  */
 function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
 	const byCategory = new Map(checks.map((c) => [c.category, c]));
+	const httpSecurityCheck = byCategory.get('http_security');
+	const staged = computeWebOnlyLadder(byCategory);
+
+	// Secondary instance of the same defect (issue #574 §"Silent ceiling"): HSTS is
+	// read off `http_security` finding titles, so an inconclusive probe yields no
+	// HSTS finding and stage 4 silently becomes unreachable. The stage below the
+	// ceiling is still HONEST as a lower bound — it is derived from signals that
+	// WERE measured — so the number stays; what was missing is the disclosure that
+	// the top rung was never assessable.
+	//
+	// Gated on ATTEMPTED-but-inconclusive rather than `!measured`: a roster that
+	// never included `http_security` has nothing to disclose, and every pre-existing
+	// caller passing a partial check set keeps its exact wording.
+	if (staged.indeterminate || staged.stage >= 4 || !attemptedButInconclusive(httpSecurityCheck)) return staged;
+	return {
+		...staged,
+		description: `${staged.description} NOTE: the HTTP security probe did not complete, so HSTS could not be measured and the top maturity stage was not assessable — this stage is a lower bound.`,
+		nextStep: `${staged.nextStep} Re-scan from an unblocked network to assess HSTS.`.trim(),
+	};
+}
+
+/** The ladder proper. `computeWebOnlyMaturity` wraps it to add the unmeasured-HSTS disclosure. */
+function computeWebOnlyLadder(byCategory: Map<string, CheckResult>): MaturityStage {
 	const sslCheck = byCategory.get('ssl');
 	const dnssecCheck = byCategory.get('dnssec');
 	const httpSecurityCheck = byCategory.get('http_security');
 	const spfCheck = byCategory.get('spf');
 	const dmarcCheck = byCategory.get('dmarc');
 
-	const hasSsl = sslCheck?.passed ?? false;
-	const hasDnssec = dnssecCheck?.passed ?? false;
+	// Every signal is now gated on the check having been MEASURED. For the
+	// `passed`-derived ones this is belt-and-braces (the pipeline already forces
+	// `passed: false` on an inconclusive check); for the finding-title ones below
+	// it is load-bearing, because an inconclusive check emits a "check error"
+	// finding rather than the "No X record" finding those probes look for — so
+	// they read TRUE and a measurement failure inflated maturity UPWARD.
+	const sslMeasured = measured(sslCheck);
+	const hasSsl = sslMeasured && (sslCheck?.passed ?? false);
+	const hasDnssec = measured(dnssecCheck) && (dnssecCheck?.passed ?? false);
 	const hasHsts =
-		httpSecurityCheck?.findings.some((f: Finding) => /HSTS/i.test(f.title) && !/missing|no HSTS|no\s+HSTS/i.test(f.title)) ?? false;
+		(measured(httpSecurityCheck) &&
+			httpSecurityCheck?.findings.some((f: Finding) => /HSTS/i.test(f.title) && !/missing|no HSTS|no\s+HSTS/i.test(f.title))) ??
+		false;
 	// Anti-spoof posture: a published SPF -all (or restrictive include) + DMARC reject is
 	// strong evidence even on a non-sending domain (defence against impersonation).
-	const hasSpfRecord = spfCheck != null && !spfCheck.findings.some((f: Finding) => /No SPF record/i.test(f.title));
+	const hasSpfRecord = measured(spfCheck) && !spfCheck!.findings.some((f: Finding) => /No SPF record/i.test(f.title));
 	const hasDmarcReject =
-		dmarcCheck != null &&
-		!dmarcCheck.findings.some((f: Finding) => /No DMARC record/i.test(f.title)) &&
-		!dmarcCheck.findings.some((f: Finding) => /policy set to (none|quarantine)/i.test(f.title));
+		measured(dmarcCheck) &&
+		!dmarcCheck!.findings.some((f: Finding) => /No DMARC record/i.test(f.title)) &&
+		!dmarcCheck!.findings.some((f: Finding) => /policy set to (none|quarantine)/i.test(f.title));
 	const hasAntiSpoof = hasSpfRecord || hasDmarcReject;
 
 	// Stage 4 — Comprehensive: SSL + DNSSEC + HSTS + anti-spoof email policy.
@@ -101,7 +182,8 @@ function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
 		return {
 			stage: 4,
 			label: 'Comprehensive',
-			description: 'This web-only domain has full transport (SSL), DNS integrity (DNSSEC), browser hardening (HSTS), and an anti-spoof email policy (SPF -all / DMARC reject).',
+			description:
+				'This web-only domain has full transport (SSL), DNS integrity (DNSSEC), browser hardening (HSTS), and an anti-spoof email policy (SPF -all / DMARC reject).',
 			nextStep: '',
 		};
 	}
@@ -113,7 +195,8 @@ function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
 		return {
 			stage: 3,
 			label: 'Defensive',
-			description: 'This web-only domain has SSL, DNSSEC, and an anti-spoof email policy (SPF -all / DMARC reject). Strong defensive posture.',
+			description:
+				'This web-only domain has SSL, DNSSEC, and an anti-spoof email policy (SPF -all / DMARC reject). Strong defensive posture.',
 			nextStep: 'Add HSTS preload and CAA pinning to reach full hardening.',
 		};
 	}
@@ -146,7 +229,33 @@ function computeWebOnlyMaturity(checks: CheckResult[]): MaturityStage {
 		};
 	}
 
-	// Stage 0 — Unprotected
+	// Not determined — the TLS probe was never measured (issue #574).
+	//
+	// This ladder is STRICTLY NESTED on `hasSsl`: rungs 4/3/2/1 are all gated on it,
+	// so an unmeasured `ssl` is not "one signal missing", it is an unconditional
+	// fallthrough to the bottom rung. And the bottom rung's description is an
+	// affirmative, falsifiable factual claim published on a public report URL. When
+	// an edge/CDN blocks or times out the HTTPS probe (22+ named consumer-banking
+	// hosts in a single 2026-07-27 sweep) that claim is simply false: those hosts
+	// demonstrably do serve TLS.
+	//
+	// The claim must therefore be UNREACHABLE without a TLS measurement — hence a
+	// replacement, not an annotation. `capMaturityStage` cannot rescue this: it only
+	// engages below score 63/50, and the affected hosts scored 67.
+	if (!sslMeasured) {
+		return {
+			stage: 0,
+			indeterminate: true,
+			label: 'Not determined (TLS not measured)',
+			description:
+				'The TLS probe for this domain did not complete — it was blocked or timed out at the edge (a CDN or WAF commonly does this to automated clients). This is a measurement gap, NOT a security verdict: no conclusion about this domain’s transport security can be drawn from it, in either direction.',
+			nextStep:
+				'Re-scan later, or verify HTTPS directly from an unblocked network (for example `openssl s_client -connect <domain>:443`), before reading anything into this result.',
+		};
+	}
+
+	// Stage 0 — Unprotected. Reachable only when the TLS probe COMPLETED and found
+	// no usable HTTPS; that zero is a measurement.
 	return {
 		stage: 0,
 		label: 'Unprotected',
@@ -181,9 +290,9 @@ export function computeMaturityStage(checks: CheckResult[], profile?: DomainProf
 	// Legacy fallback: when `profile` is undefined (older callers) and MX records are
 	// missing, classify under the historical "DNS-Only" branch to preserve existing
 	// behaviour and test coverage.
-	const hasNoMx = mxCheck != null && mxCheck.findings.some((f: Finding) => f.title === 'No MX records found');
+	const hasNoMx = measured(mxCheck) && mxCheck!.findings.some((f: Finding) => f.title === 'No MX records found');
 	if (hasNoMx && profile === undefined) {
-		const hasDnssec = dnssecCheck?.passed ?? false;
+		const hasDnssec = measured(dnssecCheck) && (dnssecCheck?.passed ?? false);
 		return {
 			stage: hasDnssec ? 1 : 0,
 			label: hasDnssec ? 'DNS-Only' : 'Unprotected',
@@ -194,36 +303,42 @@ export function computeMaturityStage(checks: CheckResult[], profile?: DomainProf
 		};
 	}
 
+	// Every presence probe below is gated on the check having been MEASURED (issue
+	// #574). These are ABSENCE-OF-FINDING tests, which is the OPPOSITE polarity to
+	// the web-only ladder's `hasSsl` and arguably worse: an inconclusive spf/dmarc/
+	// dkim/bimi/dane emits a "check error" finding rather than the "No SPF record"
+	// finding these probes look for, so they read TRUE and a measurement failure
+	// inflated maturity UPWARD — false reassurance published as a posture verdict.
 	// Determine SPF presence
-	const hasSpf = spfCheck != null && !spfCheck.findings.some((f: Finding) => /No SPF record/i.test(f.title));
+	const hasSpf = measured(spfCheck) && !spfCheck!.findings.some((f: Finding) => /No SPF record/i.test(f.title));
 
 	// Determine DMARC presence and policy
-	const hasDmarc = dmarcCheck != null && !dmarcCheck.findings.some((f: Finding) => /No DMARC record/i.test(f.title));
+	const hasDmarc = measured(dmarcCheck) && !dmarcCheck!.findings.some((f: Finding) => /No DMARC record/i.test(f.title));
 	const dmarcPolicyNone = dmarcCheck?.findings.some((f: Finding) => /policy set to none/i.test(f.title)) ?? false;
 	const dmarcPolicyQuarantine = dmarcCheck?.findings.some((f: Finding) => /policy set to quarantine/i.test(f.title)) ?? false;
 	// reject = no "policy set to none" and no "policy set to quarantine" and DMARC exists
 	const dmarcPolicyReject = hasDmarc && !dmarcPolicyNone && !dmarcPolicyQuarantine;
-	const hasRua = dmarcCheck != null && !dmarcCheck.findings.some((f: Finding) => /No aggregate reporting/i.test(f.title));
+	const hasRua = measured(dmarcCheck) && !dmarcCheck!.findings.some((f: Finding) => /No aggregate reporting/i.test(f.title));
 
 	// Determine MTA-STS, DNSSEC, BIMI
-	const hasMtaSts = mtaStsCheck?.passed ?? false;
-	const hasDnssec = dnssecCheck?.passed ?? false;
-	const hasBimi = bimiCheck?.findings.some((f: Finding) => /BIMI record configured/i.test(f.title)) ?? false;
+	const hasMtaSts = measured(mtaStsCheck) && (mtaStsCheck?.passed ?? false);
+	const hasDnssec = measured(dnssecCheck) && (dnssecCheck?.passed ?? false);
+	const hasBimi = (measured(bimiCheck) && bimiCheck?.findings.some((f: Finding) => /BIMI record configured/i.test(f.title))) ?? false;
 
 	// DANE presence
 	const daneCheck = byCategory.get('dane');
-	const hasDane = daneCheck?.findings.some((f: Finding) => /DANE TLSA configured/i.test(f.title)) ?? false;
+	const hasDane = (measured(daneCheck) && daneCheck?.findings.some((f: Finding) => /DANE TLSA configured/i.test(f.title))) ?? false;
 
 	// CAA presence (passed = CAA records found)
 	const caaCheck = byCategory.get('caa');
-	const hasCaa = caaCheck?.passed ?? false;
+	const hasCaa = measured(caaCheck) && (caaCheck?.passed ?? false);
 
 	// DKIM "discovered" = at least one selector physically found (not provider-implied)
 	// Provider-implied findings have metadata.detectionMethod === 'provider-implied'
 	const hasDkimDiscovered =
-		dkimCheck != null &&
-		!dkimCheck.findings.some((f: Finding) => /No DKIM records found|DKIM selector not discovered/i.test(f.title)) &&
-		!dkimCheck.findings.some((f: Finding) => f.metadata?.detectionMethod === 'provider-implied');
+		measured(dkimCheck) &&
+		!dkimCheck!.findings.some((f: Finding) => /No DKIM records found|DKIM selector not discovered/i.test(f.title)) &&
+		!dkimCheck!.findings.some((f: Finding) => f.metadata?.detectionMethod === 'provider-implied');
 
 	// Stage 4 — Hardened: Stage 3 + at least 2 of (MTA-STS, DNSSEC, BIMI, DANE, CAA, DKIM-discovered)
 	// AND at least one TRANSPORT/INTEGRITY signal: DNSSEC, MTA-STS, or DANE.
@@ -278,7 +393,32 @@ export function computeMaturityStage(checks: CheckResult[], profile?: DomainProf
 		};
 	}
 
-	// Stage 0 — Unprotected
+	// Not determined — an email-authentication probe was attempted and did not
+	// complete (issue #574). Gating the presence probes on `measured()` above closes
+	// the false-REASSURANCE path, but without this branch it would simply convert
+	// that into a false ALARM: the bottom rung's description is the same class of
+	// affirmative, falsifiable claim as the web-only ladder's "No TLS detected", and
+	// an inconclusive spf or dmarc cannot support it. (A domain with a real
+	// `p=reject` whose DMARC probe timed out would be told any server can send as
+	// it.) The unmeasured input abstains at BOTH ends.
+	//
+	// Deliberately keyed on ATTEMPTED-but-inconclusive, not `!measured`: an ABSENT
+	// spf/dmarc entry is the long-standing contracted meaning of this rung ("nothing
+	// is published"), locked by `test/maturity-staging.spec.ts` — including the
+	// empty-check-set case, which `format-report.ts` already withholds one layer up
+	// via `isGraded`.
+	if (attemptedButInconclusive(spfCheck) || attemptedButInconclusive(dmarcCheck)) {
+		return {
+			stage: 0,
+			indeterminate: true,
+			label: 'Not determined (email authentication not measured)',
+			description:
+				'The SPF and/or DMARC lookup for this domain did not complete, so its email-authentication posture could not be measured. This is a measurement gap, NOT a security verdict — no conclusion can be drawn from it in either direction.',
+			nextStep: 'Re-scan later, or verify the SPF/DMARC TXT records directly, before reading anything into this result.',
+		};
+	}
+
+	// Stage 0 — Unprotected. Reachable only when SPF/DMARC were measured.
 	return {
 		stage: 0,
 		label: 'Unprotected',

--- a/test/contracts/maturity-evidence-gating.contract.test.ts
+++ b/test/contracts/maturity-evidence-gating.contract.test.ts
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * CONTRACT — the maturity ladder's evidence invariant (issue #574).
+ *
+ * Both ladders must obey the rule #455 / v3.25.4 established for
+ * `check_mta_sts`: **an unmeasurable input produces an abstention, never a
+ * confident verdict.** Stated as two properties that hold for EVERY category
+ * either ladder reads:
+ *
+ *   1. MONOTONICITY — replacing a completed check with an inconclusive one
+ *      (`checkStatus: 'error' | 'timeout'`) never RAISES the stage. Violating
+ *      this is false reassurance: it is how an errored `spf`/`dmarc`/`dkim`
+ *      (whose absence-of-finding probes then read `true`) inflated maturity.
+ *   2. NO CONFIDENT BOTTOM RUNG — if the degraded input lands the domain on the
+ *      bottom rung, that result must be flagged `indeterminate`, because every
+ *      bottom-rung description is an affirmative factual claim ("No TLS
+ *      detected…", "No email authentication…") that the missing measurement
+ *      cannot support.
+ *
+ * This is a property test over the category set, not a fixture test: a NEW
+ * signal wired into either ladder is covered the moment it is added to the
+ * arrays below, and the ladder's own baseline is asserted first so the whole
+ * file cannot pass vacuously.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeMaturityStage } from '../../src/tools/scan/maturity-staging';
+import { buildCheckResult, createFinding } from '../../src/lib/scoring';
+import type { CheckResult } from '../../src/lib/scoring';
+
+/** The exact shape `scan-domain.ts` re-stamps onto an inconclusive check. */
+function inconclusive(category: Parameters<typeof buildCheckResult>[0], status: 'error' | 'timeout'): CheckResult {
+	return {
+		...buildCheckResult(category, [createFinding(category, `${category} check error`, 'high', 'Check failed: probe did not complete')]),
+		score: 0,
+		passed: false,
+		checkStatus: status,
+		partial: true,
+	};
+}
+
+function pass(category: Parameters<typeof buildCheckResult>[0], title: string): CheckResult {
+	return buildCheckResult(category, [createFinding(category, title, 'info', 'ok')]);
+}
+
+/** Ladder A (web_only): a fully-measured stage-4 "Comprehensive" domain. */
+const WEB_ONLY_BASELINE: CheckResult[] = [
+	buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only')]),
+	buildCheckResult('spf', [createFinding('spf', 'SPF record found', 'info', 'v=spf1 -all')]),
+	buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+	pass('ssl', 'SSL certificate valid'),
+	pass('dnssec', 'DNSSEC validated'),
+	buildCheckResult('http_security', [createFinding('http_security', 'HSTS configured (preload)', 'info', 'HSTS')]),
+];
+const WEB_ONLY_CATEGORIES = ['ssl', 'dnssec', 'http_security', 'spf', 'dmarc'] as const;
+
+/** Ladder B (mail_enabled): a fully-measured stage-4 "Hardened" domain. */
+const MAIL_BASELINE: CheckResult[] = [
+	buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records')]),
+	buildCheckResult('spf', [createFinding('spf', 'SPF record configured', 'info', 'ok')]),
+	buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+	buildCheckResult('dkim', [createFinding('dkim', 'DKIM configured', 'info', 'selectors', { selectorsFound: ['s1'] })]),
+	pass('mta_sts', 'MTA-STS configured'),
+	pass('dnssec', 'DNSSEC validated'),
+	pass('caa', 'CAA records found'),
+	buildCheckResult('bimi', [createFinding('bimi', 'BIMI record configured', 'info', 'ok')]),
+	buildCheckResult('dane', [createFinding('dane', 'DANE TLSA configured', 'info', 'ok')]),
+];
+const MAIL_CATEGORIES = ['spf', 'dmarc', 'dkim', 'mta_sts', 'dnssec', 'bimi', 'dane', 'caa'] as const;
+
+function degrade(checks: CheckResult[], category: string, status: 'error' | 'timeout'): CheckResult[] {
+	return checks.map((c) => (c.category === category ? inconclusive(c.category, status) : c));
+}
+
+describe('CONTRACT: maturity ladders are evidence-gated (#574)', () => {
+	it('baseline (non-vacuity): both ladders reach stage 4 when everything is measured', () => {
+		const web = computeMaturityStage(WEB_ONLY_BASELINE, 'web_only');
+		expect(web.stage).toBe(4);
+		expect(web.indeterminate).toBeUndefined();
+
+		const mail = computeMaturityStage(MAIL_BASELINE, 'mail_enabled');
+		expect(mail.stage).toBe(4);
+		expect(mail.indeterminate).toBeUndefined();
+	});
+
+	describe.each([['web_only', WEB_ONLY_BASELINE, WEB_ONLY_CATEGORIES] as const, ['mail_enabled', MAIL_BASELINE, MAIL_CATEGORIES] as const])(
+		'%s ladder',
+		(profile, baseline, categories) => {
+			const baselineStage = () => computeMaturityStage(baseline, profile).stage;
+
+			it.each(categories.flatMap((c) => [[c, 'error'] as const, [c, 'timeout'] as const]))(
+				'an inconclusive %s (%s) never RAISES the stage',
+				(category, status) => {
+					const degraded = computeMaturityStage(degrade(baseline, category, status), profile);
+					expect(degraded.stage).toBeLessThanOrEqual(baselineStage());
+				},
+			);
+
+			it.each(categories.flatMap((c) => [[c, 'error'] as const, [c, 'timeout'] as const]))(
+				'an inconclusive %s (%s) never yields a CONFIDENT bottom-rung verdict',
+				(category, status) => {
+					const degraded = computeMaturityStage(degrade(baseline, category, status), profile);
+					if (degraded.stage === 0) {
+						expect(degraded.indeterminate, `${profile}/${category}/${status} landed on stage 0 as a confident verdict`).toBe(true);
+					}
+					// An indeterminate result must never carry a bottom-rung factual claim.
+					if (degraded.indeterminate) {
+						const prose = `${degraded.label} ${degraded.description}`;
+						expect(prose).not.toMatch(/No TLS detected|not authenticated or encrypted|No email authentication|any server can send/i);
+					}
+				},
+			);
+		},
+	);
+});

--- a/test/format-scan-report.spec.ts
+++ b/test/format-scan-report.spec.ts
@@ -374,6 +374,62 @@ describe('format-scan-report', () => {
 		expect(formatScanReport(result, 'compact')).not.toContain('Scoring model:');
 	});
 
+	/**
+	 * Issue #574. `isGraded` is the wrong instrument for THIS state: the scan IS
+	 * graded (17/19 checks completed, ratio 0.894 — comfortably over the 0.6
+	 * evidence-sufficiency threshold), so the existing gate passes the stage
+	 * straight through. But the ladder's one load-bearing input (`ssl`) was never
+	 * measured, so its stage number is not a measurement. The number is withheld;
+	 * the LABEL stays, because "Not determined (TLS not measured)" is information.
+	 */
+	function indeterminateMaturityResult(): ScanDomainResult {
+		return {
+			domain: 'secure.bank.example',
+			score: {
+				overall: 67,
+				grade: 'C',
+				categoryScores: { dnssec: 60, ns: 95, caa: 100 },
+				findings: [],
+				summary: 'Grade: C',
+				evidence: { attempted: 19, completed: 17, ratio: 17 / 19 },
+			},
+			checks: [
+				{ category: 'dnssec', passed: true, score: 60, findings: [] },
+				{ category: 'ssl', passed: false, score: 0, findings: [], checkStatus: 'error' },
+			],
+			maturity: {
+				stage: 0,
+				label: 'Not determined (TLS not measured)',
+				description: 'The TLS probe did not complete.',
+				nextStep: 'Re-scan later.',
+				indeterminate: true,
+			},
+			cached: false,
+			timestamp: '2026-07-27T00:00:00.000Z',
+		} as unknown as ScanDomainResult;
+	}
+
+	it('#574 withholds the stage NUMBER for an indeterminate maturity on a GRADED scan', () => {
+		const result = indeterminateMaturityResult();
+		// Non-vacuity: the scan really is graded, so `isGraded` alone would emit 0.
+		expect(result.score.overall).toBe(67);
+
+		const structured = buildStructuredScanResult(result);
+		expect(structured.maturityStage).toBeNull();
+		// The label survives — abstention, not suppression.
+		expect(structured.maturityLabel).toBe('Not determined (TLS not measured)');
+		expect(JSON.stringify(structured)).not.toContain('"maturityStage":0');
+	});
+
+	it.each(['compact', 'full'] as const)('#574 prose never prints "Stage 0" for an indeterminate maturity [%s]', (format) => {
+		const text = formatScanReport(indeterminateMaturityResult(), format);
+		const line = text.split('\n').find((l) => l.includes('Maturity'));
+		expect(line, format).toBeDefined();
+		expect(line, format).not.toContain('Stage 0');
+		expect(line, format).toContain('Not determined');
+		expect(text, format).not.toMatch(/No TLS detected/i);
+	});
+
 	it('carries evidence through buildToolResult into structuredContent', async () => {
 		const { buildToolResult } = await import('../src/handlers/tool-formatters');
 		const structured = { domain: 'x.example', evidence: { attempted: 19, completed: 4, ratio: 4 / 19 }, evidenceInsufficient: true };

--- a/test/maturity-staging-profile.spec.ts
+++ b/test/maturity-staging-profile.spec.ts
@@ -38,7 +38,9 @@ function govUkChecks(): CheckResult[] {
 		]),
 		passingCheck('dnssec', 'DNSSEC validated'),
 		passingCheck('ssl', 'SSL certificate valid'),
-		buildCheckResult('http_security', [createFinding('http_security', 'HSTS configured (preload)', 'info', 'HSTS preload + max-age >= 1y')]),
+		buildCheckResult('http_security', [
+			createFinding('http_security', 'HSTS configured (preload)', 'info', 'HSTS preload + max-age >= 1y'),
+		]),
 	];
 }
 
@@ -48,9 +50,7 @@ function stripeChecks(): CheckResult[] {
 		buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records')]),
 		passingCheck('spf', 'SPF record configured'),
 		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
-		buildCheckResult('dkim', [
-			createFinding('dkim', 'DKIM configured', 'info', 'selectors found', { selectorsFound: ['s1', 's2'] }),
-		]),
+		buildCheckResult('dkim', [createFinding('dkim', 'DKIM configured', 'info', 'selectors found', { selectorsFound: ['s1', 's2'] })]),
 		buildCheckResult('caa', [createFinding('caa', 'CAA records found', 'info', '0 issue "amazon.com"')]),
 		buildCheckResult('ssl', [createFinding('ssl', 'SSL certificate valid', 'info', 'ok')]),
 		// No DNSSEC, no MTA-STS, no BIMI, no DANE — stripe.com lacks transport hardening.
@@ -187,5 +187,199 @@ describe('Defect I — computeMaturityStage accepts profile and respects it', ()
 		const stage = computeMaturityStage(checks, 'web_only');
 		expect(stage.stage).toBeGreaterThanOrEqual(3);
 		expect(stage.label).toBe('Defensive');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Issue #574 — an UNMEASURABLE input must produce an abstention, never a
+// confident negative verdict (the principle already established for
+// `check_mta_sts` by #455 / v3.25.4).
+//
+// Live repro 2026-07-27: 22+ `bnz.co.nz` hosts whose `ssl` probe Akamai blocked
+// were published as "Stage 0 — Unprotected / No TLS detected on this web-only
+// domain. Traffic is not authenticated or encrypted." Those hosts (named
+// consumer-banking hostnames) demonstrably DO serve TLS. The ladder read only
+// `passed`, which the scan pipeline forcibly stamps `false` on any inconclusive
+// check — so a measurement GAP became an affirmative security CLAIM.
+// ---------------------------------------------------------------------------
+
+/** The exact shape `scan-domain.ts` re-stamps onto an inconclusive check. */
+function erroredCheck(category: Parameters<typeof buildCheckResult>[0]): CheckResult {
+	return {
+		...buildCheckResult(category, [
+			createFinding(category, `${category} check error`, 'high', 'Check failed: connection blocked at the edge'),
+		]),
+		score: 0,
+		passed: false,
+		checkStatus: 'error' as const,
+		partial: true,
+	};
+}
+
+/**
+ * The CONTROL half of the one-variable pair: a web-only domain with anti-spoof
+ * email policy + TLS + DNSSEC, and an http_security check that COMPLETED and
+ * found no HSTS. Ladder A places it at stage 3 "Defensive".
+ */
+function defensiveWebOnlyChecks(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'No MX records found', 'info', 'web-only')]),
+		buildCheckResult('spf', [createFinding('spf', 'SPF record found', 'info', 'v=spf1 -all')]),
+		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+		passingCheck('ssl', 'SSL certificate valid'),
+		passingCheck('dnssec', 'DNSSEC validated'),
+		buildCheckResult('http_security', [createFinding('http_security', 'No HSTS header', 'medium', 'Strict-Transport-Security absent')]),
+	];
+}
+
+/** The VARIABLE half: byte-identical, except the TLS probe never completed. */
+function tlsUnmeasuredWebOnlyChecks(): CheckResult[] {
+	return defensiveWebOnlyChecks().map((c) => (c.category === 'ssl' ? erroredCheck('ssl') : c));
+}
+
+describe('#574 — web-only ladder abstains when the TLS probe was never measured', () => {
+	it('CONTROL: the measured variant is unchanged at stage 3 "Defensive"', () => {
+		// Non-vacuity guard. Without this, a fix that abstained on EVERYTHING
+		// would satisfy every assertion below.
+		const stage = computeMaturityStage(defensiveWebOnlyChecks(), 'web_only');
+		expect(stage.stage).toBe(3);
+		expect(stage.label).toBe('Defensive');
+		expect(stage.indeterminate).toBeUndefined();
+	});
+
+	it('VARIABLE: an errored ssl check yields an indeterminate result, not stage 0', () => {
+		const stage = computeMaturityStage(tlsUnmeasuredWebOnlyChecks(), 'web_only');
+		expect(stage.indeterminate).toBe(true);
+	});
+
+	it('VARIABLE: the "No TLS detected" claim is unreachable when ssl was never measured', () => {
+		const stage = computeMaturityStage(tlsUnmeasuredWebOnlyChecks(), 'web_only');
+		const prose = `${stage.label} ${stage.description} ${stage.nextStep}`;
+		// The exact published sentence, and its component claims.
+		expect(prose).not.toMatch(/No TLS detected/i);
+		expect(prose).not.toMatch(/not authenticated or encrypted/i);
+		expect(stage.label).not.toBe('Unprotected');
+	});
+
+	it('VARIABLE: the prose names the measurement gap and how to resolve it', () => {
+		const stage = computeMaturityStage(tlsUnmeasuredWebOnlyChecks(), 'web_only');
+		expect(stage.label).toMatch(/not determined/i);
+		// It must read as a measurement gap, not a verdict…
+		expect(stage.description).toMatch(/could not be measured|not measured|blocked|timed out/i);
+		expect(stage.description).toMatch(/not a security verdict|measurement gap/i);
+		// …and tell the reader what to do about it.
+		expect(stage.nextStep).toMatch(/re-?scan|verify/i);
+	});
+
+	it('a timed-out ssl check abstains the same way an errored one does', () => {
+		const checks = defensiveWebOnlyChecks().map((c) =>
+			c.category === 'ssl' ? { ...erroredCheck('ssl'), checkStatus: 'timeout' as const } : c,
+		);
+		expect(computeMaturityStage(checks, 'web_only').indeterminate).toBe(true);
+	});
+
+	it('non_mail domains route through the same ladder and abstain identically', () => {
+		expect(computeMaturityStage(tlsUnmeasuredWebOnlyChecks(), 'non_mail').indeterminate).toBe(true);
+	});
+});
+
+describe('#574 — web-only ladder keeps the stage but discloses an unmeasured http_security', () => {
+	it('an errored http_security (ssl measured) keeps the honest stage-3 floor', () => {
+		const checks = defensiveWebOnlyChecks().map((c) => (c.category === 'http_security' ? erroredCheck('http_security') : c));
+		const stage = computeMaturityStage(checks, 'web_only');
+		// The stage is a LOWER BOUND and remains honest — only stage 4 was gated on HSTS.
+		expect(stage.stage).toBe(3);
+		expect(stage.label).toBe('Defensive');
+		expect(stage.indeterminate).toBeUndefined();
+	});
+
+	it('…and discloses that HSTS could not be measured, so stage 4 was not assessable', () => {
+		const checks = defensiveWebOnlyChecks().map((c) => (c.category === 'http_security' ? erroredCheck('http_security') : c));
+		const stage = computeMaturityStage(checks, 'web_only');
+		const prose = `${stage.description} ${stage.nextStep}`;
+		expect(prose).toMatch(/HSTS/);
+		expect(prose).toMatch(/could not be measured|not measured/i);
+	});
+
+	it('CONTROL: a completed http_security adds no disclosure', () => {
+		const stage = computeMaturityStage(defensiveWebOnlyChecks(), 'web_only');
+		expect(`${stage.description} ${stage.nextStep}`).not.toMatch(/could not be measured/i);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Ladder B (mail-enabled). OPPOSITE polarity, and arguably worse: `hasSpf` /
+// `hasDmarc` are ABSENCE-of-finding tests, so an errored spf/dmarc — which emits
+// a "check error" finding rather than a "No SPF record" finding — read TRUE and
+// a measurement failure inflated maturity UPWARD. False reassurance.
+// ---------------------------------------------------------------------------
+describe('#574 — mail ladder: an unmeasured spf/dmarc never reads as present', () => {
+	function enforcingMailChecks(): CheckResult[] {
+		return [
+			buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records')]),
+			buildCheckResult('spf', [createFinding('spf', 'SPF record configured', 'info', 'ok')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+		];
+	}
+
+	it('CONTROL: the measured variant is unchanged at stage 3 "Enforcing"', () => {
+		const stage = computeMaturityStage(enforcingMailChecks(), 'mail_enabled');
+		expect(stage.stage).toBe(3);
+		expect(stage.label).toBe('Enforcing');
+		expect(stage.indeterminate).toBeUndefined();
+	});
+
+	it('an errored spf check no longer inflates the domain to "Enforcing"', () => {
+		const checks = enforcingMailChecks().map((c) => (c.category === 'spf' ? erroredCheck('spf') : c));
+		const stage = computeMaturityStage(checks, 'mail_enabled');
+		expect(stage.label).not.toBe('Enforcing');
+		expect(stage.stage).not.toBe(3);
+	});
+
+	it('an errored dmarc check no longer inflates the domain to "Enforcing"', () => {
+		const checks = enforcingMailChecks().map((c) => (c.category === 'dmarc' ? erroredCheck('dmarc') : c));
+		const stage = computeMaturityStage(checks, 'mail_enabled');
+		expect(stage.label).not.toBe('Enforcing');
+	});
+
+	it('…and abstains rather than swapping false reassurance for a false alarm', () => {
+		// Deflating an unmeasured check into stage 0 "No email authentication — any
+		// server can send email as this domain" would be the SAME defect pointing the
+		// other way. The unmeasured input abstains at BOTH ends.
+		const checks = enforcingMailChecks().map((c) => (c.category === 'dmarc' ? erroredCheck('dmarc') : c));
+		const stage = computeMaturityStage(checks, 'mail_enabled');
+		expect(stage.indeterminate).toBe(true);
+		expect(`${stage.label} ${stage.description}`).not.toMatch(/No email authentication|any server can send/i);
+	});
+
+	it('an errored bimi/dane/dkim check no longer counts as a hardening signal', () => {
+		// hasBimi / hasDane / hasDkimDiscovered are finding-title probes with the same
+		// absence polarity — an errored check emitted no "No DKIM records found"
+		// finding, so DKIM read as "discovered".
+		const base: CheckResult[] = [
+			buildCheckResult('spf', [createFinding('spf', 'SPF record configured', 'info', 'ok')]),
+			buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+			buildCheckResult('mta_sts', [createFinding('mta_sts', 'MTA-STS configured', 'info', 'ok')]),
+		];
+		// mta_sts (1 signal) + an ERRORED dkim must NOT reach the 2 signals stage 4 needs.
+		const stage = computeMaturityStage([...base, erroredCheck('dkim')], 'mail_enabled');
+		expect(stage.stage).toBe(3);
+		expect(stage.label).not.toBe('Hardened');
+
+		// CONTROL: a genuinely discovered DKIM selector still reaches stage 4.
+		const control = computeMaturityStage(
+			[...base, buildCheckResult('dkim', [createFinding('dkim', 'DKIM configured', 'info', 'ok', { selectorsFound: ['s1'] })])],
+			'mail_enabled',
+		);
+		expect(control.stage).toBe(4);
+	});
+
+	it('an EMPTY check set keeps its historical stage 0 (contract preserved)', () => {
+		// `test/maturity-staging.spec.ts:93` locks this. "Nothing was attempted" is
+		// already withheld one layer up by `isGraded` in format-report; the abstention
+		// added here keys on a check that was ATTEMPTED and did not complete.
+		const stage = computeMaturityStage([]);
+		expect(stage.stage).toBe(0);
+		expect(stage.indeterminate).toBeUndefined();
 	});
 });


### PR DESCRIPTION
Fixes #574.

## What was wrong

When the `ssl` check could not be **measured** — an edge/CDN blocked or timed out the HTTPS probe — `computeWebOnlyMaturity` fell through to the bottom rung and published:

> **"Unprotected"** — *"No TLS detected on this web-only domain. Traffic is not authenticated or encrypted."*

That is an affirmative, falsifiable factual claim, emitted on a public report URL, about hosts that plainly do serve TLS. It was produced by a **measurement gap**, not a security finding.

**Real-world impact:** reproduced live 2026-07-27 — **22+ hosts in a single `bnz.co.nz` sweep** carried this false public statement about their transport security, including named consumer-banking hostnames (`mybnz`, `cardsecurity`, `realme`, `ams.privatebank`, `myaccess`, `mobilesecure`, `ma.sso`). The issue's one-variable control pair is the proof: `secure.bnz.co.nz` and `api.bnz.co.nz` have 13 byte-identical scored categories and differ in exactly one bit — whether Akamai let the TLS probe through — yet were published as stage 0 "Unprotected" vs stage 3 "Defensive".

Same defect family as the already-fixed #455 / v3.25.4 (`check_mta_sts` emitting a confident `high` on a WAF-challenged 403). The principle established there — **an unmeasurable input produces an abstention, never a confident negative verdict** — had never been applied to the maturity ladder.

## Root cause

`computeMaturityStage` received the full `CheckResult[]` *including* `checkStatus` but read only `passed` (`grep -c checkStatus src/tools/scan/maturity-staging.ts` → **0**). The pipeline forcibly stamps `score: 0, passed: false` onto every inconclusive check (`scan-domain.ts:686-692` `degradedStatuses`), and that runs at `:688`, **before** `computeMaturityStage` at `:833`. So the ladder collapsed the two states the rest of the codebase works hard to separate: INCONCLUSIVE ("we could not measure it") vs ABSENT ("we measured, the control is not there"). The web-only ladder is strictly nested on `hasSsl`, so this was not "one signal missing" — it was an unconditional fallthrough to the bottom rung. `capMaturityStage` could not correct it: it only engages below 63/50 and the affected hosts scored 67.

## The fix (worker layer only)

- **`measured(c)`** — `checkStatus 'error' | 'timeout'` (the complete inconclusive set per the `CheckStatus` type) is not a signal in **either** direction. Applied across both ladders.
- **Additive-optional `indeterminate?: true`** on `MaturityStage`, so no existing producer or consumer breaks.
- **Ladder A (`web_only`/`non_mail`)** — an unmeasured `ssl` **replaces** the stage-0 fallthrough with an indeterminate result (`Not determined (TLS not measured)`), naming the edge block as a measurement gap and *not* a verdict. The "No TLS detected" sentence is now unreachable without a TLS measurement. When `http_security` is inconclusive but ssl WAS measured, the stage is **kept** (honest as a lower bound) and the prose discloses that HSTS could not be measured, so stage 4 was not assessable.
- **Ladder B (`mail_enabled`)** — `hasSpf` / `hasDmarc` / `hasDmarcReject` / `hasBimi` / `hasDane` / `hasDkimDiscovered` are **absence-of-finding** tests, i.e. the opposite polarity: an errored check emits a *"check error"* finding rather than a *"No SPF record"* finding, so they read `true` and a measurement failure inflated maturity **UPWARD** — false reassurance, arguably worse than the false alarm. Now gated on `measured()`, **and** the stage-0 rung abstains too, so the fix does not simply swap false reassurance for a false alarm. An **absent** spf/dmarc keeps its historical stage-0 meaning (locked by `maturity-staging.spec.ts:93`).
- **Render layer** withholds the stage **NUMBER** for an indeterminate maturity and keeps the **LABEL**, reusing the abstention pattern the file already documents for ungraded scans — in `format-report.ts` (structured payload + prose), and additionally in `generate-fix-plan.ts` (else it renders "Maturity Stage: 0/4") and `tenants/scan-snapshot.ts` (else a placeholder 0 is persisted into a tenant's `scans.maturity_stage` history and every trend built off it). All three were already typed `number | null` — verified, not assumed; `batch-scan.ts` and the tenant route/queue writers read those same nullable fields.

## Tests (test-first, non-vacuous)

- **Control pair** in `maturity-staging-profile.spec.ts`: identical DNS-layer checks, `ssl` errored vs completed → `indeterminate: true` with no "No TLS detected"/"not authenticated or encrypted" prose, vs the control **unchanged at stage 3 "Defensive"**. The control is what stops a fix that abstains on everything.
- **Render layer** in `format-scan-report.spec.ts`: an indeterminate maturity on a **GRADED** scan (17/19 checks, evidence ratio 0.894 — comfortably over the 0.6 sufficiency threshold, i.e. precisely the state `isGraded` cannot see) → `maturityStage: null`, `maturityLabel` non-null, prose never prints "Stage 0" in either format.
- **Ladder B upward-inflation** cases: an errored spf/dmarc no longer reads as present, an errored dkim no longer counts toward the stage-4 hardening quorum — each with its measured control.
- **New `test/contracts/maturity-evidence-gating.contract.test.ts`** pins the invariant as a property over the category set: for every category either ladder reads, an inconclusive input (a) never RAISES the stage and (b) never yields a confident bottom-rung verdict. A new signal wired into a ladder is covered the moment it joins the array; a baseline assertion keeps the file from passing vacuously.

**Non-vacuity guards kept green:** `format-scan-report.spec.ts:245` and `ungraded-scan-abstain.spec.ts:178` (a graded, genuine stage 0 still emits `0` — that zero is a measurement), plus `maturity-staging.spec.ts`, the existing `maturity-staging-profile.spec.ts` cases, and `reporting-surfaces-unmeasured.integration.test.ts`.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean (0 errors)
- `npm test` — **6439 passed | 13 skipped**, zero test failures. The single failing FILE is `test/wasm-integration.test.ts`, a **pre-existing, environmental** failure unrelated to this change: the gitignored `crates/bv-wasm-core/pkg/` wasm-pack build artifact exists only in the main checkout, not in this worktree, so the module import fails before any test runs. No WASM code is touched by this PR.

## Deliberately out of scope

Issue #574 item 6 — `packages/dns-checks/src/scoring/profiles.ts:324` derives `sslPass` from `controlPresent`, so an unmeasured SSL can flip `web_only` → `non_mail` and change the weight table. That is the same defect family but lives in the **published, parity-locked** package: it carries a gated npm publish, a `VENDORED_VERSION` lockstep, and a bv-web-prod `parity.contract.test.ts` impact. Left for a separate PR. **This PR is worker-layer only** — no `packages/` change, no publish, no vendored-tarball bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTJZG4aY7s3HXSMb9NsXS5
