### PR TITLE
fix(lookalikes): generate cognitive misspellings; stop calling a brand's own defensive registration third-party

### DIFF
--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -14,8 +14,9 @@ import { safeFetch } from '../lib/safe-fetch';
 import type { ReconBinding, BindingDegradationSink, ReconScanResult } from '../lib/recon-binding';
 import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult, createFinding } from '../lib/scoring';
-import { generateCombosquats, generateLookalikes } from './lookalike-analysis';
-import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg, isRedactedRegistrantOrg } from './check-rdap-lookup';
+import { generateCognitiveLookalikes, generateCombosquats, generateLookalikes } from './lookalike-analysis';
+import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg, findEntityByRole, isRedactedRegistrantOrg } from './check-rdap-lookup';
+import { evaluateDefensiveRegistration, type DefensiveReason } from '../lib/brand-defensive-registration';
 import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
 import {
 	buildNonOwnedGateFinding,
@@ -116,6 +117,61 @@ const WEB_PROBE_TIMEOUT_MS = 2500;
  * corrected first when the cap binds.
  */
 const SAME_ENTITY_RDAP_CAP = 10;
+
+/**
+ * IANA registrar IDs of BRAND-PROTECTION registrars — corporate registrars
+ * that do not sell to the general public. Getting a domain registered through
+ * one requires a corporate account and a contract; you cannot buy a name at
+ * CSC or MarkMonitor the way you can at a retail registrar.
+ *
+ * WHY THIS IS DIFFERENT FROM THE REGISTRANT-ORG FIELD (and therefore why it is
+ * allowed to corroborate ownership at all). Ruling A / F2 bars the registrant
+ * org from influencing attribution because it is free text the REGISTRANT
+ * types — forgeable with one form field, and collision-prone because half the
+ * internet sits behind the same privacy services. The IANA registrar ID is
+ * neither: it is assigned by ICANN and published by the REGISTRY as part of
+ * the delegation record. A registrant cannot set it, and cannot move a domain
+ * into a corporate registrar's accreditation without that registrar's consent.
+ *
+ * It is still NOT proof of common ownership — many brands share CSC — which is
+ * why {@link isBrandHeldRegistration} requires the candidate's INFRASTRUCTURE
+ * to be defensively shaped as well, and why nothing here can ever produce an
+ * `owned_by_seed` verdict (that remains seed-side NS evidence only).
+ *
+ * RETAIL REGISTRARS MUST NEVER BE ADDED. GoDaddy (146), Namecheap (1068) and
+ * friends are shared by millions of unrelated registrants, so a shared-retail-
+ * registrar match carries no identity information whatsoever. A control test
+ * pins that GoDaddy is not treated as evidence.
+ */
+const BRAND_PROTECTION_REGISTRAR_IANA_IDS: ReadonlySet<string> = new Set([
+	'299', // CSC Corporate Domains, Inc.
+	'292', // MarkMonitor Inc.
+	'470', // Com Laude (Nom-IQ Ltd)
+	'447', // SafeNames Ltd
+	'1600', // Brandsight, Inc.
+	'106', // Ascio Technologies (corporate channel)
+	'1316', // Nameshield SAS
+	'1495', // EBRAND Services
+	'151', // Gandi SAS — corporate/enterprise channel
+	'1479', // In2net / brand-protection channel
+]);
+
+/**
+ * Human phrasing for a {@link DefensiveReason} token. Internal enum values are
+ * meaningless in a customer-facing report about a named organisation — the
+ * same rule `UNKNOWN_REASON_PHRASES` exists for in `registration-state.ts`.
+ *
+ * WORDING CONSTRAINT: none of these may contain `missing`, `required`,
+ * `not found`, or the `no <...> record` shape. `scoreIndicatesMissingControl()`
+ * in the vendored scoring package matches finding TEXT, and a match on a
+ * high-severity finding ZEROES the whole category score — the one way a
+ * wording change in this file could move a number. Pinned by a boundary test.
+ */
+export const DEFENSIVE_REASON_PHRASES: Record<DefensiveReason, string> = {
+	'redirect-to-target': 'its web root redirects back to the scanned domain',
+	'parked-ns': 'its nameservers are at a domain-parking provider',
+	'no-mx': 'it carries no active mail service',
+};
 
 /**
  * Check whether an MX record represents real mail infrastructure.
@@ -343,6 +399,16 @@ function buildThreatObservationFinding(
 	ownership: OwnershipAssessment,
 	corroboratorReasons: string,
 	sharedRegistrantOrg: string | undefined,
+	/**
+	 * True when {@link isBrandHeldRegistration} corroborated that the candidate
+	 * is the scanned organisation's OWN defensive registration. Changes the
+	 * closing REMEDIATION sentence only — the observation and its calibrated
+	 * severity are emitted unchanged, per the F1 ruling that an attribution
+	 * signal may annotate the threat axis but never switch it off or discount
+	 * it. Telling a customer to report their own domain for takedown is not a
+	 * severity question; it is simply wrong advice.
+	 */
+	brandHeld = false,
 ): Finding {
 	const infraPhrase = signals.hasMX
 		? `active mail infrastructure (MX records), so it is capable of sending mail that resembles ${seedDomain}`
@@ -355,12 +421,24 @@ function buildThreatObservationFinding(
 	const registrantNote = sharedRegistrantOrg
 		? ` Its RDAP registrant-organisation string matches the one published for ${seedDomain} ("${sharedRegistrantOrg}"); that field is self-declared, unverified by the registry, and frequently a shared privacy-service placeholder, so it is recorded but does not reduce what was observed here.`
 		: '';
+	// The attribution clause and the closing remediation clause both assume the
+	// candidate is an outside party's. When the registration record corroborates
+	// that it is the scanned organisation's OWN defensive registration, both are
+	// replaced — the observation itself and its calibrated severity are
+	// untouched, so nothing here moves a score.
+	const attributionClause = brandHeld
+		? `the registry publishes the same brand-protection registrar for it as for ${seedDomain}, so it is most likely the scanned organisation's own defensive registration`
+		: `${candidateDomain} does not appear to belong to the scanned organisation, this finding claims no control over it, and no change to it is requested`;
+	const remediationClause = brandHeld
+		? `Because this looks like your own defensive registration, treat it as portfolio hygiene rather than a threat: confirm it against your domain portfolio, and keep it parked with mail explicitly disabled so it cannot be used to send. Do NOT report it for takedown without confirming ownership first.`
+		: `Defensive options that need no access to ${candidateDomain}: monitor it, block or quarantine mail bearing that name at the gateway, and report it to its registrar or a takedown provider.`;
 	return createFinding(
 		'lookalikes',
 		`Impersonation-shaped ${signals.hasMX ? 'infrastructure' : 'web infrastructure'} observed: ${candidateDomain}`,
 		severity,
-		`${candidateDomain} is a confusable variant of ${seedDomain} and was observed with ${observed}. This is an infrastructure observation only: ${candidateDomain} does not appear to belong to the scanned organisation, this finding claims no control over it, and no change to it is requested.${registrantNote} Defensive options that need no access to ${candidateDomain}: monitor it, block or quarantine mail bearing that name at the gateway, and report it to its registrar or a takedown provider.`,
+		`${candidateDomain} is a confusable variant of ${seedDomain} and was observed with ${observed}. This is an infrastructure observation only: ${attributionClause}.${registrantNote} ${remediationClause}`,
 		{
+			...(brandHeld ? { brandHeldRegistration: true } : {}),
 			lookalikeDomain: candidateDomain,
 			hasA: signals.hasA,
 			hasMX: signals.hasMX,
@@ -465,11 +543,24 @@ async function checkLookalikesCore(
 	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
 ): Promise<CheckResult> {
 	const findings: Finding[] = [];
-	// Typo/homoglyph permutations PLUS combosquats (brand + lure affix). The two
-	// generators are disjoint by construction — combosquats defeat the edit-distance
-	// mutators — so the union is deduped to a single candidate set that flows through
-	// the same NS-existence → probe → enrich → severity pipeline.
-	const permutations = [...new Set([...generateLookalikes(domain), ...generateCombosquats(domain)])];
+	// THREE disjoint candidate lanes, deduped into one set that flows through the
+	// same NS-existence → probe → enrich → severity pipeline:
+	//
+	//  - `generateLookalikes` — MOTOR errors (keyboard adjacency, omission,
+	//    duplication, dot insertion, TLD swap, homoglyph): a slip of the finger
+	//    by someone who knows the correct spelling.
+	//  - `generateCognitiveLookalikes` — COGNITIVE errors: the spelling a large
+	//    population believes IS correct (`sketchers`, `berenstein`), typed
+	//    deliberately and repeatedly. The motor set cannot reach these except by
+	//    coincidence, so before this lane existed they were simply never probed.
+	//  - `generateCombosquats` — brand + lure affix, which defeats edit distance
+	//    entirely.
+	//
+	// Each lane carries its OWN cap, so adding one can never evict another's
+	// candidates through a shared truncation.
+	const permutations = [
+		...new Set([...generateLookalikes(domain), ...generateCognitiveLookalikes(domain), ...generateCombosquats(domain)]),
+	];
 
 	if (permutations.length === 0) {
 		findings.push(
@@ -606,12 +697,44 @@ async function checkLookalikesCore(
 	// by `isSameEntityOrgMatch()`, which rejects privacy-proxy / redacted /
 	// generic strings on BOTH sides.
 	const sameEntityCandidates = computeSameEntityCandidates(results, ownershipByDomain, enrichment);
-	const primaryRegistrantOrg = sameEntityCandidates.length > 0 ? await probePrimaryRegistrantOrg(domain) : null;
+	// ONE RDAP fetch for the seed, reused for BOTH correlations: the registrant
+	// org (unverified, wording-only) and the registry-published registrar ID
+	// (the brand-held-registration signal). No extra network cost for the second.
+	const primaryRegistration = sameEntityCandidates.length > 0 ? await probePrimaryRegistration(domain) : EMPTY_RDAP_PROBE;
+	const primaryRegistrantOrg = primaryRegistration.registrantOrg;
 	const sameEntityMatches = new Map<string, string>();
+	/** Candidates the registration record corroborates as the seed org's own defensive registrations. */
+	const brandHeldMatches = new Map<string, { registrarIanaId: string; registrarName: string | null; reason: DefensiveReason }>();
 	for (const candidateDomain of sameEntityCandidates) {
-		const candidateOrg = enrichment.get(candidateDomain)?.registrantOrg ?? null;
+		const corroborators = enrichment.get(candidateDomain);
+		const candidateOrg = corroborators?.registrantOrg ?? null;
 		if (candidateOrg !== null && isSameEntityOrgMatch(primaryRegistrantOrg, candidateOrg)) {
 			sameEntityMatches.set(candidateDomain, candidateOrg);
+		}
+		const probe = results.find((r) => r.domain === candidateDomain);
+		// An ABSENT probe is "we never looked", which is NOT "there is no mail" —
+		// and the defensive-shape heuristic fires its `no-mx` reason on an empty
+		// array. Defaulting to `[]` here would therefore manufacture a defensive
+		// verdict out of a missing measurement, the exact
+		// unmeasured-signal-compiled-into-an-affirmative-claim trap. Skip instead.
+		// (`computeSameEntityCandidates` only ever names domains drawn from
+		// `results`, so this is unreachable today — it is a guard against a
+		// future caller widening the eligible set, not a live bug fix.)
+		if (probe === undefined) continue;
+		const brandHeld = isBrandHeldRegistration({
+			seedDomain: domain,
+			candidateDomain,
+			seedRegistrarIanaId: primaryRegistration.registrarIanaId,
+			candidateRegistrarIanaId: corroborators?.registrarIanaId ?? null,
+			candidateMxExchanges: probe.mxExchanges,
+			candidateNsHosts: Array.from(lookalikeNsMap.get(candidateDomain) ?? []),
+		});
+		if (brandHeld.brandHeld) {
+			brandHeldMatches.set(candidateDomain, {
+				registrarIanaId: brandHeld.registrarIanaId,
+				registrarName: corroborators?.registrarName ?? null,
+				reason: brandHeld.reason,
+			});
 		}
 	}
 
@@ -708,7 +831,46 @@ async function checkLookalikesCore(
 		// registrant-organisation SIGNAL, distinct from (and weaker than) the
 		// structural NS-based evidence, whose own finding is quoted verbatim.
 		const matchedOrg = sameEntityMatches.get(result.domain);
-		if (matchedOrg !== undefined) {
+		const brandHeld = brandHeldMatches.get(result.domain);
+		if (brandHeld !== undefined) {
+			// AXIS 1 — the registration record corroborates that this is the
+			// scanned organisation's OWN defensive registration. Emitted INSTEAD
+			// of the neutral D4 gate template, which would otherwise state
+			// positively that the domain "is registered to a different
+			// organisation" — a claim the nameserver evidence alone never
+			// supported and which is simply false here.
+			//
+			// SEVERITY IS `info`, EXACTLY AS `applyOwnershipGate()` WOULD HAVE
+			// CAPPED IT. This branch changes what the report SAYS, never what it
+			// SCORES: `capAttributionSeverity()` caps every non-`owned_by_seed`
+			// attribution finding at `info` regardless, so swapping the prose
+			// moves no penalty. Pinned by the boundary test in
+			// `test/ownership-attribution.spec.ts`.
+			const registrarLabel = brandHeld.registrarName
+				? `${brandHeld.registrarName} (IANA ${brandHeld.registrarIanaId})`
+				: `IANA registrar ${brandHeld.registrarIanaId}`;
+			findings.push(
+				createFinding(
+					'lookalikes',
+					`Confusable domain held at the same brand-protection registrar: ${result.domain}`,
+					'info',
+					`The domain ${result.domain} is a confusable variant of ${domain}, and the registry publishes the SAME brand-protection registrar for both (${registrarLabel}). Its infrastructure also has the shape of a defensive registration — ${DEFENSIVE_REASON_PHRASES[brandHeld.reason]}. Brand-protection registrars do not sell to the general public and the IANA registrar ID is published by the registry rather than declared by the registrant, so this corroborates that ${result.domain} is held by the scanned organisation itself; it is not proof, since one such registrar serves many brands. Nameserver evidence is separate and did not link the two: ${ownership.rationale} Confirm against your own domain portfolio before treating ${result.domain} as an outside party's.`,
+					{
+						lookalikeDomain: result.domain,
+						hasA: result.hasA,
+						hasMX: result.hasMX,
+						brandHeldRegistration: true,
+						sharedRegistrarIanaId: brandHeld.registrarIanaId,
+						defensiveReason: brandHeld.reason,
+						// Ruling A holds: registrar evidence never manufactures
+						// `owned_by_seed`. The STRUCTURAL verdict travels unchanged.
+						ownershipVerdict: ownership.verdict,
+						ownershipRationale: ownership.rationale,
+						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+					},
+				),
+			);
+		} else if (matchedOrg !== undefined) {
 			// AXIS 1 — the registrant-org observation REPLACES the neutral D4 gate
 			// template for this candidate (it is strictly more informative), but it
 			// is still an attribution statement capped at info.
@@ -780,7 +942,18 @@ async function checkLookalikesCore(
 		// F1: that string is unverified and collision-prone, so it may annotate the
 		// observation but must never switch the axis off). Only `owned_by_seed`
 		// candidates are exempt — they `continue` above.
-		findings.push(buildThreatObservationFinding(result.domain, domain, severity, signals, ownership, corroboratorReasons, matchedOrg));
+		findings.push(
+			buildThreatObservationFinding(
+				result.domain,
+				domain,
+				severity,
+				signals,
+				ownership,
+				corroboratorReasons,
+				matchedOrg,
+				brandHeld !== undefined,
+			),
+		);
 		if (result.hasMX && severity === 'high') {
 			highCount++;
 			highDomains.push(result.domain);
@@ -908,6 +1081,14 @@ interface LookalikeCorroborators {
 	 * stands; a real threat is never suppressed on missing RDAP).
 	 */
 	registrantOrg: string | null;
+	/**
+	 * Registry-published IANA registrar ID for this candidate, harvested from
+	 * the same single RDAP fetch as everything else here. Feeds
+	 * {@link isBrandHeldRegistration}; `null` fails soft to "no evidence".
+	 */
+	registrarIanaId: string | null;
+	/** Registrar display name, for report prose only. */
+	registrarName: string | null;
 }
 
 /**
@@ -960,18 +1141,40 @@ export function isSameEntityOrgMatch(primaryOrg: string | null, candidateOrg: st
  * classification loop's decision so we never fetch the primary's registrant
  * org speculatively: a candidate qualifies only when `ownershipByDomain`
  * does NOT already attribute it to the seed (`owned_by_seed` — CALL SITE 3
- * of the D4 2026-07-26 correctness-defects design's ownership gate), has
- * mail/web infra, AND its calibrated severity is medium or high (low
- * web-only matches aren't worth the RDAP cost). The result
- * is sorted high-before-medium and capped at {@link SAME_ENTITY_RDAP_CAP} so a
- * permutation explosion can't widen the RDAP fan-out unbounded.
+ * of the D4 2026-07-26 correctness-defects design's ownership gate) and has
+ * mail/web infra. The result is sorted by calibrated severity, highest first,
+ * and capped at {@link SAME_ENTITY_RDAP_CAP} so a permutation explosion can't
+ * widen the RDAP fan-out unbounded.
+ *
+ * LOW-SEVERITY CANDIDATES ARE ELIGIBLE (changed — they used to be excluded as
+ * "not worth the RDAP cost"). That exclusion was the mechanical cause of the
+ * brand's-own-defensive-registration defect: a defensive registration is
+ * PARKED, so it is web-only, aged and mail-less, and therefore calibrates
+ * exactly `low`. The tool skipped the one fetch that would have told it who
+ * held the domain, then asserted the domain "is registered to a different
+ * organisation" and offered to report it for takedown — a positive
+ * non-ownership CLAIM derived from evidence it declined to gather.
+ *
+ * Severity is a THREAT tier, so gating an ATTRIBUTION lookup on it was a
+ * category error: the cheapest candidates to dismiss as low-threat are
+ * precisely the ones most likely to be the customer's own.
+ *
+ * COST OF THE WIDENING IS ONE FETCH, MEASURED NOT ASSUMED. Candidate RDAP was
+ * never gated on severity — `enrichLookalikes()` already fetches it for every
+ * non-owned candidate with mail/web infra. The medium/high gate only decided
+ * whether the SEED's single RDAP fetch happened. So widening to `low` adds at
+ * most ONE request per scan, on scans that have a registered non-owned
+ * candidate at all. `SAME_ENTITY_RDAP_CAP` still bounds the set; severity now
+ * only decides ORDER within it, and `owned_by_seed` candidates are still
+ * excluded outright, so the shared-NS short-circuit still pays no RDAP cost.
  */
 function computeSameEntityCandidates(
 	results: LookalikeResult[],
 	ownershipByDomain: Map<string, OwnershipAssessment>,
 	enrichment: Map<string, LookalikeCorroborators>,
 ): string[] {
-	const eligible: Array<{ domain: string; severity: 'medium' | 'high' }> = [];
+	const SEVERITY_ORDER: Record<LookalikeSeverity, number> = { high: 0, medium: 1, low: 2 };
+	const eligible: Array<{ domain: string; severity: LookalikeSeverity }> = [];
 	for (const result of results) {
 		const sameOwner = ownershipByDomain.get(result.domain)?.verdict === 'owned_by_seed';
 		if (sameOwner) continue;
@@ -984,11 +1187,9 @@ function computeSameEntityCandidates(
 			mxOnDisposable: corroborators?.mxOnDisposable ?? false,
 			hasWebContent: corroborators?.hasWebContent ?? true,
 		});
-		if (severity === 'medium' || severity === 'high') {
-			eligible.push({ domain: result.domain, severity });
-		}
+		eligible.push({ domain: result.domain, severity });
 	}
-	eligible.sort((a, b) => (a.severity === b.severity ? 0 : a.severity === 'high' ? -1 : 1));
+	eligible.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
 	return eligible.slice(0, SAME_ENTITY_RDAP_CAP).map((e) => e.domain);
 }
 
@@ -1015,6 +1216,8 @@ async function enrichLookalikes(candidates: LookalikeResult[]): Promise<Map<stri
 				mxOnDisposable,
 				hasWebContent,
 				registrantOrg: rdap.registrantOrg,
+				registrarIanaId: rdap.registrarIanaId,
+				registrarName: rdap.registrarName,
 			});
 		}),
 	);
@@ -1027,10 +1230,129 @@ interface RdapProbeResult {
 	registrationDays: number | null;
 	/** Normalised RDAP registrant org, or `null` on any failure / missing data. */
 	registrantOrg: string | null;
+	/**
+	 * Registry-published IANA registrar ID, or `null` on any failure / absence.
+	 * Distinct in kind from {@link registrantOrg}: assigned by ICANN, published
+	 * by the registry, and not settable by the registrant — see
+	 * {@link BRAND_PROTECTION_REGISTRAR_IANA_IDS}.
+	 */
+	registrarIanaId: string | null;
+	/** Registrar display name, for report prose only. Never compared. */
+	registrarName: string | null;
 }
 
 /** Empty probe result — used for early-outs and the catch path (fail-soft). */
-const EMPTY_RDAP_PROBE: RdapProbeResult = { registrationDays: null, registrantOrg: null };
+const EMPTY_RDAP_PROBE: RdapProbeResult = { registrationDays: null, registrantOrg: null, registrarIanaId: null, registrarName: null };
+
+/**
+ * Pull the registrar's IANA ID and display name out of a parsed RDAP domain
+ * response. Local to this file rather than imported because
+ * `check-rdap-lookup.ts` keeps its vCard/publicId readers private; only
+ * `findEntityByRole` is exported, so the traversal is reused and just the two
+ * field reads are done here.
+ *
+ * Fail-soft in every branch — a non-conforming shape yields nulls, which the
+ * brand-held predicate treats as "no evidence" (never as a match).
+ */
+function extractRegistrar(rdapData: unknown): { ianaId: string | null; name: string | null } {
+	if (typeof rdapData !== 'object' || rdapData === null) return { ianaId: null, name: null };
+	const entities = (rdapData as { entities?: unknown }).entities;
+	if (!Array.isArray(entities)) return { ianaId: null, name: null };
+	const registrar = findEntityByRole(entities as Parameters<typeof findEntityByRole>[0], 'registrar');
+	if (!registrar) return { ianaId: null, name: null };
+
+	let ianaId: string | null = null;
+	const publicIds = (registrar as { publicIds?: unknown }).publicIds;
+	if (Array.isArray(publicIds)) {
+		for (const publicId of publicIds) {
+			if (typeof publicId !== 'object' || publicId === null) continue;
+			const { type, identifier } = publicId as { type?: unknown; identifier?: unknown };
+			if (typeof type === 'string' && /^IANA Registrar ID$/i.test(type.trim()) && typeof identifier === 'string' && identifier.trim()) {
+				ianaId = identifier.trim();
+				break;
+			}
+		}
+	}
+
+	let name: string | null = null;
+	const vcardArray = (registrar as { vcardArray?: unknown }).vcardArray;
+	if (Array.isArray(vcardArray) && vcardArray[0] === 'vcard' && Array.isArray(vcardArray[1])) {
+		for (const prop of vcardArray[1] as unknown[]) {
+			if (Array.isArray(prop) && prop[0] === 'fn' && typeof prop[3] === 'string' && prop[3].trim()) {
+				name = prop[3].trim();
+				break;
+			}
+		}
+	}
+	return { ianaId, name };
+}
+
+/**
+ * THE predicate deciding whether a candidate is the scanned organisation's own
+ * DEFENSIVE REGISTRATION rather than a third party's domain.
+ *
+ * Requires BOTH, and neither alone is sufficient:
+ *
+ *  1. REGISTRATION-RECORD corroboration — the candidate and the seed share an
+ *     IANA registrar ID belonging to a brand-protection registrar
+ *     ({@link BRAND_PROTECTION_REGISTRAR_IANA_IDS}). A shared RETAIL registrar
+ *     is explicitly not evidence: millions of unrelated registrants share one.
+ *
+ *  2. DEFENSIVE INFRASTRUCTURE SHAPE — `evaluateDefensiveRegistration()`
+ *     (`src/lib/brand-defensive-registration.ts`) agrees the candidate is a
+ *     typo-close label parked with minimal infrastructure. An attacker who
+ *     somehow reached the same corporate registrar but stood up live mail
+ *     still fails this leg and gets the full threat treatment.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO: it does not, and must not, produce an
+ * `owned_by_seed` ownership verdict. `classifyOwnership()` stays driven by
+ * seed-side nameserver evidence alone (Ruling A), and every finding about this
+ * candidate keeps carrying its structural `third_party` verdict. What changes
+ * is what the report CLAIMS and RECOMMENDS: it stops asserting the domain
+ * "is registered to a different organisation" on evidence that never
+ * addressed the question, and stops telling the customer to report their own
+ * domain for takedown.
+ *
+ * NULL-GUARD NOTE — VERIFIED BY MUTATION, NOT ASSUMED (the same disclosure
+ * `isSameEntityOrgMatch` above makes about its own both-sides gate). The
+ * `=== null` guard on the first line is currently REDUNDANT: deleting it left
+ * the entire suite green, because two `null` IDs pass the equality check and
+ * are then rejected by `BRAND_PROTECTION_REGISTRAR_IANA_IDS.has(null)` anyway.
+ * No fixture can discriminate the two implementations while membership is an
+ * exact-set test, so none is shipped pretending to.
+ *
+ * It is kept as DEFENCE IN DEPTH and becomes load-bearing the moment that
+ * membership test is relaxed — a name-based or fuzzy registrar comparison, or
+ * an "any shared registrar" mode — at which point "both sides published
+ * nothing" would read as a match and silently mark every RDAP-less candidate
+ * as brand-held. Anyone relaxing it MUST keep this guard and ship a fixture
+ * that discriminates it, which only becomes constructible then.
+ */
+export function isBrandHeldRegistration(input: {
+	seedDomain: string;
+	candidateDomain: string;
+	seedRegistrarIanaId: string | null;
+	candidateRegistrarIanaId: string | null;
+	candidateMxExchanges: readonly string[];
+	candidateNsHosts: readonly string[];
+}): { brandHeld: false } | { brandHeld: true; registrarIanaId: string; reason: DefensiveReason } {
+	const { seedRegistrarIanaId, candidateRegistrarIanaId } = input;
+	if (seedRegistrarIanaId === null || candidateRegistrarIanaId === null) return { brandHeld: false };
+	if (seedRegistrarIanaId !== candidateRegistrarIanaId) return { brandHeld: false };
+	if (!BRAND_PROTECTION_REGISTRAR_IANA_IDS.has(candidateRegistrarIanaId)) return { brandHeld: false };
+
+	const shape = evaluateDefensiveRegistration({
+		candidateDomain: input.candidateDomain,
+		targetDomain: input.seedDomain,
+		// A concrete array (never `undefined`) — we DID look, via the Phase 2
+		// probe, so an empty set means "no mail", not "unknown". The heuristic
+		// abstains on `undefined`, which would silently disable this leg.
+		mxRecords: input.candidateMxExchanges,
+		nsHosts: input.candidateNsHosts,
+	});
+	if (!shape.defensive || shape.reason === undefined) return { brandHeld: false };
+	return { brandHeld: true, registrarIanaId: candidateRegistrarIanaId, reason: shape.reason };
+}
 
 /**
  * Lightweight RDAP lookup constrained for use inside the lookalike check.
@@ -1077,18 +1399,26 @@ async function probeRdap(domain: string): Promise<RdapProbeResult> {
 				registrationDays = Math.floor((Date.now() - creationTime) / (1000 * 60 * 60 * 24));
 			}
 		}
-		return { registrationDays, registrantOrg: extractRegistrantOrg(data) };
+		const registrar = extractRegistrar(data);
+		return {
+			registrationDays,
+			registrantOrg: extractRegistrantOrg(data),
+			registrarIanaId: registrar.ianaId,
+			registrarName: registrar.name,
+		};
 	} catch {
 		return EMPTY_RDAP_PROBE;
 	}
 }
 
 /**
- * Fetch the scan domain's normalised RDAP registrant org for same-entity
- * correlation (issue #263). Reuses {@link probeRdap}; fail-soft `null`.
+ * Fetch the scan domain's own registration record — registrant org for the
+ * same-entity correlation (issue #263) AND the registry-published registrar ID
+ * for {@link isBrandHeldRegistration}. ONE fetch serves both; reuses
+ * {@link probeRdap} and fails soft to {@link EMPTY_RDAP_PROBE}.
  */
-async function probePrimaryRegistrantOrg(domain: string): Promise<string | null> {
-	return (await probeRdap(domain)).registrantOrg;
+async function probePrimaryRegistration(domain: string): Promise<RdapProbeResult> {
+	return probeRdap(domain);
 }
 
 /**

--- a/src/tools/lookalike-analysis.ts
+++ b/src/tools/lookalike-analysis.ts
@@ -9,8 +9,14 @@
 
 import { LABEL_REGEX, MAX_DOMAIN_LENGTH, MAX_LABEL_LENGTH } from '../lib/config';
 
-/** QWERTY keyboard adjacency map for typosquat detection */
-const QWERTY_ADJACENT: Record<string, string[]> = {
+/**
+ * QWERTY keyboard adjacency map for typosquat detection.
+ *
+ * Exported so {@link COGNITIVE_SUBSTITUTIONS} can be proven disjoint from it —
+ * a "non-adjacent" substitution pair that is in fact adjacent adds no reach
+ * over the motor pass and is silently dead weight.
+ */
+export const QWERTY_ADJACENT: Record<string, string[]> = {
 	q: ['w', 'a'],
 	w: ['q', 'e', 's', 'a'],
 	e: ['w', 'r', 'd', 's'],
@@ -173,6 +179,269 @@ export function generateLookalikes(domain: string): string[] {
 		.sort();
 
 	return results.slice(0, MAX_PERMUTATIONS);
+}
+
+/* -------------------------------------------------------------------------
+ * COGNITIVE-ERROR GENERATION
+ *
+ * Everything above this line models a MOTOR error — a slip of the finger by
+ * someone who knows the correct spelling: a neighbouring key, a dropped
+ * character, a doubled character, a swapped TLD, a glyph that looks like
+ * another glyph.
+ *
+ * A Mandela-effect misspelling is a COGNITIVE error: the spelling a large
+ * population believes IS correct. It is typed deliberately, repeatedly, and
+ * without the typist ever noticing — which makes it strictly more valuable to
+ * an attacker than a motor typo, because the traffic is sustained rather than
+ * accidental. `sketchers` (Skechers), `berenstein` (Berenstain) and `febreeze`
+ * (Febreze) are the canonical examples.
+ *
+ * The motor operation set CANNOT reach one except by coincidence: it reaches
+ * `febreeze` only because vowel lengthening happens to look like a duplicated
+ * character, and it never reaches `sketchers` (an inserted letter) or
+ * `berenstein` (a substitution across the keyboard). The three operations
+ * below close that gap and are deliberately kept in their OWN function with
+ * their OWN cap, so they cannot displace motor candidates through
+ * `generateLookalikes`' alphabetical MAX_PERMUTATIONS truncation.
+ * ---------------------------------------------------------------------- */
+
+/**
+ * OPERATION 1 — non-adjacent substitution.
+ *
+ * Phonetically confusable letter pairs: a speller who has only ever HEARD the
+ * name picks the wrong grapheme for the right phoneme. Every pair here is
+ * NON-adjacent on QWERTY by construction (pinned by a test against
+ * {@link QWERTY_ADJACENT}) — an adjacent pair would already be covered by the
+ * keyboard pass and would only burn probe budget. That is why `s`/`z`, `f`/`v`
+ * and `d`/`c` are deliberately absent: the keyboard pass already emits them.
+ */
+export const COGNITIVE_SUBSTITUTIONS: ReadonlyArray<readonly [string, string]> = [
+	// Vowel confusions — by far the largest real-world class.
+	['a', 'e'],
+	['e', 'a'],
+	['e', 'i'],
+	['i', 'e'],
+	['i', 'y'],
+	['y', 'i'],
+	['o', 'u'],
+	['u', 'o'],
+	['a', 'o'],
+	['o', 'a'],
+	// Consonant graphemes sharing a phoneme.
+	['c', 'k'],
+	['k', 'c'],
+	['c', 's'],
+	['s', 'c'],
+	['g', 'j'],
+	['j', 'g'],
+	['k', 'q'],
+	['q', 'k'],
+];
+
+/**
+ * OPERATION 2 — arbitrary insertion, bounded by English orthography.
+ *
+ * Unbounded insertion is `positions x 26` candidates, which at one DNS probe
+ * each is not affordable. The bound is linguistic rather than arbitrary: an
+ * inserted letter only counts when it COMPLETES a cluster that really occurs
+ * in English spelling. That is exactly the mechanism behind `sketchers` —
+ * `/tʃ/` after a short vowel is spelled `tch` far more often than `ch`, so
+ * writers "restore" a `t` that was never there.
+ *
+ * Trigraphs are ranked ahead of digraphs when the cap bites: completing a
+ * three-letter cluster is a much stronger orthographic signal than completing
+ * a two-letter one.
+ */
+const ORTHOGRAPHIC_TRIGRAPHS: readonly string[] = ['tch', 'sch', 'ght', 'dge', 'tio', 'sio', 'ough', 'aigh'];
+const ORTHOGRAPHIC_DIGRAPHS: readonly string[] = [
+	'ck',
+	'ng',
+	'nk',
+	'mp',
+	'nd',
+	'st',
+	'sh',
+	'ch',
+	'th',
+	'ph',
+	'wh',
+	'kn',
+	'wr',
+	'mb',
+	'gh',
+	'qu',
+	'dg',
+	'ct',
+	'ps',
+	'rh',
+	'll',
+	'ss',
+	'tt',
+	'nn',
+	'rr',
+	'ee',
+	'oo',
+	'ea',
+	'ie',
+	'ei',
+	'ou',
+	'ai',
+	'au',
+	'oa',
+	'ue',
+];
+/**
+ * Letters that carry the insertion. Restricted to the graphemes that actually
+ * participate in the clusters above — inserting `x` or `z` never completes one,
+ * so trying them would only cost cycles.
+ */
+const INSERTION_LETTERS: readonly string[] = ['a', 'c', 'e', 'g', 'h', 'i', 'k', 'n', 'o', 'r', 's', 't', 'u', 'w'];
+
+/**
+ * OPERATION 3 — morpheme swap.
+ *
+ * Whole-morpheme substitution: the speller reaches for a DIFFERENT, more
+ * familiar morpheme that sounds the same. This is the operation that has no
+ * single-character analogue at all — `tunes`->`toons` is four edits, so no
+ * edit-distance mutator will ever propose it, yet it is one of the most
+ * reliably mis-remembered spellings there is.
+ *
+ * Ordered longest-first so a specific morpheme wins over a generic affix.
+ */
+const MORPHEME_SWAPS: ReadonlyArray<readonly [string, string]> = [
+	['tunes', 'toons'],
+	['toons', 'tunes'],
+	['stain', 'stein'],
+	['stein', 'stain'],
+	['froot', 'fruit'],
+	['fruit', 'froot'],
+	['tion', 'sion'],
+	['sion', 'tion'],
+	['ance', 'ence'],
+	['ence', 'ance'],
+	['ise', 'ize'],
+	['ize', 'ise'],
+	['our', 'or'],
+	['ant', 'ent'],
+	['ent', 'ant'],
+	['ph', 'f'],
+	['f', 'ph'],
+	['ey', 'y'],
+	['ie', 'y'],
+	['re', 'er'],
+	['er', 're'],
+];
+
+/**
+ * Cap on cognitive permutations returned. Bounds the extra DNS-probe cost the
+ * same way {@link MAX_COMBOSQUATS} does for the combosquat lane. The ordering
+ * below is by OPERATION CLASS, not alphabetical, precisely so this cap can
+ * never evict a morpheme swap or a substitution in favour of a low-signal
+ * insertion — the failure mode `generateLookalikes`' alphabetical `.sort()`
+ * + `.slice()` truncation has.
+ *
+ * SIZED ON MEASUREMENT, not taste. Against the four-brand Mandela corpus the
+ * known cognitive spelling lands at rank 1 (`berenstein`, `jcpenny`), 13
+ * (`sketchers`) and 16 (`febreeze`) — so 30 carries roughly 2x headroom over
+ * the observed worst case. It also bounds what this lane costs
+ * `check_lookalikes`, whose candidate set (motor + cognitive + combosquat)
+ * goes from ~70 to ~96 probes on a saturating brand.
+ */
+export const MAX_COGNITIVE_LOOKALIKES = 30;
+
+/** Apply a table of one-at-a-time string rewrites at every occurrence. */
+function applyRewrites(base: string, pairs: ReadonlyArray<readonly [string, string]>): string[] {
+	const out: string[] = [];
+	for (const [from, to] of pairs) {
+		let idx = base.indexOf(from);
+		while (idx !== -1) {
+			out.push(base.slice(0, idx) + to + base.slice(idx + from.length));
+			idx = base.indexOf(from, idx + 1);
+		}
+	}
+	return out;
+}
+
+/**
+ * Insert one letter at every position, keeping only insertions that complete a
+ * real English cluster. Returns trigraph-completing insertions before
+ * digraph-completing ones (see {@link ORTHOGRAPHIC_TRIGRAPHS}).
+ */
+function orthographicInsertions(base: string): string[] {
+	const trigraphHits: string[] = [];
+	const digraphHits: string[] = [];
+	for (let i = 0; i <= base.length; i++) {
+		for (const letter of INSERTION_LETTERS) {
+			const candidate = base.slice(0, i) + letter + base.slice(i);
+			// A cluster counts only when it CONTAINS the inserted character —
+			// otherwise every candidate would qualify off a cluster the seed
+			// already had, and the bound would do nothing.
+			let tier: 0 | 2 | 3 = 0;
+			for (const cluster of ORTHOGRAPHIC_TRIGRAPHS) {
+				const from = Math.max(0, i - cluster.length + 1);
+				if (candidate.slice(from, i + cluster.length).includes(cluster)) {
+					tier = 3;
+					break;
+				}
+			}
+			if (tier === 0) {
+				for (const cluster of ORTHOGRAPHIC_DIGRAPHS) {
+					const from = Math.max(0, i - cluster.length + 1);
+					if (candidate.slice(from, i + cluster.length).includes(cluster)) {
+						tier = 2;
+						break;
+					}
+				}
+			}
+			if (tier === 3) trigraphHits.push(candidate);
+			else if (tier === 2) digraphHits.push(candidate);
+		}
+	}
+	return [...trigraphHits, ...digraphHits];
+}
+
+/**
+ * Generate COGNITIVE-error lookalike permutations — the misspellings a large
+ * population believes are correct, which the motor operation set in
+ * {@link generateLookalikes} cannot reach.
+ *
+ * Applies three operations, emitted in descending signal order so the
+ * {@link MAX_COGNITIVE_LOOKALIKES} cap only ever truncates the weakest class:
+ *   1. morpheme swap (no edit-distance mutator can propose these at all),
+ *   2. non-adjacent phonetic substitution,
+ *   3. orthographically-bounded arbitrary insertion.
+ *
+ * Deliberately a SEPARATE function with its own cap rather than more branches
+ * inside `generateLookalikes()`: that function sorts alphabetically and slices
+ * at `MAX_PERMUTATIONS`, so folding these in would silently evict existing
+ * motor candidates on any brand that already saturates the cap (most do).
+ *
+ * Returns up to {@link MAX_COGNITIVE_LOOKALIKES} unique, valid permutations.
+ * Deterministic; only the label is mutated, never the (possibly multi-part)
+ * eTLD.
+ */
+export function generateCognitiveLookalikes(domain: string): string[] {
+	const normalizedDomain = domain.toLowerCase();
+	const { base, tld } = splitDomainTld(normalizedDomain);
+	if (!base || !tld) return [];
+
+	const ordered = [
+		...applyRewrites(base, MORPHEME_SWAPS),
+		...applyRewrites(base, COGNITIVE_SUBSTITUTIONS),
+		...orthographicInsertions(base),
+	];
+
+	const seen = new Set<string>();
+	const results: string[] = [];
+	for (const permuted of ordered) {
+		const candidate = permuted + tld;
+		if (candidate === normalizedDomain || seen.has(candidate)) continue;
+		if (!isDomainValid(candidate)) continue;
+		seen.add(candidate);
+		results.push(candidate);
+		if (results.length >= MAX_COGNITIVE_LOOKALIKES) break;
+	}
+	return results;
 }
 
 /**

--- a/src/tools/markov-generator.ts
+++ b/src/tools/markov-generator.ts
@@ -8,6 +8,7 @@
  */
 
 import { LABEL_REGEX, MAX_LABEL_LENGTH } from '../lib/config';
+import { generateCognitiveLookalikes } from './lookalike-analysis';
 
 /**
  * Trigram model: map of "prefix" (2 chars) to map of "next char" to frequency.
@@ -96,24 +97,28 @@ function pickNextChar(transitions: Map<string, number>): string {
 /**
  * Common brand-related affixes to provide branching points for the Markov model.
  */
-const BRAND_AFFIXES = [
-	'auth',
-	'login',
-	'verify',
-	'cloud',
-	'secure',
-	'api',
-	'dev',
-	'cdn',
-	'mail',
-	'apps',
-	'portal',
-	'support',
-	'update',
-];
+const BRAND_AFFIXES = ['auth', 'login', 'verify', 'cloud', 'secure', 'api', 'dev', 'cdn', 'mail', 'apps', 'portal', 'support', 'update'];
 
 /**
- * Generate brand-related lookalike candidates using a Markov Chain approach.
+ * Generate brand-related lookalike candidates for the brand-discovery
+ * candidate universe.
+ *
+ * TWO LANES, unioned:
+ *
+ *  1. COGNITIVE misspellings ({@link generateCognitiveLookalikes}) — the
+ *     spellings a large population believes are correct (`sketchers`,
+ *     `berenstein`). These are ADDITIVE and carry their own cap, so `count`
+ *     still governs the Markov lane exactly as before. They are added because
+ *     a Mandela spelling that only reached `check_lookalikes` would remain
+ *     invisible to `discover_brand_domains`, which builds its universe from
+ *     this function alone.
+ *
+ *  2. The trigram Markov lane — `count` brand-SOUNDING names sampled from a
+ *     model trained on the base label plus {@link BRAND_AFFIXES}. This is a
+ *     different target: plausible-but-unseen names, not known misspellings.
+ *
+ * The two are disjoint in intent and near-disjoint in output; the union is
+ * deduped and sorted.
  */
 export function generateMarkovLookalikes(domain: string, count = 20): string[] {
 	const normalized = domain.toLowerCase();
@@ -135,16 +140,23 @@ export function generateMarkovLookalikes(domain: string, count = 20): string[] {
 
 	const model = trainTrigramModel(samples);
 
-	const candidates = new Set<string>();
+	// Lane 1 — cognitive misspellings. Additive: seeded before the Markov loop
+	// but NOT counted against `count`, so the trigram lane still yields the
+	// same number of samples it did before this union existed.
+	const candidates = new Set<string>(generateCognitiveLookalikes(normalized));
+	const markovCandidates = new Set<string>();
 	let attempts = 0;
-	// We want candidates that sound like the brand but aren't just the brand.
-	while (candidates.size < count && attempts < count * 20) {
+	// Lane 2 — we want candidates that sound like the brand but aren't just the
+	// brand. Sized against `markovCandidates`, never the union, so a brand with
+	// many cognitive misspellings does not starve the trigram lane.
+	while (markovCandidates.size < count && attempts < count * 20) {
 		attempts++;
 		const generated = generateFromModel(model, Math.max(3, base.length - 3), base.length + 10);
 		if (generated && generated !== base && !BRAND_AFFIXES.includes(generated)) {
-			candidates.add(generated + tld);
+			markovCandidates.add(generated + tld);
 		}
 	}
 
+	for (const candidate of markovCandidates) candidates.add(candidate);
 	return Array.from(candidates).sort();
 }

--- a/test/brand-defensive-registration.test.ts
+++ b/test/brand-defensive-registration.test.ts
@@ -18,6 +18,7 @@ import {
 	damerauLevenshtein,
 	evaluateDefensiveRegistration,
 	isParkingNsHost,
+	type DefensiveReason,
 } from '../src/lib/brand-defensive-registration';
 
 describe('damerauLevenshtein', () => {
@@ -197,5 +198,93 @@ describe('evaluateDefensiveRegistration', () => {
 		});
 		// 'brandepsil' vs 'brandepsilon' — distance 2 (two insertions).
 		expect(result.defensive).toBe(true);
+	});
+});
+
+/**
+ * CALL-SITE CONTRACT FOR `check_lookalikes`.
+ *
+ * This heuristic is now consumed by `check-lookalikes.ts` (via
+ * `isBrandHeldRegistration()`), where it supplies the "defensive infrastructure
+ * shape" leg that must agree before a shared brand-protection registrar is
+ * allowed to corroborate that a confusable domain is the scanned
+ * organisation's OWN defensive registration.
+ *
+ * The module JSDoc used to record that no caller could reach the MX/redirect
+ * legs because "the candidate enrichment pipeline does not surface
+ * per-candidate MX records or HTTP redirect targets". `check_lookalikes` DOES:
+ * it probes MX and NS for every registered candidate. That makes the
+ * abstain-versus-fire distinction below load-bearing rather than theoretical,
+ * so it is pinned here at the unit layer.
+ */
+describe('evaluateDefensiveRegistration — check_lookalikes call-site contract', () => {
+	const TARGET = 'contoso.com';
+
+	it('ABSTAINS on undefined mxRecords — "we did not look" is not "there is no mail"', () => {
+		// The trap the call site guards against: passing `undefined` (or
+		// defaulting an unprobed candidate to `[]`) silently converts a missing
+		// measurement into an affirmative "parked, therefore defensive" claim.
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'cont0so.com',
+			targetDomain: TARGET,
+			mxRecords: undefined,
+			nsHosts: ['ns1.cscdns.net'],
+		});
+		expect(result.defensive).toBe(false);
+	});
+
+	it('FIRES on an empty mxRecords array — "we looked, there is nothing"', () => {
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'cont0so.com',
+			targetDomain: TARGET,
+			mxRecords: [],
+			nsHosts: ['ns1.cscdns.net'],
+		});
+		expect(result).toEqual({ defensive: true, reason: 'no-mx' });
+	});
+
+	it('does NOT fire for a candidate with live mail, however corporate its registrar', () => {
+		// The leg that keeps a shared brand-protection registrar from excusing
+		// working phishing infrastructure.
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'cont0so.com',
+			targetDomain: TARGET,
+			mxRecords: ['mail.attacker.example'],
+			nsHosts: ['ns1.cscdns.net'],
+		});
+		expect(result.defensive).toBe(false);
+	});
+
+	it('does NOT fire for a label too far from the target to be a typo of it', () => {
+		// Distance gate: an unrelated domain that merely happens to sit at the
+		// same registrar must never be labelled the brand's own.
+		const result = evaluateDefensiveRegistration({
+			candidateDomain: 'totally-unrelated.com',
+			targetDomain: TARGET,
+			mxRecords: [],
+			nsHosts: ['ns1.cscdns.net'],
+		});
+		expect(result.defensive).toBe(false);
+	});
+
+	it('every reason token has customer-facing phrasing that cannot trip the missing-control score rule', async () => {
+		// `scoreIndicatesMissingControl()` matches finding TEXT; a phrase like
+		// "no MX records" inside a high-severity finding zeroes the whole
+		// category score. The reason tokens are rendered into finding prose by
+		// `DEFENSIVE_REASON_PHRASES` in check-lookalikes.ts, so every token this
+		// module can emit must have a phrase that is safe there. This test fails
+		// if a new DefensiveReason is added without a phrase.
+		const { scoreIndicatesMissingControl } = await import('@blackveil/dns-checks/scoring');
+		const reasons: DefensiveReason[] = ['redirect-to-target', 'no-mx', 'parked-ns'];
+		const { DEFENSIVE_REASON_PHRASES } = await import('../src/tools/check-lookalikes');
+		for (const reason of reasons) {
+			const phrase = DEFENSIVE_REASON_PHRASES[reason];
+			expect(phrase).toBeTruthy();
+			expect(
+				scoreIndicatesMissingControl([
+					{ category: 'lookalikes', title: 'x', severity: 'high', detail: `The domain is defensive because ${phrase}.` },
+				]),
+			).toBe(false);
+		}
 	});
 });

--- a/test/markov-generator.spec.ts
+++ b/test/markov-generator.spec.ts
@@ -2,6 +2,13 @@
 
 import { describe, it, expect } from 'vitest';
 import { trainTrigramModel, generateFromModel, generateMarkovLookalikes } from '../src/tools/markov-generator';
+import {
+	COGNITIVE_SUBSTITUTIONS,
+	MAX_COGNITIVE_LOOKALIKES,
+	QWERTY_ADJACENT,
+	generateCognitiveLookalikes,
+	generateLookalikes,
+} from '../src/tools/lookalike-analysis';
 
 describe('MarkovGenerator', () => {
 	describe('trainTrigramModel', () => {
@@ -52,5 +59,112 @@ describe('MarkovGenerator', () => {
 		it('returns empty for invalid domain', () => {
 			expect(generateMarkovLookalikes('invalid', 5)).toEqual([]);
 		});
+	});
+});
+
+/**
+ * COGNITIVE-ERROR GENERATION (the "Mandela spelling" defect).
+ *
+ * Every operation the candidate generators shipped with before this suite —
+ * QWERTY-adjacency substitution, character omission, character duplication,
+ * dot insertion, TLD swap, homoglyph substitution — models a MOTOR error: a
+ * slip of the finger by someone who knows the correct spelling. A
+ * Mandela-effect misspelling is a COGNITIVE error: the spelling a large
+ * population believes IS correct, and which they will therefore type
+ * deliberately, repeatedly, and without noticing. By construction the motor
+ * operation set cannot reach one unless the cognitive spelling happens to
+ * coincide with a single-character slip.
+ *
+ * The four brands below are the measured corpus. `jcpenny` is the CONTROL: it
+ * is a plain character deletion, so the pre-existing motor generator already
+ * emitted it. If the control ever stops being generated, the mechanism itself
+ * broke and the other three assertions prove nothing.
+ */
+describe('cognitive (Mandela-effect) misspelling generation', () => {
+	/** [seed domain, the spelling a large population believes is correct]. */
+	const MANDELA_CORPUS: ReadonlyArray<readonly [string, string]> = [
+		// Insertion of a silent 't' completing the `tch` trigraph.
+		['skechers.com', 'sketchers.com'],
+		// Non-adjacent a->e substitution; also the `stain`->`stein` morpheme swap.
+		['berenstain.com', 'berenstein.com'],
+		// Vowel lengthening.
+		['febreze.com', 'febreeze.com'],
+		// CONTROL — a motor error (character deletion), already covered.
+		['jcpenney.com', 'jcpenny.com'],
+	];
+
+	it.each(MANDELA_CORPUS)('emits the known Mandela spelling of %s', (seed, mandela) => {
+		expect(generateCognitiveLookalikes(seed)).toContain(mandela);
+	});
+
+	it('CONTROL: the motor generator still emits jcpenny.com — the mechanism never broke', () => {
+		expect(generateLookalikes('jcpenney.com')).toContain('jcpenny.com');
+	});
+
+	it('CONTROL: the motor generator alone still cannot reach the cognitive spellings', () => {
+		// Pins the defect itself. `febreze`/`jcpenney` are excluded — their
+		// Mandela spellings coincide with a single-character motor slip, which
+		// is exactly why they were never evidence of the mechanism working.
+		expect(generateLookalikes('skechers.com')).not.toContain('sketchers.com');
+		expect(generateLookalikes('berenstain.com')).not.toContain('berenstein.com');
+	});
+
+	it('the whole candidate universe (motor + cognitive) covers all four brands', () => {
+		for (const [seed, mandela] of MANDELA_CORPUS) {
+			const universe = new Set([...generateLookalikes(seed), ...generateCognitiveLookalikes(seed)]);
+			expect(universe.has(mandela)).toBe(true);
+		}
+	});
+
+	it('every substitution pair is genuinely NON-adjacent on QWERTY', () => {
+		// The whole point of the operation: a pair the keyboard-adjacency pass
+		// already covers adds no new reach. Guards against someone "helpfully"
+		// padding the table with s/z or f/v.
+		for (const [from, to] of COGNITIVE_SUBSTITUTIONS) {
+			expect(QWERTY_ADJACENT[from] ?? []).not.toContain(to);
+		}
+	});
+
+	it('never emits the seed itself, and every candidate is a structurally valid domain', () => {
+		for (const seed of ['skechers.com', 'berenstain.com', 'febreze.com', 'jcpenney.com', 'looney.co.nz']) {
+			const results = generateCognitiveLookalikes(seed);
+			expect(results).not.toContain(seed);
+			for (const candidate of results) {
+				expect(candidate).toMatch(/^[a-z0-9-]+(\.[a-z0-9-]+)+$/);
+				expect(candidate.length).toBeLessThanOrEqual(253);
+			}
+		}
+	});
+
+	it('preserves a multi-part eTLD rather than mutating inside it', () => {
+		for (const candidate of generateCognitiveLookalikes('berenstain.co.nz')) {
+			expect(candidate.endsWith('.co.nz')).toBe(true);
+		}
+	});
+
+	it('is deterministic and bounded', () => {
+		const first = generateCognitiveLookalikes('berenstain.com');
+		expect(generateCognitiveLookalikes('berenstain.com')).toEqual(first);
+		expect(first.length).toBeLessThanOrEqual(MAX_COGNITIVE_LOOKALIKES);
+	});
+
+	it('returns nothing for input with no TLD', () => {
+		expect(generateCognitiveLookalikes('invalid')).toEqual([]);
+	});
+
+	it('the discovery lane (generateMarkovLookalikes) surfaces the cognitive spellings too', () => {
+		// `discover_brand_domains` builds its candidate universe from this
+		// function, so a Mandela spelling that only reached check_lookalikes
+		// would still be invisible to brand discovery.
+		for (const [seed, mandela] of MANDELA_CORPUS) {
+			expect(generateMarkovLookalikes(seed, 20)).toContain(mandela);
+		}
+	});
+
+	it('CONTROL: the Markov trigram lane still contributes its own candidates', () => {
+		// Proves the union above did not simply replace the Markov output.
+		const cognitive = new Set(generateCognitiveLookalikes('google.com'));
+		const combined = generateMarkovLookalikes('google.com', 20);
+		expect(combined.some((candidate) => !cognitive.has(candidate))).toBe(true);
 	});
 });

--- a/test/ownership-attribution.spec.ts
+++ b/test/ownership-attribution.spec.ts
@@ -550,3 +550,286 @@ describe('buildNonOwnedGateFinding — cross-tool wording parity (F1, 2026-07-27
 		}
 	});
 });
+
+/**
+ * DEFECT: OWNERSHIP INFERRED FROM NAMESERVER DELEGATION ALONE.
+ *
+ * `classifyOwnership()` is driven entirely by NS delegation — in-bailiwick NS,
+ * dedicated NS-set match, or a complete shared-provider match. Anything else
+ * registered with its own nameservers becomes `third_party`, and the report
+ * then tells the customer the domain "is registered to a different
+ * organisation" and offers to "report it to its registrar".
+ *
+ * A brand's OWN defensive registration routinely fails every one of those
+ * tests: brand-protection registrars park defensive names on their own
+ * infrastructure, not on the brand's production DNS. So a brand and its own
+ * defensive misspelling, both held at the same corporate registrar, get split
+ * apart — and the customer is advised to report their own domain for takedown.
+ *
+ * Two things make it worse than a wording bug:
+ *   (a) the tool never even LOOKED. `computeSameEntityCandidates()` gates the
+ *       RDAP fetch on a calibrated severity of medium-or-high, and a parked
+ *       defensive registration (web-only, aged, no mail) calibrates LOW. The
+ *       non-ownership claim is therefore asserted from an evidence set that
+ *       was deliberately not gathered;
+ *   (b) a downstream candidate generator depends on identifying brand-held
+ *       registrations, so a false `third_party` propagates.
+ *
+ * THE SIGNAL USED HERE IS THE IANA REGISTRAR ID, NOT THE REGISTRANT ORG. The
+ * registrant org is free text the registrant types (the reason Ruling A / F2
+ * bars it from `classifyOwnership()`); the IANA registrar ID is assigned by
+ * ICANN and published by the REGISTRY, so a registrant cannot set it. It still
+ * only ever corroborates — no path here can produce `owned_by_seed`.
+ */
+describe('brand-held defensive registration — NS delegation is not the only ownership evidence', () => {
+	let restoreThisTest: (() => void) | undefined;
+	afterEach(() => {
+		restoreThisTest?.();
+		restoreThisTest = undefined;
+	});
+
+	/** IANA registrar IDs: CSC Corporate Domains = 299 (corporate-only), GoDaddy = 146 (retail). */
+	const CSC_IANA_ID = '299';
+	const GODADDY_IANA_ID = '146';
+
+	function rdapDoc(opts: { ianaId: string; registrarName: string; registrationDaysAgo?: number; registrantOrg?: string }) {
+		const days = opts.registrationDaysAgo ?? 3000;
+		return {
+			events: [{ eventAction: 'registration', eventDate: new Date(Date.now() - days * 86_400_000).toISOString() }],
+			entities: [
+				{
+					objectClassName: 'entity',
+					roles: ['registrar'],
+					publicIds: [{ type: 'IANA Registrar ID', identifier: opts.ianaId }],
+					vcardArray: [
+						'vcard',
+						[
+							['version', {}, 'text', '4.0'],
+							['fn', {}, 'text', opts.registrarName],
+						],
+					],
+				},
+				// Registrant is REDACTED, as it is for most gTLD registrations
+				// post-GDPR — so the existing registrant-org correlation cannot
+				// fire and the registrar signal is doing all the work.
+				{
+					objectClassName: 'entity',
+					roles: ['registrant'],
+					vcardArray: [
+						'vcard',
+						[
+							['version', {}, 'text', '4.0'],
+							['fn', {}, 'text', opts.registrantOrg ?? 'REDACTED FOR PRIVACY'],
+						],
+					],
+				},
+			],
+		};
+	}
+
+	/**
+	 * Seed `contoso.com` + one candidate. The candidate always resolves to its
+	 * OWN nameservers, so `classifyOwnership()` returns `third_party` in every
+	 * variant below — the NS evidence is identical throughout and only the
+	 * REGISTRATION RECORD and the infrastructure shape change.
+	 */
+	async function runFixture(opts: {
+		candidate: string;
+		candidateRdap: object;
+		seedRdap: object;
+		/** Defensive shape = parked: A record, no mail. Set true to give it live mail instead. */
+		withMx?: boolean;
+	}) {
+		const { setupFetchMock, createDohResponse } = await import('./helpers/dns-mock');
+		const { restore } = setupFetchMock();
+		restoreThisTest = restore;
+		globalThis.fetch = (async (input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				const parsed = new URL(url);
+				const name = parsed.searchParams.get('name') ?? '';
+				const type = parsed.searchParams.get('type') ?? '';
+				if (name === 'contoso.com' && (type === 'NS' || type === '2')) {
+					return createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]);
+				}
+				if (name === opts.candidate) {
+					if (type === 'NS' || type === '2') {
+						return createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.cscdns.net.' }]);
+					}
+					if (type === 'A' || type === '1') {
+						return createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.10' }]);
+					}
+					if ((type === 'MX' || type === '15') && opts.withMx) {
+						return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mail.contoso.com.' }]);
+					}
+				}
+				return createDohResponse([], []);
+			}
+			if (url.includes('rdap') && url.includes(`/domain/${opts.candidate}`)) {
+				return { ok: true, status: 200, json: () => Promise.resolve(opts.candidateRdap) } as unknown as Response;
+			}
+			if (url.includes('rdap') && url.includes('/domain/contoso.com')) {
+				return { ok: true, status: 200, json: () => Promise.resolve(opts.seedRdap) } as unknown as Response;
+			}
+			// HEAD web probe — reachable (a parked redirect page).
+			return { ok: true, status: 200, headers: new Headers(), json: () => Promise.resolve({}) } as unknown as Response;
+		}) as unknown as typeof fetch;
+
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		return checkLookalikes('contoso.com');
+	}
+
+	/** The defensive registration: parked at CSC, same corporate registrar as the seed. */
+	const DEFENSIVE = {
+		candidate: 'cont0so.com',
+		candidateRdap: rdapDoc({ ianaId: CSC_IANA_ID, registrarName: 'CSC Corporate Domains, Inc.' }),
+		seedRdap: rdapDoc({ ianaId: CSC_IANA_ID, registrarName: 'CSC Corporate Domains, Inc.' }),
+	};
+
+	function findingsFor(result: { findings: Array<{ metadata?: Record<string, unknown> }> }, domain: string) {
+		return result.findings.filter((f) => f.metadata?.lookalikeDomain === domain);
+	}
+
+	it('recognises a defensive registration held at the same brand-protection registrar as the seed', async () => {
+		const result = await runFixture(DEFENSIVE);
+		const attribution = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution).toBeDefined();
+		// THE DEFECT: this used to read "is registered to a different organisation".
+		expect(attribution!.detail).not.toContain('is registered to a different organisation');
+		expect(attribution!.metadata?.brandHeldRegistration).toBe(true);
+		expect(attribution!.metadata?.sharedRegistrarIanaId).toBe(CSC_IANA_ID);
+	});
+
+	it('stops advising the customer to report their own domain to its registrar', async () => {
+		const result = await runFixture(DEFENSIVE);
+		const threat = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'threat_observation');
+		expect(threat).toBeDefined();
+		expect(threat!.detail).not.toContain('report it to its registrar');
+		expect(threat!.detail).not.toContain('takedown provider');
+	});
+
+	it('CONTROL — a shared RETAIL registrar is not ownership evidence and changes nothing', async () => {
+		// Millions of unrelated registrants share GoDaddy. If this fixture ever
+		// starts reading as brand-held, the predicate has stopped discriminating.
+		const result = await runFixture({
+			candidate: 'cont0so.com',
+			candidateRdap: rdapDoc({ ianaId: GODADDY_IANA_ID, registrarName: 'GoDaddy.com, LLC' }),
+			seedRdap: rdapDoc({ ianaId: GODADDY_IANA_ID, registrarName: 'GoDaddy.com, LLC' }),
+		});
+		const attribution = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution).toBeDefined();
+		expect(attribution!.metadata?.brandHeldRegistration).toBeUndefined();
+		expect(attribution!.detail).toContain('is registered to a different organisation');
+	});
+
+	it('CONTROL — a DIFFERENT registrar on each side is not ownership evidence', async () => {
+		const result = await runFixture({
+			candidate: 'cont0so.com',
+			candidateRdap: rdapDoc({ ianaId: '1234', registrarName: 'Bulk Register LLC' }),
+			seedRdap: rdapDoc({ ianaId: CSC_IANA_ID, registrarName: 'CSC Corporate Domains, Inc.' }),
+		});
+		const attribution = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution!.metadata?.brandHeldRegistration).toBeUndefined();
+		expect(attribution!.detail).toContain('is registered to a different organisation');
+	});
+
+	it('CONTROL — TWO DIFFERENT brand-protection registrars are not a match either', async () => {
+		// The discriminating case for the registrar-EQUALITY check specifically.
+		// The variant above cannot test it: its candidate registrar is not in the
+		// brand-protection set, so the set-membership check rejects the candidate
+		// even when the equality check is deleted. Here BOTH sides are corporate
+		// registrars, so equality is the only thing standing between this fixture
+		// and a false brand-held verdict — as a mutation run confirmed (deleting
+		// the equality line left the variant above green and only this one red).
+		const result = await runFixture({
+			candidate: 'cont0so.com',
+			candidateRdap: rdapDoc({ ianaId: CSC_IANA_ID, registrarName: 'CSC Corporate Domains, Inc.' }),
+			seedRdap: rdapDoc({ ianaId: '292', registrarName: 'MarkMonitor Inc.' }),
+		});
+		const attribution = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution!.metadata?.brandHeldRegistration).toBeUndefined();
+		expect(attribution!.detail).toContain('is registered to a different organisation');
+	});
+
+	it('CONTROL — an absent registrar ID on either side is never treated as a match', async () => {
+		// `null === null` must not read as "same registrar". Pins the fail-soft
+		// direction: no registration evidence means no corroboration, never
+		// corroboration by default.
+		const noRegistrar = {
+			events: [{ eventAction: 'registration', eventDate: new Date(Date.now() - 3000 * 86_400_000).toISOString() }],
+			entities: [],
+		};
+		const result = await runFixture({
+			candidate: 'cont0so.com',
+			candidateRdap: noRegistrar,
+			seedRdap: noRegistrar,
+		});
+		const attribution = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution!.metadata?.brandHeldRegistration).toBeUndefined();
+		expect(attribution!.detail).toContain('is registered to a different organisation');
+	});
+
+	it('CONTROL — a shared corporate registrar does NOT excuse live mail infrastructure', async () => {
+		// An attacker who somehow lands at the same corporate registrar still
+		// gets the full threat treatment: the registrar corroborates ownership
+		// only for a candidate whose INFRASTRUCTURE is also defensively shaped.
+		const result = await runFixture({ ...DEFENSIVE, withMx: true });
+		const attribution = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution!.metadata?.brandHeldRegistration).toBeUndefined();
+		const threat = findingsFor(result, 'cont0so.com').find((f) => f.metadata?.findingAxis === 'threat_observation');
+		expect(threat!.detail).toContain('report it to its registrar');
+	});
+
+	it('never manufactures owned_by_seed — the structural verdict stays third_party on registrar evidence alone', async () => {
+		// Ruling A: only SEED-SIDE nameserver evidence may produce owned_by_seed.
+		// A registry-published registrar ID is stronger than a registrant-typed
+		// org string but it is still not proof of common ownership.
+		const result = await runFixture(DEFENSIVE);
+		for (const finding of findingsFor(result, 'cont0so.com')) {
+			expect(finding.metadata?.ownershipVerdict).toBe('third_party');
+		}
+	});
+
+	/**
+	 * THE LOAD-BEARING BOUNDARY. This fix is allowed to change WHICH DOMAINS ARE
+	 * FOUND and what the report SAYS about them. It is not allowed to change how
+	 * a found domain SCORES — per-check scores are locked downstream against the
+	 * vendored scoring package.
+	 *
+	 * `computeCategoryScore` is a pure function of finding severities (plus an
+	 * optional `penaltyOverride`), and `buildCheckResult` additionally zeroes the
+	 * category when `scoreIndicatesMissingControl()` matches finding TEXT on a
+	 * critical/high finding — which is the one way a WORDING change could move a
+	 * score. Both are pinned here.
+	 */
+	it('BOUNDARY: rewording the brand-held case moves no score', async () => {
+		const brandHeld = await runFixture(DEFENSIVE);
+		const retail = await runFixture({
+			candidate: 'cont0so.com',
+			candidateRdap: rdapDoc({ ianaId: GODADDY_IANA_ID, registrarName: 'GoDaddy.com, LLC' }),
+			seedRdap: rdapDoc({ ianaId: GODADDY_IANA_ID, registrarName: 'GoDaddy.com, LLC' }),
+		});
+		// Same probe inputs, same severities, therefore the same category score —
+		// only the prose and the attribution metadata differ.
+		expect(brandHeld.score).toBe(retail.score);
+		expect(brandHeld.passed).toBe(retail.passed);
+		const severities = (r: typeof brandHeld) => r.findings.map((f) => f.severity).sort();
+		expect(severities(brandHeld)).toEqual(severities(retail));
+	});
+
+	it('BOUNDARY: no wording this path emits trips the missing-control text rule', async () => {
+		const { scoreIndicatesMissingControl } = await import('@blackveil/dns-checks/scoring');
+		const result = await runFixture(DEFENSIVE);
+		expect(scoreIndicatesMissingControl(result.findings)).toBe(false);
+
+		// The assertion above alone is VACUOUS: `scoreIndicatesMissingControl`
+		// only inspects critical/high findings, and this fixture calibrates
+		// `low`/`info`. Re-run it with every finding forced to `high` so the
+		// predicate is decided by the TEXT — the actual risk, since a phrase
+		// like "no MX records" inside a high-severity finding zeroes the whole
+		// category score. This is the trap the wording of the new brand-held
+		// finding and DEFENSIVE_REASON_PHRASES is written to avoid.
+		const asHigh = result.findings.map((f) => ({ ...f, severity: 'high' as const }));
+		expect(scoreIndicatesMissingControl(asHigh)).toBe(false);
+	});
+});


