### PR TITLE
fix(repo): untrack node_modules symlink; make .gitignore match non-directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Dependencies
-node_modules/
+node_modules
 .pnpm-store/
 
 # Build outputs

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Applications/Github/bv-mcp/node_modules


### PR DESCRIPTION
## What

`7864d851` (#576) committed the repo root's `node_modules` as a **tracked symlink** (mode `120000`) pointing at the absolute path `/Applications/Github/bv-mcp/node_modules` — i.e. at itself. It reached `origin/main`, so every fresh clone materialises a self-referential symlink that resolves only on the machine that authored it and dangles everywhere else.

Verified by cloning `origin/main` to a scratch dir:

```
node_modules -> /Applications/Github/bv-mcp/node_modules
```

## Root cause is the ignore pattern, not the accident

`.gitignore` line 2 read `node_modules/`. **A trailing slash restricts the match to directories, and a symlink is not a directory**, so `git add -A` swept it in. Dropping the slash matches both.

Regression proven closed — recreating a `node_modules` symlink and running `git add -A` now stages nothing:

```
$ ln -s /tmp node_modules && git add -A && git status --porcelain | grep node_modules
(no output)
```

## Gate blind spot (not fixed here)

Both `Symlink escape gate` and `Repo Hygiene` ran **green** on the introducing commit. A self-referential link points *inside* the repo, so it never "escapes". Worth a follow-up having one gate reject any tracked mode-120000 entry outright; this PR deliberately does not touch either workflow.

## Blast radius

Contained. `node_modules` is the only tracked symlink in the index (`git ls-files -s | awk '$1=="120000"'`) and the only unintended path in `7864d851`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YTJZG4aY7s3HXSMb9NsXS5