### PR TITLE
test(scoring): pin dane's not-applicable reporting under non-mail profiles (#639)

### DIFF
--- a/test/format-report-na-reconciliation.spec.ts
+++ b/test/format-report-na-reconciliation.spec.ts
@@ -162,7 +162,7 @@ describe('Defect G — categoryScores / notApplicableCategories never overlap (s
 });
 
 describe('Defect H — web_only profile suppresses mail-only categories', () => {
-	const MAIL_ONLY_CATEGORIES = ['dkim', 'mta_sts', 'bimi', 'mx'] as const;
+	const MAIL_ONLY_CATEGORIES = ['dkim', 'mta_sts', 'bimi', 'mx', 'dane'] as const;
 
 	for (const category of MAIL_ONLY_CATEGORIES) {
 		it(`marks ${category} as notApplicable under web_only profile (gov.uk pattern: ${category}:0 → null)`, () => {
@@ -193,6 +193,49 @@ describe('Defect H — web_only profile suppresses mail-only categories', () => 
 			expect(s.categoryScores[category]).toBeNull();
 		});
 	}
+
+	/**
+	 * #639 — `dane` self-declared "not applicable (no inbound mail)" in its own finding
+	 * text and then took a FULL 100 for the control, while `dkim`/`mta_sts`/`bimi`/`mx`
+	 * on the same domain were correctly nulled. Awarding full marks for a control the
+	 * domain had no opportunity to fail inflates the overall score.
+	 *
+	 * The 100 shape is what makes this distinct from the cases above: those pin the
+	 * pre-fix gov.uk pattern of a numeric 0 being reported as 0. Rule 2 fires at ANY
+	 * score, so both ends need pinning — a regression that re-narrowed Rule 2 to
+	 * "only when the score is 0" would pass every case above and still ship #639.
+	 */
+	it('nulls a self-declared-inapplicable dane scoring 100 under a non-mail profile (#639)', () => {
+		const result = makeMockScanResult({
+			score: {
+				overall: 85,
+				grade: 'A',
+				categoryScores: { dane: 100 } as Record<CheckCategory, number>,
+				findings: [],
+				summary: 'ok',
+				evidence: { attempted: 1, completed: 1, ratio: 1 },
+			} as ScanScore,
+			context: { profile: 'non_mail', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			checks: [
+				{
+					category: 'dane',
+					passed: true,
+					score: 100,
+					findings: [
+						{
+							category: 'dane',
+							title: 'SMTP DANE not applicable (no inbound mail)',
+							severity: 'info',
+							detail: 'Domain publishes no usable MX records; TLSA at _25._tcp is therefore not applicable.',
+						},
+					],
+				},
+			] as CheckResult[],
+		});
+		const s = buildStructuredScanResult(result);
+		expect(s.notApplicableCategories).toContain('dane');
+		expect(s.categoryScores.dane).toBeNull();
+	});
 
 	it('still scores web categories normally under web_only profile (ssl, dnssec, http_security)', () => {
 		const result = makeMockScanResult({

--- a/test/format-report-na-reconciliation.spec.ts
+++ b/test/format-report-na-reconciliation.spec.ts
@@ -11,8 +11,22 @@
 import { describe, it, expect } from 'vitest';
 import type { ScanDomainResult, MaturityStage } from '../src/tools/scan-domain';
 import type { CheckCategory, CheckResult, ScanScore, DomainContext } from '../src/lib/scoring';
-import { computeScanEvidence } from '../src/lib/scoring';
+import { computeScanEvidence, PROFILE_WEIGHTS } from '../src/lib/scoring';
 import { buildStructuredScanResult } from '../src/tools/scan/format-report';
+
+/**
+ * A REAL `DomainContext`, not a cast.
+ *
+ * Every context in this file used to be `{ profile, signals: [], weights: {}, … } as
+ * DomainContext`, which TypeScript rejected (TS2352) because `weights` is a
+ * `Record<CheckCategory, ImportanceProfile>` and `{}` is not one. Eight suppressed
+ * errors in a spec whose entire subject is per-category scoring behaviour is exactly
+ * the vacuity risk the `typecheck:tests` ratchet exists to catch — a cast that wide
+ * would have hidden a genuinely wrong `profile` value too.
+ */
+function makeContext(profile: DomainContext['profile']): DomainContext {
+	return { profile, signals: [], weights: PROFILE_WEIGHTS[profile], detectedProvider: null };
+}
 
 function makeMockScanResult(overrides: Partial<ScanDomainResult> = {}): ScanDomainResult {
 	return {
@@ -28,7 +42,7 @@ function makeMockScanResult(overrides: Partial<ScanDomainResult> = {}): ScanDoma
 		} as ScanScore,
 		checks: [],
 		maturity: null as unknown as MaturityStage,
-		context: { profile: 'mail_enabled', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+		context: makeContext('mail_enabled'),
 		cached: false,
 		timestamp: '2026-05-28T00:00:00Z',
 		scoringNote: null,
@@ -51,7 +65,7 @@ describe('Defect G — categoryScores / notApplicableCategories never overlap (s
 				// One CheckResult below (spf), no checkStatus set → completed.
 				evidence: { attempted: 1, completed: 1, ratio: 1 },
 			} as ScanScore,
-			context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			context: makeContext('web_only'),
 			checks: [
 				{
 					category: 'spf',
@@ -77,7 +91,7 @@ describe('Defect G — categoryScores / notApplicableCategories never overlap (s
 				// One CheckResult below (spf), no checkStatus set → completed.
 				evidence: { attempted: 1, completed: 1, ratio: 1 },
 			} as ScanScore,
-			context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			context: makeContext('web_only'),
 			checks: [
 				{
 					category: 'spf',
@@ -141,7 +155,7 @@ describe('Defect G — categoryScores / notApplicableCategories never overlap (s
 
 		for (const input of corpusInputs) {
 			const result = makeMockScanResult({
-				context: { profile: input.profile, signals: [], weights: {}, detectedProvider: null } as DomainContext,
+				context: makeContext(input.profile),
 				checks: input.checks,
 				score: {
 					overall: 85,
@@ -178,7 +192,7 @@ describe('Defect H — web_only profile suppresses mail-only categories', () => 
 					// One CheckResult below, no checkStatus set → completed.
 					evidence: { attempted: 1, completed: 1, ratio: 1 },
 				} as ScanScore,
-				context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+				context: makeContext('web_only'),
 				checks: [
 					{
 						category,
@@ -215,7 +229,7 @@ describe('Defect H — web_only profile suppresses mail-only categories', () => 
 				summary: 'ok',
 				evidence: { attempted: 1, completed: 1, ratio: 1 },
 			} as ScanScore,
-			context: { profile: 'non_mail', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			context: makeContext('non_mail'),
 			checks: [
 				{
 					category: 'dane',
@@ -248,7 +262,7 @@ describe('Defect H — web_only profile suppresses mail-only categories', () => 
 				// Three CheckResults below, none with checkStatus set → all completed.
 				evidence: { attempted: 3, completed: 3, ratio: 1 },
 			} as ScanScore,
-			context: { profile: 'web_only', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			context: makeContext('web_only'),
 			checks: [
 				{ category: 'ssl', passed: true, score: 90, findings: [] },
 				{ category: 'dnssec', passed: true, score: 100, findings: [] },
@@ -275,7 +289,7 @@ describe('Defect H — web_only profile suppresses mail-only categories', () => 
 				// Two CheckResults below, no checkStatus set → completed.
 				evidence: { attempted: 2, completed: 2, ratio: 1 },
 			} as ScanScore,
-			context: { profile: 'mail_enabled', signals: [], weights: {}, detectedProvider: null } as DomainContext,
+			context: makeContext('mail_enabled'),
 			checks: [
 				{ category: 'dkim', passed: true, score: 75, findings: [] },
 				{ category: 'mta_sts', passed: false, score: 60, findings: [] },

--- a/test/typecheck-baseline.json
+++ b/test/typecheck-baseline.json
@@ -2,7 +2,7 @@
 	"$comment": "Ratchet baseline for `npm run typecheck:tests` (issue #645). Per-file tsc error counts for the test trees, which no other gate typechecks. An INCREASE fails CI; a decrease is reported and should be banked by re-running with `-- --update`. Regenerate deliberately — never to silence a new error.",
 	"generatedBy": "scripts/ci/typecheck-tests.mjs --update",
 	"typescript": "6.0.3",
-	"total": 1073,
+	"total": 1066,
 	"projects": {
 		"test/tsconfig.json": {
 			"packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts": 4,
@@ -111,7 +111,6 @@
 			"test/discover-subdomains-resilience.spec.ts": 10,
 			"test/dmarc-impersonation-escalation.spec.ts": 1,
 			"test/dns-transport.spec.ts": 1,
-			"test/format-report-na-reconciliation.spec.ts": 7,
 			"test/format-report.spec.ts": 9,
 			"test/format-scan-report.spec.ts": 4,
 			"test/free-tier-gating.spec.ts": 2,


### PR DESCRIPTION
`dane` was added to `MAIL_ONLY_CATEGORIES_FOR_NON_MAIL_PROFILE` in #646, which resolves #639 — but **nothing pinned it**, so the fix was one careless edit away from regressing silently.

## Two additions

- `dane` joins the parametrized `MAIL_ONLY_CATEGORIES` list (score-0 shape, alongside `dkim`/`mta_sts`/`bimi`/`mx`).
- A dedicated case for **#639's actual observation**: `dane` scoring a full **100** while its own finding text says *"SMTP DANE not applicable (no inbound mail)"*.

That second case is the load-bearing one. Rule 2 fires at **any** score, but every pre-existing case in this block pins the *score-0* gov.uk pattern. A regression that re-narrowed Rule 2 to "only when the score is 0" would pass all of them and still ship #639 — full marks awarded for a control the domain had no opportunity to fail.

No production code changed; this is coverage for behaviour already shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)