### PR TITLE
chore: release 3.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.52.0] - 2026-08-15
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.17.0 — no weight, tier, grade band, severity penalty or profile rule moved. **Scores can move on non-apex hosts** because scan profile selection changed (see below).
+
+### Fixed
+
+- `scan_domain`: non-apex hosts with no MX that inherit their zone (e.g. `www.example.com`) are now scored with the `web_only` profile instead of being penalized for absent SPF/DMARC/DKIM/MTA-STS the apex already governs. Mail-control "missing" findings on such hosts are downgraded to informational/not-applicable; TLS, HTTP security, DNS and subdomain-takeover checks are unaffected. (#688, PR #690)
+- `batch_scan`: an unexpected zero-evidence scan result (zero checks completed without an explicit NXDOMAIN/broken-DNS resolution) is now marked retryable with `error: "scan_produced_no_evidence"`, `evidenceInsufficient: true` and `scoringProfile: null`, instead of being silently graded. Explicit NXDOMAIN abstains are preserved; error placeholders no longer fabricate `mail_enabled`. (#686, PR #689)
+- `batch_scan`: `format: "compact"` now returns a genuinely compact structured payload — top-level `scoringModelVersion`/`scoringConfigHash` plus per-domain `domain`, `score`, `grade`, `measured`, `findingCounts`, `categoryScores`, `scoringProfile`, `evidence`, and optional `error` — dropping per-finding and per-check diagnostics (>90% JSON reduction on a 10-domain batch). `format: "full"` is unchanged. (#687, PR #691)
+
+### Changed
+
+- `get_ca_policies` tool description no longer implies responses are always sample data; it now describes the per-response `representative` marker. (#417, PR #692)
+
 ## [3.51.2] - 2026-08-15
 
 **Internal maintainability and characterization release. No public API, tool contract, scoring, schema, configuration-value, or user-facing behavior changes.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.51.2",
+	"version": "3.52.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.51.2",
+			"version": "3.52.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.51.2",
+	"version": "3.52.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.51.2",
+  "version": "3.52.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Version bump to 3.52.0 across package.json, package-lock.json, server.json, CHANGELOG.md.

Covers merged fixes #689 (#686), #690 (#688), #691 (#687), #692 (#417 wording). No scoring-model change (SCORING_MODEL_VERSION 1.10.0, dns-checks 1.17.0).