### PR TITLE
chore: release 3.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.39.0] - 2026-08-02
+
+### Added
+
+- **`@blackveil/dns-checks` 1.9.0 — the package now owns the non-resolving guard.** A domain that does not resolve has no security posture to measure; running the check matrix against one manufactures clean passes (no bad DNSSEC to find on a dead name, no dangling CNAME, no lax DANE — those categories scored 100 for the absence of problems only a real domain could have). bv-mcp's orchestrator already guarded this (`scan-domain.ts` → `buildNonResolvingResult`, `overall: null` on apex RCODE 3), but the guard was never in the shared package, so consumers running their own orchestration got no short-circuit. `computeScanScore` now accepts an explicit `resolution` signal (the orchestrator tri-state verbatim — `true`/`false`/`'broken'` — plus package-native spellings) and, when no signal is passed, derives a floor from the check roster itself, keyed on check-ns concluding no-NS-AND-no-A via a structured metadata marker. Conservative by design: reports `unresolvable` (never claims `nxdomain` — this evidence cannot tell absent from broken), ignores an errored ns check (inconclusive is not proof of absence), and is not vetoed by positive evidence elsewhere (a DNS-level fact outranks an HTTP-level observation from a parking origin). Abstains through the existing `overall: null` / `evidenceInsufficient` channel, so consumers already handling ungraded scans need no change. `PARITY_CORPUS_VERSION` moves to 1.9.0 in lockstep. (#597)
+
+### Fixed
+
+- **A measurement failure no longer selects the scoring weight table.** Profile resolution treated an errored measurement as evidence when choosing the weight profile; an inconclusive check is now excluded from profile selection the same way it is excluded from scoring. (#597)
+
 ## [3.38.0] - 2026-07-31
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.38.0",
+	"version": "3.39.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.38.0",
+			"version": "3.39.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"
@@ -5188,7 +5188,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.8.0",
+			"version": "1.9.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.38.0",
+	"version": "3.39.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.8.0",
+	"version": "1.9.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.8.0';
+export const PARITY_CORPUS_VERSION = '1.9.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.38.0",
+	"version": "3.39.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Version-sync for the 3.39.0 cut carrying #597 (the package-owned non-resolving guard + the profile weight-table fix):

- `package.json` + lock → **3.39.0** (`SERVER_VERSION` auto-derives)
- `packages/dns-checks` → **1.9.0** (scoring semantics changed; consumers running their own orchestration gain the derived non-resolving floor)
- `PARITY_CORPUS_VERSION` → 1.9.0 (lockstep contract; package suite 556/556 green incl. parity corpus)
- `server.json` → 3.39.0 (remotes-only single field)
- `CHANGELOG.md` → [3.39.0]

Post-merge: tag `v3.39.0` on the merge commit → `deploy:prod` → live verify → `mcp-publisher publish` (registry last, per the deploy-before-publish ordering rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)