### PR TITLE
feat(ns): detect lame delegation ("Sitting Ducks") in the NS check

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/ns-lame-delegation.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/ns-lame-delegation.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure verdict arithmetic + finding shape for lame-delegation ("Sitting Ducks")
+ * detection. The I/O side (per-nameserver probing through `checkNS`) is covered
+ * end-to-end in `test/check-ns-lame-delegation.spec.ts`.
+ *
+ * The invariant these cases exist to lock: an `unknown` outcome — a probe that
+ * FAILED rather than answered — must never move the verdict toward a scored
+ * deficiency. A measurement failure is not a finding.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+	MAX_LAME_DELEGATION_PROBES,
+	assessLameDelegation,
+	getPartialLameDelegationFinding,
+	getTotalLameDelegationFinding,
+	type NameserverProbeResult,
+} from '../../checks/ns-analysis';
+
+function probes(...pairs: Array<[string, NameserverProbeResult['outcome']]>): NameserverProbeResult[] {
+	return pairs.map(([nameserver, outcome]) => ({ nameserver, outcome }));
+}
+
+describe('MAX_LAME_DELEGATION_PROBES', () => {
+	it('is pinned at 4 — the NS check adds at most 4 subrequests to a healthy scan', () => {
+		// A cold scan_domain already fans out ~20 subrequests. Raising this raises the
+		// per-scan DNS cost for every domain, so it is a deliberate, tested constant.
+		expect(MAX_LAME_DELEGATION_PROBES).toBe(4);
+	});
+});
+
+describe('assessLameDelegation', () => {
+	it('classifies a mixed set as partial — the exploitable Sitting Ducks shape', () => {
+		const a = assessLameDelegation(probes(['ns1', 'resolves'], ['ns2', 'no_address']));
+		expect(a.verdict).toBe('partial');
+		expect(a.resolving).toEqual(['ns1']);
+		expect(a.nonResolving).toEqual(['ns2']);
+		expect(a.unknown).toEqual([]);
+	});
+
+	it('classifies an all-determinately-failing set as total', () => {
+		expect(assessLameDelegation(probes(['ns1', 'no_address'], ['ns2', 'no_address'])).verdict).toBe('total');
+	});
+
+	it('classifies an all-resolving set as healthy', () => {
+		expect(assessLameDelegation(probes(['ns1', 'resolves'], ['ns2', 'resolves'])).verdict).toBe('healthy');
+	});
+
+	it('classifies an all-unknown set as indeterminate, never total', () => {
+		// Every probe errored: nothing was measured, so nothing is claimed. Reporting
+		// `total` here would let a flaky resolver mark a healthy zone inconclusive.
+		const a = assessLameDelegation(probes(['ns1', 'unknown'], ['ns2', 'unknown']));
+		expect(a.verdict).toBe('indeterminate');
+		expect(a.unknown).toEqual(['ns1', 'ns2']);
+	});
+
+	it('treats an empty probe set as indeterminate', () => {
+		expect(assessLameDelegation([]).verdict).toBe('indeterminate');
+	});
+
+	it('an unknown outcome cannot suppress a real partial verdict', () => {
+		const a = assessLameDelegation(probes(['ns1', 'resolves'], ['ns2', 'no_address'], ['ns3', 'unknown']));
+		expect(a.verdict).toBe('partial');
+		expect(a.unknown).toEqual(['ns3']);
+	});
+
+	it('one determinate failure with the rest unmeasurable stays inconclusive, not a HIGH claim', () => {
+		// Nothing was PROVEN to still answer, so `partial` (a scored HIGH finding) would be
+		// asserting more than the evidence supports. `total` routes to the inconclusive
+		// path instead — the conservative direction.
+		const a = assessLameDelegation(probes(['ns1', 'no_address'], ['ns2', 'unknown']));
+		expect(a.verdict).toBe('total');
+		expect(a.resolving).toEqual([]);
+	});
+});
+
+describe('lame-delegation findings', () => {
+	it('the partial finding is HIGH and names both sides of the split', () => {
+		const a = assessLameDelegation(probes(['ns1.a.com', 'resolves'], ['ns2.b.net', 'no_address']));
+		const f = getPartialLameDelegationFinding('example.com', a);
+		expect(f.category).toBe('ns');
+		expect(f.severity).toBe('high');
+		expect(f.detail).toContain('ns2.b.net');
+		expect(f.detail).toContain('ns1.a.com');
+		expect(f.metadata?.lameDelegation).toBe('partial');
+	});
+
+	it('the partial finding does NOT set missingControl — it is a penalty, not a category-zeroing absence', () => {
+		const a = assessLameDelegation(probes(['ns1.a.com', 'resolves'], ['ns2.b.net', 'no_address']));
+		expect(getPartialLameDelegationFinding('example.com', a).metadata?.missingControl).toBeUndefined();
+	});
+
+	it('the total finding carries the transient shape so scoring EXCLUDES the category', () => {
+		const a = assessLameDelegation(probes(['ns1.a.com', 'no_address'], ['ns2.b.net', 'no_address']));
+		const f = getTotalLameDelegationFinding('example.com', a);
+		expect(f.severity).toBe('low');
+		expect(f.metadata?.errorKind).toBe('dns_error');
+		expect(f.metadata?.inconclusive).toBe(true);
+	});
+
+	it('the total finding never asserts domainResolves — that key belongs to the NS/A visibility probe', () => {
+		// `domainResolves: false` is the package's non-resolving guard key (scoring/resolution.ts).
+		// This probe only proves the nameserver HOSTS have no address, which cannot distinguish
+		// a dead zone from a resolver-side outage.
+		const a = assessLameDelegation(probes(['ns1.a.com', 'no_address'], ['ns2.b.net', 'no_address']));
+		expect(getTotalLameDelegationFinding('example.com', a).metadata?.domainResolves).toBeUndefined();
+	});
+});

