### PR TITLE
feat(dkim): cover 8 providers the selector probe missed; anchor the Mailgun attribution label

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.11.0",
+	"version": "1.12.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-dkim.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dkim.test.ts
@@ -215,12 +215,16 @@ describe('checkDKIM', () => {
 	});
 
 	it('attributes Mailgun CNAME delegation', async () => {
+		// Target measured live on mailgun.com, 2026-08-06: mg._domainkey CNAMEs to
+		// dkim.mailgun.NET. The previous fixture used a fabricated `mailo._mailgun.org`
+		// — the label there is `_mailgun`, so it only ever matched because the pattern
+		// was an unanchored suffix. Both were corrected together.
 		const queryDNS = createCnameAwareDNS(
 			{
-				'mailo._mailgun.org': ['k=rsa; p=' + 'A'.repeat(600)],
+				'dkim.mailgun.net': ['k=rsa; p=' + 'A'.repeat(600)],
 			},
 			{
-				'mail._domainkey.example.com': 'mailo._mailgun.org',
+				'mg._domainkey.example.com': 'dkim.mailgun.net',
 			},
 		);
 		const result = await checkDKIM('example.com', queryDNS);

--- a/packages/dns-checks/src/__tests__/checks/dkim-selector-coverage.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dkim-selector-coverage.test.ts
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Provider coverage guard for the DKIM selector probe list.
+ *
+ * Every selector asserted here was confirmed by a live Cloudflare DoH probe on
+ * 2026-08-06 against a real domain (named per case). The list is a heuristic —
+ * a miss hard-floors the dkim category at 50 — so each provider gets a
+ * regression test proving the default probe path finds a key published ONLY at
+ * that provider's selector.
+ *
+ * Control arm included: an unlisted selector must still read as "not found",
+ * otherwise these tests would pass vacuously against a probe list that matched
+ * everything.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { checkDKIM } from '../../checks/check-dkim';
+import { COMMON_DKIM_SELECTORS } from '../../checks/dkim-selectors';
+import type { DNSQueryFunction } from '../../types';
+
+const VALID_KEY = 'v=DKIM1; k=rsa; p=' + 'A'.repeat(392);
+/** SendGrid-family records omit v=DKIM1 by design (RFC 6376 §3.6.1 tolerates it). */
+const NO_VERSION_KEY = 'k=rsa; t=s; p=' + 'A'.repeat(392);
+
+function dnsFor(txt: Record<string, string[]>, cname: Record<string, string> = {}): DNSQueryFunction {
+	function resolveTxt(name: string, depth = 0): string[] {
+		if (depth > 5) return [];
+		if (cname[name] !== undefined) return resolveTxt(cname[name], depth + 1);
+		return txt[name] ?? [];
+	}
+	return vi.fn(async (name: string, type: string) => {
+		if (type === 'CNAME') return cname[name] !== undefined ? [cname[name]] : [];
+		return resolveTxt(name);
+	});
+}
+
+/** Each row verified by a live Cloudflare DoH probe on 2026-08-06. */
+const MEASURED_COVERAGE = [
+	{ provider: 'Fastmail', selector: 'fm1', record: VALID_KEY, evidence: 'fastmail.com' },
+	{ provider: 'Fastmail', selector: 'fm2', record: VALID_KEY, evidence: 'fastmail.com' },
+	{ provider: 'Fastmail', selector: 'fm3', record: VALID_KEY, evidence: 'fastmail.com' },
+	{ provider: 'Klaviyo', selector: 'kl', record: NO_VERSION_KEY, evidence: 'glossier.com' },
+	{ provider: 'Klaviyo', selector: 'kl2', record: NO_VERSION_KEY, evidence: 'glossier.com' },
+	{ provider: 'Mailchimp', selector: 'k2', record: VALID_KEY, evidence: 'mailchimp.com' },
+	{ provider: 'Mailchimp', selector: 'k3', record: VALID_KEY, evidence: 'mailchimp.com' },
+	{ provider: 'HubSpot', selector: 'hs1', record: NO_VERSION_KEY, evidence: 'hubspot.com' },
+	{ provider: 'HubSpot', selector: 'hs2', record: NO_VERSION_KEY, evidence: 'hubspot.com' },
+	{ provider: 'Mailgun', selector: 'mg', record: NO_VERSION_KEY, evidence: 'mailgun.com' },
+	{ provider: 'Mailgun', selector: 'pic', record: NO_VERSION_KEY, evidence: 'hubspot.com' },
+	{ provider: 'SendGrid legacy', selector: 'smtpapi', record: NO_VERSION_KEY, evidence: 'klaviyo.com' },
+	{ provider: 'SendGrid legacy', selector: 'm1', record: NO_VERSION_KEY, evidence: 'hubspot.com' },
+	{ provider: 'Zendesk', selector: 'zendesk1', record: VALID_KEY, evidence: 'mailchimp.com' },
+	{ provider: 'Zendesk', selector: 'zendesk2', record: VALID_KEY, evidence: 'mailchimp.com' },
+	{ provider: 'Mailjet', selector: 'mailjet', record: NO_VERSION_KEY, evidence: 'mailgun.com' },
+];
+
+describe('DKIM selector coverage (default probe list)', () => {
+	it.each(MEASURED_COVERAGE)(
+		'$provider: probes "$selector" and finds a key published only there (observed on $evidence)',
+		async ({ selector, record }) => {
+			expect(COMMON_DKIM_SELECTORS).toContain(selector);
+			const result = await checkDKIM(
+				'example.com',
+				dnsFor({ [`${selector}._domainkey.example.com`]: [record] }),
+			);
+			expect(result.findings.some((f) => f.title === 'No DKIM records found among tested selectors')).toBe(
+				false,
+			);
+			expect(result.score).toBeGreaterThan(50);
+		},
+	);
+
+	it('CONTROL: an unlisted selector is still reported as not found', async () => {
+		const result = await checkDKIM(
+			'example.com',
+			dnsFor({ 'not-a-real-selector._domainkey.example.com': [VALID_KEY] }),
+		);
+		expect(result.findings.some((f) => f.title === 'No DKIM records found among tested selectors')).toBe(true);
+		expect(result.score).toBe(50);
+	});
+
+	it('CONTROL: a total miss still hard-floors the category at 50', async () => {
+		const result = await checkDKIM('example.com', dnsFor({}));
+		expect(result.score).toBe(50);
+	});
+});
+
+describe('DKIM SaaS attribution reachable from the default probe list', () => {
+	it('attributes HubSpot via hs1 → hubspotemail.net', async () => {
+		const result = await checkDKIM(
+			'example.com',
+			dnsFor(
+				{ 'example-com.hs01a.dkim.hubspotemail.net': [NO_VERSION_KEY] },
+				{ 'hs1._domainkey.example.com': 'example-com.hs01a.dkim.hubspotemail.net' },
+			),
+		);
+		expect(result.findings.some((f) => f.metadata?.delegatedTo === 'HubSpot')).toBe(true);
+	});
+
+	it('attributes Mailgun via mg → dkim.mailgun.net (the .net target, not .org)', async () => {
+		const result = await checkDKIM(
+			'example.com',
+			dnsFor(
+				{ 'dkim.mailgun.net': [NO_VERSION_KEY] },
+				{ 'mg._domainkey.example.com': 'dkim.mailgun.net' },
+			),
+		);
+		expect(result.findings.some((f) => f.metadata?.delegatedTo === 'Mailgun')).toBe(true);
+	});
+
+	it('attributes Klaviyo selectors to SendGrid, which actually holds the key', async () => {
+		// Measured on glossier.com: kl → kl.domainkey.u161779.wl030.sendgrid.net.
+		const result = await checkDKIM(
+			'example.com',
+			dnsFor(
+				{ 'kl.domainkey.u161779.wl030.sendgrid.net': [NO_VERSION_KEY] },
+				{ 'kl._domainkey.example.com': 'kl.domainkey.u161779.wl030.sendgrid.net' },
+			),
+		);
+		expect(result.findings.some((f) => f.metadata?.delegatedTo === 'SendGrid')).toBe(true);
+	});
+});

--- a/packages/dns-checks/src/__tests__/checks/dkim-selector-coverage.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dkim-selector-coverage.test.ts
@@ -17,6 +17,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { checkDKIM } from '../../checks/check-dkim';
 import { COMMON_DKIM_SELECTORS } from '../../checks/dkim-selectors';
+import { attributeCnameChain } from '../../checks/dkim-saas-attribution';
 import type { DNSQueryFunction } from '../../types';
 
 const VALID_KEY = 'v=DKIM1; k=rsa; p=' + 'A'.repeat(392);
@@ -119,5 +120,15 @@ describe('DKIM SaaS attribution reachable from the default probe list', () => {
 			),
 		);
 		expect(result.findings.some((f) => f.metadata?.delegatedTo === 'SendGrid')).toBe(true);
+	});
+});
+
+describe('SaaS attribution cannot be claimed by a lookalike domain', () => {
+	it('does not attribute an attacker-registered evil-mailgun.net to Mailgun', () => {
+		expect(attributeCnameChain(['dkim.mailgun.net'])).toBe('Mailgun');
+		expect(attributeCnameChain(['mailgun.net'])).toBe('Mailgun');
+		// Attribution downgrades severity, so a bare suffix match is exploitable.
+		expect(attributeCnameChain(['evil-mailgun.net'])).toBeUndefined();
+		expect(attributeCnameChain(['notmailgun.org'])).toBeUndefined();
 	});
 });

