### PR TITLE
chore: release 3.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.42.0] - 2026-08-04
+
+**Scoring model 1.6.0 → 1.7.0. `@blackveil/dns-checks` 1.10.0 → 1.11.0** (package check behaviour changed, so `PARITY_CORPUS_VERSION` moves in lockstep and the bv-web-prod tarball needs re-vendoring).
+
+### Changed
+
+- **Mailjet is now recognised in the core SPF trust-surface catalog.** The worker layer learned Mailjet in 3.36.x (#566 / #570), but the parity-locked core catalog did not — so every DIRECT consumer of the published package under-counted the trust surface, reporting e.g. "2 shared platforms" for a three-ESP record. bv-web-prod is such a consumer: it calls the package's `checkSPF`, not the bv-mcp worker wrapper, so its scan output carried the under-count. The registrable key `mailjet.com` is now in `MULTI_TENANT_PLATFORMS`, matching `spf.mailjet.com` and any Mailjet sub-host through the existing suffix rule. (#614, closes part 1 of #572)
+
+  **This moves scores for a narrow population, and the direction is down.** The worker's trust-surface post-processor reconstructs its DMARC context from the core's own trust-surface finding metadata, falling back to no-corroboration when the core recognised nothing. A Mailjet-only SPF record previously produced no core trust-surface finding at all, so the worker always defaulted to `info`. The core now supplies real corroboration metadata, so a Mailjet include on a domain with `p=none` and relaxed alignment surfaces as `medium` (the ordinary −15 severity penalty on the `spf` category) rather than `info`. This is the existing corroboration rule finally applying to Mailjet as it already did to the other 18 cataloged platforms — Mailjet was the anomaly, not the new severity. Domains with enforcing DMARC are unaffected. The affected population is unmeasured against the corpus.
+
+  Deliberately NOT included: counting unrecognised broad shared senders toward the trust-surface total (part 2 of #572). That moves the `matchedPlatforms.length > 1` emission threshold and would re-grade corpus-wide, so it stays an explicit operator call; the core carries a documented `it.todo` rather than silently adopting either semantics.
+
+- **`hono` 4.12.32 → 4.12.34** — moderate ReDoS in the CORS middleware via `Access-Control-Request-Headers` ([GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239)). Minimal fix version taken rather than the available 4.13.0. (#615)
+
+### Added
+
+- Core coverage for the SPF trust-surface catalog (`packages/dns-checks/src/__tests__/checks/spf-trust-surface.test.ts`). The core had none, which is why the worker/core catalog drift went unnoticed.
+
 ## [3.41.0] - 2026-08-03
 
 **Scoring model 1.5.0 → 1.6.0. `@blackveil/dns-checks` 1.9.0 → 1.10.0** (package scoring behaviour changed, so `PARITY_CORPUS_VERSION` moves in lockstep and the bv-web-prod tarball needs re-vendoring).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.41.0",
+	"version": "3.42.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.41.0",
+			"version": "3.42.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"
@@ -5188,7 +5188,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.10.0",
+			"version": "1.11.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.41.0",
+	"version": "3.42.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.10.0",
+	"version": "1.11.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.10.0';
+export const PARITY_CORPUS_VERSION = '1.11.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.41.0",
+  "version": "3.42.0",
   "remotes": [
     {
       "type": "streamable-http",

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -78,8 +78,18 @@
  *   floor (the only non-arbitrary crossover — below it the floor dominates); the same corpus
  *   observed a maximum CAA TTL of 6h across 135 RRsets, so this finding fires ~never either
  *   way and no score moves because of it.
+ * - 1.7.0 — Mailjet joins the core SPF trust-surface catalog, so its trust-surface finding
+ *   now participates in the existing weak-DMARC corroboration rule instead of always reading
+ *   `info`. The worker post-processor reconstructs its DMARC context from the CORE's trust-surface
+ *   finding metadata and falls back to no-corroboration when the core recognised nothing; a
+ *   Mailjet-only SPF record previously produced no core finding, so it always took that fallback.
+ *   With Mailjet cataloged, a Mailjet include on a domain with `p=none` and relaxed alignment now
+ *   surfaces as `medium` (ordinary −15 severity penalty on `spf`) rather than `info` — the same
+ *   treatment the other 18 cataloged platforms already received. Domains with enforcing DMARC are
+ *   unaffected. No weight, tier, grade band, severity penalty, missing-control rule or
+ *   profile-detection rule changed. The affected population is unmeasured against the corpus.
  */
-export const SCORING_MODEL_VERSION = '1.6.0';
+export const SCORING_MODEL_VERSION = '1.7.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';


### PR DESCRIPTION
Version-sync commit for 3.42.0. All hand-edited surfaces moved together: `package.json` + `package-lock.json`, `server.json` (top-level `version` — remotes-only, single field), `CHANGELOG.md`. `SERVER_VERSION` auto-derives from `pkg.version` and is not hand-edited.

Also bumped, because this release changes package behaviour:

- `@blackveil/dns-checks` 1.10.0 -> 1.11.0, with `PARITY_CORPUS_VERSION` moved in lockstep (the version-lock contract asserted by `parity-corpus.contract.test.ts`).
- `SCORING_MODEL_VERSION` 1.6.0 -> 1.7.0, with a history entry recording the effect.

## Why the scoring model moves

Adding Mailjet to the core SPF trust-surface catalog (#614) is not score-neutral. The worker's trust-surface post-processor reconstructs its DMARC context from the core's own trust-surface finding metadata and falls back to no-corroboration when the core recognised nothing. A Mailjet-only SPF record previously produced no core finding, so it always took that fallback and read `info`. With Mailjet cataloged, a Mailjet include on a domain with `p=none` and relaxed alignment now surfaces as `medium` — the ordinary -15 severity penalty on the `spf` category.

This is the existing corroboration rule applying to Mailjet as it already did to the other 18 cataloged platforms, so it is a correction rather than a new penalty. Domains with enforcing DMARC are unaffected. The affected population is **unmeasured** against the 1000-domain corpus; that is recorded honestly in both the CHANGELOG and the model-version history rather than implied to be zero.

## Contents

- #614 — Mailjet in the core SPF trust-surface catalog (part 1 of #572)
- #615 — hono 4.12.32 -> 4.12.34 (GHSA-8j4g-w8fx-2239)

## Verification

Full suite on this branch: 6972 passed, 13 skipped, 1 todo, 0 failed, exit 0. `packages/dns-checks` suite 621 passed incl. the parity-corpus version-lock contract. `npm run typecheck` and `npm run lint` exit 0.

Known unrelated red: the non-required `contract` job's full `npm audit` (including devDependencies) fails on postcss and undici advisories published after 2026-08-02 — `main` was green on the same lockfile two days ago. Dev-only, not in the Worker bundle, and the undici fix requires a wrangler major. Tracked separately, not part of this release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)