--- a/packages/dns-checks/src/checks/check-ns.ts
+++ b/packages/dns-checks/src/checks/check-ns.ts
@@ -11,16 +11,82 @@
 import type { CheckResult, DNSQueryFunction, Finding, RawDNSQueryFunction, ZoneContext } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
 import {
+	MAX_LAME_DELEGATION_PROBES,
+	assessLameDelegation,
 	getInheritedNsFinding,
 	getNameserverDiversityFinding,
 	getNsConfiguredFinding,
 	getNsVisibilityFinding,
+	getPartialLameDelegationFinding,
 	getSingleNsFinding,
 	getSoaValidationFindings,
+	getTotalLameDelegationFinding,
 	getUndelegatedInconclusiveFinding,
 	normalizeNsRecords,
 	parseSoaValues,
 } from './ns-analysis';
+import type { NameserverProbeOutcome, NameserverProbeResult } from './ns-analysis';
+
+/** DoH numeric record types used by the nameserver-reachability probe. */
+const DOH_TYPE_A = 1;
+const DOH_TYPE_AAAA = 28;
+
+/**
+ * Probe one delegated nameserver for reachability.
+ *
+ * Workers cannot open a UDP socket to an individual nameserver, so authority is
+ * established the only way a recursive-resolver vantage point allows: a delegated
+ * nameserver with NO address cannot be queried by anyone, and therefore cannot be
+ * answering authoritatively for the zone. That is exactly the delegation an attacker
+ * claims in a Sitting Ducks hijack.
+ *
+ * AAAA is consulted ONLY when A came back empty, so an IPv6-only nameserver is not a
+ * false positive while a healthy zone still costs one subrequest per nameserver.
+ * A thrown probe yields `unknown` (never `no_address`) — a failure to measure must not
+ * be reported as a failure.
+ */
+async function probeNameserverReachable(
+	nameserver: string,
+	rawQueryDNS: RawDNSQueryFunction,
+	timeout: number,
+): Promise<NameserverProbeOutcome> {
+	try {
+		const a = await rawQueryDNS(nameserver, 'A', false, { timeout });
+		if ((a.Answer ?? []).some((ans) => ans.type === DOH_TYPE_A || ans.type === DOH_TYPE_AAAA)) {
+			return 'resolves';
+		}
+	} catch {
+		return 'unknown';
+	}
+
+	try {
+		const aaaa = await rawQueryDNS(nameserver, 'AAAA', false, { timeout });
+		if ((aaaa.Answer ?? []).some((ans) => ans.type === DOH_TYPE_AAAA)) {
+			return 'resolves';
+		}
+	} catch {
+		return 'unknown';
+	}
+
+	return 'no_address';
+}
+
+/**
+ * Probe up to `MAX_LAME_DELEGATION_PROBES` delegated nameservers in parallel.
+ * Never throws — every rejection degrades to an `unknown` outcome.
+ */
+async function probeDelegatedNameservers(
+	nsRecords: string[],
+	rawQueryDNS: RawDNSQueryFunction,
+	timeout: number,
+): Promise<NameserverProbeResult[]> {
+	const targets = nsRecords.slice(0, MAX_LAME_DELEGATION_PROBES);
+	const settled = await Promise.allSettled(targets.map((ns) => probeNameserverReachable(ns, rawQueryDNS, timeout)));
+	return targets.map((nameserver, i) => {
+		const outcome = settled[i];
+		return { nameserver, outcome: outcome.status === 'fulfilled' ? outcome.value : 'unknown' };
+	});
+}
 
 /**
  * Check nameserver configuration for a domain.
@@ -114,6 +180,25 @@ export async function checkNS(
 	const diversityFinding = getNameserverDiversityFinding(nsRecords);
 	if (diversityFinding) {
 		findings.push(diversityFinding);
+	}
+
+	// Lame delegation ("Sitting Ducks") — does every delegated nameserver actually
+	// answer for this zone? Runs before the SOA/wildcard probes so the TOTAL case
+	// short-circuits without spending further subrequests.
+	if (rawQueryDNS) {
+		const assessment = assessLameDelegation(await probeDelegatedNameservers(nsRecords, rawQueryDNS, timeout));
+		if (assessment.verdict === 'total') {
+			// Nothing in the delegation answered — a resolution failure, not a posture
+			// reading. Mark the category INCONCLUSIVE so scoring EXCLUDES it (same shape as
+			// the undelegated branch above) rather than zeroing a category we never measured.
+			// The partial findings gathered so far are dropped deliberately: a category that
+			// could not be measured must not also ship scored deficiencies.
+			const result = buildCheckResult('ns', [getTotalLameDelegationFinding(domain, assessment)]);
+			return { ...result, score: 0, passed: false, checkStatus: 'error', partial: true };
+		}
+		if (assessment.verdict === 'partial') {
+			findings.push(getPartialLameDelegationFinding(domain, assessment));
+		}
 	}
 
 	// Check SOA record exists and validate parameters

--- a/packages/dns-checks/src/checks/ns-analysis.ts
+++ b/packages/dns-checks/src/checks/ns-analysis.ts
@@ -190,6 +190,139 @@ export function getInheritedNsFinding(zone: ZoneContext): Finding {
 	);
 }
 
+// ---------------------------------------------------------------------------
+// Lame delegation ("Sitting Ducks")
+// ---------------------------------------------------------------------------
+
+/**
+ * Hard cap on how many delegated nameservers are probed for lame delegation.
+ *
+ * A cold `scan_domain` already fans out ~20 subrequests; each probed nameserver
+ * costs one A query, plus one AAAA query ONLY when the A query came back empty
+ * (so a healthy zone costs exactly one query per nameserver). With this cap the
+ * NS check adds at most 4 subrequests in the healthy case and at most 8 in the
+ * all-broken case — bounded regardless of how many NS records a zone publishes.
+ *
+ * Four is enough evidence: the finding needs one working nameserver and one
+ * broken one to establish the partial-lame shape, and RFC 1035 §2.2 zones
+ * publish 2–4 in practice.
+ */
+export const MAX_LAME_DELEGATION_PROBES = 4;
+
+/**
+ * Per-nameserver probe outcome.
+ *
+ * - `resolves` — the nameserver hostname has an address, so queries can reach it.
+ * - `no_address` — DETERMINED to have no A/AAAA address. The parent delegates to a
+ *   host that cannot serve the zone; this is the Sitting Ducks precondition.
+ * - `unknown` — the probe itself failed (resolver timeout/network error). NOT
+ *   evidence of anything: a failure to MEASURE is never scored as a failure.
+ */
+export type NameserverProbeOutcome = 'resolves' | 'no_address' | 'unknown';
+
+/** One nameserver's probe result. */
+export interface NameserverProbeResult {
+	nameserver: string;
+	outcome: NameserverProbeOutcome;
+}
+
+/**
+ * Verdict over the probed set.
+ *
+ * - `healthy` — every determinate probe resolved.
+ * - `partial` — at least one resolved AND at least one determinately did not.
+ *   The exploitable shape: the zone still answers (so nothing looks broken to the
+ *   owner) while a delegated nameserver sits unclaimed.
+ * - `total` — at least one determinate `no_address` and NOTHING resolved. That is a
+ *   whole-zone resolution failure, not a posture deficiency, so it must route to
+ *   the inconclusive path rather than score 0.
+ * - `indeterminate` — no determinate outcome at all (every probe errored). Emits
+ *   nothing and leaves the rest of the NS result untouched.
+ */
+export type LameDelegationVerdict = 'healthy' | 'partial' | 'total' | 'indeterminate';
+
+export interface LameDelegationAssessment {
+	verdict: LameDelegationVerdict;
+	resolving: string[];
+	nonResolving: string[];
+	unknown: string[];
+}
+
+/**
+ * Classify a set of per-nameserver probe outcomes into a lame-delegation verdict.
+ *
+ * Pure — the I/O lives in `checkNS`. `unknown` outcomes are deliberately excluded
+ * from the verdict arithmetic so a flaky resolver can never manufacture a `total`
+ * (or suppress a real `partial`).
+ */
+export function assessLameDelegation(results: NameserverProbeResult[]): LameDelegationAssessment {
+	const resolving = results.filter((r) => r.outcome === 'resolves').map((r) => r.nameserver);
+	const nonResolving = results.filter((r) => r.outcome === 'no_address').map((r) => r.nameserver);
+	const unknown = results.filter((r) => r.outcome === 'unknown').map((r) => r.nameserver);
+
+	let verdict: LameDelegationVerdict;
+	if (nonResolving.length === 0) {
+		verdict = resolving.length > 0 ? 'healthy' : 'indeterminate';
+	} else if (resolving.length > 0) {
+		verdict = 'partial';
+	} else {
+		verdict = 'total';
+	}
+
+	return { verdict, resolving, nonResolving, unknown };
+}
+
+/**
+ * HIGH finding for partial lame delegation — some delegated nameservers do not
+ * answer for the zone while others still do.
+ *
+ * This is the "Sitting Ducks" hijack precondition: the zone keeps resolving via the
+ * healthy nameservers, so nothing looks broken, while an attacker who can claim the
+ * non-responsive nameserver at its DNS provider gains authoritative control of the
+ * zone without ever touching the registrar.
+ */
+export function getPartialLameDelegationFinding(domain: string, assessment: LameDelegationAssessment): Finding {
+	return createFinding(
+		'ns',
+		'Lame delegation — nameserver does not answer for the zone',
+		'high',
+		`The parent zone delegates ${domain} to ${assessment.nonResolving.join(', ')}, but ${
+			assessment.nonResolving.length === 1 ? 'that nameserver is' : 'those nameservers are'
+		} not reachable for this zone (no address resolves). ${assessment.resolving.join(', ')} still answer${
+			assessment.resolving.length === 1 ? 's' : ''
+		}, so the domain keeps resolving and the fault is invisible in normal use. This is the "Sitting Ducks" precondition: an attacker who registers the unclaimed nameserver at its DNS provider becomes authoritative for ${domain} without touching the registrar. Remove the stale delegation at the registrar, or re-provision the zone on that nameserver.`,
+		{
+			lameDelegation: 'partial',
+			nonResolvingNameservers: assessment.nonResolving,
+			resolvingNameservers: assessment.resolving,
+			...(assessment.unknown.length > 0 ? { unprobedNameservers: assessment.unknown } : {}),
+		},
+	);
+}
+
+/**
+ * Inconclusive finding for TOTAL lame delegation — no delegated nameserver resolves.
+ *
+ * Deliberately NOT a scored deficiency. When nothing in the delegation answers, the
+ * NS posture was not measured, it was merely unobservable; scoring it 0 would penalize
+ * a category we never got a reading for (the same rule `getUndelegatedInconclusiveFinding`
+ * exists for). Carries the transient shape so scoring EXCLUDES the category.
+ *
+ * Deliberately does NOT set `domainResolves: false` — that key is the package's
+ * non-resolving guard and belongs only to `getNsVisibilityFinding`, which has actually
+ * probed NS *and* A. This probe only establishes that the nameserver HOSTS have no
+ * address, which cannot distinguish a dead zone from a resolver-side outage.
+ */
+export function getTotalLameDelegationFinding(domain: string, assessment: LameDelegationAssessment): Finding {
+	return createFinding(
+		'ns',
+		'Nameserver reachability not assessed',
+		'low',
+		`None of the nameservers delegated for ${domain} (${assessment.nonResolving.join(', ')}) resolved to an address during this run. That is a resolution failure rather than a measurable nameserver posture, so this control was not assessed.`,
+		{ errorKind: 'dns_error', inconclusive: true, lameDelegation: 'total', nonResolvingNameservers: assessment.nonResolving },
+	);
+}
+
 /**
  * Inconclusive finding when the zone-apex walk could not be resolved (resolver
  * timeout/error). Carries the transient shape so scoring EXCLUDES the category

--- a/test/check-ns-lame-delegation.spec.ts
+++ b/test/check-ns-lame-delegation.spec.ts
@@ -1,0 +1,222 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Lame delegation ("Sitting Ducks") detection in the NS check.
+ *
+ * A lame delegation is a parent zone pointing at nameservers that do not answer for
+ * the zone. The exploitable shape is the PARTIAL one: the domain still resolves via
+ * its healthy nameservers, so nothing looks broken, while an attacker who claims the
+ * non-responsive nameserver at its DNS provider becomes authoritative for the zone
+ * without touching the registrar.
+ *
+ * Workers cannot open a UDP socket to an individual nameserver, so reachability is
+ * established through the recursive-resolver seam the rest of this codebase uses: a
+ * delegated nameserver whose hostname has no address cannot be queried by anyone.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { RecordType } from '../src/lib/dns';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+const DOMAIN = 'example.com';
+const SOA_DATA = 'ns1.provider-a.com. admin.example.com. 2024010101 3600 900 604800 86400';
+
+interface MockOptions {
+	/** Nameserver hostnames delegated in the parent zone. */
+	nsRecords: string[];
+	/** Subset of `nsRecords` that resolve to an address. Everything else answers empty. */
+	reachable: string[];
+	/** Nameserver hostnames whose address lookup THROWS (resolver flake, not evidence). */
+	throwing?: string[];
+	/** Nameserver hostnames reachable over IPv6 only (A empty, AAAA answers). */
+	ipv6Only?: string[];
+}
+
+/**
+ * Fetch mock that answers NS for the scanned domain and routes A/AAAA per-name so the
+ * reachability of each individual nameserver can be controlled.
+ */
+function mockDelegation(opts: MockOptions) {
+	const calls: Array<{ name: string; type: string }> = [];
+	const nsAnswers = opts.nsRecords.map((data) => ({ name: DOMAIN, type: RecordType.NS, TTL: 86400, data }));
+
+	globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+		const nameMatch = url.match(/[?&]name=([^&]+)/);
+		const typeMatch = url.match(/[?&]type=([^&]+)/);
+		const name = nameMatch ? decodeURIComponent(nameMatch[1]).replace(/\.$/, '').toLowerCase() : '';
+		const type = typeMatch ? typeMatch[1] : '';
+		calls.push({ name, type });
+
+		if (type === 'NS') {
+			return Promise.resolve(createDohResponse([{ name: DOMAIN, type: RecordType.NS }], nsAnswers));
+		}
+		if (type === 'SOA') {
+			return Promise.resolve(
+				createDohResponse([{ name: DOMAIN, type: RecordType.SOA }], [{ name: DOMAIN, type: RecordType.SOA, TTL: 3600, data: SOA_DATA }]),
+			);
+		}
+		if (type === 'A' || type === 'AAAA') {
+			if ((opts.throwing ?? []).includes(name)) {
+				return Promise.reject(new Error('Network error'));
+			}
+			if (type === 'A' && opts.reachable.includes(name)) {
+				return Promise.resolve(
+					createDohResponse([{ name, type: RecordType.A }], [{ name, type: RecordType.A, TTL: 300, data: '192.0.2.53' }]),
+				);
+			}
+			if (type === 'AAAA' && (opts.ipv6Only ?? []).includes(name)) {
+				return Promise.resolve(
+					createDohResponse([{ name, type: RecordType.AAAA }], [{ name, type: RecordType.AAAA, TTL: 300, data: '2001:db8::53' }]),
+				);
+			}
+			return Promise.resolve(createDohResponse([{ name, type: RecordType.A }], []));
+		}
+		return Promise.resolve(createDohResponse([], []));
+	});
+
+	return calls;
+}
+
+async function run(domain = DOMAIN) {
+	const { checkNs } = await import('../src/tools/check-ns');
+	return checkNs(domain);
+}
+
+describe('checkNs — lame delegation (Sitting Ducks)', () => {
+	it('emits a HIGH finding when SOME delegated nameservers do not answer for the zone', async () => {
+		mockDelegation({
+			nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'],
+			reachable: ['ns1.provider-a.com'],
+		});
+		const r = await run();
+
+		const f = r.findings.find((finding) => finding.title.match(/lame delegation/i));
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('high');
+		expect(f!.detail).toContain('ns2.provider-b.net');
+		expect(f!.metadata?.lameDelegation).toBe('partial');
+		expect(f!.metadata?.nonResolvingNameservers).toEqual(['ns2.provider-b.net']);
+		expect(f!.metadata?.resolvingNameservers).toEqual(['ns1.provider-a.com']);
+	});
+
+	it('the partial case stays SCORED — it is a posture finding, not a measurement failure', async () => {
+		mockDelegation({
+			nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'],
+			reachable: ['ns1.provider-a.com'],
+		});
+		const r = await run();
+
+		// The zone still answers, so the category WAS measured: it must be graded, not excluded.
+		expect(r.checkStatus).not.toBe('error');
+		expect(r.partial).not.toBe(true);
+		// The `high` carries a real deduction (−25) rather than passing silently. It does NOT
+		// zero the category — deliberately no `missingControl`, so the NS weight is unchanged.
+		expect(r.score).toBe(75);
+	});
+
+	it('routes the ALL-fail case to the inconclusive path instead of scoring it 0', async () => {
+		mockDelegation({
+			nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'],
+			reachable: [],
+		});
+		const r = await run();
+
+		// A whole-delegation resolution failure is not a posture reading — the category is
+		// EXCLUDED from scoring (checkStatus 'error' + partial) rather than zeroed as a deficiency.
+		expect(r.checkStatus).toBe('error');
+		expect(r.partial).toBe(true);
+		expect(r.findings).toHaveLength(1);
+		expect(r.findings[0].severity).toBe('low');
+		expect(r.findings[0].title).toContain('not assessed');
+		expect(r.findings[0].metadata?.errorKind).toBe('dns_error');
+		expect(r.findings[0].metadata?.inconclusive).toBe(true);
+	});
+
+	it('the ALL-fail finding never claims the domain does not resolve', async () => {
+		// `domainResolves: false` is the package's non-resolving guard key. This probe only
+		// proves the nameserver HOSTS have no address, which cannot distinguish a dead zone
+		// from a resolver-side outage — asserting it here would fabricate an NXDOMAIN verdict.
+		mockDelegation({ nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'], reachable: [] });
+		const r = await run();
+		expect(r.findings[0].metadata?.domainResolves).toBeUndefined();
+	});
+
+	it('stays silent when every delegated nameserver resolves', async () => {
+		mockDelegation({
+			nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'],
+			reachable: ['ns1.provider-a.com', 'ns2.provider-b.net'],
+		});
+		const r = await run();
+
+		expect(r.findings.some((f) => f.title.match(/lame delegation/i))).toBe(false);
+		expect(r.findings).toHaveLength(1);
+		expect(r.findings[0].title).toContain('properly configured');
+		expect(r.passed).toBe(true);
+	});
+
+	it('does not flag an IPv6-only nameserver (AAAA fallback)', async () => {
+		mockDelegation({
+			nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'],
+			reachable: ['ns1.provider-a.com'],
+			ipv6Only: ['ns2.provider-b.net'],
+		});
+		const r = await run();
+
+		expect(r.findings.some((f) => f.title.match(/lame delegation/i))).toBe(false);
+		expect(r.checkStatus).not.toBe('error');
+	});
+
+	it('a THROWN probe is never reported as a lame nameserver (fail-soft, not evidence)', async () => {
+		mockDelegation({
+			nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'],
+			reachable: ['ns1.provider-a.com'],
+			throwing: ['ns2.provider-b.net'],
+		});
+		const r = await run();
+
+		expect(r.findings.some((f) => f.title.match(/lame delegation/i))).toBe(false);
+		expect(r.checkStatus).not.toBe('error');
+	});
+
+	it('every probe throwing leaves the rest of the NS result intact (indeterminate, not inconclusive)', async () => {
+		mockDelegation({
+			nsRecords: ['ns1.provider-a.com.', 'ns2.provider-b.net.'],
+			reachable: [],
+			throwing: ['ns1.provider-a.com', 'ns2.provider-b.net'],
+		});
+		const r = await run();
+
+		// No determinate outcome at all → emit nothing rather than manufacture a `total`
+		// verdict from a flaky resolver.
+		expect(r.findings.some((f) => f.title.match(/lame delegation|not assessed/i))).toBe(false);
+		expect(r.checkStatus).not.toBe('error');
+		expect(r.findings[0].title).toContain('properly configured');
+	});
+
+	it('probes at most 4 nameservers (bounded subrequest budget)', async () => {
+		// 4 == MAX_LAME_DELEGATION_PROBES; the constant's own value is pinned in
+		// packages/dns-checks/src/__tests__/checks/ns-lame-delegation.test.ts.
+		const nsRecords = ['ns1.p.com.', 'ns2.p.com.', 'ns3.p.com.', 'ns4.p.com.', 'ns5.p.com.', 'ns6.p.com.'];
+		const calls = mockDelegation({
+			nsRecords,
+			reachable: nsRecords.map((n) => n.replace(/\.$/, '')),
+		});
+		await run();
+
+		const probed = new Set(calls.filter((c) => c.type === 'A' && c.name.startsWith('ns')).map((c) => c.name));
+		expect(probed.size).toBe(4);
+		// Healthy zone → exactly one query per probed nameserver, no AAAA fallback spent.
+		expect(calls.filter((c) => c.type === 'AAAA' && c.name.startsWith('ns'))).toHaveLength(0);
+	});
+
+	it('does not probe when no NS records were returned (no wasted subrequests)', async () => {
+		const calls = mockDelegation({ nsRecords: [], reachable: [] });
+		const r = await run();
+
+		expect(r.findings[0].title).toMatch(/No NS records/i);
+		expect(calls.filter((c) => c.type === 'AAAA')).toHaveLength(0);
+	});
+});

--- a/test/check-ns.spec.ts
+++ b/test/check-ns.spec.ts
@@ -21,11 +21,31 @@ function mockNsResponses(nsRecords: string[], soaData?: string, aRecords?: strin
 	globalThis.fetch = vi.fn().mockImplementation((url: string) => {
 		const typeMatch = url.match(/type=([^&]+)/);
 		const type = typeMatch ? typeMatch[1] : '';
+		const nameMatch = url.match(/[?&]name=([^&]+)/);
+		const name = nameMatch ? decodeURIComponent(nameMatch[1]).replace(/\.$/, '').toLowerCase() : '';
 		if (type === 'NS') {
 			return Promise.resolve(createDohResponse([{ name: 'example.com', type: RecordType.NS }], nsAnswers));
 		}
-		if (type === 'A') {
-			return Promise.resolve(createDohResponse([{ name: 'example.com', type: RecordType.A }], aAnswers));
+		if (type === 'A' || type === 'AAAA') {
+			// The scanned domain keeps the caller-supplied A set — that is what drives the
+			// "delegation-only zone still resolves" branch.
+			if (name === 'example.com') {
+				return Promise.resolve(createDohResponse([{ name, type: RecordType.A }], type === 'A' ? aAnswers : []));
+			}
+			// The wildcard probe's random label must stay unanswered, or every case would
+			// report wildcard DNS.
+			if (name.startsWith('_bv-probe-')) {
+				return Promise.resolve(createDohResponse([{ name, type: RecordType.A }], []));
+			}
+			// Any other name here is a delegated nameserver hostname being probed for
+			// reachability. Default them to RESOLVING — a healthy delegation, which is what
+			// every case in this file models. Lame delegation has its own spec file.
+			return Promise.resolve(
+				createDohResponse(
+					[{ name, type: RecordType.A }],
+					type === 'A' ? [{ name, type: RecordType.A, TTL: 300, data: '192.0.2.53' }] : [],
+				),
+			);
 		}
 		if (type === 'SOA') {
 			return Promise.resolve(createDohResponse([{ name: 'example.com', type: RecordType.SOA }], soaAnswers));


### PR DESCRIPTION
## What

Adds lame-delegation detection to the NS check. A **lame delegation** is a parent zone pointing at nameservers that do not answer for the zone. The **partial** case is the exploitable one — the "Sitting Ducks" domain-hijack precondition: the domain still resolves via its healthy nameservers so nothing looks broken, while an attacker who claims the non-responsive nameserver at its DNS provider becomes authoritative for the zone **without ever touching the registrar**.

## The gap was verified, not assumed

`packages/dns-checks/src/scoring/classifiers/` holds only `dmarc.ts` — there is no NS classifier, and `checkNS` emits its own findings via `ns-analysis.ts`. A repo-wide grep for the concept found only two **non-detecting** mentions:

- a comment in `scoring/resolution.ts`,
- `scan-domain.ts`'s whole-zone `resolves: 'broken'` tri-state (apex SERVFAIL — a different layer, complementary rather than duplicative).

`check_authoritative_dns_infra` is a separate scored category that fully delegates to the operator-only `BV_INFRA_PROBE` binding.

## How the probe works

Workers cannot open a UDP socket to an individual nameserver, so authority is established the only way the recursive-resolver seam allows: **a delegated nameserver whose hostname has no address cannot be queried by anyone**, and therefore cannot be answering authoritatively for the zone. AAAA is consulted **only** when A comes back empty, so an IPv6-only nameserver is not a false positive.

| Verdict | Condition | Result |
|---|---|---|
| `partial` | some answer, some determinately do not | **HIGH** scored finding |
| `total` | at least one determinate failure, nothing answers | inconclusive path — `checkStatus: 'error'` + `partial: true` |
| `healthy` | every determinate probe resolved | silent |
| `indeterminate` | every probe threw | silent, rest of the NS result untouched |

`total` routes to the **existing inconclusive path** rather than scoring 0, because a whole-delegation resolution failure is a failure to *measure*, not a posture deficiency — the repo's "a measurement failure must not be scored as a failure" rule. It deliberately does **not** set `domainResolves: false` (the package's non-resolving guard key): this probe cannot distinguish a dead zone from a resolver-side outage.

An `unknown` outcome (a probe that *threw*) is excluded from the verdict arithmetic entirely, so a flaky resolver can neither manufacture a `total` nor suppress a real `partial`.

## Bounded

`MAX_LAME_DELEGATION_PROBES = 4`. At most **4 subrequests on a healthy zone** (one A each, no AAAA fallback spent) and at most 8 when all fail — regardless of how many NS records a zone publishes. The `total` case short-circuits before the SOA and wildcard probes. A cold `scan_domain` already fans out ~20, so the constant is pinned by a test.

## Scoring shape unchanged

Findings only. No weight, `CATEGORY_TIERS`, `IMPORTANCE_WEIGHTS`, `PROFILE_WEIGHTS`, or category change. The partial finding deliberately carries **no `missingControl`** — it penalises (−25 → category 75) without zeroing the category. All findings go through `createFinding()` / `buildCheckResult()`. Every probe path is fail-soft; nothing throws out of `checkNS`.

## Test-mock fidelity fix

`test/check-ns.spec.ts`'s shared mock answered *every* A query with the scanned domain's answer set, so probed nameserver hostnames resolved to nothing and 8 pre-existing cases went inconclusive. Made it name-aware: NS hostnames now resolve by default (a healthy delegation, which is what every case in that file models) and the wildcard probe's random label stays unanswered. **No assertion was changed.**

## Verification

| Gate | Exit |
|---|---|
| `npm run typecheck` | 0 |
| `npx eslint` (5 touched files) | 0 |
| NS specs (5 files, 44 tests) | 0 |
| `npm test` | 6842 passed, 13 skipped, **0 test failures** |

The full run reports one **suite-load** failure, `test/wasm-integration.test.ts`, which is pre-existing and environmental: `crates/bv-wasm-core/pkg/` does not exist on disk because `scripts/worktree-setup.sh` does not run wasm-pack (CI builds it with a cached binary). Confirmed failing standalone; this diff touches no Rust/wasm.

## Deliberately not done

- The non-apex **inherited** path returns before the probe — it is not probed, to avoid adding subrequests to every non-apex scan for a posture attributed to the apex.
- No per-nameserver `AA`/`REFUSED`/`SERVFAIL` observation — those are invisible through a recursive DoH resolver; address reachability is the observable proxy.
- `src/tools/ns-analysis.ts` (a legacy worker-side duplicate of the package helpers, unused by `src/tools/check-ns.ts`) was left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
