### PR TITLE
fix(ci): keep codeql-action init/analyze in version lockstep

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,16 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 5
+    groups:
+      # github/codeql-action/init and .../analyze are ONE action published from one
+      # repo, and they must run at the SAME version: init writes a config file
+      # stamped with its own version, and analyze hard-fails reading it back with
+      # "Loaded a configuration file for version 'X', but running version 'Y'".
+      # Dependabot keys the github-actions ecosystem on the full action path, so
+      # without this group it opens a separate PR per sub-action — each one
+      # internally version-mismatched and therefore red on arrival. This split has
+      # recurred on every codeql-action release (v4.37.0 #499/#500,
+      # v4.37.3 #536/#538, v4.37.4 #627/#628). Grouping keeps them in lockstep.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -111,6 +111,6 @@ jobs:
           dependency-caching: true
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Problem

Both CodeQL matrix legs fail on the open Dependabot PRs #627 and #628:

```
##[error]Loaded a configuration file for version '4.37.3', but running version '4.37.4'
CodeQL job status was configuration error.
```

`github/codeql-action/init` and `github/codeql-action/analyze` are **one action published from one repo**, and they must run at the same version — `init` writes a config file stamped with its own version, and `analyze` hard-fails reading it back on a mismatch.

Dependabot keys the `github-actions` ecosystem on the **full action path**, so it treats them as two independent dependencies and opens one PR per sub-action:

- #627 bumps `init` only → `init` 4.37.4 + `analyze` 4.37.3
- #628 bumps `analyze` only → `init` 4.37.3 + `analyze` 4.37.4

Each PR is therefore **internally version-mismatched and red on arrival**, and whichever merged first would leave `main` red until the other landed. The same split recurred at v4.37.0 (#499/#500) and v4.37.3 (#536/#538) — this is structural, not a one-off.

Ruled out: code-scanning default setup is `not-configured`, so this is not the usual default-vs-advanced conflict.

## Fix

1. **Immediate** — bump both pins to v4.37.4 in one commit, restoring lockstep.
2. **Durable** — add a `codeql-action` Dependabot group so future releases arrive as a **single** PR instead of two mutually-inconsistent ones.

Supply chain verified: the upstream annotated tag `v4.37.4` dereferences to exactly `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (release merge into `releases/v4`). Full-SHA pinning preserved.

## Verification

- `npm run audit:oss-safety` — 16 files, 60 tests, exit 0 (this is the required *File hygiene check* gate, and it's what runs the Workers-pool-excluded `workflow-cost.audit.test.ts`)
- `workflow-permissions` / `workflow-safety-gates` / `workflow-secret-check` audits — 15 tests pass
- `scripts/ci/check-workflow-cost.mjs` — "$0 pipeline", exit 0

## Follow-up

#627 and #628 become no-ops once this lands; Dependabot should auto-close them on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)