### PR TITLE
chore: release 3.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.41.0] - 2026-08-03
+
+**Scoring model 1.5.0 → 1.6.0. `@blackveil/dns-checks` 1.9.0 → 1.10.0** (package scoring behaviour changed, so `PARITY_CORPUS_VERSION` moves in lockstep and the bv-web-prod tarball needs re-vendoring).
+
+Both changes here were driven by a **1000-domain stratified measurement** of the live model rather than by argument — a Tranco-derived corpus spanning four popularity bands, 154 TLDs, and four detected profiles, scanned locally at model 1.5.0 with zero attrition.
+
+### Changed
+
+- **MTA-STS absence is now graded, not category-zeroing — most domains score HIGHER.** Across the corpus, `mta_sts` had a mean score of **3.3 with 96.5% of measured domains scoring exactly zero**. A control that virtually nobody passes is a flat penalty, not a discriminator: it separated no domains while consuming 3 of ~80 base points and zeroing its own category. Independent research found no documented incidents attributable to a missing MTA-STS policy and a ~29.6% misconfiguration rate among adopters. Absence now behaves like CAA, SVCB-HTTPS and TLS-RPT, which deliberately do not set `missingControl` for exactly this reason. **The weight (3), the severity, and the tier are unchanged** — only the zeroing behaviour. Deployed-but-broken MTA-STS is untouched: a bad `version:`, a missing or `none` `mode:`, an uncovered MX set, and an unfetchable policy all continue to emit confident graded findings, and a test now locks that boundary. Measured impact on a 150-domain resample, restricted to the 141 domains where no check's status changed between runs: mean **+1.73**, median +2, **nothing moved down**, maximum gain +4, and **14 domains (9.9%) crossed a NIST band — every one upward** (C→B 9, D→C 3, B→A 1, F→D 1). (#610)
+- **CAA long-TTL threshold corrected to the CA/Browser Forum floor.** It shipped in 3.40.0 at 24h, which was a guess with an arbitrary buffer. Direct measurement of all 161 CAA-publishing corpus domains found 135 RRsets with a **maximum TTL of 21600s (6h)** — and since the BR rule permits issuing within the record's TTL *or* 8 hours, whichever is **greater**, the 8h floor dominated every observed TTL and the finding could not fire by construction. The threshold is now the 28800s floor itself, so the finding fires only when a TTL genuinely extends the reuse window beyond it. It will still fire very rarely; that is a property of real-world CAA TTLs, not a dead detector, and the code comment records the measured basis so it is not re-tuned. (#610)
+
 ## [3.40.0] - 2026-08-03
 
 **Scoring model 1.4.0 → 1.5.0.** Three new detection families measure defects that were previously invisible. No weight, tier, grade band, severity penalty, missing-control rule, or profile-detection rule changed — but scores move, and a domain may move in **either** direction, because two DKIM parser fixes also remove false positives. Consumers comparing two scans should read `scoringModelVersion` before attributing a delta to the domain. (#607)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.40.0",
+	"version": "3.41.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.40.0",
+			"version": "3.41.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.40.0",
+	"version": "3.41.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.9.0",
+	"version": "1.10.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.9.0';
+export const PARITY_CORPUS_VERSION = '1.10.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.40.0",
+  "version": "3.41.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Cuts 3.41.0. Version-sync surfaces: `package.json` + lock, `server.json` (top-level, remotes-only), `CHANGELOG.md`. `SERVER_VERSION` auto-derives from `pkg.version`.

**Also bumps `@blackveil/dns-checks` 1.9.0 → 1.10.0** with `PARITY_CORPUS_VERSION` in lockstep. #610 changed *package* scoring behaviour, so shipping it under an unchanged package version would let bv-web-prod vendor a tarball whose scoring moved beneath a pinned version — the same defect class as shipping changed scores under an unchanged `SCORING_MODEL_VERSION`. The bump also rotates the `src/lib/cache.ts` scan cache key, which is correct: cached pre-1.6.0 scores should not be served alongside post-1.6.0 ones.

**Scoring model 1.5.0 → 1.6.0.** Contents: MTA-STS absence grades instead of zeroing its category, and the CAA long-TTL threshold moves to the CA/Browser Forum 8h floor.

### Both changes were decided by measurement, not argument

A **1000-domain stratified corpus** (Tranco-derived, four popularity bands, 154 TLDs, four detected profiles, zero attrition, scanned locally at model 1.5.0) showed:

- `mta_sts` at **mean 3.3 with 96.5% of measured domains scoring exactly zero** — a flat penalty that discriminated nothing while consuming 3 of ~80 points and zeroing its own category.
- The 24h CAA TTL threshold shipped in 3.40.0 sat **above the entire observed distribution** (max 21600s / 6h across 135 RRsets from 161 CAA publishers), so that finding could not fire by construction.

### Measured impact of the MTA-STS change

150-domain resample, restricted to the **141 domains whose check statuses were identical between runs** (so the only thing that can move a score is this change):

| metric | value |
| --- | ---: |
| mean delta | **+1.73** |
| median delta | +2 |
| moved down | **0** |
| max gain | +4 |
| crossed a NIST band | **14 (9.9%) — all upward** |

Band transitions: C→B 9, D→C 3, B→A 1, F→D 1.

Four downward movers across the full 149 were each investigated and are measurement variance (an `ssl` check timing out and being excluded, an `http_security` check newly completing and joining the denominator) — none attributable to the change.

**Deployed-but-broken MTA-STS is untouched.** A bad `version:`, a missing or `none` `mode:`, an uncovered MX set, and an unfetchable policy all continue to emit confident graded findings; #610 added a test locking that boundary.

**Verified** (exit codes captured directly, not through a pipe): `worktree-setup` 0 · package build 0 · `npm run typecheck` 0 · `test/audits/` 424 passed · parity contract + package suite 618 passed across 32 files.

Post-merge: tag → `npm run deploy:prod` → verify live → MCP Registry publish **last**. Prod goes 3.39.0 → 3.41.0 in a single deploy (model 1.4.0 → 1.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)