### PR TITLE
chore: release 3.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.53.0] - 2026-08-19
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.17.0 — no weight, tier, grade band, severity penalty or profile rule moved. **One narrow score change is intentional:** a `profile: "authoritative_dns_infra"` scan whose infra probe measured nothing now returns an **ungraded** result instead of `100 (A+)`. No other profile is affected, and no scan that actually measured its checks changes.
+
+### Fixed
+
+- Tools that could not measure no longer report a clean pass. An unavailable lane's only finding is informational, from which the score is derived, so `osint_investigate_*`, `osint_investigation_*`, `scan_buckets_*` and `check_realtime_threat_feed` returned `passed: true, score: 100` when a capability was absent or an upstream did not answer. They now carry `checkStatus: "error"`, and the report prints `Status: not measured` with no score line rather than `✅ Passed / 100/100`. (#695, PRs #697, #698)
+- Authorization refusals (`tierDenied`, `notOwned`) are returned as failed tool calls rather than green security verdicts, matching the HTTP 403 a free caller already receives from a paid-gated tool. They deliberately do **not** set `checkStatus: "error"` — that is the retryable class and would loop an agentic caller on a permanent refusal. (#695, PR #698)
+- Recon poll tools distinguish "not provisioned in this deployment" from "the upstream did not answer". Previously both rendered as unprovisioned, so a live outage told operators to configure a binding that was already bound. The upstream-failure case is marked partial so it is not cached and self-heals. (#695, PR #698)
+- `scan_domain` with `profile: "authoritative_dns_infra"`: when the infra probe establishes nothing, the scan no longer publishes `Overall Score: 100 (A+)` beside `No security issues found.`. The category is excluded as inconclusive and the scan returns ungraded. `official_root_hints_match` is no longer reported as a passed capability when nothing was queried — the "match" compared the check's own embedded constant against itself. (#696, PR #699)
+
+### Added
+
+- `dnssec` check results now populate `recordPresent`/`controlPresent`, separating unsigned (`false`/`false`), published-but-broken (`true`/`false`) and signed-and-validating (`true`/`true`). DNSSEC is the one scored category whose score band cannot answer "is this control present" — an unsigned zone lands at exactly 60 — so a uniform `score > 0` sweep reports ~95–100% adoption against a true single-digit rate. Score-neutral. (PR #680)
+- Scan reports show a row for categories that were excluded as inconclusive, instead of omitting them silently, so a reader can tell "passed the web checks" from "the web checks never ran". (PR #680)
+- `checkStatus` and `partial` are named in the published `CheckResult` output schema (as strings, not an enum, so a future status member stays additive rather than breaking already-deployed clients). (PR #698)
+
+### Changed
+
+- The ten `osint_investigate_*` / `osint_investigation_*` / `scan_buckets_*` tools no longer advertise an `outputSchema`. They are `CheckResult`-shaped only because that is the tool registry's return type; every branch including success emits an informational finding, so publishing a schema pinning `score`/`passed` as required advertised a verdict these tools never compute. Response bodies are unchanged. (#695, PR #698)
+- Documented the DNSSEC adoption measurement rule (`dnssec > 60`, never `> 0`) and corrected the `missingControl` emitter list in `docs/scoring.md`, `docs/troubleshooting.md` and `CLAUDE.md`: HTTP Security sets the flag on no path, BIMI fires on a published-but-ineffective record rather than a missing one, and DMARC, DNSSEC and `authoritative_dns_infra` were missing from the list. (PR #679)
+
 ## [3.52.0] - 2026-08-15
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.17.0 — no weight, tier, grade band, severity penalty or profile rule moved. **Scores can move on non-apex hosts** because scan profile selection changed (see below).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.52.0",
+	"version": "3.53.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.52.0",
+			"version": "3.53.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.52.0",
+	"version": "3.53.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.52.0",
+  "version": "3.53.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Version bump only — no code changes. Prepares the release of the work merged today.

## Version surfaces (all four, as the read-only `version-bump` gate asserts)

| Surface | Value |
|---|---|
| `package.json` + `package-lock.json` | 3.53.0 |
| `server.json` (top-level, remotes-only) | 3.53.0 |
| `CHANGELOG.md` heading | `[3.53.0] - 2026-08-19` |
| `SERVER_VERSION` | auto-derives from `pkg.version` — not hand-edited |

`server.json` was edited by **targeted substitution, not a JSON round-trip**. Re-serializing it
reindents the committed 2-space file to tabs, which is precisely what defeated the byte-level
idempotency guard and half-failed releases 3.40.0–3.42.0.

## Scoring impact — one intentional change, disclosed

`SCORING_MODEL_VERSION` stays **1.10.0**; `@blackveil/dns-checks` stays **1.17.0**. No weight, tier,
grade band, severity penalty or profile rule moved.

The one deliberate change: a `profile: "authoritative_dns_infra"` scan whose infra probe measured
nothing now returns **ungraded** instead of `100 (A+)`. That is the #696 fix working as intended — it
removes a fabricated grade rather than re-grading a measurement. **No scan that actually measured its
checks moves**, and no other profile is affected.

## What this releases

- **#695 / PRs #697, #698** — unmeasured and refused lanes stop reporting clean passes
- **#696 / PR #699** — infra probe withholds the verdict; drops the unearned root-hints claim
- **PR #680** — DNSSEC `recordPresent`/`controlPresent` adoption signal + inconclusive-category rows
- **PR #679** — DNSSEC measurement rule + corrected `missingControl` emitter list

## Verification

`npm ci` clean, `npm -w packages/dns-checks run build` clean, and **all 83 audit files pass**
(439 tests), including the version-sync audits that gate the release.

## ⚠️ Not covered by this PR — two follow-ups

1. **`packages/dns-checks` source changed without a version bump.** PR #680 modified
   `check-dnssec.ts` while the package stays at 1.17.0, so `main`'s 1.17.0 no longer matches the
   published/vendored 1.17.0 by content. npm publish is currently gated off, so nothing collides
   today — but a future re-vendor keyed on the version number would pick up different contents. See
   below before choosing the next dns-checks version.
2. **bv-web-prod vendors `@blackveil/dns-checks@1.18.0` whose source is not in this repo's history.**
   The tarball (added in bv-web-prod #2132, 2026-08-17) contains `dist/rating.js`; the corresponding
   source exists only as *uncommitted* working-tree state in the shared bv-mcp checkout
   (`packages/dns-checks/src/rating.ts` untracked). `git log --all -S'"version": "1.18.0"'` returns
   nothing. That version number is therefore already claimed by an artifact with no committed
   provenance — a bump to 1.18.0 here would collide.

## Release sequence after merge (operator)

```
git tag v3.53.0 <merged-main-HEAD> && git push origin v3.53.0
npm -w packages/dns-checks run build && npm run deploy:prod
# verify serverInfo.version on prod, THEN:
mcp-publisher publish
```

Registry publish must follow the prod deploy — publishing first advertises a version prod isn't
serving. Note a `v*` tag arms **both** `publish.yml` and `deploy-prod.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)