### PR TITLE
feat(scoring): the package owns the non-resolving guard

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/non-resolving-guard-wiring.audit.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/non-resolving-guard-wiring.audit.test.ts
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Wiring guard: the marker the `ns` check EMITS and the marker the scoring gate READS
+ * must be the same thing.
+ *
+ * The non-resolving gate's derived floor works by reading a structured metadata key off
+ * the `ns` check\'s own no-NS-and-no-A determination. Those two live in different modules
+ * (`checks/ns-analysis.ts` and `scoring/resolution.ts`), and nothing in the type system
+ * couples them: if the check stops emitting the key, or renames it, the gate does not
+ * break loudly — it silently stops firing and dead domains start scoring again. That is
+ * the precise failure mode this whole change exists to remove, so it gets a test that
+ * fails instead.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getNsVisibilityFinding } from '../../checks/ns-analysis';
+import { deriveResolutionState, DOMAIN_RESOLVES_METADATA_KEY } from '../../scoring/resolution';
+import { buildCheckResult } from '../../check-utils';
+
+describe('non-resolving guard wiring', () => {
+	it('the ns check emits the structured marker when the domain does not resolve', () => {
+		const finding = getNsVisibilityFinding('example.invalid', false);
+		expect(finding.metadata?.[DOMAIN_RESOLVES_METADATA_KEY]).toBe(false);
+	});
+
+	it('the scoring gate DERIVES non-resolution from that exact finding, unmodified', () => {
+		// End-to-end tie: the real emitter\'s output fed to the real reader, with no hand-built
+		// fixture in between — a fixture is what lets the two drift apart unnoticed.
+		const finding = getNsVisibilityFinding('example.invalid', false);
+		expect(deriveResolutionState([buildCheckResult('ns', [finding])])).toBe('unresolvable');
+	});
+
+	it('DISCRIMINATES: the resolving branch emits no such marker and does not trigger the gate', () => {
+		// `domainResolves: true` is the "NS not directly visible, but the domain resolves"
+		// case (delegation-only zones like govt.nz). It must never read as non-resolution.
+		const finding = getNsVisibilityFinding('example.invalid', true);
+		expect(finding.metadata?.[DOMAIN_RESOLVES_METADATA_KEY]).not.toBe(false);
+		expect(deriveResolutionState([buildCheckResult('ns', [finding])])).toBeUndefined();
+	});
+});

--- a/packages/dns-checks/src/__tests__/scoring/resolution.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/resolution.spec.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import {
+	buildUnresolvableNote,
+	deriveResolutionState,
+	isMeasurableDomain,
+	normalizeResolutionSignal,
+	resolveScanResolutionState,
+	DOMAIN_RESOLVES_METADATA_KEY,
+} from '../../scoring/resolution';
+import { buildCheckResult, createFinding } from '../../check-utils';
+import type { CheckResult } from '../../types';
+
+/** An `ns` result carrying the check's own non-resolution determination. */
+function nsNonResolving(checkStatus?: 'timeout' | 'error'): CheckResult {
+	const result = buildCheckResult('ns', [
+		createFinding('ns', 'No NS records found', 'critical', 'Without NS records, the domain cannot resolve.', {
+			missingControl: true,
+			[DOMAIN_RESOLVES_METADATA_KEY]: false,
+		}),
+	]);
+	return checkStatus ? { ...result, checkStatus } : result;
+}
+
+describe('normalizeResolutionSignal', () => {
+	it('accepts the orchestrator tri-state verbatim', () => {
+		// bv-mcp's ScanDomainResult.resolves is `boolean | 'broken'`. Accepting it without a
+		// mapping layer is deliberate: a mapping layer is one more place to forget.
+		expect(normalizeResolutionSignal(true)).toBe('resolves');
+		expect(normalizeResolutionSignal(false)).toBe('nxdomain');
+		expect(normalizeResolutionSignal('broken')).toBe('unresolvable');
+	});
+
+	it('accepts the package-native spellings', () => {
+		expect(normalizeResolutionSignal('resolves')).toBe('resolves');
+		expect(normalizeResolutionSignal('nxdomain')).toBe('nxdomain');
+		expect(normalizeResolutionSignal('unresolvable')).toBe('unresolvable');
+	});
+
+	it('treats a missing signal as UNKNOWN, not as a claim that the domain resolves', () => {
+		expect(normalizeResolutionSignal(undefined)).toBeUndefined();
+	});
+
+	it('treats an out-of-union value as unknown rather than asserting health', () => {
+		// A version-skewed producer or an unvalidated cache re-read can supply a string
+		// outside the union. Falling through to the derived floor is safe; silently
+		// reading it as "resolves" would disable the guard.
+		expect(normalizeResolutionSignal('yes' as never)).toBeUndefined();
+		expect(normalizeResolutionSignal(1 as never)).toBeUndefined();
+	});
+});
+
+describe('deriveResolutionState', () => {
+	it('reads the ns check structured marker', () => {
+		expect(deriveResolutionState([nsNonResolving()])).toBe('unresolvable');
+	});
+
+	it('never claims NXDOMAIN — this evidence cannot distinguish absent from broken', () => {
+		expect(deriveResolutionState([nsNonResolving()])).not.toBe('nxdomain');
+	});
+
+	it('ignores the marker on an UNMEASURED ns check (inconclusive is not proof)', () => {
+		// "The failure earns the exemption" in reverse: an errored check must not be able to
+		// assert a fact either.
+		expect(deriveResolutionState([nsNonResolving('error')])).toBeUndefined();
+		expect(deriveResolutionState([nsNonResolving('timeout')])).toBeUndefined();
+	});
+
+	it('returns unknown for a roster with no ns check — a coverage gap is not health', () => {
+		expect(deriveResolutionState([buildCheckResult('spf', [])])).toBeUndefined();
+		expect(deriveResolutionState([])).toBeUndefined();
+	});
+
+	it('does not fire for an ns check that found nameservers', () => {
+		const healthy = buildCheckResult('ns', [createFinding('ns', 'Nameservers properly configured', 'info', '2 found')]);
+		expect(deriveResolutionState([healthy])).toBeUndefined();
+	});
+
+	it('is not vetoed by positive evidence from another check', () => {
+		// The located incident: the dead domain's `ssl` carried controlPresent:true because a
+		// parking origin answered on the HTTPS path, while the name itself was NXDOMAIN. A
+		// DNS-level determination outranks an HTTP-level observation.
+		const sslPresent = buildCheckResult('ssl', [createFinding('ssl', 'HTTPS reachable', 'info', 'ok')], true);
+		expect(deriveResolutionState([nsNonResolving(), sslPresent])).toBe('unresolvable');
+	});
+});
+
+describe('resolveScanResolutionState', () => {
+	it('prefers the explicit signal over the derived floor', () => {
+		expect(resolveScanResolutionState([nsNonResolving()], true)).toBe('resolves');
+	});
+
+	it('falls back to the derived floor when no signal is supplied', () => {
+		expect(resolveScanResolutionState([nsNonResolving()], undefined)).toBe('unresolvable');
+	});
+});
+
+describe('isMeasurableDomain', () => {
+	it('treats unknown as measurable (fail-open) but both failure states as not', () => {
+		expect(isMeasurableDomain(undefined)).toBe(true);
+		expect(isMeasurableDomain('resolves')).toBe(true);
+		expect(isMeasurableDomain('nxdomain')).toBe(false);
+		expect(isMeasurableDomain('unresolvable')).toBe(false);
+	});
+});
+
+describe('buildUnresolvableNote', () => {
+	it('frames both states as a measurement gap, never a security verdict', () => {
+		for (const state of ['nxdomain', 'unresolvable'] as const) {
+			const note = buildUnresolvableNote(state);
+			expect(note).toMatch(/not a security verdict/i);
+			expect(note).not.toMatch(/Grade: [A-F]/);
+		}
+	});
+
+	it('names the distinct causes so a report can explain which one applies', () => {
+		expect(buildUnresolvableNote('nxdomain')).toMatch(/NXDOMAIN/);
+		expect(buildUnresolvableNote('unresolvable')).toMatch(/nameservers/i);
+	});
+});

