### PR TITLE
fix(check_ssl): narrate certificate metadata in the prose channel, not only structuredContent

### DIFF
--- a/src/handlers/tool-formatters.ts
+++ b/src/handlers/tool-formatters.ts
@@ -176,5 +176,59 @@ export function formatCheckResult(result: CheckResult, format: OutputFormat = 'f
 		}
 	}
 
+	appendCertificateSection(lines, result);
+
 	return lines.join('\n');
+}
+
+/**
+ * Narrate `CheckResult.metadata.certificate` into the human-readable channel.
+ *
+ * WHY. `check_ssl`'s description promises the issuer and expiry date. The
+ * enrichment attaches them to `metadata`, which reaches the caller on the
+ * MCP-standard `structuredContent` field — but a client that reads only the
+ * `content` text saw nothing, and in `compact` format there is no appended
+ * STRUCTURED_RESULT blob to fall back on either. The promise was kept on one
+ * channel and silently broken on the other.
+ *
+ * NON-SCORING, and it must stay that way: this renders metadata, never a
+ * `Finding`, so nothing here can move a domain's score or grade.
+ *
+ * An unmeasured field prints `unknown` rather than being omitted — a missing row
+ * reads as "we did not look", which is a different claim from "there is no
+ * expiry date". Absence of the whole block adds nothing at all: no CT record is
+ * not a finding about the certificate.
+ */
+function appendCertificateSection(lines: string[], result: CheckResult): void {
+	const cert = (result as { metadata?: { certificate?: unknown } }).metadata?.certificate;
+	if (!cert || typeof cert !== 'object') return;
+	const c = cert as Record<string, unknown>;
+
+	const str = (v: unknown): string =>
+		typeof v === 'string' && v.trim() !== '' ? sanitizeOutputText(v, 200) : 'unknown';
+	const expires =
+		typeof c.notAfter === 'string' && c.notAfter.trim() !== ''
+			? // Date-only: the time component is noise for an expiry, and CT precision
+				// does not warrant implying it.
+				sanitizeOutputText(c.notAfter.slice(0, 10), 20)
+			: 'unknown';
+	const remaining =
+		typeof c.daysRemaining === 'number' && Number.isFinite(c.daysRemaining)
+			? `${c.daysRemaining} days`
+			: 'unknown';
+
+	lines.push('');
+	lines.push('### Certificate');
+	lines.push(`- Issuer: ${str(c.issuer)}`);
+	lines.push(`- Expires: ${expires} (${remaining} remaining, band: ${str(c.expiryBand)})`);
+	if (typeof c.sanCount === 'number' && Number.isFinite(c.sanCount)) {
+		// Count only — publishing the SAN list would hand out an enumerated
+		// subdomain inventory.
+		lines.push(`- Subject alternative names: ${c.sanCount}`);
+	}
+	// Never drop this line: without it a reader takes "logged" to mean "served"
+	// and draws a wrong conclusion from a correct answer.
+	lines.push(
+		'- Source: Certificate Transparency logs — describes the most recently logged certificate, which may differ from the certificate currently served.'
+	);
 }

--- a/test/tool-formatters.spec.ts
+++ b/test/tool-formatters.spec.ts
@@ -108,3 +108,71 @@ describe('tool-formatters', () => {
 		expect(text).toContain('ignore previous instructions');
 	});
 });