### PR DESCRIPTION
Phase 3a. **Merge consent has NOT been given** — this PR is open for review only. Do not merge without an explicit per-PR go-ahead from the operator.

Both defects were **re-verified at the emit site before any code was written**. One of the two reported observations turned out to be partly wrong; the correction is below.

## Defect 1 — the generators emitted motor errors only

Keyboard-adjacency substitution, character omission, character duplication, dot insertion, TLD swap and homoglyph substitution all model a **motor** error: a slip of the finger by someone who knows the correct spelling. A Mandela-effect misspelling is a **cognitive** error — the spelling a large population believes *is* correct, typed deliberately and repeatedly. The motor operation set cannot reach one except by coincidence.

Measured on `origin/main` before the fix:

| seed | Mandela spelling | emitted before? | mechanism |
|---|---|---|---|
| `skechers.com` | `sketchers.com` | ❌ no | needs an inserted letter |
| `berenstain.com` | `berenstein.com` | ❌ no | needs a substitution across the keyboard |
| `febreze.com` | `febreeze.com` | ✅ **yes** | coincides with character duplication |
| `jcpenney.com` | `jcpenny.com` | ✅ yes (**control**) | plain character deletion |

**Correction to the reported evidence:** `febreeze` was already generated, by character duplication. The reported "3 of 4 missing" is really **2 of 4** — the two that need a genuinely new operation. `jcpenny` is the control and never broke.

