### PR TITLE
chore(scoring): make the worker's scoring SSOT and its stamps honest

### DIFF
--- a/src/lib/adaptive-weights.ts
+++ b/src/lib/adaptive-weights.ts
@@ -11,7 +11,9 @@
 
 import type { CheckCategory } from '@blackveil/dns-checks/scoring';
 import type { DomainProfile } from '@blackveil/dns-checks/scoring';
-import { PROFILE_WEIGHTS } from '@blackveil/dns-checks/scoring';
+import { DEFAULT_SCORING_CONFIG, PROFILE_WEIGHTS, getProfileWeights } from '@blackveil/dns-checks/scoring';
+import type { ScoringConfig } from '@blackveil/dns-checks/scoring';
+import { parseScoringConfigCached } from './scoring-config';
 
 // ─── Telemetry interfaces ──────────────────────────────────────────────
 
@@ -58,7 +60,23 @@ export const EMA_ALPHA = 2 / (EMA_SPAN + 1);
 /** Minimum |scoreDelta| before a scoring note is generated. */
 export const SCORING_NOTE_DELTA_THRESHOLD = 3;
 
-/** Expected failure rate per category across all domains (prior). */
+/**
+ * Expected failure rate per category across all domains (prior) — the WORKER-SIDE
+ * source of truth for the adaptive-weight baseline.
+ *
+ * This is the single place the worker states these numbers. `ProfileAccumulator`
+ * reads it through {@link resolveBaselineFailureRates} (never a private copy), and
+ * `test/adaptive-weights.spec.ts` asserts the SHAPE of this object rather than
+ * restating its literals — a third copy of the table is exactly what let the
+ * scoring-config key drift out of the loop unnoticed.
+ *
+ * Deliberately a SUBSET of `DEFAULT_SCORING_CONFIG.baselineFailureRates` (the
+ * package's 28-category table): only these 13 categories have a calibrated prior,
+ * and every other category falls through to `0` at the call site. Keeping the
+ * subset (rather than adopting the package's full table wholesale) is what makes
+ * {@link resolveBaselineFailureRates} exactly behaviour-neutral when no
+ * `SCORING_CONFIG` override is set.
+ */
 export const BASELINE_FAILURE_RATES: Record<string, number> = {
 	dmarc: 0.40,
 	spf: 0.25,
@@ -74,6 +92,52 @@ export const BASELINE_FAILURE_RATES: Record<string, number> = {
 	subdomain_takeover: 0.10,
 	lookalikes: 0.00,
 };
+
+/**
+ * Resolve the EFFECTIVE adaptive-weight baseline for a raw `SCORING_CONFIG` value.
+ *
+ * Before this existed, `DEFAULT_SCORING_CONFIG.baselineFailureRates` — and therefore
+ * the `SCORING_CONFIG.baselineFailureRates` override key — was **inert**: the
+ * accumulator read {@link BASELINE_FAILURE_RATES} directly, so an operator could set
+ * the key and nothing anywhere would consume it. This makes the key live while
+ * keeping the un-overridden path byte-identical to the previous behaviour:
+ *
+ * - No `SCORING_CONFIG`, unparseable config, or a config that does not move any
+ *   baseline off the package default → returns the {@link BASELINE_FAILURE_RATES}
+ *   object itself (same 13 keys, same values, same identity).
+ * - A config that DOES move a baseline → returns a copy of
+ *   {@link BASELINE_FAILURE_RATES} with only the moved categories overlaid.
+ *
+ * Only entries that DIFFER from the package default are overlaid, deliberately: the
+ * parsed config is always fully populated (`parseScoringConfig` merges onto the
+ * package's 28-category defaults), so copying it wholesale would silently introduce
+ * priors for 15 categories that today resolve to `0` — a behaviour change nobody
+ * asked for. Adaptive weights never reach a reported score (see `scanDomain`), so
+ * this is confined to `scoringNote` / `adaptiveWeightDeltas` either way.
+ */
+export function resolveBaselineFailureRates(rawScoringConfig?: string): Record<string, number> {
+	if (!rawScoringConfig) return BASELINE_FAILURE_RATES;
+
+	let configured: Record<string, number>;
+	try {
+		configured = parseScoringConfigCached(rawScoringConfig).baselineFailureRates;
+	} catch {
+		// Fail-soft: a malformed override must never disarm the adaptive baseline.
+		return BASELINE_FAILURE_RATES;
+	}
+
+	const packageDefaults = DEFAULT_SCORING_CONFIG.baselineFailureRates;
+	let overlaid: Record<string, number> | null = null;
+
+	for (const [category, rate] of Object.entries(configured)) {
+		if (typeof rate !== 'number' || !isFinite(rate) || rate < 0) continue;
+		if (rate === packageDefaults[category]) continue;
+		overlaid ??= { ...BASELINE_FAILURE_RATES };
+		overlaid[category] = rate;
+	}
+
+	return overlaid ?? BASELINE_FAILURE_RATES;
+}
 
 // ─── Weight bounds ─────────────────────────────────────────────────────
 
@@ -97,7 +161,21 @@ export function defaultBounds(staticWeight: number, isCriticalMail: boolean): We
 	};
 }
 
