### PR TITLE
refactor(evidence): delegate isCompletedCheck to the package isCheckMeasured + cover the boundary

### DIFF
--- a/src/lib/ungraded-display.ts
+++ b/src/lib/ungraded-display.ts
@@ -4,22 +4,39 @@
  * The single vocabulary for "this scan produced no grade", and the single place
  * a `score/grade` pair is turned into display text.
  *
- * A deliberately tiny leaf module (no imports) so every formatter in `src/tools/`
- * can depend on it without an import cycle through the scan orchestrator.
+ * A deliberately tiny module whose ONLY import is the external
+ * `@blackveil/dns-checks` package, so every formatter in `src/tools/` can depend
+ * on it without an import cycle through the scan orchestrator. That property is
+ * about the `src/` import graph, and an external-package edge cannot join it:
+ * `packages/dns-checks/src` imports nothing outside relative paths, `zod`, and
+ * (in its own tests) `vitest` — it has no edge back into `src/` at all, so it
+ * cannot reach the orchestrator. The rule to preserve is therefore narrower than
+ * "no imports": no `src/`-relative import may be added here. Pinned by
+ * `test/audits/completed-evidence-cross-package-parity.audit.test.ts` (LEG 3).
  *
  * `isCompletedCheck`/`hasCompletedEvidence`/`normalizeCheckStatus` below are the
- * SSOT for "did this check/scan produce usable evidence" on the `src/` side only —
+ * SSOT for "did this check/scan produce usable evidence" on the `src/` side —
  * `test/audits/completed-evidence-predicate-ssot.audit.test.ts` bans any other
