### PR TITLE
feat(internal-auth): add per-consumer BV_MOBILE_INTERNAL_KEY, scoped to /internal/tools/*

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -244,13 +244,30 @@ const internalLenientAuthGate = (
 		return next();
 	};
 };
-// /tools/* additionally accepts the BizFit mobile Worker's own credential. /analytics/* and
-// /tenants/* deliberately do NOT — the mobile Worker calls `scan_domain` and nothing else, and
-// widening it to tenant or analytics data would defeat the point of giving it a separate key.
-// `test/internal-mobile-key-auth.test.ts` pins that scoping.
-internalRoutes.use('/tools/*', internalLenientAuthGate(['BV_WEB_INTERNAL_KEY', 'BV_MOBILE_INTERNAL_KEY']));
-internalRoutes.use('/analytics/*', internalLenientAuthGate(['BV_WEB_INTERNAL_KEY']));
-internalRoutes.use('/tenants/*', internalLenientAuthGate(['BV_WEB_INTERNAL_KEY']));
+const webOnlyGate = internalLenientAuthGate(['BV_WEB_INTERNAL_KEY']);
+const webAndMobileGate = internalLenientAuthGate(['BV_WEB_INTERNAL_KEY', 'BV_MOBILE_INTERNAL_KEY']);
+
+/**
+ * The exact internal paths `BV_MOBILE_INTERNAL_KEY` may reach. Everything else under
+ * /internal/* stays web-key-only.
+ *
+ * Deliberately `/tools/call` and NOT all of `/tools/*`: `/tools/batch` takes `domains: string[]`
+ * plus a caller-set `concurrency`, so one request there fans out a scan across many domains. The
+ * mobile Worker's client posts to `/tools/call` and nothing else, so a leak of its key must not
+ * become a bulk-scanning capability. Full mount path — `internalRoutes` is mounted at `/internal`
+ * in src/index.ts.
+ */
+const MOBILE_ACCESSIBLE_PATHS: ReadonlySet<string> = new Set(['/internal/tools/call']);
+
+// One registration, not two: Hono runs EVERY matching middleware in registration order, so a
+// narrow `.use('/tools/call', …)` plus a broad `.use('/tools/*', …)` would run both on
+// /tools/call and the broader web-only gate would then reject a valid mobile bearer. Selecting
+// the gate per-request inside a single registration is what keeps that correct.
+internalRoutes.use('/tools/*', (c, next) =>
+	(MOBILE_ACCESSIBLE_PATHS.has(new URL(c.req.url).pathname) ? webAndMobileGate : webOnlyGate)(c, next),
+);
+internalRoutes.use('/analytics/*', webOnlyGate);
+internalRoutes.use('/tenants/*', webOnlyGate);
 
 // Tenant orchestrator routes (per tenant-Scalable-Architecture-Design.md §4.1).
 // Mounted AFTER `internalLenientAuthGate` is registered so the gate covers

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -107,6 +107,20 @@ type InternalEnv = {
 	CF_ANALYTICS_TOKEN?: string;
 	BV_WEB_INTERNAL_KEY?: string;
 	/**
+	 * Independent internal-door credential for the BizFit mobile Worker (`claude-proxy`),
+	 * accepted on /internal/tools/* ONLY — never /analytics/* or /tenants/*.
+	 *
+	 * Exists so a lower-trust consumer is not handed `BV_WEB_INTERNAL_KEY`, which is a
+	 * BIDIRECTIONAL shared bearer with bv-web-prod (bv-web-prod → here, and here → bv-web-prod's
+	 * validate-key / get_domain_rank benchmark / M365 proxy). A separate slot means the mobile
+	 * Worker can be rotated or revoked without touching bv-web-prod, and a leak on the mobile
+	 * side does not expose bv-web-prod's credential in either direction.
+	 *
+	 * Same rationale as the BV_INTERNAL_DEV_KEY / BV_INTERNAL_DEV_KEY_2 pair in
+	 * src/lib/tier-auth.ts: add a per-consumer key without rotating the incumbent.
+	 */
+	BV_MOBILE_INTERNAL_KEY?: string;
+	/**
 	 * Opt-out flag for the defense-in-depth bearer gate on /tools/* and /analytics/*.
 	 * Default: gate is ACTIVE (bearer required). Set to 'false' to disable the bearer
 	 * requirement and rely solely on the cf-connecting-ip network guard.
@@ -182,12 +196,17 @@ internalRoutes.use('*', async (c, next) => {
  * Defense-in-depth bearer gate for /tools/*, /analytics/*, and /tenants/*.
  *
  * **Secure by default (FIND-12):** the gate is ACTIVE unless explicitly opted
- * out. Callers must present `Authorization: Bearer ${BV_WEB_INTERNAL_KEY}`.
+ * out. Callers must present `Authorization: Bearer <one of the accepted keys>`.
  * Set `REQUIRE_INTERNAL_AUTH=false` to disable and rely solely on the
  * cf-connecting-ip network guard (e.g. during a controlled migration window).
  *
- * Fail-closed: if the gate is active but `BV_WEB_INTERNAL_KEY` is unset,
- * the route returns 503 rather than silently passing unauthenticated requests.
+ * Takes the list of env var names whose values are accepted on the routes it fronts, so a
+ * per-consumer credential can be granted to one route group without granting it everywhere.
+ * `/tools/*` accepts `BV_WEB_INTERNAL_KEY` + `BV_MOBILE_INTERNAL_KEY`; `/analytics/*` and
+ * `/tenants/*` accept only `BV_WEB_INTERNAL_KEY`.
+ *
+ * Fail-closed: if the gate is active but NONE of its accepted keys is configured (unset or
+ * empty), the route returns 503 rather than silently passing unauthenticated requests.
  *
  * Unlike trialKeysAuthGate (which always enforces because it mints credentials),
  * this gate can be disabled at the operator's explicit request via the env flag.
@@ -199,24 +218,39 @@ internalRoutes.use('*', async (c, next) => {
  * Registered BEFORE the route handlers below — Hono middleware applies only to
  * routes registered after the .use() call.
  */
-const internalLenientAuthGate: import('hono').MiddlewareHandler<{ Bindings: InternalEnv }> = async (c, next) => {
-	if (c.env.REQUIRE_INTERNAL_AUTH === 'false') {
-		// Explicitly opted out — rely on the network guard (cf-connecting-ip) alone.
+const internalLenientAuthGate = (
+	acceptedKeys: ReadonlyArray<'BV_WEB_INTERNAL_KEY' | 'BV_MOBILE_INTERNAL_KEY'>,
+): import('hono').MiddlewareHandler<{ Bindings: InternalEnv }> => {
+	return async (c, next) => {
+		if (c.env.REQUIRE_INTERNAL_AUTH === 'false') {
+			// Explicitly opted out — rely on the network guard (cf-connecting-ip) alone.
+			return next();
+		}
+		// Empty strings are dropped, not treated as credentials: `wrangler secret put` will
+		// store an empty value, and an empty expected token must never authorize anything nor
+		// count towards "a credential is configured" below.
+		const expected = acceptedKeys.map((name) => c.env[name]).filter((k): k is string => typeof k === 'string' && k.length > 0);
+		if (expected.length === 0) {
+			// Misconfig: gate is active but no key configured for this route group — fail closed.
+			return c.json({ error: 'internal_auth_not_configured' }, 503, { 'Cache-Control': 'no-store' });
+		}
+		const header = c.req.header('authorization');
+		// Every candidate is evaluated (no `||` short-circuit) so the number of constant-time
+		// comparisons performed does not vary with WHICH key matched.
+		const matches = await Promise.all(expected.map((key) => isAuthorizedRequest(header, key)));
+		if (!matches.some(Boolean)) {
+			return c.json({ error: 'unauthorized' }, 401, { 'Cache-Control': 'no-store' });
+		}
 		return next();
-	}
-	const expected = c.env.BV_WEB_INTERNAL_KEY;
-	if (!expected) {
-		// Misconfig: gate is active but no key configured — fail closed.
-		return c.json({ error: 'internal_auth_not_configured' }, 503, { 'Cache-Control': 'no-store' });
-	}
-	if (!(await isAuthorizedRequest(c.req.header('authorization'), expected))) {
-		return c.json({ error: 'unauthorized' }, 401, { 'Cache-Control': 'no-store' });
-	}
-	return next();
+	};
 };
-internalRoutes.use('/tools/*', internalLenientAuthGate);
-internalRoutes.use('/analytics/*', internalLenientAuthGate);
-internalRoutes.use('/tenants/*', internalLenientAuthGate);
+// /tools/* additionally accepts the BizFit mobile Worker's own credential. /analytics/* and
+// /tenants/* deliberately do NOT — the mobile Worker calls `scan_domain` and nothing else, and
+// widening it to tenant or analytics data would defeat the point of giving it a separate key.
+// `test/internal-mobile-key-auth.test.ts` pins that scoping.
+internalRoutes.use('/tools/*', internalLenientAuthGate(['BV_WEB_INTERNAL_KEY', 'BV_MOBILE_INTERNAL_KEY']));
+internalRoutes.use('/analytics/*', internalLenientAuthGate(['BV_WEB_INTERNAL_KEY']));
+internalRoutes.use('/tenants/*', internalLenientAuthGate(['BV_WEB_INTERNAL_KEY']));
 
 // Tenant orchestrator routes (per tenant-Scalable-Architecture-Design.md §4.1).
 // Mounted AFTER `internalLenientAuthGate` is registered so the gate covers

--- a/test/internal-mobile-key-auth.test.ts
+++ b/test/internal-mobile-key-auth.test.ts
@@ -102,6 +102,38 @@ describe('internal auth gate: per-consumer BV_MOBILE_INTERNAL_KEY', () => {
 		expect(res.status).toBe(401);
 	});
 
+	it('scopes the mobile key to /internal/tools/call — it must NOT unlock /internal/tools/batch', async () => {
+		// Raised in review of #594. `/tools/batch` accepts `domains: string[]` plus a caller-set
+		// `concurrency`, so it is a fan-out amplification surface: one request can drive a scan
+		// across many domains. The mobile Worker's client (`bv-mcp-client.ts`) only ever posts to
+		// `/internal/tools/call`, so the mobile credential has no business reaching batch — a leak
+		// of it must not become a bulk-scanning capability.
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv;
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/batch', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${MOBILE_KEY}` },
+			body: JSON.stringify({ tool: 'check_spf', domains: ['example.com'] }),
+		});
+		const res = await send(req, customEnv);
+		expect(res.status).toBe(401);
+	});
+
+	it('still lets the web key reach /internal/tools/batch', async () => {
+		// The narrowing above must constrain the MOBILE key only — bv-web-prod's existing batch
+		// access is unchanged.
+		const { mockTxtRecords } = await import('./helpers/dns-mock');
+		mockTxtRecords(['v=spf1 -all']);
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv;
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/batch', {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${WEB_KEY}` },
+			body: JSON.stringify({ tool: 'check_spf', domains: ['example.com'] }),
+		});
+		const res = await send(req, customEnv);
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(503);
+	});
+
 	it('scopes the mobile key to /internal/tools/* — it must NOT unlock /internal/analytics/*', async () => {
 		// Least privilege: the BizFit mobile Worker only ever calls /internal/tools/call. The
 		// shared gate also fronts /analytics/* and /tenants/*, so the mobile slot is wired into

--- a/test/internal-mobile-key-auth.test.ts
+++ b/test/internal-mobile-key-auth.test.ts
@@ -1,0 +1,143 @@
+// Per-consumer credentials on the internal bearer gate.
+//
+// `BV_WEB_INTERNAL_KEY` is a BIDIRECTIONAL shared bearer between bv-mcp and bv-web-prod
+// (bv-web-prod → /internal/tools/*, and bv-mcp → bv-web-prod's validate-key / get_domain_rank
+// benchmark / M365 proxy). Handing that same value to a third consumer — the BizFit mobile
+// Worker (`claude-proxy`), a lower-trust surface — would mean a leak there exposes
+// bv-web-prod's credential in both directions, and that rotating for one consumer breaks the
+// others.
+//
+// `BV_MOBILE_INTERNAL_KEY` is an INDEPENDENT slot accepted by the same gate, so the mobile
+// Worker can be rotated or revoked on its own. This mirrors the established
+// BV_INTERNAL_DEV_KEY / BV_INTERNAL_DEV_KEY_2 pattern in src/lib/tier-auth.ts, whose comment
+// states the same rationale: "Lets a per-machine key be added without rotating
+// BV_INTERNAL_DEV_KEY."
+//
+// The load-bearing invariants below: an absent BV_MOBILE_INTERNAL_KEY must change NOTHING for
+// existing deployments (every current deploy has only BV_WEB_INTERNAL_KEY set), and the
+// fail-closed 503 must still fire when NEITHER key is configured — not merely when the web key
+// alone is missing.
+
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import worker from '../src';
+
+const WEB_KEY = 'web-internal-key-fixture';
+const MOBILE_KEY = 'mobile-internal-key-fixture';
+
+type TestEnv = typeof env & {
+	BV_WEB_INTERNAL_KEY?: string;
+	BV_MOBILE_INTERNAL_KEY?: string;
+	REQUIRE_INTERNAL_AUTH?: string;
+};
+
+async function send(req: Request, customEnv: TestEnv): Promise<Response> {
+	const ctx = createExecutionContext();
+	const res = await worker.fetch(req, customEnv, ctx);
+	await waitOnExecutionContext(ctx);
+	return res;
+}
+
+/** POST /internal/tools/call — the exact route the BizFit mobile Worker calls. */
+function callRequest(bearer?: string): Request {
+	const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+	if (bearer !== undefined) headers.Authorization = `Bearer ${bearer}`;
+	return new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tools/call', {
+		method: 'POST',
+		headers,
+		body: JSON.stringify({ name: 'check_spf', arguments: { domain: 'example.com' } }),
+	});
+}
+
+async function expectPassesGate(customEnv: TestEnv, bearer: string): Promise<void> {
+	const { mockTxtRecords } = await import('./helpers/dns-mock');
+	mockTxtRecords(['v=spf1 -all']);
+	const res = await send(callRequest(bearer), customEnv);
+	// Anything other than the gate's own two rejections means the gate let it through.
+	expect(res.status).not.toBe(401);
+	expect(res.status).not.toBe(503);
+}
+
+describe('internal auth gate: per-consumer BV_MOBILE_INTERNAL_KEY', () => {
+	it('accepts a valid BV_MOBILE_INTERNAL_KEY bearer', async () => {
+		await expectPassesGate({ ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv, MOBILE_KEY);
+	});
+
+	it('still accepts a valid BV_WEB_INTERNAL_KEY bearer when both slots are configured', async () => {
+		// Regression guard: adding the mobile slot must not displace the web key.
+		await expectPassesGate({ ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv, WEB_KEY);
+	});
+
+	it('rejects a bearer matching neither slot → 401', async () => {
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv;
+		const res = await send(callRequest('neither-of-them'), customEnv);
+		expect(res.status).toBe(401);
+	});
+
+	it('accepts the mobile key when it is the ONLY key configured (no 503)', async () => {
+		// The fail-closed 503 must key off "no credential configured at all", not off
+		// BV_WEB_INTERNAL_KEY specifically — otherwise a mobile-only deployment is bricked.
+		await expectPassesGate({ ...env, BV_WEB_INTERNAL_KEY: undefined, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv, MOBILE_KEY);
+	});
+
+	it('fails closed with 503 when NEITHER key is configured', async () => {
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: undefined, BV_MOBILE_INTERNAL_KEY: undefined } as TestEnv;
+		const res = await send(callRequest(WEB_KEY), customEnv);
+		expect(res.status).toBe(503);
+	});
+
+	it('does not widen access when BV_MOBILE_INTERNAL_KEY is unset (existing deployments unchanged)', async () => {
+		// Every deployment today sets only BV_WEB_INTERNAL_KEY. A bearer that would be valid
+		// as a mobile key must still be rejected while that slot is empty.
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: undefined } as TestEnv;
+		const res = await send(callRequest(MOBILE_KEY), customEnv);
+		expect(res.status).toBe(401);
+	});
+
+	it('an empty-string BV_MOBILE_INTERNAL_KEY is treated as unconfigured, not as a valid empty bearer', async () => {
+		// `wrangler secret put` will happily store an empty value, and an empty expected token
+		// must never authorize anything.
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: '' } as TestEnv;
+		const res = await send(callRequest(''), customEnv);
+		expect(res.status).toBe(401);
+	});
+
+	it('scopes the mobile key to /internal/tools/* — it must NOT unlock /internal/analytics/*', async () => {
+		// Least privilege: the BizFit mobile Worker only ever calls /internal/tools/call. The
+		// shared gate also fronts /analytics/* and /tenants/*, so the mobile slot is wired into
+		// the tools gate ONLY. This is a standing guard against a future refactor collapsing the
+		// three registrations back into one key list and silently granting the mobile Worker
+		// tenant and analytics access.
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv;
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/analytics/tier-summary', {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${MOBILE_KEY}` },
+		});
+		const res = await send(req, customEnv);
+		expect(res.status).toBe(401);
+	});
+
+	it('scopes the mobile key to /internal/tools/* — it must NOT unlock /internal/tenants/*', async () => {
+		const customEnv = { ...env, BV_WEB_INTERNAL_KEY: WEB_KEY, BV_MOBILE_INTERNAL_KEY: MOBILE_KEY } as TestEnv;
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tenants', {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${MOBILE_KEY}` },
+		});
+		const res = await send(req, customEnv);
+		expect(res.status).toBe(401);
+	});
+
+	it('honours the REQUIRE_INTERNAL_AUTH=false opt-out unchanged', async () => {
+		const { mockTxtRecords } = await import('./helpers/dns-mock');
+		mockTxtRecords(['v=spf1 -all']);
+		const customEnv = {
+			...env,
+			BV_WEB_INTERNAL_KEY: undefined,
+			BV_MOBILE_INTERNAL_KEY: undefined,
+			REQUIRE_INTERNAL_AUTH: 'false',
+		} as TestEnv;
+		const res = await send(callRequest(), customEnv);
+		expect(res.status).not.toBe(401);
+		expect(res.status).not.toBe(503);
+	});
+});


