### PR TITLE
ci: scope the contract job's audit to production dependencies

### DIFF
--- a/.github/workflows/ci-contract.yml
+++ b/.github/workflows/ci-contract.yml
@@ -51,4 +51,4 @@ jobs:
         run: npm test
 
       - name: Security audit
-        run: npm audit --audit-level=high
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
Closes #619.

The `contract` workflow's Security audit ran `npm audit --audit-level=high` across **all** dependencies including dev. It went red repo-wide on 2026-08-03 with no commit involved — `npm audit` re-evaluates against the live advisory database, so a job pinning no advisory snapshot flips red when a CVE is published. The trigger was `undici 7.0.0 - 7.28.0` picking up two HIGH advisories, reaching us only through `wrangler` → `miniflare` → `@cloudflare/vitest-pool-workers`. None of it ships in the Worker.

Adding `--omit=dev` matches the required `Dependency audit` gate in `security.yml`, which was narrowed exactly this way in the 3.34.0 window for the same class of dev-tooling noise. `npm audit --omit=dev` currently reports 0 vulnerabilities.

**Correction to #619 as I filed it:** postcss is a *moderate* advisory, so at `--audit-level=high` it was never the trigger — undici's two highs were doing all the work. The issue overstated the failure set.

**Worth a follow-up decision, not made here:** once scoped to prod deps, this step is arguably redundant with `security.yml`'s required gate, which runs the same audit at a *stricter* threshold (`--audit-level=moderate`). I left it in place rather than delete a security step unilaterally. Say if you'd rather drop it.

The dev-side undici exposure is real but needs a wrangler major; that stays tracked separately rather than being forced through here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)