### PR TITLE
chore(scoring): bump SCORING_MODEL_VERSION to 1.5.0 for the new detections

### DIFF
--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -48,8 +48,22 @@
  *   `prioritize_csc_leads`) now ABSTAIN on a check that never completed — `not_assessed` /
  *   `assessed: false` — rather than grading it as a pass or fail; see the `[3.37.0]`
  *   CHANGELOG.md entry for the full per-tool breakdown.
+ * - 1.5.0 — three new detection families that penalise previously-unmeasured defects. No
+ *   weight, tier, grade band, severity penalty or profile-detection rule changed; scores move
+ *   only because real defects are now seen. (a) NS: lame delegation — a delegated nameserver
+ *   whose hostname resolves to no address cannot answer for the zone, the "Sitting Ducks"
+ *   hijack precondition. Partial (some NS resolving) is a scored `high`; total is routed to
+ *   the inconclusive path, NOT scored 0. (b) CAA: a long RRset TTL widens the CA reuse window
+ *   (the CA/Browser Forum BRs permit issuing within the TTL **or** 8 hours, whichever is
+ *   GREATER), and a CAA policy on an unsigned zone is strippable in transit — read from the
+ *   lookup's own AD flag. Both `low`/`info`. (c) DKIM: `s=` admitting neither `email` nor `*`,
+ *   `h=` omitting sha256, sha1 alongside sha256, and multiple RRs at one selector. Also two
+ *   parser fixes that REMOVE false positives — folding whitespace around `=` is RFC-legal and
+ *   previously made every tag on such a record read as absent (for `p=` that surfaced as a
+ *   spurious revoked-key finding), and `t=` is an unordered colon list so `t=s:y` missed test
+ *   mode. A domain may therefore move in EITHER direction under 1.5.0.
  */
-export const SCORING_MODEL_VERSION = '1.4.0';
+export const SCORING_MODEL_VERSION = '1.5.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';


### PR DESCRIPTION
**Blocks the deploy.** The three detection families merged today — #601 lame delegation, #602 DKIM abuse surface, #603 CAA enforceability — all move real domains' scores, and nothing bumped the model version.

That is exactly what this constant exists to prevent. Without the bump, every `analyze_drift` and `compare_baseline` consumer sees movement between two scans and attributes it to **their own domain** rather than to a policy change on our side. Shipping the detections without the stamp would corrupt customer drift baselines with no way to tell why.

Precedent: **1.3.0** was also a finding-level change (non-apex targets no longer firing false NS/CAA/DNSSEC missing-record findings) rather than a weight change — and it bumped.

To be explicit about what did *not* change: no weight, tier, grade band, severity penalty, missing-control rule, or profile-detection rule moved in any of those three PRs. Scores move only because defects that were previously invisible are now measured.

The history entry records that a domain may move in **either** direction, because #602 also fixed two parser bugs that were generating false positives:
- RFC-legal folding whitespace around `=` made every tag on such a record read as absent — for `p=` that surfaced as a spurious revoked-key finding
- `t=` is an unordered colon list, so `t=s:y` missed test mode

**Verified** (exit codes captured directly, not through a pipe): `worktree-setup` 0 · `npm run typecheck` 0 · `scoring-version` + `format-scan-report` specs 0 (21 passed). Both suites reference the constant symbolically, so no literal needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)