### PR TITLE
fix(scan): suppress mail findings for non-apex hosts

### DIFF
--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -62,7 +62,7 @@ import { checkSvcbHttps } from './check-svcb-https';
 import { checkSubdomailing } from './check-subdomailing';
 import { checkAuthoritativeDnsInfra } from './check-authoritative-dns-infra';
 import { checkRootServerSet } from './check-root-server-set';
-import { applyScanPostProcessing } from './scan/post-processing';
+import { applyScanPostProcessing, mxDeclaresNoInboundMail } from './scan/post-processing';
 import { resolveScanTimeoutBudget } from './scan/timeouts';
 import type { ScanRuntimeOptions } from './scan/post-processing';
 import { logError } from '../lib/log';
@@ -768,7 +768,11 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 
 	let result: ScanDomainResult;
 	try {
-		checkResults = await applyScanPostProcessing(domain, checkResults, runtimeOptions);
+		const isNonApexNonMailHost = zone?.isApex === false && mxDeclaresNoInboundMail(checkResults.find((result) => result.category === 'mx'));
+		checkResults = await applyScanPostProcessing(domain, checkResults, {
+			...runtimeOptions,
+			nonApexHost: isNonApexNonMailHost,
+		});
 
 		// Re-apply score=0 and checkStatus for checks that errored or timed out.
 		// Post-processing calls buildCheckResult() which creates new objects that lose checkStatus,
@@ -783,8 +787,17 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 		// Detect domain context from check results
 		let domainContext = detectDomainContext(checkResults);
 
-		// If an explicit profile was requested, override detection
-		if (isExplicit) {
+		// A non-delegated host with no MX is a web target, not a mail domain. Its
+		// host-specific TLS/HTTP/takeover checks remain deliberate scan evidence;
+		// mail controls are not scored against a label that does not receive mail.
+		if (isNonApexNonMailHost) {
+			domainContext = {
+				profile: 'web_only',
+				signals: [...domainContext.signals, 'non-apex host has no MX; mail controls not applicable'],
+				weights: getProfileWeights('web_only', runtimeOptions?.scoringConfig),
+				detectedProvider: domainContext.detectedProvider,
+			};
+		} else if (isExplicit) {
 			domainContext = {
 				profile: explicitProfile as DomainProfile,
 				signals: [...domainContext.signals, `explicit profile override: ${explicitProfile}`],

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -64,6 +64,8 @@ export interface ScanRuntimeOptions {
 	certstreamAuthToken?: string;
 	/** Bypass cache and run a fresh scan. Useful for troubleshooting after DNS changes. */
 	forceRefresh?: boolean;
+	/** Internal: scan target inherits its DNS zone rather than owning a delegation. */
+	nonApexHost?: boolean;
 	/**
 	 * Auth tier of the requesting principal. Threaded from ToolRuntimeOptions so
 	 * scan_domain can gate paid-tier enrichments (e.g. TLS probe Browser Rendering).
@@ -94,6 +96,13 @@ export async function applyScanPostProcessing(
 	const declaresNoInboundMail = mxDeclaresNoInboundMail(mxResult);
 
 	if (declaresNoInboundMail) {
+		// A non-delegated host such as www.example.com can legitimately have no MX
+		// or mail-auth records of its own. Preserve its web/TLS checks, but do not
+		// report absent host-label mail records as security failures.
+		if (runtimeOptions?.nonApexHost) {
+			results = adjustForNonApexNonMailHost(results);
+		}
+
 		// The downgrade is GATED on real inherited protection, not on MX absence alone.
 		//
 		// Absent MX means the domain cannot RECEIVE mail. It says nothing about whether
@@ -567,6 +576,24 @@ function clarifyMtaStsForMailDomain(domain: string, results: CheckResult[]): Che
 				return {
 					...finding,
 					detail: `Neither MTA-STS nor TLS-RPT records are present for ${domain}. Since this domain has MX records and accepts email, adding MTA-STS and TLS-RPT is recommended to protect inbound email in transit.`,
+				};
+			}
+			return finding;
+		});
+		return buildCheckResult(result.category, adjusted);
+	});
+}
+
+function adjustForNonApexNonMailHost(results: CheckResult[]): CheckResult[] {
+	const mailCategories: CheckCategory[] = ['spf', 'dmarc', 'dkim', 'mta_sts', 'bimi', 'tlsrpt', 'dane', 'subdomailing'];
+	return results.map((result) => {
+		if (!mailCategories.includes(result.category)) return result;
+		const adjusted = result.findings.map((finding: Finding) => {
+			if ((finding.severity === 'critical' || finding.severity === 'high') && isMissingRecordFinding(finding)) {
+				return {
+					...finding,
+					severity: 'info' as const,
+					detail: `${finding.detail} (not applicable — this non-apex host has no MX; mail controls are evaluated at its mail domain)`,
 				};
 			}
 			return finding;

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -539,6 +539,32 @@ describe('scanDomain integration - DMARC/DKIM/DNSSEC/CAA with mocked DoH', () =>
 		expect(auto.score.overall).toBe(explicit.score.overall);
 	});
 
+	it('treats a non-apex host with no MX as web-only without mail-auth false positives', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (!url.includes('cloudflare-dns.com')) return Promise.resolve(httpResponse('OK'));
+
+			const name = decodeURIComponent(url.match(/[?&]name=([^&]+)/)?.[1] ?? '').replace(/\.$/, '');
+			const type = url.match(/[?&]type=([^&]+)/)?.[1];
+			if ((type === 'NS' || type === '2') && name === 'example.com') {
+				return Promise.resolve(nsResponse('example.com', ['ns1.example.com.', 'ns2.example.com.']));
+			}
+			// www inherits example.com's zone and has no mail records of its own.
+			return Promise.resolve(createDohResponse([], []));
+		});
+
+		const { scanDomain } = await import('../src/tools/scan-domain');
+		const result = await scanDomain('www.example.com', undefined, { forceRefresh: true });
+
+		expect(result.context.profile).toBe('web_only');
+		expect(result.context.signals).toContain('non-apex host has no MX; mail controls not applicable');
+		expect(result.checks.find((check) => check.category === 'http_security')).toBeDefined();
+		for (const category of ['spf', 'dmarc', 'dkim', 'mta_sts', 'bimi', 'tlsrpt', 'dane']) {
+			const check = findCheck(result, category);
+			expect(check?.findings.some((finding) => finding.severity === 'critical' || finding.severity === 'high')).toBe(false);
+		}
+	});
+
 	it('detects DMARC p=none policy as medium severity', async () => {
 		mockWithOverrides({
 			'_dmarc.': () => Promise.resolve(txtResponse('_dmarc.example.com', ['v=DMARC1; p=none'])),


### PR DESCRIPTION
Fixes #688

scan_domain on a www.-style host inheriting the apex zone with no MX now uses web_only scoring (retaining TLS/HTTP/DNS/takeover checks) instead of applying a mail profile that reports a critical missing-SPF finding for a name that cannot carry SPF. post-processing.ts downgrades absent mail-control findings on those hosts to informational.

Verified: `npx vitest run test/scan-domain.spec.ts` (51/51), `npm run typecheck`.