### PR TITLE
fix(release): make version-bump a read-only gate instead of pushing to main

### DIFF
--- a/.claude/skills/bv-mcp-release/SKILL.md
+++ b/.claude/skills/bv-mcp-release/SKILL.md
@@ -19,7 +19,7 @@ A version lives in **4 hand-edited places** (plus the auto-derived `SERVER_VERSI
 
 ## Pre-bump locally before tagging
 
-The `publish.yml` version-sync step auto-commits a bump and **pushes to `main` — which branch protection rejects** unless you've already done it. So do it first:
+Pre-bumping is **enforced, not merely advised**. `publish.yml`'s `version-bump` job is a read-only *verification gate* (PR #632): it asserts `package.json`, `package-lock.json`, `server.json` (plus `packages[0].version` if that stanza ever returns) and the `CHANGELOG.md` heading already match the tag, and fails the release with a per-surface `::error::` if any disagree. It edits and pushes nothing. So do the bump first:
 
 ```bash
 npm version <X.Y.Z> --no-git-tag-version --allow-same-version   # package.json + lock; SERVER_VERSION auto-derives
@@ -28,7 +28,20 @@ git commit -am "chore: release <X.Y.Z>" && git push origin main   # via PR — d
 git tag v<X.Y.Z> <merged-main-HEAD> && git push origin v<X.Y.Z>   # tag the squashed merge commit, not the bump-branch tip
 ```
 
-Then `publish.yml` runs: validate → version-sync (no-op, already bumped) → npm publish (provenance) ‖ Cloudflare deploy → MCP Registry → GH Release. Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in the `production` env (fail-fast if absent).
+Then `publish.yml` runs: validate → version-verify (read-only gate) → npm publish (provenance) ‖ Cloudflare deploy → MCP Registry → GH Release. Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in the `production` env (fail-fast if absent).
+
+### Why the gate replaced the auto-bump (3.40.0–3.42.0 incident)
+
+Releases **3.40.0, 3.41.0 and 3.42.0 all half-failed** and nobody noticed for weeks, because the failure was in a job everything else `needs:` — npm publish, Cloudflare deploy, registry publish **and Create GitHub Release** all reported `skipped`, so the GH Release had to be cut by hand each time.
+
+The job pushed an auto-bump commit to `main`, which protected-branch rules reject unconditionally (`GH006 … 4 of 4 required status checks are expected`) — a direct push can never satisfy required checks. The skill and CLAUDE.md both said pre-bumping made the step "a no-op". **It did not.** The step re-serialized `server.json` with `JSON.stringify(o, null, '\t')`, reindenting the committed **2-space** file to **tabs**; the no-op guard `git diff --cached --quiet` is a **byte** test, so a whitespace-only, semantically-identical rewrite took the "version changed" branch and pushed anyway. Replayed against the real v3.42.0 tag: `package.json`/`package-lock.json` clean, `server.json` 14 insertions / 14 deletions.
+
+Two transferable lessons:
+
+- **A "this becomes a no-op" claim is worth executing once.** This one was documented in two places and false in both for three releases.
+- **Never re-serialize a file to check whether it needs changing.** Compare the parsed value; write only on a real difference. Any `JSON.stringify` round-trip silently normalizes indentation, key quoting and trailing newline, which defeats every byte-level idempotency guard downstream.
+
+`test/audits/workflow-permissions.audit.test.ts` now pins this shut: `contents: write` may appear **only** in `github-release`, and a tripwire asserts `version-bump` stays read-only and never regains `git push origin HEAD:main`.
 
 ## Current publish reality (verify, don't assume)
 
@@ -67,7 +80,8 @@ Never commit `.npmrc`, registry tokens, the DNS publisher key, or generated prod
 ## Red flags
 
 - Bumping `package.json` only → CI version-sync audit fails. Hit all 4 surfaces (package.json + lock, server.json, CHANGELOG).
-- Letting `publish.yml` do the bump push → rejected by branch protection. Pre-bump locally.
+- Tagging without pre-bumping → the `version-bump` gate fails the release with a per-surface `::error::` and nothing publishes. Bump all 4 surfaces, then move the tag. (It no longer tries to fix this up for you — see the 3.40.0–3.42.0 incident above.)
+- "Reformatting" `server.json` to tabs to match Prettier → harmless now, but it is the *shape* of the bug that cost three releases. Prettier flags the file; leave it alone unless you also re-verify the release path.
 - Re-adding a `packages` stanza to `server.json` and syncing only the top-level `version` → registry/version mismatch. Sync both fields.
 - `mcp-publisher publish` BEFORE `deploy:prod` → registry advertises a version prod doesn't serve (stale-prod, public). Deploy first, publish last.
 - Hand-editing `SERVER_VERSION` → no-op at best (it auto-derives from `pkg.version`); bump `package.json` instead.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,19 +69,21 @@ jobs:
         run: npm audit --omit=dev --audit-level=high
 
   version-bump:
-    name: Sync version to tag
+    name: Verify version matches tag
     needs: validate
     runs-on: ubuntu-latest
-    # Pushes the version-bump commit back to `main`.
+    # Read-only: this job verifies, it never writes. Its previous incarnation
+    # pushed an auto-bump commit to `main`, which protected-branch rules always
+    # reject ("4 of 4 required status checks are expected") — that failed the
+    # job on every release since v3.40.0 and skipped ALL downstream publish /
+    # deploy / registry jobs, forcing the GitHub Release to be cut by hand.
     permissions:
-      contents: write
+      contents: read
     outputs:
       version: ${{ steps.extract.outputs.version }}
       changelog: ${{ steps.changelog.outputs.body }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - id: extract
         name: Extract version from tag
@@ -92,23 +94,43 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Releasing version: $VERSION"
 
-      - name: Update package.json version
-        env:
-          VERSION: ${{ steps.extract.outputs.version }}
-        run: npm version "$VERSION" --no-git-tag-version --allow-same-version
-
-      # SERVER_VERSION is intentionally NOT bumped here: src/lib/server-version.ts
-      # auto-derives it from package.json (`export const SERVER_VERSION: string =
-      # pkg.version;`), which `npm version` above already updated. The prior
-      # `sed` step targeted a hand-edited literal that no longer exists — it was
-      # a silent no-op implying it maintained a surface it did not.
-
-      - name: Update server.json version
+      # The supported release path is to pre-bump locally before tagging (see
+      # CLAUDE.md "Release"). This gate ASSERTS that happened rather than trying
+      # to fix it up in CI, and deliberately rewrites nothing.
+      #
+      # Why not rewrite: the old step re-serialized server.json with
+      # `JSON.stringify(o, null, '\t')`, reindenting a 2-space file to tabs. The
+      # `git diff --cached --quiet` no-op guard is a BYTE test, so that
+      # whitespace-only churn made it take the "version changed" branch and push
+      # even when the version already matched the tag — which is exactly why the
+      # documented "pre-bump so this becomes a no-op" workaround never worked.
+      #
+      # SERVER_VERSION is not checked: src/lib/server-version.ts auto-derives it
+      # from package.json (`export const SERVER_VERSION: string = pkg.version;`).
+      - name: Verify version surfaces match tag
         env:
           VERSION: ${{ steps.extract.outputs.version }}
         run: |
-          node -e "const fs=require('fs');const o=JSON.parse(fs.readFileSync('server.json','utf8'));o.version=process.env.VERSION;if(o.packages&&o.packages[0])o.packages[0].version=process.env.VERSION;fs.writeFileSync('server.json',JSON.stringify(o,null,'\t')+'\n');"
-          grep -n '"version"' server.json
+          PKG=$(node -p "require('./package.json').version")
+          LOCK=$(node -p "require('./package-lock.json').version")
+          SRV=$(node -p "require('./server.json').version")
+          fail=0
+          [ "$PKG" = "$VERSION" ] || { echo "::error::package.json is $PKG, expected $VERSION"; fail=1; }
+          [ "$LOCK" = "$VERSION" ] || { echo "::error::package-lock.json is $LOCK, expected $VERSION"; fail=1; }
+          [ "$SRV" = "$VERSION" ] || { echo "::error::server.json is $SRV, expected $VERSION"; fail=1; }
+          # server.json is currently remotes-only. If an npm `packages` stanza is
+          # ever re-added it carries its own version that must match too.
+          PKGVER=$(node -p "const o=require('./server.json'); o.packages && o.packages[0] ? o.packages[0].version : ''")
+          if [ -n "$PKGVER" ] && [ "$PKGVER" != "$VERSION" ]; then
+            echo "::error::server.json packages[0].version is $PKGVER, expected $VERSION"
+            fail=1
+          fi
+          grep -q "^## \[$VERSION\]" CHANGELOG.md || { echo "::error::no CHANGELOG.md entry for $VERSION"; fail=1; }
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::Version surfaces disagree with tag v$VERSION. Pre-bump locally before tagging (see CLAUDE.md \"Release\"), then move the tag."
+            exit 1
+          fi
+          echo "All version surfaces match $VERSION."
 
       - id: changelog
         name: Extract changelog for this version
@@ -125,24 +147,6 @@ jobs:
             echo "$BODY"
             echo "CHANGELOG_EOF"
           } >> "$GITHUB_OUTPUT"
-
-      # Note: the push below is rejected by `main` branch protection unless
-      # the workflow runs under a token with bypass permission (RELEASE_TOKEN).
-      # The supported workflow is to pre-bump the version locally before
-      # tagging so this step becomes a no-op. See CLAUDE.md "Release workflow".
-      - name: Commit version bump if changed
-        env:
-          VERSION: ${{ steps.extract.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add package.json package-lock.json server.json
-          if git diff --cached --quiet; then
-            echo "Version already matches tag"
-          else
-            git commit -m "chore: auto-bump version to $VERSION [skip ci]"
-            git push origin HEAD:main
-          fi
 
   publish-npm:
     name: Publish to npm

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ Workflows: `ci.yml` (adds a non-required parallel `fast-checks` typecheck+lint j
 
 ### Release (`publish.yml`)
 
-**Pre-bump locally before tagging** to avoid the workflow's auto-bump push being rejected by branch protection:
+**Pre-bump locally before tagging — this is now enforced, not just advised.** The `version-bump` job is a read-only *verification gate*: it asserts `package.json`, `package-lock.json`, `server.json` and the `CHANGELOG.md` heading all already match the tag, and fails the release with a per-surface `::error::` if any disagree. It no longer edits or pushes anything. (It previously tried to auto-bump and push to `main`, which protected-branch rules always reject — that failed every release from 3.40.0 to 3.42.0 and skipped all downstream publish/deploy jobs. The documented "no-op if pre-bumped" escape never worked because the step re-serialized `server.json` from 2-space to tab indent, so the byte-level `git diff --cached --quiet` guard always saw a change.)
 
 ```bash
 npm version <X.Y.Z> --no-git-tag-version --allow-same-version   # bumps package.json + lock; SERVER_VERSION auto-derives
@@ -276,7 +276,7 @@ git commit -am "chore: bump version to <X.Y.Z>" && git push origin main
 git tag v<X.Y.Z> && git push origin v<X.Y.Z>
 ```
 
-Pipeline: validate → version-sync (no-op if pre-bumped) → npm publish (provenance) || Cloudflare deploy → MCP Registry → GH Release. Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in `production` env — fail-fast if absent. `wrangler d1 execute --remote --file=-` does NOT accept stdin; pass a real path.
+Pipeline: validate → version-verify (read-only gate; fails if the tree doesn't already match the tag) → npm publish (provenance) || Cloudflare deploy → MCP Registry → GH Release. Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in `production` env — fail-fast if absent. `wrangler d1 execute --remote --file=-` does NOT accept stdin; pass a real path.
 
 **Workflow secret-check audit** (`test/audits/workflow-secret-check.audit.test.ts`): every `[ -z "$*_TOKEN" ]` guard must `exit 1`; no warn-and-skip. Codifies v2.10.2–v2.10.6 silent prod-stale.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,7 +267,7 @@ Workflows: `ci.yml` (adds a non-required parallel `fast-checks` typecheck+lint j
 
 ### Release (`publish.yml`)
 
-**Pre-bump locally before tagging — this is now enforced, not just advised.** The `version-bump` job is a read-only *verification gate*: it asserts `package.json`, `package-lock.json`, `server.json` and the `CHANGELOG.md` heading all already match the tag, and fails the release with a per-surface `::error::` if any disagree. It no longer edits or pushes anything. (It previously tried to auto-bump and push to `main`, which protected-branch rules always reject — that failed every release from 3.40.0 to 3.42.0 and skipped all downstream publish/deploy jobs. The documented "no-op if pre-bumped" escape never worked because the step re-serialized `server.json` from 2-space to tab indent, so the byte-level `git diff --cached --quiet` guard always saw a change.)
+**Pre-bump locally before tagging — enforced.** `version-bump` is a read-only gate: it fails the release unless all 4 version surfaces already match the tag. Why: `bv-mcp-release` skill.
 
 ```bash
 npm version <X.Y.Z> --no-git-tag-version --allow-same-version   # bumps package.json + lock; SERVER_VERSION auto-derives
@@ -276,7 +276,7 @@ git commit -am "chore: bump version to <X.Y.Z>" && git push origin main
 git tag v<X.Y.Z> && git push origin v<X.Y.Z>
 ```
 
-Pipeline: validate → version-verify (read-only gate; fails if the tree doesn't already match the tag) → npm publish (provenance) || Cloudflare deploy → MCP Registry → GH Release. Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in `production` env — fail-fast if absent. `wrangler d1 execute --remote --file=-` does NOT accept stdin; pass a real path.
+Pipeline: validate → version-verify (read-only gate) → npm publish (provenance) || Cloudflare deploy → MCP Registry → GH Release. Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in `production` env — fail-fast if absent. `wrangler d1 execute --remote --file=-` does NOT accept stdin; pass a real path.
 
 **Workflow secret-check audit** (`test/audits/workflow-secret-check.audit.test.ts`): every `[ -z "$*_TOKEN" ]` guard must `exit 1`; no warn-and-skip. Codifies v2.10.2–v2.10.6 silent prod-stale.
 

--- a/test/audits/workflow-permissions.audit.test.ts
+++ b/test/audits/workflow-permissions.audit.test.ts
@@ -9,7 +9,10 @@
 //   Expected layout:
 //     workflow-level:  permissions: { contents: read }
 //     id-token: write  -> ONLY publish-npm  (npm provenance / OIDC)
-//     contents: write  -> ONLY version-bump (push bump) + github-release (gh release create)
+//     contents: write  -> ONLY github-release (gh release create)
+//   version-bump held `contents: write` to push an auto-bump commit to `main`.
+//   That push is always rejected by protected-branch rules, so the job was
+//   converted to a read-only verification gate and the grant was dropped.
 //
 // FINDING F11 — actions must be SHA-pinned (40-hex), not tag-pinned, so a
 //   re-tagged upstream action can't silently change executed code.
@@ -156,12 +159,23 @@ describe('workflow permissions audit (F10 — least-privilege OIDC)', () => {
 		expect(withIdToken).toEqual(['publish-npm']);
 	});
 
-	it('contents: write appears ONLY in version-bump and github-release jobs', () => {
+	it('contents: write appears ONLY in the github-release job', () => {
 		const withContentsWrite = jobs
 			.filter((j) => hasWrite(j.permissions, 'contents'))
 			.map((j) => j.name)
 			.sort();
-		expect(withContentsWrite).toEqual(['github-release', 'version-bump']);
+		expect(withContentsWrite).toEqual(['github-release']);
+	});
+
+	// version-bump is a verification gate: it reads the tree and compares it to
+	// the tag. It must never regain write access — the auto-bump push it used to
+	// perform is structurally incompatible with protected `main`.
+	it('the version-bump gate is read-only (never re-acquires push capability)', () => {
+		const versionBump = jobs.find((j) => j.name === 'version-bump');
+		expect(versionBump, 'version-bump job present').toBeTruthy();
+		expect(Object.values(versionBump!.permissions ?? {}), 'version-bump must not grant write').not.toContain('write');
+		expect(Object.values(versionBump!.permissions ?? {}), 'version-bump must not grant write-all').not.toContain('write-all');
+		expect(publish, 'version-bump must not push to main').not.toContain('git push origin HEAD:main');
 	});
 
 	it('the untrusted-code job (validate) has no write permission', () => {


### PR DESCRIPTION
## Problem

The **"Sync version to tag"** job has failed on **every release since v3.40.0** (3.40.0, 3.41.0, 3.42.0). Because all publish/deploy jobs `needs: version-bump`, each failure skipped **npm publish, Cloudflare deploy, MCP Registry publish and the GitHub Release** — which is why the GH Release has had to be cut by hand.

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - 4 of 4 required status checks are expected.
! [remote rejected] HEAD -> main (protected branch hook declined)
```

### Two independent defects

**1. It pushes to protected `main`.** A direct push can never satisfy the 4 required status checks, so branch protection rejects it unconditionally.

**2. The documented escape hatch never worked.** CLAUDE.md says to pre-bump locally "so this step becomes a no-op". It isn't one. The step re-serialized `server.json` with `JSON.stringify(o, null, '\t')`, reindenting the committed **2-space** file to **tabs**. The no-op guard is `git diff --cached --quiet` — a *byte* test — so whitespace-only churn took the "version changed" branch and pushed anyway.

Reproduced against the real v3.42.0 tag:

```
tag version in package.json: 3.42.0
 M server.json
 server.json | 28 ++++++++++++++--------------
committed indent: "  "      rewritten indent: "\t"
semantically identical: true
```

v3.42.0 **was** correctly pre-bumped. Only the whitespace rewrite broke it.

## Fix

Convert the job to a **read-only verification gate** (`contents: read`, no checkout token, no push). It asserts `package.json`, `package-lock.json`, `server.json` — plus `packages[0].version` if that stanza ever returns — and the `CHANGELOG.md` heading already match the tag, emitting a per-surface `::error::` and a "pre-bump locally" pointer when they don't. It rewrites nothing, so the formatting trap cannot recur.

This matches the already-documented supported path and removes an unsupported push-to-main entirely.

## Verification

- Gate replayed against the **real v3.42.0 tree** → passes (exit 0)
- Gate against a tag ahead of the tree → fails with 4 actionable errors (exit 1)
- **Mutation test**: restoring `contents: write` fails the audit (2 tests) — the new tripwire is not vacuous; restoring the fix returns 8/8 green
- `npm run audit:oss-safety` (the required *File hygiene check*): 16 files, 60 tests, exit 0
- workflow permission/secret/safety audits: 16 tests, exit 0
- `tsc --noEmit`: clean; `prettier --check`: clean

## Also included

- `workflow-permissions.audit.test.ts` tightened: `contents: write` is now expected in **only** `github-release`, plus a new tripwire asserting version-bump stays read-only and never regains `git push origin HEAD:main`.
- CLAUDE.md updated — it documented the removed auto-bump behaviour and the "no-op if pre-bumped" claim that never held.

> [!NOTE]
> GitHub Actions is in a [major outage](https://www.githubstatus.com) right now (webhooks throttled to ~15%), so CI may not dispatch on this PR until it recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)