### PR TITLE
chore: release 3.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [3.44.0] - 2026-08-07
 
-**Scoring model unchanged. No weight, tier, grade band, severity penalty, `missingControl` rule, or profile changed** — verified by the absence of any `createFinding(` edit under `packages/dns-checks/src/checks/`. The only weights introduced (`CONTROL_WEIGHTS`) are local to `assess_spoofability`, which is `group: 'intelligence'`, `scanIncluded: false` and carries no `tier`, so it cannot move a domain's scan grade.
+**Scoring model unchanged at 1.7.0. `@blackveil/dns-checks` 1.12.0 → 1.13.0** (package check behaviour changed, so `PARITY_CORPUS_VERSION` moves in lockstep and the bv-web-prod tarball needs re-vendoring).
+
+**No weight, tier, grade band, severity penalty, `missingControl` rule, or profile changed** — verified by the absence of any `createFinding(` edit under `packages/dns-checks/src/checks/`. The only weights introduced (`CONTROL_WEIGHTS`) are local to `assess_spoofability`, which is `group: 'intelligence'`, `scanIncluded: false` and carries no `tier`, so it cannot move a domain's scan grade.
 
 ### Fixed — scan consistency (round 2)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.43.0",
+	"version": "3.44.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.43.0",
+			"version": "3.44.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"
@@ -5188,7 +5188,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.12.0",
+			"version": "1.13.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.43.0",
+	"version": "3.44.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.12.0",
+	"version": "1.13.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.12.0';
+export const PARITY_CORPUS_VERSION = '1.13.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.43.0",
+  "version": "3.44.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Cuts 3.44.0, covering both accuracy fix rounds (#644, #646) plus the merged Dependabot queue.

## Version surfaces

| Surface | 3.43.0 → 3.44.0 |
|---|---|
| `package.json` + `package-lock.json` | ✅ |
| `server.json` (top-level, remotes-only) | ✅ |
| `CHANGELOG.md` `[3.44.0]` heading | ✅ |
| `SERVER_VERSION` | auto-derives from `pkg.version` — not hand-edited |

## Package bump: `@blackveil/dns-checks` 1.12.0 → 1.13.0

Seven core files changed since the 1.12.0 bump (`a1805ad3`): `check-bimi`, `check-dane`, `check-http-security`, `check-spf`, `spf-analysis`, `spf-trust-surface`, `types`. Package check *behaviour* changed, so `PARITY_CORPUS_VERSION` moves to 1.13.0 in lockstep per the version-lock contract.

**bv-web-prod re-vendor target moves to 1.13.0.**

## Scoring

Unchanged at model **1.7.0**. No weight, tier, grade band, severity penalty, `missingControl` rule or profile changed across either fix round — every fix was measured through `computeScanScore` on the real roster before being applied, and anything that moved a cleanly-resolving domain's score was left unapplied and reported for an operator decision instead.

## What's in it

Ten defects of one family — a control asserting a value it never measured:

- `assess_spoofability` reported `spfProtection: 100` for `v=spf1 +all` (ladder substring-matched remediation prose containing `-all`)
- `get_domain_rank` fabricated a percentile from a zero-domain cohort
- `explain_finding` returned remediation for defects the finding didn't have
- `check_ptr` treated an RFC 7505 null MX as a mail host
- `resolve_spf_chain` reported exactly 10/10 lookups as healthy
- WAF-blocked checks claimed the control was *missing* rather than unmeasured
- `check_dane` awarded 100 for "not assessed", including filing a SERVFAIL as "not applicable"
- Grade **D** rendered beside maturity stage 4 "Hardened"
- BIMI recommended to domains that send no email; MTA-STS asserting "accepts email" beside a null MX
- `check_ptr` serialised 27 DNS round-trips into an 8s budget → now 8 bounded-parallel rounds, same 27 queries

## Verification

Full suite **7151 passed / 0 failed** after a `dns-checks` rebuild; version-sync audits 430 passed; typecheck and build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)