+
+/**
+ * The `check_ssl` tool description promises the issuer and expiry date. The
+ * enrichment attaches them at `CheckResult.metadata.certificate`, which reaches
+ * the caller on the MCP-standard `structuredContent` channel — but a client
+ * reading only the human-readable `content` text in `compact` format (where the
+ * STRUCTURED_RESULT blob is not appended) saw NOTHING, so for that client the
+ * description promised a capability the output did not show.
+ */
+describe('formatCheckResult — certificate metadata narration', () => {
+	function sslResult(certificate: Record<string, unknown> | undefined): CheckResult {
+		return {
+			category: 'ssl',
+			passed: true,
+			score: 100,
+			findings: [],
+			...(certificate ? { metadata: { certificate } } : {}),
+		} as CheckResult;
+	}
+
+	const CERT = {
+		issuer: "Let's Encrypt",
+		notBefore: '2026-03-02T00:00:00.000Z',
+		notAfter: '2026-05-31T00:00:00.000Z',
+		expiryBand: 'ok',
+		daysRemaining: 120,
+		sanCount: 2,
+		serial: '04ab',
+		source: 'ct',
+	};
+
+	it('narrates issuer, expiry and days remaining in the prose channel', () => {
+		const text = formatCheckResult(sslResult(CERT));
+		expect(text).toContain('### Certificate');
+		expect(text).toContain("Issuer: Let's Encrypt");
+		expect(text).toContain('2026-05-31');
+		expect(text).toContain('120 days');
+	});
+
+	it('carries the CT sourcing caveat — a logged certificate is not necessarily the served one', () => {
+		const text = formatCheckResult(sslResult(CERT));
+		expect(text).toMatch(/Certificate Transparency/i);
+		expect(text).toMatch(/may differ from the certificate currently served/i);
+	});
+
+	it('narrates in COMPACT format too — that is the format with no structured blob to fall back on', () => {
+		const text = formatCheckResult(sslResult(CERT), 'compact');
+		expect(text).toContain("Issuer: Let's Encrypt");
+	});
+
+	it('renders an unmeasured field as "unknown" rather than omitting or guessing it', () => {
+		const text = formatCheckResult(
+			sslResult({ ...CERT, issuer: null, notAfter: null, daysRemaining: null })
+		);
+		expect(text).toContain('Issuer: unknown');
+		expect(text).toContain('Expires: unknown');
+	});
+
+	it('adds NOTHING when no certificate metadata was obtained (absence is not a finding)', () => {
+		expect(formatCheckResult(sslResult(undefined))).not.toContain('### Certificate');
+	});
+
+	it('ignores a non-object metadata.certificate instead of throwing', () => {
+		const bogus = { category: 'ssl', passed: true, score: 100, findings: [], metadata: { certificate: 'nope' } } as unknown as CheckResult;
+		expect(() => formatCheckResult(bogus)).not.toThrow();
+		expect(formatCheckResult(bogus)).not.toContain('### Certificate');
+	});
+});


### PR DESCRIPTION
Follow-up to #586, found by re-verifying that change against primary evidence.

## The gap

`check_ssl`'s tool description promises the issuer and expiry date. #586 wired the data in — but only as far as `CheckResult.metadata.certificate`.

`formatCheckResult` reads only *per-finding* `metadata`, never `result.metadata` (verified: zero cert references in `tool-formatters.ts`). So the data reached the caller on:

- ✅ `structuredContent` (always set by `buildToolResult`)
- ✅ the appended `STRUCTURED_RESULT` blob — but **only in `full` format**, and `stripRedundantStructuredComment` strips it for modern clients
- ❌ the human-readable `content` text — **never**

Net: a client reading just the prose, in `compact` format, saw nothing. The description's promise was kept on one channel and silently broken on the other.

## The fix

A `### Certificate` section rendering issuer, expiry (date-only), days remaining, band, and SAN **count**.

Deliberate choices worth reviewing:

- **Strictly non-scoring.** Renders metadata, never a `Finding` — nothing here can move a domain's score or grade. Same invariant as the enrichment itself.
- **An unmeasured field prints `unknown`** rather than being omitted. "We did not look" is a different claim from "there is no expiry date".
- **No metadata at all adds nothing.** Absence of a CT record is not a finding about the certificate.
- **SAN count only, never the list** — publishing it would hand out an enumerated subdomain inventory.
- **The CT sourcing caveat is carried verbatim.** Without it a reader takes "logged" to mean "served" and draws a wrong conclusion from a correct answer.
- A non-object `metadata.certificate` is ignored rather than thrown on.

## Also verified and deliberately NOT changed

`scan_domain` does **not** opt into `certMetadata` (`resolveSslOptions` returns only the TLS-probe options). That was flagged as a possible gap; it is not — it is the documented opt-out in `check-ssl.ts`, and the rationale holds: Certspotter's free tier is ~100 req/hr/egress-IP shared across everything this Worker does, and `scan_domain` fans out 17 checks per call. Enriching there would spend the quota at scan volume, and an exhausted quota degrades to no metadata for *every* caller. Turning it on everywhere needs a caching layer this Worker does not have.

## Tests

6 added — narration, CT caveat, compact format, unknown fields, absent block, malformed input. **4 failed before this change and pass after** (the other 2 are negative cases that correctly passed already).

## Gates

Run on a clean isolated `npm ci` — the worktree initially inherited a stale `packages/dns-checks` build via a shared workspace symlink, which failed 6 unrelated tests and typecheck. Proven pre-existing by re-running on clean `origin/main` in the same environment (identical failures), then fixed properly by installing in isolation.

- `typecheck` rc=0
- **6,648 tests passed / 0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)