### PR DESCRIPTION
## Why

The BizFit mobile Worker (`claude-proxy`, in bv-mobile) calls `/internal/tools/call` for `scan_domain`. The only credential that door accepts today is **`BV_WEB_INTERNAL_KEY`** — a *bidirectional* shared bearer with bv-web-prod, used both for bv-web-prod → here **and** here → bv-web-prod's `validate-key`, `get_domain_rank` benchmark, and M365 proxy.

Giving that value to the mobile Worker would mean:

- a leak on the mobile side exposes bv-web-prod's credential **in both directions**
- the mobile Worker cannot be revoked without cutting off bv-web-prod
- rotation becomes a coordinated three-repo operation

## What

An independent `BV_MOBILE_INTERNAL_KEY` slot, mirroring the established `BV_INTERNAL_DEV_KEY` / `BV_INTERNAL_DEV_KEY_2` pattern in `src/lib/tier-auth.ts`, whose comment states the same rationale: *"Lets a per-machine key be added without rotating BV_INTERNAL_DEV_KEY."*

`internalLenientAuthGate` becomes a small factory taking the env var names it accepts:

| Route group | Accepted credentials |
|---|---|
| `/internal/tools/*` | `BV_WEB_INTERNAL_KEY`, `BV_MOBILE_INTERNAL_KEY` |
| `/internal/analytics/*` | `BV_WEB_INTERNAL_KEY` |
| `/internal/tenants/*` | `BV_WEB_INTERNAL_KEY` |

