### PR TITLE
fix(discover_subdomains): replace the `enumerationComplete` overclaim with an honest CT coverage record

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1637,7 +1637,13 @@ export async function handleToolsCall(
 						// CT source that has quietly started capping us.
 						truncated: result.truncated ?? false,
 						returned: result.returned ?? result.subdomains.length,
-						enumerationComplete: result.enumerationComplete ?? true,
+						// Renamed from `enumerationComplete`, which asserted estate-level
+						// completeness a single CT source can never support. The narrow
+						// per-source truth is unchanged; only the (misreadable) name is.
+						sourceIndexExhausted: result.sourceIndexExhausted ?? true,
+						// Degraded recall — a source was asked and failed, or was never
+						// consulted — is now visible in tail, not just in the payload.
+						coverageDegraded: result.coverage?.degraded ?? false,
 						...(result.sources ? { sources: result.sources.join(',') } : {}),
 						...(result.stale ? { cacheAgeMinutes: result.cacheAgeMinutes ?? 0 } : {}),
 					};

--- a/src/lib/ct-coverage.ts
+++ b/src/lib/ct-coverage.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Certificate-Transparency COVERAGE contract.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `discover_subdomains` used to answer with `enumerationComplete: boolean`. The
+ * flag's authored meaning was narrow and true — "the ONE source that answered
+ * was paginated to the end of its index" — but its NAME asserts something much
+ * larger, and every reasonable consumer read `true` as "this is the estate".
+ *
+ * Measured against production on 2026-07-27 (bnz.co.nz):
+ *   - the tool returned 165 unique names with `sources: ["certspotter"]`,
+ *     `truncated: false`, `enumerationComplete: true`;
+ *   - crt.sh's unfiltered CT history for the same estate holds 420 unique names;
+ *   - `ams.privatebank`, `realme`, `cardsecurity` and `myaccess` .bnz.co.nz are
+ *     absent from the tool's answer and all four resolve to live production IPs.
+ * A `true` completeness flag therefore accompanied a ~60%-short answer about a
+ * bank's external attack surface.
+ *
+ * THE CEILING IS STRUCTURAL, NOT A BUG TO OUTRUN
+ * ----------------------------------------------
+ * No amount of pagination makes a CT sweep an inventory:
+ *   - a host that never had a publicly-logged certificate never appears in CT
+ *     at all — an entire class of asset is invisible by construction;
+ *   - Certspotter's unauthenticated feed is a ROLLING WINDOW (measured
+ *     2025-07-07 → 2026-07-27 for bnz.co.nz, ~1 year), so exhausting its index
+ *     still cannot see older issuance;
+ *   - crt.sh is queried with `exclude=expired`, so even a healthy crt.sh only
+ *     shows currently-valid certificates — that single parameter is where the
+ *     254 missing bnz.co.nz names went.
+ *
+ * So the honest contract cannot be "did we finish?" — it must be "what did we
+ * actually look at, and what could that possibly have seen?". Hence:
+ *   - {@link CtCoverage.basis} is the LITERAL `'ct-sample'`, a one-member union.
+ *     There is no representable value meaning "complete inventory"; a consumer
+ *     cannot branch its way into the old misreading.
+ *   - every source is reported individually with its outcome, whether we read
+ *     its index to the end, and the slice of CT history it can see AT ALL.
+ *   - sources that were never consulted are named explicitly, so a fast-path
+ *     single-source answer cannot masquerade as a multi-source consensus.
+ *
+ * Pure module — no I/O, no bindings. Safe to unit-test in isolation.
+ */
+
+/** Per-source health outcome, shared with the tool's `ct_source` health log. */
+export type CtSourceOutcome = 'ok' | 'empty' | 'http_error' | 'timeout' | 'error';
+
+/**
+ * How much of CT history a source can see AT ALL, independent of whether we
+ * finished reading it. This is the bound that pagination cannot lift.
+ *
+ *  - `unexpired-only`  — only currently-valid certificates are visible (crt.sh
+ *                        as queried, i.e. with `exclude=expired`).
+ *  - `recent-window`   — a rolling recent window only (Certspotter's free tier).
+ *  - `unknown`         — an upstream aggregator whose retention we do not
+ *                        control or publish (the certstream worker).
+ */
+export type CtHistoryWindow = 'unexpired-only' | 'recent-window' | 'unknown';
+
+/** What one CT source contributed to this answer. */
+export interface CtSourceCoverage {
+	source: string;
+	outcome: CtSourceOutcome;
+	/** True when this source's names are in the returned set. */
+	contributed: boolean;
+	/**
+	 * True when WE read this source's index to the end (no pagination cap, no
+	 * budget stop, no upstream truncation flag). Narrow and per-source — it says
+	 * nothing about the estate. Undefined when the source never answered.
+	 */
+	indexExhausted?: boolean;
+	/** The slice of CT history this source can see even in the best case. */
+	historyWindow: CtHistoryWindow;
+}
+
+/**
+ * The completeness contract that replaces `enumerationComplete`.
+ *
+ * `basis` is deliberately a one-member literal union. Widening it to add a
+ * second member (e.g. `'inventory'`) would reintroduce the exact defect this
+ * type exists to prevent — don't.
+ */
+export interface CtCoverage {
+	/** Always `'ct-sample'`. A CT sweep is evidence, never an asset inventory. */
+	basis: 'ct-sample';
+	/** Every source attempted on this call, in attempt order. */
+	perSource: CtSourceCoverage[];
+	/** Sources whose names are in the returned set. */
+	contributing: string[];
+	/** Sources attempted that produced nothing usable (failed or empty). */
+	unavailable: string[];
+	/** Known sources never asked on this call (e.g. skipped by a fast path). */
+	notConsulted: string[];
+	/**
+	 * True when at least one known source was unavailable or never consulted —
+	 * i.e. recall on this call is below what this tool can normally reach. NOT a
+	 * completeness claim when false; `basis` still governs.
+	 */
+	degraded: boolean;
+	/** Always-populated prose stating the sample caveat. Never omitted. */
+	caveat: string;
+}
+
+/**
+ * Every CT source this tool can reach. Used to compute `notConsulted`, so a
+ * fast-path answer names the sources it skipped rather than implying consensus.
+ */
+export const KNOWN_CT_SOURCES = ['certstream', 'crtsh', 'certspotter'] as const;
+
+/** Static per-source history bound (see {@link CtHistoryWindow}). */
+const SOURCE_HISTORY_WINDOW: Record<string, CtHistoryWindow> = {
+	crtsh: 'unexpired-only',
+	certspotter: 'recent-window',
+	certstream: 'unknown',
+};
+
+/** The history bound for a source name; unknown sources are assumed opaque. */
+export function historyWindowFor(source: string): CtHistoryWindow {
+	return SOURCE_HISTORY_WINDOW[source] ?? 'unknown';
+}
+
+/** One recorded source attempt, as the tool observes it. */
+export interface CtSourceAttempt {
+	source: string;
+	outcome: CtSourceOutcome;
+	contributed: boolean;
+	indexExhausted?: boolean;
+}
+
+/**
+ * Build the coverage record from the attempts actually made.
+ *
+ * `totalReturned` only shapes the wording — the caveat is emitted regardless,
+ * because the dangerous case is precisely the one that looks healthy.
+ */
+export function buildCtCoverage(attempts: CtSourceAttempt[]): CtCoverage {
+	const perSource: CtSourceCoverage[] = attempts.map((a) => ({
+		source: a.source,
+		outcome: a.outcome,
+		contributed: a.contributed,
+		...(a.indexExhausted === undefined ? {} : { indexExhausted: a.indexExhausted }),
+		historyWindow: historyWindowFor(a.source),
+	}));
+
+	const contributing = perSource.filter((s) => s.contributed).map((s) => s.source);
+	const unavailable = perSource.filter((s) => !s.contributed).map((s) => s.source);
+	const attempted = new Set(perSource.map((s) => s.source));
+	const notConsulted = KNOWN_CT_SOURCES.filter((s) => !attempted.has(s));
+
+	return {
+		basis: 'ct-sample',
+		perSource,
+		contributing,
+		unavailable,
+		notConsulted: [...notConsulted],
+		degraded: unavailable.length > 0 || notConsulted.length > 0,
+		caveat: coverageCaveat(contributing, unavailable, [...notConsulted], perSource),
+	};
+}
+
+/**
+ * The prose the caller actually reads. Three sentences, in descending order of
+ * what a security consumer would get wrong:
+ *   1. this is a sample and the count is a LOWER BOUND;
+ *   2. which sources answered and which did not;
+ *   3. what those sources structurally cannot see even when healthy.
+ */
+function coverageCaveat(contributing: string[], unavailable: string[], notConsulted: string[], perSource: CtSourceCoverage[]): string {
+	const parts: string[] = [
+		'This is a Certificate Transparency SAMPLE, not an inventory of the estate — the subdomain count is a LOWER BOUND. A host that has never had a publicly-logged certificate does not appear in CT at all.',
+	];
+
+	parts.push(
+		contributing.length > 0 ? `Sources that answered: ${contributing.join(', ')}.` : 'No CT source contributed names on this call.',
+	);
+	if (unavailable.length > 0) parts.push(`Attempted but returned nothing usable: ${unavailable.join(', ')}.`);
+	if (notConsulted.length > 0) parts.push(`Not consulted on this call: ${notConsulted.join(', ')}.`);
+
+	const bounds = perSource
+		.filter((s) => s.contributed && s.historyWindow !== 'unknown')
+		.map((s) =>
+			s.historyWindow === 'unexpired-only'
+				? `${s.source} shows currently-valid certificates only`
+				: `${s.source} covers a recent rolling window only`,
+		);
+	if (bounds.length > 0) parts.push(`Source history bounds: ${bounds.join('; ')}.`);
+
+	return parts.join(' ');
+}
+
+/**
+ * One-line rendering of the coverage record for the human/LLM-readable output.
+ * Emitted on EVERY result — including the clean single-source path, which is
+ * exactly the shape that previously read as authoritative.
+ */
+export function formatCoverageLine(coverage: CtCoverage): string {
+	const bits: string[] = [];
+	for (const s of coverage.perSource) {
+		const exhausted = s.indexExhausted === true ? ' index-exhausted' : s.indexExhausted === false ? ' index-partial' : '';
+		bits.push(`${s.source}=${s.outcome}${exhausted}`);
+	}
+	for (const s of coverage.notConsulted) bits.push(`${s}=not-consulted`);
+	return `Coverage [${coverage.basis}]: ${bits.join(', ')}`;
+}

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -445,7 +445,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	discover_subdomains: {
 		description:
-			'Find subdomains of a domain using Certificate Transparency logs. Reveals shadow IT, forgotten services, and unauthorized certificate issuance.',
+			'Find subdomains of a domain using Certificate Transparency logs. Reveals shadow IT, forgotten services, and unauthorized certificate issuance. Returns a CT SAMPLE, not an asset inventory: the count is a lower bound, a host with no publicly-logged certificate never appears, and the result carries a per-source `coverage` record stating what was actually consulted.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,
@@ -551,7 +551,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	check_subdomain_takeover: {
 		description:
-			'Sweep subdomains for dangling CNAMEs pointing to deprovisioned cloud services that could be claimed by an attacker (subdomain takeover vulnerabilities). Detects 16 provider families (AWS S3/CloudFront, Azure Front Door/CDN/Blob/App Service, GCP Cloud Storage, Heroku, GitHub Pages, Vercel, Firebase, Shopify, etc.). Use when asked if subdomains are pointing to deprovisioned cloud services. Pair with discover_subdomains for full inventory.',
+			'Sweep subdomains for dangling CNAMEs pointing to deprovisioned cloud services that could be claimed by an attacker (subdomain takeover vulnerabilities). Detects 16 provider families (AWS S3/CloudFront, Azure Front Door/CDN/Blob/App Service, GCP Cloud Storage, Heroku, GitHub Pages, Vercel, Firebase, Shopify, etc.). Use when asked if subdomains are pointing to deprovisioned cloud services. Pair with discover_subdomains to widen the candidate set — note that returns a CT sample, not a full inventory.',
 		schema: CheckSubdomainTakeoverArgs,
 		group: 'infrastructure',
 		tier: 'protective',

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -15,10 +15,21 @@
  *      bounded retry and a per-source `ct_source` health log, then
  *   3. last-known-good KV cache, returned marked `stale` with its age.
  * Only when all of the above are exhausted do we report `sourceUnavailable`.
+ *
+ * COMPLETENESS HONESTY (this is a SAMPLE, never an inventory):
+ * The result carries a `coverage` record whose `basis` is the literal
+ * `'ct-sample'` — there is no value meaning "complete inventory", by design.
+ * The former `enumerationComplete` boolean is GONE: its narrow per-source truth
+ * now lives on as `sourceIndexExhausted`, a name that cannot be misread. See
+ * `src/lib/ct-coverage.ts` for the measured evidence (bnz.co.nz, 2026-07-27:
+ * 165 names + `enumerationComplete: true` against 420 in crt.sh's unfiltered
+ * history, four of the missing ones resolving to live production IPs).
  */
 
 import type { OutputFormat } from '../handlers/tool-args';
 import { cacheGet, cacheSet } from '../lib/cache';
+import type { CtCoverage, CtSourceAttempt, CtSourceOutcome } from '../lib/ct-coverage';
+import { buildCtCoverage, formatCoverageLine } from '../lib/ct-coverage';
 import { logEvent } from '../lib/log';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import { disposeUnreadResponseBody, readBoundedOrNull } from '../lib/response-body';
@@ -225,7 +236,20 @@ export interface DiscoveredSubdomain {
 
 /** An issue detected during subdomain discovery. */
 export interface SubdomainIssue {
-	type: 'expired_subdomain' | 'wildcard_exposure' | 'many_issuers' | 'recent_issuance' | 'shadow_subdomain' | 'unconfirmed_zero';
+	type:
+		| 'expired_subdomain'
+		| 'wildcard_exposure'
+		| 'many_issuers'
+		| 'recent_issuance'
+		| 'shadow_subdomain'
+		| 'unconfirmed_zero'
+		/**
+		 * Always emitted on a non-empty result. Structured consumers that read
+		 * ONLY `issues[]` — the same class the `unconfirmed_zero` issue was added
+		 * for — would otherwise see a clean list of hosts with nothing telling
+		 * them it is a floor, not an inventory.
+		 */
+		| 'ct_sample_not_inventory';
 	severity: 'high' | 'medium' | 'low' | 'info';
 	detail: string;
 }
@@ -264,27 +288,49 @@ export interface SubdomainDiscoveryResult {
 	 * True when this result is NOT the whole story — either the returned
 	 * {@link subdomains} array is a strict subset of what was enumerated
 	 * (`returned < totalSubdomains`, the {@link MAX_SUBDOMAINS} cap), or the
-	 * upstream enumeration itself was incomplete ({@link enumerationComplete}
+	 * source's own index was not read to the end ({@link sourceIndexExhausted}
 	 * false). A security caller that sweeps only `subdomains` MUST branch on
 	 * this: before #573 the cap was silent and the tool read as authoritative.
+	 *
+	 * NOTE the asymmetry, and it is deliberate: `truncated: false` does NOT mean
+	 * "you have the estate". It means nothing was dropped BETWEEN the source and
+	 * you. What the source itself could never see is {@link coverage}'s job.
 	 */
 	truncated?: boolean;
 	/** How many entries the {@link subdomains} array actually carries. */
 	returned?: number;
-	/** Which CT source(s) produced this answer, e.g. `['crtsh']`, `['certspotter']`. */
+	/** Which CT source(s) contributed names, e.g. `['crtsh']`, `['certspotter']`. */
 	sources?: string[];
 	/**
-	 * True when we believe we read the source's index exhaustively: every page
+	 * True when we read the contributing source's index to the end: every page
 	 * followed, no upstream truncation flag, no entry-cap applied. False means
-	 * `totalSubdomains` is a FLOOR, not a total — the real count is higher.
+	 * `totalSubdomains` is a FLOOR even relative to that ONE source.
+	 *
+	 * REPLACES the former `enumerationComplete`. Same narrow truth, a name that
+	 * cannot be misread: exhausting one source's index is not enumerating an
+	 * estate. Measured 2026-07-27, bnz.co.nz returned `enumerationComplete: true`
+	 * on 165 names while crt.sh's unfiltered history held 420, four of the
+	 * missing ones resolving to live production IPs. See {@link coverage} and
+	 * `src/lib/ct-coverage.ts` for the full rationale.
 	 */
-	enumerationComplete?: boolean;
+	sourceIndexExhausted?: boolean;
+	/**
+	 * What was actually looked at, and what that could possibly have seen. Always
+	 * populated by every production path in this module; optional only so that
+	 * hand-built fixtures in unrelated suites still typecheck.
+	 *
+	 * Its `basis` is the literal `'ct-sample'` — a one-member union, so there is
+	 * no value a consumer can read as "complete inventory".
+	 */
+	coverage?: CtCoverage;
 }
 
 /** Provenance/completeness metadata threaded from a source into the result builders. */
 interface EnumerationMeta {
 	sources?: string[];
-	enumerationComplete?: boolean;
+	sourceIndexExhausted?: boolean;
+	/** Per-source attempt log; folded into {@link SubdomainDiscoveryResult.coverage}. */
+	attempts?: CtSourceAttempt[];
 }
 
 /**
@@ -402,7 +448,11 @@ export async function discoverSubdomains(
 	// and a bounded retry: crt.sh (rich metadata) → Certspotter (names + dates).
 	const direct = await queryDirectSources(domain, options);
 	if (direct.available) {
-		const meta: EnumerationMeta = { sources: direct.sources, enumerationComplete: direct.enumerationComplete };
+		const meta: EnumerationMeta = {
+			sources: direct.sources,
+			sourceIndexExhausted: direct.sourceIndexExhausted,
+			attempts: direct.attempts,
+		};
 		const result =
 			direct.entries.length > 0 ? buildResultFromEntries(domain, direct.entries, meta) : emptyResult(domain, false, false, meta);
 		await cacheSuccess(domain, result, options);
@@ -415,7 +465,7 @@ export async function discoverSubdomains(
 	const stale = await readLastKnownGood(domain, options);
 	if (stale) return stale;
 
-	return emptyResult(domain, true);
+	return emptyResult(domain, true, false, { attempts: direct.attempts });
 }
 
 /**
@@ -595,7 +645,11 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[],
 		});
 	}
 
-	const enumerationComplete = (meta?.enumerationComplete ?? true) && !entryCapHit;
+	const sourceIndexExhausted = (meta?.sourceIndexExhausted ?? true) && !entryCapHit;
+	const flags = enumerationFlags(allSubdomains.length, subdomains.length, meta?.sources, sourceIndexExhausted, meta?.attempts);
+	// Prepended, not appended: a caller that truncates the issue list for display
+	// must not lose the one line saying the list itself is a floor.
+	if (flags.coverage) issues.unshift(sampleCaveatIssue(flags.coverage, allSubdomains.length));
 
 	return {
 		domain,
@@ -606,33 +660,86 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[],
 		expiredCerts,
 		uniqueIssuers,
 		issues,
-		...enumerationFlags(allSubdomains.length, subdomains.length, meta?.sources, enumerationComplete),
+		...flags,
 	};
 }
 
 /**
- * Build the {@link SubdomainDiscoveryResult} truncation contract from a
- * (total, returned) pair. `truncated` is deliberately the UNION of both ways an
- * answer can be partial — the return cap bit, or the upstream enumeration being
- * incomplete — because a caller asking "is this the whole estate?" needs one
- * flag, with `enumerationComplete` available to say WHICH.
+ * Build the {@link SubdomainDiscoveryResult} completeness contract from a
+ * (total, returned) pair plus the per-source attempt log.
+ *
+ * `truncated` stays the UNION of the two ways data can be lost BETWEEN the
+ * source and the caller — the return cap, or the source's index not being read
+ * to the end. `coverage` answers the different and larger question the old
+ * `enumerationComplete` flag pretended to: what was consulted, and what could
+ * that possibly have seen. Both are always emitted; neither can be `true` in a
+ * way that means "this is the estate".
  */
 function enumerationFlags(
 	total: number,
 	returned: number,
 	sources: string[] | undefined,
-	enumerationComplete: boolean,
-): Pick<SubdomainDiscoveryResult, 'truncated' | 'returned' | 'sources' | 'enumerationComplete'> {
+	sourceIndexExhausted: boolean,
+	attempts: CtSourceAttempt[] | undefined,
+): Pick<SubdomainDiscoveryResult, 'truncated' | 'returned' | 'sources' | 'sourceIndexExhausted' | 'coverage'> {
 	return {
 		returned,
-		truncated: returned < total || !enumerationComplete,
-		enumerationComplete,
+		truncated: returned < total || !sourceIndexExhausted,
+		sourceIndexExhausted,
+		coverage: buildCtCoverage(attempts ?? attemptsFromSources(sources, sourceIndexExhausted)),
 		...(sources && sources.length > 0 ? { sources } : {}),
 	};
 }
 
-/** Per-source health outcome, emitted to the `ct_source` log for observability. */
-type CtSourceOutcome = 'ok' | 'empty' | 'http_error' | 'timeout' | 'error';
+/**
+ * Fallback attempt log for paths that know WHICH source answered but kept no
+ * per-source failure record (the certstream fast path, and cached results
+ * rebuilt from an older payload). Everything not named is reported as
+ * `notConsulted` rather than silently assumed healthy.
+ */
+function attemptsFromSources(sources: string[] | undefined, sourceIndexExhausted: boolean): CtSourceAttempt[] {
+	if (!sources || sources.length === 0) return [];
+	return sources.map((source) => ({ source, outcome: 'ok' as CtSourceOutcome, contributed: true, indexExhausted: sourceIndexExhausted }));
+}
+
+/**
+ * The always-present sample caveat on `issues[]`.
+ *
+ * `unconfirmed_zero` already covers the empty case, so this one rides on
+ * non-empty results — the shape that looked healthy and therefore did the
+ * damage. Severity `info`: it is a standing property of CT-derived evidence,
+ * not a finding about the domain.
+ */
+function sampleCaveatIssue(coverage: CtCoverage, total: number): SubdomainIssue {
+	// Kept SHORT deliberately, and BOUNDED: `formatCompact`/`formatFull` push issue
+	// details through `sanitizeOutputText(…, 200|300)`, so a detail that carried the
+	// full `coverage.caveat` prose was truncated mid-sentence — losing the clause
+	// that matters. The long form still rides on the banner and `coverage.caveat`.
+	//
+	// The lead sentence is the non-negotiable part and is built first; the source
+	// summary is appended only while it still fits under the tightest cap, so a
+	// long source list can never push the meaning off the end.
+	const lead = `${total} subdomains is a LOWER BOUND from a CT sample, not an inventory — hosts with no logged certificate never appear.`;
+	const answered = coverage.contributing.length > 0 ? coverage.contributing.join(', ') : 'no source';
+	const missing = [...coverage.unavailable, ...coverage.notConsulted];
+	const suffix = ` Answered: ${answered}${missing.length > 0 ? `; no data from ${missing.join(', ')}` : ''}.`;
+	return {
+		type: 'ct_sample_not_inventory',
+		severity: 'info',
+		detail: lead.length + suffix.length <= COMPACT_ISSUE_DETAIL_CAP ? `${lead}${suffix}` : lead,
+	};
+}
+
+/**
+ * The tightest cap any renderer applies to `SubdomainIssue.detail`
+ * (`formatCompact` → `sanitizeOutputText(detail, 200)`). Kept next to the caveat
+ * builder so the two cannot drift apart silently.
+ */
+const COMPACT_ISSUE_DETAIL_CAP = 200;
+
+// `CtSourceOutcome` (the per-source health outcome emitted to the `ct_source`
+// log) now lives in `../lib/ct-coverage` — the coverage record reports the same
+// values, so one definition serves both.
 
 /** Normalized result of one direct-source attempt. */
 interface SourceResult {
@@ -888,7 +995,7 @@ function delayWithSignal(ms: number, signal?: AbortSignal): Promise<void> {
 async function queryDirectSources(
 	domain: string,
 	options?: DiscoverSubdomainsOptions,
-): Promise<{ available: boolean; entries: CrtShEntry[]; sources?: string[]; enumerationComplete?: boolean }> {
+): Promise<{ available: boolean; entries: CrtShEntry[]; sources?: string[]; sourceIndexExhausted?: boolean; attempts: CtSourceAttempt[] }> {
 	// Per-source timeouts differ by backend: crt.sh is Postgres-backed and often
 	// slow on a cold query, while Certspotter is a fast JSON API — giving the
 	// fallback a tighter bound keeps both inside one budget.
@@ -907,6 +1014,16 @@ async function queryDirectSources(
 	// has had a chance to corroborate it or supersede it with real data.
 	let sawEmpty = false;
 
+	// Per-source attempt log for the coverage record. Last outcome per source
+	// wins across retry passes; a source never reached stays out entirely so
+	// `buildCtCoverage` reports it as `notConsulted` rather than as healthy.
+	const attemptLog = new Map<string, CtSourceAttempt>();
+	const recordAttempt = (source: string, outcome: CtSourceOutcome, contributed: boolean, indexExhausted?: boolean): void => {
+		attemptLog.set(source, { source, outcome, contributed, ...(indexExhausted === undefined ? {} : { indexExhausted }) });
+	};
+	const attempts = (): CtSourceAttempt[] =>
+		sources.filter((s) => attemptLog.has(s.name)).map((s) => attemptLog.get(s.name) as CtSourceAttempt);
+
 	for (let pass = 0; pass <= CT_SOURCE_MAX_RETRIES; pass++) {
 		// Backoff applies BETWEEN passes, not between sources — failover should be
 		// immediate, only a repeat attempt at the same source needs to back off.
@@ -918,7 +1035,7 @@ async function queryDirectSources(
 			// information — surface it rather than downgrading to a bare outage
 			// just because we ran out of budget to corroborate further.
 			if (deadlineExceeded(options) || !hasBudgetFor(options, source.timeoutMs)) {
-				return sawEmpty ? { available: true, entries: [] } : { available: false, entries: [] };
+				return sawEmpty ? { available: true, entries: [], attempts: attempts() } : { available: false, entries: [], attempts: attempts() };
 			}
 			const composed = composeAbortSignal(source.timeoutMs, options?.signal);
 			let res: SourceResult;
@@ -928,12 +1045,24 @@ async function queryDirectSources(
 				composed.cleanup();
 			}
 			logCtSource(domain, source.name, res.outcome);
-			// #573 metadata (which source answered, was its enumeration complete) rides
+			// Every attempt is recorded — including the failures. The pre-fix payload
+			// reported only the winner (`sources: ["certspotter"]`), so a caller could
+			// not tell that crt.sh had been asked and had failed, i.e. that recall on
+			// that call was degraded. That omission is now impossible.
+			recordAttempt(source.name, res.outcome, res.outcome === 'ok', res.enumerationComplete);
+			// #573 metadata (which source answered, was its index read to the end) rides
 			// on the ok path only. #575's `sawEmpty` fall-through is preserved: an
 			// `empty` outcome must NOT short-circuit, because a source that answers
 			// "nothing" is not authoritative until every source has been tried.
-			const meta = { sources: [source.name], enumerationComplete: res.enumerationComplete ?? true };
-			if (res.outcome === 'ok') return { available: true, entries: res.entries, ...meta };
+			if (res.outcome === 'ok') {
+				return {
+					available: true,
+					entries: res.entries,
+					sources: [source.name],
+					sourceIndexExhausted: res.enumerationComplete ?? true,
+					attempts: attempts(),
+				};
+			}
 			if (res.outcome === 'empty') sawEmpty = true;
 			// empty / http_error / timeout / error all fall through to try the
 			// next source instead of short-circuiting.
@@ -943,9 +1072,9 @@ async function queryDirectSources(
 		// authoritative empty from at least one source is a real (if
 		// unconfirmed) answer — report it rather than burning a retry pass
 		// chasing a source that merely failed to respond.
-		if (sawEmpty) return { available: true, entries: [] };
+		if (sawEmpty) return { available: true, entries: [], attempts: attempts() };
 	}
-	return { available: false, entries: [] };
+	return { available: false, entries: [], attempts: attempts() };
 }
 
 /** LKG cache key for a domain. */
@@ -1242,7 +1371,14 @@ function buildCertstreamResult(
 		});
 	}
 
-	const enumerationComplete = !upstream?.truncated && !upstream?.timedOut;
+	const sourceIndexExhausted = !upstream?.truncated && !upstream?.timedOut;
+	// The fast path answers from ONE aggregator and never asks crt.sh or
+	// Certspotter — `buildCtCoverage` turns that into an explicit `notConsulted`
+	// list rather than letting a single opinion read as consensus.
+	const flags = enumerationFlags(dedupedAll.length, deduped.length, ['certstream'], sourceIndexExhausted, [
+		{ source: 'certstream', outcome: dedupedAll.length === 0 ? 'empty' : 'ok', contributed: true, indexExhausted: sourceIndexExhausted },
+	]);
+	if (flags.coverage && dedupedAll.length > 0) issues.unshift(sampleCaveatIssue(flags.coverage, dedupedAll.length));
 
 	return {
 		domain,
@@ -1253,7 +1389,7 @@ function buildCertstreamResult(
 		expiredCerts: 0,
 		uniqueIssuers: [],
 		issues,
-		...enumerationFlags(dedupedAll.length, deduped.length, ['certstream'], enumerationComplete),
+		...flags,
 	};
 }
 
@@ -1273,9 +1409,9 @@ function buildCertstreamResult(
  * found.
  */
 function emptyResult(domain: string, sourceUnavailable = false, partial = false, meta?: EnumerationMeta): SubdomainDiscoveryResult {
-	// A source outage or a budget trip is by definition not an exhaustive
-	// enumeration — never let an empty error read as a complete "none found".
-	const enumerationComplete = sourceUnavailable || partial ? false : (meta?.enumerationComplete ?? true);
+	// A source outage or a budget trip is by definition not an exhaustive read —
+	// never let an empty error read as a confident "none found".
+	const sourceIndexExhausted = sourceUnavailable || partial ? false : (meta?.sourceIndexExhausted ?? true);
 	return {
 		domain,
 		totalSubdomains: 0,
@@ -1295,26 +1431,35 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false,
 		],
 		sourceUnavailable,
 		...(partial ? { partial: true } : {}),
-		...enumerationFlags(0, 0, meta?.sources, enumerationComplete),
+		...enumerationFlags(0, 0, meta?.sources, sourceIndexExhausted, meta?.attempts),
 	};
 }
 
 /** Format subdomain discovery result as human-readable text. */
 export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, format: OutputFormat = 'full'): string {
+	// Both zero-ish branches carry the per-source coverage line: "which source
+	// failed" is the first thing a caller needs in order to judge a zero.
+	const coverageLine = result.coverage ? `\n${formatCoverageLine(result.coverage)}` : '';
+
 	if (result.sourceUnavailable) {
-		return `Subdomain Discovery: ${result.domain} — Certificate Transparency source unavailable (the CT log endpoint returned an error or was unreachable); could not enumerate subdomains. This does not mean the domain has no subdomains — retry shortly.`;
+		return `Subdomain Discovery: ${result.domain} — Certificate Transparency source unavailable (the CT log endpoint returned an error or was unreachable); could not enumerate subdomains. This does not mean the domain has no subdomains — retry shortly.${coverageLine}`;
 	}
 	if (result.totalSubdomains === 0) {
 		// A STALE empty set is not a confident "none found" — say so, or the
 		// original failure mode (an unreliable answer read as authoritative)
 		// comes back through the zero branch.
 		return result.stale
-			? `${staleBanner(result)}\n\nSubdomain Discovery: ${result.domain} — the cached enumeration contains no subdomains; this is NOT a confirmed empty result.`
-			: `Subdomain Discovery: ${result.domain} — no subdomains found in Certificate Transparency logs (unconfirmed: CT logs only capture certificate issuance, so this is not a verified absence)`;
+			? `${staleBanner(result)}\n\nSubdomain Discovery: ${result.domain} — the cached enumeration contains no subdomains; this is NOT a confirmed empty result.${coverageLine}`
+			: `Subdomain Discovery: ${result.domain} — no subdomains found in Certificate Transparency logs (unconfirmed: CT logs only capture certificate issuance, so this is not a verified absence)${coverageLine}`;
 	}
 
 	const body = format === 'compact' ? formatCompact(result) : formatFull(result);
 	const banners: string[] = [];
+	// The sample caveat leads, UNCONDITIONALLY. The dangerous production shape was
+	// a clean, exhausted, single-source answer — no banner fired, and the reader
+	// took 165 names for a bank's estate. A caveat that only appears when
+	// something visibly went wrong is the same false confidence in a new place.
+	banners.push(sampleBanner(result));
 	if (result.stale) banners.push(staleBanner(result));
 	// Distinct from `stale` (served from the last-known-good cache): `partial`
 	// here means a live source answered but timed out mid-query, so the data
@@ -1324,6 +1469,21 @@ export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, forma
 	// the paths that set `partial:true` with real subdomain data.
 	if (result.partial && !result.stale) banners.push(partialBanner());
 	return banners.length > 0 ? `${banners.join('\n\n')}\n\n${body}` : body;
+}
+
+/**
+ * The standing sample caveat + per-source coverage line, prepended to EVERY
+ * rendered result.
+ *
+ * Falls back to fixed prose when `coverage` is absent (a hand-built fixture, or
+ * a payload cached before this contract existed) — the caveat is never the thing
+ * that goes missing.
+ */
+function sampleBanner(result: SubdomainDiscoveryResult): string {
+	if (!result.coverage) {
+		return `ℹ️ CT SAMPLE — NOT AN INVENTORY: ${result.totalSubdomains} is a LOWER BOUND. A host that has never had a publicly-logged certificate does not appear in Certificate Transparency at all.`;
+	}
+	return `ℹ️ CT SAMPLE — NOT AN INVENTORY: ${result.coverage.caveat}\n${formatCoverageLine(result.coverage)}`;
 }
 
 /** Staleness notice prepended when a result came from the last-known-good cache. */
@@ -1346,7 +1506,7 @@ function staleBanner(result: SubdomainDiscoveryResult): string {
 function overflowLines(result: SubdomainDiscoveryResult, shownCount: number, style: 'compact' | 'full'): string[] {
 	const lines: string[] = [];
 	const hidden = Math.max(0, result.totalSubdomains - shownCount);
-	const incomplete = result.enumerationComplete === false;
+	const incomplete = result.sourceIndexExhausted === false;
 
 	if (hidden > 0) {
 		// "at least N" — never a bare N — once the enumeration is known partial.
@@ -1356,7 +1516,9 @@ function overflowLines(result: SubdomainDiscoveryResult, shownCount: number, sty
 
 	if (incomplete) {
 		const source = result.sources && result.sources.length > 0 ? result.sources.join(', ') : 'the Certificate Transparency source';
-		const note = `⚠️ Enumeration INCOMPLETE (${source}): ${result.totalSubdomains} is a FLOOR, not a total — more subdomains exist than were retrieved. Treat this as a partial inventory.`;
+		// Escalation ON TOP of the standing sample caveat: not merely "CT can't see
+		// everything", but "we did not even finish reading the source we used".
+		const note = `⚠️ SOURCE INDEX NOT EXHAUSTED (${source}): we stopped reading this source before its index ended, so ${result.totalSubdomains} is short even of what THIS source holds.`;
 		lines.push(style === 'compact' ? ` ${note}` : `_${note}_`);
 	}
 

--- a/test/discover-subdomains-coverage.spec.ts
+++ b/test/discover-subdomains-coverage.spec.ts
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Regression suite for the CT ENUMERATION-HONESTY defect (follow-on to #573/#577).
+//
+// #577 fixed a real silent truncation and, in doing so, shipped a field named
+// `enumerationComplete`. Its authored meaning was narrow and true — "we
+// paginated the ONE source that answered to the end of its index" — but its
+// NAME asserts something far larger, and a reasonable consumer reads
+// `enumerationComplete: true` as "this is the estate".
+//
+// Measured against production on 2026-07-27 (bnz.co.nz):
+//   - the tool returned 165 unique names, `sources: ["certspotter"]`,
+//     `truncated: false`, `enumerationComplete: true`;
+//   - crt.sh's full CT history for the same estate holds 420 unique names;
+//   - four of the missing names — ams.privatebank / realme / cardsecurity /
+//     myaccess .bnz.co.nz — resolve to live production IPs.
+// So a `true` flag accompanied a ~60%-short answer about a bank's external
+// attack surface. That is the same false-confidence class the whole #573/#575/
+// #577 campaign exists to remove, one level up.
+//
+// What is locked here:
+//   1. NO field on the result may assert estate-level completeness. The
+//      `enumerationComplete` NAME is gone; the narrow truth it encoded lives on
+//      as `sourceIndexExhausted`, which cannot be misread.
+//   2. Every result carries a `coverage` record whose `basis` is the literal
+//      'ct-sample' — a one-member union, so there is no representable value
+//      meaning "inventory".
+//   3. Coverage names which sources contributed, which were attempted and
+//      failed, and which were never consulted at all — the production payload
+//      showed `["certspotter"]` with no hint that crt.sh had been asked and had
+//      failed, nor that Certspotter's free tier only sees a ~1-year window.
+//   4. The rendered text ALWAYS carries the sample caveat, including on the
+//      fully-successful single-source path — the exact case that read as
+//      authoritative before.
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { setupFetchMock } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+function entry(name: string, i: number) {
+	return {
+		name_value: name,
+		issuer_name: "CN=R3, O=Let's Encrypt",
+		not_before: `2026-01-01T00:00:00.${String(9_999 - i).padStart(4, '0')}Z`,
+		not_after: '2030-01-01T00:00:00Z',
+	};
+}
+
+/** One Certspotter issuance with an `id` (the pagination cursor). */
+function issuance(id: number, names: string[]) {
+	return {
+		id: String(id),
+		dns_names: names,
+		not_before: '2026-02-01T00:00:00Z',
+		not_after: '2030-05-01T00:00:00Z',
+		issuer: { name: "C=US, O=Let's Encrypt, CN=R11" },
+	};
+}
+
+describe('discover_subdomains — no field may assert estate completeness', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('does not expose an `enumerationComplete` field at all', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([entry('a.example.com', 0)], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		// The name is the defect. Not renamed-and-aliased — gone.
+		expect(result).not.toHaveProperty('enumerationComplete');
+		expect(JSON.stringify(result)).not.toContain('enumerationComplete');
+	});
+
+	it('reports the narrow per-source truth as `sourceIndexExhausted` while refusing the inventory claim', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([entry('a.example.com', 0), entry('b.example.com', 1)], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		// We DID read crt.sh's answer to the end — that narrow claim survives…
+		expect(result.sourceIndexExhausted).toBe(true);
+		// …but it is explicitly NOT an estate inventory.
+		expect(result.coverage?.basis).toBe('ct-sample');
+		expect(result.coverage?.caveat).toMatch(/not (an )?(estate )?inventory/i);
+	});
+});
+
+describe('discover_subdomains — per-source coverage record', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('records a failed source alongside the one that answered (the production bnz.co.nz shape)', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			// crt.sh 502s — exactly what it did on 6 of 8 live samples on 2026-07-27.
+			if (s.includes('crt.sh')) return Response.json({}, { status: 502 });
+			if (s.includes('certspotter.com')) {
+				return Response.json([issuance(1, ['api.example.com']), issuance(2, ['vpn.example.com'])], { status: 200 });
+			}
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(result.sources).toEqual(['certspotter']);
+		// The old payload stopped there. A caller could not tell that crt.sh had
+		// been asked and had failed — i.e. that recall was degraded.
+		const crtsh = result.coverage?.perSource.find((s) => s.source === 'crtsh');
+		expect(crtsh).toBeDefined();
+		expect(crtsh?.outcome).toBe('http_error');
+		expect(crtsh?.contributed).toBe(false);
+		expect(result.coverage?.contributing).toEqual(['certspotter']);
+		expect(result.coverage?.degraded).toBe(true);
+	});
+
+	it('names the sources that were never consulted on the certstream fast path', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const certstreamFetch = vi.fn(async () =>
+			Response.json({
+				domain: 'example.com',
+				subdomains: ['api.example.com', 'vpn.example.com'],
+				certificateCount: 2,
+				timedOut: false,
+				cached: false,
+			}),
+		);
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('direct sources must not be used when certstream answers');
+		});
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch });
+
+		expect(result.coverage?.contributing).toEqual(['certstream']);
+		// A fast-path answer is ONE source's view. crt.sh and Certspotter were
+		// never asked, and the caller has to be able to see that.
+		expect(result.coverage?.notConsulted).toContain('crtsh');
+		expect(result.coverage?.notConsulted).toContain('certspotter');
+	});
+
+	it('labels each source with the slice of CT history it can even see', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json({}, { status: 502 });
+			if (s.includes('certspotter.com')) return Response.json([issuance(1, ['api.example.com'])], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		// Measured 2026-07-27: Certspotter's unauthenticated feed for bnz.co.nz
+		// spanned 2025-07-07 → 2026-07-27 only. Exhausting its index is therefore
+		// structurally incapable of covering an estate's certificate history.
+		const cs = result.coverage?.perSource.find((s) => s.source === 'certspotter');
+		expect(cs?.indexExhausted).toBe(true);
+		expect(cs?.historyWindow).toBe('recent-window');
+
+		// crt.sh is queried with `exclude=expired`, so even a healthy crt.sh only
+		// ever shows currently-valid certificates.
+		const crt = result.coverage?.perSource.find((s) => s.source === 'crtsh');
+		expect(crt?.historyWindow).toBe('unexpired-only');
+	});
+
+	it('carries coverage through the MCP handler structuredContent', async () => {
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([entry('a.example.com', 0)], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const res = await handleToolsCall({ name: 'discover_subdomains', arguments: { domain: 'example.com' } }, undefined, undefined);
+		const payload = res.structuredContent as Record<string, unknown>;
+
+		expect(payload).not.toHaveProperty('enumerationComplete');
+		expect((payload.coverage as { basis?: string } | undefined)?.basis).toBe('ct-sample');
+	});
+});
+
+describe('discover_subdomains — issues[] carries the sample caveat', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('always emits a ct_sample_not_inventory issue on a non-empty result', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([entry('a.example.com', 0)], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		// Structured consumers that read ONLY `issues[]` (the failure mode the
+		// `unconfirmed_zero` issue was added for) must also see the caveat.
+		const caveat = result.issues.find((i) => i.type === 'ct_sample_not_inventory');
+		expect(caveat).toBeDefined();
+		expect(caveat?.detail).toMatch(/lower bound|not an inventory|not a complete/i);
+	});
+
+	it('keeps the caveat detail short enough to survive the 200-char compact sanitizer', async () => {
+		const { discoverSubdomains, formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([entry('a.example.com', 0)], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+		const caveat = result.issues.find((i) => i.type === 'ct_sample_not_inventory');
+
+		// `formatCompact` pushes issue details through `sanitizeOutputText(…, 200)`.
+		// A caveat truncated mid-sentence loses the clause that carries the meaning,
+		// so the rendered line must be a complete sentence.
+		expect(caveat!.detail.length).toBeLessThanOrEqual(200);
+		expect(formatSubdomainDiscovery(result, 'compact')).toContain(caveat!.detail);
+	});
+
+	it('prepends the caveat so a display-truncated issue list cannot drop it', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) {
+				return Response.json(
+					Array.from({ length: 40 }, (_, i) => entry(`shadow${i}.example.com`, i)),
+					{ status: 200 },
+				);
+			}
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+		expect(result.issues[0].type).toBe('ct_sample_not_inventory');
+	});
+});
+
+describe('discover_subdomains — rendered text always states the sample caveat', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	async function renderLiveRun(format: 'full' | 'compact') {
+		const { discoverSubdomains, formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json({}, { status: 502 });
+			if (s.includes('certspotter.com')) return Response.json([issuance(1, ['api.example.com'])], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		const result = await discoverSubdomains('example.com');
+		return formatSubdomainDiscovery(result, format);
+	}
+
+	it('states the caveat in full format even when the single source was exhausted', async () => {
+		const output = await renderLiveRun('full');
+		expect(output).toMatch(/lower bound/i);
+		expect(output).toMatch(/sample/i);
+		// It must never read as an inventory.
+		expect(output).not.toMatch(/complete inventory|full inventory|entire estate/i);
+	});
+
+	it('states the caveat in compact format too', async () => {
+		const output = await renderLiveRun('compact');
+		expect(output).toMatch(/lower bound/i);
+	});
+
+	it('names the failed source in the rendered coverage line', async () => {
+		const output = await renderLiveRun('full');
+		expect(output).toContain('crtsh');
+		expect(output).toContain('certspotter');
+	});
+});

--- a/test/discover-subdomains-truncation.spec.ts
+++ b/test/discover-subdomains-truncation.spec.ts
@@ -6,7 +6,7 @@
 //
 // Four defect classes are locked here:
 //   A. cap with no signal          → `truncated` / `returned` / `sources` /
-//                                    `enumerationComplete` on the result.
+//                                    `sourceIndexExhausted` on the result.
 //   B. single-page Certspotter     → follow `Link: rel="next"` via `after=`,
 //                                    bounded by MAX_CT_PAGES + the sync budget.
 //   C. wildcard/expired counted     → counts are taken over the WHOLE enumerated
@@ -125,7 +125,7 @@ describe('discover_subdomains — explicit truncation contract (defect A)', () =
 		expect(result.sources).toContain('crtsh');
 		// crt.sh answers in one shot — the ENUMERATION was complete even though
 		// the returned list is capped.
-		expect(result.enumerationComplete).toBe(true);
+		expect(result.sourceIndexExhausted).toBe(true);
 	});
 
 	it('leaves truncated falsy and reports `returned` when the set fits under the cap', async () => {
@@ -137,7 +137,7 @@ describe('discover_subdomains — explicit truncation contract (defect A)', () =
 		expect(result.totalSubdomains).toBe(12);
 		expect(result.returned).toBe(12);
 		expect(result.truncated).toBeFalsy();
-		expect(result.enumerationComplete).toBe(true);
+		expect(result.sourceIndexExhausted).toBe(true);
 	});
 
 	it('surfaces the contract through the MCP handler structuredContent', async () => {
@@ -211,7 +211,7 @@ describe('discover_subdomains — Certspotter pagination (defect B)', () => {
 		expect(names).toContain('page2-b.example.com');
 		expect(result.totalSubdomains).toBe(102);
 		expect(result.sources).toContain('certspotter');
-		expect(result.enumerationComplete).toBe(true);
+		expect(result.sourceIndexExhausted).toBe(true);
 		expect(result.truncated).toBeFalsy();
 	});
 
@@ -235,7 +235,7 @@ describe('discover_subdomains — Certspotter pagination (defect B)', () => {
 		const result = await discoverSubdomains('example.com');
 
 		expect(pages).toBe(8); // MAX_CT_PAGES
-		expect(result.enumerationComplete).toBe(false);
+		expect(result.sourceIndexExhausted).toBe(false);
 		expect(result.truncated).toBe(true);
 		expect(result.totalSubdomains).toBe(160);
 	});
@@ -269,7 +269,7 @@ describe('discover_subdomains — Certspotter pagination (defect B)', () => {
 
 		expect(pages).toBe(1);
 		expect(result.subdomains.map((s) => s.subdomain)).toContain('p1-0.example.com');
-		expect(result.enumerationComplete).toBe(false);
+		expect(result.sourceIndexExhausted).toBe(false);
 		expect(result.truncated).toBe(true);
 	});
 
@@ -311,7 +311,7 @@ describe('discover_subdomains — certstream path totals (defect D)', () => {
 		expect(result.sources).toContain('certstream');
 	});
 
-	it('reads the certstream /sans `truncated` flag into enumerationComplete', async () => {
+	it('reads the certstream /sans `truncated` flag into sourceIndexExhausted', async () => {
 		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
 		const certstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
@@ -332,7 +332,7 @@ describe('discover_subdomains — certstream path totals (defect D)', () => {
 		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch });
 
 		expect(result.totalSubdomains).toBe(2);
-		expect(result.enumerationComplete).toBe(false);
+		expect(result.sourceIndexExhausted).toBe(false);
 		// An incomplete upstream enumeration is a truncated answer even though
 		// every enumerated name was returned.
 		expect(result.truncated).toBe(true);
@@ -369,28 +369,28 @@ describe('discover_subdomains — honest overflow wording', () => {
 
 	it('caps the RENDERED host list at 100 even when 500 are returned structurally', async () => {
 		const formatSubdomainDiscovery = await fmt();
-		const output = formatSubdomainDiscovery(bulkResult({ returned: 140, truncated: false, enumerationComplete: true }), 'full');
+		const output = formatSubdomainDiscovery(bulkResult({ returned: 140, truncated: false, sourceIndexExhausted: true }), 'full');
 
 		expect(output).toContain('sub99.bnz.co.nz');
 		expect(output).not.toContain('sub100.bnz.co.nz');
 		expect(output).toContain('40 more subdomains not shown');
 	});
 
-	it('says "at least N more" and names the source when the enumeration was incomplete', async () => {
+	it('says "at least N more" and names the source when the source index was not exhausted', async () => {
 		const formatSubdomainDiscovery = await fmt();
-		const result = bulkResult({ returned: 140, truncated: true, enumerationComplete: false, sources: ['certspotter'] });
+		const result = bulkResult({ returned: 140, truncated: true, sourceIndexExhausted: false, sources: ['certspotter'] });
 
 		const full = formatSubdomainDiscovery(result, 'full');
 		expect(full).toContain('at least 40 more');
-		expect(full).toMatch(/incomplete/i);
+		expect(full).toMatch(/index not exhausted/i);
 		expect(full).toContain('certspotter');
 
 		const compact = formatSubdomainDiscovery(result, 'compact');
 		expect(compact).toContain('at least 40 more');
-		expect(compact).toMatch(/incomplete/i);
+		expect(compact).toMatch(/index not exhausted/i);
 	});
 
-	it('warns about an incomplete enumeration even when nothing is hidden by the display cap', async () => {
+	it('warns that the source index was not exhausted even when nothing is hidden by the display cap', async () => {
 		const formatSubdomainDiscovery = await fmt();
 		const result = {
 			domain: 'bnz.co.nz',
@@ -406,12 +406,12 @@ describe('discover_subdomains — honest overflow wording', () => {
 			issues: [],
 			returned: 2,
 			truncated: true,
-			enumerationComplete: false,
+			sourceIndexExhausted: false,
 			sources: ['certspotter'],
 		};
 
 		const full = formatSubdomainDiscovery(result, 'full');
-		expect(full).toMatch(/incomplete/i);
+		expect(full).toMatch(/index not exhausted/i);
 		expect(full).toContain('certspotter');
 		// No phantom "and 0 more".
 		expect(full).not.toMatch(/and (at least )?0 more/);
@@ -419,7 +419,7 @@ describe('discover_subdomains — honest overflow wording', () => {
 
 	it('keeps the exact wording when the display cap alone hides names', async () => {
 		const formatSubdomainDiscovery = await fmt();
-		const output = formatSubdomainDiscovery(bulkResult({ returned: 140, truncated: false, enumerationComplete: true }), 'compact');
+		const output = formatSubdomainDiscovery(bulkResult({ returned: 140, truncated: false, sourceIndexExhausted: true }), 'compact');
 
 		expect(output).toContain('...and 40 more');
 		expect(output).not.toContain('at least');


### PR DESCRIPTION
## The defect

`discover_subdomains` returned `enumerationComplete: boolean`. The value was narrow and true — *"the ONE source that answered was paginated to the end of its index"* — but the **name** asserts estate-level completeness, and that is how any reasonable consumer reads it. The arithmetic was right; the claim attached to it was not.

**Measured against production, 2026-07-27 (`bnz.co.nz`):**

| | |
|---|---|
| Tool returned | 165 unique names, `sources: ["certspotter"]`, `truncated: false`, **`enumerationComplete: true`** |
| crt.sh unfiltered history | **420** unique names |
| Missing but live | `ams.privatebank`, `realme`, `cardsecurity`, `myaccess` `.bnz.co.nz` — all four resolve to production IPs |

A `true` completeness flag accompanied a **~60%-short** answer about a bank's external attack surface. Same false-confidence class the #573/#575/#577 campaign exists to remove, one level up.

### The ceiling is structural

No amount of pagination makes a CT sweep an inventory:

- a host that never had a publicly-logged certificate **never appears in CT at all**;
- Certspotter's unauthenticated feed is a **rolling ~1-year window** (measured `2025-07-07 → 2026-07-27` for this estate);
- crt.sh is queried with `exclude=expired`, so even a healthy crt.sh shows **currently-valid certificates only** — that one parameter is where the 254 missing names went.

So "did we finish?" is the wrong question. The honest one is *"what did we look at, and what could that possibly have seen?"*

## The fix

- **`enumerationComplete` is removed.** Its narrow truth survives as **`sourceIndexExhausted`** — same value, a name that cannot be misread.
- **New `coverage` record** (`src/lib/ct-coverage.ts`) whose `basis` is the **literal `'ct-sample'`** — a one-member union. There is no representable value meaning "complete inventory", so a consumer cannot branch its way back into the old misreading.
- **Per-source reporting.** Every source carries its outcome, whether we read its index to the end, and the slice of CT history it can see *at all*. Sources never consulted are named explicitly. The old payload reported only the winner (`sources: ["certspotter"]`), so a caller could not tell crt.sh had been asked and had failed — i.e. that recall was degraded.
- **`issues[]` always carries `ct_sample_not_inventory`** on a non-empty result — prepended and length-bounded so a display-truncated issue list cannot drop it. Closes the same structured-consumer gap `unconfirmed_zero` was added for.
- **Rendered text leads with the caveat + coverage line, unconditionally.** The dangerous shape was the *clean, exhausted, single-source* answer where no banner fired at all. A caveat that only appears when something visibly broke is the same false confidence in a new place.
- **Tool descriptions** no longer promise an inventory (`"Pair with discover_subdomains for full inventory"` → *a CT sample, not a full inventory*).

Example output on the production failure shape (crt.sh down, Certspotter exhausted):

```
ℹ️ CT SAMPLE — NOT AN INVENTORY: This is a Certificate Transparency SAMPLE, not an
inventory of the estate — the subdomain count is a LOWER BOUND. A host that has never
had a publicly-logged certificate does not appear in CT at all. Sources that answered:
certspotter. Attempted but returned nothing usable: crtsh. Not consulted on this call:
certstream. Source history bounds: certspotter covers a recent rolling window only.
Coverage [ct-sample]: crtsh=http_error, certspotter=ok index-exhausted, certstream=not-consulted
```

## crt.sh was deliberately NOT added

It is **already** wired as source #1. Measured live, it cannot help:

| Measurement | Result |
|---|---|
| Availability | **502 on 6 of 8 samples** (~25% success) |
| Latency, `exclude=expired` | **23.9 s** (vs 10 s per-source timeout) |
| Latency, full history | **31.0 s** / 1.29 MB (vs 24 s handler budget) |
| Recall vs Certspotter, `exclude=expired` | **166 vs 166 — zero unique names either way** |
| Certspotter, full pagination | 4.1 s, 2 pages |

The entire 254-name gap is *expired-certificate history* that costs 31 s and 1.29 MB to reach. Forcing crt.sh in would have recreated this exact defect — a second source that times out and silently degrades. Its measured failure is now reported honestly instead, which is the actionable part. The numbers are recorded in `src/lib/ct-coverage.ts` so the next reader need not redo them.

## Verification

- `npm test` — **6594 passed, 0 test failures**, 13 skipped (+12 new tests).
- `npx tsc --noEmit` — clean, no output.
- `npx eslint .` — clean.
- **Baseline-checked:** the 1 failed *file* (`test/wasm-integration.test.ts`, gitignored wasm-pack artifact) and the 29 miniflare pool-teardown errors reproduce **identically on unmodified `origin/main`** (580 passed / 1 failed file / 29 errors there vs 581 / 1 / 29 here). Pre-existing, not introduced.

Behaviour otherwise unchanged: failover order, the empty-corroboration rule, LKG staleness, pagination bounds and the truncation contract are untouched. `packages/dns-checks/**` is not touched — worker-layer only, no npm publish, no cross-repo parity impact.

### Note for review
Two edits fall outside the tool file, both required and minimal: `src/handlers/tools.ts` (one `logDetails` block — the renamed field plus a `coverageDegraded` telemetry line; without it the rename does not typecheck) and `src/schemas/tool-definitions.ts` (the two overclaiming descriptions).
