### PR TITLE
feat(ns): verify delegation, glue, and authoritative consistency

### DIFF
--- a/src/handlers/resources.ts
+++ b/src/handlers/resources.ts
@@ -86,7 +86,7 @@ ${TOOL_COUNT} MCP tools, including ${CHECK_TOOL_COUNT} \`check_*\` tools and \`s
 | \`check_dnssec\` | DNSSEC | AD validation, DNSKEY/DS records, algorithm strength |
 | \`check_ssl\` | SSL/TLS | HTTPS reachability, HSTS policy |
 | \`check_mta_sts\` | MTA-STS | TXT policy presence, policy retrieval |
-| \`check_ns\` | NS | Delegation resilience, provider diversity |
+| \`check_ns\` | NS | Parent/child delegation, authoritative AA, glue, provider diversity |
 | \`check_caa\` | CAA | CA authorization, issuance restrictions |
 | \`check_mx\` | MX | MX presence, routing quality, provider detection |
 | \`check_http_security\` | HTTP Security | CSP, X-Frame-Options, COOP, CORP, Permissions-Policy |

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -464,7 +464,10 @@ export const TOOL_REGISTRY: Record<
 			}),
 	},
 	check_mta_sts: { cacheKey: () => 'mta_sts', execute: (d, _args, ro) => checkMtaSts(d, buildDnsOptions(ro)) },
-	check_ns: { cacheKey: () => 'ns', execute: (d, _args, ro) => checkNs(d, buildDnsOptions(ro)) },
+	check_ns: {
+		cacheKey: (_args, ro) => (ro?.infraProbe ? 'ns:delegation-probe' : 'ns'),
+		execute: (d, _args, ro) => checkNs(d, buildDnsOptions(ro), undefined, { infraProbe: ro?.infraProbe }),
+	},
 	check_caa: { cacheKey: () => 'caa', execute: (d, _args, ro) => checkCaa(d, buildDnsOptions(ro)) },
 	check_bimi: { cacheKey: () => 'bimi', execute: (d, _args, ro) => checkBimi(d, buildDnsOptions(ro)) },
 	check_tlsrpt: { cacheKey: () => 'tlsrpt', execute: (d, _args, ro) => checkTlsrpt(d, buildDnsOptions(ro)) },

--- a/src/lib/alerting.ts
+++ b/src/lib/alerting.ts
@@ -9,6 +9,7 @@
  */
 
 import { logError } from './log';
+import type { FuzzingAlert } from '../schemas/alerting';
 
 /** Bounded timeout for webhook alert delivery so a stalled endpoint can't hang the cron. */
 const ALERT_WEBHOOK_TIMEOUT_MS = 5000;
@@ -37,37 +38,124 @@ export function buildAlertPayload(input: AlertPayloadInput): AlertPayload {
 	return { text, content: text };
 }
 
-/** Send an alert payload to a webhook URL. Fail-open. */
-export async function sendAlert(webhookUrl: string, payload: AlertPayload): Promise<void> {
-	if (!webhookUrl) return;
+/**
+ * Path prefix of bv-web-prod's bv-mcp alert ingest route
+ * (`POST /api/internal/ops/bv-mcp-alerts/:token`).
+ *
+ * Matching on the PATH alone is deliberate: it is unique to that route, so the
+ * predicate stays correct across hosts (www / apex / staging) without carrying a
+ * hostname allowlist that would silently stop matching when a host changes. A
+ * generic Slack/Discord webhook can never collide with it.
+ */
+const BV_WEB_INGEST_PATH_PREFIX = '/api/internal/ops/bv-mcp-alerts/';
+
+export interface SendAlertOptions {
+	/**
+	 * bv-web-prod service binding. When present AND the webhook URL is the bv-web
+	 * ingest route, delivery goes over the binding instead of the public URL.
+	 */
+	bvWeb?: Fetcher;
+}
+
+/** True when this webhook URL is bv-web-prod's own alert ingest route. */
+export function isBvWebIngestUrl(webhookUrl: string): boolean {
+	try {
+		return new URL(webhookUrl).pathname.startsWith(BV_WEB_INGEST_PATH_PREFIX);
+	} catch {
+		return false;
+	}
+}
+
+/**
+ * Send an alert payload to a webhook URL. Fail-open — never throws.
+ *
+ * Returns whether the alert was ACCEPTED (2xx). Callers use this to emit a
+ * delivery-failure signal on a channel that does not itself depend on the
+ * webhook; a `void` return is what let a dead webhook go unnoticed for days.
+ *
+ * DISPATCH: when `options.bvWeb` is bound and the URL is bv-web's ingest route,
+ * the POST goes over the service binding. Worker-originated fetches to the
+ * public hostname are intercepted by the zone's Cloudflare bot challenge and
+ * returned as 403 before ever reaching bv-web; service bindings bypass the edge.
+ * Any other URL — and every deployment without the binding, e.g. BSL
+ * self-hosts — keeps the generic global-`fetch` path unchanged.
+ */
+export async function sendAlert(webhookUrl: string, payload: AlertPayload, options?: SendAlertOptions): Promise<boolean> {
+	if (!webhookUrl) return false;
 
 	try {
 		const parsed = new URL(webhookUrl);
-		if (parsed.protocol !== 'https:') return;
+		if (parsed.protocol !== 'https:') return false;
 	} catch {
-		return;
+		return false;
 	}
 
+	return postWebhookJson(webhookUrl, payload, options, 'Failed to deliver alert webhook');
+}
+
+/**
+ * Send a fuzzing alert as a JSON payload — a different payload shape from
+ * {@link sendAlert}, but the SAME transport, guards, and dispatch rules.
+ *
+ * Lives here rather than in scheduled.ts so it shares one dispatch path (it
+ * previously hand-rolled its own and, critically, discarded the response
+ * entirely — a rejected fuzzing alert was completely silent, not even logged).
+ */
+export async function sendFuzzingAlert(webhookUrl: string, payload: FuzzingAlert, options?: SendAlertOptions): Promise<boolean> {
+	if (!webhookUrl) return false;
+
 	try {
-		const response = await fetch(webhookUrl, {
+		const parsed = new URL(webhookUrl);
+		if (parsed.protocol !== 'https:') return false;
+	} catch {
+		return false;
+	}
+
+	return postWebhookJson(webhookUrl, payload, options, 'fuzz_alert_dispatch_failed');
+}
+
+/**
+ * Shared POST used by every webhook sender. Fail-open: returns whether the
+ * endpoint ACCEPTED the payload (2xx), never throws.
+ *
+ * `transport` is recorded on both failure paths because "403 over public_url"
+ * and "403 over service_binding" have completely different causes — the former
+ * is the edge bot challenge, the latter would be a real bv-web rejection.
+ */
+async function postWebhookJson(
+	webhookUrl: string,
+	body: unknown,
+	options: SendAlertOptions | undefined,
+	failureMessage: string
+): Promise<boolean> {
+	const binding = options?.bvWeb && isBvWebIngestUrl(webhookUrl) ? options.bvWeb : undefined;
+	const transport = binding ? 'service_binding' : 'public_url';
+
+	try {
+		const init: RequestInit = {
 			method: 'POST',
 			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(payload),
+			body: JSON.stringify(body),
 			redirect: 'manual',
 			signal: AbortSignal.timeout(ALERT_WEBHOOK_TIMEOUT_MS),
-		});
+		};
+		const response = binding ? await binding.fetch(webhookUrl, init) : await fetch(webhookUrl, init);
 		if (!response.ok) {
 			logError(`Alert webhook returned HTTP ${response.status}`, {
 				severity: 'warn',
 				category: 'alerting',
+				details: { transport },
 			});
+			return false;
 		}
+		return true;
 	} catch (err) {
 		logError(err instanceof Error ? err : String(err), {
 			severity: 'warn',
 			category: 'alerting',
-			details: { message: 'Failed to deliver alert webhook' },
+			details: { message: failureMessage, transport },
 		});
+		return false;
 	}
 }
 

--- a/src/lib/authoritative-dns-infra/delegation-analysis.ts
+++ b/src/lib/authoritative-dns-infra/delegation-analysis.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { type Finding, createFinding } from '../scoring';
+import type { DelegationConsistencyEvidence } from './delegation-types';
+
+function canonical(values: string[]): string {
+	return [...new Set(values.map((value) => value.replace(/\.$/, '').toLowerCase()))].sort().join('|');
+}
+
+function sameSet(left: string[], right: string[]): boolean {
+	return canonical(left) === canonical(right);
+}
+
+function addressesDiffer(parent: string[], current: string[] | undefined): boolean {
+	if (current === undefined || current.length === 0) return false;
+	return !sameSet(parent, current);
+}
+
+export interface DelegationAnalysis {
+	findings: Finding[];
+	conclusive: boolean;
+	failedChecks: string[];
+}
+
+/** Convert raw direct-DNS evidence into conservative, scored NS findings. */
+export function analyzeDelegationConsistency(evidence: DelegationConsistencyEvidence): DelegationAnalysis {
+	const findings: Finding[] = [];
+	const failedChecks: string[] = [];
+	const conclusiveChildren = evidence.childObservations.filter(
+		(observation) => !observation.error && observation.rcode === 0 && typeof observation.aaFlag === 'boolean',
+	);
+
+	const parentSets = evidence.parentObservations
+		.filter((observation) => !observation.error && observation.rcode === 0 && (observation.delegationNs?.length ?? 0) > 0)
+		.map((observation) => canonical(observation.delegationNs ?? []));
+	if (new Set(parentSets).size > 1) {
+		failedChecks.push('parent_consistency');
+		findings.push(
+			createFinding(
+				'ns',
+				'Parent nameservers disagree on delegation',
+				'medium',
+				`Authoritative nameservers for ${evidence.parentZone} returned different NS delegations for ${evidence.hostname}. This can produce resolver-dependent routing during an incomplete registrar or registry update.`,
+				{ parentObservations: evidence.parentObservations },
+			),
+		);
+	}
+
+	const nonAuthoritative = conclusiveChildren
+		.filter((observation) => observation.aaFlag === false)
+		.map((observation) => observation.nameserver);
+	if (nonAuthoritative.length > 0) {
+		failedChecks.push('authoritative_aa');
+		findings.push(
+			createFinding(
+				'ns',
+				'Delegated nameserver is not authoritative',
+				'high',
+				`The parent delegates ${evidence.hostname} to ${nonAuthoritative.join(', ')}, but direct RD=0 queries did not return the authoritative AA flag. Remove stale registrar delegation entries or provision the zone on those nameservers.`,
+				{ nonAuthoritativeNameservers: nonAuthoritative, evidenceMode: 'direct_dns_tcp' },
+			),
+		);
+	}
+
+	const childMismatches = conclusiveChildren.filter(
+		(observation) => observation.aaFlag === true && !sameSet(observation.publishedNs ?? [], evidence.parentDelegationNs),
+	);
+	if (childMismatches.length > 0) {
+		failedChecks.push('parent_child_ns_match');
+		findings.push(
+			createFinding(
+				'ns',
+				'Parent and child NS sets do not match',
+				'high',
+				`The parent delegation for ${evidence.hostname} does not match the NS set published by ${childMismatches.map((observation) => observation.nameserver).join(', ')}. Resolvers may use stale or unintended authoritative servers until both sides are aligned.`,
+				{
+					parentNs: evidence.parentDelegationNs,
+					childObservations: childMismatches,
+					evidenceMode: 'direct_dns_tcp',
+				},
+			),
+		);
+	}
+
+	const missingGlue = evidence.glue
+		.filter((observation) => observation.parentIpv4.length === 0 && observation.parentIpv6.length === 0)
+		.map((observation) => observation.nameserver);
+	if (missingGlue.length > 0) {
+		failedChecks.push('in_bailiwick_glue');
+		findings.push(
+			createFinding(
+				'ns',
+				'In-bailiwick nameserver glue is missing',
+				'high',
+				`${missingGlue.join(', ')} ${missingGlue.length === 1 ? 'is' : 'are'} inside ${evidence.hostname} but the parent referral supplied no A or AAAA glue. This creates a circular dependency that can make the delegation unreachable. Publish glue at the registrar or registry.`,
+				{ missingGlueNameservers: missingGlue, evidenceMode: 'direct_dns_tcp' },
+			),
+		);
+	}
+
+	const staleGlue = evidence.glue.filter(
+		(observation) =>
+			addressesDiffer(observation.parentIpv4, observation.currentIpv4) ||
+			addressesDiffer(observation.parentIpv6, observation.currentIpv6),
+	);
+	if (staleGlue.length > 0) {
+		failedChecks.push('glue_address_match');
+		findings.push(
+			createFinding(
+				'ns',
+				'Parent glue addresses are stale',
+				'medium',
+				`Parent glue for ${staleGlue.map((observation) => observation.nameserver).join(', ')} does not match the nameservers' current A/AAAA records. Update host/glue records at the registrar to prevent intermittent delegation failures.`,
+				{ staleGlue, evidenceMode: 'direct_dns_tcp' },
+			),
+		);
+	}
+
+	const conclusive = evidence.parentDelegationNs.length > 0 && conclusiveChildren.some((observation) => observation.aaFlag === true);
+	if (findings.length === 0 && conclusive) {
+		findings.push(
+			createFinding(
+				'ns',
+				'Parent/child delegation and glue are consistent',
+				'info',
+				`Direct DNS-over-TCP checks confirmed that the parent and child NS sets for ${evidence.hostname} align, delegated servers answer authoritatively, and required in-bailiwick glue is present.`,
+				{ evidenceMode: 'direct_dns_tcp', checkedAt: evidence.checkedAt },
+			),
+		);
+	}
+
+	return { findings, conclusive, failedChecks };
+}