The mobile Worker calls `scan_domain` and nothing else, so granting it tenant or analytics data would defeat the purpose of a separate key. Two tests pin that scoping against a future refactor collapsing the registrations back into one key list.

## Behaviour when `BV_MOBILE_INTERNAL_KEY` is unset

Unchanged — which is every current deployment. Two details worth review attention:

- **Fail-closed 503** now keys off *"none of this route group's accepted keys is configured"* rather than `BV_WEB_INTERNAL_KEY` specifically. This keeps `/analytics/*` failing closed correctly while not bricking a hypothetical mobile-only deployment.
- **Empty-string values are dropped**, not treated as credentials. `wrangler secret put` will store an empty secret and every listing API then reports it as present. This was observed for real while provisioning the mobile Worker: an empty `BV_MCP_KEY` read as configured in `secret list` *and* `versions view`, but failed at runtime.

Every accepted key is compared via `Promise.all`, not `||`, so the number of constant-time comparisons does not vary with which key matched.

## Tests

New `test/internal-mobile-key-auth.test.ts` (10 cases), written test-first — the two new-capability cases were confirmed failing (401 / 503) before implementation:

- accepts a valid mobile-key bearer
- still accepts a web-key bearer when both slots are set (regression guard)
- rejects a bearer matching neither → 401
- accepts the mobile key when it is the only key configured (no 503)
- fails closed with 503 when neither key is configured
- does not widen access while the mobile slot is unset
- empty-string mobile key is unconfigured, not a valid empty bearer
- mobile key does **not** unlock `/analytics/*` or `/tenants/*`
- `REQUIRE_INTERNAL_AUTH=false` opt-out unchanged

Verification: 68 pre-existing auth tests green (`internal-tools-analytics-auth`, `internal-auth-default.audit`, `internal-trial-keys-auth`, `tier-auth`); full suite **6676 passed, 0 test failures**; `lint` and `audit:repo-safety` clean.

`test/wasm-integration.test.ts` fails to load locally — `crates/bv-wasm-core/pkg` is gitignored and unbuilt in a fresh worktree. Unrelated to this change; CI builds it.

## Deploy note

No behaviour changes until an operator sets `BV_MOBILE_INTERNAL_KEY` via `wrangler secret put`. `BV_WEB_INTERNAL_KEY` is untouched and must not be rotated as part of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011WSsvqY3D4JrWP8nJfCtNf