- * `src/` module from re-deriving the same check. `packages/dns-checks/src/scoring/evidence.ts`
- * (`computeScanEvidence`'s per-result completed/attempted accounting) is a
- * DELIBERATE, KNOWN twin on the other side of the package boundary — it is a
- * published SSOT vendored by another repo and frozen for this campaign, so it
- * cannot import from `src/`, and this module cannot be vendored into it
- * without inverting the dependency direction (`src/` already depends on
- * `@blackveil/dns-checks`, not the other way around). The two are kept in
- * semantic lockstep by hand, not by a shared import; a change to what
- * "completed" means must be applied to BOTH deliberately.
+ * `src/` module from re-deriving the same check, including this file itself.
+ *
+ * ACROSS the package boundary there is now ONE implementation, not a twin. This
+ * module used to re-derive the comparison independently of
+ * `packages/dns-checks/src/scoring/evidence.ts` (`computeScanEvidence`'s
+ * per-result completed/attempted accounting), justified on the grounds that no
+ * shared import was possible. That justification no longer holds: the package
+ * exports the predicate as `isCheckMeasured` on the
+ * `@blackveil/dns-checks/scoring` subpath this repo ALREADY consumes
+ * (`src/lib/adaptive-weights.ts`, `src/lib/category-interactions.ts`,
+ * `src/lib/scoring.ts`), so `isCompletedCheck` DELEGATES to it. The dependency
+ * direction is unchanged and correct — `src/` depends on the published package,
+ * never the reverse. A change to what "completed" means is now made once, in the
+ * package, and reaches this side automatically; the type union itself is
+ * likewise imported (`CheckStatus`) rather than hand-copied, so a new member
+ * cannot appear on one side of the boundary only.
  */
+
+import type { CheckStatus } from '@blackveil/dns-checks/scoring';
+import { isCheckMeasured } from '@blackveil/dns-checks/scoring';
 
 /**
  * The SINGLE rendered token for a scan that produced no grade. One constant so
@@ -68,21 +85,31 @@ export function formatScoreGrade(score: number | null | undefined, grade: string
  * checks ran and only the scoring bundle failed, so its per-check results stay
  * genuinely evaluable. This predicate keeps those two cases apart.
  *
- * Deliberately typed on the array's length alone (`readonly unknown[]`) so this
- * stays an import-free leaf module with no edge to the scan orchestrator.
+ * Deliberately typed on the array's length alone (`readonly unknown[]`) rather
+ * than on `CheckResult[]`, so this predicate adds no edge to `src/`'s scan
+ * orchestrator — the leaf property the file-level doc describes. (The file does
+ * import from the external `@blackveil/dns-checks` package; that edge cannot
+ * reach the orchestrator, see the file-level doc.)
  */
 export function isMeasured(checks: readonly unknown[]): boolean {
 	return checks.length > 0;
 }
 
 /**
- * Minimal shape this leaf module needs from a check result to answer "did
- * anything complete" — a local structural type instead of importing
- * `CheckResult`, so this file stays a zero-import leaf with no edge to the
- * scan orchestrator.
+ * Minimal shape this module needs from a check result to answer "did anything
+ * complete" — a local structural type instead of importing `CheckResult`, so
+ * this file keeps no edge into `src/`'s scan orchestrator.
+ *
+ * The status TYPE is the package's `CheckStatus`, not a hand-copied
+ * `'completed' | 'timeout' | 'error'` literal union. That copy was the second
+ * half of the same cross-boundary duplication `isCompletedCheck` had: a new
+ * union member added in the package would leave a re-spelled local union
+ * silently narrower, and the resulting `CheckResult` would fail to typecheck
+ * here — or worse, be narrowed away — while the package considered it valid.
+ * Importing the union makes such a member a COMPILE-time event on this side.
  */
 interface CheckStatusBearer {
-	readonly checkStatus?: 'completed' | 'timeout' | 'error';
+	readonly checkStatus?: CheckStatus;
 }
 
 /**
@@ -125,17 +152,22 @@ export function hasCompletedEvidence(checks: readonly CheckStatusBearer[]): bool
  * uses internally, instead of re-deriving it — see `test/audits/*evidence*`
  * for the ban on re-spelling this check.
  *
- * Deliberately an ALLOWLIST (`undefined | 'completed'` counts as completed),
- * not a denylist (`!== 'timeout' && !== 'error'`). Both forms agree today
- * because `CheckStatus` is a closed 3-member union, but they diverge the
- * moment a new member is added: a denylist silently treats an unrecognized
- * future status as "completed" (wrong — an incomplete measurement must never
- * read as confident evidence, the campaign invariant this whole module
- * exists to protect), while this allowlist correctly treats it as NOT
- * completed until a maintainer deliberately adds it here.
+ * The rule itself is NOT spelled here. This is a thin object-shape adapter over
+ * the package's `isCheckMeasured`, which owns the semantics: an ALLOWLIST
+ * (`undefined | 'completed'` counts as measured), deliberately not a denylist
+ * (`!== 'timeout' && !== 'error'`). Both forms agree while `CheckStatus` is a
+ * closed 3-member union, but they diverge the moment a new member is added — a
+ * denylist silently treats an unrecognized future status as "completed", which
+ * is the exact defect this evidence campaign exists to prevent. Because the two
+ * layers now share ONE implementation, that divergence can no longer happen
+ * BETWEEN them either; the only difference is the argument shape (a check
+ * object here, a bare status value there). Pinned by
+ * `test/audits/completed-evidence-cross-package-parity.audit.test.ts`, which
+ * asserts both behavioural parity and that this body delegates rather than
+ * re-deriving.
  */
 export function isCompletedCheck(check: CheckStatusBearer): boolean {
-	return check.checkStatus === undefined || check.checkStatus === 'completed';
+	return isCheckMeasured(check.checkStatus);
 }
 
 /**
@@ -145,11 +177,18 @@ export function isCompletedCheck(check: CheckStatusBearer): boolean {
  * `StructuredScanResult.checkStatuses` (`format-report.ts`), which is
  * customer-facing and contractually typed `Record<string, 'completed' | 'timeout' | 'error'>`
  * — it cannot carry `undefined`, so an absent `checkStatus` must be normalized
- * to a concrete member before it can go on the wire. Sharing this rule with
- * `isCompletedCheck` (rather than re-deriving `?? 'completed'` at the call
- * site) is what keeps the two in lockstep if a new `CheckStatus` member is
- * ever added.
+ * to a concrete member before it can go on the wire. Keeping this in ONE place
+ * (rather than re-deriving `?? 'completed'` at the call site) is what stops the
+ * absent-means-completed premise from being restated per-surface.
+ *
+ * This is a VALUE normalization, not the boolean predicate, so it does not
+ * delegate to `isCheckMeasured` — there is nothing in the package that maps a
+ * status to a status. It does share the premise, and the union it is typed on
+ * is the package's `CheckStatus` rather than a hand-copied literal union, so a
+ * new member added upstream surfaces here as a compile error at the call sites
+ * that pinned the old three (notably `format-report.ts`'s wire contract) rather
+ * than passing silently.
  */
-export function normalizeCheckStatus(checkStatus: 'completed' | 'timeout' | 'error' | undefined): 'completed' | 'timeout' | 'error' {
+export function normalizeCheckStatus(checkStatus: CheckStatus | undefined): CheckStatus {
 	return checkStatus ?? 'completed';
 }

--- a/test/audits/completed-evidence-cross-package-parity.audit.test.ts
+++ b/test/audits/completed-evidence-cross-package-parity.audit.test.ts
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * "Did this check produce usable evidence?" must have exactly ONE implementation
+ * ACROSS the `src/` ↔ `packages/dns-checks` package boundary.
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM
+ * `completed-evidence-predicate-ssot.audit.test.ts`:
+ *
+ * That sibling audit is a TEXT scanner whose scope is `src/` BY DESIGN — it
+ * globs `../../src/**` and its own doc states it "does not, and must not, reach
+ * into `packages/dns-checks`", because its job is to stop the many `src/`
+ * surfaces from drifting from EACH OTHER. That decision is still correct and is
+ * deliberately left intact: widening its glob to `packages/` would silently
+ * change the corpus its anti-vacuity guard (`paths.length > 200`) and its
+ * `KNOWN_DIFFERENT_PURPOSE` exact-occurrence-count assertion are calibrated
+ * against, and would make a package-side edit fail an audit whose whole
+ * vocabulary (SSOT_PATH, the `src/`-relative exclusions) is `src/`-shaped.
+ *
+ * So the cross-boundary leg lives HERE instead, and it is deliberately a
+ * different KIND of check: a BEHAVIOURAL parity contract plus a delegation
+ * lock, not a text scan. Text scanning cannot prove two independent
+ * implementations agree; calling both with the same inputs can.
+ *
+ * WHAT DRIFT THIS CLOSES. Before PR #578 the two sides were an acknowledged,
+ * hand-maintained twin: `isCompletedCheck` in `src/lib/ungraded-display.ts`
+ * re-derived `checkStatus === undefined || checkStatus === 'completed'`
+ * independently of `computeScanEvidence`'s identical accounting in
+ * `packages/dns-checks/src/scoring/evidence.ts`, and NOTHING in CI compared
+ * them. Both spellings were allowlist-shaped, so both failed safe — this was a
+ * drift RISK, not a live bug. The risk is concrete: `CheckStatus` is a closed
+ * three-member union today, and a future member added to the package's
+ * `isCheckMeasured` but not to the worker's hand-copy (or vice versa) would
+ * reach only one side. A scan carrying that new status would then be
+ * "incomplete evidence" to the scoring engine and "completed evidence" to the
+ * report formatter — the exact split-brain the evidence campaign exists to
+ * prevent, shipping green.
+ *
+ * PR #578 removed the excuse: it extracted the package side into the exported
+ * `isCheckMeasured`, on the `@blackveil/dns-checks/scoring` subpath `src/`
+ * ALREADY consumes (`src/lib/adaptive-weights.ts`,
+ * `src/lib/category-interactions.ts`, `src/lib/scoring.ts`). The dependency
+ * direction is `src/` → package, which is the direction that already exists;
+ * no cycle is created (`packages/dns-checks/src` imports nothing outside
+ * relative paths, `zod` and `vitest` — verified, see the leaf-module test
+ * below). `isCompletedCheck` therefore now DELEGATES, and this audit pins that.
+ *
+ * THREE LEGS, each catching a different failure:
+ *   1. BEHAVIOURAL PARITY — the two predicates agree on every `CheckStatus`
+ *      member, on `undefined`, and on out-of-union values a version-skewed
+ *      cache read can produce. Type-level exhaustiveness (`Record<CheckStatus, …>`)
+ *      makes adding a union member a COMPILE error here, so the sweep can never
+ *      silently narrow.
+ *   2. DELEGATION LOCK — `isCompletedCheck` must literally call the package
+ *      export, not re-derive an extensionally-equal copy. Leg 1 alone cannot
+ *      catch a re-derived-but-currently-identical copy (it passes), which is
+ *      precisely how the pre-#578 twin looked on the day it was written; leg 2
+ *      is what makes a future divergence impossible rather than merely
+ *      detectable-in-hindsight.
+ *   3. LEAF-MODULE PRESERVATION — `ungraded-display.ts` is documented as a tiny
+ *      module with no edge to the scan orchestrator, so every formatter in
+ *      `src/tools/` can import it cycle-free. The new import must stay confined
+ *      to the external package.
+ *
+ * The negative control below proves leg 1 has teeth: a deliberately drifted
+ * re-derivation is run through the SAME parity sweep and MUST be reported as
+ * divergent. Without it, a parity assertion over a domain that happens to
+ * contain no distinguishing input would pass vacuously forever.
+ */
+
+import { describe, expect, it } from 'vitest';
+import ungradedDisplaySource from '../../src/lib/ungraded-display.ts?raw';
+import { isCompletedCheck } from '../../src/lib/ungraded-display';
+import { isCheckMeasured } from '@blackveil/dns-checks/scoring';
+import type { CheckStatus } from '@blackveil/dns-checks/scoring';
+
+/**
+ * Type-level exhaustiveness lock. Adding a member to the package's `CheckStatus`
+ * union without adding it here is a COMPILE error (`npx tsc --noEmit`), so the
+ * parity sweep below can never silently stop covering the full domain — the
+ * single most likely way this audit would rot into a vacuous green.
+ */
+const CHECK_STATUS_TABLE: Record<CheckStatus, true> = {
+	completed: true,
+	timeout: true,
+	error: true,
+};
+
+const ALL_CHECK_STATUSES = Object.keys(CHECK_STATUS_TABLE) as CheckStatus[];
+
+/**
+ * Values outside the declared union. These are not hypothetical: `isCheckMeasured`'s
+ * own doc calls out a `CheckResult` re-read from an untrusted source (a `JSON.parse`
+ * of a cached KV entry with no Zod revalidation, or a version-skewed deploy) carrying
+ * a status outside the union at runtime. They are also the closest stand-in available
+ * for "a `CheckStatus` member that exists on one side of the boundary and not the
+ * other" — the exact drift this audit exists to catch — so parity MUST hold here too,
+ * not just on the three declared members.
+ */
+const OUT_OF_UNION_STATUSES = ['skipped', 'partial', 'pending', 'COMPLETED', '', 'unknown-future-member'] as const;
+
+/** Every input both predicates must agree on: the declared union, `undefined`, and out-of-union noise. */
+const PARITY_DOMAIN: ReadonlyArray<CheckStatus | string | undefined> = [...ALL_CHECK_STATUSES, undefined, ...OUT_OF_UNION_STATUSES];
+
+/**
+ * Run an arbitrary per-check predicate against the package's `isCheckMeasured`
+ * over the whole parity domain and report every input the two disagree on.
+ *
+ * Parameterised on the candidate rather than hard-coding `isCompletedCheck` so
+ * the SAME sweep can be pointed at the negative control below — a divergence
+ * detector that has never been shown to detect a divergence is not evidence.
+ */
+function divergences(candidate: (check: { readonly checkStatus?: CheckStatus }) => boolean): Array<{
+	input: string;
+	candidate: boolean;
+	packageSide: boolean;
+}> {
+	const found: Array<{ input: string; candidate: boolean; packageSide: boolean }> = [];
+	for (const status of PARITY_DOMAIN) {
+		// The cast is the point: these inputs model values that reach the predicate
+		// at RUNTIME from an unvalidated source, which the compile-time union cannot
+		// express. `isCheckMeasured` accepts a widened `string` for the same reason.
+		const candidateAnswer = candidate({ checkStatus: status as CheckStatus });
+		const packageAnswer = isCheckMeasured(status);
+		if (candidateAnswer !== packageAnswer) {
+			found.push({ input: String(status), candidate: candidateAnswer, packageSide: packageAnswer });
+		}
+	}
+	return found;
+}
+
+/**
+ * NEGATIVE CONTROL — what the worker side looked like if a maintainer had
+ * "simplified" the allowlist into the denylist form while the package kept the
+ * allowlist. Extensionally identical on all three CURRENT union members, and
+ * divergent the instant any other value appears. This is not dead code: the
+ * test below asserts the sweep REPORTS it as divergent, which is the only proof
+ * that a green parity result on the real predicate means anything.
+ */
+function driftedDenylistReDerivation(check: { readonly checkStatus?: CheckStatus }): boolean {
+	const status: string | undefined = check.checkStatus;
+	return status !== 'timeout' && status !== 'error';
+}
+
+describe('completed-evidence predicate parity across the src/ ↔ packages/dns-checks boundary', () => {
+	it('is not vacuous: the parity domain covers the full CheckStatus union, undefined, and out-of-union values', () => {
+		// If CHECK_STATUS_TABLE and the runtime array ever drift, every parity
+		// assertion below silently narrows. Both are pinned.
+		expect(ALL_CHECK_STATUSES.slice().sort()).toEqual(['completed', 'error', 'timeout']);
+		expect(PARITY_DOMAIN.length).toBe(ALL_CHECK_STATUSES.length + 1 + OUT_OF_UNION_STATUSES.length);
+		expect(PARITY_DOMAIN).toContain(undefined);
+	});
+
+	it('LEG 1 — isCompletedCheck agrees with the package isCheckMeasured on every input', () => {
+		expect(
+			divergences(isCompletedCheck),
+			'src/lib/ungraded-display.ts isCompletedCheck has diverged from @blackveil/dns-checks/scoring isCheckMeasured',
+		).toEqual([]);
+	});
+
+	it('LEG 1 (negative control) — the sweep actually DETECTS a drifted re-derivation', () => {
+		// Proof of teeth. A denylist re-derivation agrees on all three declared
+		// members but disagrees on every out-of-union value, which is exactly the
+		// shape a future-CheckStatus-member drift takes.
+		const found = divergences(driftedDenylistReDerivation);
+		expect(found.length).toBeGreaterThan(0);
+		// It must agree on the three CURRENT members — otherwise the control is
+		// detecting something cruder than the drift class this audit models.
+		for (const status of ALL_CHECK_STATUSES) {
+			expect(driftedDenylistReDerivation({ checkStatus: status })).toBe(isCheckMeasured(status));
+		}
+		// …and disagree on an unknown future member, awarding it "measured".
+		expect(found.map((d) => d.input)).toContain('unknown-future-member');
+		expect(found.every((d) => d.candidate === true && d.packageSide === false)).toBe(true);
+	});
+
+	it('LEG 2 — isCompletedCheck DELEGATES to the package export rather than re-deriving it', () => {
+		// Leg 1 passes for a re-derived-but-currently-identical copy (that is what
+		// the pre-#578 twin was). Only this leg makes divergence impossible instead
+		// of merely detectable.
+		expect(ungradedDisplaySource).toMatch(/import\s*\{[^}]*\bisCheckMeasured\b[^}]*\}\s*from\s*'@blackveil\/dns-checks\/scoring'/);
+		expect(ungradedDisplaySource).toMatch(/export function isCompletedCheck\([^)]*\)\s*:\s*boolean\s*\{\s*return isCheckMeasured\(check\.checkStatus\);\s*\}/);
+	});
+
+	it('LEG 2 — the file no longer claims the two sides are an un-shareable hand-maintained twin', () => {
+		// PR #578 invalidated that rationale by exporting the predicate on a subpath
+		// src/ already consumes. A doc left asserting "kept in semantic lockstep by
+		// hand, not by a shared import" would be actively false and would invite the
+		// next maintainer to re-derive rather than import.
+		expect(ungradedDisplaySource).not.toMatch(/semantic lockstep by hand/);
+		expect(ungradedDisplaySource).not.toMatch(/DELIBERATE, KNOWN twin/);
+		expect(ungradedDisplaySource).not.toMatch(/A deliberately tiny leaf module \(no imports\)/);
+	});
+
+	it('LEG 3 — stays a leaf module: its ONLY import is the external package, no edge into src/', () => {
+		// The documented reason ungraded-display.ts avoids imports is to keep every
+		// formatter in src/tools/ able to depend on it without a cycle through the
+		// scan orchestrator. An EXTERNAL-package import cannot create that cycle —
+		// packages/dns-checks/src imports nothing outside relative paths, zod and
+		// vitest — but the property is only preserved if no src/-relative import is
+		// ever added here, which is what this pins.
+		const importSpecifiers = [...ungradedDisplaySource.matchAll(/from\s*'([^']+)'/g)].map((m) => m[1]);
+		expect(importSpecifiers.length).toBeGreaterThan(0);
+		expect(importSpecifiers.filter((s) => s.startsWith('.'))).toEqual([]);
+		expect([...new Set(importSpecifiers)]).toEqual(['@blackveil/dns-checks/scoring']);
+	});
+});

