### PR TITLE
fix(discover-subdomains): paginate Certspotter + make CT truncation explicit (fixes #573)

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1632,6 +1632,13 @@ export async function handleToolsCall(
 						issues: result.issues.length,
 						sourceUnavailable: result.sourceUnavailable ?? false,
 						stale: result.stale ?? false,
+						// #573: an under-reported enumeration must be visible in tail, not
+						// just in the payload — a rising truncated-rate is the alarm for a
+						// CT source that has quietly started capping us.
+						truncated: result.truncated ?? false,
+						returned: result.returned ?? result.subdomains.length,
+						enumerationComplete: result.enumerationComplete ?? true,
+						...(result.sources ? { sources: result.sources.join(',') } : {}),
 						...(result.stale ? { cacheAgeMinutes: result.cacheAgeMinutes ?? 0 } : {}),
 					};
 					// A CT-source outage (sourceUnavailable) is NOT a clean "0 subdomains found" — for a

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -81,8 +81,57 @@ const CT_SOURCE_MAX_BODY_BYTES = 5 * 1024 * 1024;
 const SUBDOMAIN_LKG_KEY_PREFIX = 'cache:subdomains-lkg:';
 const SUBDOMAIN_LKG_TTL_SECONDS = 7 * 24 * 60 * 60;
 
-/** Maximum subdomains to return (CT logs can contain thousands). */
-const MAX_SUBDOMAINS = 100;
+/**
+ * Maximum subdomains carried in the STRUCTURED result (CT logs can contain
+ * thousands).
+ *
+ * Raised 100 → 500 for issue #573. The list is sorted `lastSeen` DESCENDING
+ * before the cap is applied, so a 100-name cap does not truncate randomly — it
+ * truncates the long-lived production hosts that renew infrequently while
+ * keeping recently-issued throwaways. On a real bank's estate that dropped
+ * `internetbanking`, `payonline`, `mybnz` and kept `test-fc1` / `m.www.sandbox`.
+ * 500 covers the overwhelming majority of real estates; whatever it still cuts
+ * is now reported explicitly via {@link SubdomainDiscoveryResult.truncated}.
+ */
+const MAX_SUBDOMAINS = 500;
+
+/**
+ * Maximum subdomains RENDERED into the human/LLM-readable text.
+ *
+ * Deliberately far below {@link MAX_SUBDOMAINS}: `formatFull` emits ~4 lines per
+ * host, so 500 hosts is ~100KB of prose that would swamp an LLM context window
+ * for no analytical gain. The full list stays available in `structuredContent`;
+ * the text says honestly how many it is not showing.
+ */
+const MAX_RENDERED_SUBDOMAINS = 100;
+
+/**
+ * Cap on per-NAME issue rows emitted for a single issue type.
+ *
+ * The derived COUNTS (`wildcardCerts` / `expiredCerts`) are always whole-set —
+ * only the enumerated rows are bounded, with a roll-up row naming the
+ * remainder. Without this a 500-name estate could emit 500 issue rows.
+ */
+const MAX_PER_NAME_ISSUES = 25;
+
+/**
+ * Maximum Certspotter pages followed per attempt.
+ *
+ * Certspotter paginates at 100 issuances and ignores `&limit=` without an API
+ * key, so following `Link: <…>; rel="next"` via `&after=<last id>` is the only
+ * lever on recall. Measured ~1.5s/page unauthenticated; 8 pages is ~800
+ * issuances, comfortably more than any realistic estate while staying inside
+ * both the per-source timeout and the caller's synchronous budget.
+ */
+const MAX_CT_PAGES = 8;
+
+/**
+ * Budget an additional Certspotter page must fit inside before it is started.
+ * Measured page cost is ~1.5s; 2s carries headroom without letting the page
+ * loop erode the ~24s handler budget. The caller's `deadlineMs` stays
+ * authoritative — see {@link hasBudgetFor}.
+ */
+const CERTSPOTTER_PAGE_BUDGET_MS = 2_000;
 
 /** Common subdomain prefixes that are expected infrastructure. */
 const COMMON_SUBDOMAINS = new Set([
@@ -191,6 +240,31 @@ export interface SubdomainDiscoveryResult {
 	stale?: boolean;
 	/** Age of a `stale` result in whole minutes since it was cached. */
 	cacheAgeMinutes?: number;
+	/**
+	 * True when this result is NOT the whole story — either the returned
+	 * {@link subdomains} array is a strict subset of what was enumerated
+	 * (`returned < totalSubdomains`, the {@link MAX_SUBDOMAINS} cap), or the
+	 * upstream enumeration itself was incomplete ({@link enumerationComplete}
+	 * false). A security caller that sweeps only `subdomains` MUST branch on
+	 * this: before #573 the cap was silent and the tool read as authoritative.
+	 */
+	truncated?: boolean;
+	/** How many entries the {@link subdomains} array actually carries. */
+	returned?: number;
+	/** Which CT source(s) produced this answer, e.g. `['crtsh']`, `['certspotter']`. */
+	sources?: string[];
+	/**
+	 * True when we believe we read the source's index exhaustively: every page
+	 * followed, no upstream truncation flag, no entry-cap applied. False means
+	 * `totalSubdomains` is a FLOOR, not a total — the real count is higher.
+	 */
+	enumerationComplete?: boolean;
+}
+
+/** Provenance/completeness metadata threaded from a source into the result builders. */
+interface EnumerationMeta {
+	sources?: string[];
+	enumerationComplete?: boolean;
 }
 
 /**
@@ -308,7 +382,9 @@ export async function discoverSubdomains(
 	// and a bounded retry: crt.sh (rich metadata) → Certspotter (names + dates).
 	const direct = await queryDirectSources(domain, options);
 	if (direct.available) {
-		const result = direct.entries.length > 0 ? buildResultFromEntries(domain, direct.entries) : emptyResult(domain);
+		const meta: EnumerationMeta = { sources: direct.sources, enumerationComplete: direct.enumerationComplete };
+		const result =
+			direct.entries.length > 0 ? buildResultFromEntries(domain, direct.entries, meta) : emptyResult(domain, false, false, meta);
 		await cacheSuccess(domain, result, options);
 		return result;
 	}
@@ -328,11 +404,14 @@ export async function discoverSubdomains(
  * subdomain, track first/last-seen + issuer per name, and derive the wildcard /
  * expired / many-issuers / shadow-subdomain issues. Pure — no I/O.
  */
-export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[]): SubdomainDiscoveryResult {
+export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[], meta?: EnumerationMeta): SubdomainDiscoveryResult {
 	const now = new Date();
 
-	// Cap entries to prevent memory exhaustion on domains with huge CT histories
-	const entries = rawEntries.length > 5000 ? rawEntries.slice(0, 5000) : rawEntries;
+	// Cap entries to prevent memory exhaustion on domains with huge CT histories.
+	// Hitting this cap makes the enumeration incomplete regardless of what the
+	// source reported — the discarded certs may carry names nothing else covers.
+	const entryCapHit = rawEntries.length > 5000;
+	const entries = entryCapHit ? rawEntries.slice(0, 5000) : rawEntries;
 
 	// Parse and aggregate subdomain data
 	const trackers = new Map<string, SubdomainTracker>();
@@ -407,7 +486,10 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[])
 	// Sort by lastSeen descending (most recent first)
 	allSubdomains.sort((a, b) => (b.lastSeen > a.lastSeen ? 1 : b.lastSeen < a.lastSeen ? -1 : 0));
 
-	// Limit to MAX_SUBDOMAINS
+	// Limit to MAX_SUBDOMAINS. NOTE: every derived statistic below is computed
+	// over `allSubdomains`, NOT this slice — the counts describe the ESTATE, and
+	// a count taken after the display cut is a silently wrong security answer
+	// (issue #573 defect C: 3 wildcards on the wire were reported as 2).
 	const subdomains = allSubdomains.slice(0, MAX_SUBDOMAINS);
 
 	// Collect unique issuers
@@ -417,22 +499,32 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[])
 	}
 	const uniqueIssuers = Array.from(issuerSet);
 
