### PR TITLE
feat(dkim): extend the DKIM check into the record abuse surface

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/dkim-record-hygiene.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dkim-record-hygiene.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Pure-parser coverage for the DKIM record abuse-surface tags.
+ *
+ * Scope note: `x=` (signature expiry) and `l=` (body-length) are the tags that actually
+ * govern DKIM replay exposure, but RFC 6376 places them in the per-message DKIM-Signature
+ * HEADER (§3.5), not the DNS key record (§3.6.1). A passive DNS scanner never sees a
+ * message, so there is deliberately no parser for them here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { parseDkimFlags, analyzeHashRestriction, analyzeServiceTypes } from '../../checks/dkim-analysis';
+
+describe('parseDkimFlags', () => {
+	it('returns all-false when t= is absent', () => {
+		expect(parseDkimFlags('v=DKIM1; k=rsa; p=AAAA')).toEqual({ testMode: false, strictSubdomain: false, flags: [] });
+	});
+
+	it('parses t=y as test mode', () => {
+		expect(parseDkimFlags('v=DKIM1; t=y; p=AAAA').testMode).toBe(true);
+	});
+
+	it('parses flags in either order', () => {
+		expect(parseDkimFlags('v=DKIM1; t=y:s; p=AAAA')).toMatchObject({ testMode: true, strictSubdomain: true });
+		// The ordering the old /t=y/ substring scan missed.
+		expect(parseDkimFlags('v=DKIM1; t=s:y; p=AAAA')).toMatchObject({ testMode: true, strictSubdomain: true });
+	});
+
+	it('parses t=s alone as strict-only, never test mode', () => {
+		expect(parseDkimFlags('v=DKIM1; t=s; p=AAAA')).toMatchObject({ testMode: false, strictSubdomain: true });
+	});
+
+	it('tolerates whitespace and case', () => {
+		expect(parseDkimFlags('v=DKIM1;  t = Y ; p=AAAA').testMode).toBe(true);
+	});
+
+	it('ignores a t=y substring inside another tag value', () => {
+		expect(parseDkimFlags('v=DKIM1; n=remove t=y after rollout; p=AAAA').testMode).toBe(false);
+	});
+
+	it('does not read a tag whose name merely ends in t', () => {
+		expect(parseDkimFlags('v=DKIM1; nt=y; p=AAAA').testMode).toBe(false);
+	});
+
+	it('retains unknown flags without inventing meaning', () => {
+		expect(parseDkimFlags('v=DKIM1; t=y:z; p=AAAA').flags).toEqual(['y', 'z']);
+	});
+
+	it('treats an empty t= as no flags', () => {
+		expect(parseDkimFlags('v=DKIM1; t=; p=AAAA')).toEqual({ testMode: false, strictSubdomain: false, flags: [] });
+	});
+});
+
+describe('analyzeHashRestriction', () => {
+	it('returns null when h= is absent', () => {
+		expect(analyzeHashRestriction('v=DKIM1; k=rsa; p=AAAA')).toBeNull();
+	});
+
+	it('returns null for a healthy sha256-only restriction', () => {
+		expect(analyzeHashRestriction('v=DKIM1; h=sha256; p=AAAA')).toBeNull();
+	});
+
+	it('classifies sha1 without sha256 as sha1-only', () => {
+		expect(analyzeHashRestriction('v=DKIM1; h=sha1; p=AAAA')).toEqual({ algorithms: ['sha1'], kind: 'sha1-only' });
+	});
+
+	it('classifies a restriction omitting both sha256 and sha1 as no-sha256', () => {
+		expect(analyzeHashRestriction('v=DKIM1; h=sha512; p=AAAA')).toEqual({ algorithms: ['sha512'], kind: 'no-sha256' });
+	});
+
+	it('classifies sha1 listed alongside sha256 as sha1-permitted', () => {
+		expect(analyzeHashRestriction('v=DKIM1; h=sha256:sha1; p=AAAA')).toEqual({
+			algorithms: ['sha256', 'sha1'],
+			kind: 'sha1-permitted',
+		});
+	});
+
+	it('is order- and case-insensitive', () => {
+		expect(analyzeHashRestriction('v=DKIM1; h=SHA1 : SHA256; p=AAAA')?.kind).toBe('sha1-permitted');
+	});
+
+	it('does not mistake a sha1-prefixed algorithm name for sha1', () => {
+		// Exact-token comparison, so "sha1024"-shaped values cannot masquerade as sha1.
+		expect(analyzeHashRestriction('v=DKIM1; h=sha1024; p=AAAA')).toEqual({ algorithms: ['sha1024'], kind: 'no-sha256' });
+	});
+
+	it('returns null for an empty h=', () => {
+		expect(analyzeHashRestriction('v=DKIM1; h=; p=AAAA')).toBeNull();
+	});
+});
+
+describe('analyzeServiceTypes', () => {
+	it('returns null when s= is absent', () => {
+		expect(analyzeServiceTypes('v=DKIM1; k=rsa; p=AAAA')).toBeNull();
+	});
+
+	it('returns null for an empty s= (defaults to *)', () => {
+		expect(analyzeServiceTypes('v=DKIM1; s=; p=AAAA')).toBeNull();
+	});
+
+	it('treats s=* as covering email', () => {
+		expect(analyzeServiceTypes('v=DKIM1; s=*; p=AAAA')).toEqual({ services: ['*'], coversEmail: true });
+	});
+
+	it('treats s=email as covering email', () => {
+		expect(analyzeServiceTypes('v=DKIM1; s=email; p=AAAA')?.coversEmail).toBe(true);
+	});
+
+	it('treats email anywhere in the list as covering email', () => {
+		expect(analyzeServiceTypes('v=DKIM1; s=web:email; p=AAAA')?.coversEmail).toBe(true);
+	});
+
+	it('flags a list that admits neither email nor the wildcard', () => {
+		expect(analyzeServiceTypes('v=DKIM1; s=web; p=AAAA')).toEqual({ services: ['web'], coversEmail: false });
+	});
+
+	it('is case- and whitespace-insensitive', () => {
+		expect(analyzeServiceTypes('v=DKIM1; s= EMAIL ; p=AAAA')?.coversEmail).toBe(true);
+	});
+});