--- a/test/audits/completed-evidence-predicate-ssot.audit.test.ts
+++ b/test/audits/completed-evidence-predicate-ssot.audit.test.ts
@@ -26,14 +26,27 @@
  * switch/case, loose (`!=`/`==`) comparison, or a comment wedged between the
  * two halves of a split comparison) — see FORBIDDEN_SHAPES below.
  *
- * SCOPE: `src/` only. `packages/dns-checks/src/scoring/evidence.ts` carries
- * its own DELIBERATE twin (`computeScanEvidence`'s per-result
- * completed/attempted accounting) — that package is a published SSOT
- * vendored by another repo and is frozen for this campaign (see
- * `src/lib/ungraded-display.ts`'s file-level doc for the cross-package
- * pointer). This audit does not, and must not, reach into
- * `packages/dns-checks`; it exists solely to stop the `src/`-side surfaces
- * from drifting from EACH OTHER and from their own SSOT.
+ * SCOPE: `src/` only — a TEXT scan of the `src/` corpus. This audit does not,
+ * and must not, reach into `packages/dns-checks`: its glob, its anti-vacuity
+ * threshold (`paths.length > 200`), its `SSOT_PATH`/`KNOWN_DIFFERENT_PURPOSE`
+ * vocabulary and the exact-occurrence-count assertion on those exclusions are
+ * all calibrated to THIS corpus, and widening the glob would silently
+ * recalibrate every one of them. It exists solely to stop the `src/`-side
+ * surfaces from drifting from EACH OTHER and from their own SSOT.
+ *
+ * The CROSS-BOUNDARY leg is therefore a separate file, not a wider glob here:
+ * `test/audits/completed-evidence-cross-package-parity.audit.test.ts`. It is
+ * also a different KIND of check — a behavioural parity contract (call both
+ * predicates over the whole `CheckStatus` domain and compare) plus a delegation
+ * lock — because text scanning cannot prove two implementations agree. That
+ * pairing is what closes the gap this audit was structurally blind to: the
+ * package side used to carry a hand-maintained twin of the same predicate
+ * (`computeScanEvidence`'s per-result completed/attempted accounting) that
+ * nothing compared against the `src/` side. PR #578 exported it as
+ * `isCheckMeasured` on the `@blackveil/dns-checks/scoring` subpath `src/`
+ * already consumes, so `src/lib/ungraded-display.ts` now DELEGATES to it and
+ * the twin is gone — which is also why the SSOT file is no longer exempt from
+ * the shape rules (see the dedicated test below).
  *
  * This is a TEXT scanner, not a parser — it cannot catch every conceivable
  * rewrite (a fully abstracted local helper with a made-up name, a computed
@@ -376,6 +389,34 @@ describe('completed-evidence predicate SSOT (src/ only)', () => {
 		const source = STRIPPED[SSOT_PATH];
 		expect(source).toBeDefined();
 		expect(source).toMatch(/checks\.some\(isCompletedCheck\)/);
+	});
+
+	it('the SSOT file ITSELF no longer spells the comparison — isCompletedCheck delegates across the package boundary', () => {
+		// The corpus sweep below deliberately SKIPS `SSOT_PATH` (its subject is
+		// "no OTHER module"), which left the SSOT file as the one place in `src/`
+		// where the raw comparison could legally live — and therefore the one place
+		// a re-derivation could reappear with the whole audit staying green.
+		//
+		// That exemption was load-bearing while the comparison had nowhere else to
+		// go. It no longer is: PR #578 exported `isCheckMeasured` from
+		// `@blackveil/dns-checks/scoring` — a subpath `src/` already consumes
+		// (`adaptive-weights.ts`, `category-interactions.ts`, `scoring.ts`) — so
+		// `isCompletedCheck` delegates and the last hand-spelled copy in `src/` is
+		// gone. Holding the SSOT file to the same shape rules as every other `src/`
+		// module is what stops it silently growing a new one.
+		//
+		// SCOPE UNCHANGED: this is still a `src/`-only text assertion. The
+		// BEHAVIOURAL half of the cross-boundary contract (do the two predicates
+		// actually agree, and does the worker side literally call the package
+		// export) lives in `completed-evidence-cross-package-parity.audit.test.ts`
+		// — a different kind of check, deliberately not bolted onto this text
+		// scanner, whose `src/`-shaped glob, anti-vacuity threshold and
+		// KNOWN_DIFFERENT_PURPOSE counts are all calibrated to this corpus.
+		const source = STRIPPED[SSOT_PATH];
+		const matched = buildForbiddenShapes(identifierPattern(findCheckStatusAliases(source)))
+			.filter((shape) => shape.test(source))
+			.map((shape) => shape.source);
+		expect(matched, `${SSOT_PATH} must delegate to isCheckMeasured, not re-spell the completed/not-completed comparison`).toEqual([]);
 	});
 
 	it('has no OTHER src/ module re-deriving the completed/not-completed check inline (copy-paste OR rewritten, incl. renamed/aliased identifiers)', () => {


### PR DESCRIPTION
> **Stacks on #578** (`claude/dns-checks-evidence-predicate`). This PR targets **#578's branch, not `main`**, and **must merge after #578**. It is a pure CONSUMER of the `isCheckMeasured` export #578 adds — **no file under `packages/dns-checks/**` is touched.**

## The duplication

One concept — *"did this check produce usable evidence?"* — had two independent implementations on opposite sides of the package boundary:

| Layer | File | Spelling |
|---|---|---|
| Worker | `src/lib/ungraded-display.ts` | `isCompletedCheck(check)` → `check.checkStatus === undefined \|\| check.checkStatus === 'completed'` |
| Package | `packages/dns-checks/src/scoring/evidence.ts` (#578) | `isCheckMeasured(checkStatus)` → `checkStatus === undefined \|\| checkStatus === 'completed'` |

They differ only in argument shape. `ungraded-display.ts` had **no imports from the package at all** — an independent re-derivation.

**This is a drift risk, not an active bug.** Both spellings are allowlist-shaped, so both fail safe today. The danger is a future `CheckStatus` union member reaching only one of them.

`ungraded-display.ts`'s doc justified the duplication as an unavoidable hand-maintained twin — *"kept in semantic lockstep by hand, not by a shared import"* — on the grounds that no shared import was possible. **#578 invalidates that rationale** by exporting the predicate on `@blackveil/dns-checks/scoring`, a subpath `src/` already consumes (`adaptive-weights.ts`, `category-interactions.ts`, `scoring.ts`).

## Changes

**`src/lib/ungraded-display.ts`**
- `isCompletedCheck` **delegates**: `return isCheckMeasured(check.checkStatus)`. It is now a thin object-shape adapter; the package owns the semantics.
- `CheckStatusBearer` and `normalizeCheckStatus` are typed on the package's `CheckStatus` instead of a hand-copied `'completed' | 'timeout' | 'error'` literal union — the **second half of the same duplication**. A new upstream member is now a compile-time event on this side rather than a silently-narrower local union.
- The file-level doc no longer makes the twin / no-shared-import claim.
- **Leaf-module property preserved, and the claim corrected rather than dropped.** The doc said *"tiny leaf module (no imports)"*; the real invariant is **no `src/`-relative import**, which is what prevented the cycle through the scan orchestrator. Verified rather than assumed: `packages/dns-checks/src` imports nothing outside relative paths, `zod`, and (in its own tests) `vitest` — it has **no edge back into `src/`**, so an external-package edge cannot reach the orchestrator. LEG 3 below pins it.

## Boundary coverage — and why it is split across two files

The existing `completed-evidence-predicate-ssot.audit.test.ts` is scoped to `src/` **by design** and explicitly declines to reach into `packages/`. **That decision is left intact** — its glob, its `paths.length > 200` anti-vacuity threshold, and its `KNOWN_DIFFERENT_PURPOSE` *exact-occurrence-count* assertion are all calibrated to the `src/` corpus; widening the glob would silently recalibrate every one of them, and its whole vocabulary (`SSOT_PATH`, `src/`-relative exclusions) is `src/`-shaped.

**1. Extended in-scope (existing audit).** The audit skipped the SSOT file in its own shape sweep (`if (path === SSOT_PATH) continue`) — leaving it the one place in `src/` where a re-derivation could reappear with the whole audit green. That exemption was load-bearing only while the comparison had nowhere else to go. A new test now holds the SSOT file to the same shape rules. Still a `src/`-only text assertion; scope unchanged.

**2. New file for the cross-boundary leg** — `test/audits/completed-evidence-cross-package-parity.audit.test.ts`. Deliberately a **different kind of check**: text scanning cannot prove two implementations agree; calling both with the same inputs can. Precedent for cross-boundary reach already exists (`evidence-threshold-ssot.audit.test.ts`, `ungraded-representation.audit.test.ts`).

| Leg | Catches |
|---|---|
| **LEG 1** behavioural parity | Both predicates agree over the full `CheckStatus` union, `undefined`, and out-of-union values. A `Record<CheckStatus, true>` table makes a new union member a **compile error here**, so the sweep can never silently narrow. |
| **LEG 2** delegation lock | `isCompletedCheck` must literally call the package export, not re-derive an extensionally-equal copy. Also asserts the stale twin doc claims are gone. |
| **LEG 3** leaf-module preservation | The only import specifier may be `@blackveil/dns-checks/scoring`; no `src/`-relative import. |

A **negative control** runs a deliberately drifted denylist re-derivation through the same sweep and asserts it is reported as divergent — so a green LEG 1 is never vacuous.

## Proof the new check fails on divergence

Both scenarios were re-run against a patched `ungraded-display.ts`, then reverted.

**A — denylist re-derivation (semantic divergence).** LEG 1 **and** LEG 2 fail:
```
× LEG 1 — isCompletedCheck agrees with the package isCheckMeasured on every input
× LEG 2 — isCompletedCheck DELEGATES to the package export rather than re-deriving it
AssertionError: src/lib/ungraded-display.ts isCompletedCheck has diverged from
  @blackveil/dns-checks/scoring isCheckMeasured: expected [ { input: 'skipped', …(2) }, …(5) ] to deeply equal []
+     "input": "skipped",      +     "input": "partial",   +     "input": "pending",
+     "input": "COMPLETED",     +     "input": "",          +     "input": "unknown-future-member",
Tests  2 failed | 11 passed (13)
```

**B — re-derived allowlist copy (extensionally identical today — exactly what the old twin looked like the day it was written).** LEG 1 **passes**; LEG 2 and the extended `src/` audit fail:
```
× LEG 2 — isCompletedCheck DELEGATES to the package export rather than re-deriving it
× the SSOT file ITSELF no longer spells the comparison — isCompletedCheck delegates across the package boundary
Tests  2 failed | 11 passed (13)
```

That layering is the point: **LEG 1 alone cannot catch scenario B**, which is how this duplication came to exist in the first place. LEG 2 is what makes future divergence impossible rather than merely detectable in hindsight.

Written test-first: all four new assertions were confirmed **red** against the unmodified source before the fix (LEG 1 correctly passed then too — consistent with "drift risk, not active bug").

## Verification

- `npm test` → **`Tests 6512 passed | 13 skipped (6525)`**, `Test Files 1 failed | 579 passed | 4 skipped`. The one failed **file** is `test/wasm-integration.test.ts` — the gitignored `wasm-pack` artifact absent in any worktree (**0 failed tests**). The 29 unhandled errors are the documented miniflare pool-teardown noise.
- `npx tsc --noEmit` → clean, exit 0.
- `eslint` on all three changed files → clean.

## Note for reviewers

The worktree's `node_modules/@blackveil/dns-checks` symlink has no local `dist/` until built, so module resolution silently falls through to any **ancestor** checkout's `dist` (a stale v1.7.0 here). Run `npm -w packages/dns-checks run build` before `npm test` / `tsc` — CI already does this in every workflow.