-/** Pre-computed bounds for every profile × category combination. */
+/**
+ * Pre-computed bounds for every profile × category combination.
+ *
+ * KNOWN LIMITATION (not fixed here): these bounds — and the accumulator's own static
+ * blend base — come from the RAW `PROFILE_WEIGHTS` table, not from
+ * `getProfileWeights(profile, config)`. With no `profileWeights` override the two are
+ * numerically identical (`DEFAULT_SCORING_CONFIG.profileWeights` is DERIVED from
+ * `PROFILE_WEIGHTS` via `deriveDefaultProfileWeights()`), so today this is inert. Under
+ * a live `profileWeights` override it is not: the adaptive blend would be anchored to
+ * the un-overridden weights. Making it config-aware means threading the effective
+ * config into the ProfileAccumulator DO and changing the adaptive weight VALUES it
+ * returns — a behaviour change, so it is recorded rather than silently made. Adaptive
+ * output never reaches a reported score, so the blast radius is `scoringNote` /
+ * `adaptiveWeightDeltas`.
+ */
 export const WEIGHT_BOUNDS: Record<DomainProfile, Record<CheckCategory, WeightBound>> = (() => {
 	const profiles = Object.keys(PROFILE_WEIGHTS) as DomainProfile[];
 	const result = {} as Record<DomainProfile, Record<CheckCategory, WeightBound>>;
@@ -164,14 +242,29 @@ export function blendWeights(staticWeight: number, adaptiveWeight: number, sampl
 /**
  * Convert a DO-returned weight map to a CheckCategory-keyed importance record.
  *
- * Falls back to the static profile weight for any category not present in the
+ * Falls back to the profile's static weight for any category not present in the
  * DO response. Returns `null` if any value is non-finite or negative.
+ *
+ * `config` MUST be the same effective `ScoringConfig` the caller uses to compute the
+ * static comparison side of `adaptiveWeightDeltas` (`scan-domain.ts` passes
+ * `runtimeOptions.scoringConfig`). Before it was threaded, this fallback read the raw
+ * `PROFILE_WEIGHTS` table while the delta's other operand came from
+ * `getProfileWeights(profile, config)` — under a live `profileWeights` override the two
+ * bases disagreed, so every category the accumulator had NO data for reported a
+ * non-zero "adaptive" delta that no adaptation produced, and the customer-visible
+ * `scoringNote` could fire off it. Omitting `config` reproduces the old raw-table
+ * behaviour and is correct only when the caller also compares against the raw table.
+ *
+ * NOTE: this closes the CALLER-side half only. The accumulator still computes its
+ * blend (and `WEIGHT_BOUNDS`) from the raw `PROFILE_WEIGHTS`, so a category the DO DID
+ * return still carries an override-skewed base. See the module note on `WEIGHT_BOUNDS`.
  */
 export function adaptiveWeightsToContext(
 	doWeights: Record<string, number>,
 	profile: DomainProfile,
+	config?: ScoringConfig,
 ): Record<CheckCategory, { importance: number }> | null {
-	const staticWeights = PROFILE_WEIGHTS[profile];
+	const staticWeights = getProfileWeights(profile, config);
 	const categories = Object.keys(staticWeights) as CheckCategory[];
 	const result = {} as Record<CheckCategory, { importance: number }>;
 

--- a/src/lib/profile-accumulator.ts
+++ b/src/lib/profile-accumulator.ts
@@ -20,10 +20,10 @@ import { logError } from './log';
 import {
 	EMA_ALPHA,
 	MATURITY_THRESHOLD,
-	BASELINE_FAILURE_RATES,
 	WEIGHT_BOUNDS,
 	computeAdaptiveWeight,
 	blendWeights,
+	resolveBaselineFailureRates,
 } from './adaptive-weights';
 import type { AdaptiveWeightsResponse } from './adaptive-weights';
 import { PROFILE_WEIGHTS } from '@blackveil/dns-checks/scoring';
@@ -138,6 +138,23 @@ export class ProfileAccumulator extends DurableObject<Env> {
 				this.ctx.storage.sql.exec(stmt + ';');
 			}
 		});
+	}
+
+	/**
+	 * The EFFECTIVE adaptive-weight baseline for this DO's environment.
+	 *
+	 * Single read point for the baseline table — `handleGetWeights` and
+	 * `handleBenchmark` must both come through here rather than importing the
+	 * static map, so an operator-supplied `SCORING_CONFIG.baselineFailureRates`
+	 * reaches the accumulator instead of being silently inert. Falls back to the
+	 * static `BASELINE_FAILURE_RATES` when no override is set.
+	 *
+	 * `SCORING_CONFIG` is an optional var not declared on every generated `Env`
+	 * shape, so it is read through a narrow structural type (the same pattern the
+	 * Worker entrypoints use with their own local `Env` interfaces).
+	 */
+	private effectiveBaselineFailureRates(): Record<string, number> {
+		return resolveBaselineFailureRates((this.env as { SCORING_CONFIG?: string }).SCORING_CONFIG);
 	}
 
 	/** Handle incoming HTTP requests. */
@@ -521,6 +538,8 @@ export class ProfileAccumulator extends DurableObject<Env> {
 			}
 		}
 
+		const baselineFailureRates = this.effectiveBaselineFailureRates();
+
 		const weights: Record<string, number> = {};
 		const boundHits: string[] = [];
 		let minSampleCount = Infinity;
