### PR TITLE
chore: release 3.51.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.51.2] - 2026-08-15
+
+**Internal maintainability and characterization release. No public API, tool contract, scoring, schema, configuration-value, or user-facing behavior changes.**
+
+### Changed
+
+- Added characterization contracts for MCP transports, scan result shapes, tool dispatch parity, brand discovery fixtures, and Worker runtime configuration.
+- Extracted private Worker runtime and MCP response helpers to reduce composition-root complexity while preserving route order and response envelopes.
+- Centralized repeated DNS endpoint, brand-audit category, OAuth test cleanup, and operational-script endpoint constants.
+- Added test-environment and coverage-strategy guidance, including the current Workerd coverage constraints.
+- Removed two stale broken maintenance scripts and the redundant `@types/marked` development dependency.
+
 ## [3.51.1] - 2026-08-15
 
 **Internal refactor only. No public API, tool contract, scoring, or user-facing behavior changes.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.51.1",
+	"version": "3.51.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.51.1",
+			"version": "3.51.2",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.51.1",
+	"version": "3.51.2",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.51.1",
+  "version": "3.51.2",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
## Summary
- synchronize release surfaces at 3.51.2
- document the behavior-preserving maintainability and characterization work

## Verification
- version surface assertion
- npm run typecheck
- npm run build
- git diff --check