--- a/packages/dns-checks/src/checks/check-dkim.ts
+++ b/packages/dns-checks/src/checks/check-dkim.ts
@@ -10,7 +10,14 @@
 
 import type { CheckResult, DNSQueryFunction, Finding } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
-import { analyzeKeyStrength, consolidateSelectorProbeKeyStrengthFindings, getDkimTagValue } from './dkim-analysis';
+import {
+	analyzeHashRestriction,
+	analyzeKeyStrength,
+	analyzeServiceTypes,
+	consolidateSelectorProbeKeyStrengthFindings,
+	getDkimTagValue,
+	parseDkimFlags,
+} from './dkim-analysis';
 import { COMMON_DKIM_SELECTORS } from './dkim-selectors';
 import { attributeCnameChain } from './dkim-saas-attribution';
 
@@ -90,6 +97,31 @@ export async function checkDKIM(
 			foundSelectors.push(result.selector);
 			const delegatedTo = attributeCnameChain(result.chain);
 
+			// Multiple DKIM RRs published at one selector.
+			// RFC 6376 §3.6.2 (Resource Record Types for Key Storage) leaves verifier
+			// behaviour undefined when a selector resolves to
+			// more than one key record, so which key validates a signature is not something the
+			// domain owner controls. This is NOT the long-key-split case: the resolver layer
+			// rejoins the multiple character-strings of a single TXT RR before we see it, so two
+			// surviving DKIM-shaped entries here are two distinct RRs — the shape a stale key left
+			// behind by a half-finished rotation takes, and the shape an injected rogue key would
+			// take alongside the legitimate one.
+			if (result.records.length > 1) {
+				findings.push(
+					createFinding(
+						'dkim',
+						`Multiple DKIM records at one selector: ${result.selector}`,
+						'low',
+						`DKIM selector "${result.selector}" publishes ${result.records.length} separate key records. RFC 6376 §3.6.2 leaves it undefined which one a verifier uses, so signing outcomes are not deterministic — a stale key from an incomplete rotation can validate signatures the current key would reject. Publish exactly one key record per selector and use a fresh selector name to rotate.`,
+						{
+							recordCount: result.records.length,
+							selector: result.selector,
+							...(delegatedTo ? { delegatedTo } : {}),
+						},
+					),
+				);
+			}
+
 			// Validate each DKIM record
 			for (const record of result.records) {
 				const isRevoked = /p=\s*;/i.test(record) || /p=\s*$/i.test(record);
@@ -123,8 +155,12 @@ export async function checkDKIM(
 					);
 				}
 
-				// Check for testing mode
-				if (/t=y/i.test(record)) {
+				// Check for testing mode.
+				// Tag-aware parse rather than a bare /t=y/ scan: RFC 6376 §3.6.1 makes `t=` a
+				// colon-separated flag list in ANY order, so `t=s:y` is exactly as much test
+				// mode as `t=y:s` — the old substring test saw only the latter. It also stops a
+				// `t=y` substring inside the free-text `n=` notes tag from inventing a finding.
+				if (parseDkimFlags(record).testMode) {
 					findings.push(
 						createFinding(
 							'dkim',
@@ -252,16 +288,12 @@ export async function checkDKIM(
 					}
 				}
 
-				// Check for deprecated SHA-1 hash algorithm (RFC 8301)
-				// h= tag restricts which hash algorithms are accepted for this key.
-				// If only sha1 is listed (no sha256), the key cannot verify modern DKIM signatures.
-				const hashTag = getDkimTagValue(record, 'h');
-				if (hashTag) {
-					const hashAlgs = hashTag
-						.split(':')
-						.map((h) => h.trim().toLowerCase())
-						.filter(Boolean);
-					if (hashAlgs.length > 0 && !hashAlgs.includes('sha256') && hashAlgs.includes('sha1')) {
+				// Check the h= hash-algorithm restriction (RFC 8301).
+				// h= restricts which hash algorithms this key will verify. Three unhealthy
+				// shapes, only the first of which was previously detected.
+				const hashRestriction = analyzeHashRestriction(record);
+				if (hashRestriction) {
+					if (hashRestriction.kind === 'sha1-only') {
 						findings.push(
 							createFinding(
 								'dkim',
@@ -272,7 +304,56 @@ export async function checkDKIM(
 								`DKIM selector "${result.selector}" only accepts SHA-1 signatures (h=sha1). RFC 8301 §3.1 states SHA-1 MUST NOT be used and such signatures have permanently failed evaluation. Add sha256 to the h= tag or remove the restriction.`,
 							),
 						);
+					} else if (hashRestriction.kind === 'no-sha256') {
+						findings.push(
+							createFinding(
+								'dkim',
+								`Hash restriction excludes SHA-256: ${result.selector}`,
+								'medium',
+								`DKIM selector "${result.selector}" restricts acceptable hash algorithms to "${hashRestriction.algorithms.join(':')}", which omits sha256. RFC 8301 §3.2 makes rsa-sha256 the mandatory-to-implement algorithm, so conforming signers and verifiers are turned away by this key. Add sha256 to the h= tag or drop the restriction.`,
+								{
+									hashAlgorithms: hashRestriction.algorithms,
+									selector: result.selector,
+									...(delegatedTo ? { delegatedTo } : {}),
+								},
+							),
+						);
+					} else {
+						findings.push(
+							createFinding(
+								'dkim',
+								`SHA-1 permitted alongside SHA-256: ${result.selector}`,
+								'low',
+								`DKIM selector "${result.selector}" advertises "${hashRestriction.algorithms.join(':')}", accepting SHA-1 in addition to SHA-256. Modern signatures still verify, but the key tells verifiers it will honour a hash RFC 8301 §3.1 prohibits — an avoidable downgrade surface. Remove sha1 from the h= tag.`,
+								{
+									hashAlgorithms: hashRestriction.algorithms,
+									selector: result.selector,
+									...(delegatedTo ? { delegatedTo } : {}),
+								},
+							),
+						);
 					}
+				}
+
+				// Check the s= service-type restriction (RFC 6376 §3.6.1, §6.1.2).
+				// A list that admits neither "email" nor the "*" wildcard obliges verifiers to
+				// ignore the key for mail — the record looks healthy in DNS while the selector
+				// is inert for the one service it was almost certainly published to serve.
+				const serviceTypes = analyzeServiceTypes(record);
+				if (serviceTypes && !serviceTypes.coversEmail) {
+					findings.push(
+						createFinding(
+							'dkim',
+							`Service type excludes email: ${result.selector}`,
+							'medium',
+							`DKIM selector "${result.selector}" declares s=${serviceTypes.services.join(':')}, which admits neither "email" nor the "*" wildcard. RFC 6376 §6.1.2 obliges a verifier to ignore this key when validating mail, so signatures made with it do not authenticate. Set s=email or s=* (the default).`,
+							{
+								selector: result.selector,
+								serviceTypes: serviceTypes.services,
+								...(delegatedTo ? { delegatedTo } : {}),
+							},
+						),
+					);
 				}
 			}
 		}

--- a/packages/dns-checks/src/checks/dkim-analysis.ts
+++ b/packages/dns-checks/src/checks/dkim-analysis.ts
@@ -33,11 +33,106 @@ const RSA_SPKI_HEADERS: ReadonlyArray<{ prefix: string; bits: number; fullChars:
 	{ prefix: 'MIICIjANBgkqhkiG9w0BAQEFAAOCAg8A', bits: 4096, fullChars: 736 },
 ];
 
+/**
+ * Parsed RFC 6376 §3.6.1 `t=` flag list (colon-separated).
+ *
+ * Parsing goes through {@link getDkimTagValue} rather than a bare `/t=y/` scan so that
+ * (a) flags declared in any order are seen (`t=s:y` is as valid as `t=y:s`),
+ * (b) surrounding whitespace (`; t = y ;`) does not hide the flag, and
+ * (c) a `t=y` substring inside another tag's value (notably the free-text `n=` notes
+ *     tag) cannot manufacture a phantom test-mode finding.
+ */
+export type DkimFlags = {
+	/** `t=y` — test mode. Verifiers are told to treat a failure as if DKIM were not deployed. */
+	testMode: boolean;
+	/** `t=s` — strict mode: the signature's `i=` domain must not be a subdomain of `d=`. */
+	strictSubdomain: boolean;
+	/** Every parsed flag token, lowercased (unknown flags included; RFC 6376 says ignore them). */
+	flags: string[];
+};
+
+/** Parse the DKIM `t=` flag list from a record. Absent/empty `t=` yields all-false. */
+export function parseDkimFlags(record: string): DkimFlags {
+	const raw = getDkimTagValue(record, 't');
+	const flags = raw
+		? raw
+				.split(':')
+				.map((f) => f.trim().toLowerCase())
+				.filter(Boolean)
+		: [];
+	return { testMode: flags.includes('y'), strictSubdomain: flags.includes('s'), flags };
+}
+
+/**
+ * Classification of an `h=` (acceptable hash algorithms) restriction, per RFC 8301.
+ *
+ * - `sha1-only`     — sha1 listed, sha256 absent. RFC 8301 §3.1: rsa-sha1 MUST NOT be used and
+ *                     such signatures "have permanently failed evaluation" — the key cannot
+ *                     verify a conforming signature at all.
+ * - `no-sha256`     — the restriction lists neither sha256 nor sha1 (e.g. `h=sha512`). sha256 is
+ *                     the only mandatory-to-implement hash (RFC 8301 §3.2), so a signer/verifier
+ *                     pair using it is turned away by the key record.
+ * - `sha1-permitted`— sha256 IS listed but sha1 is listed alongside it. The key still verifies
+ *                     modern signatures, but it also advertises acceptance of a hash RFC 8301
+ *                     prohibits, leaving a downgrade surface for a forged sha1 signature.
+ */
+export type DkimHashRestriction = {
+	algorithms: string[];
+	kind: 'sha1-only' | 'no-sha256' | 'sha1-permitted';
+};
+
+/** Classify a record's `h=` restriction, or `null` when `h=` is absent, empty, or healthy. */
+export function analyzeHashRestriction(record: string): DkimHashRestriction | null {
+	const raw = getDkimTagValue(record, 'h');
+	if (!raw) return null;
+	const algorithms = raw
+		.split(':')
+		.map((h) => h.trim().toLowerCase())
+		.filter(Boolean);
+	if (algorithms.length === 0) return null;
+
+	const hasSha256 = algorithms.includes('sha256');
+	const hasSha1 = algorithms.includes('sha1');
+	if (!hasSha256) return { algorithms, kind: hasSha1 ? 'sha1-only' : 'no-sha256' };
+	if (hasSha1) return { algorithms, kind: 'sha1-permitted' };
+	return null;
+}
+
+/** Parsed RFC 6376 §3.6.1 `s=` service-type list. */
+export type DkimServiceTypes = {
+	services: string[];
+	/** True when the list admits email — i.e. contains `email` or the `*` wildcard. */
+	coversEmail: boolean;
+};
+
+/**
+ * Parse the `s=` service-type restriction. Returns `null` when `s=` is absent or empty
+ * (both mean the `*` default, which covers email).
+ *
+ * RFC 6376 §6.1.2 requires a verifier to ignore a key record whose service-type list does
+ * not admit email — so a mistyped or over-narrow `s=` silently disables the selector for
+ * mail while leaving a perfectly well-formed-looking record published in DNS.
+ */
+export function analyzeServiceTypes(record: string): DkimServiceTypes | null {
+	const raw = getDkimTagValue(record, 's');
+	if (!raw) return null;
+	const services = raw
+		.split(':')
+		.map((s) => s.trim().toLowerCase())
+		.filter(Boolean);
+	if (services.length === 0) return null;
+	return { services, coversEmail: services.includes('*') || services.includes('email') };
+}
+
 export function getDkimTagValue(record: string, tag: string): string | undefined {
 	if (!/^[a-zA-Z0-9]+$/.test(tag)) return undefined;
+	// `\s*` on BOTH sides of the `=`: RFC 6376 §3.2 defines `tag-spec = [FWS] tag-name [FWS]
+	// "=" [FWS] tag-value [FWS]`, so folding whitespace around the equals sign is valid and
+	// `t = y` / `p = <key>` must parse. Requiring a bare `tag=` silently returned undefined
+	// for every tag on such a record — for `p=` that reads as "no key material".
 	// nosemgrep: detect-non-literal-regexp -- `tag` is guarded to /^[a-zA-Z0-9]+$/ above (no metachars);
 	// pattern has no nested quantifiers, so it is linear-time (verified <2ms @ 500K chars). Not ReDoS.
-	const match = record.match(new RegExp(`(?:^|;)\\s*${tag}=([^;]*)`, 'i'));
+	const match = record.match(new RegExp(`(?:^|;)\\s*${tag}\\s*=([^;]*)`, 'i'));
 	return match?.[1]?.trim();
 }
 

--- a/test/check-dkim-abuse-surface.spec.ts
+++ b/test/check-dkim-abuse-surface.spec.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DKIM record abuse-surface checks — the record-hygiene signals that sit past
+ * "a selector with a usable key exists".
+ *
+ * Scope note: DKIM *replay* (re-sending a validly-signed message to new recipients to
+ * borrow the signer's reputation) is mitigated by the `x=` signature-expiry tag and
+ * worsened by the `l=` body-length tag — but both are per-MESSAGE DKIM-Signature HEADER
+ * tags, not DNS TXT record tags (RFC 6376 §3.5 vs §3.6.1). They are structurally invisible
+ * to a passive DNS scanner, so nothing here reads them. See `dkim-record-hygiene.test.ts`
+ * for the pure-parser coverage.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { RecordType } from '../src/lib/dns';
+import { scoreIndicatesMissingControl } from '../src/lib/scoring';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/** A ~4096-bit-length key body: long enough that analyzeKeyStrength returns `info`, so
+ *  key-strength findings never pollute these record-hygiene assertions. */
+const STRONG_KEY = 'A'.repeat(600);
+
+/**
+ * Mock DKIM TXT lookups for `<selector>._domainkey.example.com`.
+ * CNAME probes deliberately answer empty so SaaS attribution (`delegatedTo`) stays out
+ * of these assertions — the abuse-surface findings are what is under test, not attribution.
+ */
+function mockDkim(selectorRecords: Record<string, string[]>, domain = 'example.com') {
+	globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+		const params = new URL(url).searchParams;
+		const queriedName = params.get('name') ?? '';
+		const queriedType = params.get('type') ?? 'TXT';
+
+		if (queriedType === 'CNAME') {
+			return Promise.resolve(createDohResponse([{ name: queriedName, type: RecordType.CNAME }], []));
+		}
+
+		const selector = Object.keys(selectorRecords).find((sel) => queriedName === `${sel}._domainkey.${domain}`);
+		const answers = (selector ? selectorRecords[selector] : []).map((data) => ({
+			name: queriedName,
+			type: RecordType.TXT,
+			TTL: 300,
+			data: `"${data}"`,
+		}));
+		return Promise.resolve(createDohResponse([{ name: queriedName, type: RecordType.TXT }], answers));
+	});
+}
+
+async function runSelector(record: string | string[], selector = 'sel') {
+	const { checkDkim } = await import('../src/tools/check-dkim');
+	mockDkim({ [selector]: Array.isArray(record) ? record : [record] });
+	return checkDkim('example.com', selector);
+}
+
+describe('DKIM t= flag parsing', () => {
+	it('detects test mode when t=y is not the first flag (t=s:y)', async () => {
+		// RFC 6376 §3.6.1 makes t= an unordered colon-separated list. The previous
+		// substring scan (/t=y/) saw `t=y:s` but silently missed `t=s:y`.
+		const r = await runSelector(`v=DKIM1; k=rsa; t=s:y; p=${STRONG_KEY}`);
+		expect(r.findings.some((f) => f.title.includes('testing mode'))).toBe(true);
+	});
+
+	it('detects test mode across whitespace around the tag', async () => {
+		const r = await runSelector(`v=DKIM1; k=rsa; t = y ; p=${STRONG_KEY}`);
+		expect(r.findings.some((f) => f.title.includes('testing mode'))).toBe(true);
+	});
+
+	it('still detects the plain t=y form', async () => {
+		const r = await runSelector(`v=DKIM1; k=rsa; t=y; p=${STRONG_KEY}`);
+		const f = r.findings.find((x) => x.title.includes('testing mode'));
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('low');
+	});
+
+	it('does not fire on a t=y substring inside the free-text n= notes tag', async () => {
+		const r = await runSelector(`v=DKIM1; k=rsa; n=remove t=y after rollout; p=${STRONG_KEY}`);
+		expect(r.findings.some((f) => f.title.includes('testing mode'))).toBe(false);
+	});
+
+	it('does not treat t=s (strict subdomain) as test mode', async () => {
+		const r = await runSelector(`v=DKIM1; k=rsa; t=s; p=${STRONG_KEY}`);
+		expect(r.findings.some((f) => f.title.includes('testing mode'))).toBe(false);
+	});
+});
+
+describe('DKIM h= hash restriction', () => {
+	it('keeps the high-severity sha1-only finding (RFC 8301 §3.1)', async () => {
+		const r = await runSelector(`v=DKIM1; h=sha1; k=rsa; p=${STRONG_KEY}`);
+		const f = r.findings.find((x) => x.title.includes('Deprecated hash algorithm'));
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('high');
+	});
+
+	it('flags a restriction that omits sha256 entirely (h=sha512)', async () => {
+		const r = await runSelector(`v=DKIM1; h=sha512; k=rsa; p=${STRONG_KEY}`);
+		const f = r.findings.find((x) => x.title.includes('Hash restriction excludes SHA-256'));
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('medium');
+		expect(f!.metadata?.hashAlgorithms).toEqual(['sha512']);
+	});
+
+	it('flags sha1 permitted alongside sha256 as a downgrade surface', async () => {
+		const r = await runSelector(`v=DKIM1; h=sha256:sha1; k=rsa; p=${STRONG_KEY}`);
+		const f = r.findings.find((x) => x.title.includes('SHA-1 permitted alongside SHA-256'));
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('low');
+		// Not ALSO reported as sha1-only — the three h= shapes are mutually exclusive.
+		expect(r.findings.some((x) => x.title.includes('Deprecated hash algorithm'))).toBe(false);
+	});
+
+	it('stays silent on a healthy h=sha256 restriction', async () => {
+		const r = await runSelector(`v=DKIM1; h=sha256; k=rsa; p=${STRONG_KEY}`);
+		expect(r.findings.some((x) => /hash|SHA-1|SHA-256/i.test(x.title))).toBe(false);
+	});
+
+	it('stays silent when h= is absent', async () => {
+		const r = await runSelector(`v=DKIM1; k=rsa; p=${STRONG_KEY}`);
+		expect(r.findings.some((x) => /hash|SHA-1|SHA-256/i.test(x.title))).toBe(false);
+	});
+});
+
+describe('DKIM s= service-type restriction', () => {
+	it('flags a service list that admits neither email nor the wildcard', async () => {
+		const r = await runSelector(`v=DKIM1; s=web; k=rsa; p=${STRONG_KEY}`);
+		const f = r.findings.find((x) => x.title.includes('Service type excludes email'));
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('medium');
+		expect(f!.metadata?.serviceTypes).toEqual(['web']);
+	});
+
+	it('stays silent on s=email', async () => {
+		const r = await runSelector(`v=DKIM1; s=email; k=rsa; p=${STRONG_KEY}`);
+		expect(r.findings.some((x) => x.title.includes('Service type'))).toBe(false);
+	});
+
+	it('stays silent on the s=* wildcard', async () => {
+		const r = await runSelector(`v=DKIM1; s=*; k=rsa; p=${STRONG_KEY}`);
+		expect(r.findings.some((x) => x.title.includes('Service type'))).toBe(false);
+	});
+
+	it('stays silent when email appears anywhere in the list', async () => {
+		const r = await runSelector(`v=DKIM1; s=web:email; k=rsa; p=${STRONG_KEY}`);
+		expect(r.findings.some((x) => x.title.includes('Service type'))).toBe(false);
+	});
+
+	it('stays silent when s= is absent (default is *)', async () => {
+		const r = await runSelector(`v=DKIM1; k=rsa; p=${STRONG_KEY}`);
+		expect(r.findings.some((x) => x.title.includes('Service type'))).toBe(false);
+	});
+});
+
+describe('DKIM multiple records at one selector', () => {
+	it('flags two distinct key RRs published at the same selector', async () => {
+		const r = await runSelector([`v=DKIM1; k=rsa; p=${STRONG_KEY}`, `v=DKIM1; k=rsa; p=${'B'.repeat(600)}`]);
+		const f = r.findings.find((x) => x.title.includes('Multiple DKIM records at one selector'));
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('low');
+		expect(f!.metadata?.recordCount).toBe(2);
+	});
+
+	it('stays silent for a single record at the selector', async () => {
+		const r = await runSelector(`v=DKIM1; k=rsa; p=${STRONG_KEY}`);
+		expect(r.findings.some((x) => x.title.includes('Multiple DKIM records'))).toBe(false);
+	});
+});
+
+describe('DKIM abuse-surface findings respect the confidence model', () => {
+	// A selector discovered by probing is HEURISTIC. None of the record-hygiene findings
+	// may promote a result into the deterministic/verified + high-severity + missing-control
+	// shape that `scoreIndicatesMissingControl()` zeroes a Core category on.
+	const cases: Array<[string, string]> = [
+		['h= omits sha256', `v=DKIM1; h=sha512; k=rsa; p=${STRONG_KEY}`],
+		['h= permits sha1', `v=DKIM1; h=sha256:sha1; k=rsa; p=${STRONG_KEY}`],
+		['s= excludes email', `v=DKIM1; s=web; k=rsa; p=${STRONG_KEY}`],
+		['t=s:y test mode', `v=DKIM1; t=s:y; k=rsa; p=${STRONG_KEY}`],
+	];
+
+	for (const [name, record] of cases) {
+		it(`does not zero the category for: ${name}`, async () => {
+			const r = await runSelector(record);
+			expect(scoreIndicatesMissingControl(r.findings)).toBe(false);
+			expect(r.score).toBeGreaterThan(0);
+			// An observed active key is still an observed active key.
+			expect(r.controlPresent).toBe(true);
+		});
+	}
+
+	it('does not zero the category for multiple records at one selector', async () => {
+		const r = await runSelector([`v=DKIM1; k=rsa; p=${STRONG_KEY}`, `v=DKIM1; k=rsa; p=${'B'.repeat(600)}`]);
+		expect(scoreIndicatesMissingControl(r.findings)).toBe(false);
+		expect(r.score).toBeGreaterThan(0);
+	});
+
+	it('leaves the heuristic probe-miss path untouched', async () => {
+		const { checkDkim } = await import('../src/tools/check-dkim');
+		mockDkim({});
+		const r = await checkDkim('example.com');
+		expect(scoreIndicatesMissingControl(r.findings)).toBe(false);
+		expect(r.score).toBe(50);
+	});
+});


### PR DESCRIPTION
## Summary

Extends the DKIM check past key-existence into the record's **abuse surface**, and fixes two tag-parsing bugs that were silently suppressing findings the check already intended to make.

Verification of the brief first: **all four signals named in the task were already implemented** in `packages/dns-checks/src/checks/check-dkim.ts`. What was genuinely missing were adjacent shapes of the same tags, plus the parser bugs. There is **no DKIM classifier** — `scoring/classifiers/` contains only `dmarc.ts` — so `check-dkim.ts` is the single emission site and there is no double-counting hazard.

### Already covered (no change made)

| Signal | Status |
|---|---|
| `t=y` test mode | Covered — `low`, severity left untouched |
| Weak key length | Covered thoroughly by `analyzeKeyStrength` (DER SPKI header + char-count fallback, RFC 8301 1024-bit deprecation, truncated/split-key detection) |
| `h=` naming a broken hash | Covered **only** for the sha1-without-sha256 case (`high`) |
| Revoked empty `p=` | Covered — `medium`, plus the all-revoked → `info` non-sending consolidation |

### Genuinely added

- **`s=` service type admitting neither `email` nor `*`** (`medium`). RFC 6376 §6.1.2 obliges a verifier to ignore such a key for mail — the selector is inert for email while the record looks perfectly healthy in DNS. Nothing read `s=` before.
- **`h=` omitting sha256 entirely**, e.g. `h=sha512` (`medium`). rsa-sha256 is mandatory-to-implement, so conforming signers and verifiers are turned away. Previously silent — the old condition required sha1 to be present.
- **`h=` listing sha1 *alongside* sha256** (`low`). Modern signatures still verify, but the key advertises acceptance of a hash RFC 8301 prohibits — an avoidable downgrade surface. Previously silent.
- **Multiple DKIM RRs at one selector** (`low`). RFC 6376 leaves verifier selection undefined, so signing outcomes are non-deterministic. This is the shape a half-finished rotation takes — and the shape an injected rogue key takes alongside the legitimate one. Explicitly *not* the long-key-split case: the resolver rejoins a single RR's character-strings before the check sees them, so two surviving entries are two distinct RRs.

### Parsing fixes

- **`t=` is an unordered colon-separated flag list.** `t=s:y` is exactly as much test mode as `t=y:s`, but the `/t=y/` substring scan saw only the latter. The same scan would also fire on a `t=y` substring inside the free-text `n=` notes tag. Now parsed tag-aware.
- **`getDkimTagValue` rejected folding whitespace around `=`.** RFC 6376's `tag-spec` ABNF is `[FWS] tag-name [FWS] "=" [FWS] tag-value`, so `t = y` is valid — and the helper returned `undefined` for *every* tag on such a record. For `p=` that read as "no key material at all". Blast radius is DKIM-only (helper is used by nothing else).

## Scope: DKIM replay is not DNS-observable

DKIM **replay** — re-sending a validly-signed message to new recipients to borrow the signer's reputation — is mitigated by the `x=` signature-expiry tag and worsened by the `l=` body-length tag. Both live in the **per-message `DKIM-Signature` header** (RFC 6376 §3.5), **not** the DNS key record (§3.6.1). A passive DNS scanner never sees a message, so no check here reads them, and none should be added.

The one replay-adjacent tag that *is* in DNS is `t=s` (requires `i=` to match `d=` exactly rather than permitting any subdomain). Its **absence** is the internet-wide default, so flagging it would be pure noise — it is parsed and exposed on `DkimFlags.strictSubdomain`, but deliberately emits no finding.

## Constraints honoured

- **Findings only.** No change to any weight, `CATEGORY_TIERS`, `IMPORTANCE_WEIGHTS`, `PROFILE_WEIGHTS`, or grade band. No existing finding's severity changed, and no existing test assertion was edited.
- All findings built via `createFinding()` / `buildCheckResult()`.
- **Confidence model respected.** Every new finding is `medium`/`low`, so none can reach the deterministic/verified + high-severity + missing-control-text shape that `scoreIndicatesMissingControl()` zeroes a Core category on. A probe-discovered selector stays heuristic. Asserted directly in a dedicated test block, including that the heuristic probe-miss floor (score 50) is untouched.
- **Cross-repo scoring parity unaffected** — `parity-corpus.contract.test.ts` passes; no DKIM parity fixture exercises `t=`, `s=`, or multi-record selectors.

## Tests

- `test/check-dkim-abuse-surface.spec.ts` (new, 23 cases) — worker-side via `test/helpers/dns-mock.ts`, `restore()` in `afterEach`, dynamic `await import()` inside test fns. Every new signal gets a fires-when-it-should **and** stays-silent-when-it-should case, plus the confidence-model block.
- `packages/dns-checks/src/__tests__/checks/dkim-record-hygiene.test.ts` (new, 24 cases) — pure-parser coverage for `parseDkimFlags` / `analyzeHashRestriction` / `analyzeServiceTypes`, including the `sha1024`-must-not-match-sha1 trap and the `nt=y` must-not-read-as-`t=` trap.

## Verification

| Gate | Exit |
|---|---|
| `npm run typecheck` | **0** |
| `npm -w packages/dns-checks run typecheck` | **0** |
| `npx eslint` (4 touched files) | **0** |
| DKIM + parity specs (6 files, 171 tests) | **0** |
| `npm test` (full) | **1** — see below |

The full suite is **6867 passed / 0 failed / 13 skipped**, with one *suite* failing to load: `test/wasm-integration.test.ts` errors at module load with `No such module …bv_wasm_core_bg.wasm`. `crates/bv-wasm-core/pkg/` does not exist in this worktree — that artifact is produced only by `npm run build:wasm` (wasm-pack), which neither `scripts/worktree-setup.sh` nor `npm ci` runs. Pre-existing environment gap, unrelated to this change, which touches no wasm code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
