### PR TITLE
fix(deploy): build the workspace package before typechecking it

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"check:deploy-freshness": "tsx scripts/ci/deploy-freshness-check.ts",
 		"check:bindings": "npm run typecheck",
 		"check:bindings:prod": "wrangler types --config wrangler.production.jsonc && tsc --noEmit",
-		"deploy:prod": "npm run check:deploy-freshness && npm run check:bindings && npm -w packages/dns-checks run build && node scripts/inject-private-config.cjs && npm run check:bindings:prod && npx wrangler deploy --minify --config wrangler.production.jsonc",
+		"deploy:prod": "npm run check:deploy-freshness && npm -w packages/dns-checks run build && npm run check:bindings && node scripts/inject-private-config.cjs && npm run check:bindings:prod && npx wrangler deploy --minify --config wrangler.production.jsonc",
 		"test": "node scripts/vitest-filter-workerd.mjs",
 		"typecheck": "wrangler types && tsc --noEmit",
 		"lint": "eslint .",


### PR DESCRIPTION
`deploy:prod` ran `check:bindings` (= typecheck) **before** `npm -w packages/dns-checks run build`:

```
check:deploy-freshness && check:bindings && npm -w packages/dns-checks run build && …
                          ^^^^^^^^^^^^^^     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                          typecheck here     but the types it needs are built here
```

Worker code imports the package's built `dist/`, not its `src/`, so any checkout whose `dist/` is stale fails the gate with errors that look like genuine type breaks but are artifacts of the build order.

**This bit the real 3.41.0 deploy.** The work had been done in git worktrees and the package was never rebuilt in the main checkout, so `dist/` was ~3h behind `src/` and predated #603's `rawQueryDNS` option. The deploy aborted with four errors in `src/tools/check-caa.ts` — including `'rawQueryDNS' does not exist in type` — none of which reflected anything wrong with the code on `main`. CI never sees this because it always builds fresh.

The build is a prerequisite of the typecheck, so ordering it first is correct independently of the bug.

### Note on verification

Removing `dist/` entirely does **not** reproduce the failure — typecheck exits 0, because TypeScript resolves an *absent* `dist` differently than a *stale* one. The reproduction that matters is the real deploy, which failed on a stale `dist` and succeeded immediately after a package build.

Verified here that the new order is green (exit codes captured directly): package build **0**, typecheck **0**, and `rawQueryDNS` present in the rebuilt declarations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)