Adds `generateCognitiveLookalikes()` with three operations:

1. **non-adjacent phonetic substitution** — every pair proven disjoint from `QWERTY_ADJACENT` by test, since an adjacent pair adds no reach;
2. **orthographically-bounded arbitrary insertion** — an inserted letter counts only when it completes a real English cluster. `tch` (the standard spelling of /tʃ/ after a short vowel) is exactly what produces `sketchers`. Unbounded insertion would be positions × 26 at one DNS probe each;
3. **morpheme swap** — `stain`→`stein`, `tunes`→`toons`, which no edit-distance mutator can propose at all (four edits).

Deliberately a **separate function with its own cap** rather than more branches inside `generateLookalikes()`: that function sorts alphabetically and slices at `MAX_PERMUTATIONS`, which most brands already saturate, so folding these in would have silently evicted existing motor candidates. Cap sized on measured rank (worst observed 16 of 30), taking `check_lookalikes` from ~70 to ~96 probes on a saturating brand. Wired into both `check_lookalikes` and the `discover_brand_domains` candidate universe.

## Defect 2 — ownership inferred from nameserver delegation alone

Reproduced verbatim. For a domain parked at the **same corporate registrar as the seed**, the report emitted:

> `cont0so.com` shares the "contoso" label with the scanned domain but **is registered to a different organisation**.

