### PR TITLE
chore(deps): bump hono 4.12.32 -> 4.12.34 (GHSA-8j4g-w8fx-2239)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
 				"@types/punycode": "^2.1.4",
 				"drizzle-kit": "^0.31.10",
 				"eslint": "10.8.0",
-				"hono": "4.12.32",
+				"hono": "4.12.34",
 				"playwright": "^1.62.0",
 				"tsup": "8.5.1",
 				"typescript": "6.0.3",
@@ -3393,9 +3393,9 @@
 			}
 		},
 		"node_modules/hono": {
-			"version": "4.12.32",
-			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz",
-			"integrity": "sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==",
+			"version": "4.12.34",
+			"resolved": "https://registry.npmjs.org/hono/-/hono-4.12.34.tgz",
+			"integrity": "sha512-GqXJqY/xJkJmuloTrnV1ZEXG3fqte+VjkUqoRNZXcrUidiUOP4fMSIHHY4tsqZBK++kVyWmt/AAfSUuy57/eSA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=16.9.0"
@@ -5188,7 +5188,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.9.0",
+			"version": "1.10.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
 		"@types/punycode": "^2.1.4",
 		"drizzle-kit": "^0.31.10",
 		"eslint": "10.8.0",
-		"hono": "4.12.32",
+		"hono": "4.12.34",
 		"playwright": "^1.62.0",
 		"tsup": "8.5.1",
 		"typescript": "6.0.3",


### PR DESCRIPTION
Unblocks merges repo-wide. The required `Dependency audit` check is currently red on `main` and on every open branch: hono `<4.12.34` carries a moderate ReDoS in the CORS middleware via `Access-Control-Request-Headers` ([GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239)), so `npm audit --omit=dev --audit-level=moderate` exits 1.

Takes the minimal fix version `4.12.34` rather than the available `4.13.0`, to keep the blast radius to the advisory itself. Root `package.json` pins hono exactly; `packages/bv-whois` already carries a `^4.12.32` range that admits the fix, so it needs no edit.

Verification: `npm audit --omit=dev --audit-level=moderate` now reports 0 vulnerabilities. Full suite run locally against the bumped dependency; CI `build-and-test` is the authority.

Found while trying to merge #614, which this blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)