### PR TITLE
fix(batch): distinguish unexpected zero-evidence scans

### DIFF
--- a/src/tools/batch-scan.ts
+++ b/src/tools/batch-scan.ts
@@ -57,7 +57,7 @@ function emptyResult(domain: string, error: string, scoringConfigHash: string): 
 		categoryScores: {},
 		findingCounts: { critical: 0, high: 0, medium: 0, low: 0 },
 		findings: [],
-		scoringProfile: 'mail_enabled',
+		scoringProfile: null,
 		scoringSignals: [],
 		scoringNote: null,
 		adaptiveWeightDeltas: null,
@@ -86,6 +86,31 @@ function emptyResult(domain: string, error: string, scoringConfigHash: string): 
 		scoringModelVersion: SCORING_MODEL_VERSION,
 		scoringConfigHash,
 		error,
+	};
+}
+
+/**
+ * A scan that returned without recording a check is not equivalent to an apex
+ * NXDOMAIN/broken-DNS short circuit. The latter explicitly sets `resolves`; the
+ * former is an execution failure worth retrying, even when no exception escaped.
+ */
+function markUnexpectedNoEvidence(result: BatchScanResultItem): BatchScanResultItem {
+	if (
+		result.evidence.attempted > 0 ||
+		result.score !== null ||
+		result.grade !== null ||
+		result.resolves === false ||
+		result.resolves === 'broken'
+	) {
+		return result;
+	}
+
+	return {
+		...result,
+		scoringProfile: null,
+		evidenceInsufficient: true,
+		evidenceNote: 'No checks ran for a domain whose DNS resolution was not reported as absent or broken; retry the scan.',
+		error: 'scan_produced_no_evidence',
 	};
 }
 
@@ -146,7 +171,7 @@ export async function batchScan(domains: string[], options: BatchScanOptions = {
 					timeoutId = setTimeout(() => reject(new Error('batch_budget_exceeded')), remaining);
 				});
 				const scanResult = await Promise.race([scanPromise, timeoutPromise]);
-				results[task.idx] = buildStructuredScanResult(scanResult, { scoringConfigHash });
+				results[task.idx] = markUnexpectedNoEvidence(buildStructuredScanResult(scanResult, { scoringConfigHash }));
 			} catch (err) {
 				const msg = err instanceof Error ? err.message : 'Scan failed';
 				results[task.idx] = emptyResult(task.domain, msg, scoringConfigHash);

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -56,7 +56,8 @@ export interface StructuredScanResult {
 	 * construction time, so it is passed through verbatim, not re-sanitized here.
 	 */
 	findings: Array<{ category: string; title: string; severity: 'critical' | 'high' | 'medium' | 'low' | 'info'; detail: string }>;
-	scoringProfile: string;
+	/** Detected scoring profile; null when the scan produced no evidence to infer one. */
+	scoringProfile: string | null;
 	scoringSignals: string[];
 	scoringNote: string | null;
 	adaptiveWeightDeltas: Record<string, number> | null;

--- a/test/batch-scan.spec.ts
+++ b/test/batch-scan.spec.ts
@@ -123,6 +123,45 @@ describe('batchScan', () => {
 		expect(results[0].evidenceNote).toBeNull();
 	});
 
+	it('marks a zero-check scan without an NXDOMAIN/broken-DNS signal as retryable, unlike a genuine no-DNS abstain', async () => {
+		const { batchScan } = await import('../src/tools/batch-scan');
+		// This is the batch-only failure shape from #686: scanDomain returned without
+		// an exception but also without ever starting its check matrix. It must not be
+		// indistinguishable from the explicit NXDOMAIN short-circuit below.
+		const noEvidenceScan = (async (domain: string) => ({
+			...fakeScanResult(domain),
+			score: { overall: null, grade: null, summary: 'no checks ran', categoryScores: {}, findings: [] },
+			checks: [],
+			context: { profile: 'mail_enabled', signals: [], weights: {}, detectedProvider: null },
+			// No `resolves` status: this is not a confirmed absent/broken domain.
+		})) as never;
+		const nxdomainScan = (async (domain: string) => ({
+			...fakeScanResult(domain),
+			score: { overall: null, grade: null, summary: 'NXDOMAIN', categoryScores: {}, findings: [] },
+			checks: [],
+			context: { profile: 'mail_enabled', signals: [], weights: {}, detectedProvider: null },
+			resolves: false,
+		})) as never;
+
+		const [unexpected, nxdomain] = await Promise.all([
+			batchScan(['live-no-evidence.com'], { scanFn: noEvidenceScan }),
+			batchScan(['missing-no-evidence.com'], { scanFn: nxdomainScan }),
+		]);
+
+		expect(unexpected[0]).toMatchObject({
+			evidence: { attempted: 0, completed: 0, ratio: 0 },
+			evidenceInsufficient: true,
+			scoringProfile: null,
+			error: 'scan_produced_no_evidence',
+		});
+		expect(unexpected[0].evidenceNote).toMatch(/retry/i);
+		expect(nxdomain[0]).toMatchObject({
+			resolves: false,
+			evidenceInsufficient: false,
+		});
+		expect(nxdomain[0].error).toBeUndefined();
+	});
+
 	it('should reject more than 10 domains', async () => {
 		const { batchScan } = await import('../src/tools/batch-scan');
 		const tooMany = Array.from({ length: 11 }, (_, i) => `domain${i}.com`);


### PR DESCRIPTION
Fixes #686

batch_scan now marks an ungraded zero-check result lacking explicit NXDOMAIN/broken-DNS resolution as retryable (`error: scan_produced_no_evidence`, `evidenceInsufficient`/`evidenceNote`, `scoringProfile: null`), while preserving explicit NXDOMAIN abstains. Error placeholders no longer fabricate `mail_enabled`.

Verified: `npx vitest run test/batch-scan.spec.ts` (15/15), `npm run typecheck`.