### PR TITLE
chore(dns-checks): bump to 1.19.0, skipping 1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [3.53.0] - 2026-08-19
 
-**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.17.0 — no weight, tier, grade band, severity penalty or profile rule moved. **One narrow score change is intentional:** a `profile: "authoritative_dns_infra"` scan whose infra probe measured nothing now returns an **ungraded** result instead of `100 (A+)`. No other profile is affected, and no scan that actually measured its checks changes.
+**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 — no weight, tier, grade band, severity penalty or profile rule moved. `@blackveil/dns-checks` goes **1.17.0 → 1.19.0** (with `PARITY_CORPUS_VERSION` in lockstep) because PR #680 changed core check source; the bump is additive and score-neutral. **1.18.0 is deliberately skipped** — that number is already claimed by a tarball vendored downstream whose source was never committed to this repository, so reusing it would leave two different artifacts sharing one version. Because `PARITY_CORPUS_VERSION` is folded into every scan cache key, this bump invalidates cached scans on deploy. That is intended: results cached before this release carry the old shapes that reported unmeasured lanes as clean passes. **One narrow score change is intentional:** a `profile: "authoritative_dns_infra"` scan whose infra probe measured nothing now returns an **ungraded** result instead of `100 (A+)`. No other profile is affected, and no scan that actually measured its checks changes.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5163,7 +5163,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.17.0",
+			"version": "1.19.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.17.0",
+	"version": "1.19.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.17.0';
+export const PARITY_CORPUS_VERSION = '1.19.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):


### PR DESCRIPTION
Version metadata only — four lines across four files, no logic.

**⚠️ Merge this before tagging `v3.53.0`.** It folds into that unreleased version rather than taking
its own, and it corrects the 3.53.0 CHANGELOG entry, which currently claims dns-checks stays at
1.17.0. Tagging first would ship a release whose notes contradict its tree.

## Why bump at all

PR #680 changed core check source — `check-dnssec.ts` now populates `controlPresent`/`recordPresent`
— while the package stayed at **1.17.0**. So `main`'s 1.17.0 no longer matches the published 1.17.0
by content. A version whose contents differ from the same version elsewhere is precisely the trap the
vendoring contract warns about: *verify contents, not filename*.

## Why 1.18.0 is skipped

**Deliberately, not by accident.** That number is already claimed by a tarball vendored into
bv-web-prod (its PR #2132, 2026-08-17) whose source was never committed to this repository:

```
git log --all -- packages/dns-checks/src/rating.ts     → nothing
git log --all -S'"version": "1.18.0"'                   → nothing
16 worktrees scanned for rating.ts                      → only the main checkout, status `??`
```

Reusing 1.18.0 would leave two different artifacts sharing one version number. The skip is recorded
in the CHANGELOG so the next reader does not "correct" the 1.17.0 → 1.19.0 gap back onto a number
that is already taken downstream.

> This does mean **1.18.0 remains unbuildable from source control**. That is a known, accepted
> consequence of taking this option rather than landing the rating-contract work first — flagged here
> so it stays visible rather than becoming folklore.

## Lockstep and blast radius

`PARITY_CORPUS_VERSION` moves with it, as required — `parity-corpus.contract.test.ts` asserts
`pkg.version === PARITY_CORPUS_VERSION` and passes.

⚠️ That constant is folded into **every scan cache key** (`src/lib/cache.ts`), so this bump
**invalidates cached scans on deploy**. Intended here: results cached before this release carry the
pre-fix shapes that reported unmeasured lanes as clean passes. Expect the first post-deploy wave to
run cold (~20 subrequests/domain) rather than hitting cache.

The root `package-lock.json` change is exactly one line — the workspace version entry. Nothing else
moved.

## Verification

- Full suite: **7332 passed, 0 failures** (`wasm-integration` is the known fresh-worktree
  suite-*load* error, absent `npm run build:wasm`)
- Node config (holds the version-lock contract): 13 files, 57 passed
- All audits: 448 passed
- `npm ci` and `npm -w packages/dns-checks run build` clean

## Release sequence after this merges

```
git tag v3.53.0 <merged-main-HEAD> && git push origin v3.53.0
npm -w packages/dns-checks run build && npm run deploy:prod
# verify serverInfo.version === 3.53.0 on prod, THEN:
mcp-publisher publish
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)