-	// Count wildcards and expired
-	const wildcardCerts = subdomains.filter((s) => s.isWildcard).length;
-	const expiredCerts = subdomains.filter((s) => s.isExpired).length;
+	// Count wildcards and expired — whole set, never the returned slice.
+	const wildcardCerts = allSubdomains.filter((s) => s.isWildcard).length;
+	const expiredCerts = allSubdomains.filter((s) => s.isExpired).length;
 
 	// Detect issues
 	const issues: SubdomainIssue[] = [];
 
-	// Expired subdomains — only certs expired
-	for (const sd of subdomains) {
-		if (sd.isExpired) {
-			issues.push({
-				type: 'expired_subdomain',
-				severity: 'medium',
-				detail: `${sd.subdomain} has only expired certificates — may be abandoned`,
-			});
-		}
+	// Expired subdomains — only certs expired. Rows are bounded (a 500-name
+	// estate must not emit 500 rows) but the roll-up keeps the total honest.
+	let expiredRows = 0;
+	for (const sd of allSubdomains) {
+		if (!sd.isExpired) continue;
+		if (expiredRows >= MAX_PER_NAME_ISSUES) break;
+		expiredRows++;
+		issues.push({
+			type: 'expired_subdomain',
+			severity: 'medium',
+			detail: `${sd.subdomain} has only expired certificates — may be abandoned`,
+		});
+	}
+	if (expiredCerts > expiredRows) {
+		issues.push({
+			type: 'expired_subdomain',
+			severity: 'medium',
+			detail: `…and ${expiredCerts - expiredRows} further subdomains have only expired certificates (rows capped at ${MAX_PER_NAME_ISSUES} for readability; see the full list in the structured result)`,
+		});
 	}
 
 	// Wildcard exposure
@@ -453,14 +545,21 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[])
 		});
 	}
 
-	// Shadow subdomains — not matching common patterns, with recent certs
+	// Shadow subdomains — not matching common patterns, with recent certs.
+	// Swept over the whole set (a shadow host that fell past the return cap is
+	// exactly the one worth naming), with the same bounded-rows discipline.
 	const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000).toISOString();
-	for (const sd of subdomains) {
+	let shadowRows = 0;
+	let shadowTotal = 0;
+	for (const sd of allSubdomains) {
 		if (sd.isWildcard || sd.isExpired) continue;
 		const label = sd.subdomain.replace(domainSuffix, '').replace(/\.$/, '');
 		// Only consider single-label subdomains for shadow detection
 		if (label.includes('.')) continue;
 		if (!COMMON_SUBDOMAINS.has(label) && sd.lastSeen >= thirtyDaysAgo) {
+			shadowTotal++;
+			if (shadowRows >= MAX_PER_NAME_ISSUES) continue;
+			shadowRows++;
 			issues.push({
 				type: 'shadow_subdomain',
 				severity: 'info',
@@ -468,6 +567,15 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[])
 			});
 		}
 	}
+	if (shadowTotal > shadowRows) {
+		issues.push({
+			type: 'shadow_subdomain',
+			severity: 'info',
+			detail: `…and ${shadowTotal - shadowRows} further subdomains with recent certificate activity are not common service names (rows capped at ${MAX_PER_NAME_ISSUES} for readability; see the full list in the structured result)`,
+		});
+	}
+
+	const enumerationComplete = (meta?.enumerationComplete ?? true) && !entryCapHit;
 
 	return {
 		domain,
@@ -478,6 +586,28 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[])
 		expiredCerts,
 		uniqueIssuers,
 		issues,
+		...enumerationFlags(allSubdomains.length, subdomains.length, meta?.sources, enumerationComplete),
+	};
+}
+
+/**
+ * Build the {@link SubdomainDiscoveryResult} truncation contract from a
+ * (total, returned) pair. `truncated` is deliberately the UNION of both ways an
+ * answer can be partial — the return cap bit, or the upstream enumeration being
+ * incomplete — because a caller asking "is this the whole estate?" needs one
+ * flag, with `enumerationComplete` available to say WHICH.
+ */
+function enumerationFlags(
+	total: number,
+	returned: number,
+	sources: string[] | undefined,
+	enumerationComplete: boolean,
+): Pick<SubdomainDiscoveryResult, 'truncated' | 'returned' | 'sources' | 'enumerationComplete'> {
+	return {
+		returned,
+		truncated: returned < total || !enumerationComplete,
+		enumerationComplete,
+		...(sources && sources.length > 0 ? { sources } : {}),
 	};
 }
 
@@ -488,10 +618,20 @@ type CtSourceOutcome = 'ok' | 'empty' | 'http_error' | 'timeout' | 'error';
 interface SourceResult {
 	outcome: CtSourceOutcome;
 	entries: CrtShEntry[];
+	/**
+	 * False when the source's index was NOT read exhaustively (pagination cut
+	 * short by {@link MAX_CT_PAGES}, the budget, or a mid-pagination failure).
+	 * Defaults to true for single-shot sources.
+	 */
+	enumerationComplete?: boolean;
 }
 
-/** A single Certspotter issuance (with `expand=dns_names&expand=issuer`). */
+/**
+ * A single Certspotter issuance (with `expand=dns_names&expand=issuer`).
+ * `id` is the pagination cursor — `&after=<id>` fetches the next page.
+ */
 interface CertspotterIssuance {
+	id?: string | number;
 	dns_names?: string[];
 	not_before?: string;
 	not_after?: string;
@@ -551,46 +691,116 @@ async function fetchCrtShEntries(domain: string, signal: AbortSignal): Promise<S
 		const parsed = JSON.parse(rawBody) as unknown;
 		if (!Array.isArray(parsed)) return { outcome: 'error', entries: [] };
 		const entries = parsed as CrtShEntry[];
-		return { outcome: entries.length === 0 ? 'empty' : 'ok', entries };
+		// crt.sh answers the whole query in one response — no pagination to miss.
+		return { outcome: entries.length === 0 ? 'empty' : 'ok', entries, enumerationComplete: true };
 	} catch (err) {
 		return { outcome: classifyFetchError(err), entries: [] };
 	}
+}
+
+/** True when a Certspotter response advertises another page (`Link: …; rel="next"`). */
+function hasNextCertspotterPage(response: Response): boolean {
+	const link = response.headers.get('link');
+	return typeof link === 'string' && /rel\s*=\s*"?next"?/i.test(link);
 }
 
 /**
  * Fetch + parse Certspotter issuances into normalized {@link CrtShEntry}s so the
  * shared aggregation applies unchanged. Unauthenticated (rate-limited but
  * functional for occasional failover); `not_before`/`not_after` are best-effort.
+ *
+ * PAGINATION (issue #573): Certspotter serves 100 issuances per page and
+ * **silently ignores `&limit=` without an API key**, so a single request is
+ * page 1 of N — for bnz.co.nz that was 140 names reported out of 165 the index
+ * actually holds. We follow `Link: <…>; rel="next"` by re-requesting with
+ * `&after=<last issuance id>` until a short page, a missing next link,
+ * {@link MAX_CT_PAGES}, or the caller's budget stops us.
+ *
+ * Failure posture is asymmetric on purpose: a failure on page 1 is a SOURCE
+ * failure (failover to the next source), while a failure mid-pagination keeps
+ * the pages already read and marks the enumeration incomplete — partial real
+ * data beats discarding it and reporting an outage.
  */