--- a/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
@@ -136,6 +136,139 @@ export function defineScoringEngineSuite(s: ScoringModule): void {
 			expect(Object.keys(PROTECTIVE_WEIGHTS)).toContain('subdomain_takeover');
 		});
 
+		describe('non-resolving domain gate', () => {
+			// A domain that does not resolve has no security posture to measure. Running the
+			// check matrix against one only manufactures "absence = clean" passes: on a dead
+			// name, dnssec/dane/subdomain_takeover/subdomailing all score 100 because there is
+			// nothing bad to find. Located 2026-08-02 behind a fabricated 88 on a domain that
+			// had been NXDOMAIN for 100 days.
+			//
+			// The guard already existed and was RIGHT — but it lived in one consumer's
+			// orchestrator (bv-mcp `scan-domain.ts` `buildNonResolvingResult`) and not in this
+			// package, so any other consumer running its own orchestration got no short-circuit
+			// at all. This moves the SEMANTICS into the shared core.
+			//
+			// Non-resolution is the trigger, NOT absence-of-mail: a domain that RESOLVES with a
+			// null MX and `v=spf1 -all` is good posture and must still score. See the
+			// discriminating case at the end.
+			function vacuousPass(category: CheckCategory, score = 100): CheckResult {
+				// How a dead domain actually scores: nothing bad found, so the check "passes"
+				// and sets no controlPresent (it observed no active control either).
+				return { ...buildCheckResult(category, [createFinding(category, `${category} OK`, 'info', 'ok')]), score, checkStatus: 'completed' };
+			}
+			function absent(category: CheckCategory): CheckResult {
+				return { ...buildCheckResult(category, [], false), score: 0, passed: false, checkStatus: 'completed' };
+			}
+
+			/** The `ns` check's own no-NS-and-no-A determination, exactly as it emits it. */
+			function nsSaysDomainDoesNotResolve(): CheckResult {
+				return buildCheckResult('ns', [
+					createFinding('ns', 'No NS records found', 'critical', 'Without NS records, the domain cannot resolve.', {
+						missingControl: true,
+						domainResolves: false,
+					}),
+				]);
+			}
+
+			// Mirrors the stored datta.ng row: 100 days NXDOMAIN, yet `ssl` carried
+			// controlPresent=1 (a parking origin answered 5xx on the HTTPS path). Positive
+			// evidence from ANOTHER check must not suppress the gate — the `ns` determination
+			// is a DNS-level fact and outranks it.
+			const deadDomain: CheckResult[] = [
+				nsSaysDomainDoesNotResolve(),
+				absent('spf'),
+				absent('dmarc'),
+				absent('dkim'),
+				absent('mx'),
+				absent('caa'),
+				{ ...buildCheckResult('ssl', [createFinding('ssl', 'ssl', 'info', 'ok')], true), score: 100, checkStatus: 'completed' },
+				vacuousPass('dnssec'),
+				vacuousPass('dane'),
+				vacuousPass('subdomain_takeover'),
+				vacuousPass('subdomailing'),
+				vacuousPass('mta_sts', 95),
+				vacuousPass('dane_https', 95),
+				vacuousPass('svcb_https', 95),
+				vacuousPass('bimi', 95),
+				vacuousPass('tlsrpt', 95),
+				vacuousPass('http_security', 85),
+			];
+
+			describe('explicit signal from the orchestrator', () => {
+				it('abstains on NXDOMAIN (`false` — the orchestrator tri-state, verbatim)', () => {
+					const score = computeScanScore(deadDomain, undefined, undefined, { resolution: false });
+					expect(score.overall).toBeNull();
+					expect(score.grade).toBeNull();
+					expect(score.evidenceInsufficient).toBe(true);
+				});
+
+				it("abstains on a broken zone (`'broken'` — the orchestrator tri-state, verbatim)", () => {
+					const score = computeScanScore(deadDomain, undefined, undefined, { resolution: 'broken' });
+					expect(score.overall).toBeNull();
+					expect(score.evidenceInsufficient).toBe(true);
+				});
+
+				it('accepts the package-native spellings too', () => {
+					expect(computeScanScore(deadDomain, undefined, undefined, { resolution: 'nxdomain' }).overall).toBeNull();
+					expect(computeScanScore(deadDomain, undefined, undefined, { resolution: 'unresolvable' }).overall).toBeNull();
+				});
+
+				it('explains the withheld grade as a measurement gap, not a security verdict', () => {
+					const score = computeScanScore(deadDomain, undefined, undefined, { resolution: false });
+					expect(score.summary).toBe(score.evidenceNote);
+					expect(score.summary).not.toMatch(/Grade: [A-F]/);
+					expect(score.summary).toMatch(/does not (resolve|exist)/i);
+					expect(score.summary).toMatch(/not a security verdict/i);
+				});
+			});
+
+			describe('derived floor — a producer that forgets still gets protection', () => {
+				it('abstains with NO explicit signal, from the roster alone', () => {
+					// The whole point of the belt-and-braces design: a guard that fires only on an
+					// explicit input is silently disabled by a consumer that forgets to pass it —
+					// re-creating the exact failure being fixed, one layer down.
+					const score = computeScanScore(deadDomain);
+					expect(score.overall).toBeNull();
+					expect(score.evidenceInsufficient).toBe(true);
+					expect(score.summary).toMatch(/does not resolve/i);
+				});
+
+				it('an EXPLICIT resolves signal outranks the derived floor', () => {
+					// The orchestrator ran an apex probe; that is better evidence than our
+					// inference. Explicit wins when present — documented contract.
+					expect(computeScanScore(deadDomain, undefined, undefined, { resolution: true }).overall).not.toBeNull();
+				});
+
+				it('does NOT fire when the ns check merely ERRORED (inconclusive is not proof)', () => {
+					const nsErrored: CheckResult = {
+						...buildCheckResult('ns', [createFinding('ns', 'Nameserver configuration not assessed', 'info', 'transient')]),
+						checkStatus: 'error',
+					};
+					const score = computeScanScore([nsErrored, ...deadDomain.slice(1)]);
+					expect(score.evidenceNote ?? '').not.toMatch(/does not (resolve|exist)/i);
+				});
+			});
+
+			it('DISCRIMINATES: an honest PARKED domain still scores normally', () => {
+				// Resolves, has nameservers, deliberately no mail (null MX + `v=spf1 -all`).
+				// GOOD posture, not a dead domain — must never be caught by this gate.
+				const parked: CheckResult[] = [
+					buildCheckResult('ns', [createFinding('ns', 'Nameservers properly configured', 'info', '2 nameservers found')], true),
+					vacuousPass('spf'),
+					vacuousPass('dmarc'),
+					vacuousPass('dkim'),
+					vacuousPass('dnssec'),
+					vacuousPass('ssl'),
+					vacuousPass('caa'),
+					buildCheckResult('mx', [createFinding('mx', 'Null MX (RFC 7505)', 'info', 'declares no mail')], false),
+				];
+				const score = computeScanScore(parked);
+				expect(score.overall).not.toBeNull();
+				expect(score.grade).not.toBeNull();
+				expect(score.evidenceInsufficient).toBeUndefined();
+			});
+		});
+
 		describe('evidence-sufficiency gate', () => {
 			function ok(category: CheckCategory): CheckResult {
 				return { ...buildCheckResult(category, [createFinding(category, `${category} OK`, 'info', 'ok')], true), checkStatus: 'completed' };

--- a/packages/dns-checks/src/__tests__/scoring/scoring-profiles.suite.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-profiles.suite.ts
@@ -102,6 +102,77 @@ export function defineScoringProfilesSuite(s: ScoringModule): void {
 	}
 
 	describe('scoring-profiles', () => {
+		describe('profile selection ignores UNMEASURED checks', () => {
+			// Located 2026-08-02 as the mechanism behind a fabricated 88 on a domain that
+			// does not exist. Profile detection reads `controlPresent` to decide whether a
+			// domain is a web-only (non-mail) domain:
+			//
+			//     if (hasNoMx) { if (caaPass || sslPass) profile = 'web_only'; else 'non_mail'; }
+			//
+			// `sslPass`/`caaPass` consulted `controlPresent` WITHOUT checking `checkStatus`,
+			// so a check that errored could still supply the positive evidence that selects
+			// `web_only` — the one profile that weights spf/dmarc/dkim/mx at ZERO. The four
+			// checks that correctly detected total failure were then weighted out of the
+			// score entirely, and a dead domain graded ~88.
+			//
+			// The engine already knew better one screen down: `measuredChecks` filters BOTH
+			// 'timeout' and 'error' before computing the failure-ratio signal. Only the
+			// controlPresent reads were status-blind.
+			function unmeasured(result: CheckResult, checkStatus: 'timeout' | 'error' = 'error'): CheckResult {
+				return { ...result, checkStatus };
+			}
+
+			/** No MX, plus whatever ssl/caa evidence the caller wants to supply. */
+			function noMxWith(overrides: Partial<Record<CheckCategory, CheckResult>>): CheckResult[] {
+				return buildFullResults({
+					spf: makeResult('spf', 0),
+					dmarc: makeResult('dmarc', 0),
+					dkim: makeResult('dkim', 0),
+					mx: makeResult('mx', 0, 'No MX records found', 'info'),
+					...overrides,
+				});
+			}
+
+			it('an ERRORED ssl check cannot select the web_only profile', () => {
+				const ctx = detectDomainContext(
+					noMxWith({ ssl: unmeasured(makeResult('ssl', 100)), caa: makeResult('caa', 0) }),
+				);
+				expect(ctx.profile).not.toBe('web_only');
+			});
+
+			it('an ERRORED caa check cannot select the web_only profile either', () => {
+				// Both reads are status-blind, so fixing only `sslPass` would leave the same
+				// path open through CAA.
+				const ctx = detectDomainContext(
+					noMxWith({ ssl: makeResult('ssl', 0), caa: unmeasured(makeResult('caa', 100)) }),
+				);
+				expect(ctx.profile).not.toBe('web_only');
+			});
+
+			it('a TIMED-OUT check is treated the same as an errored one', () => {
+				const ctx = detectDomainContext(
+					noMxWith({ ssl: unmeasured(makeResult('ssl', 100), 'timeout'), caa: makeResult('caa', 0) }),
+				);
+				expect(ctx.profile).not.toBe('web_only');
+			});
+
+			it('an unmeasured MX check cannot assert "no MX" and downgrade the profile', () => {
+				// `hasNoMx` is the gate in front of both non-mail profiles. An MX lookup that
+				// FAILED must fall back to mail_enabled, never assert absence.
+				const ctx = detectDomainContext(
+					noMxWith({ mx: unmeasured(makeResult('mx', 0, 'No MX records found', 'info')), ssl: makeResult('ssl', 100) }),
+				);
+				expect(ctx.profile).toBe('mail_enabled');
+			});
+
+			it('DISCRIMINATES: a MEASURED ssl/caa pass still selects web_only', () => {
+				// Without this the suite would also pass against an implementation that simply
+				// never selects web_only. Genuine web-only domains must keep their profile.
+				const ctx = detectDomainContext(noMxWith({ ssl: makeResult('ssl', 100), caa: makeResult('caa', 100) }));
+				expect(ctx.profile).toBe('web_only');
+			});
+		});
+
 		describe('profile-aware auto scoring', () => {
 			it('auto-detects web_only context and matches explicit web_only scoring', () => {
 				const results = buildFullResults({

--- a/packages/dns-checks/src/checks/ns-analysis.ts
+++ b/packages/dns-checks/src/checks/ns-analysis.ts
@@ -40,12 +40,17 @@ export function getNsVisibilityFinding(domain: string, domainResolves: boolean):
 		);
 	}
 
+	// `domainResolves: false` is the STRUCTURED marker the scoring engine's non-resolving
+	// gate keys on (see scoring/resolution.ts). This branch is the only place in the package
+	// that has actually determined non-resolution — NS returned nothing AND the A-record
+	// fallback above returned nothing — so it is the only honest place to assert it.
+	// Structured, not prose: the title is customer-facing copy and will be reworded.
 	return createFinding(
 		'ns',
 		'No NS records found',
 		'critical',
 		`No nameserver records found for ${domain}. Without NS records, the domain cannot resolve.`,
-		{ missingControl: true },
+		{ missingControl: true, domainResolves: false },
 	);
 }
 

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -15,6 +15,8 @@ import type { ScoringConfig } from './config';
 import { DEFAULT_SCORING_CONFIG } from './config';
 import { buildEvidenceNote, computeScanEvidence, isCheckMeasured, isEvidenceSufficient, EVIDENCE_SUFFICIENCY_THRESHOLD } from './evidence';
 import { computeGenericScore } from './generic';
+import type { DomainResolutionSignal } from './resolution';
+import { buildUnresolvableNote, isMeasurableDomain, resolveScanResolutionState } from './resolution';
 import type { GenericScoringContext, FindingSeverityCounts } from './generic';
 
 interface ImportanceProfile {
@@ -315,7 +317,28 @@ function buildGenericContext(
  * When a `DomainContext` is provided, uses profile-specific weights partitioned by CATEGORY_TIERS,
  * critical gap categories, and email bonus eligibility instead of defaults.
  */
-export function computeScanScore(results: CheckResult[], context?: DomainContext, config?: ScoringConfig): ScanScore {
+/** Per-scan inputs that are neither check results nor scoring policy. */
+export interface ScanScoreOptions {
+	/**
+	 * Explicit resolution signal from the caller's own apex probe.
+	 *
+	 * Accepts bv-mcp's orchestrator tri-state verbatim (`true` / `false` / `'broken'`) as
+	 * well as the package-native spellings. When supplied it WINS over the derived floor —
+	 * an apex probe is better evidence than inference from the roster.
+	 *
+	 * OPTIONAL BY DESIGN, and the guard does not depend on it: omitting it falls back to
+	 * {@link deriveResolutionState}. A guard that fires only on an explicit input is
+	 * silently disabled by a producer that forgets to pass it.
+	 */
+	resolution?: DomainResolutionSignal;
+}
+
+export function computeScanScore(
+	results: CheckResult[],
+	context?: DomainContext,
+	config?: ScoringConfig,
+	options?: ScanScoreOptions,
+): ScanScore {
 	// Only categories that produced a conclusive result appear here. A category that was NEVER
 	// run (absent from `results`) is "not measured", NOT a perfect 100 — seeding it to 100 both
 	// showed a misleading phantom score (a never-run category read as clean) and, via the generic
@@ -372,6 +395,36 @@ export function computeScanScore(results: CheckResult[], context?: DomainContext
 			findings: [],
 			summary: evidenceNote,
 			evidence,
+			evidenceInsufficient: true,
+			evidenceNote,
+		};
+	}
+
+	// --- Non-resolving domain gate ---
+	// Runs BEFORE any scoring work, because on a domain that does not resolve the check
+	// results are not weak evidence — they are anti-evidence. A dead name has no bad DNSSEC
+	// to find, no dangling CNAME to take over, no lax DANE record, so those checks score 100
+	// for the absence of problems only a real domain could have. No weighting of those
+	// numbers is correct, because the premise that they measure something is false.
+	//
+	// Explicit signal wins; otherwise the derived floor reads it off the roster, so a
+	// producer that forgets to pass one still gets the guard. See scoring/resolution.ts.
+	//
+	// Returns EMPTY categoryScores and findings, matching the reference implementation this
+	// generalizes (bv-mcp `buildNonResolvingResult`): the per-check numbers on a dead domain
+	// are fabricated passes, and laundering them through the score object invites a consumer
+	// to publish "dnssec: 100" for a name that does not exist. The caller still holds the raw
+	// results if it wants to display them as diagnostics.
+	const resolutionState = resolveScanResolutionState(results, options?.resolution);
+	if (!isMeasurableDomain(resolutionState)) {
+		const evidenceNote = buildUnresolvableNote(resolutionState as 'nxdomain' | 'unresolvable');
+		return {
+			overall: null,
+			grade: null,
+			categoryScores: {} as Record<CheckCategory, number>,
+			findings: [],
+			summary: evidenceNote,
+			evidence: computeScanEvidence(results),
 			evidenceInsufficient: true,
 			evidenceNote,
 		};
@@ -456,7 +509,7 @@ export interface ProfileAwareScanScore {
 
 export function computeProfileAwareScanScore(
 	results: CheckResult[],
-	options: { profile?: DomainContext['profile'] | 'auto'; config?: ScoringConfig } = {},
+	options: { profile?: DomainContext['profile'] | 'auto'; config?: ScoringConfig; resolution?: DomainResolutionSignal } = {},
 ): ProfileAwareScanScore {
 	const detectedContext = detectDomainContext(results);
 	const explicitProfile = options.profile && options.profile !== 'auto' ? options.profile : null;
@@ -473,7 +526,7 @@ export function computeProfileAwareScanScore(
 			};
 
 	return {
-		score: computeScanScore(results, context, options.config),
+		score: computeScanScore(results, context, options.config, { resolution: options.resolution }),
 		context,
 		profile: context.profile,
 		detectedProfile: detectedContext.profile,

--- a/packages/dns-checks/src/scoring/index.ts
+++ b/packages/dns-checks/src/scoring/index.ts
@@ -30,7 +30,7 @@ export {
 	computeScanScore,
 	computeProfileAwareScanScore,
 } from './engine';
-export type { ProfileAwareScanScore, NistGrade } from './engine';
+export type { ProfileAwareScanScore, NistGrade, ScanScoreOptions } from './engine';
 
 export { DEFAULT_SCORING_CONFIG, toImportanceRecord, parseScoringConfig } from './config';
 export type { ScoringConfig } from './config';
@@ -56,6 +56,15 @@ export {
 export { computeGenericScore } from './generic';
 export type { GenericScoringContext, GenericScanScore, FindingSeverityCounts, EmailBonusKeyMap, TierBreakdown } from './generic';
 
+export type { DomainResolutionState, DomainResolutionSignal } from './resolution';
+export {
+	DOMAIN_RESOLVES_METADATA_KEY,
+	normalizeResolutionSignal,
+	deriveResolutionState,
+	resolveScanResolutionState,
+	isMeasurableDomain,
+	buildUnresolvableNote,
+} from './resolution';
 export { EVIDENCE_SUFFICIENCY_THRESHOLD, computeScanEvidence, isCheckMeasured, isEvidenceSufficient, buildEvidenceNote } from './evidence';
 export type { ScanEvidence } from './evidence';
 

--- a/packages/dns-checks/src/scoring/profiles.ts
+++ b/packages/dns-checks/src/scoring/profiles.ts
@@ -255,13 +255,33 @@ const ENTERPRISE_PROVIDERS = ['google workspace', 'microsoft 365', 'proofpoint',
 export function detectDomainContext(results: CheckResult[]): DomainContext {
 	const signals: string[] = [];
 
-	const mxResult = results.find((r) => r.category === 'mx');
-	const sslResult = results.find((r) => r.category === 'ssl');
-	const caaResult = results.find((r) => r.category === 'caa');
-	const dkimResult = results.find((r) => r.category === 'dkim');
-	const mtaStsResult = results.find((r) => r.category === 'mta_sts');
-	const bimiResult = results.find((r) => r.category === 'bimi');
-	const dmarcResult = results.find((r) => r.category === 'dmarc');
+	// Profile selection may only read evidence from checks that were actually MEASURED.
+	//
+	// Every signal below is derived from `controlPresent`, and `controlPresent` is set by
+	// a check that reached a conclusion. A check with `checkStatus` 'timeout'/'error'
+	// (or any non-'completed' value from an unvalidated cache re-read) did NOT reach one,
+	// yet its `controlPresent` was still being consulted — so a MEASUREMENT FAILURE could
+	// select the weight table that then graded the domain.
+	//
+	// That is not hypothetical. It produced a fabricated ~88 on a domain that does not
+	// exist (located 2026-08-02): with no MX, an errored `ssl` or `caa` still satisfied
+	// `sslPass`/`caaPass` and selected `web_only` — the one profile that weights
+	// spf/dmarc/dkim/mx at ZERO — so the four checks that correctly detected total
+	// failure were weighted out of the score entirely.
+	//
+	// The failure-ratio signal further down already applied exactly this rule via
+	// `measuredChecks`, for exactly this reason ("the measurement failure selected the
+	// weight table that then graded the domain"). It was simply never applied to the
+	// `controlPresent` reads. One filter now governs both, so they cannot drift again.
+	const measuredChecks = results.filter((r) => isCheckMeasured(r.checkStatus));
+
+	const mxResult = measuredChecks.find((r) => r.category === 'mx');
+	const sslResult = measuredChecks.find((r) => r.category === 'ssl');
+	const caaResult = measuredChecks.find((r) => r.category === 'caa');
+	const dkimResult = measuredChecks.find((r) => r.category === 'dkim');
+	const mtaStsResult = measuredChecks.find((r) => r.category === 'mta_sts');
+	const bimiResult = measuredChecks.find((r) => r.category === 'bimi');
+	const dmarcResult = measuredChecks.find((r) => r.category === 'dmarc');
 
 	// Detect MX presence from the structured controlPresent signal (set by check-mx), not finding
 	// prose. true = real mail-routing MX; false = no MX or null MX (RFC 7505 → not a mail domain);
@@ -332,7 +352,8 @@ export function detectDomainContext(results: CheckResult[]): DomainContext {
 	// produces an identical ratio, profile and score. Uses the shared `isCheckMeasured`
 	// allowlist predicate (see evidence.ts) rather than a local denylist, so an out-of-union
 	// `checkStatus` (reachable via an unvalidated cache re-read) is excluded here too.
-	const measuredChecks = results.filter((r) => isCheckMeasured(r.checkStatus));
+	// `measuredChecks` is now computed once at the top of this function and shared with the
+	// controlPresent reads — see the note there.
 	const totalChecks = measuredChecks.length;
 	const failedChecks = measuredChecks.filter((r) => !r.passed).length;
 	const failureRatio = totalChecks > 0 ? failedChecks / totalChecks : 0;

--- a/packages/dns-checks/src/scoring/resolution.ts
+++ b/packages/dns-checks/src/scoring/resolution.ts
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Domain-resolution accounting — is there a domain here to measure at all?
+ *
+ * The failure mode this module removes: the check matrix was run against domains that
+ * DO NOT EXIST, and a non-existent domain manufactures clean passes. On a dead name
+ * there is no bad DNSSEC to find, no dangling CNAME to take over, no lax DANE record —
+ * so `dnssec`/`dane`/`subdomain_takeover`/`subdomailing` all score 100 for the absence
+ * of a problem that only a real domain could have. Located 2026-08-02 behind a
+ * fabricated 88 on a name that had been NXDOMAIN for 100 days.
+ *
+ * A working guard already existed and was correct, but it lived in ONE consumer's
+ * orchestrator (bv-mcp's `scan-domain.ts` → `buildNonResolvingResult`, which returns
+ * `overall: null` with the note that scoring it "would fabricate a posture for an
+ * unregistered name"). It was never in this package, so every OTHER consumer — anyone
+ * vendoring `@blackveil/dns-checks` and running their own orchestration — got no
+ * short-circuit at all. This module moves the SEMANTICS into the shared core.
+ *
+ * ## Two sources, deliberately
+ *
+ * 1. **Explicit** — the orchestrator's apex probe, passed in. Best evidence: it can
+ *    distinguish NXDOMAIN from a broken/lame delegation. Wins whenever present.
+ * 2. **Derived** — inferred from the check roster this package was handed. This is the
+ *    FLOOR, and it is the reason the design is not "accept a new input": a guard that
+ *    fires only on an explicit signal is silently disabled by a producer that forgets
+ *    to pass it, which re-creates the exact failure being fixed one layer down.
+ *
+ * ## What is NOT a trigger
+ *
+ * Absence of mail. A domain that RESOLVES, publishes a null MX (RFC 7505) and
+ * `v=spf1 -all` has deliberately and correctly opted out of mail; that is good posture
+ * and must still score well. Non-resolution is the trigger, never non-use.
+ *
+ * Runtime-agnostic, Workers-safe: no Node APIs, no I/O.
+ */
+
+import type { CheckResult } from '../types';
+import { isCheckMeasured } from './evidence';
+
+/** Whether a domain could be measured at all. */
+export type DomainResolutionState = 'resolves' | 'nxdomain' | 'unresolvable';
+
+/**
+ * Accepted spellings for the explicit resolution signal.
+ *
+ * The `boolean | 'broken'` arm is the tri-state bv-mcp's orchestrator already carries on
+ * `ScanDomainResult.resolves`, accepted VERBATIM so the reference consumer needs no
+ * mapping layer (a mapping layer is one more place to forget). The string arm is the
+ * package-native spelling for new callers, which reads better than a bare boolean.
+ */
+export type DomainResolutionSignal = boolean | 'broken' | DomainResolutionState;
+
+/**
+ * Metadata key a check sets when it has DETERMINED that the domain does not resolve.
+ *
+ * Structured, not prose. Matching on a finding title would re-introduce the brittleness
+ * this codebase has already been bitten by ("the old DKIM prose check counted revoked
+ * keys as present"), and a title is a customer-facing string that will be reworded.
+ */
+export const DOMAIN_RESOLVES_METADATA_KEY = 'domainResolves';
+
+/** Normalize any accepted spelling to the canonical state. `undefined` stays unknown. */
+export function normalizeResolutionSignal(signal: DomainResolutionSignal | undefined): DomainResolutionState | undefined {
+	if (signal === undefined) return undefined;
+	if (signal === true || signal === 'resolves') return 'resolves';
+	if (signal === false || signal === 'nxdomain') return 'nxdomain';
+	if (signal === 'broken' || signal === 'unresolvable') return 'unresolvable';
+	// An out-of-union value (a version-skewed producer, an unvalidated cache re-read) is
+	// treated as NO signal rather than as a resolution claim — it then falls through to
+	// the derived floor instead of silently asserting the domain is fine.
+	return undefined;
+}
+
+/**
+ * Infer non-resolution from the check roster alone.
+ *
+ * Keys on the `ns` check, which already makes exactly this determination and is the only
+ * honest place to make it: a registered, delegated domain HAS nameservers. `check-ns`
+ * queries NS, and when it finds none it falls back to an A-record probe before concluding
+ * — so its `domainResolves: false` means "no NS records AND no A records", which is a
+ * DNS-level fact, not a heuristic. A parked-but-live domain has nameservers and can never
+ * reach that branch.
+ *
+ * Deliberately conservative in three ways:
+ *
+ * - Returns `'unresolvable'`, never `'nxdomain'`. This evidence proves the name did not
+ *   answer; it cannot distinguish "never existed" from "delegated but broken". Only the
+ *   explicit apex probe can, and it says so itself.
+ * - Requires the `ns` check to have been MEASURED. An `ns` check that errored is
+ *   inconclusive, and inconclusive is not proof of absence — that conflation is the
+ *   "failure earns the exemption" bug this package has already been bitten by three
+ *   times in profile detection.
+ * - Does NOT consider positive evidence from other checks as a veto. On the located
+ *   incident the dead domain's `ssl` check carried `controlPresent: true` (a parking
+ *   origin answered on the HTTPS path) while the name itself was NXDOMAIN. A DNS-level
+ *   determination outranks an HTTP-level observation.
+ *
+ * Returns `undefined` when nothing can be concluded — including when the roster contains
+ * no `ns` check at all, which is a coverage gap, not evidence of health.
+ */
+export function deriveResolutionState(results: CheckResult[]): DomainResolutionState | undefined {
+	for (const result of results) {
+		if (result.category !== 'ns') continue;
+		if (!isCheckMeasured(result.checkStatus)) continue;
+		for (const finding of result.findings) {
+			if (finding.metadata?.[DOMAIN_RESOLVES_METADATA_KEY] === false) return 'unresolvable';
+		}
+	}
+	return undefined;
+}
+
+/**
+ * The resolution state a scan should be judged against: explicit signal if the caller
+ * supplied one, otherwise the derived floor.
+ */
+export function resolveScanResolutionState(
+	results: CheckResult[],
+	signal: DomainResolutionSignal | undefined,
+): DomainResolutionState | undefined {
+	return normalizeResolutionSignal(signal) ?? deriveResolutionState(results);
+}
+
+/** Whether a scan in this state can carry an honest grade. Unknown counts as measurable. */
+export function isMeasurableDomain(state: DomainResolutionState | undefined): boolean {
+	return state === undefined || state === 'resolves';
+}
+
+/**
+ * Human-readable explanation for a scan ungraded because the domain could not be
+ * resolved. Safe to render verbatim in a customer report.
+ *
+ * Says "measurement gap, not a security verdict" in the same words as the other ungraded
+ * notes: a domain that does not resolve is not a domain with bad security, and a report
+ * that implies otherwise is wrong about a third party.
+ */
+export function buildUnresolvableNote(state: 'nxdomain' | 'unresolvable'): string {
+	const cause =
+		state === 'nxdomain'
+			? 'The domain does not exist in DNS (NXDOMAIN)'
+			: 'The domain does not resolve — its nameservers returned no usable answer';
+	return (
+		`${cause}, so there is no security posture to assess and no grade is reported. ` +
+		`This is a measurement gap, not a security verdict: an unresolvable name cannot be scored, ` +
+		`and scoring it anyway would fabricate a posture for a domain that is not there.`
+	);
+}

--- a/test/generate-fix-plan.spec.ts
+++ b/test/generate-fix-plan.spec.ts
@@ -22,7 +22,14 @@ function mockScanResponses(options: { hasSpf?: boolean; hasDmarc?: boolean; hasD
 		// DoH requests
 		if (u.hostname.includes('cloudflare-dns') || u.hostname.includes('dns.google')) {
 			const name = u.searchParams.get('name') ?? '';
-			const type = Number(u.searchParams.get('type') ?? '0');
+			// lib/dns builds DoH URLs with LETTER types (`type=NS`), so a bare
+			// Number() parse leaves every branch below unmatched (NaN) and the whole
+			// scan runs on the default empty answers. Map only NS/A: the package's
+			// derived non-resolving floor needs the domain to look registered and
+			// delegated, while every other record type keeps its long-standing
+			// empty-answer behaviour this spec's assertions were written against.
+			const rawType = u.searchParams.get('type') ?? '0';
+			const type = rawType === 'NS' ? 2 : rawType === 'A' ? 1 : Number(rawType);
 
 			// TXT records
 			if (type === 16) {

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -552,6 +552,15 @@ describe('formatCheckResult - via handleToolsCall', () => {
 				}
 			}
 
+			// The apex must resolve: the package's derived non-resolving floor reads
+			// no-NS-AND-no-A as an unresolvable domain and abstains, which withholds
+			// the takeover-verification section this test asserts on.
+			if (/[?&]type=NS(&|$)/.test(url)) {
+				return Promise.resolve(
+					createDohResponse([{ name: 'example.com', type: 2 }], [{ name: 'example.com', type: 2, TTL: 300, data: 'ns1.example-dns.com.' }]),
+				);
+			}
+
 			return Promise.resolve(createDohResponse([], []));
 		});
 

--- a/test/internal.spec.ts
+++ b/test/internal.spec.ts
@@ -597,6 +597,22 @@ describe('Internal service binding routes', () => {
 				if (url.startsWith('https://example.com') || url.startsWith('http://example.com')) {
 					return Promise.resolve(httpResponse('', 200));
 				}
+				// NS and A must resolve: the package's derived non-resolving floor
+				// reads all-empty DNS as an unresolvable domain and abstains, which
+				// would null the numeric score this test asserts on.
+				if (/[?&]type=NS(&|$)/.test(url)) {
+					return Promise.resolve(
+						createDohResponse(
+							[{ name: 'example.com', type: 2 }],
+							[{ name: 'example.com', type: 2, TTL: 300, data: 'ns1.example-dns.com.' }],
+						),
+					);
+				}
+				if (/[?&]type=A(&|$)/.test(url)) {
+					return Promise.resolve(
+						createDohResponse([{ name: 'example.com', type: 1 }], [{ name: 'example.com', type: 1, TTL: 300, data: '192.0.2.10' }]),
+					);
+				}
 				return Promise.resolve(createDohResponse([{ name: 'example.com', type: 1 }], []));
 			});
 

--- a/test/ungraded-scan-abstain.spec.ts
+++ b/test/ungraded-scan-abstain.spec.ts
@@ -26,17 +26,6 @@ afterEach(() => {
 	vi.restoreAllMocks();
 });
 
-/** Every DoH query answers NOERROR-with-no-records; every other fetch is a benign 200. */
-function installEmptyDnsFetch() {
-	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
-		const url = String(input instanceof Request ? input.url : input);
-		if (/dns-query|\/resolve|dns-json|dns\.google|cloudflare-dns/.test(url)) {
-			return Promise.resolve(createDohResponse([], []));
-		}
-		return Promise.resolve(new Response('', { status: 200 }));
-	}) as unknown as typeof globalThis.fetch;
-}
-
 /**
  * NS and A queries resolve (the domain is registered and delegated); every other
  * record type answers NOERROR-with-no-records. The controls need this since the

--- a/test/ungraded-scan-abstain.spec.ts
+++ b/test/ungraded-scan-abstain.spec.ts
@@ -37,6 +37,32 @@ function installEmptyDnsFetch() {
 	}) as unknown as typeof globalThis.fetch;
 }
 
+/**
+ * NS and A queries resolve (the domain is registered and delegated); every other
+ * record type answers NOERROR-with-no-records. The controls need this since the
+ * package grew its own derived non-resolving floor (keyed on check-ns concluding
+ * no-NS-AND-no-A): an all-empty DoH mock now reads as an unresolvable domain and
+ * the scan abstains, so "measured domain" fixtures must actually resolve.
+ */
+function installResolvingDnsFetch() {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = String(input instanceof Request ? input.url : input);
+		if (/dns-query|\/resolve|dns-json|dns\.google|cloudflare-dns/.test(url)) {
+			const parsed = new URL(url);
+			const name = (parsed.searchParams.get('name') ?? 'resolving-probe.test').replace(/\.$/, '');
+			const type = (parsed.searchParams.get('type') ?? 'A').toUpperCase();
+			if (type === 'NS' || type === '2') {
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.example-dns.com.' }]));
+			}
+			if (type === 'A' || type === '1') {
+				return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.10' }]));
+			}
+			return Promise.resolve(createDohResponse([], []));
+		}
+		return Promise.resolve(new Response('', { status: 200 }));
+	}) as unknown as typeof globalThis.fetch;
+}
+
 /** Every DoH query answers NXDOMAIN, so scanDomain short-circuits to the ungraded result. */
 function installNxdomainDnsFetch(domain: string) {
 	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
@@ -470,7 +496,7 @@ describe('analyze_drift cached baseline — ungraded cached scan is rejected', (
 	});
 
 	it('still accepts a caller-supplied JSON baseline carrying a real grade letter (control)', async () => {
-		installEmptyDnsFetch();
+		installResolvingDnsFetch();
 		const { handleToolsCall } = await import('../src/handlers/tools');
 		const baseline = JSON.stringify({ overall: 78, grade: 'B', categoryScores: {}, findings: [], summary: 'Grade: B' });
 
@@ -538,7 +564,7 @@ describe('analyze_drift CURRENT side — an unmeasured current scan cannot fabri
 	});
 
 	it('still produces a real drift report when the current scan IS measured (control)', async () => {
-		installEmptyDnsFetch();
+		installResolvingDnsFetch();
 		const { handleToolsCall } = await import('../src/handlers/tools');
 
 		const result = await handleToolsCall(
@@ -596,7 +622,7 @@ describe('scan_domain tool_call analytics — ungraded scan', () => {
 			// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		} as any;
 
-		installEmptyDnsFetch();
+		installResolvingDnsFetch();
 		const { handleToolsCall } = await import('../src/handlers/tools');
 		await handleToolsCall({ name: 'scan_domain', arguments: { domain: 'measured-analytics-probe.com', force_refresh: true } }, undefined, {
 			analytics,

--- a/test/unmeasured-check-exemption.audit.test.ts
+++ b/test/unmeasured-check-exemption.audit.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * STANDING INVARIANT: an unmeasured check must be exactly equivalent to an absent one.
+ *
+ * `detectDomainContext` chooses the WEIGHT TABLE that then grades the domain. Three
+ * separate times, a check that FAILED to run was allowed to influence that choice — so
+ * the measurement failure selected the lens through which the domain was judged:
+ *
+ *   1. `failureRatio` counted unmeasured checks as failures, flipping domains to the
+ *      `minimal` profile. Fixed by introducing `measuredChecks`.
+ *   2. `sslPass` / `caaPass` read `controlPresent` with no `checkStatus` check, so an
+ *      ERRORED ssl selected `web_only` — the one profile weighting spf/dmarc/dkim/mx at
+ *      ZERO. This produced a fabricated 88 on a domain that had been NXDOMAIN for 100
+ *      days: the four checks that correctly detected total failure were weighted out.
+ *   3. `hasNoMx` asserted "no MX" from an MX lookup that had itself failed.
+ *
+ * Three instances of one shape is a structural hazard, not three coincidences. Rather
+ * than a fourth point fix later, this pins the general property:
+ *
+ *     detectDomainContext(results where X errored) === detectDomainContext(results without X)
+ *
+ * ## Why a MATRIX of rosters, not one
+ *
+ * The property is only sharp when the signal under test is load-bearing for the profile
+ * actually being selected. On an all-healthy roster, erroring `ssl` changes nothing
+ * (the domain is mail_enabled either way), so a single-roster version of this test
+ * silently misses instance #2 — verified: reverting the `measuredChecks` fix fails only
+ * the `mx` case against a healthy roster. Each roster below is shaped to put a different
+ * signal on the critical path, so the whole class is covered:
+ *
+ *   - `mailEnabled`   — everything active (exercises hasMx / enterprise detection)
+ *   - `webOnlyViaSsl` — no MX, no CAA: `ssl` alone decides web_only vs non_mail
+ *   - `webOnlyViaCaa` — no MX, no SSL: `caa` alone decides web_only vs non_mail
+ *
+ * If someone adds a new signal that reads a check field without consulting
+ * `checkStatus`, this fails in CI instead of shipping.
+ *
+ * Runs against the BUILT package so source→dist drift is caught too.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildCheckResult, createFinding, detectDomainContext } from '@blackveil/dns-checks/scoring';
+import type { CheckCategory, CheckResult } from '@blackveil/dns-checks/scoring';
+
+function active(category: CheckCategory): CheckResult {
+	return buildCheckResult(category, [createFinding(category, `${category} configured`, 'info', 'active control observed')], true);
+}
+function absent(category: CheckCategory): CheckResult {
+	return buildCheckResult(category, [createFinding(category, `no ${category}`, 'medium', 'absent')], false);
+}
+
+const CATEGORIES: CheckCategory[] = ['spf', 'dmarc', 'dkim', 'ssl', 'caa', 'mx', 'mta_sts', 'bimi', 'ns', 'dnssec'];
+
+/** Rosters shaped so that a DIFFERENT detection signal is load-bearing in each. */
+const ROSTERS: Record<string, () => CheckResult[]> = {
+	mailEnabled: () => CATEGORIES.map(active),
+	webOnlyViaSsl: () => CATEGORIES.map((c) => (c === 'mx' || c === 'caa' ? absent(c) : active(c))),
+	webOnlyViaCaa: () => CATEGORIES.map((c) => (c === 'mx' || c === 'ssl' ? absent(c) : active(c))),
+};
+
+const UNMEASURED = ['timeout', 'error'] as const;
+
+describe('an unmeasured check is equivalent to an absent one (profile detection)', () => {
+	for (const [rosterName, roster] of Object.entries(ROSTERS)) {
+		describe(rosterName, () => {
+			for (const category of CATEGORIES) {
+				for (const status of UNMEASURED) {
+					it(`${category} '${status}' does not change the detected profile`, () => {
+						const withoutCheck = roster().filter((r) => r.category !== category);
+						const withUnmeasured = roster().map((r) => (r.category === category ? { ...r, checkStatus: status } : r));
+
+						expect(detectDomainContext(withUnmeasured).profile).toBe(detectDomainContext(withoutCheck).profile);
+					});
+				}
+
+				it(`a FAILING ${category} that could not be measured cannot assert absence either`, () => {
+					// The `hasNoMx` instance: an unmeasured check carrying controlPresent:false
+					// must not be read as a determination that the control is absent.
+					const withoutCheck = roster().filter((r) => r.category !== category);
+					const unmeasuredAbsent = roster().map((r) => (r.category === category ? { ...absent(category), checkStatus: 'error' as const } : r));
+
+					expect(detectDomainContext(unmeasuredAbsent).profile).toBe(detectDomainContext(withoutCheck).profile);
+				});
+			}
+		});
+	}
+
+	describe('DISCRIMINATION — the property must not be vacuously true', () => {
+		// Without these, the suite above would also pass against an implementation that
+		// ignores every check equally, or that never varies the profile at all. Detection
+		// must still respond to real, MEASURED evidence — that is the point of profiles.
+		it('a measured roster difference DOES move the profile', () => {
+			expect(detectDomainContext(ROSTERS.mailEnabled!()).profile).toBe('mail_enabled');
+			expect(detectDomainContext(ROSTERS.webOnlyViaSsl!()).profile).not.toBe('mail_enabled');
+		});
+
+		it('each no-mail roster reaches web_only through the signal it is named for', () => {
+			// Proves ssl and caa are each genuinely load-bearing in their roster — i.e. the
+			// corresponding `X 'error'` cases above are real tests, not no-ops.
+			expect(detectDomainContext(ROSTERS.webOnlyViaSsl!()).profile).toBe('web_only');
+			expect(detectDomainContext(ROSTERS.webOnlyViaCaa!()).profile).toBe('web_only');
+
+			const sslRemoved = ROSTERS.webOnlyViaSsl!().filter((r) => r.category !== 'ssl');
+			const caaRemoved = ROSTERS.webOnlyViaCaa!().filter((r) => r.category !== 'caa');
+			expect(detectDomainContext(sslRemoved).profile).not.toBe('web_only');
+			expect(detectDomainContext(caaRemoved).profile).not.toBe('web_only');
+		});
+	});
+});


### PR DESCRIPTION
A domain that does not resolve has no security posture to measure — running the check matrix against one manufactures clean passes (no bad DNSSEC to find on a dead name, no dangling CNAME, no lax DANE → dnssec/dane/subdomain_takeover/subdomailing all score 100 for the absence of problems only a real domain could have).

bv-mcp's orchestrator already guards this correctly (`scan-domain.ts` → `buildNonResolvingResult`, `overall: null` on apex RCODE 3) — but the guard was never in `@blackveil/dns-checks`, so every other consumer vendoring the package with their own orchestration got no short-circuit at all. This moves the semantics into the shared core.

## Design — deliberately two sources

1. **Explicit**: `computeScanScore(results, context, config, { resolution })` — accepts the orchestrator tri-state verbatim (`true`/`false`/`'broken'`) plus package-native spellings; wins whenever present (an apex probe beats inference).
2. **Derived floor**: inferred from the check roster when no signal is passed — keyed on `check-ns` (which already makes this determination, NS + A-record fallback) via a structured metadata marker, not customer-facing finding copy. A guard that fires only on explicit input is silently disabled by a producer that forgets to pass it.

Conservative in three ways: reports `unresolvable`, never claims `nxdomain` (this evidence can't tell absent from broken); ignores an errored ns check (inconclusive ≠ proof of absence); not vetoed by positive evidence elsewhere (the located incident: dead domain's ssl carried `controlPresent: true` from a parking origin while the name was NXDOMAIN — a DNS-level fact outranks an HTTP-level observation).

Abstains through the existing channel (`overall: null` / `evidenceInsufficient`) — consumers already handling ungraded scans need no change.

Second commit: **fix(profiles) — a measurement failure must not select the weight table** (profile resolution no longer lets an errored measurement pick the weight profile).

## Surfaces
- `packages/dns-checks/src/scoring/resolution.ts` (new), `engine.ts`, `profiles.ts`, `index.ts`, `checks/ns-analysis.ts`
- Tests: `resolution.spec.ts` (121 lines), engine + profiles `.suite.ts` extensions (source+built dual-run), `non-resolving-guard-wiring.audit.test.ts`, `test/unmeasured-check-exemption.audit.test.ts` — +724/−13 total

Scoring change to `packages/dns-checks` → next release should bump the package + root (3.39.0) and re-vendor into bv-web-prod per the lockstep seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)