> Defensive options: monitor it, block or quarantine mail bearing that name at the gateway, and **report it to its registrar or a takedown provider**.

The mechanical cause was that **the tool never looked**. `computeSameEntityCandidates()` gated the registration lookup on a calibrated severity of medium-or-high, and a parked defensive registration (web-only, aged, mail-less) calibrates `low`. So a positive non-ownership *claim* was asserted from evidence deliberately not gathered. Severity is a threat tier; gating an *attribution* lookup on it was a category error — the cheapest candidates to dismiss as low-threat are precisely the ones most likely to be the customer's own.

Fix has two parts:

- **low-severity candidates are now eligible.** Cost is **one** extra RDAP fetch per scan — candidate RDAP was never severity-gated (`enrichLookalikes()` already fetched it for every non-owned candidate with infra); only the *seed's* fetch was. `SAME_ENTITY_RDAP_CAP` still bounds the set, and `owned_by_seed` candidates are still excluded outright so the shared-NS short-circuit still pays no RDAP cost.
- **new `isBrandHeldRegistration()`** requiring **both** a shared IANA registrar ID belonging to a brand-protection registrar **and** agreement from the existing `evaluateDefensiveRegistration()` shape heuristic — which this wires up for the first time (its own JSDoc flagged the wiring as the outstanding follow-up).