-async function fetchCertspotterEntries(domain: string, signal: AbortSignal): Promise<SourceResult> {
+async function fetchCertspotterEntries(domain: string, signal: AbortSignal, options?: DiscoverSubdomainsOptions): Promise<SourceResult> {
+	const base = `https://api.certspotter.com/v1/issuances?domain=${encodeURIComponent(domain)}&include_subdomains=true&expand=dns_names&expand=issuer`;
+	const entries: CrtShEntry[] = [];
+	let after: string | undefined;
+	let pagesRead = 0;
+	let enumerationComplete = true;
+
+	/** A mid-pagination stop: keep what we have, flag the gap. */
+	const stopIncomplete = (): boolean => {
+		enumerationComplete = false;
+		return true;
+	};
+
 	try {
-		const url = `https://api.certspotter.com/v1/issuances?domain=${encodeURIComponent(domain)}&include_subdomains=true&expand=dns_names&expand=issuer`;
-		const response = await fetch(url, { signal, redirect: 'manual' });
-		if (!response.ok) {
-			await disposeUnreadResponseBody(response);
-			return { outcome: 'http_error', entries: [] };
+		while (pagesRead < MAX_CT_PAGES) {
+			// The caller's synchronous budget stays authoritative over the page
+			// loop — an extra page is never worth tripping the 28s guillotine.
+			if (pagesRead > 0 && (deadlineExceeded(options) || !hasBudgetFor(options, CERTSPOTTER_PAGE_BUDGET_MS))) {
+				stopIncomplete();
+				break;
+			}
+
+			const url = after ? `${base}&after=${encodeURIComponent(after)}` : base;
+			const response = await fetch(url, { signal, redirect: 'manual' });
+
+			if (!response.ok) {
+				await disposeUnreadResponseBody(response);
+				if (pagesRead === 0) return { outcome: 'http_error', entries: [] };
+				stopIncomplete();
+				break;
+			}
+			const declaredLength = Number(response.headers.get('content-length'));
+			if (Number.isFinite(declaredLength) && declaredLength > CT_SOURCE_MAX_BODY_BYTES) {
+				await disposeUnreadResponseBody(response);
+				if (pagesRead === 0) return { outcome: 'http_error', entries: [] };
+				stopIncomplete();
+				break;
+			}
+			const rawBody = await readBoundedOrNull(response.body, CT_SOURCE_MAX_BODY_BYTES);
+			if (rawBody === null) {
+				if (pagesRead === 0) return { outcome: 'http_error', entries: [] };
+				stopIncomplete();
+				break;
+			}
+			const parsed = JSON.parse(rawBody) as unknown;
+			if (!Array.isArray(parsed)) {
+				if (pagesRead === 0) return { outcome: 'error', entries: [] };
+				stopIncomplete();
+				break;
+			}
+
+			const page = parsed as CertspotterIssuance[];
+			pagesRead++;
+			let lastId: string | undefined;
+			for (const item of page) {
+				if (item && (typeof item.id === 'string' || typeof item.id === 'number')) lastId = String(item.id);
+				if (!item || !Array.isArray(item.dns_names) || item.dns_names.length === 0) continue;
+				entries.push({
+					name_value: item.dns_names.join('\n'),
+					issuer_name: item.issuer?.name ?? '',
+					not_before: item.not_before ?? '',
+					not_after: item.not_after ?? '',
+				});
+			}
+
+			// Index exhausted, or the server says this is the last page.
+			if (page.length === 0 || !hasNextCertspotterPage(response)) break;
+			// A next page exists but we cannot address it (no usable cursor) or we
+			// have spent the page budget — either way the enumeration is partial.
+			if (!lastId || pagesRead >= MAX_CT_PAGES) {
+				stopIncomplete();
+				break;
+			}
+			after = lastId;
 		}
-		const declaredLength = Number(response.headers.get('content-length'));
-		if (Number.isFinite(declaredLength) && declaredLength > CT_SOURCE_MAX_BODY_BYTES) {
-			await disposeUnreadResponseBody(response);
-			return { outcome: 'http_error', entries: [] };
-		}
-		const rawBody = await readBoundedOrNull(response.body, CT_SOURCE_MAX_BODY_BYTES);
-		if (rawBody === null) return { outcome: 'http_error', entries: [] };
-		const parsed = JSON.parse(rawBody) as unknown;
-		if (!Array.isArray(parsed)) return { outcome: 'error', entries: [] };
-		const entries: CrtShEntry[] = [];
-		for (const item of parsed as CertspotterIssuance[]) {
-			if (!item || !Array.isArray(item.dns_names) || item.dns_names.length === 0) continue;
-			entries.push({
-				name_value: item.dns_names.join('\n'),
-				issuer_name: item.issuer?.name ?? '',
-				not_before: item.not_before ?? '',
-				not_after: item.not_after ?? '',
-			});
-		}
-		return { outcome: entries.length === 0 ? 'empty' : 'ok', entries };
+
+		return { outcome: entries.length === 0 ? 'empty' : 'ok', entries, enumerationComplete };
 	} catch (err) {
+		// An abort/network error AFTER a successful page is still usable data.
+		if (entries.length > 0) return { outcome: 'ok', entries, enumerationComplete: false };
 		return { outcome: classifyFetchError(err), entries: [] };
 	}
 }
@@ -642,11 +852,15 @@ function delayWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
 async function queryDirectSources(
 	domain: string,
 	options?: DiscoverSubdomainsOptions,
-): Promise<{ available: boolean; entries: CrtShEntry[] }> {
+): Promise<{ available: boolean; entries: CrtShEntry[]; sources?: string[]; enumerationComplete?: boolean }> {
 	// Per-source timeouts differ by backend: crt.sh is Postgres-backed and often
 	// slow on a cold query, while Certspotter is a fast JSON API — giving the
 	// fallback a tighter bound keeps both inside one budget.
-	const sources: Array<{ name: string; timeoutMs: number; fetch: (d: string, signal: AbortSignal) => Promise<SourceResult> }> = [
+	const sources: Array<{
+		name: string;
+		timeoutMs: number;
+		fetch: (d: string, signal: AbortSignal, options?: DiscoverSubdomainsOptions) => Promise<SourceResult>;
+	}> = [
 		{ name: 'crtsh', timeoutMs: CT_SOURCE_TIMEOUT_MS, fetch: fetchCrtShEntries },
 		{ name: 'certspotter', timeoutMs: CERTSPOTTER_TIMEOUT_MS, fetch: fetchCertspotterEntries },
 	];
@@ -664,13 +878,14 @@ async function queryDirectSources(
 			const composed = composeAbortSignal(source.timeoutMs, options?.signal);
 			let res: SourceResult;
 			try {
-				res = await source.fetch(domain, composed.signal);
+				res = await source.fetch(domain, composed.signal, options);
 			} finally {
 				composed.cleanup();
 			}
 			logCtSource(domain, source.name, res.outcome);
-			if (res.outcome === 'ok') return { available: true, entries: res.entries };
-			if (res.outcome === 'empty') return { available: true, entries: [] };
+			const meta = { sources: [source.name], enumerationComplete: res.enumerationComplete ?? true };
+			if (res.outcome === 'ok') return { available: true, entries: res.entries, ...meta };
+			if (res.outcome === 'empty') return { available: true, entries: [], ...meta };
 		}
 	}
 	return { available: false, entries: [] };
@@ -748,10 +963,16 @@ async function queryCertstream(
 		return emptyResult(domain, true, true);
 	}
 
-	const enumerate = await queryCertstreamEndpoint<CertstreamEnumerateResponse>('enumerate', domain, certstream, certstreamAuthToken, options);
+	const enumerate = await queryCertstreamEndpoint<CertstreamEnumerateResponse>(
+		'enumerate',
+		domain,
+		certstream,
+		certstreamAuthToken,
+		options,
+	);
 	const enumerateResult =
 		enumerate && !enumerate.error && Array.isArray(enumerate.subdomains)
-			? buildCertstreamResult(domain, enumerate.subdomains, enumerate.certificateCount)
+			? buildCertstreamResult(domain, enumerate.subdomains, enumerate.certificateCount, { timedOut: enumerate.timedOut })
 			: null;
 	if (enumerateResult) return enumerateResult;
 
@@ -762,7 +983,12 @@ async function queryCertstream(
 	}
 
 	const sans = await queryCertstreamEndpoint<CertstreamSansResponse>('sans', domain, certstream, certstreamAuthToken, options);
-	return sans && !sans.error && Array.isArray(sans.names) ? buildCertstreamResult(domain, sans.names, sans.certificateCount) : null;
+	// `/sans` reports its own upstream truncation — read it (it was declared and
+	// silently discarded before #573) so an incomplete SAN sweep is not served
+	// as a complete enumeration.
+	return sans && !sans.error && Array.isArray(sans.names)
+		? buildCertstreamResult(domain, sans.names, sans.certificateCount, { truncated: sans.truncated, timedOut: sans.timedOut })
+		: null;
 }
 
 async function queryCertstreamEndpoint<T>(
@@ -837,7 +1063,20 @@ function composeAbortSignal(timeoutMs: number, outer?: AbortSignal): ComposedSig
 	return { signal: controller.signal, cleanup: () => clearTimeout(timeoutId) };
 }
 
-function buildCertstreamResult(domain: string, names: string[], certificateCount: number | undefined): SubdomainDiscoveryResult {
+/**
+ * Aggregate a certstream name list into a result.
+ *
+ * Issue #573 defect D: this path used to `.slice(0, MAX_SUBDOMAINS)` BEFORE
+ * counting, so `totalSubdomains` could never exceed the cap and the overflow
+ * line could never render — strictly worse than the crt.sh path. Totals are now
+ * taken over the full deduped set and the slice is applied afterwards.
+ */
+function buildCertstreamResult(
+	domain: string,
+	names: string[],
+	certificateCount: number | undefined,
+	upstream?: { truncated?: boolean; timedOut?: boolean },
+): SubdomainDiscoveryResult {
 	const domainLower = domain.toLowerCase();
 	const domainSuffix = `.${domainLower}`;
 	const subdomains: DiscoveredSubdomain[] = [];
@@ -873,8 +1112,10 @@ function buildCertstreamResult(domain: string, names: string[], certificateCount
 		}
 	}
 
-	const deduped = Array.from(seen.values()).slice(0, MAX_SUBDOMAINS);
-	const wildcardCerts = deduped.filter((s) => s.isWildcard).length;
+	// Count over the WHOLE deduped set; slice only what we return.
+	const dedupedAll = Array.from(seen.values());
+	const deduped = dedupedAll.slice(0, MAX_SUBDOMAINS);
+	const wildcardCerts = dedupedAll.filter((s) => s.isWildcard).length;
 
 	const issues: SubdomainIssue[] = [];
 	if (wildcardCerts > 0) {
@@ -885,12 +1126,17 @@ function buildCertstreamResult(domain: string, names: string[], certificateCount
 		});
 	}
 
-	// Shadow subdomain detection
-	for (const sd of deduped) {
+	// Shadow subdomain detection — whole set, bounded rows (see MAX_PER_NAME_ISSUES).
+	let shadowRows = 0;
+	let shadowTotal = 0;
+	for (const sd of dedupedAll) {
 		if (sd.isWildcard) continue;
 		const label = sd.subdomain.replace(domainSuffix, '').replace(/\.$/, '');
 		if (label.includes('.')) continue;
 		if (!COMMON_SUBDOMAINS.has(label)) {
+			shadowTotal++;
+			if (shadowRows >= MAX_PER_NAME_ISSUES) continue;
+			shadowRows++;
 			issues.push({
 				type: 'shadow_subdomain',
 				severity: 'info',
@@ -898,16 +1144,26 @@ function buildCertstreamResult(domain: string, names: string[], certificateCount
 			});
 		}
 	}
+	if (shadowTotal > shadowRows) {
+		issues.push({
+			type: 'shadow_subdomain',
+			severity: 'info',
+			detail: `…and ${shadowTotal - shadowRows} further subdomains are not common service names (rows capped at ${MAX_PER_NAME_ISSUES} for readability; see the full list in the structured result)`,
+		});
+	}
+
+	const enumerationComplete = !upstream?.truncated && !upstream?.timedOut;
 
 	return {
 		domain,
-		totalSubdomains: deduped.length,
-		totalCertificates: certificateCount ?? deduped.length,
+		totalSubdomains: dedupedAll.length,
+		totalCertificates: certificateCount ?? dedupedAll.length,
 		subdomains: deduped,
 		wildcardCerts,
 		expiredCerts: 0,
 		uniqueIssuers: [],
 		issues,
+		...enumerationFlags(dedupedAll.length, deduped.length, ['certstream'], enumerationComplete),
 	};
 }
 
@@ -916,7 +1172,10 @@ function buildCertstreamResult(domain: string, names: string[], certificateCount
  * (crt.sh non-OK / network error) from a successful query that found nothing.
  * `partial` indicates the deadline tripped before a stage could run.
  */
-function emptyResult(domain: string, sourceUnavailable = false, partial = false): SubdomainDiscoveryResult {
+function emptyResult(domain: string, sourceUnavailable = false, partial = false, meta?: EnumerationMeta): SubdomainDiscoveryResult {
+	// A source outage or a budget trip is by definition not an exhaustive
+	// enumeration — never let an empty error read as a complete "none found".
+	const enumerationComplete = sourceUnavailable || partial ? false : (meta?.enumerationComplete ?? true);
 	return {
 		domain,
 		totalSubdomains: 0,
@@ -928,6 +1187,7 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false)
 		issues: [],
 		sourceUnavailable,
 		...(partial ? { partial: true } : {}),
+		...enumerationFlags(0, 0, meta?.sources, enumerationComplete),
 	};
 }
 
@@ -952,8 +1212,38 @@ export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, forma
 /** Staleness notice prepended when a result came from the last-known-good cache. */
 function staleBanner(result: SubdomainDiscoveryResult): string {
 	const age = result.cacheAgeMinutes ?? 0;
-	const ageText = age < 60 ? `${age} minute${age === 1 ? '' : 's'}` : `${Math.floor(age / 60)} hour${Math.floor(age / 60) === 1 ? '' : 's'}`;
+	const ageText =
+		age < 60 ? `${age} minute${age === 1 ? '' : 's'}` : `${Math.floor(age / 60)} hour${Math.floor(age / 60) === 1 ? '' : 's'}`;
 	return `⚠️ STALE RESULT (cached ${ageText} ago): every live Certificate Transparency source is currently unreachable, so this is the last known good enumeration — not a fresh one. Newly-issued certificates may be missing.`;
+}
+
+/**
+ * Honest overflow/completeness lines for a rendered subdomain list.
+ *
+ * Two distinct truths, reported separately (issue #573 defect A): how many
+ * enumerated names the TEXT is not showing, and whether the ENUMERATION itself
+ * was complete. The old wording collapsed both into "…and N more", which under
+ * a capped upstream fetch under-states the remainder and reads as reassurance —
+ * bnz.co.nz rendered "and 40 more" when ~320 more existed.
+ */
+function overflowLines(result: SubdomainDiscoveryResult, shownCount: number, style: 'compact' | 'full'): string[] {
+	const lines: string[] = [];
+	const hidden = Math.max(0, result.totalSubdomains - shownCount);
+	const incomplete = result.enumerationComplete === false;
+
+	if (hidden > 0) {
+		// "at least N" — never a bare N — once the enumeration is known partial.
+		const count = incomplete ? `at least ${hidden}` : `${hidden}`;
+		lines.push(style === 'compact' ? ` ...and ${count} more` : `_...and ${count} more subdomains not shown_`);
+	}
+
+	if (incomplete) {
+		const source = result.sources && result.sources.length > 0 ? result.sources.join(', ') : 'the Certificate Transparency source';
+		const note = `⚠️ Enumeration INCOMPLETE (${source}): ${result.totalSubdomains} is a FLOOR, not a total — more subdomains exist than were retrieved. Treat this as a partial inventory.`;
+		lines.push(style === 'compact' ? ` ${note}` : `_${note}_`);
+	}
+
+	return lines;
 }
 
 /** Compact format: concise one-line-per-subdomain output. */
@@ -964,7 +1254,10 @@ function formatCompact(result: SubdomainDiscoveryResult): string {
 		lines.push(`Issuers: ${result.uniqueIssuers.map((i) => sanitizeOutputText(i, 60)).join(', ')}`);
 	}
 
-	for (const sd of result.subdomains) {
+	// Text rendering is capped well below the structural cap — the full list
+	// stays in `structuredContent`.
+	const shown = result.subdomains.slice(0, MAX_RENDERED_SUBDOMAINS);
+	for (const sd of shown) {
 		const tags: string[] = [];
 		if (sd.isWildcard) tags.push('[WILDCARD]');
 		if (sd.isExpired) tags.push('[EXPIRED]');
@@ -975,9 +1268,7 @@ function formatCompact(result: SubdomainDiscoveryResult): string {
 		);
 	}
 
-	if (result.totalSubdomains > result.subdomains.length) {
-		lines.push(` ...and ${result.totalSubdomains - result.subdomains.length} more`);
-	}
+	lines.push(...overflowLines(result, shown.length, 'compact'));
 
 	if (result.issues.length > 0) {
 		lines.push('');
@@ -1001,7 +1292,10 @@ function formatFull(result: SubdomainDiscoveryResult): string {
 	lines.push('');
 
 	lines.push('## Subdomains');
-	for (const sd of result.subdomains) {
+	// ~4 lines per host, so the rendered list is capped far below the structural
+	// cap; the complete list is in the structured payload.
+	const shown = result.subdomains.slice(0, MAX_RENDERED_SUBDOMAINS);
+	for (const sd of shown) {
 		const tags: string[] = [];
 		if (sd.isWildcard) tags.push('🔓 WILDCARD');
 		if (sd.isExpired) tags.push('⏰ EXPIRED');
@@ -1012,8 +1306,9 @@ function formatFull(result: SubdomainDiscoveryResult): string {
 		lines.push('');
 	}
 
-	if (result.totalSubdomains > result.subdomains.length) {
-		lines.push(`_...and ${result.totalSubdomains - result.subdomains.length} more subdomains not shown_`);
+	const overflow = overflowLines(result, shown.length, 'full');
+	if (overflow.length > 0) {
+		lines.push(...overflow);
 		lines.push('');
 	}
 

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -45,12 +45,23 @@ export const DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS = 24_000;
 const CT_SOURCE_TIMEOUT_MS = 10_000;
 
 /**
- * Per-attempt timeout for the Certspotter fallback (ms). Tighter than crt.sh's:
- * it is a plain JSON API that normally answers in well under a second, so a
- * shorter bound keeps a full failover pass comfortably inside the ~24s handler
- * budget instead of letting one slow fallback consume it.
+ * Per-ATTEMPT timeout for the Certspotter fallback (ms) — this bounds the whole
+ * paginated run, not one page: `queryDirectSources` composes ONE abort signal per
+ * source attempt and threads it through every page fetch.
+ *
+ * Sized against {@link MAX_CT_PAGES}: 8 pages at the measured ~1.5s/page is ~12s,
+ * so 8s (the pre-pagination value, set when this was a single request) would have
+ * aborted mid-run around page 5 and silently capped recall — the exact under-
+ * delivery this pagination work exists to remove. 14s fits the full 8 pages with
+ * headroom.
+ *
+ * This does NOT risk the ~24s handler budget: {@link CERTSPOTTER_PAGE_BUDGET_MS}
+ * is re-checked against the caller's real deadline before every page after the
+ * first, so a slow crt.sh attempt ahead of this one still clamps pagination — the
+ * caller's budget stays authoritative and the stop is non-fatal (pages already
+ * read are kept, `enumerationComplete: false`).
  */
-const CERTSPOTTER_TIMEOUT_MS = 8_000;
+const CERTSPOTTER_TIMEOUT_MS = 14_000;
 
 /**
  * Retry PASSES over the whole source list on a transient outcome (timeout / 5xx
@@ -120,8 +131,17 @@ const MAX_PER_NAME_ISSUES = 25;
  * Certspotter paginates at 100 issuances and ignores `&limit=` without an API
  * key, so following `Link: <…>; rel="next"` via `&after=<last id>` is the only
  * lever on recall. Measured ~1.5s/page unauthenticated; 8 pages is ~800
- * issuances, comfortably more than any realistic estate while staying inside
- * both the per-source timeout and the caller's synchronous budget.
+ * issuances, more than any realistic estate.
+ *
+ * TWO INDEPENDENT BOUNDS apply, and the page counter is NOT the binding one in
+ * practice — {@link CERTSPOTTER_TIMEOUT_MS} is a single abort signal composed
+ * ONCE per source attempt (see `queryDirectSources`), so it caps the WHOLE
+ * paginated run, not each page. It is sized to fit `MAX_CT_PAGES` at the
+ * measured per-page cost with headroom; if either constant moves, re-check that
+ * `MAX_CT_PAGES * ~1.5s` still fits inside it, or pagination will silently stop
+ * early. The per-page {@link CERTSPOTTER_PAGE_BUDGET_MS} check additionally
+ * yields to the caller's synchronous deadline. Both stop paths are non-fatal:
+ * pages already read are kept and `enumerationComplete: false` is reported.
  */
 const MAX_CT_PAGES = 8;
 

--- a/test/discover-subdomains-truncation.spec.ts
+++ b/test/discover-subdomains-truncation.spec.ts
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Regression suite for issue #573 — `discover_subdomains` silently returned a
+// partial, biased subset of a domain's CT-attested hostnames and reported
+// totals that made the truncation undetectable by the caller.
+//
+// Four defect classes are locked here:
+//   A. cap with no signal          → `truncated` / `returned` / `sources` /
+//                                    `enumerationComplete` on the result.
+//   B. single-page Certspotter     → follow `Link: rel="next"` via `after=`,
+//                                    bounded by MAX_CT_PAGES + the sync budget.
+//   C. wildcard/expired counted     → counts are taken over the WHOLE enumerated
+//      after the display slice        set, never the returned slice.
+//   D. certstream path sliced       → totals computed pre-slice.
+//      before counting
+//
+// The pre-existing cap test gave every name its own cert and NO wildcards, so
+// the post-slice counting bug (C) was never exercised. These fixtures do the
+// opposite: the wildcards/expired names sort to the BACK of the list, exactly
+// where the display slice would drop them.
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { setupFetchMock } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/**
+ * Build a crt.sh entry whose `not_before` sorts deterministically: `rank` 0 is
+ * the NEWEST (sorted first), higher ranks sort later — i.e. toward the slice
+ * boundary. Lexicographic ISO comparison is what the tool actually uses.
+ */
+function rankedEntry(name: string, rank: number, expired = false) {
+	const millis = String(9_999 - rank).padStart(4, '0');
+	return {
+		name_value: name,
+		issuer_name: "CN=R3, O=Let's Encrypt",
+		not_before: `2026-01-01T00:00:00.${millis}Z`,
+		not_after: expired ? '2020-01-02T00:00:00Z' : '2030-01-01T00:00:00Z',
+	};
+}
+
+/** Mock ONLY crt.sh; everything else resolves as an empty DoH answer. */
+function mockCrtSh(response: unknown, ok = true) {
+	globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+		const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+		if (s.includes('crt.sh')) return Response.json(response, { status: ok ? 200 : 500 });
+		return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+	});
+}
+
+describe('discover_subdomains — whole-set counting (defect C)', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('counts wildcards and expired certs over the FULL set, not the returned slice', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+
+		// 600 names: the first 500 are plain + current, and the 3 wildcards + 4
+		// expired names deliberately sort past the 500-name return cap. A
+		// post-slice count reports 0/0 here; the honest count is 3/4.
+		const entries = [
+			...Array.from({ length: 520 }, (_, i) => rankedEntry(`sub${i}.example.com`, i)),
+			rankedEntry('*.a.example.com', 550),
+			rankedEntry('*.b.example.com', 551),
+			rankedEntry('*.c.example.com', 552),
+			rankedEntry('gone1.example.com', 560, true),
+			rankedEntry('gone2.example.com', 561, true),
+			rankedEntry('gone3.example.com', 562, true),
+			rankedEntry('gone4.example.com', 563, true),
+		];
+		mockCrtSh(entries);
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(result.totalSubdomains).toBe(527);
+		expect(result.subdomains).toHaveLength(500);
+		// None of the wildcard/expired names survive the slice…
+		expect(result.subdomains.some((s) => s.isWildcard)).toBe(false);
+		expect(result.subdomains.some((s) => s.isExpired)).toBe(false);
+		// …but the counts are still the truth about the estate.
+		expect(result.wildcardCerts).toBe(3);
+		expect(result.expiredCerts).toBe(4);
+
+		// And the derived issues follow the counts, not the slice.
+		const wildcardIssue = result.issues.find((i) => i.type === 'wildcard_exposure');
+		expect(wildcardIssue?.detail).toContain('3 wildcard');
+		expect(result.issues.some((i) => i.type === 'expired_subdomain')).toBe(true);
+	});
+
+	it('keeps per-name issue rows bounded so a 500-name estate cannot flood the output', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const entries = Array.from({ length: 300 }, (_, i) => rankedEntry(`gone${i}.example.com`, i, true));
+		mockCrtSh(entries);
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(result.expiredCerts).toBe(300);
+		const expiredRows = result.issues.filter((i) => i.type === 'expired_subdomain');
+		// Bounded rows + one roll-up row naming the remainder.
+		expect(expiredRows.length).toBeLessThanOrEqual(26);
+		expect(expiredRows.some((i) => /further|more/i.test(i.detail))).toBe(true);
+	});
+});
+
+describe('discover_subdomains — explicit truncation contract (defect A)', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('sets truncated:true with an accurate `returned` when the set exceeds the cap', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		mockCrtSh(Array.from({ length: 640 }, (_, i) => rankedEntry(`sub${i}.example.com`, i)));
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(result.totalSubdomains).toBe(640);
+		expect(result.returned).toBe(500);
+		expect(result.subdomains).toHaveLength(500);
+		expect(result.truncated).toBe(true);
+		expect(result.sources).toContain('crtsh');
+		// crt.sh answers in one shot — the ENUMERATION was complete even though
+		// the returned list is capped.
+		expect(result.enumerationComplete).toBe(true);
+	});
+
+	it('leaves truncated falsy and reports `returned` when the set fits under the cap', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		mockCrtSh(Array.from({ length: 12 }, (_, i) => rankedEntry(`sub${i}.example.com`, i)));
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(result.totalSubdomains).toBe(12);
+		expect(result.returned).toBe(12);
+		expect(result.truncated).toBeFalsy();
+		expect(result.enumerationComplete).toBe(true);
+	});
+
+	it('surfaces the contract through the MCP handler structuredContent', async () => {
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		mockCrtSh(Array.from({ length: 640 }, (_, i) => rankedEntry(`sub${i}.example.com`, i)));
+
+		const res = await handleToolsCall({ name: 'discover_subdomains', arguments: { domain: 'example.com' } }, undefined, undefined);
+		const payload = res.structuredContent as Record<string, unknown>;
+
+		expect(payload.truncated).toBe(true);
+		expect(payload.returned).toBe(500);
+		expect(payload.sources).toEqual(['crtsh']);
+	});
+});
+
+describe('discover_subdomains — Certspotter pagination (defect B)', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	/** One Certspotter issuance with an `id` (the pagination cursor). */
+	function issuance(id: number, names: string[]) {
+		return {
+			id: String(id),
+			dns_names: names,
+			not_before: '2026-02-01T00:00:00Z',
+			not_after: '2030-05-01T00:00:00Z',
+			issuer: { name: "C=US, O=Let's Encrypt, CN=R11" },
+		};
+	}
+
+	function certspotterPage(body: unknown, next: boolean) {
+		return Response.json(body, {
+			status: 200,
+			headers: next ? { Link: '<https://api.certspotter.com/v1/issuances?after=next>; rel="next"' } : {},
+		});
+	}
+
+	it('follows Link: rel="next" via after=<id> and unions every page', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const urls: string[] = [];
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json({}, { status: 503 });
+			if (s.includes('certspotter.com')) {
+				urls.push(s);
+				if (!s.includes('after=')) {
+					// Page 1: full page + a next link.
+					return certspotterPage(
+						Array.from({ length: 100 }, (_, i) => issuance(i + 1, [`page1-${i}.example.com`])),
+						true,
+					);
+				}
+				// Page 2: short page, no next link.
+				return certspotterPage([issuance(101, ['page2-a.example.com']), issuance(102, ['page2-b.example.com'])], false);
+			}
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(urls).toHaveLength(2);
+		// The cursor must be the LAST issuance id of the previous page.
+		expect(urls[1]).toContain('after=100');
+
+		const names = result.subdomains.map((s) => s.subdomain);
+		expect(names).toContain('page1-0.example.com');
+		expect(names).toContain('page1-99.example.com');
+		expect(names).toContain('page2-a.example.com');
+		expect(names).toContain('page2-b.example.com');
+		expect(result.totalSubdomains).toBe(102);
+		expect(result.sources).toContain('certspotter');
+		expect(result.enumerationComplete).toBe(true);
+		expect(result.truncated).toBeFalsy();
+	});
+
+	it('stops at MAX_CT_PAGES and reports the enumeration as incomplete', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		let pages = 0;
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json({}, { status: 503 });
+			if (s.includes('certspotter.com')) {
+				pages++;
+				// Never-ending index: every page is full and advertises a next link.
+				return certspotterPage(
+					Array.from({ length: 20 }, (_, i) => issuance(pages * 1000 + i, [`p${pages}-${i}.example.com`])),
+					true,
+				);
+			}
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(pages).toBe(8); // MAX_CT_PAGES
+		expect(result.enumerationComplete).toBe(false);
+		expect(result.truncated).toBe(true);
+		expect(result.totalSubdomains).toBe(160);
+	});
+
+	it('stops paginating when the synchronous budget is exhausted, keeping page-1 data', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		let pages = 0;
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json({}, { status: 503 });
+			if (s.includes('certspotter.com')) {
+				pages++;
+				return certspotterPage(
+					Array.from({ length: 5 }, (_, i) => issuance(pages * 1000 + i, [`p${pages}-${i}.example.com`])),
+					true,
+				);
+			}
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		// A deadline that flips from "plenty" to "exhausted" the instant page 1 is
+		// read, so the BUDGET — not MAX_CT_PAGES — is what terminates the loop.
+		// (A getter keeps the wall-clock cost of the assertion at zero.)
+		const options = {
+			get deadlineMs() {
+				return pages >= 1 ? Date.now() - 1 : Date.now() + 20_000;
+			},
+		};
+
+		const result = await discoverSubdomains('example.com', undefined, undefined, options);
+
+		expect(pages).toBe(1);
+		expect(result.subdomains.map((s) => s.subdomain)).toContain('p1-0.example.com');
+		expect(result.enumerationComplete).toBe(false);
+		expect(result.truncated).toBe(true);
+	});
+
+	it('treats a first-page failure as a source failure (unchanged failover semantics)', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+		expect(result.sourceUnavailable).toBe(true);
+	});
+});
+
+describe('discover_subdomains — certstream path totals (defect D)', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('computes totals BEFORE the return cap on the certstream fast path', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const names = Array.from({ length: 640 }, (_, i) => `cs${i}.example.com`);
+		const certstreamFetch = vi.fn(async () =>
+			Response.json({ domain: 'example.com', subdomains: names, certificateCount: 700, timedOut: false, cached: false }),
+		);
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('crt.sh fallback should not be used');
+		});
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch });
+
+		expect(result.totalSubdomains).toBe(640);
+		expect(result.returned).toBe(500);
+		expect(result.subdomains).toHaveLength(500);
+		expect(result.truncated).toBe(true);
+		expect(result.sources).toContain('certstream');
+	});
+
+	it('reads the certstream /sans `truncated` flag into enumerationComplete', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const certstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+			if (url.includes('/enumerate')) return new Response('{}', { status: 502 });
+			return Response.json({
+				domain: 'example.com',
+				names: ['api.example.com', 'vpn.example.com'],
+				certificateCount: 2,
+				timedOut: false,
+				truncated: true,
+				cached: false,
+			});
+		});
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('crt.sh fallback should not be used');
+		});
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch });
+
+		expect(result.totalSubdomains).toBe(2);
+		expect(result.enumerationComplete).toBe(false);
+		// An incomplete upstream enumeration is a truncated answer even though
+		// every enumerated name was returned.
+		expect(result.truncated).toBe(true);
+	});
+});
+
+describe('discover_subdomains — honest overflow wording', () => {
+	async function fmt() {
+		const { formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+		return formatSubdomainDiscovery;
+	}
+
+	function bulkResult(overrides: Record<string, unknown>) {
+		return {
+			domain: 'bnz.co.nz',
+			totalSubdomains: 140,
+			totalCertificates: 100,
+			subdomains: Array.from({ length: 140 }, (_, i) => ({
+				subdomain: `sub${i}.bnz.co.nz`,
+				firstSeen: '2026-01-01',
+				lastSeen: '2026-01-01',
+				issuer: 'R3',
+				certCount: 1,
+				isWildcard: false,
+				isExpired: false,
+			})),
+			wildcardCerts: 0,
+			expiredCerts: 0,
+			uniqueIssuers: ['R3'],
+			issues: [],
+			...overrides,
+		};
+	}
+
+	it('caps the RENDERED host list at 100 even when 500 are returned structurally', async () => {
+		const formatSubdomainDiscovery = await fmt();
+		const output = formatSubdomainDiscovery(bulkResult({ returned: 140, truncated: false, enumerationComplete: true }), 'full');
+
+		expect(output).toContain('sub99.bnz.co.nz');
+		expect(output).not.toContain('sub100.bnz.co.nz');
+		expect(output).toContain('40 more subdomains not shown');
+	});
+
+	it('says "at least N more" and names the source when the enumeration was incomplete', async () => {
+		const formatSubdomainDiscovery = await fmt();
+		const result = bulkResult({ returned: 140, truncated: true, enumerationComplete: false, sources: ['certspotter'] });
+
+		const full = formatSubdomainDiscovery(result, 'full');
+		expect(full).toContain('at least 40 more');
+		expect(full).toMatch(/incomplete/i);
+		expect(full).toContain('certspotter');
+
+		const compact = formatSubdomainDiscovery(result, 'compact');
+		expect(compact).toContain('at least 40 more');
+		expect(compact).toMatch(/incomplete/i);
+	});
+
+	it('warns about an incomplete enumeration even when nothing is hidden by the display cap', async () => {
+		const formatSubdomainDiscovery = await fmt();
+		const result = {
+			domain: 'bnz.co.nz',
+			totalSubdomains: 2,
+			totalCertificates: 2,
+			subdomains: [
+				{ subdomain: 'a.bnz.co.nz', firstSeen: '', lastSeen: '', issuer: 'R3', certCount: 1, isWildcard: false, isExpired: false },
+				{ subdomain: 'b.bnz.co.nz', firstSeen: '', lastSeen: '', issuer: 'R3', certCount: 1, isWildcard: false, isExpired: false },
+			],
+			wildcardCerts: 0,
+			expiredCerts: 0,
+			uniqueIssuers: ['R3'],
+			issues: [],
+			returned: 2,
+			truncated: true,
+			enumerationComplete: false,
+			sources: ['certspotter'],
+		};
+
+		const full = formatSubdomainDiscovery(result, 'full');
+		expect(full).toMatch(/incomplete/i);
+		expect(full).toContain('certspotter');
+		// No phantom "and 0 more".
+		expect(full).not.toMatch(/and (at least )?0 more/);
+	});
+
+	it('keeps the exact wording when the display cap alone hides names', async () => {
+		const formatSubdomainDiscovery = await fmt();
+		const output = formatSubdomainDiscovery(bulkResult({ returned: 140, truncated: false, enumerationComplete: true }), 'compact');
+
+		expect(output).toContain('...and 40 more');
+		expect(output).not.toContain('at least');
+	});
+});

--- a/test/discover-subdomains.spec.ts
+++ b/test/discover-subdomains.spec.ts
@@ -88,7 +88,10 @@ describe('discoverSubdomains', () => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
 			expect(init?.headers).toMatchObject({ Authorization: 'Bearer shared-internal-key' });
 			if (url === 'https://certstream/enumerate?domain=example.com') {
-				return new Response(JSON.stringify({ error: 'upstream transient' }), { status: 502, headers: { 'Content-Type': 'application/json' } });
+				return new Response(JSON.stringify({ error: 'upstream transient' }), {
+					status: 502,
+					headers: { 'Content-Type': 'application/json' },
+				});
 			}
 			if (url === 'https://certstream/sans?domain=example.com') {
 				return new Response(
@@ -266,7 +269,10 @@ describe('discoverSubdomains', () => {
 		expect(subdomainNames).not.toContain('example.com');
 	});
 
-	it('should limit output to 100 subdomains', async () => {
+	// The structural return cap is 500 (raised from 100 in #573 — a 100-name cap
+	// silently dropped the majority of a real bank's estate). The ~100-name cap
+	// that remains is a TEXT-rendering cap, asserted in the truncation suite.
+	it('returns the full set structurally when it fits under the 500 cap', async () => {
 		// Generate 150 unique subdomains
 		const manyEntries = Array.from({ length: 150 }, (_, i) => ({
 			name_value: `sub${i}.example.com`,
@@ -277,8 +283,25 @@ describe('discoverSubdomains', () => {
 		mockCrtSh(manyEntries);
 		const result = await run();
 
-		expect(result.subdomains).toHaveLength(100);
+		expect(result.subdomains).toHaveLength(150);
 		expect(result.totalSubdomains).toBe(150);
+		expect(result.truncated).toBeFalsy();
+	});
+
+	it('should limit structured output to 500 subdomains', async () => {
+		const manyEntries = Array.from({ length: 640 }, (_, i) => ({
+			name_value: `sub${i}.example.com`,
+			issuer_name: 'CN=R3',
+			not_before: '2026-01-01',
+			not_after: '2026-04-01',
+		}));
+		mockCrtSh(manyEntries);
+		const result = await run();
+
+		expect(result.subdomains).toHaveLength(500);
+		expect(result.totalSubdomains).toBe(640);
+		expect(result.returned).toBe(500);
+		expect(result.truncated).toBe(true);
 	});
 
 	it('should sort subdomains by lastSeen descending', async () => {
@@ -569,11 +592,9 @@ describe('discover_subdomains handler — loud degrade on CT-source outage', () 
 			if (s.includes('crt.sh')) return Response.json({}, { status: 500 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		const result = await handleToolsCall(
-			{ name: 'discover_subdomains', arguments: { domain: 'example.com' } },
-			undefined,
-			{ certstream: { fetch: certstreamFetch as unknown as typeof fetch } } as never,
-		);
+		const result = await handleToolsCall({ name: 'discover_subdomains', arguments: { domain: 'example.com' } }, undefined, {
+			certstream: { fetch: certstreamFetch as unknown as typeof fetch },
+		} as never);
 		expect(result.isError).toBe(true);
 		expect((result.structuredContent as Record<string, unknown> | undefined)?.sourceUnavailable).toBe(true);
 	});
@@ -585,11 +606,7 @@ describe('discover_subdomains handler — loud degrade on CT-source outage', () 
 			if (s.includes('crt.sh')) return Response.json([], { status: 200 }); // available, genuinely empty
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		const result = await handleToolsCall(
-			{ name: 'discover_subdomains', arguments: { domain: 'example.com' } },
-			undefined,
-			undefined,
-		);
+		const result = await handleToolsCall({ name: 'discover_subdomains', arguments: { domain: 'example.com' } }, undefined, undefined);
 		expect(result.isError).toBeFalsy();
 		expect((result.structuredContent as Record<string, unknown> | undefined)?.sourceUnavailable).toBeFalsy();
 	});


### PR DESCRIPTION
Fixes #573.

`discover_subdomains` silently returned a partial, **biased** subset of a domain's CT-attested hostnames, and reported totals that made the truncation undetectable by the caller. Reproduced live against `bnz.co.nz`: `140 total / 100 returned / 0 truncation signal`, against a crt.sh ground truth of 420 unique names.

The bias matters more than the cap: `allSubdomains` is sorted `lastSeen` **descending** before slicing, so long-lived production hosts that renew infrequently fall off the end while recently-issued throwaways are retained. The returned 100 kept dozens of `test-fc1` / `m.www.sandbox` hosts and dropped `internetbanking`, `payonline`, `mybnz`, `ams.privatebank`, `realme`, `wealthnet`, `cardsecurity`. A sweep trusting the tool alone reported a clean estate and missed two real failures found by going direct to CT (`iag.bnz.co.nz` 57/F, no DMARC at all; `sandbox-comms.bnz.co.nz` 58/F).

## Scope

**All worker-layer (`src/`).** `packages/dns-checks` contains no CT code, so there is **no npm publish, no version lockstep, and no parity-contract exposure** (including bv-web-prod's vendored `parity.contract.test.ts`). `discover_subdomains` is in `NON_CHECK_RESULT_TOOLS`, so the new `structuredContent` fields are additive and need no `outputSchema` change.

## What changed

**Defect A — cap with no signal.** `SubdomainDiscoveryResult` gains `truncated` / `returned` / `sources` / `enumerationComplete`, populated on **every** path (direct sources, certstream, available-but-empty, outage). `truncated` is deliberately the union of both ways an answer can be partial — the return cap bit, or the upstream enumeration being incomplete — because a caller asking "is this the whole estate?" needs one flag, with `enumerationComplete` available to say which. Also echoed into the handler's tail log so a rising truncation rate is alertable, not just discoverable in a payload.

**Defect B — Certspotter fetched page 1 only.** Certspotter paginates at 100 issuances and **silently ignores `&limit=` without an API key**, so the single request was page 1 of N. `fetchCertspotterEntries` now follows `Link: <…>; rel="next"` via `&after=<last issuance id>` (added `id` to `CertspotterIssuance`), bounded by a new `MAX_CT_PAGES = 8` **and** gated per-iteration through the existing `hasBudgetFor` so the 24s `DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS` stays authoritative. `&limit=1000` is deliberately not sent. Failure posture is asymmetric on purpose: a **page-1** failure is a source failure (failover semantics unchanged), while a **mid-pagination** failure keeps the pages already read and marks the enumeration incomplete — partial real data beats discarding it and reporting an outage.

**Defect C — wildcard/expired counted after the display slice.** `wildcardCerts`/`expiredCerts` and the derived issues now iterate `allSubdomains`, matching what `uniqueIssuers` already did correctly. Page 1 for `bnz.co.nz` genuinely had 3 wildcards; only 2 survived the slice. Per-name issue rows are bounded at 25 with a roll-up row naming the remainder, so whole-set counting can't flood the output.

**Defect D — latent certstream path (worse, currently dormant).** That path sliced *before* counting, so `totalSubdomains` could never exceed the cap and the overflow line could never render. Totals are now computed over the full deduped set with the slice applied after, and the declared-but-never-read `CertstreamSansResponse.truncated` is now honoured.

**Cap + wording.** `MAX_SUBDOMAINS` 100 → 500 for the **structured** result, with a new `MAX_RENDERED_SUBDOMAINS = 100` keeping the *text* capped (`formatFull` emits ~4 lines/host; 500 hosts is ~100KB of prose that would swamp an LLM context). Overflow wording is now honest: **"at least N more"** rather than a bare "N more" whenever the enumeration was itself incomplete, plus a named-source `⚠️ Enumeration INCOMPLETE (certspotter): N is a FLOOR, not a total` line.

## Calibration — please read

**Pagination gets `bnz.co.nz` from 140 to ~165 names, NOT to 420.** Certspotter's index is genuinely smaller than crt.sh's; two pages / 167 issuances / 165 unique names / 3 wildcards is the whole of what Certspotter holds. Reaching 420 requires crt.sh, which is unreachable within budget today (>40s / HTTP 503 against a 10s per-source timeout). The durable fix for the 165-vs-420 gap is **merging** sources instead of first-authoritative-wins — still worker-layer, but a separate decision and out of scope here. What this PR guarantees is that the caller is never again told a floor is a total.

## Testing

New `test/discover-subdomains-truncation.spec.ts` (Vitest unit, Workers pool), written test-first and watched fail before implementation:

- **whole-set counting under truncation** — 527 names where the 3 wildcards + 4 expired sort *past* the return cap; counts must be 3/4, not 0/0. The pre-existing cap test gave every name its own cert and **no wildcards**, which is precisely why this bug shipped.
- **bounded issue rows** — 300 expired names yield ≤26 rows plus a roll-up.
- **truncation contract** — `truncated: true` + accurate `returned` above the cap; falsy below it; surfaced through the MCP handler's `structuredContent`.
- **Certspotter pagination** — a full page 1 with `Link: rel="next"` plus a short page 2: both pages' names appear, the cursor is the last issuance `id` (`after=100`); `MAX_CT_PAGES` terminates a never-ending index at exactly 8 pages with `enumerationComplete: false`; budget exhaustion terminates after page 1 keeping page-1 data; a page-1 failure still reports `sourceUnavailable`.
- **certstream path** — totals reflect the pre-slice count; `sans.truncated` reaches `enumerationComplete`.
- **overflow wording** — text capped at 100 rendered hosts, exact "N more" when only the display cap hides names, "at least N more" + named source when the enumeration was partial, and an incomplete warning even when nothing is hidden.

The existing cap test at `discover-subdomains.spec.ts:269` (which locked the cap at 100) was split into a fits-under-cap case and a 640-name over-cap case.

### Verification

```
npx tsc --noEmit                     → exit 0
npx eslint <changed files>           → exit 0
npx vitest run test/discover-subdomains{,-truncation,-resilience,-deadline}.spec.ts
                                     → 4 files passed, 57 tests passed
npm test (full suite)                → 6384 passed | 13 skipped (6397)
                                       576 files passed | 4 skipped
```

One pre-existing, unrelated suite-level failure: `test/wasm-integration.test.ts` cannot resolve the compiled Rust `.wasm` when run from a git worktree (the path resolves outside it, and the artefact is gitignored / built only in the main checkout). It reports `0 test` — nothing in it ran, and it does not touch this code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTJZG4aY7s3HXSMb9NsXS5