@@ -531,7 +550,7 @@ export class ProfileAccumulator extends DurableObject<Env> {
 			if (!staticEntry) continue;
 
 			const staticWeight = staticEntry.importance;
-			const baseline = BASELINE_FAILURE_RATES[cat] ?? 0;
+			const baseline = baselineFailureRates[cat] ?? 0;
 			const bounds = boundsMap[cat] ?? { min: 0, max: staticWeight * 2 + 3 };
 
 			const { weight: adaptiveWeight, boundHit } = computeAdaptiveWeight({
@@ -604,7 +623,7 @@ export class ProfileAccumulator extends DurableObject<Env> {
 				profile,
 				totalScans,
 				minimumRequired: MIN_BENCHMARK_SCANS,
-				baselineFailureRates: BASELINE_FAILURE_RATES,
+				baselineFailureRates: this.effectiveBaselineFailureRates(),
 			});
 		}
 

--- a/src/tools/batch-scan.ts
+++ b/src/tools/batch-scan.ts
@@ -45,7 +45,7 @@ const MAX_DOMAINS = 10;
  * here (the pre-3.35.0 behaviour) published a fabricated failing measurement about
  * a real named organisation into customer reports.
  */
-function emptyResult(domain: string, error: string): BatchScanResultItem {
+function emptyResult(domain: string, error: string, scoringConfigHash: string): BatchScanResultItem {
 	return {
 		domain,
 		score: null,
@@ -78,10 +78,13 @@ function emptyResult(domain: string, error: string): BatchScanResultItem {
 		evidenceNote: null,
 		timestamp: new Date().toISOString(),
 		cached: false,
-		// No scan ran for an error placeholder (invalid domain / budget exceeded),
-		// so there is no effective config to fingerprint — stamp the default marker.
+		// No scan ran for an error placeholder (invalid domain / budget exceeded), but the
+		// batch itself DID run under a scoring config — stamp that config's fingerprint,
+		// not the `'default'` marker. Stamping `'default'` while a live `SCORING_CONFIG`
+		// override was in force made the placeholder claim a reproducibility it could not
+		// back, and made an error item disagree with its own siblings in the same batch.
 		scoringModelVersion: SCORING_MODEL_VERSION,
-		scoringConfigHash: computeScoringConfigHash(),
+		scoringConfigHash,
 		error,
 	};
 }
@@ -100,6 +103,9 @@ export async function batchScan(domains: string[], options: BatchScanOptions = {
 	const concurrency = Math.max(1, Math.min(options.concurrency ?? DEFAULT_CONCURRENCY, domains.length || 1));
 	const scan = options.scanFn ?? scanDomain;
 	const deadline = Date.now() + budgetMs;
+	// One fingerprint for the whole batch — every item (scanned or placeholder) is
+	// produced under the same effective scoring config.
+	const scoringConfigHash = computeScoringConfigHash(options.runtimeOptions?.scoringConfig);
 
 	const results: BatchScanResultItem[] = new Array(domains.length);
 	const pending: Array<{ idx: number; domain: string }> = [];
@@ -109,7 +115,7 @@ export async function batchScan(domains: string[], options: BatchScanOptions = {
 		const raw = domains[i];
 		const validation = validateDomain(raw);
 		if (!validation.valid) {
-			results[i] = emptyResult(raw, validation.error ?? 'Invalid domain');
+			results[i] = emptyResult(raw, validation.error ?? 'Invalid domain', scoringConfigHash);
 			continue;
 		}
 		pending.push({ idx: i, domain: sanitizeDomain(raw) });
@@ -124,7 +130,7 @@ export async function batchScan(domains: string[], options: BatchScanOptions = {
 
 			const remaining = deadline - Date.now();
 			if (remaining <= 0) {
-				results[task.idx] = emptyResult(task.domain, 'batch_budget_exceeded');
+				results[task.idx] = emptyResult(task.domain, 'batch_budget_exceeded', scoringConfigHash);
 				continue;
 			}
 
@@ -140,12 +146,10 @@ export async function batchScan(domains: string[], options: BatchScanOptions = {
 					timeoutId = setTimeout(() => reject(new Error('batch_budget_exceeded')), remaining);
 				});
 				const scanResult = await Promise.race([scanPromise, timeoutPromise]);
-				results[task.idx] = buildStructuredScanResult(scanResult, {
-					scoringConfigHash: computeScoringConfigHash(options.runtimeOptions?.scoringConfig),
-				});
+				results[task.idx] = buildStructuredScanResult(scanResult, { scoringConfigHash });
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : 'Scan failed';
-				results[task.idx] = emptyResult(task.domain, msg);
+				results[task.idx] = emptyResult(task.domain, msg, scoringConfigHash);
 			} finally {
 				if (timeoutId !== undefined) clearTimeout(timeoutId);
 			}

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -35,6 +35,7 @@ import {
 	type ScanTelemetry,
 } from '../lib/adaptive-weights';
 import { applyInteractionPenalties, type InteractionEffect } from '../lib/category-interactions';
+import { computeScoringConfigHash } from '../lib/scoring-version';
 import { buildCheckCacheKey, buildScanCacheKey, cacheGet, cacheSet, runWithCache } from '../lib/cache';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { queryDns } from '../lib/dns';
@@ -210,6 +211,24 @@ export interface ScanDomainResult {
 	 * results rather than averaging an ungraded result into a population score.
 	 */
 	resolves?: boolean | 'broken';
+	/**
+	 * Fingerprint of the **effective** scoring config this result was produced
+	 * under — `computeScoringConfigHash(runtimeOptions.scoringConfig)`.
+	 *
+	 * Stamped by `scanDomain` on every return path (including the non-resolving /
+	 * DNS-broken short-circuits and the cached path, which carries the hash it was
+	 * originally scored with) so that `buildStructuredScanResult` can report a
+	 * TRUTHFUL `scoringConfigHash` without the caller having to thread it. Before
+	 * this existed, any caller that did not pass an enrichment — every consumer of
+	 * the exported `buildStructuredScanResult` from the npm package, and the
+	 * batch error placeholders — stamped the literal `'default'` marker even while
+	 * a live `SCORING_CONFIG` override was in force, i.e. the output claimed a
+	 * reproducibility it could not back.
+	 *
+	 * Additive-optional: `undefined` only on hand-built results (tests) and on
+	 * cache entries written before this field existed.
+	 */
+	scoringConfigHash?: string;
 }
 
 /**
@@ -463,11 +482,21 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 	// Versioned (cache:v<version>:...) so a deploy auto-invalidates — see buildScanCacheKey.
 	const cacheKey = isExplicit ? buildScanCacheKey(domain, explicitProfile) : buildScanCacheKey(domain);
 
+	// Fingerprint of the EFFECTIVE scoring config this scan runs under. Stamped onto
+	// every result this function returns so downstream formatting reports the config
+	// that actually produced the numbers instead of the `'default'` marker.
+	const scoringConfigHash = computeScoringConfigHash(runtimeOptions?.scoringConfig);
+
 	// Check cache first (skip when force_refresh is requested)
 	if (!runtimeOptions?.forceRefresh) {
 		const cached = await cacheGet<ScanDomainResult>(cacheKey, kv);
 		if (cached) {
-			return { ...cached, cached: true };
+			// Deliberately NOT re-stamped with the current hash: a cached result's score
+			// was computed under the config in force when it was written, so it must keep
+			// carrying THAT fingerprint. `?? scoringConfigHash` only covers cache entries
+			// written before this field existed (bounded by the 5-min TTL and the
+			// deploy-versioned cache key).
+			return { ...cached, cached: true, scoringConfigHash: cached.scoringConfigHash ?? scoringConfigHash };
 		}
 	}
 
@@ -536,7 +565,7 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 		try {
 			const apex = await queryDns(domain, 'NS', false, scanDns);
 			if (apex.Status === 3) {
-				return buildNonResolvingResult(domain);
+				return { ...buildNonResolvingResult(domain), scoringConfigHash };
 			}
 			if (apex.Status === 2) {
 				// CD-disabled retry on a fresh cache (no cd=0/default collision).
@@ -547,11 +576,11 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 						queryCache: new Map(),
 					});
 					// Resolves only with validation off ⇒ DNSSEC-bogus; still SERVFAIL/other ⇒ unresolvable.
-					return buildDnsBrokenResult(domain, cdDisabled.Status === 0 ? 'dnssec_bogus' : 'unresolvable');
+					return { ...buildDnsBrokenResult(domain, cdDisabled.Status === 0 ? 'dnssec_bogus' : 'unresolvable'), scoringConfigHash };
 				} catch {
 					// The confirming retry itself failed transport-wise — treat the
 					// confirmed validating-SERVFAIL as a persistent unresolvable delegation.
-					return buildDnsBrokenResult(domain, 'unresolvable');
+					return { ...buildDnsBrokenResult(domain, 'unresolvable'), scoringConfigHash };
 				}
 			}
 		} catch {
@@ -801,7 +830,10 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 		let adaptiveWeightDeltas: Record<string, number> | null = null;
 
 		if (adaptiveResponse && adaptiveResponse.sampleCount > 0) {
-			const adaptiveWeights = adaptiveWeightsToContext(adaptiveResponse.weights, domainContext.profile);
+			// Same effective config as the `getProfileWeights(...)` static side below — the two
+			// operands of `deltas` must share a base, else an override manufactures phantom
+			// deltas for every category the accumulator returned no data for.
+			const adaptiveWeights = adaptiveWeightsToContext(adaptiveResponse.weights, domainContext.profile, runtimeOptions?.scoringConfig);
 			if (adaptiveWeights) {
 				// Compute adaptive score (for the reported delta only)
 				const adaptiveContext: DomainContext = { ...domainContext, weights: adaptiveWeights };
@@ -936,6 +968,10 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 			);
 		}
 	}
+
+	// Stamp the effective-config fingerprint BEFORE caching, so a cache hit replays the
+	// hash the result was actually scored under (see the cache-read branch above).
+	result = { ...result, scoringConfigHash };
 
 	// Cache the result (use configurable TTL if provided)
 	// Defer the write via waitUntil when available to avoid blocking the response.

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -244,7 +244,8 @@ export interface ScanResultEnrichment {
 	/**
 	 * Precomputed fingerprint of the effective scoring config, threaded from the
 	 * call site that holds the parsed config (`runtimeOptions.scoringConfig`). When
-	 * omitted, `buildStructuredScanResult` falls back to the `'default'` marker.
+	 * omitted, `buildStructuredScanResult` falls back to the hash `scanDomain`
+	 * stamped onto the result itself, and only then to the `'default'` marker.
 	 */
 	scoringConfigHash?: string;
 }
@@ -416,7 +417,12 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		timestamp: result.timestamp,
 		cached: result.cached,
 		scoringModelVersion: SCORING_MODEL_VERSION,
-		scoringConfigHash: enrichment?.scoringConfigHash ?? computeScoringConfigHash(),
+		// Three-step, most-specific-first: an explicitly threaded hash wins; else the
+		// hash `scanDomain` stamped onto this very result (so a caller that passes no
+		// enrichment — every npm-package consumer of this function — still reports the
+		// config the scan actually ran under); only a hand-built result with neither
+		// falls back to the `'default'` marker.
+		scoringConfigHash: enrichment?.scoringConfigHash ?? result.scoringConfigHash ?? computeScoringConfigHash(),
 		// Additive-optional: only emit `resolves` when known (omit otherwise so
 		// tolerant downstream parsers see the same shape they always have).
 		...(result.resolves !== undefined ? { resolves: result.resolves } : {}),

--- a/test/adaptive-weights.spec.ts
+++ b/test/adaptive-weights.spec.ts
@@ -8,6 +8,7 @@ import {
 	EMA_ALPHA,
 	SCORING_NOTE_DELTA_THRESHOLD,
 	BASELINE_FAILURE_RATES,
+	resolveBaselineFailureRates,
 	WEIGHT_BOUNDS,
 	defaultBounds,
 	computeAdaptiveWeight,
@@ -16,7 +17,7 @@ import {
 	generateScoringNote,
 } from '../src/lib/adaptive-weights';
 // Type-only imports verified to exist: ScanTelemetry, AdaptiveWeightsResponse, WeightBound
-import { PROFILE_WEIGHTS } from '@blackveil/dns-checks/scoring';
+import { DEFAULT_SCORING_CONFIG, PROFILE_WEIGHTS, getProfileWeights, parseScoringConfig } from '@blackveil/dns-checks/scoring';
 import type { DomainProfile } from '@blackveil/dns-checks/scoring';
 import type { CheckCategory } from '@blackveil/dns-checks/scoring';
 
@@ -41,23 +42,142 @@ describe('adaptive-weights', () => {
 			expect(SCORING_NOTE_DELTA_THRESHOLD).toBe(3);
 		});
 
-		it('BASELINE_FAILURE_RATES has all 13 categories', () => {
-			const expected: Record<string, number> = {
-				dmarc: 0.4,
-				spf: 0.25,
-				dkim: 0.35,
-				ssl: 0.08,
-				mta_sts: 0.85,
-				dnssec: 0.8,
-				mx: 0.05,
-				caa: 0.7,
-				ns: 0.03,
-				bimi: 0.95,
-				tlsrpt: 0.9,
-				subdomain_takeover: 0.1,
-				lookalikes: 0.0,
-			};
-			expect(BASELINE_FAILURE_RATES).toEqual(expected);
+		// Deliberately asserts the SHAPE of the imported constant, never a restatement of
+		// its 13 literals. The table used to be written out a third time right here (once
+		// in `src/lib/adaptive-weights.ts`, once in the scoring package's
+		// `DEFAULT_SCORING_CONFIG.baselineFailureRates`, once here) — three copies that
+		// could drift independently, and a spec that "passed" by agreeing with a copy of
+		// itself rather than checking anything.
+		it('BASELINE_FAILURE_RATES covers exactly the 13 prior-calibrated categories', () => {
+			expect(Object.keys(BASELINE_FAILURE_RATES).sort()).toEqual(
+				[
+					'bimi',
+					'caa',
+					'dkim',
+					'dmarc',
+					'dnssec',
+					'lookalikes',
+					'mta_sts',
+					'mx',
+					'ns',
+					'spf',
+					'ssl',
+					'subdomain_takeover',
+					'tlsrpt',
+				].sort(),
+			);
+		});
+
+		it('BASELINE_FAILURE_RATES values are all valid probabilities', () => {
+			for (const [category, rate] of Object.entries(BASELINE_FAILURE_RATES)) {
+				expect(typeof rate, category).toBe('number');
+				expect(Number.isFinite(rate), category).toBe(true);
+				expect(rate, category).toBeGreaterThanOrEqual(0);
+				expect(rate, category).toBeLessThanOrEqual(1);
+			}
+		});
+
+		// The SSOT lock: the worker's table must not drift from the scoring package's
+		// `DEFAULT_SCORING_CONFIG.baselineFailureRates`, which is what a `SCORING_CONFIG`
+		// override is merged onto. If these two disagree, an operator setting the override
+		// key gets a baseline that silently differs from the one they read in the package.
+		it('BASELINE_FAILURE_RATES agrees with the scoring package defaults for every category it covers', () => {
+			for (const [category, rate] of Object.entries(BASELINE_FAILURE_RATES)) {
+				expect(DEFAULT_SCORING_CONFIG.baselineFailureRates[category], category).toBe(rate);
+			}
+		});
+	});
+
+	// ─── SCORING_CONFIG.baselineFailureRates must actually reach the accumulator ──
+
+	describe('resolveBaselineFailureRates', () => {
+		it('returns the static table (same identity) when no config is supplied', () => {
+			expect(resolveBaselineFailureRates()).toBe(BASELINE_FAILURE_RATES);
+			expect(resolveBaselineFailureRates('')).toBe(BASELINE_FAILURE_RATES);
+		});
+
+		it('returns the static table when the config supplies no baseline override', () => {
+			const resolved = resolveBaselineFailureRates(JSON.stringify({ coreWeights: { dmarc: 22 } }));
+			expect(resolved).toBe(BASELINE_FAILURE_RATES);
+		});
+
+		it('fails soft to the static table on an unparseable config', () => {
+			expect(resolveBaselineFailureRates('{not json')).toBe(BASELINE_FAILURE_RATES);
+		});
+
+		it('overlays only the categories the config actually moves', () => {
+			const resolved = resolveBaselineFailureRates(JSON.stringify({ baselineFailureRates: { dmarc: 0.9 } }));
+
+			// The overridden category is live — this is the whole point: before this
+			// function existed the key parsed fine and was then read by nobody.
+			expect(resolved.dmarc).toBe(0.9);
+			// Every other category is untouched, and the static object itself is not mutated.
+			expect(resolved.spf).toBe(BASELINE_FAILURE_RATES.spf);
+			expect(BASELINE_FAILURE_RATES.dmarc).not.toBe(0.9);
+			expect(resolved).not.toBe(BASELINE_FAILURE_RATES);
+		});
+
+		it('does not import priors for categories the worker deliberately leaves unset', () => {
+			// `http_security` has a 0.35 prior in the PACKAGE table but no worker prior:
+			// the accumulator resolves it to 0. Copying the parsed config wholesale would
+			// silently switch that on for 15 categories — a behaviour change, not a dedup.
+			const resolved = resolveBaselineFailureRates(JSON.stringify({ baselineFailureRates: { dmarc: 0.9 } }));
+			expect(resolved.http_security).toBeUndefined();
+			expect(DEFAULT_SCORING_CONFIG.baselineFailureRates.http_security).toBe(0.35);
+		});
+
+		it('defers to the package sanitizer for junk override values', () => {
+			// `parseScoringConfig`'s `mergeWeights` already clamps negatives to 0 and drops
+			// non-numeric values, so the resolver inherits exactly those semantics rather
+			// than inventing a second, divergent validation policy.
+			const resolved = resolveBaselineFailureRates(JSON.stringify({ baselineFailureRates: { dmarc: -1, spf: 'nope' } }));
+			expect(resolved.dmarc).toBe(0);
+			expect(resolved.spf).toBe(BASELINE_FAILURE_RATES.spf);
+		});
+
+		it('drops override keys the package does not recognise as categories', () => {
+			const resolved = resolveBaselineFailureRates(JSON.stringify({ baselineFailureRates: { not_a_category: 0.5 } }));
+			expect(resolved).toBe(BASELINE_FAILURE_RATES);
+		});
+	});
+
+	// ─── The adaptive delta's two operands must share a base ──────────────
+
+	describe('adaptiveWeightsToContext — static base', () => {
+		it('falls back to the CONFIG-resolved profile weight, not the raw table', () => {
+			const config = parseScoringConfig(JSON.stringify({ profileWeights: { mail_enabled: { spf: 30 } } }));
+			// Empty DO response ⇒ every category takes the fallback path.
+			const resolved = adaptiveWeightsToContext({}, 'mail_enabled', config);
+
+			expect(resolved).not.toBeNull();
+			expect(resolved!.spf.importance).toBe(30);
+			expect(PROFILE_WEIGHTS.mail_enabled.spf.importance).not.toBe(30);
+		});
+
+		it('produces zero deltas against getProfileWeights when the DO has no data (no phantom deltas)', () => {
+			// This is the exact computation `scan-domain.ts` performs. Reading the fallback
+			// from the raw `PROFILE_WEIGHTS` while the static side came from
+			// `getProfileWeights(profile, config)` made every overridden category report a
+			// non-zero "adaptive" delta that no adaptation produced — and the customer-visible
+			// `scoringNote` fires off exactly those deltas.
+			const config = parseScoringConfig(JSON.stringify({ profileWeights: { mail_enabled: { spf: 30, dmarc: 1 } } }));
+			const adaptive = adaptiveWeightsToContext({}, 'mail_enabled', config)!;
+			const staticWeights = getProfileWeights('mail_enabled', config);
+
+			for (const cat of Object.keys(staticWeights) as CheckCategory[]) {
+				expect(adaptive[cat].importance - staticWeights[cat].importance, cat).toBe(0);
+			}
+		});
+
+		it('still honours a real DO weight over the static base', () => {
+			const config = parseScoringConfig(JSON.stringify({ profileWeights: { mail_enabled: { spf: 30 } } }));
+			const resolved = adaptiveWeightsToContext({ spf: 12 }, 'mail_enabled', config)!;
+			expect(resolved.spf.importance).toBe(12);
+		});
+
+		it('omitting the config reproduces the raw-table base', () => {
+			const resolved = adaptiveWeightsToContext({}, 'mail_enabled')!;
+			expect(resolved.spf.importance).toBe(PROFILE_WEIGHTS.mail_enabled.spf.importance);
 		});
 	});
 

--- a/test/profile-accumulator.spec.ts
+++ b/test/profile-accumulator.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { describe, expect, it } from 'vitest';
-import { env } from 'cloudflare:test';
+import { env, runInDurableObject } from 'cloudflare:test';
 import type { ScanTelemetry } from '../src/lib/adaptive-weights';
 
 function getStub(name: string): DurableObjectStub {
@@ -563,5 +563,86 @@ describe('ProfileAccumulator — Intelligence Layer', () => {
 			// Running average of 60, 70, 80, 90 = 75
 			expect(body.snapshots[0].avgScore).toBeCloseTo(75, 0);
 		});
+	});
+});
+
+/**
+ * The `SCORING_CONFIG.baselineFailureRates` key was parsed by the scoring package
+ * and then read by NOBODY: `handleGetWeights` imported the static
+ * `BASELINE_FAILURE_RATES` map from `src/lib/adaptive-weights.ts` directly, so an
+ * operator could set the key and observe no effect anywhere. These tests lock the
+ * wiring end-to-end at the Durable Object boundary — pure-function coverage of the
+ * resolver itself lives in `test/adaptive-weights.spec.ts`.
+ *
+ * Adaptive weights never reach a reported score (`scanDomain` always reports the
+ * canonical static-weight score), so this is confined to the `scoringNote` /
+ * `adaptiveWeightDeltas` surfaces by construction.
+ */
+describe('ProfileAccumulator — SCORING_CONFIG.baselineFailureRates wiring', () => {
+	/**
+	 * Run `body` with the DO instance's `env.SCORING_CONFIG` temporarily set.
+	 * The DO receives its env at construction from the runtime, so mutating the
+	 * test worker's `env` object would not reach it — we have to reach into the
+	 * instance. Restored unconditionally so no sibling test inherits the override.
+	 */
+	async function withScoringConfig<T>(stub: DurableObjectStub, raw: string | undefined, body: () => Promise<T>): Promise<T> {
+		const restore = await runInDurableObject(stub, (instance) => {
+			const doEnv = (instance as unknown as { env: Record<string, unknown> }).env;
+			const previous = doEnv.SCORING_CONFIG;
+			doEnv.SCORING_CONFIG = raw;
+			return previous;
+		});
+		try {
+			return await body();
+		} finally {
+			await runInDurableObject(stub, (instance) => {
+				(instance as unknown as { env: Record<string, unknown> }).env.SCORING_CONFIG = restore;
+			});
+		}
+	}
+
+	it('an override reaches the /benchmark baseline echo', async () => {
+		const stub = getStub('baseline-override-benchmark');
+
+		const unset = await (await getBenchmark(stub, 'mail_enabled')).json();
+		expect(unset.baselineFailureRates.dmarc).toBe(0.4);
+
+		const overridden = await withScoringConfig(stub, JSON.stringify({ baselineFailureRates: { dmarc: 0.99 } }), async () =>
+			(await getBenchmark(stub, 'mail_enabled')).json(),
+		);
+		expect(overridden.baselineFailureRates.dmarc).toBe(0.99);
+		// Untouched categories still come from the worker-side static table.
+		expect(overridden.baselineFailureRates.spf).toBe(0.25);
+
+		// And the override does not leak once it is removed again.
+		const after = await (await getBenchmark(stub, 'mail_enabled')).json();
+		expect(after.baselineFailureRates.dmarc).toBe(0.4);
+	});
+
+	it('an override changes the adaptive weight the accumulator computes', async () => {
+		const stub = getStub('baseline-override-weights');
+
+		// Seed enough samples that the blend factor is non-trivial, with an observed
+		// failure rate well away from the default 0.40 dmarc baseline.
+		for (let i = 0; i < 50; i++) {
+			await ingest(stub, {
+				profile: 'mail_enabled',
+				provider: null,
+				categoryFindings: [{ category: 'dmarc', score: 20, passed: false }],
+				timestamp: Date.now(),
+				overallScore: 40,
+			});
+		}
+
+		const baselineWeights = await (await getWeights(stub, 'mail_enabled')).json();
+		expect(baselineWeights.sampleCount).toBeGreaterThan(0);
+		expect(typeof baselineWeights.weights.dmarc).toBe('number');
+
+		// A HIGHER baseline means the observed failure rate looks less anomalous, so the
+		// adaptive weight moves DOWN relative to the un-overridden run.
+		const overriddenWeights = await withScoringConfig(stub, JSON.stringify({ baselineFailureRates: { dmarc: 0.99 } }), async () =>
+			(await getWeights(stub, 'mail_enabled')).json(),
+		);
+		expect(overriddenWeights.weights.dmarc).toBeLessThan(baselineWeights.weights.dmarc);
 	});
 });

--- a/test/scoring-config-hash-stamp.spec.ts
+++ b/test/scoring-config-hash-stamp.spec.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * The reproducibility stamp must not lie.
+ *
+ * `computeScoringConfigHash()` returns the literal `'default'` marker when called
+ * with no argument, and two producer call sites called it argument-free:
+ * `buildStructuredScanResult`'s fallback and `batchScan`'s error placeholder. Both
+ * therefore stamped `scoringConfigHash: 'default'` — a claim that the result is
+ * reproducible under the default scoring policy — even while a live
+ * `SCORING_CONFIG` override was in force. A prod override existed for an unknown
+ * period while every scan stamped `'default'`; these tests make that state
+ * unrepresentable.
+ *
+ * The hash ALGORITHM is deliberately untested here (that is `scoring-version.spec.ts`);
+ * what is locked is that the stamp tracks the EFFECTIVE config at every producer.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { IN_MEMORY_CACHE } from '../src/lib/cache';
+import { setupFetchMock } from './helpers/dns-mock';
+import { parseScoringConfigCached, resetScoringConfigCache } from '../src/lib/scoring-config';
+import { computeScoringConfigHash } from '../src/lib/scoring-version';
+
+const { restore } = setupFetchMock();
+
+beforeEach(() => {
+	IN_MEMORY_CACHE.clear();
+	resetScoringConfigCache();
+	// Blanket mock: every check errors/parses-empty, which is irrelevant here — the
+	// stamp is metadata about the CONFIG, not about what the checks measured.
+	globalThis.fetch = vi.fn().mockResolvedValue(new Response('OK', { status: 200, headers: { 'content-type': 'text/plain' } }));
+});
+
+afterEach(() => {
+	restore();
+	resetScoringConfigCache();
+});
+
+/**
+ * An override that is deliberately NOT score-bearing: `baselineFailureRates` only
+ * feeds the adaptive-weight baseline, which never reaches a reported score. It still
+ * produces a distinct effective config, which is exactly what the stamp must
+ * reflect — the fingerprint has to move whenever the config object moves, whether or
+ * not that particular key moved a score. (Picking a score-bearing key here would
+ * conflate "the stamp tracks the config" with "the config changed the numbers".)
+ */
+const OVERRIDE_RAW = JSON.stringify({ baselineFailureRates: { dmarc: 0.5 } });
+
+describe('scoringConfigHash — scan_domain', () => {
+	it('stamps the effective config even when NO enrichment is threaded', async () => {
+		const { scanDomain, buildStructuredScanResult } = await import('../src/tools/scan-domain');
+
+		const plain = await scanDomain('hash-stamp-plain.example', undefined, {
+			scoringConfig: parseScoringConfigCached(undefined),
+		});
+		// The un-enriched call is the one that used to lie — every npm-package consumer
+		// of the exported `buildStructuredScanResult` takes this path.
+		const stamped = buildStructuredScanResult(plain).scoringConfigHash;
+
+		expect(stamped).not.toBe('default');
+		expect(stamped).toBe(computeScoringConfigHash(parseScoringConfigCached(undefined)));
+	});
+
+	it('a run WITH an override stamps a different hash than a run without', async () => {
+		const { scanDomain, buildStructuredScanResult } = await import('../src/tools/scan-domain');
+
+		const withoutOverride = await scanDomain('hash-stamp-a.example', undefined, {
+			scoringConfig: parseScoringConfigCached(undefined),
+		});
+		resetScoringConfigCache();
+		const withOverride = await scanDomain('hash-stamp-b.example', undefined, {
+			scoringConfig: parseScoringConfigCached(OVERRIDE_RAW),
+		});
+
+		const plainHash = buildStructuredScanResult(withoutOverride).scoringConfigHash;
+		const overrideHash = buildStructuredScanResult(withOverride).scoringConfigHash;
+
+		expect(plainHash).not.toBe('default');
+		expect(overrideHash).not.toBe('default');
+		expect(overrideHash).not.toBe(plainHash);
+	});
+
+	it('an explicitly threaded enrichment hash still wins over the result stamp', async () => {
+		const { scanDomain, buildStructuredScanResult } = await import('../src/tools/scan-domain');
+
+		const result = await scanDomain('hash-stamp-enrich.example', undefined, {
+			scoringConfig: parseScoringConfigCached(undefined),
+		});
+		expect(buildStructuredScanResult(result, { scoringConfigHash: 'abc123' }).scoringConfigHash).toBe('abc123');
+	});
+
+	it('a hand-built result carrying no stamp still degrades to the default marker', async () => {
+		// The `'default'` marker is not removed, only demoted: it remains the honest
+		// answer for a result that never passed through `scanDomain` at all.
+		const { buildStructuredScanResult } = await import('../src/tools/scan-domain');
+		const { scanDomain } = await import('../src/tools/scan-domain');
+
+		const real = await scanDomain('hash-stamp-strip.example', undefined, {
+			scoringConfig: parseScoringConfigCached(undefined),
+		});
+		const { scoringConfigHash: _dropped, ...withoutStamp } = real;
+		expect(buildStructuredScanResult(withoutStamp).scoringConfigHash).toBe('default');
+	});
+});
+
+describe('scoringConfigHash — batch_scan', () => {
+	it('the never-measured error placeholder carries the batch’s effective config, not the default marker', async () => {
+		const { batchScan } = await import('../src/tools/batch-scan');
+
+		const results = await batchScan(['not a valid domain'], {
+			runtimeOptions: { scoringConfig: parseScoringConfigCached(OVERRIDE_RAW) },
+		});
+
+		expect(results).toHaveLength(1);
+		expect(results[0].error).toBeTruthy();
+		expect(results[0].measured).toBe(false);
+		expect(results[0].scoringConfigHash).not.toBe('default');
+		expect(results[0].scoringConfigHash).toBe(computeScoringConfigHash(parseScoringConfigCached(OVERRIDE_RAW)));
+	});
+
+	it('an error placeholder and a scanned sibling agree on the stamp within one batch', async () => {
+		const { batchScan } = await import('../src/tools/batch-scan');
+
+		const results = await batchScan(['not a valid domain', 'hash-stamp-batch.com'], {
+			runtimeOptions: { scoringConfig: parseScoringConfigCached(OVERRIDE_RAW) },
+		});
+
+		expect(results).toHaveLength(2);
+		expect(results[0].error).toBeTruthy();
+		expect(results[1].error).toBeUndefined();
+		// The disagreement this asserts against was real: the placeholder said 'default'
+		// while its sibling in the same response said the override hash.
+		expect(results[0].scoringConfigHash).toBe(results[1].scoringConfigHash);
+	});
+});


### PR DESCRIPTION
Two fixes on the worker side of the scoring config, both found while auditing why prod's `SCORING_CONFIG` override never moved a score.

**FIX 1 — baseline triplication + inert config key.** `resolveBaselineFailureRates()` overlays only categories an override actually moves off the package default (returns the static object *by identity* when there is no override, so the un-overridden path is byte-identical). `ProfileAccumulator` reads it through one accessor used by both `/weights` and `/benchmark`, so they cannot drift apart. The 13-literal restatement in the spec is gone.

**FIX 2 — the reproducibility stamp.** `scanDomain` now stamps the effective-config fingerprint at *every* return path, including the NXDOMAIN and DNS-broken short-circuits. A cache hit deliberately replays the hash it was originally scored under. `batchScan` threads one fingerprint per batch into `emptyResult` placeholders — previously a batch error item said `'default'` while its scanned sibling said the override hash.

**Adaptive-base mismatch**: fixed the caller-side half (`adaptiveWeightsToContext` takes the effective config, so its fallback shares a base with the delta's other operand — without this every no-data category reported a phantom non-zero delta under an override, and `scoringNote` is customer-visible). The accumulator-side half is documented in place, not changed — it would alter stored adaptive values.

Full suite green: 593 files, 6871 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)