### PR TITLE
docs(m365): fix get_ca_policies description — representative marker is per-response

### DIFF
--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -753,7 +753,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	get_ca_policies: {
 		description:
-			'Retrieve Conditional Access policies for a Microsoft Entra tenant. Requires m365Proxy service binding; returns { unprovisioned: true } when absent. A `representative: true` field in the response marks sample (non-live) data until live Graph reads land.',
+			'Retrieve Conditional Access policies for a Microsoft Entra tenant. Requires m365Proxy service binding; returns { unprovisioned: true } when absent. A `representative` field in the response marks each call: `true` for sample (non-live) data, `false` once a live Microsoft Graph read succeeded for that tenant — check it per-response rather than assuming one or the other.',
 		schema: GetCaPoliciesArgs,
 		group: 'identity_secops',
 		tier: 'protective',


### PR DESCRIPTION
Refs #417

Cheap follow-up flagged in the #417 thread: get_ca_policies now has a live Microsoft Graph read path on bv-web-prod (liveGetCaPolicies()), so the shared 'until live Graph reads land' phrasing is stale for this one tool — representative can already be false on a successful live call. Reworded to describe the per-response marker. query_signins/query_ual/assess_coverage remain representative-only, so their wording is untouched.

Verified: `npx tsc --noEmit`, `npx vitest run test/contracts/m365-proxy-envelope.contract.test.ts test/schemas` (217/217).