**Why the IANA registrar ID rather than the registrant org.** The registrant org is free text the registrant types — the attacker-influenceable class Ruling A / F2 bars from attribution. The IANA registrar ID is assigned by ICANN and published by the **registry**; a registrant cannot set it, and cannot move a domain into a corporate registrar's accreditation without that registrar's consent. Brand-protection registrars do not sell to the public. It still only **corroborates**: nothing here can produce `owned_by_seed`, and every finding keeps carrying its structural `third_party` verdict. What changes is what the report *claims* and *recommends*. Retail registrars must never be added to the set, and a control test pins that GoDaddy is not treated as evidence.

## The boundary: no score moves

The fix changes **which domains are found** and **what the report says**, never **how a found domain scores**.

- The diff touches no scoring code and nothing under `packages/dns-checks` (`git status` confirms 6 files, all `src/tools/` + `test/`).
- Verified independently that the published package carries only the `'lookalikes'` **registry key** — zero generator code, `CATEGORY_DISPLAY_WEIGHTS.lookalikes = 0`. So no re-vendor is implied and bv-web-prod's `parity.contract.test.ts` cannot see this change.
- The new attribution finding is emitted at `info` — exactly the cap `capAttributionSeverity()` already applied — and the threat-observation finding keeps its calibrated severity; only its remediation sentence changes.
- Pinned by two boundary tests: one asserting identical `score`/`passed`/severity multiset between the brand-held and retail fixtures, and one re-running `scoreIndicatesMissingControl()` with **every finding forced to `high`** so the missing-control text rule is decided by wording rather than passing vacuously (that predicate only inspects critical/high findings, so the naive assertion would have been vacuous on a `low` fixture).

