### PR TITLE
chore: release 3.51.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.51.1] - 2026-08-15
+
+**Internal refactor only. No public API, tool contract, scoring, or user-facing behavior changes.**
+
+### Changed
+
+- Consolidated duplicate asynchronous brand-discovery start error construction into a shared typed helper. Existing categories, severity, summaries, metadata flags, and response shapes are preserved.
+
 ## [3.51.0] - 2026-08-14
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.17.0 — no weight, tier, grade band, severity penalty or profile rule moved. **Scores can still move**, in two specific and deliberate ways described below, because what changed is *what the scanner is willing to claim it measured*.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.51.0",
+	"version": "3.51.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.51.0",
+			"version": "3.51.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.51.0",
+	"version": "3.51.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.51.0",
+  "version": "3.51.1",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary
- bump server version surfaces to 3.51.1
- document the behavior-preserving async start error-builder refactor

## Verification
- npm run lint
- npm run typecheck
- focused integration tests (13/13)
- npm run build
- npm audit --omit=dev --audit-level=high (0 vulnerabilities)