### PR TITLE
fix(batch): compact structured output omits findings and per-check diagnostics

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -30,7 +30,7 @@ import { checkZoneHygiene } from '../tools/check-zone-hygiene';
 import { checkSubdomailing } from '../tools/check-subdomailing';
 import { scanDomain, formatScanReport, buildStructuredScanResult } from '../tools/scan-domain';
 import { computeScoringConfigHash } from '../lib/scoring-version';
-import { batchScan, formatBatchScan } from '../tools/batch-scan';
+import { batchScan, compactBatchScanResults, formatBatchScan } from '../tools/batch-scan';
 import { compareDomains, formatDomainComparison, COMPARE_DOMAINS_SYNC_BUDGET_MS } from '../tools/compare-domains';
 import { explainFinding, formatExplanation } from '../tools/explain-finding';
 import { compareBaseline, formatBaselineResult } from '../tools/compare-baseline';
@@ -1357,7 +1357,11 @@ export async function handleToolsCall(
 						logDetails: { totalDomains: batchResults.length },
 						severity: 'info',
 					});
-					return buildToolResult(batchText, batchResults, effectiveFormat);
+					return buildToolResult(
+						batchText,
+						effectiveFormat === 'compact' ? compactBatchScanResults(batchResults) : batchResults,
+						effectiveFormat,
+					);
 				}
 				case 'compare_domains': {
 					const domains = validatedArgs.domains as string[];

--- a/src/tools/batch-scan.ts
+++ b/src/tools/batch-scan.ts
@@ -29,7 +29,7 @@ export interface CompactBatchScanResultItem {
 	measured: boolean;
 	findingCounts: StructuredScanResult['findingCounts'];
 	categoryScores: StructuredScanResult['categoryScores'];
-	scoringProfile: string;
+	scoringProfile: string | null;
 	evidence: StructuredScanResult['evidence'];
 	error?: string;
 }

--- a/src/tools/batch-scan.ts
+++ b/src/tools/batch-scan.ts
@@ -22,6 +22,25 @@ export interface BatchScanResultItem extends StructuredScanResult {
 /** Signature compatible with `scanDomain`. Exposed as an option for testing. */
 type ScanFn = typeof scanDomain;
 
+export interface CompactBatchScanResultItem {
+	domain: string;
+	score: number | null;
+	grade: string | null;
+	measured: boolean;
+	findingCounts: StructuredScanResult['findingCounts'];
+	categoryScores: StructuredScanResult['categoryScores'];
+	scoringProfile: string;
+	evidence: StructuredScanResult['evidence'];
+	error?: string;
+}
+
+/** Compact wire payload for bulk triage; use `format: "full"` for complete findings. */
+export interface CompactBatchScanResult {
+	results: CompactBatchScanResultItem[];
+	scoringModelVersion: string;
+	scoringConfigHash: string;
+}
+
 export interface BatchScanOptions {
 	force_refresh?: boolean;
 	kv?: KVNamespace;
@@ -158,6 +177,31 @@ export async function batchScan(domains: string[], options: BatchScanOptions = {
 
 	await Promise.all(Array.from({ length: concurrency }, () => worker()));
 	return results;
+}
+
+/**
+ * Reduce a batch to the fields needed to rank an estate and select domains for
+ * a full scan. Findings and per-check diagnostics are intentionally excluded:
+ * their repeated explanatory prose makes multi-domain MCP responses unusable.
+ */
+export function compactBatchScanResults(results: BatchScanResultItem[]): CompactBatchScanResult {
+	return {
+		results: results.map(({ domain, score, grade, measured, findingCounts, categoryScores, scoringProfile, evidence, error }) => ({
+			domain,
+			score,
+			grade,
+			measured,
+			findingCounts,
+			categoryScores,
+			scoringProfile,
+			evidence,
+			...(error === undefined ? {} : { error }),
+		})),
+		// These are computed once for the batch, so hoist them rather than repeating
+		// identical values in every domain result.
+		scoringModelVersion: results[0]?.scoringModelVersion ?? SCORING_MODEL_VERSION,
+		scoringConfigHash: results[0]?.scoringConfigHash ?? computeScoringConfigHash(),
+	};
 }
 
 /** Format batch scan results as a text summary. */

--- a/test/batch-scan.spec.ts
+++ b/test/batch-scan.spec.ts
@@ -155,6 +155,45 @@ describe('batchScan', () => {
 		};
 	}
 
+	it('makes compact structured batch output materially smaller while full results retain findings', async () => {
+		const { batchScan, compactBatchScanResults } = await import('../src/tools/batch-scan');
+		const detail = 'Repeated finding detail. '.repeat(100);
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		const verboseScan = (async (domain: string): Promise<any> => ({
+			...fakeScanResult(domain),
+			score: {
+				...fakeScanResult(domain).score,
+				findings: Array.from({ length: 12 }, (_, i) => ({
+					category: 'dmarc',
+					title: `Finding ${i}`,
+					severity: 'medium',
+					detail,
+				})),
+			},
+		})) as any;
+		const results = await batchScan(
+			Array.from({ length: 10 }, (_, i) => `compact-${i}.example.com`),
+			{ scanFn: verboseScan },
+		);
+		const compact = compactBatchScanResults(results);
+
+		expect(results[0].findings).toHaveLength(12);
+		expect(compact.results).toHaveLength(10);
+		expect(compact.results[0]).toMatchObject({
+			domain: 'compact-0.example.com',
+			score: 80,
+			grade: 'B',
+			measured: true,
+			findingCounts: { medium: 12 },
+			scoringProfile: 'mail_enabled',
+		});
+		expect(compact.results[0]).not.toHaveProperty('findings');
+		expect(compact.results[0]).not.toHaveProperty('checkStatuses');
+		expect(compact).toHaveProperty('scoringModelVersion');
+		expect(compact).toHaveProperty('scoringConfigHash');
+		expect(JSON.stringify(compact).length).toBeLessThan(JSON.stringify(results).length / 10);
+	});
+
 	it('emits null score/grade for a budget-exceeded domain instead of a fabricated F', async () => {
 		const { batchScan } = await import('../src/tools/batch-scan');
 		// Each scan takes 300ms; a 10ms budget guarantees every domain is

--- a/test/batch-scan.spec.ts
+++ b/test/batch-scan.spec.ts
@@ -158,8 +158,8 @@ describe('batchScan', () => {
 	it('makes compact structured batch output materially smaller while full results retain findings', async () => {
 		const { batchScan, compactBatchScanResults } = await import('../src/tools/batch-scan');
 		const detail = 'Repeated finding detail. '.repeat(100);
-		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const verboseScan = (async (domain: string): Promise<any> => ({
+		/* eslint-disable @typescript-eslint/no-explicit-any -- fake ScanFn stub, see fakeScanResult() above */
+		const verboseScan = async (domain: string): Promise<any> => ({
 			...fakeScanResult(domain),
 			// isMeasured() reads checks.length > 0 — a real scan always populates this,
 			// so the stub needs at least one entry for `measured: true` to be exercised.
@@ -173,7 +173,8 @@ describe('batchScan', () => {
 					detail,
 				})),
 			},
-		})) as any;
+		});
+		/* eslint-enable @typescript-eslint/no-explicit-any */
 		const results = await batchScan(
 			Array.from({ length: 10 }, (_, i) => `compact-${i}.example.com`),
 			{ scanFn: verboseScan },

--- a/test/batch-scan.spec.ts
+++ b/test/batch-scan.spec.ts
@@ -161,6 +161,9 @@ describe('batchScan', () => {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 		const verboseScan = (async (domain: string): Promise<any> => ({
 			...fakeScanResult(domain),
+			// isMeasured() reads checks.length > 0 — a real scan always populates this,
+			// so the stub needs at least one entry for `measured: true` to be exercised.
+			checks: [{ category: 'dmarc', checkStatus: 'completed' }],
 			score: {
 				...fakeScanResult(domain).score,
 				findings: Array.from({ length: 12 }, (_, i) => ({


### PR DESCRIPTION
Fixes #687

batch_scan with format:"compact" now returns a compact structured object (top-level scoringModelVersion/scoringConfigHash; per-domain domain/score/grade/measured/findingCounts/categoryScores/scoringProfile/evidence/error) instead of the full findings array, which overflowed the MCP tool-result limit at 8+ domains. format:"full" is unchanged.

Verified: `npx vitest run test/batch-scan.spec.ts` (15/15, includes a 10-domain verbose-findings regression asserting >90% JSON reduction), `npm run typecheck`.