### PR TITLE
fix(core): add Mailjet to the SPF trust-surface catalog (#572 part 1)

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/spf-trust-surface.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/spf-trust-surface.test.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Core SPF trust-surface catalog coverage.
+ *
+ * The worker layer (`src/tools/spf-trust-surface.ts`) carries its own copy of this
+ * catalog, so a platform recognized there is NOT automatically recognized here —
+ * and DIRECT consumers of the vendored core (bv-web-prod calls `checkSPF` from
+ * the published package, not the bv-mcp worker wrapper) see only this file's
+ * catalog. Issue #572 was exactly that drift: Mailjet was added worker-side in
+ * PR #570 and left out of the core, so bv-web-prod under-counted the trust surface.
+ *
+ * These cases pin the core half of that parity.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { analyzeTrustSurface } from '../../checks/spf-trust-surface';
+
+describe('core SPF trust-surface catalog — Mailjet (#572)', () => {
+	it('recognizes the canonical spf.mailjet.com include', () => {
+		const findings = analyzeTrustSurface('v=spf1 include:spf.mailjet.com -all');
+
+		expect(findings).toHaveLength(1);
+		expect(findings[0].metadata?.platform).toBe('Mailjet');
+		expect(findings[0].metadata?.trustSurface).toBe(true);
+		expect(findings[0].metadata?.includeDomain).toBe('spf.mailjet.com');
+	});
+
+	it('matches Mailjet sub-hosts via the registrable-key suffix rule', () => {
+		const findings = analyzeTrustSurface('v=spf1 include:eu.spf.mailjet.com -all');
+
+		expect(findings).toHaveLength(1);
+		expect(findings[0].metadata?.platform).toBe('Mailjet');
+		expect(findings[0].metadata?.includeDomain).toBe('eu.spf.mailjet.com');
+	});
+
+	it('counts Mailjet toward the multi-platform trust-surface summary', () => {
+		const findings = analyzeTrustSurface('v=spf1 include:_spf.google.com include:spf.mailjet.com -all');
+
+		// 2 per-platform findings + 1 summary.
+		expect(findings).toHaveLength(3);
+		const summary = findings.find((f) => f.metadata?.platformCount !== undefined);
+		expect(summary).toBeDefined();
+		expect(summary!.metadata?.platformCount).toBe(2);
+		expect(summary!.title).toContain('2 shared platforms');
+	});
+});
+
+describe('core SPF trust-surface catalog — unrecognized senders (#572 part 2, PARKED)', () => {
+	// The worker layer also counts unrecognized-but-broad shared senders toward the
+	// trust-surface total (`src/tools/spf-trust-surface.ts`, the `unrecognized shared
+	// sender` heuristic). The core deliberately does NOT — adopting it changes count
+	// semantics corpus-wide and moves the `matchedPlatforms.length > 1` emission
+	// threshold, so it is an operator call, not a config edit.
+	//
+	// TODO(operator decision): pin the CURRENT core semantics here, so that adopting
+	// part 2 later has to break a test on purpose rather than drift silently.
+	//
+	// The trade-off to encode:
+	//   - Assert the gap (e.g. one recognized + one unrecognized ESP yields exactly 1
+	//     finding and no summary) → part 2 becomes a deliberate, reviewed change, but
+	//     this file then asserts behavior we may consider a defect.
+	//   - Leave it unasserted → the core stays free to converge on the worker heuristic
+	//     without a test edit, at the cost of no tripwire on the divergence.
+	//
+	// A record that exercises the seam: 'v=spf1 include:_spf.google.com include:mail.some-esp.example -all'
+	it.todo('pins whether unrecognized shared senders count toward the trust surface');
+});

--- a/packages/dns-checks/src/checks/spf-trust-surface.ts
+++ b/packages/dns-checks/src/checks/spf-trust-surface.ts
@@ -46,6 +46,10 @@ const MULTI_TENANT_PLATFORMS: ReadonlyMap<string, PlatformInfo> = new Map([
 	['spf.messagelabs.com', { name: 'Symantec/Broadcom', risk: 'Shared sending infrastructure' }],
 	['_spf.atlassian.net', { name: 'Atlassian', risk: 'Any Atlassian customer can send as your domain' }],
 	['xero.com', { name: 'Xero', risk: 'Any Xero customer can send as your domain' }],
+	// #572: Mailjet — multi-tenant ESP. Registrable key so `spf.mailjet.com` and any
+	// Mailjet sub-host match via the endsWith('.'+key) rule. Mirrors the worker-layer
+	// catalog in bv-mcp `src/tools/spf-trust-surface.ts` (added in PR #570 / #566).
+	['mailjet.com', { name: 'Mailjet', risk: 'Any Mailjet customer can send as your domain' }],
 ]);
 
 /**


### PR DESCRIPTION
Closes the core half of #572 (part 1 only).

## What

The worker layer learned Mailjet in PR #570 (#566), but the parity-locked core catalog did not. DIRECT consumers of the vendored package — notably bv-web-prod, which calls core `checkSPF` rather than the bv-mcp worker wrapper — therefore still under-count the SPF trust surface, reporting e.g. "2 shared platforms" for a 3-ESP record.

- Adds the registrable key `mailjet.com` to `MULTI_TENANT_PLATFORMS`, so `spf.mailjet.com` and any Mailjet sub-host match via the existing `endsWith('.' + key)` rule.
- Adds `packages/dns-checks/src/__tests__/checks/spf-trust-surface.test.ts` — the core had no trust-surface coverage at all, so nothing tripped on the worker/core catalog drift.

## What this deliberately does NOT do

Part 2 of #572 (counting unrecognized broad shared senders toward the total) is **not** included. It moves the `matchedPlatforms.length > 1` emission threshold, so a "1 recognized + 1 unrecognized ESP" domain would start emitting a trust-surface finding corpus-wide and the SPF parity corpus would move. That is an operator call, not a config edit. Left as a documented `it.todo` rather than silently adopting either semantics.

## Release impact

This is a core change, so the bv-web-prod under-count does not clear until: `@blackveil/dns-checks` version bump (currently 1.10.0 — the exact version vendored) → npm publish → re-vendor into bv-web-prod (tarball + sha256 + `VENDORED_VERSION` in BOTH `shared/lib/scan/parity.contract.test.ts` and `shared/lib/mcp-scan/mcp-grade-parity.contract.test.ts`) → redeploy. Operator-gated cross-repo release; check the app Worker bundle budget before re-vendoring.

## Verification

- `packages/dns-checks` suite: 621 passed / 33 files, exit 0 (incl. `parity-corpus.contract.test.ts`)
- Rebuilt `dist` confirms Mailjet compiled into the published artifact
- Worker `spf-trust-surface` + `check-spf` + `scan-domain` specs: 87 passed, exit 0
- `npm run typecheck` and `npm run lint`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)