## Every new guard was mutation-tested

| mutation planted | result |
|---|---|
| retail registrar (GoDaddy 146) added to the brand-protection set | ✅ control went red |
| defensive-infrastructure-shape leg removed | ✅ control went red |
| registrar-equality check removed | ✅ control went red *(after the control was fixed — see below)* |
| missing-control phrase planted in the reason phrases | ✅ boundary test went red |
| low-severity eligibility reverted (the original defect) | ✅ both repro tests went red |
| null-registrar guard removed | ❌ **nothing went red** — see below |

Two honest findings from this pass:

- The first "different registrar" control **did not discriminate**: its candidate registrar was not in the brand-protection set, so set membership rejected the fixture even with the equality check deleted. Replaced with a **two-corporate-registrar** fixture (two different brand-protection registrars) where equality is the only thing standing between the fixture and a false verdict. That one does go red.
- The `=== null` guard is **provably redundant** today — two `null` IDs pass equality and are then rejected by set membership anyway. It is documented in-code as defence-in-depth with the conditions that would make it load-bearing, rather than pinned by a fixture that cannot tell the two implementations apart. This follows the disclosure the neighbouring `isSameEntityOrgMatch` JSDoc already makes about its own both-sides gate.

## Tests

Baseline captured on `origin/main` before the first edit: **6969 passing**, 1 pre-existing failing file (`test/wasm-integration.test.ts` — a worktree-only WASM artifact path error, unrelated).

After: **6998 passing (+29), 0 test failures.** Same single pre-existing file still fails identically. `npm run typecheck` and `eslint` both clean.

Tests extend the three designated files — no parallel files were created.

## Residual risk noted

`evaluateDefensiveRegistration`'s `redirect-to-target` reason is attacker-settable (anyone can redirect their domain at the victim's apex). It is gated behind the registrar-ID leg, which is not — an attacker would need a corporate account at the victim's own brand-protection registrar. And even a successful forge yields **no severity discount**: the threat observation is still emitted at full calibrated severity and still counts toward `highCount`. Only the closing advice sentence changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YRS64majttgooayX33uiEp