--- a/packages/dns-checks/src/checks/dkim-saas-attribution.ts
+++ b/packages/dns-checks/src/checks/dkim-saas-attribution.ts
@@ -35,7 +35,12 @@ export const DKIM_SAAS_PATTERNS: readonly DkimSaasAttribution[] = [
 	// SUBDOMAIN customers are told to create, never the DKIM CNAME target — so
 	// this never matched a real chain. Both are kept: .org costs nothing and
 	// guards against a future change of target.
-	{ provider: 'Mailgun', pattern: /mailgun\.(net|org)\.?$/i },
+	//
+	// `(^|\.)` is load-bearing. Attribution DOWNGRADES finding severity (a weak
+	// 1024-bit key drops high → medium because only the provider can rotate it),
+	// so an unanchored suffix would let an attacker-registered `evil-mailgun.net`
+	// claim provider status and soften findings about a key it fully controls.
+	{ provider: 'Mailgun', pattern: /(^|\.)mailgun\.(net|org)\.?$/i },
 	{ provider: 'Postmark', pattern: /\.mtasv\.net\.?$/i },
 	{ provider: 'Mailchimp', pattern: /\.(mcsv|mailchimpapp)\.net\.?$/i },
 	{ provider: 'Amazon SES', pattern: /\.dkim\.amazonses\.com\.?$/i },

--- a/packages/dns-checks/src/checks/dkim-saas-attribution.ts
+++ b/packages/dns-checks/src/checks/dkim-saas-attribution.ts
@@ -30,7 +30,12 @@ export interface DkimSaasAttribution {
  */
 export const DKIM_SAAS_PATTERNS: readonly DkimSaasAttribution[] = [
 	{ provider: 'SendGrid', pattern: /\.sendgrid\.net\.?$/i },
-	{ provider: 'Mailgun', pattern: /mailgun\.org\.?$/i },
+	// Mailgun delegates DKIM to dkim.mailgun.NET (measured on mailgun.com,
+	// 2026-08-06). The pattern was `.org` only — mailgun.org is the sending
+	// SUBDOMAIN customers are told to create, never the DKIM CNAME target — so
+	// this never matched a real chain. Both are kept: .org costs nothing and
+	// guards against a future change of target.
+	{ provider: 'Mailgun', pattern: /mailgun\.(net|org)\.?$/i },
 	{ provider: 'Postmark', pattern: /\.mtasv\.net\.?$/i },
 	{ provider: 'Mailchimp', pattern: /\.(mcsv|mailchimpapp)\.net\.?$/i },
 	{ provider: 'Amazon SES', pattern: /\.dkim\.amazonses\.com\.?$/i },

--- a/packages/dns-checks/src/checks/dkim-selectors.ts
+++ b/packages/dns-checks/src/checks/dkim-selectors.ts
@@ -15,8 +15,26 @@
  *   CNAME to *.domainkey.*.sendgrid.net (records lack v=DKIM1 — see
  *   dkim-saas-attribution.ts).
  * - Mandrill uses `mandrill`; MailerSend uses `mte1`/`mte2`; SparkPost
- *   ships `scph<yyyymm>` rotated keys; Klaviyo/HubSpot default to
- *   `dkim1`/`dkim2`.
+ *   ships `scph<yyyymm>` rotated keys.
+ * - Klaviyo uses `kl`/`kl2` and HubSpot uses `hs1`/`hs2` — NOT `dkim1`/`dkim2`
+ *   as this comment previously claimed. Corrected 2026-08-06 from live DoH
+ *   probes (glossier.com, hubspot.com); the mistaken claim is why the HubSpot
+ *   entry in dkim-saas-attribution.ts had been unreachable.
+ *
+ * Every entry below is backed by an observed key on a real domain. Do NOT add
+ * speculative selectors: the check fans out with Promise.all over the WHOLE
+ * list on every scan of every domain, under an 8s per-check timeout, and a
+ * check that times out is excluded from the score entirely — an over-long list
+ * degrades into no DKIM signal at all, which is worse than the false negative
+ * it was meant to fix. Provider-specific tails belong behind a second stage
+ * conditioned on MX/SPF, not in this list.
+ *
+ * Selectors that CANNOT be enumerated, and must not be attempted here:
+ * - Amazon SES Easy DKIM — three random 32-char tokens per domain.
+ * - Microsoft 365 `selector1-<domain>` — that is the CNAME *target* under
+ *   <tenant>.onmicrosoft.com, not a selector on the customer domain.
+ * - Date-stamped selectors (20161025, 20120113, …) — per-key-generation names
+ *   on the provider's own domain; unbounded search space.
  */
 export const COMMON_DKIM_SELECTORS: readonly string[] = [
 	// Generic defaults
@@ -54,4 +72,31 @@ export const COMMON_DKIM_SELECTORS: readonly string[] = [
 	'scph0322',
 	// Postmark
 	'pm',
+	// --- Added 2026-08-06, each confirmed by a live DoH probe (evidence domain
+	// in parentheses). Regression-guarded by dkim-selector-coverage.test.ts. ---
+	// Fastmail (fastmail.com published NOTHING at any pre-existing selector —
+	// a total false negative for every Fastmail-hosted domain)
+	'fm1',
+	'fm2',
+	'fm3',
+	// Mailchimp rotation beyond k1 (mailchimp.com → dkim2/dkim3.mcsv.net)
+	'k2',
+	'k3',
+	// HubSpot (hubspot.com, mailgun.com → <domain>.hs01a.dkim.hubspotemail.net)
+	'hs1',
+	'hs2',
+	// Klaviyo (glossier.com → kl.domainkey.*.sendgrid.net — SendGrid holds the key)
+	'kl',
+	'kl2',
+	// Mailgun (mailgun.com → dkim.mailgun.net; `pic` observed on hubspot.com)
+	'mg',
+	'pic',
+	// SendGrid legacy selectors, still live (klaviyo.com, hubspot.com)
+	'smtpapi',
+	'm1',
+	// Zendesk (mailchimp.com, klaviyo.com → zendesk[12]._domainkey.zendesk.com)
+	'zendesk1',
+	'zendesk2',
+	// Mailjet (mailgun.com)
+	'mailjet',
 ];

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -40,6 +40,12 @@ export { createFinding, buildCheckResult, computeCategoryScore, inferFindingConf
 // Robot policy
 export { SCANNER_USER_AGENT, RobotsDisallowedError, withRobotsGate } from './robots-gate';
 
+// DKIM selector probe list. Exported so downstream consumers can assert provider
+// coverage without re-declaring the list (a second copy would drift and, because
+// a probe miss hard-floors the dkim category at 50, drift is scored as a real
+// finding on a domain whose email auth is fine).
+export { COMMON_DKIM_SELECTORS } from './checks/dkim-selectors';
+
 // Check implementations
 export {
 	checkSPF,

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.11.0';
+export const PARITY_CORPUS_VERSION = '1.12.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):


### PR DESCRIPTION
## Why

The DKIM check probes a fixed selector list. A total miss does not merely lose a finding — it **hard-floors the category at 50**:

```js
if (foundSelectors.length === 0 && result.score > 50) return { ...result, score: 50 };
```

With `dkim` at `importance: 10` in the `mail_enabled` core pool (54 → 70 points), a false negative costs **≈6.5 overall points** — enough to move a NIST band on a domain whose email authentication is actually fine.

## What measurement found

Live Cloudflare DoH probing on 2026-08-06. Harness validated on a known-good (`20161025._domainkey.google.com`) and known-bad (`zzzz-not-real`) fixture before use.

**`fastmail.com` publishes NOTHING at any of the 24 existing selectors** while carrying real keys at `fm1`/`fm2`/`fm3` — a complete false negative for every Fastmail-hosted domain. Seven more providers were partially or wholly unreachable.

All 16 additions are backed by an observed key on a named domain. Nothing speculative was added.

| Provider | Selectors | Evidence domain |
|---|---|---|
| Fastmail | `fm1` `fm2` `fm3` | fastmail.com — **total miss before this** |
| Mailchimp | `k2` `k3` | mailchimp.com → `dkim2/dkim3.mcsv.net` |
| HubSpot | `hs1` `hs2` | hubspot.com, mailgun.com |
| Klaviyo | `kl` `kl2` | glossier.com |
| Mailgun | `mg` `pic` | mailgun.com → `dkim.mailgun.net` |
| SendGrid legacy | `smtpapi` `m1` | klaviyo.com, hubspot.com |
| Zendesk | `zendesk1` `zendesk2` | mailchimp.com, klaviyo.com |
| Mailjet | `mailjet` | mailgun.com |

## Three defects fixed

1. **The HubSpot entry in `DKIM_SAAS_PATTERNS` was unreachable.** No selector in the list could produce a matching CNAME chain, because `dkim-selectors.ts` claimed *"Klaviyo/HubSpot default to `dkim1`/`dkim2`"* — they do not. Comment corrected in place with the measured selectors.

2. **The Mailgun pattern matched `mailgun.ORG`.** The measured DKIM CNAME target is `dkim.mailgun.NET`; `mailgun.org` is the sending subdomain customers create, never the delegation target — so the pattern never matched a real chain.

3. **Security (found in self-review of commit 1):** the widened pattern was an unanchored suffix, so `evil-mailgun.net` matched. Attribution **downgrades finding severity** (a 1024-bit key drops high → medium because "only the provider can rotate it"), so an attacker registering a `*mailgun.net` lookalike and delegating a selector to it gets the scanner to soften findings about a key they fully control. Anchored to `(^|\.)mailgun\.(net|org)\.?$`.

   This also explains why the pre-existing attribution test missed it: its fixture was a fabricated `mailo._mailgun.org`, whose label is `_mailgun`. The test passed only because fixture and regex were wrong in the same direction. It now uses the measured `dkim.mailgun.net`.

## What was deliberately NOT added

The check fans out with `Promise.all` over the **whole** list on every scan of every domain, under an 8s per-check timeout — and a timed-out check is *excluded from the score entirely*, so an over-long list degrades into no DKIM signal at all. The docstring now records the unenumerable classes: SES Easy DKIM's random per-domain tokens, M365's `selector1-<domain>` (that is the CNAME *target*, not a selector), and date-stamped selectors.

A ~150-selector "exhaustive" list was considered and rejected: 6.3× amplification, and ~500M extra DoH queries per full GSI corpus pass downstream. If the tail is wanted later, the right shape is two-stage probing conditioned on MX/SPF.

## Tests

`dkim-selector-coverage.test.ts` guards each provider and carries **CONTROL arms** — an unlisted selector must still read as not-found, and a total miss must still floor at 50 — so the suite cannot pass vacuously against a list that matched everything. Plus a lookalike-attribution guard asserting both directions.

`COMMON_DKIM_SELECTORS` is now exported from the package index so downstream consumers can assert coverage instead of keeping a second copy that would drift — and drift here is scored as a real finding.

**643 tests pass, typecheck clean.** Package `1.11.0 → 1.12.0`; `PARITY_CORPUS_VERSION` moved in lockstep.

## Downstream impact

Scores move **upward only**, for domains that were false negatives. bv-web-prod re-vendor must bump `VENDORED_VERSION` in **both** `parity.contract.test.ts` and `mcp-grade-parity.contract.test.ts`. Re-vendoring is a fleet event — `dns-recon` and `bv2-ops` also run the scan engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)