--- a/src/lib/authoritative-dns-infra/delegation-probe.ts
+++ b/src/lib/authoritative-dns-infra/delegation-probe.ts
@@ -1,0 +1,199 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** Ordinary-zone parent/child delegation and glue probe orchestration. */
+
+import { queryDns } from '../dns';
+import { RecordType, type RecordTypeName } from '../dns-types';
+import { directDnsQuery, type DirectDnsQuery, type DirectDnsResponse } from './dns-tcp';
+import type {
+	ChildAuthorityObservation,
+	DelegationConsistencyEvidence,
+	GlueObservation,
+	ParentDelegationObservation,
+} from './delegation-types';
+
+const MAX_PARENT_NAMESERVERS = 2;
+const MAX_CHILD_NAMESERVERS = 4;
+const DIRECT_QUERY_TIMEOUT_MS = 1200;
+
+export type RecursiveDnsQuery = (name: string, type: RecordTypeName) => Promise<string[]>;
+
+export interface DelegationProbeDependencies {
+	directQuery?: DirectDnsQuery;
+	recursiveQuery?: RecursiveDnsQuery;
+	now?: () => Date;
+}
+
+function normalizeName(name: string): string {
+	return name.replace(/\.$/, '').toLowerCase();
+}
+
+function uniqueSorted(values: string[]): string[] {
+	return [...new Set(values.map(normalizeName).filter(Boolean))].sort();
+}
+
+function normalizeAddress(address: string): string {
+	const lower = address.toLowerCase();
+	if (!lower.includes(':')) return lower;
+	const halves = lower.split('::');
+	if (halves.length > 2) return lower;
+	const left = halves[0] ? halves[0].split(':') : [];
+	const right = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+	const missing = halves.length === 2 ? 8 - left.length - right.length : 0;
+	const groups = halves.length === 2 ? [...left, ...Array(Math.max(0, missing)).fill('0'), ...right] : left;
+	if (groups.length !== 8 || groups.some((group) => !/^[0-9a-f]{1,4}$/.test(group))) return lower;
+	return groups.map((group) => group.padStart(4, '0')).join(':');
+}
+
+function parentZoneOf(hostname: string): string {
+	const dot = hostname.indexOf('.');
+	if (dot <= 0 || dot === hostname.length - 1) throw new Error('A delegated DNS name must contain at least two labels');
+	return hostname.slice(dot + 1);
+}
+
+function records(response: DirectDnsResponse, type: number, owner?: string): string[] {
+	const normalizedOwner = owner ? normalizeName(owner) : undefined;
+	return uniqueSorted(
+		[...response.answers, ...response.authority]
+			.filter((record) => record.type === type && record.data && (!normalizedOwner || record.name === normalizedOwner))
+			.map((record) => record.data),
+	);
+}
+
+function glueRecords(response: DirectDnsResponse, type: number, delegated: Set<string>): Record<string, string[]> {
+	const grouped: Record<string, string[]> = {};
+	for (const record of response.additional) {
+		if (record.type !== type || !record.data || !delegated.has(record.name)) continue;
+		(grouped[record.name] ??= []).push(normalizeAddress(record.data));
+	}
+	for (const name of Object.keys(grouped)) grouped[name] = [...new Set(grouped[name])].sort();
+	return grouped;
+}
+
+async function defaultRecursiveQuery(name: string, type: RecordTypeName): Promise<string[]> {
+	const response = await queryDns(name, type, false, { timeoutMs: DIRECT_QUERY_TIMEOUT_MS, retries: 0 });
+	return (response.Answer ?? [])
+		.filter((answer) => answer.type === RecordType[type])
+		.map((answer) => answer.data.replace(/\.$/, '').toLowerCase());
+}
+
+async function observeParent(
+	nameserver: string,
+	hostname: string,
+	query: DirectDnsQuery,
+): Promise<ParentDelegationObservation> {
+	try {
+		const response = await query(nameserver, hostname, RecordType.NS, DIRECT_QUERY_TIMEOUT_MS);
+		const delegationNs = records(response, RecordType.NS, hostname);
+		const delegated = new Set(delegationNs);
+		return {
+			nameserver,
+			delegationNs,
+			glueIpv4: glueRecords(response, RecordType.A, delegated),
+			glueIpv6: glueRecords(response, RecordType.AAAA, delegated),
+			rcode: response.rcode,
+		};
+	} catch (error) {
+		return { nameserver, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+async function observeChild(nameserver: string, hostname: string, query: DirectDnsQuery): Promise<ChildAuthorityObservation> {
+	try {
+		const response = await query(nameserver, hostname, RecordType.NS, DIRECT_QUERY_TIMEOUT_MS);
+		return {
+			nameserver,
+			aaFlag: response.aa,
+			publishedNs: records(response, RecordType.NS, hostname),
+			rcode: response.rcode,
+		};
+	} catch (error) {
+		return { nameserver, error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function aggregateGlue(
+	observations: ParentDelegationObservation[],
+	field: 'glueIpv4' | 'glueIpv6',
+	nameserver: string,
+): string[] {
+	return [...new Set(observations.flatMap((observation) => observation[field]?.[nameserver] ?? []))].sort();
+}
+
+function isInBailiwick(nameserver: string, hostname: string): boolean {
+	return nameserver === hostname || nameserver.endsWith(`.${hostname}`);
+}
+
+async function observeGlue(
+	nameserver: string,
+	parentObservations: ParentDelegationObservation[],
+	recursiveQuery: RecursiveDnsQuery,
+): Promise<GlueObservation> {
+	const [ipv4, ipv6] = await Promise.allSettled([
+		recursiveQuery(nameserver, 'A'),
+		recursiveQuery(nameserver, 'AAAA'),
+	]);
+	return {
+		nameserver,
+		parentIpv4: aggregateGlue(parentObservations, 'glueIpv4', nameserver),
+		parentIpv6: aggregateGlue(parentObservations, 'glueIpv6', nameserver),
+		...(ipv4.status === 'fulfilled' ? { currentIpv4: [...new Set(ipv4.value.map(normalizeAddress))].sort() } : {}),
+		...(ipv6.status === 'fulfilled' ? { currentIpv6: [...new Set(ipv6.value.map(normalizeAddress))].sort() } : {}),
+	};
+}
+
+/**
+ * Query the parent directly for its referral, then query each delegated child
+ * server directly with RD=0. Every fan-out is hard-capped and every individual
+ * failure remains explicit evidence rather than becoming a false finding.
+ */
+export async function probeDelegationConsistency(
+	domain: string,
+	dependencies: DelegationProbeDependencies = {},
+): Promise<DelegationConsistencyEvidence> {
+	const hostname = normalizeName(domain);
+	const parentZone = parentZoneOf(hostname);
+	const recursiveQuery = dependencies.recursiveQuery ?? defaultRecursiveQuery;
+	const directQuery = dependencies.directQuery ?? directDnsQuery;
+	const errors: string[] = [];
+
+	let parentNameservers: string[] = [];
+	try {
+		parentNameservers = uniqueSorted(await recursiveQuery(parentZone, 'NS'));
+	} catch (error) {
+		errors.push(`parent_ns_lookup_failed:${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	const parentObservations = await Promise.all(
+		parentNameservers
+			.slice(0, MAX_PARENT_NAMESERVERS)
+			.map((nameserver) => observeParent(nameserver, hostname, directQuery)),
+	);
+	const parentDelegationNs = uniqueSorted(parentObservations.flatMap((observation) => observation.delegationNs ?? []));
+	if (parentNameservers.length === 0) errors.push('parent_nameservers_unavailable');
+	if (parentObservations.length > 0 && parentDelegationNs.length === 0) errors.push('parent_delegation_unavailable');
+
+	const childObservations = await Promise.all(
+		parentDelegationNs
+			.slice(0, MAX_CHILD_NAMESERVERS)
+			.map((nameserver) => observeChild(nameserver, hostname, directQuery)),
+	);
+	const glue = await Promise.all(
+		parentDelegationNs
+			.filter((nameserver) => isInBailiwick(nameserver, hostname))
+			.slice(0, MAX_CHILD_NAMESERVERS)
+			.map((nameserver) => observeGlue(nameserver, parentObservations, recursiveQuery)),
+	);
+
+	return {
+		hostname,
+		parentZone,
+		checkedAt: (dependencies.now?.() ?? new Date()).toISOString(),
+		parentNameservers,
+		parentDelegationNs,
+		parentObservations,
+		childObservations,
+		glue,
+		...(errors.length > 0 ? { errors } : {}),
+	};
+}

--- a/src/lib/authoritative-dns-infra/delegation-types.ts
+++ b/src/lib/authoritative-dns-infra/delegation-types.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export interface ParentDelegationObservation {
+	nameserver: string;
+	delegationNs?: string[];
+	glueIpv4?: Record<string, string[]>;
+	glueIpv6?: Record<string, string[]>;
+	rcode?: number;
+	error?: string;
+}
+
+export interface ChildAuthorityObservation {
+	nameserver: string;
+	aaFlag?: boolean;
+	publishedNs?: string[];
+	rcode?: number;
+	error?: string;
+}
+
+export interface GlueObservation {
+	nameserver: string;
+	parentIpv4: string[];
+	parentIpv6: string[];
+	currentIpv4?: string[];
+	currentIpv6?: string[];
+}
+
+/** Raw ordinary-zone delegation evidence returned by BV_INFRA_PROBE. */
+export interface DelegationConsistencyEvidence {
+	hostname: string;
+	parentZone: string;
+	checkedAt: string;
+	parentNameservers: string[];
+	parentDelegationNs: string[];
+	parentObservations: ParentDelegationObservation[];
+	childObservations: ChildAuthorityObservation[];
+	glue: GlueObservation[];
+	errors?: string[];
+}

--- a/src/lib/authoritative-dns-infra/dns-tcp.ts
+++ b/src/lib/authoritative-dns-infra/dns-tcp.ts
@@ -1,0 +1,256 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Minimal DNS-over-TCP client for direct authoritative queries.
+ *
+ * This deliberately supports only the record types needed by delegation
+ * analysis (A, AAAA, NS). It sends RD=0 so the response is evidence from the
+ * selected nameserver, not a recursive resolver projection.
+ */
+
+const DNS_PORT = 53;
+const DNS_HEADER_BYTES = 12;
+const DNS_CLASS_IN = 1;
+const MAX_DNS_MESSAGE_BYTES = 65_535;
+
+export interface DirectDnsRecord {
+	name: string;
+	type: number;
+	data: string;
+}
+
+export interface DirectDnsResponse {
+	aa: boolean;
+	rcode: number;
+	answers: DirectDnsRecord[];
+	authority: DirectDnsRecord[];
+	additional: DirectDnsRecord[];
+}
+
+export type DirectDnsQuery = (
+	nameserver: string,
+	name: string,
+	type: number,
+	timeoutMs?: number,
+) => Promise<DirectDnsResponse>;
+
+function encodeName(name: string): Uint8Array {
+	const normalized = name.replace(/\.$/, '').toLowerCase();
+	const labels = normalized.split('.');
+	if (!normalized || labels.some((label) => label.length === 0 || label.length > 63)) {
+		throw new Error('Invalid DNS name');
+	}
+
+	const encoder = new TextEncoder();
+	const encodedLabels = labels.map((label) => encoder.encode(label));
+	const size = encodedLabels.reduce((total, label) => total + 1 + label.length, 1);
+	if (size > 255) throw new Error('DNS name is too long');
+
+	const output = new Uint8Array(size);
+	let offset = 0;
+	for (const label of encodedLabels) {
+		output[offset++] = label.length;
+		output.set(label, offset);
+		offset += label.length;
+	}
+	output[offset] = 0;
+	return output;
+}
+
+export function buildDirectDnsQuery(name: string, type: number, id: number): Uint8Array {
+	const qname = encodeName(name);
+	const message = new Uint8Array(DNS_HEADER_BYTES + qname.length + 4);
+	const view = new DataView(message.buffer);
+	view.setUint16(0, id);
+	view.setUint16(2, 0); // RD=0: ask this server directly; never recurse.
+	view.setUint16(4, 1); // QDCOUNT
+	message.set(qname, DNS_HEADER_BYTES);
+	const tail = DNS_HEADER_BYTES + qname.length;
+	view.setUint16(tail, type);
+	view.setUint16(tail + 2, DNS_CLASS_IN);
+	return message;
+}
+
+interface DecodedName {
+	name: string;
+	nextOffset: number;
+}
+
+function decodeName(message: Uint8Array, startOffset: number): DecodedName {
+	const labels: string[] = [];
+	const visited = new Set<number>();
+	const decoder = new TextDecoder();
+	let offset = startOffset;
+	let nextOffset = startOffset;
+	let jumped = false;
+
+	for (let hops = 0; hops < 128; hops += 1) {
+		if (offset >= message.length || visited.has(offset)) throw new Error('Malformed compressed DNS name');
+		visited.add(offset);
+		const length = message[offset];
+
+		if ((length & 0xc0) === 0xc0) {
+			if (offset + 1 >= message.length) throw new Error('Truncated DNS compression pointer');
+			const pointer = ((length & 0x3f) << 8) | message[offset + 1];
+			if (!jumped) nextOffset = offset + 2;
+			offset = pointer;
+			jumped = true;
+			continue;
+		}
+		if ((length & 0xc0) !== 0) throw new Error('Unsupported DNS label encoding');
+		if (length === 0) {
+			if (!jumped) nextOffset = offset + 1;
+			return { name: labels.join('.').toLowerCase(), nextOffset };
+		}
+
+		const labelStart = offset + 1;
+		const labelEnd = labelStart + length;
+		if (labelEnd > message.length) throw new Error('Truncated DNS label');
+		labels.push(decoder.decode(message.subarray(labelStart, labelEnd)));
+		offset = labelEnd;
+		if (!jumped) nextOffset = offset;
+	}
+
+	throw new Error('DNS compression chain is too deep');
+}
+
+function ipv6Presentation(bytes: Uint8Array): string {
+	if (bytes.length !== 16) throw new Error('Invalid AAAA record length');
+	const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+	const groups: string[] = [];
+	for (let i = 0; i < 8; i += 1) groups.push(view.getUint16(i * 2).toString(16).padStart(4, '0'));
+	return groups.join(':');
+}
+
+function parseRecord(message: Uint8Array, startOffset: number): { record: DirectDnsRecord; nextOffset: number } {
+	const owner = decodeName(message, startOffset);
+	if (owner.nextOffset + 10 > message.length) throw new Error('Truncated DNS resource record');
+	const view = new DataView(message.buffer, message.byteOffset, message.byteLength);
+	const type = view.getUint16(owner.nextOffset);
+	const dataLength = view.getUint16(owner.nextOffset + 8);
+	const dataOffset = owner.nextOffset + 10;
+	const nextOffset = dataOffset + dataLength;
+	if (nextOffset > message.length) throw new Error('Truncated DNS RDATA');
+
+	let data = '';
+	if (type === 1 && dataLength === 4) {
+		data = [...message.subarray(dataOffset, nextOffset)].join('.');
+	} else if (type === 28) {
+		data = ipv6Presentation(message.subarray(dataOffset, nextOffset));
+	} else if (type === 2 || type === 5 || type === 12) {
+		data = decodeName(message, dataOffset).name;
+	}
+
+	return { record: { name: owner.name, type, data }, nextOffset };
+}
+
+export function parseDirectDnsResponse(message: Uint8Array, expectedId: number): DirectDnsResponse {
+	if (message.length < DNS_HEADER_BYTES) throw new Error('Truncated DNS response');
+	const view = new DataView(message.buffer, message.byteOffset, message.byteLength);
+	if (view.getUint16(0) !== expectedId) throw new Error('DNS transaction ID mismatch');
+	const flags = view.getUint16(2);
+	if ((flags & 0x8000) === 0) throw new Error('DNS packet is not a response');
+
+	const questionCount = view.getUint16(4);
+	const sectionCounts = [view.getUint16(6), view.getUint16(8), view.getUint16(10)];
+	let offset = DNS_HEADER_BYTES;
+	for (let i = 0; i < questionCount; i += 1) {
+		const question = decodeName(message, offset);
+		offset = question.nextOffset + 4;
+		if (offset > message.length) throw new Error('Truncated DNS question');
+	}
+
+	const sections: DirectDnsRecord[][] = [[], [], []];
+	for (let section = 0; section < sections.length; section += 1) {
+		for (let i = 0; i < sectionCounts[section]; i += 1) {
+			const parsed = parseRecord(message, offset);
+			sections[section].push(parsed.record);
+			offset = parsed.nextOffset;
+		}
+	}
+
+	return {
+		aa: (flags & 0x0400) !== 0,
+		rcode: flags & 0x000f,
+		answers: sections[0],
+		authority: sections[1],
+		additional: sections[2],
+	};
+}
+
+function frameQuery(message: Uint8Array): Uint8Array {
+	const framed = new Uint8Array(message.length + 2);
+	new DataView(framed.buffer).setUint16(0, message.length);
+	framed.set(message, 2);
+	return framed;
+}
+
+async function readFramedResponse(stream: ReadableStream<Uint8Array>): Promise<Uint8Array> {
+	const reader = stream.getReader();
+	let buffered = new Uint8Array(0);
+	let expectedLength: number | undefined;
+	try {
+		while (true) {
+			const { value, done } = await reader.read();
+			if (done) throw new Error('DNS TCP connection closed before a full response');
+			if (!value?.length) continue;
+			const next = new Uint8Array(buffered.length + value.length);
+			next.set(buffered);
+			next.set(value, buffered.length);
+			buffered = next;
+
+			if (expectedLength === undefined && buffered.length >= 2) {
+				expectedLength = new DataView(buffered.buffer, buffered.byteOffset, buffered.byteLength).getUint16(0);
+				if (expectedLength === 0 || expectedLength > MAX_DNS_MESSAGE_BYTES) throw new Error('Invalid DNS TCP frame length');
+			}
+			if (expectedLength !== undefined && buffered.length >= expectedLength + 2) {
+				return buffered.slice(2, expectedLength + 2);
+			}
+		}
+	} finally {
+		reader.releaseLock();
+	}
+}
+
+async function withTimeout<T>(operation: Promise<T>, timeoutMs: number): Promise<T> {
+	let timer: ReturnType<typeof setTimeout> | undefined;
+	try {
+		return await Promise.race([
+			operation,
+			new Promise<never>((_, reject) => {
+				timer = setTimeout(() => reject(new Error('Direct DNS query timed out')), timeoutMs);
+			}),
+		]);
+	} finally {
+		if (timer !== undefined) clearTimeout(timer);
+	}
+}
+
+export const directDnsQuery: DirectDnsQuery = async (nameserver, name, type, timeoutMs = 2500) => {
+	// Keep the runtime-only module behind the execution seam so Node-side tooling
+	// can import and test the wire codec without trying to resolve cloudflare: URLs.
+	const { connect } = await import('cloudflare:sockets');
+	const id = crypto.getRandomValues(new Uint16Array(1))[0];
+	const query = buildDirectDnsQuery(name, type, id);
+	const socket = connect({ hostname: nameserver, port: DNS_PORT }, { secureTransport: 'off', allowHalfOpen: true });
+	void socket.closed.catch(() => undefined);
+
+	try {
+		const response = await withTimeout(
+			(async () => {
+				await socket.opened;
+				const writer = socket.writable.getWriter();
+				try {
+					await writer.write(frameQuery(query));
+				} finally {
+					writer.releaseLock();
+				}
+				return readFramedResponse(socket.readable);
+			})(),
+			timeoutMs,
+		);
+		return parseDirectDnsResponse(response, id);
+	} finally {
+		await socket.close().catch(() => undefined);
+	}
+};

--- a/src/lib/authoritative-dns-infra/probe-client.ts
+++ b/src/lib/authoritative-dns-infra/probe-client.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import type { DelegationConsistencyEvidence } from './delegation-types';
 import type { AuthoritativeDnsInfraEvidence, RootServerSetEvidence } from './types';
 
 export interface InfraProbeBinding {
@@ -27,6 +28,19 @@ export async function fetchAuthoritativeDnsEvidence(
 		body: JSON.stringify({ hostname: normalizeInfraHostname(domain) }),
 	});
 	return readJsonResponse<AuthoritativeDnsInfraEvidence>(response, 'authoritative dns probe');
+}
+
+export async function fetchDelegationConsistencyEvidence(
+	domain: string,
+	infraProbe: InfraProbeBinding,
+): Promise<DelegationConsistencyEvidence> {
+	const response = await infraProbe.fetch('https://infra-probe.internal/probe/delegation-consistency', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({ hostname: normalizeInfraHostname(domain) }),
+		signal: AbortSignal.timeout(5000),
+	});
+	return readJsonResponse<DelegationConsistencyEvidence>(response, 'delegation consistency probe');
 }
 
 export async function fetchRootServerSetEvidence(

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -20,7 +20,8 @@ import {
 	queryTailExceptions,
 	resolveAnalyticsDataset,
 } from './lib/analytics-queries';
-import { buildAlertPayload, buildDigestPayload, sendAlert } from './lib/alerting';
+import { buildAlertPayload, buildDigestPayload, sendAlert, sendFuzzingAlert } from './lib/alerting';
+import type { SendAlertOptions } from './lib/alerting';
 import { queryAnalyticsEngine } from './lib/analytics-engine';
 import { logEvent, logError } from './lib/log';
 import { scoreWindow } from './lib/fuzzing-detector';
@@ -388,6 +389,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 						},
 						threshold: `error_pct > ${errorThreshold}%`,
 					}),
+					alertOptions(env),
 				);
 			}
 
@@ -403,6 +405,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 						},
 						threshold: `p95_ms > ${p95Threshold}ms`,
 					}),
+					alertOptions(env),
 				);
 			}
 		}
@@ -423,6 +426,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 					metrics: { total_hits: rateLimitData.total_hits },
 					threshold: `rate_limit_hits > ${rateLimitThreshold}`,
 				}),
+				alertOptions(env),
 			);
 		}
 
@@ -458,6 +462,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 					metrics: { total_events: totalDegradations, breakdown: breakdown || '(none)' },
 					threshold: `binding_degradation_events >= ${bindingDegradationThreshold}`,
 				}),
+				alertOptions(env),
 			);
 		}
 
@@ -491,6 +496,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 					},
 					threshold: `queue_failures >= ${queueFailureThreshold}`,
 				}),
+				alertOptions(env),
 			);
 		}
 
@@ -510,6 +516,7 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 					metrics: { exception_count: tailExceptionCount },
 					threshold: `tail_exceptions >= ${tailExceptionThreshold}`,
 				}),
+				alertOptions(env),
 			);
 		}
 
@@ -547,36 +554,21 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 				metrics: { pipeline_failed: 1 },
 				threshold: 'alerting_self_check',
 			}),
+			alertOptions(env),
 		).catch(() => {});
 	}
 }
 
-/** Send a fuzzing alert as a JSON payload — separate from sendAlert which is Slack-shaped. */
-async function sendFuzzingAlert(webhookUrl: string, payload: import('./schemas/alerting').FuzzingAlert): Promise<void> {
-	if (!webhookUrl) return;
-	try {
-		const parsed = new URL(webhookUrl);
-		if (parsed.protocol !== 'https:') return;
-	} catch {
-		return;
-	}
-	try {
-		await fetch(webhookUrl, {
-			method: 'POST',
-			headers: { 'Content-Type': 'application/json' },
-			body: JSON.stringify(payload),
-			redirect: 'manual',
-			// Bound the operator webhook so a stalled endpoint can't hang the 15-min
-			// cron tick (parity with sendAlert in lib/alerting.ts).
-			signal: AbortSignal.timeout(5_000),
-		});
-	} catch (err) {
-		logError(err instanceof Error ? err : String(err), {
-			severity: 'warn',
-			category: 'alerting',
-			details: { message: 'fuzz_alert_dispatch_failed' },
-		});
-	}
+/**
+ * Transport options for this cron tick's alert dispatches.
+ *
+ * Passing `BV_WEB` lets `sendAlert`/`sendFuzzingAlert` deliver bv-web's own
+ * ingest URL over the service binding instead of the public hostname, which the
+ * zone's Cloudflare bot challenge intercepts with a 403 before the request ever
+ * reaches bv-web. Undefined on BSL self-hosts, where the public-URL path is kept.
+ */
+function alertOptions(env: ScheduledEnv): SendAlertOptions {
+	return { bvWeb: env.BV_WEB };
 }
 
 /**
@@ -672,7 +664,7 @@ export async function handleFuzzingScan(env: ScheduledEnv): Promise<void> {
 			const rawHash = principalId.startsWith('i_') ? principalId.slice(2) : principalId;
 			const principalIdHash = rawHash.padEnd(16, '0').slice(0, 16);
 			const payload = buildFuzzingAlertPayload(verdict, { principalKind, principalIdHash, observedAt });
-			await sendFuzzingAlert(fuzzingWebhookUrl, payload);
+			await sendFuzzingAlert(fuzzingWebhookUrl, payload, alertOptions(env));
 			alertsSent++;
 
 			// Mark suppression AFTER successful dispatch attempt. sendFuzzingAlert is
@@ -714,7 +706,7 @@ export async function handleDailyDigest(env: ScheduledEnv): Promise<void> {
 			queryTierDigest('1', resolveAnalyticsDataset(env.ANALYTICS_DATASET)),
 		);
 		const payload = buildDigestPayload(rows, 1);
-		await sendAlert(digestWebhookUrl, payload);
+		await sendAlert(digestWebhookUrl, payload, alertOptions(env));
 
 		logEvent({
 			timestamp: new Date().toISOString(),
@@ -785,6 +777,7 @@ export async function handleSpfCanary(env: ScheduledEnv): Promise<void> {
 				},
 				threshold: `spf_null_rate >= ${(threshold * 100).toFixed(0)}%`,
 			}),
+			alertOptions(env),
 		);
 	} catch (err) {
 		logError(err instanceof Error ? err : String(err), {

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -229,7 +229,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 		scanIncluded: true,
 	},
 	check_ns: {
-		description: 'Look up NS (nameserver) records for a domain. Identifies the DNS nameserver provider (Cloudflare, Route53, NS1, etc.) and shows delegation and redundancy. Use to find out which authoritative nameserver or DNS hosting service is used for a domain.',
+		description: 'Audit a domain’s nameserver delegation and redundancy. Identifies the DNS hosting provider and, when the infrastructure probe is available, directly compares parent and child NS sets, verifies authoritative AA responses, and checks required glue addresses. Use to detect stale registrar delegations, lame nameservers, and intermittent resolution risk.',
 		schema: BaseDomainArgs,
 		group: 'infrastructure',
 		tier: 'protective',

--- a/src/tools/check-ns.ts
+++ b/src/tools/check-ns.ts
@@ -7,19 +7,35 @@
 
 import { checkNS } from '@blackveil/dns-checks';
 import type { ZoneContext } from '@blackveil/dns-checks';
+import { analyzeDelegationConsistency } from '../lib/authoritative-dns-infra/delegation-analysis';
+import {
+	type InfraProbeBinding,
+	fetchDelegationConsistencyEvidence,
+} from '../lib/authoritative-dns-infra/probe-client';
 import { queryDns } from '../lib/dns';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import { resolveZoneApex } from '../lib/zone-apex';
 import type { QueryDnsOptions } from '../lib/dns-types';
-import type { CheckResult } from '../lib/scoring';
+import { buildCheckResult, type CheckResult } from '../lib/scoring';
+
+export interface NsCheckOptions {
+	/** Optional service binding that can query parent and child authoritative servers directly over TCP/53. */
+	infraProbe?: InfraProbeBinding;
+}
 
 /**
  * Check nameserver configuration for a domain.
- * Validates NS records exist, checks for diversity, and verifies responsiveness.
+ * Validates NS records, diversity, SOA posture, and — when BV_INFRA_PROBE is
+ * available — parent/child delegation, authoritative AA, and glue consistency.
  */
-export async function checkNs(domain: string, dnsOptions?: QueryDnsOptions, zone?: ZoneContext): Promise<CheckResult> {
+export async function checkNs(
+	domain: string,
+	dnsOptions?: QueryDnsOptions,
+	zone?: ZoneContext,
+	options: NsCheckOptions = {},
+): Promise<CheckResult> {
 	const resolvedZone = zone ?? (await resolveZoneApex(domain, dnsOptions));
-	return checkNS(
+	const base = await checkNS(
 		domain,
 		makeQueryDNS(dnsOptions),
 		{
@@ -30,5 +46,44 @@ export async function checkNs(domain: string, dnsOptions?: QueryDnsOptions, zone
 				return { AD: resp.AD, Answer: resp.Answer };
 			},
 		},
-	) as Promise<CheckResult>;
+	) as CheckResult;
+
+	// An inherited subdomain is not itself delegated, and a failed core check
+	// lacks enough evidence to safely enrich. Self-hosts without the optional
+	// binding retain the exact worker-only behavior.
+	if (!options.infraProbe || !resolvedZone.isApex || base.checkStatus === 'error') return base;
+
+	try {
+		const evidence = await fetchDelegationConsistencyEvidence(resolvedZone.zoneApex, options.infraProbe);
+		const analysis = analyzeDelegationConsistency(evidence);
+		if (analysis.findings.length === 0) {
+			return {
+				...base,
+				metadata: { ...base.metadata, delegationEvidenceMode: 'inconclusive' },
+			};
+		}
+
+		const hasRiskFinding = analysis.findings.some((finding) => finding.severity !== 'info');
+		const baseFindings = hasRiskFinding
+			? base.findings.filter((finding) => finding.title !== 'Nameservers properly configured')
+			: base.findings;
+		const rebuilt = buildCheckResult('ns', [...baseFindings, ...analysis.findings]);
+		return {
+			...base,
+			...rebuilt,
+			metadata: {
+				...base.metadata,
+				delegationEvidenceMode: 'direct_dns_tcp',
+				delegationCheckedAt: evidence.checkedAt,
+				delegationFailedChecks: analysis.failedChecks,
+			},
+		};
+	} catch {
+		// Optional enrichment is fail-soft. A probe outage is not evidence that the
+		// domain's delegation is bad and must never alter the core NS score.
+		return {
+			...base,
+			metadata: { ...base.metadata, delegationEvidenceMode: 'probe_unavailable' },
+		};
+	}
 }

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -177,7 +177,7 @@ const CHECK_DISPATCH: Record<string, CheckRunner> = {
 	// policy-fetch and fingerprint-probe timeouts), so they take the budget for the same
 	// reason `ssl` and `http_security` do.
 	mta_sts: (d, dns, _rt, _sig, zone, _robots, budget) => checkMtaSts(d, dns, zone, { budgetMs: budget }),
-	ns: (d, dns, _rt, _sig, zone) => checkNs(d, dns, zone),
+	ns: (d, dns, rt, _sig, zone) => checkNs(d, dns, zone, { infraProbe: rt?.infraProbe }),
 	caa: (d, dns, _rt, _sig, zone) => checkCaa(d, dns, zone),
 	bimi: (d, dns) => checkBimi(d, dns),
 	tlsrpt: (d, dns) => checkTlsrpt(d, dns),

--- a/src/workers/infra-probe.ts
+++ b/src/workers/infra-probe.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 
+import { probeDelegationConsistency, type DelegationProbeDependencies } from '../lib/authoritative-dns-infra/delegation-probe';
 import { ROOT_HINTS, ROOT_SERVER_NAMES } from '../lib/authoritative-dns-infra/root-hints';
 import { normalizeInfraHostname } from '../lib/authoritative-dns-infra/probe-client';
 import type {
@@ -30,7 +31,11 @@ async function readJson(request: Request): Promise<unknown> {
 }
 
 function validHostname(value: string): boolean {
-	return value.length > 0 && value.length <= 253 && !value.includes('/') && !value.includes('\\');
+	if (value.length === 0 || value.length > 253 || value.includes('/') || value.includes('\\')) return false;
+	const labels = value.split('.');
+	return labels.length >= 2 && labels.every(
+		(label) => label.length > 0 && label.length <= 63 && /^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(label),
+	);
 }
 
 function rootHintForHostname(hostname: string) {
@@ -77,6 +82,31 @@ async function handleAuthoritativeDnsProbe(request: Request): Promise<Response> 
 	return jsonResponse(evidence);
 }
 
+export async function handleDelegationConsistencyProbe(
+	request: Request,
+	dependencies: DelegationProbeDependencies = {},
+): Promise<Response> {
+	if (request.method !== 'POST') {
+		return jsonResponse({ error: 'method_not_allowed' }, 405);
+	}
+
+	const body = await readJson(request) as AuthoritativeProbeRequest;
+	const rawHostname = typeof body.hostname === 'string' ? body.hostname : '';
+	const hostname = normalizeInfraHostname(rawHostname);
+	if (!validHostname(hostname)) {
+		return jsonResponse({ error: 'invalid_hostname' }, 400);
+	}
+
+	try {
+		return jsonResponse(await probeDelegationConsistency(hostname, dependencies));
+	} catch (error) {
+		return jsonResponse(
+			{ error: 'delegation_probe_failed', detail: error instanceof Error ? error.message : String(error) },
+			502,
+		);
+	}
+}
+
 function handleRootServerSetProbe(request: Request): Response {
 	if (request.method !== 'POST') {
 		return jsonResponse({ error: 'method_not_allowed' }, 405);
@@ -102,6 +132,9 @@ export default {
 		}
 		if (url.pathname === '/probe/authoritative-dns') {
 			return handleAuthoritativeDnsProbe(request);
+		}
+		if (url.pathname === '/probe/delegation-consistency') {
+			return handleDelegationConsistencyProbe(request);
 		}
 		if (url.pathname === '/probe/root-server-set') {
 			return handleRootServerSetProbe(request);

--- a/test/alerting.spec.ts
+++ b/test/alerting.spec.ts
@@ -1,5 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { buildAlertPayload, sendAlert } from '../src/lib/alerting';
+import { buildAlertPayload, sendAlert, sendFuzzingAlert } from '../src/lib/alerting';
+import type { FuzzingAlert } from '../src/schemas/alerting';
+
+const FUZZ_PAYLOAD: FuzzingAlert = {
+	type: 'fuzzing_suspected',
+	principalKind: 'ip',
+	principalIdHash: 'i_deadbeef',
+	kind: 'unknown_tool',
+	count: 42,
+	windowSeconds: 900,
+	observedAt: '2026-08-09T00:00:00.000Z',
+};
 
 describe('buildAlertPayload', () => {
 	it('builds Slack-compatible payload', () => {
@@ -98,5 +109,127 @@ describe('sendAlert', () => {
 		globalThis.fetch = mockFetch;
 		await sendAlert('http://hooks.slack.com/test', { text: 'hello' });
 		expect(mockFetch).not.toHaveBeenCalled();
+	});
+});
+
+describe('sendAlert delivery outcome', () => {
+	let originalFetch: typeof globalThis.fetch;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it('reports true when the webhook accepts the alert', async () => {
+		globalThis.fetch = vi.fn(async () => new Response('ok', { status: 200 })) as typeof fetch;
+		expect(await sendAlert('https://hooks.slack.com/test', { text: 'hello' })).toBe(true);
+	});
+
+	it('reports false when the webhook rejects the alert', async () => {
+		// The exact production failure: a Cloudflare bot challenge returns 403 and the
+		// alert is dropped. Callers could not observe this because sendAlert was void.
+		globalThis.fetch = vi.fn(async () => new Response('Forbidden', { status: 403 })) as typeof fetch;
+		expect(await sendAlert('https://hooks.slack.com/test', { text: 'hello' })).toBe(false);
+	});
+
+	it('reports false when delivery throws', async () => {
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('network error');
+		}) as typeof fetch;
+		expect(await sendAlert('https://hooks.slack.com/test', { text: 'hello' })).toBe(false);
+	});
+
+	it('reports false for an unusable webhook URL', async () => {
+		globalThis.fetch = vi.fn() as typeof fetch;
+		expect(await sendAlert('', { text: 'hello' })).toBe(false);
+		expect(await sendAlert('http://hooks.slack.com/test', { text: 'hello' })).toBe(false);
+	});
+});
+
+describe('sendAlert service-binding dispatch', () => {
+	let originalFetch: typeof globalThis.fetch;
+	const INGEST_URL = 'https://www.blackveilsecurity.com/api/internal/ops/bv-mcp-alerts/abc123';
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it('delivers the bv-web ingest URL over the service binding, not the public edge', async () => {
+		// Why this exists: Worker-originated fetches to www.blackveilsecurity.com are
+		// intercepted by the zone's bot challenge and 403'd before reaching bv-web.
+		// Service bindings bypass the edge entirely.
+		const globalCalls: string[] = [];
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+			globalCalls.push(String(input));
+			return new Response('Forbidden', { status: 403 });
+		}) as typeof fetch;
+
+		const bindingCalls: string[] = [];
+		const bvWeb = {
+			fetch: vi.fn(async (input: RequestInfo | URL) => {
+				bindingCalls.push(String(input));
+				return new Response(JSON.stringify({ ok: true }), { status: 200 });
+			}),
+		};
+
+		const delivered = await sendAlert(INGEST_URL, { text: 'hello' }, { bvWeb: bvWeb as unknown as Fetcher });
+
+		expect(delivered).toBe(true);
+		expect(bindingCalls).toHaveLength(1);
+		expect(globalCalls).toHaveLength(0);
+	});
+
+	it('leaves a generic webhook on global fetch even when the binding is available', async () => {
+		// sendAlert is deliberately a generic Slack/Discord-shaped poster. Only the
+		// bv-web ingest path may be re-routed through the internal binding.
+		const globalCalls: string[] = [];
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+			globalCalls.push(String(input));
+			return new Response('ok', { status: 200 });
+		}) as typeof fetch;
+		const bvWeb = { fetch: vi.fn(async () => new Response('ok', { status: 200 })) };
+
+		await sendAlert('https://hooks.slack.com/test', { text: 'hello' }, { bvWeb: bvWeb as unknown as Fetcher });
+
+		expect(globalCalls).toHaveLength(1);
+		expect(bvWeb.fetch).not.toHaveBeenCalled();
+	});
+
+	it('routes a fuzzing alert over the binding and reports the outcome', async () => {
+		// sendFuzzingAlert previously discarded its response entirely, so a 403 here
+		// was 100% silent — worse than sendAlert, which at least logged.
+		globalThis.fetch = vi.fn(async () => new Response('Forbidden', { status: 403 })) as typeof fetch;
+		const bvWeb = { fetch: vi.fn(async () => new Response(JSON.stringify({ ok: true }), { status: 200 })) };
+
+		const delivered = await sendFuzzingAlert(INGEST_URL, FUZZ_PAYLOAD, { bvWeb: bvWeb as unknown as Fetcher });
+
+		expect(delivered).toBe(true);
+		expect(bvWeb.fetch).toHaveBeenCalledTimes(1);
+		expect(globalThis.fetch).not.toHaveBeenCalled();
+	});
+
+	it('reports false when a fuzzing alert is rejected', async () => {
+		globalThis.fetch = vi.fn(async () => new Response('Not Found', { status: 404 })) as typeof fetch;
+		expect(await sendFuzzingAlert('https://hooks.slack.com/test', FUZZ_PAYLOAD)).toBe(false);
+	});
+
+	it('falls back to global fetch for the ingest URL when no binding is bound', async () => {
+		// BSL self-hosts have no BV_WEB binding; they must keep the public-URL path.
+		const globalCalls: string[] = [];
+		globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+			globalCalls.push(String(input));
+			return new Response('ok', { status: 200 });
+		}) as typeof fetch;
+
+		await sendAlert(INGEST_URL, { text: 'hello' });
+
+		expect(globalCalls).toEqual([INGEST_URL]);
 	});
 });

--- a/test/audits/infra-probe-wrangler.audit.test.ts
+++ b/test/audits/infra-probe-wrangler.audit.test.ts
@@ -27,14 +27,13 @@ describe('infra probe wrangler wiring', () => {
 		expect(infraProbeConfig.compatibility_date).toBe(mainConfig.compatibility_date);
 	});
 
-	it('deploys the infra probe worker before the main MCP worker in releases', () => {
+	it('keeps its legacy Cloudflare deploy steps fenced off in CI', () => {
+		const guardIndex = publishWorkflowSource.indexOf('CI deploy is not supported');
+		const exitIndex = publishWorkflowSource.indexOf('exit 1', guardIndex);
 		const infraDeployIndex = publishWorkflowSource.indexOf('wrangler.infra-probe.jsonc');
-		const mainDeployIndex = publishWorkflowSource.indexOf('wrangler.jsonc');
 
-		expect(infraDeployIndex, 'publish.yml must deploy bv-infra-probe during releases').toBeGreaterThan(-1);
-		expect(mainDeployIndex, 'publish.yml must deploy the main MCP worker during releases').toBeGreaterThan(-1);
-		expect(infraDeployIndex, 'bv-infra-probe must deploy before the main service binding references it').toBeLessThan(
-			mainDeployIndex,
-		);
+		expect(guardIndex, 'publish.yml must declare the manual-deploy guard').toBeGreaterThan(-1);
+		expect(exitIndex, 'the manual-deploy guard must fail the CI job').toBeGreaterThan(guardIndex);
+		expect(infraDeployIndex, 'publish.yml must retain the legacy deploy sequence for auditability').toBeGreaterThan(exitIndex);
 	});
 });

--- a/test/check-ns-delegation-consistency.spec.ts
+++ b/test/check-ns-delegation-consistency.spec.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RecordType } from '../src/lib/dns';
+import type { DelegationConsistencyEvidence } from '../src/lib/authoritative-dns-infra/delegation-types';
+import { createDohResponse, setupFetchMock } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+function mockCoreNsDns() {
+	globalThis.fetch = vi.fn(async (input: string | URL | Request) => {
+		const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+		const name = (url.searchParams.get('name') ?? '').replace(/\.$/, '').toLowerCase();
+		const type = url.searchParams.get('type');
+		if (type === 'NS') {
+			return createDohResponse(
+				[{ name: 'example.com', type: RecordType.NS }],
+				[
+					{ name: 'example.com', type: RecordType.NS, TTL: 300, data: 'ns1.provider-a.com.' },
+					{ name: 'example.com', type: RecordType.NS, TTL: 300, data: 'ns2.provider-b.net.' },
+				],
+			);
+		}
+		if (type === 'SOA') {
+			return createDohResponse(
+				[{ name: 'example.com', type: RecordType.SOA }],
+				[{ name: 'example.com', type: RecordType.SOA, TTL: 300, data: 'ns1.provider-a.com. hostmaster.example.com. 1 3600 900 604800 300' }],
+			);
+		}
+		if (type === 'A' && !name.startsWith('_bv-probe-')) {
+			return createDohResponse(
+				[{ name, type: RecordType.A }],
+				[{ name, type: RecordType.A, TTL: 300, data: '192.0.2.53' }],
+			);
+		}
+		return createDohResponse([{ name, type: type === 'AAAA' ? RecordType.AAAA : RecordType.A }], []);
+	});
+}
+
+function delegationEvidence(): DelegationConsistencyEvidence {
+	return {
+		hostname: 'example.com',
+		parentZone: 'com',
+		checkedAt: '2026-08-07T00:00:00.000Z',
+		parentNameservers: ['a.gtld-servers.net'],
+		parentDelegationNs: ['ns1.provider-a.com', 'ns2.provider-b.net'],
+		parentObservations: [
+			{ nameserver: 'a.gtld-servers.net', delegationNs: ['ns1.provider-a.com', 'ns2.provider-b.net'], rcode: 0 },
+		],
+		childObservations: [
+			{ nameserver: 'ns1.provider-a.com', aaFlag: true, publishedNs: ['ns1.provider-a.com', 'ns2.provider-b.net'], rcode: 0 },
+			{ nameserver: 'ns2.provider-b.net', aaFlag: false, publishedNs: [], rcode: 0 },
+		],
+		glue: [],
+	};
+}
+
+describe('checkNs delegation consistency enrichment', () => {
+	it('adds direct authoritative-AA evidence and removes the contradictory healthy summary', async () => {
+		mockCoreNsDns();
+		const probeFetch = vi.fn(async () => new Response(JSON.stringify(delegationEvidence())));
+		const { checkNs } = await import('../src/tools/check-ns');
+		const result = await checkNs(
+			'example.com',
+			undefined,
+			{
+				scannedLabel: 'example.com',
+				registrableDomain: 'example.com',
+				isApex: true,
+				zoneApex: 'example.com',
+				apexNsRecords: [],
+				delegationStatus: 'apex',
+			},
+			{ infraProbe: { fetch: probeFetch as unknown as typeof globalThis.fetch } },
+		);
+
+		expect(probeFetch).toHaveBeenCalledOnce();
+		expect(probeFetch.mock.calls[0][0]).toBe('https://infra-probe.internal/probe/delegation-consistency');
+		expect(result.findings).toContainEqual(
+			expect.objectContaining({ title: 'Delegated nameserver is not authoritative', severity: 'high' }),
+		);
+		expect(result.findings.some((finding) => finding.title === 'Nameservers properly configured')).toBe(false);
+		expect(result.score).toBe(75);
+		expect(result.metadata).toMatchObject({
+			delegationEvidenceMode: 'direct_dns_tcp',
+			delegationFailedChecks: ['authoritative_aa'],
+		});
+	});
+
+	it('keeps the core score unchanged when the optional probe fails', async () => {
+		mockCoreNsDns();
+		const probeFetch = vi.fn(async () => new Response('unavailable', { status: 503 }));
+		const { checkNs } = await import('../src/tools/check-ns');
+		const result = await checkNs(
+			'example.com',
+			undefined,
+			{
+				scannedLabel: 'example.com', registrableDomain: 'example.com', isApex: true,
+				zoneApex: 'example.com', apexNsRecords: [], delegationStatus: 'apex',
+			},
+			{ infraProbe: { fetch: probeFetch as unknown as typeof globalThis.fetch } },
+		);
+		expect(result.score).toBe(100);
+		expect(result.metadata?.delegationEvidenceMode).toBe('probe_unavailable');
+	});
+});

--- a/test/check-ns-delegation-consistency.spec.ts
+++ b/test/check-ns-delegation-consistency.spec.ts
@@ -59,7 +59,8 @@ function delegationEvidence(): DelegationConsistencyEvidence {
 describe('checkNs delegation consistency enrichment', () => {
 	it('adds direct authoritative-AA evidence and removes the contradictory healthy summary', async () => {
 		mockCoreNsDns();
-		const probeFetch = vi.fn(async () => new Response(JSON.stringify(delegationEvidence())));
+		const probeFetch = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
+			new Response(JSON.stringify(delegationEvidence())));
 		const { checkNs } = await import('../src/tools/check-ns');
 		const result = await checkNs(
 			'example.com',

--- a/test/delegation-analysis.spec.ts
+++ b/test/delegation-analysis.spec.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { analyzeDelegationConsistency } from '../src/lib/authoritative-dns-infra/delegation-analysis';
+import type { DelegationConsistencyEvidence } from '../src/lib/authoritative-dns-infra/delegation-types';
+
+function evidence(overrides: Partial<DelegationConsistencyEvidence> = {}): DelegationConsistencyEvidence {
+	return {
+		hostname: 'example.com',
+		parentZone: 'com',
+		checkedAt: '2026-08-07T00:00:00.000Z',
+		parentNameservers: ['a.gtld-servers.net', 'b.gtld-servers.net'],
+		parentDelegationNs: ['ns1.example.com', 'ns2.provider.net'],
+		parentObservations: [
+			{
+				nameserver: 'a.gtld-servers.net',
+				delegationNs: ['ns1.example.com', 'ns2.provider.net'],
+				glueIpv4: { 'ns1.example.com': ['192.0.2.53'] },
+				glueIpv6: {},
+				rcode: 0,
+			},
+		],
+		childObservations: [
+			{ nameserver: 'ns1.example.com', aaFlag: true, publishedNs: ['ns1.example.com', 'ns2.provider.net'], rcode: 0 },
+			{ nameserver: 'ns2.provider.net', aaFlag: true, publishedNs: ['ns1.example.com', 'ns2.provider.net'], rcode: 0 },
+		],
+		glue: [
+			{
+				nameserver: 'ns1.example.com',
+				parentIpv4: ['192.0.2.53'],
+				parentIpv6: [],
+				currentIpv4: ['192.0.2.53'],
+				currentIpv6: [],
+			},
+		],
+		...overrides,
+	};
+}
+
+describe('analyzeDelegationConsistency', () => {
+	it('reports a healthy direct parent/child, AA, and glue check', () => {
+		const result = analyzeDelegationConsistency(evidence());
+		expect(result.conclusive).toBe(true);
+		expect(result.failedChecks).toEqual([]);
+		expect(result.findings).toContainEqual(
+			expect.objectContaining({ title: 'Parent/child delegation and glue are consistent', severity: 'info' }),
+		);
+	});
+
+	it('detects non-authoritative delegated servers and parent/child NS mismatch', () => {
+		const result = analyzeDelegationConsistency(evidence({
+			childObservations: [
+				{ nameserver: 'ns1.example.com', aaFlag: false, publishedNs: [], rcode: 0 },
+				{ nameserver: 'ns2.provider.net', aaFlag: true, publishedNs: ['ns2.provider.net'], rcode: 0 },
+			],
+		}));
+		expect(result.failedChecks).toEqual(expect.arrayContaining(['authoritative_aa', 'parent_child_ns_match']));
+		expect(result.findings).toEqual(expect.arrayContaining([
+			expect.objectContaining({ title: 'Delegated nameserver is not authoritative', severity: 'high' }),
+			expect.objectContaining({ title: 'Parent and child NS sets do not match', severity: 'high' }),
+		]));
+	});
+
+	it('detects missing and stale in-bailiwick glue without treating probe errors as failures', () => {
+		const result = analyzeDelegationConsistency(evidence({
+			parentDelegationNs: ['ns1.example.com', 'ns2.example.com'],
+			childObservations: [
+				{ nameserver: 'ns1.example.com', aaFlag: true, publishedNs: ['ns1.example.com', 'ns2.example.com'], rcode: 0 },
+				{ nameserver: 'ns2.example.com', error: 'timeout' },
+			],
+			glue: [
+				{ nameserver: 'ns1.example.com', parentIpv4: ['192.0.2.10'], parentIpv6: [], currentIpv4: ['192.0.2.99'] },
+				{ nameserver: 'ns2.example.com', parentIpv4: [], parentIpv6: [] },
+			],
+		}));
+		expect(result.failedChecks).toEqual(expect.arrayContaining(['in_bailiwick_glue', 'glue_address_match']));
+		expect(result.findings).toEqual(expect.arrayContaining([
+			expect.objectContaining({ title: 'In-bailiwick nameserver glue is missing', severity: 'high' }),
+			expect.objectContaining({ title: 'Parent glue addresses are stale', severity: 'medium' }),
+		]));
+		expect(result.findings.some((finding) => finding.detail.includes('timeout'))).toBe(false);
+	});
+});

--- a/test/delegation-probe.spec.ts
+++ b/test/delegation-probe.spec.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+import { probeDelegationConsistency } from '../src/lib/authoritative-dns-infra/delegation-probe';
+import type { DirectDnsResponse } from '../src/lib/authoritative-dns-infra/dns-tcp';
+import { RecordType } from '../src/lib/dns-types';
+
+function response(overrides: Partial<DirectDnsResponse>): DirectDnsResponse {
+	return { aa: false, rcode: 0, answers: [], authority: [], additional: [], ...overrides };
+}
+
+describe('probeDelegationConsistency', () => {
+	it('queries the parent referral and each delegated child directly with bounded fan-out', async () => {
+		const recursiveQuery = vi.fn(async (name: string, type: string) => {
+			if (name === 'com' && type === 'NS') return ['a.gtld-servers.net.', 'b.gtld-servers.net.'];
+			if (name === 'ns1.example.com' && type === 'A') return ['192.0.2.53'];
+			return [];
+		});
+		const directQuery = vi.fn(async (server: string) => {
+			if (server.endsWith('gtld-servers.net')) {
+				return response({
+					authority: [
+						{ name: 'example.com', type: RecordType.NS, data: 'ns1.example.com' },
+						{ name: 'example.com', type: RecordType.NS, data: 'ns2.provider.net' },
+					],
+					additional: [{ name: 'ns1.example.com', type: RecordType.A, data: '192.0.2.53' }],
+				});
+			}
+			return response({
+				aa: true,
+				answers: [
+					{ name: 'example.com', type: RecordType.NS, data: 'ns1.example.com' },
+					{ name: 'example.com', type: RecordType.NS, data: 'ns2.provider.net' },
+				],
+			});
+		});
+
+		const evidence = await probeDelegationConsistency('Example.COM.', {
+			recursiveQuery,
+			directQuery,
+			now: () => new Date('2026-08-07T00:00:00.000Z'),
+		});
+
+		expect(evidence).toMatchObject({
+			hostname: 'example.com',
+			parentZone: 'com',
+			parentNameservers: ['a.gtld-servers.net', 'b.gtld-servers.net'],
+			parentDelegationNs: ['ns1.example.com', 'ns2.provider.net'],
+			checkedAt: '2026-08-07T00:00:00.000Z',
+		});
+		expect(evidence.childObservations).toHaveLength(2);
+		expect(evidence.glue).toEqual([
+			expect.objectContaining({ nameserver: 'ns1.example.com', parentIpv4: ['192.0.2.53'], currentIpv4: ['192.0.2.53'] }),
+		]);
+		expect(directQuery).toHaveBeenCalledTimes(4); // two parent + two child
+	});
+
+	it('keeps direct-query failures as inconclusive evidence', async () => {
+		const evidence = await probeDelegationConsistency('example.com', {
+			recursiveQuery: async (name, type) => (name === 'com' && type === 'NS' ? ['a.gtld-servers.net'] : []),
+			directQuery: async () => { throw new Error('socket blocked'); },
+		});
+		expect(evidence.parentObservations[0]).toMatchObject({ nameserver: 'a.gtld-servers.net', error: 'socket blocked' });
+		expect(evidence.parentDelegationNs).toEqual([]);
+		expect(evidence.childObservations).toEqual([]);
+	});
+});

--- a/test/dns-tcp.spec.ts
+++ b/test/dns-tcp.spec.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { buildDirectDnsQuery, parseDirectDnsResponse } from '../src/lib/authoritative-dns-infra/dns-tcp';
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+	const output = new Uint8Array(parts.reduce((sum, part) => sum + part.length, 0));
+	let offset = 0;
+	for (const part of parts) {
+		output.set(part, offset);
+		offset += part.length;
+	}
+	return output;
+}
+
+function uint16(value: number): Uint8Array {
+	const bytes = new Uint8Array(2);
+	new DataView(bytes.buffer).setUint16(0, value);
+	return bytes;
+}
+
+describe('direct DNS-over-TCP wire codec', () => {
+	it('builds a recursion-disabled NS query', () => {
+		const query = buildDirectDnsQuery('Example.COM.', 2, 0x1234);
+		const view = new DataView(query.buffer);
+		expect(view.getUint16(0)).toBe(0x1234);
+		expect(view.getUint16(2)).toBe(0); // RD is deliberately disabled
+		expect(view.getUint16(4)).toBe(1);
+		expect([...query.slice(12, 25)]).toEqual([7, 101, 120, 97, 109, 112, 108, 101, 3, 99, 111, 109, 0]);
+	});
+
+	it('parses a compressed authoritative NS answer', () => {
+		const query = buildDirectDnsQuery('example.com', 2, 0x1234);
+		const header = new Uint8Array(12);
+		const view = new DataView(header.buffer);
+		view.setUint16(0, 0x1234);
+		view.setUint16(2, 0x8400); // QR + AA
+		view.setUint16(4, 1);
+		view.setUint16(6, 1);
+		const question = query.slice(12);
+		const rdata = new Uint8Array([3, 110, 115, 49, 0xc0, 0x0c]); // ns1 + pointer to example.com
+		const answer = concat(
+			new Uint8Array([0xc0, 0x0c]),
+			uint16(2),
+			uint16(1),
+			new Uint8Array([0, 0, 0, 60]),
+			uint16(rdata.length),
+			rdata,
+		);
+
+		const parsed = parseDirectDnsResponse(concat(header, question, answer), 0x1234);
+		expect(parsed.aa).toBe(true);
+		expect(parsed.rcode).toBe(0);
+		expect(parsed.answers).toEqual([{ name: 'example.com', type: 2, data: 'ns1.example.com' }]);
+	});
+});

--- a/test/infra-probe-worker.spec.ts
+++ b/test/infra-probe-worker.spec.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { describe, expect, it } from 'vitest';
-import infraProbeWorker from '../src/workers/infra-probe';
+import infraProbeWorker, { handleDelegationConsistencyProbe } from '../src/workers/infra-probe';
 import { ROOT_HINTS, ROOT_SERVER_NAMES } from '../src/lib/authoritative-dns-infra/root-hints';
 
 describe('infra probe worker', () => {
@@ -51,6 +51,39 @@ describe('infra probe worker', () => {
 			errors: ['live_root_server_set_probe_not_configured'],
 		});
 		expect(typeof body.checkedAt).toBe('string');
+	});
+
+	it('returns ordinary-zone parent/child delegation evidence through the injected probe seam', async () => {
+		const response = await handleDelegationConsistencyProbe(
+			new Request('https://infra-probe.internal/probe/delegation-consistency', {
+				method: 'POST',
+				headers: { 'content-type': 'application/json' },
+				body: JSON.stringify({ hostname: 'Example.COM.' }),
+			}),
+			{
+				recursiveQuery: async (name, type) => (name === 'com' && type === 'NS' ? ['a.gtld-servers.net'] : []),
+				directQuery: async (server) => server === 'a.gtld-servers.net'
+					? {
+						aa: false, rcode: 0, answers: [],
+						authority: [{ name: 'example.com', type: 2, data: 'ns.provider.net' }],
+						additional: [],
+					}
+					: {
+						aa: true, rcode: 0,
+						answers: [{ name: 'example.com', type: 2, data: 'ns.provider.net' }],
+						authority: [], additional: [],
+					},
+				now: () => new Date('2026-08-07T00:00:00.000Z'),
+			},
+		);
+
+		expect(response.status).toBe(200);
+		await expect(response.json()).resolves.toMatchObject({
+			hostname: 'example.com',
+			parentZone: 'com',
+			parentDelegationNs: ['ns.provider.net'],
+			childObservations: [{ nameserver: 'ns.provider.net', aaFlag: true }],
+		});
 	});
 
 	it('rejects invalid authoritative DNS probe payloads', async () => {

--- a/test/scheduled.spec.ts
+++ b/test/scheduled.spec.ts
@@ -301,7 +301,7 @@ describe('scheduled.ts alert webhook resolution', () => {
 			resolveAlertWebhookUrl: vi.fn(async () => 'https://hooks.example.com/resolved'),
 		}));
 		const alertingModule = await import('../src/lib/alerting');
-		const sendAlertSpy = vi.spyOn(alertingModule, 'sendAlert').mockResolvedValue(undefined);
+		const sendAlertSpy = vi.spyOn(alertingModule, 'sendAlert').mockResolvedValue(true);
 
 		const { handleScheduled } = await import('../src/scheduled');
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any -- minimal env for this targeted test


### PR DESCRIPTION
## Summary
- enrich `check_ns` with bounded parent/child NS, AA, and glue consistency checks through `BV_INFRA_PROBE`
- add a minimal direct DNS-over-TCP codec/probe endpoint with fail-soft analysis and scan integration
- route bv-web operator alerts over the existing service binding and correct the release-workflow audit to recognize the intentional CI deploy guard

## Review of pre-existing work
- alert transport remains generic for non-bv-web URLs and self-hosts without `BV_WEB`
- webhook delivery is HTTPS-only, bounded, fail-open, and now reports non-2xx outcomes
- excluded the untracked workload register because repository safety checks identified internal deployment/tenant identifiers unsuitable for publication

## Verification
- `npm test -- --run test/check-ns-delegation-consistency.spec.ts test/delegation-analysis.spec.ts test/delegation-probe.spec.ts test/dns-tcp.spec.ts test/infra-probe-worker.spec.ts test/alerting.spec.ts test/fuzzing-alert-dedup.test.ts test/scheduled.spec.ts test/scheduled-archive.spec.ts test/audits/infra-probe-wrangler.audit.test.ts` (55 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- `git diff --check`