### PR TITLE
fix(recon): return a discriminated outcome instead of collapsing every failure to null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Recon poll tools no longer report "the upstream did not answer" when the upstream answered perfectly well. `callRecon*` collapsed absent-binding, 404, 401/403, 5xx, schema mismatch and thrown errors into a single `null`, so the OSINT and bucket-scan tools could not tell those apart and said so in a code comment rather than in the output. They now return a discriminated `ReconOutcome`, and an unknown or expired investigation/scan id is reported as exactly that — carrying a distinct `upstreamNotFound` marker instead of `upstreamUnavailable`, because claiming an outage that did not happen is the same dishonesty #695 was about. (#695)
+- A benign recon 404 no longer emits a false operator alert. `binding-degradation.ts` already documented that the degradation kinds "deliberately exclude ... the benign recon 404", but only `check_realtime_threat_feed` honored it; every poll of an unknown, expired, or not-yet-registered id on the OSINT and bucket paths recorded `binding_5xx`, which feeds the 15-minute binding-degradation cron alert. A 404 is now silent on both paths. (#695)
+- A `2xx` response whose body is not JSON at all (an HTML error page, a truncated response) is now classified as contract drift and stays silent, instead of escaping to the transport handler and recording a `binding_unavailable` degradation — the same false-alert class as the 404. `check_realtime_threat_feed` already guarded this; the async path did not. (#695)
+- `401`/`403` from the recon service is now distinguishable from an outage. A rejected credential is an operator misconfiguration and is surfaced as such in finding metadata (`reconFailureReason`, `reconUpstreamStatus`) rather than being indistinguishable from a 5xx. (#695)
+
+### Changed
+
+- `UNMEASURED_MARKERS` gains a third member, `upstreamNotFound`. `stripReservedMarkers` and `test/audits/unmeasured-marker-scope.audit.test.ts` both derive their sets from that constant, so the new marker is automatically protected against upstream forgery and automatically barred from reaching a scored category. Unmeasured semantics are unchanged: all three markers still stamp `checkStatus: "error"` and withhold the verdict. (#695)
+- The six async recon client functions (`callReconInvestigateStart`, `callReconInvestigationStatus`, `callReconInvestigationReport`, `callReconBucketScanStart`, `callReconBucketScanStatus`, `callReconBucketFindings`) return `ReconOutcome<T>` instead of `T | null`. Internal to the Worker — not part of the published npm surface. `callReconScan` deliberately keeps `T | null`: its four call sites only ask "did I get intel?", and it already resolved the one distinction that mattered internally. (#695)
+
 ## [3.53.0] - 2026-08-19
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 — no weight, tier, grade band, severity penalty or profile rule moved. `@blackveil/dns-checks` goes **1.17.0 → 1.19.0** (with `PARITY_CORPUS_VERSION` in lockstep) because PR #680 changed core check source; the bump is additive and score-neutral. **1.18.0 is deliberately skipped** — that number is already claimed by a tarball vendored downstream whose source was never committed to this repository, so reusing it would leave two different artifacts sharing one version. Because `PARITY_CORPUS_VERSION` is folded into every scan cache key, this bump invalidates cached scans on deploy. That is intended: results cached before this release carry the old shapes that reported unmeasured lanes as clean passes. **One narrow score change is intentional:** a `profile: "authoritative_dns_infra"` scan whose infra probe measured nothing now returns an **ungraded** result instead of `100 (A+)`. No other profile is affected, and no scan that actually measured its checks changes.

--- a/src/lib/recon-binding.ts
+++ b/src/lib/recon-binding.ts
@@ -2,9 +2,15 @@
 /**
  * Fail-soft client for the operator-only bv-recon service binding.
  *
- * Every function returns null on any failure (binding absent, non-2xx,
- * malformed body, network error) so callers degrade to their pre-binding
- * behavior. Mirrors the BV_WHOIS fail-soft pattern in check-rdap-lookup.ts.
+ * Fail-soft: no function throws, so callers degrade to their pre-binding behavior.
+ * Mirrors the BV_WHOIS fail-soft pattern in check-rdap-lookup.ts.
+ *
+ * The async (investigation / bucket-scan) calls return a discriminated
+ * `ReconOutcome<T>` rather than `T | null`, so a caller can tell "not provisioned"
+ * from "no such id" from "upstream is down" — see `ReconFailureReason`. The
+ * synchronous `callReconScan` keeps `T | null`: it has four call sites that only
+ * ever ask "did I get intel?", and it already resolves the one distinction that
+ * mattered (404 => benign no-match) internally.
  */
 import { z } from 'zod';
 
@@ -152,6 +158,45 @@ export type BucketScanStart = z.infer<typeof BucketScanStartSchema>;
 const OpaqueObjectSchema = z.record(z.string(), z.unknown());
 export type ReconOpaque = Record<string, unknown>;
 
+/**
+ * Why an async recon call produced no data.
+ *
+ * These are NOT interchangeable, and collapsing them is what #695 was really about:
+ *
+ * - `unbound`      — no BV_RECON binding (BSL self-host). Structural + permanent. Expected,
+ *                    so it is SILENT: not a degradation, never alertable.
+ * - `not_found`    — upstream answered **definitively** with 404: no such investigation/scan,
+ *                    or it has expired, or the caller raced a `*_start`. Also SILENT — a data
+ *                    miss is not a binding failure. `binding-degradation.ts` already documents
+ *                    that the kind set "deliberately excludes ... the benign recon 404"; before
+ *                    this discriminant existed only `callReconScan` honored it, so every poll of
+ *                    an unknown id on THIS path emitted a false `binding_5xx` into the operator
+ *                    degradation alert.
+ * - `unauthorized` — 401/403. The binding is bound but the credential was rejected: an operator
+ *                    misconfiguration, distinct from an outage and from a data miss.
+ * - `upstream_status` — any other non-2xx. Genuine upstream failure.
+ * - `malformed`    — 2xx whose body failed schema validation. Contract drift, not an outage.
+ * - `transport`    — the fetch threw (network, timeout, abort).
+ *
+ * Everything except `unbound` and `not_found` still records a degradation, with the SAME
+ * `BindingDegradationKind` mapping as before this refactor — the discriminant is for callers;
+ * re-tuning alert routing is a separate, operator-visible decision and is deliberately not
+ * bundled in here.
+ */
+export type ReconFailureReason = 'unbound' | 'not_found' | 'unauthorized' | 'upstream_status' | 'malformed' | 'transport';
+
+/** Discriminated result of an async recon call. Replaces the former `T | null`. */
+export type ReconOutcome<T> = { ok: true; data: T } | { ok: false; reason: ReconFailureReason; status?: number };
+
+/** True when the failure is a transient upstream condition worth retrying on the next poll. */
+export function isRetryableReconFailure(reason: ReconFailureReason): boolean {
+	return reason === 'upstream_status' || reason === 'transport' || reason === 'not_found';
+}
+
+function reconFailure<T>(reason: ReconFailureReason, status?: number): ReconOutcome<T> {
+	return status === undefined ? { ok: false, reason } : { ok: false, reason, status };
+}
+
 async function reconJson(
 	binding: ReconBinding | undefined,
 	authToken: string | undefined,
@@ -160,24 +205,36 @@ async function reconJson(
 	schema: z.ZodType,
 	signal?: AbortSignal,
 	telemetry?: BindingDegradationSink,
-): Promise<unknown | null> {
+): Promise<ReconOutcome<unknown>> {
 	// Absent binding (BSL self-host) is expected, NOT a degradation — stay silent.
-	if (!binding) return null;
+	if (!binding) return reconFailure('unbound');
 	try {
 		const resp = await binding.fetch(`https://bv-recon${path}`, {
 			...init,
 			headers: { ...(authToken ? { Authorization: `Bearer ${authToken}` } : {}), ...(init.headers ?? {}) },
 			signal: composeSignal(signal),
 		});
+		// A 404 is a DATA MISS (unknown/expired id, or a poll that raced its own start), not a
+		// binding failure. Stay SILENT, matching `callReconScan` and the contract documented on
+		// `BindingDegradationKind`.
+		if (resp.status === 404) return reconFailure('not_found', 404);
+		if (resp.status === 401 || resp.status === 403) {
+			recordReconDegradation('binding_5xx', telemetry, { route: path, status: resp.status });
+			return reconFailure('unauthorized', resp.status);
+		}
 		if (!resp.ok) {
 			recordReconDegradation('binding_5xx', telemetry, { route: path, status: resp.status });
-			return null;
+			return reconFailure('upstream_status', resp.status);
 		}
-		const parsed = schema.safeParse(await resp.json());
-		return parsed.success ? parsed.data : null;
+		// `.catch(() => null)` matches `callReconScan`: a 2xx whose body is not even JSON (an HTML
+		// error page, a truncated response) is CONTRACT DRIFT, not an outage. Without the guard the
+		// throw escapes to the outer catch and is reported as `transport` WITH a `binding_unavailable`
+		// degradation — a false operator alert, the same defect class as the 404 this refactor fixed.
+		const parsed = schema.safeParse(await resp.json().catch(() => null));
+		return parsed.success ? { ok: true, data: parsed.data } : reconFailure('malformed', resp.status);
 	} catch (err) {
 		recordReconDegradation(errorToKind(err), telemetry, { route: path, errorName: err instanceof Error ? err.name : undefined });
-		return null;
+		return reconFailure('transport');
 	}
 }
 
@@ -189,7 +246,7 @@ export function callReconInvestigateStart(
 	options?: Record<string, unknown>,
 	signal?: AbortSignal,
 	telemetry?: BindingDegradationSink,
-): Promise<InvestigationStart | null> {
+): Promise<ReconOutcome<InvestigationStart>> {
 	return reconJson(
 		binding,
 		authToken,
@@ -198,7 +255,7 @@ export function callReconInvestigateStart(
 		InvestigationStartSchema,
 		signal,
 		telemetry,
-	) as Promise<InvestigationStart | null>;
+	) as Promise<ReconOutcome<InvestigationStart>>;
 }
 
 export function callReconInvestigationStatus(
@@ -207,7 +264,7 @@ export function callReconInvestigationStatus(
 	id: string,
 	signal?: AbortSignal,
 	telemetry?: BindingDegradationSink,
-): Promise<ReconOpaque | null> {
+): Promise<ReconOutcome<ReconOpaque>> {
 	return reconJson(
 		binding,
 		authToken,
@@ -216,7 +273,7 @@ export function callReconInvestigationStatus(
 		OpaqueObjectSchema,
 		signal,
 		telemetry,
-	) as Promise<ReconOpaque | null>;
+	) as Promise<ReconOutcome<ReconOpaque>>;
 }
 
 export function callReconInvestigationReport(
@@ -225,7 +282,7 @@ export function callReconInvestigationReport(
 	id: string,
 	signal?: AbortSignal,
 	telemetry?: BindingDegradationSink,
-): Promise<ReconOpaque | null> {
+): Promise<ReconOutcome<ReconOpaque>> {
 	return reconJson(
 		binding,
 		authToken,
@@ -234,7 +291,7 @@ export function callReconInvestigationReport(
 		OpaqueObjectSchema,
 		signal,
 		telemetry,
-	) as Promise<ReconOpaque | null>;
+	) as Promise<ReconOutcome<ReconOpaque>>;
 }
 
 export function callReconBucketScanStart(
@@ -243,7 +300,7 @@ export function callReconBucketScanStart(
 	body: Record<string, unknown>,
 	signal?: AbortSignal,
 	telemetry?: BindingDegradationSink,
-): Promise<BucketScanStart | null> {
+): Promise<ReconOutcome<BucketScanStart>> {
 	return reconJson(
 		binding,
 		authToken,
@@ -252,7 +309,7 @@ export function callReconBucketScanStart(
 		BucketScanStartSchema,
 		signal,
 		telemetry,
-	) as Promise<BucketScanStart | null>;
+	) as Promise<ReconOutcome<BucketScanStart>>;
 }
 
 export function callReconBucketScanStatus(
@@ -261,7 +318,7 @@ export function callReconBucketScanStatus(
 	scanId: string,
 	signal?: AbortSignal,
 	telemetry?: BindingDegradationSink,
-): Promise<ReconOpaque | null> {
+): Promise<ReconOutcome<ReconOpaque>> {
 	return reconJson(
 		binding,
 		authToken,
@@ -270,7 +327,7 @@ export function callReconBucketScanStatus(
 		OpaqueObjectSchema,
 		signal,
 		telemetry,
-	) as Promise<ReconOpaque | null>;
+	) as Promise<ReconOutcome<ReconOpaque>>;
 }
 
 export function callReconBucketFindings(
@@ -279,15 +336,9 @@ export function callReconBucketFindings(
 	scanId: string | undefined,
 	signal?: AbortSignal,
 	telemetry?: BindingDegradationSink,
-): Promise<ReconOpaque | null> {
+): Promise<ReconOutcome<ReconOpaque>> {
 	const qs = scanId ? `?scanId=${encodeURIComponent(scanId)}` : '';
-	return reconJson(
-		binding,
-		authToken,
-		`/buckets/api/findings${qs}`,
-		{ method: 'GET' },
-		OpaqueObjectSchema,
-		signal,
-		telemetry,
-	) as Promise<ReconOpaque | null>;
+	return reconJson(binding, authToken, `/buckets/api/findings${qs}`, { method: 'GET' }, OpaqueObjectSchema, signal, telemetry) as Promise<
+		ReconOutcome<ReconOpaque>
+	>;
 }

--- a/src/lib/unmeasured-result.ts
+++ b/src/lib/unmeasured-result.ts
@@ -13,10 +13,19 @@
  * into finding metadata, so the honesty rule is applied in ONE place rather than
  * re-derived per tool. Two distinct classes, deliberately kept apart:
  *
- * - **Unmeasured** (`unprovisioned`, `upstreamUnavailable`) — nothing was read.
- *   The deployment lacks the capability, or the upstream did not answer. These get
- *   `checkStatus: 'error'`, which is what the formatter and the scoring engine
- *   already gate on to withhold a verdict.
+ * - **Unmeasured** (`unprovisioned`, `upstreamUnavailable`, `upstreamNotFound`) —
+ *   nothing was read. The deployment lacks the capability, the upstream did not
+ *   answer, or the upstream answered definitively that the record does not exist.
+ *   These get `checkStatus: 'error'`, which is what the formatter and the scoring
+ *   engine already gate on to withhold a verdict.
+ *
+ *   All three mean "no measurement", but they are NOT interchangeable and are kept
+ *   apart for the same reason #695 existed at all: a result must not assert
+ *   something nobody observed. `upstreamNotFound` is a benign data miss — the
+ *   service was reachable and answered 404 — so reporting it as `upstreamUnavailable`
+ *   would claim an outage that did not happen, and would over-count on any operator
+ *   dashboard tallying upstream failures. It is also SILENT in binding-degradation
+ *   telemetry, whereas a genuine failure alerts.
  *
  * - **Access refusal** (`tierDenied`, `notOwned`) — the caller was refused. Also
  *   nothing measured, but the cause is authorization, not availability. These
@@ -38,8 +47,16 @@
 
 import type { CheckResult, Finding } from './scoring';
 
-/** Markers meaning "nothing was read" — availability, not authorization. */
-export const UNMEASURED_MARKERS = ['unprovisioned', 'upstreamUnavailable'] as const;
+/**
+ * Markers meaning "nothing was read" — availability, not authorization.
+ *
+ * `upstreamNotFound` is deliberately distinct from `upstreamUnavailable`: the upstream WAS
+ * available and gave a definitive negative (404). Adding a member here is automatically picked
+ * up by `stripReservedMarkers` (so an upstream cannot forge it) and by
+ * `test/audits/unmeasured-marker-scope.audit.test.ts` (so it cannot reach a scored category) —
+ * both derive their sets from this constant rather than repeating the list.
+ */
+export const UNMEASURED_MARKERS = ['unprovisioned', 'upstreamUnavailable', 'upstreamNotFound'] as const;
 
 /** Markers meaning "the caller was refused" — authorization, not availability. */
 export const ACCESS_REFUSAL_MARKERS = ['tierDenied', 'notOwned'] as const;

--- a/src/lib/unmeasured-result.ts
+++ b/src/lib/unmeasured-result.ts
@@ -107,6 +107,11 @@ export function markUnmeasured(result: CheckResult): CheckResult {
  * The failure is not dramatic (the findings still render; a verdict is withheld rather than
  * fabricated), but a control channel that an upstream can write to is not a control channel.
  * Reserved keys are OURS to set, at the builders, from local knowledge.
+ *
+ * The same rule applies to key ORDER at a builder: spread caller-supplied metadata FIRST and set
+ * the reserved marker LAST, so the marker cannot be overwritten by whatever the caller passed.
+ * Today every such `meta` is locally constructed, so this is defence in depth rather than a live
+ * hole — but it makes the invariant structural instead of conventional.
  */
 export function stripReservedMarkers<T extends Record<string, unknown>>(upstream: T): T {
 	const reserved = new Set<string>([...UNMEASURED_MARKERS, ...ACCESS_REFUSAL_MARKERS]);

--- a/src/tools/osint-investigate.ts
+++ b/src/tools/osint-investigate.ts
@@ -8,6 +8,7 @@ import {
 	callReconInvestigationStatus,
 	callReconInvestigationReport,
 	type ReconBinding,
+	type ReconFailureReason,
 	type ReconInvestigationType,
 	type BindingDegradationSink,
 } from '../lib/recon-binding';
@@ -29,29 +30,107 @@ function unprovisioned(detail: string): CheckResult {
 }
 
 /**
- * A poll whose upstream call came back empty while the binding IS bound — the recon service did
- * not answer, answered non-2xx, or returned a payload that failed schema validation, OR the id is
- * unknown/expired. `callRecon*` collapses all of those into one `null`
- * (`src/lib/recon-binding.ts`), so we cannot tell them apart here and must not pretend to.
+ * Shared body of the two TRANSIENT unmeasured outcomes below (`notFound` and
+ * `upstreamUnavailable`).
  *
- * Kept DISTINCT from `unprovisioned()` because the two states are opposites operationally:
- * unprovisioned is a permanent, structural fact about this deployment, while this is a transient
- * upstream condition that may resolve on the next poll. Reporting an outage as "not provisioned in
- * this deployment" — which is what this path did until #695 — tells an operator to go configure a
- * binding that is already bound, and tells a caller their investigation is unavailable when it may
- * simply not be ready yet.
+ * Both stamp the `upstreamUnavailable` marker because that is the unmeasured-availability
+ * vocabulary owned by `src/lib/unmeasured-result.ts`, and it is what makes `markUnmeasured` set
+ * `checkStatus: 'error'` so no verdict is reported for a lane nothing was read from. The two are
+ * told apart by `reconFailureReason` — ordinary metadata, greppable in a structured response and
+ * in analytics — NOT by a new marker key: the marker set is that module's SSOT and is scope-
+ * enforced by `test/audits/unmeasured-marker-scope.audit.test.ts`.
  *
  * `partial: true` is deliberate and load-bearing here (and deliberately ABSENT on the
- * structural-absence path): the registry cache predicate is `(r) => !r.partial`
- * (`src/handlers/tools.ts`), so this keeps a transient upstream blip out of the cache and lets the
+ * structural-absence path `unprovisioned()`): the registry cache predicate is `(r) => !r.partial`
+ * (`src/handlers/tools.ts`), so this keeps a transient condition out of the cache and lets the
  * next poll self-heal. A permanent deployment fact would gain nothing from cache suppression and
  * would just pay the service-binding round-trip on every call.
  */
-function upstreamUnavailable(title: string, detail: string, meta: Record<string, unknown> = {}): CheckResult {
+function transientUnmeasured(
+	marker: 'upstreamUnavailable' | 'upstreamNotFound',
+	title: string,
+	detail: string,
+	meta: Record<string, unknown>,
+): CheckResult {
 	return {
-		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { upstreamUnavailable: true, ...meta })])),
+		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { [marker]: true, ...meta })])),
 		partial: true,
 	};
+}
+
+/**
+ * The recon service answered DEFINITIVELY 404: the id is unknown or expired, or the caller raced
+ * its own `*_start` and the investigation is not registered yet.
+ *
+ * Nothing was read, so the verdict is still withheld — but this is NOT an outage and must not be
+ * reported as one, which is why it carries the distinct `upstreamNotFound` marker rather than
+ * `upstreamUnavailable` (both are unmeasured; only one claims the service failed). The distinction is available because `callRecon*` returns a discriminated
+ * `ReconOutcome` (`src/lib/recon-binding.ts`) instead of the former single `null`; upstream treats
+ * a 404 as a data miss and stays silent rather than emitting a false binding degradation.
+ *
+ * Stays `partial: true` for the race case that `isRetryableReconFailure` classes retryable: an id
+ * that 404s now may exist moments later, so this result must not be cached.
+ */
+function notFound(title: string, detail: string, meta: Record<string, unknown> = {}): CheckResult {
+	return transientUnmeasured('upstreamNotFound', title, detail, { reconFailureReason: 'not_found', ...meta });
+}
+
+/**
+ * The binding IS bound and the call still yielded no data: the credential was rejected
+ * (`unauthorized`), the upstream returned some other non-2xx (`upstream_status`), a 2xx body
+ * failed schema validation (`malformed`), or the fetch threw (`transport`).
+ *
+ * Those four are exactly what remains once `unbound` and `not_found` are excluded by the `reason`
+ * type — they are routed to `unprovisioned()` and `notFound()` — so this prose no longer has to
+ * hedge about the id being unknown or expired. That hedge existed only because `callRecon*` used
+ * to collapse every condition into one `null`; it does not any more.
+ *
+ * Kept DISTINCT from `unprovisioned()` because the two states are opposites operationally:
+ * unprovisioned is a permanent, structural fact about this deployment, while this is an upstream
+ * condition that may resolve on the next poll. Reporting an outage as "not provisioned in this
+ * deployment" — which is what this path did until #695 — tells an operator to go configure a
+ * binding that is already bound.
+ *
+ * The specific `reason` rides along in metadata so an operator reading a structured response can
+ * see WHY without a log dive: `unauthorized` means fix the credential, `malformed` means the
+ * bv-recon response contract drifted, `transport`/`upstream_status` mean wait and re-poll.
+ */
+function upstreamUnavailable(
+	reason: Exclude<ReconFailureReason, 'unbound' | 'not_found'>,
+	title: string,
+	detail: string,
+	meta: Record<string, unknown> = {},
+): CheckResult {
+	return transientUnmeasured('upstreamUnavailable', title, detail, { reconFailureReason: reason, ...meta });
+}
+
+/**
+ * Per-call-site prose for each way a recon call can come back without data. Written per call site
+ * because "no such id" reads differently on a start (the route does not exist) than on a poll (the
+ * investigation does not exist).
+ */
+interface UnavailableProse {
+	/** No BV_RECON binding at all — a permanent fact about this deployment. */
+	unbound: string;
+	/** Upstream said 404 — a data miss, not a failure. */
+	notFound: string;
+	/** Bound, but the call failed: auth, non-2xx, contract drift, or transport. */
+	upstream: string;
+}
+
+/**
+ * The single mapping from a `ReconFailureReason` to the result shape that is TRUE for it, so all
+ * three tools stay in lockstep instead of each re-deriving the distinction inline.
+ */
+function reconUnavailable(
+	reason: ReconFailureReason,
+	title: string,
+	prose: UnavailableProse,
+	meta: Record<string, unknown> = {},
+): CheckResult {
+	if (reason === 'unbound') return unprovisioned(prose.unbound);
+	if (reason === 'not_found') return notFound(title, prose.notFound, meta);
+	return upstreamUnavailable(reason, title, prose.upstream, meta);
 }
 
 const OSINT_OWNER_TTL_SECONDS = 24 * 60 * 60;
@@ -86,7 +165,7 @@ export async function osintInvestigateStart(
 	query: string,
 	options: ReconToolOptions = {},
 ): Promise<CheckResult> {
-	const started = await callReconInvestigateStart(
+	const outcome = await callReconInvestigateStart(
 		options.reconBinding,
 		options.reconAuthToken,
 		type,
@@ -95,7 +174,20 @@ export async function osintInvestigateStart(
 		undefined,
 		options.onBindingDegradation,
 	);
-	if (!started) return unprovisioned(`OSINT ${type} investigation is not provisioned in this deployment for ${query}.`);
+	if (!outcome.ok)
+		return reconUnavailable(
+			outcome.reason,
+			`OSINT ${type} investigation could not be started`,
+			{
+				unbound: `OSINT ${type} investigation is not provisioned in this deployment for ${query}.`,
+				// A 404 on the START route cannot mean "unknown id" — no id exists yet. It means the
+				// recon service does not expose this investigation type (route/contract drift).
+				notFound: `The recon service has no ${type} investigation endpoint, so no investigation was started for ${query}.`,
+				upstream: `The recon service did not start a ${type} investigation for ${query}. Nothing was read and no investigation exists — retry, or check the operator credential if this persists.`,
+			},
+			{ type },
+		);
+	const started = outcome.data;
 	await rememberInvestigationOwner(started.investigationId, options);
 	return buildCheckResult(CATEGORY, [
 		createFinding(
@@ -197,15 +289,25 @@ function shortText(s: string, max: number): string {
 
 export async function osintInvestigationStatus(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
 	if (await investigationOwnerMismatch(id, options)) return notOwned(id);
-	const s = await callReconInvestigationStatus(options.reconBinding, options.reconAuthToken, id, undefined, options.onBindingDegradation);
-	if (!s)
-		return options.reconBinding
-			? upstreamUnavailable(
-					'OSINT investigation status could not be retrieved',
-					`The recon service did not return a usable status for investigation ${id}, or that id is unknown or expired. This is not a statement about the investigation's findings — nothing was read.`,
-					{ investigationId: id },
-				)
-			: unprovisioned(`OSINT investigation status is not provisioned in this deployment (investigation ${id}).`);
+	const outcome = await callReconInvestigationStatus(
+		options.reconBinding,
+		options.reconAuthToken,
+		id,
+		undefined,
+		options.onBindingDegradation,
+	);
+	if (!outcome.ok)
+		return reconUnavailable(
+			outcome.reason,
+			'OSINT investigation status could not be retrieved',
+			{
+				unbound: `OSINT investigation status is not provisioned in this deployment (investigation ${id}).`,
+				notFound: `The recon service has no investigation ${id} — the id is unknown or expired, or it was started moments ago and is not registered yet. Nothing was read; re-poll if you have just started it.`,
+				upstream: `The recon service did not return a usable status for investigation ${id}. This is not a statement about the investigation's findings — nothing was read.`,
+			},
+			{ investigationId: id },
+		);
+	const s = outcome.data;
 	const status = typeof s.status === 'string' ? s.status : 'unknown';
 	const parts = [`status=${status}`];
 	if (typeof s.completedChecks === 'number' && typeof s.totalChecks === 'number')
@@ -224,15 +326,25 @@ export async function osintInvestigationStatus(id: string, options: ReconToolOpt
 
 export async function osintInvestigationReport(id: string, options: ReconToolOptions = {}): Promise<CheckResult> {
 	if (await investigationOwnerMismatch(id, options)) return notOwned(id);
-	const r = await callReconInvestigationReport(options.reconBinding, options.reconAuthToken, id, undefined, options.onBindingDegradation);
-	if (!r)
-		return options.reconBinding
-			? upstreamUnavailable(
-					'OSINT investigation report could not be retrieved',
-					`The recon service did not return a usable report for investigation ${id}. The investigation may still be running, or the id may be unknown or expired — poll osint_investigation_status. No findings were read.`,
-					{ investigationId: id },
-				)
-			: unprovisioned(`OSINT investigation reports are not provisioned in this deployment (investigation ${id}).`);
+	const outcome = await callReconInvestigationReport(
+		options.reconBinding,
+		options.reconAuthToken,
+		id,
+		undefined,
+		options.onBindingDegradation,
+	);
+	if (!outcome.ok)
+		return reconUnavailable(
+			outcome.reason,
+			'OSINT investigation report could not be retrieved',
+			{
+				unbound: `OSINT investigation reports are not provisioned in this deployment (investigation ${id}).`,
+				notFound: `The recon service has no report for investigation ${id} — the id is unknown or expired, or no report has been produced yet. Poll osint_investigation_status. No findings were read.`,
+				upstream: `The recon service did not return a usable report for investigation ${id}. The investigation may still be running — poll osint_investigation_status and retry. No findings were read.`,
+			},
+			{ investigationId: id },
+		);
+	const r = outcome.data;
 	const total = typeof r.total === 'number' ? r.total : Array.isArray(r.findings) ? r.findings.length : 0;
 	const summary = typeof r.summary === 'string' ? r.summary.trim() : '';
 	return buildCheckResult(CATEGORY, [

--- a/src/tools/osint-investigate.ts
+++ b/src/tools/osint-investigate.ts
@@ -53,7 +53,7 @@ function transientUnmeasured(
 	meta: Record<string, unknown>,
 ): CheckResult {
 	return {
-		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { [marker]: true, ...meta })])),
+		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { ...meta, [marker]: true })])),
 		partial: true,
 	};
 }

--- a/src/tools/scan-buckets.ts
+++ b/src/tools/scan-buckets.ts
@@ -8,6 +8,7 @@ import {
 	callReconBucketScanStatus,
 	callReconBucketFindings,
 	type ReconBinding,
+	type ReconFailureReason,
 	type BindingDegradationSink,
 } from '../lib/recon-binding';
 import { extractBrandName, getRegistrableDomain } from '../lib/public-suffix';
@@ -35,18 +36,69 @@ function unprovisioned(detail: string): CheckResult {
 }
 
 /**
- * Upstream answered with nothing while the binding IS bound. See the twin of this helper in
- * `src/tools/osint-investigate.ts` for the full rationale: `callRecon*` collapses absent-binding,
- * non-2xx, schema mismatch and thrown errors into a single `null`, so a genuine outage was being
- * reported to the caller as "not provisioned in this deployment" (#695). `partial: true` keeps the
- * transient state out of the registry cache (`(r) => !r.partial`); the structural-absence path
- * deliberately does NOT set it.
+ * Nothing was read while the binding IS bound. Reporting that as "not provisioned in this
+ * deployment" told an operator to configure a binding that is already bound (#695).
+ *
+ * `marker` separates the two unmeasured-but-bound cases, which must not be conflated:
+ * `upstreamUnavailable` = the service failed us (credential refused, non-2xx, schema mismatch,
+ * fetch threw); `upstreamNotFound` = the service answered normally with a definitive 404 and the
+ * id simply does not exist. Both withhold the verdict; only the first claims an outage, and
+ * claiming one that did not happen is the same class of dishonesty #695 was about.
+ *
+ * `partial: true` keeps the transient state out of the registry cache (`(r) => !r.partial`), so
+ * the next poll self-heals; the structural-absence path (`unprovisioned`) deliberately does NOT
+ * set it — a permanent deployment fact gains nothing from cache suppression.
  */
-function upstreamUnavailable(title: string, detail: string, meta: Record<string, unknown> = {}): CheckResult {
+function upstreamUnmeasured(
+	marker: 'upstreamUnavailable' | 'upstreamNotFound',
+	title: string,
+	detail: string,
+	meta: Record<string, unknown> = {},
+): CheckResult {
 	return {
-		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { upstreamUnavailable: true, ...meta })])),
+		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { [marker]: true, ...meta })])),
 		partial: true,
 	};
+}
+
+/** Prose for each distinguishable recon-failure class. See `reconFailureResult`. */
+interface ReconFailureProse {
+	/** `unbound` — no BV_RECON binding in this deployment. Permanent, structural. */
+	unbound: string;
+	/** `not_found` — upstream answered a definitive 404. A data miss, NOT a service failure. */
+	notFound: { title: string; detail: string };
+	/** `unauthorized` | `upstream_status` | `malformed` | `transport` — the recon service failed us. */
+	unavailable: { title: string; detail: string };
+}
+
+/**
+ * Map a `ReconOutcome` failure onto the honest unmeasured result for it.
+ *
+ * `callRecon*` no longer collapses its failure modes into a single `null` — it returns a
+ * discriminated `ReconOutcome`, so this file can finally tell "this deployment has no bucket
+ * scanner" from "that scan id does not exist" from "the recon service is down", and say so.
+ * Only the first is a deployment fact (`unprovisioned`, cacheable); the other two are transient
+ * and `partial: true`, and carry DIFFERENT markers (`upstreamNotFound` vs `upstreamUnavailable`)
+ * as well as different prose — a 404 must NOT be narrated as an upstream failure, and an upstream
+ * failure must no longer hedge "…or the id is unknown".
+ *
+ * `reconFailureReason` (and `reconUpstreamStatus`) are stamped into finding metadata for operator
+ * visibility and analytics greppability. Both are LOCALLY derived — never upstream-controlled —
+ * and neither collides with the reserved marker vocabulary in `lib/unmeasured-result.ts`.
+ */
+function reconFailureResult(
+	failure: { reason: ReconFailureReason; status?: number },
+	prose: ReconFailureProse,
+	meta: Record<string, unknown> = {},
+): CheckResult {
+	if (failure.reason === 'unbound') return unprovisioned(prose.unbound);
+	const notFound = failure.reason === 'not_found';
+	const { title, detail } = notFound ? prose.notFound : prose.unavailable;
+	return upstreamUnmeasured(notFound ? 'upstreamNotFound' : 'upstreamUnavailable', title, detail, {
+		...meta,
+		reconFailureReason: failure.reason,
+		...(failure.status !== undefined ? { reconUpstreamStatus: failure.status } : {}),
+	});
 }
 
 interface BucketScanScope {
@@ -274,18 +326,30 @@ export async function scanBucketsStart(
 		undefined,
 		options.onBindingDegradation,
 	);
-	if (!started) return unprovisioned(`Bucket discovery is not provisioned in this deployment for ${args.target}.`);
-	await rememberBucketScanScope(started.scanId, { ...args, owner: options.principalId }, options.bucketScanKv);
+	if (!started.ok)
+		return reconFailureResult(started, {
+			unbound: `Bucket discovery is not provisioned in this deployment for ${args.target}.`,
+			notFound: {
+				title: 'Bucket scan was not started',
+				detail: `The recon service has no bucket-scan trigger for this request (HTTP 404), so no scan was started for ${args.target}. Nothing was scanned.`,
+			},
+			unavailable: {
+				title: 'Bucket scan could not be started',
+				detail: `The recon service did not start a bucket scan for ${args.target}. Nothing was scanned — retry, and if it persists this is a recon-service problem, not a result.`,
+			},
+		});
+	const start = started.data;
+	await rememberBucketScanScope(start.scanId, { ...args, owner: options.principalId }, options.bucketScanKv);
 	return buildCheckResult(CATEGORY, [
 		createFinding(
 			CATEGORY,
 			'Bucket scan started',
 			'info',
-			`Bucket discovery started for ${args.target} (scanId ${started.scanId}). Poll with scan_buckets_status.`,
+			`Bucket discovery started for ${args.target} (scanId ${start.scanId}). Poll with scan_buckets_status.`,
 			{
-				...stripReservedMarkers(started),
-				scanId: started.scanId,
-				status: started.status ?? 'running',
+				...stripReservedMarkers(start),
+				scanId: start.scanId,
+				status: start.status ?? 'running',
 				pollWith: 'scan_buckets_status',
 			},
 		),
@@ -302,19 +366,28 @@ export async function scanBucketsStatus(args: { scanId: string }, options: Recon
 		undefined,
 		options.onBindingDegradation,
 	);
-	if (!s)
-		return options.reconBinding
-			? upstreamUnavailable(
-					'Bucket scan status could not be retrieved',
-					`The recon service did not return a usable status for bucket scan ${args.scanId}, or that scan id is unknown or expired. Nothing was read about the scan's findings.`,
-					{ scanId: args.scanId },
-				)
-			: unprovisioned(`Bucket scanning is not provisioned in this deployment (scan ${args.scanId}).`);
+	if (!s.ok)
+		return reconFailureResult(
+			s,
+			{
+				unbound: `Bucket scanning is not provisioned in this deployment (scan ${args.scanId}).`,
+				notFound: {
+					title: 'Bucket scan status not available yet',
+					detail: `The recon service has no record of bucket scan ${args.scanId} — the scan id is unknown or has expired, or it was only just started and is not registered yet. The recon service answered normally; this is not a service failure. Nothing was read about the scan's findings.`,
+				},
+				unavailable: {
+					title: 'Bucket scan status could not be retrieved',
+					detail: `The recon service did not return a usable status for bucket scan ${args.scanId}. Nothing was read about the scan's findings.`,
+				},
+			},
+			{ scanId: args.scanId },
+		);
+	const status = s.data;
 	return buildCheckResult(CATEGORY, [
-		createFinding(CATEGORY, `Bucket scan ${args.scanId}`, 'info', JSON.stringify(s).slice(0, 800), {
+		createFinding(CATEGORY, `Bucket scan ${args.scanId}`, 'info', JSON.stringify(status).slice(0, 800), {
 			// F7: opaque upstream payload sanitized at the createFinding chokepoint. Reserved
 			// unmeasured/refusal markers are stripped so upstream cannot write our control channel.
-			...stripReservedMarkers(s),
+			...stripReservedMarkers(status),
 			...(scope.target ? { targetScope: scope.target } : {}),
 			...(scope.providers?.length ? { providerScope: scope.providers } : {}),
 			summary: true,
@@ -333,17 +406,25 @@ export async function scanBucketsFindings(args: BucketScanFindingArgs, options: 
 		undefined,
 		options.onBindingDegradation,
 	);
-	if (!f)
-		return options.reconBinding
-			? upstreamUnavailable(
-					'Bucket findings could not be retrieved',
-					`The recon service did not return usable findings for bucket scan ${args.scanId}. The scan may still be running, or the scan id may be unknown or expired — poll scan_buckets_status. This is NOT a report that no exposed buckets exist.`,
-					{ scanId: args.scanId },
-				)
-			: unprovisioned('Bucket scanning is not provisioned in this deployment.');
+	if (!f.ok)
+		return reconFailureResult(
+			f,
+			{
+				unbound: 'Bucket scanning is not provisioned in this deployment.',
+				notFound: {
+					title: 'Bucket findings not available yet',
+					detail: `The recon service has no findings recorded for bucket scan ${args.scanId} — the scan id is unknown or has expired, or results are not ready yet; poll scan_buckets_status. The recon service answered normally; this is not a service failure. This is NOT a report that no exposed buckets exist.`,
+				},
+				unavailable: {
+					title: 'Bucket findings could not be retrieved',
+					detail: `The recon service did not return usable findings for bucket scan ${args.scanId}. Nothing was read. This is NOT a report that no exposed buckets exist.`,
+				},
+			},
+			{ scanId: args.scanId },
+		);
 	const target = normalizeTarget(args.target) ?? rememberedScope.target;
 	const providers = args.providers ?? rememberedScope.providers;
-	const filtered = filterBucketPayload(f, { target, providers });
+	const filtered = filterBucketPayload(f.data, { target, providers });
 	const filteredCount = typeof filtered.filteredOutOfScopeCount === 'number' ? filtered.filteredOutOfScopeCount : 0;
 	const detailPrefix = filteredCount > 0 ? `Bucket findings filtered ${filteredCount} out-of-scope upstream candidate(s). ` : '';
 	return buildCheckResult(CATEGORY, [

--- a/src/tools/scan-buckets.ts
+++ b/src/tools/scan-buckets.ts
@@ -56,7 +56,7 @@ function upstreamUnmeasured(
 	meta: Record<string, unknown> = {},
 ): CheckResult {
 	return {
-		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { [marker]: true, ...meta })])),
+		...markUnmeasured(buildCheckResult(CATEGORY, [createFinding(CATEGORY, title, 'info', detail, { ...meta, [marker]: true })])),
 		partial: true,
 	};
 }

--- a/test/recon-binding-async.spec.ts
+++ b/test/recon-binding-async.spec.ts
@@ -1,15 +1,68 @@
 // SPDX-License-Identifier: BUSL-1.1
 import { describe, it, expect, vi, afterEach } from 'vitest';
+
+import type { BindingDegradationSink, ReconBinding, ReconFailureReason, ReconOutcome } from '../src/lib/recon-binding';
+
 afterEach(() => vi.restoreAllMocks());
 
 function binding(body: unknown, status = 200) {
-	return { fetch: vi.fn(async () => new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })) };
+	// Params are declared (rather than a bare `async () =>`) so `fetch.mock.calls[0]`
+	// types as a 2-tuple instead of `[]` — otherwise every URL/init assertion below
+	// is a typecheck error against test/tsconfig.json.
+	return {
+		fetch: vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }),
+		),
+	};
+}
+
+/** A binding whose fetch throws — `name` selects the BindingDegradationKind mapping. */
+function throwingBinding(errorName?: string) {
+	return {
+		fetch: vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => {
+			const e = new Error('connection refused');
+			if (errorName) e.name = errorName;
+			throw e;
+		}),
+	};
+}
+
+/** Narrow an outcome to its payload, failing loudly (with the reason) when it is not ok. */
+function dataOf<T>(outcome: ReconOutcome<T>): T {
+	if (!outcome.ok) throw new Error(`expected an ok outcome, got reason=${outcome.reason}`);
+	return outcome.data;
+}
+
+/**
+ * Every async (ReconOutcome-returning) entry point, invoked with a caller-supplied
+ * binding + telemetry sink. Used by the sweeps below so a discriminant is proven on
+ * ALL six functions rather than on one lucky representative.
+ */
+async function asyncCalls(): Promise<
+	{ name: string; invoke: (b: ReconBinding | undefined, sink: BindingDegradationSink) => Promise<ReconOutcome<unknown>> }[]
+> {
+	const m = await import('../src/lib/recon-binding');
+	return [
+		{
+			name: 'callReconInvestigateStart',
+			invoke: (b, sink) => m.callReconInvestigateStart(b, 'tok', 'domain', 'example.com', undefined, undefined, sink),
+		},
+		{ name: 'callReconInvestigationStatus', invoke: (b, sink) => m.callReconInvestigationStatus(b, 'tok', 'inv_1', undefined, sink) },
+		{ name: 'callReconInvestigationReport', invoke: (b, sink) => m.callReconInvestigationReport(b, 'tok', 'inv_1', undefined, sink) },
+		{
+			name: 'callReconBucketScanStart',
+			invoke: (b, sink) => m.callReconBucketScanStart(b, 'tok', { target: 'example.com' }, undefined, sink),
+		},
+		{ name: 'callReconBucketScanStatus', invoke: (b, sink) => m.callReconBucketScanStatus(b, 'tok', 'scan_1', undefined, sink) },
+		{ name: 'callReconBucketFindings', invoke: (b, sink) => m.callReconBucketFindings(b, 'tok', 'scan_1', undefined, sink) },
+	];
 }
 
 describe('recon async proxies', () => {
-	it('callReconInvestigateStart returns null when binding absent', async () => {
+	it('callReconInvestigateStart reports `unbound` when the binding is absent', async () => {
 		const { callReconInvestigateStart } = await import('../src/lib/recon-binding');
-		expect(await callReconInvestigateStart(undefined, 't', 'domain', 'example.com')).toBeNull();
+		expect(await callReconInvestigateStart(undefined, 't', 'domain', 'example.com')).toEqual({ ok: false, reason: 'unbound' });
 	});
 	it('callReconInvestigateStart POSTs the type path with bearer + body and parses id', async () => {
 		const { callReconInvestigateStart } = await import('../src/lib/recon-binding');
@@ -19,21 +72,190 @@ describe('recon async proxies', () => {
 		expect(String(url)).toContain('/osint/api/investigate/deep_infrastructure');
 		expect((init as RequestInit).method).toBe('POST');
 		expect((init as RequestInit).headers).toMatchObject({ Authorization: 'Bearer tok' });
-		expect(out?.investigationId).toBe('inv_1');
+		expect(out.ok).toBe(true);
+		expect(dataOf(out).investigationId).toBe('inv_1');
 	});
-	it('callReconInvestigationStatus GETs by id and returns null on non-ok', async () => {
+	it('callReconInvestigationStatus GETs by id and reports `not_found` on 404', async () => {
 		const { callReconInvestigationStatus } = await import('../src/lib/recon-binding');
-		expect(await callReconInvestigationStatus(binding({ error: 'x' }, 404), 'tok', 'inv_1')).toBeNull();
+		const b = binding({ error: 'x' }, 404);
+		const out = await callReconInvestigationStatus(b, 'tok', 'inv_1');
+		expect(String(b.fetch.mock.calls[0][0])).toContain('/osint/api/investigation/inv_1');
+		expect(out).toEqual({ ok: false, reason: 'not_found', status: 404 });
 	});
 	it('callReconBucketScanStart POSTs trigger and parses scanId', async () => {
 		const { callReconBucketScanStart } = await import('../src/lib/recon-binding');
 		const b = binding({ scanId: 'scan_1', status: 'running' });
 		const out = await callReconBucketScanStart(b, 'tok', { target: 'example.com' });
 		expect(String(b.fetch.mock.calls[0][0])).toContain('/buckets/api/scan/trigger');
-		expect(out?.scanId).toBe('scan_1');
+		expect(dataOf(out).scanId).toBe('scan_1');
 	});
-	it('callReconBucketScanStatus returns null on non-ok', async () => {
+	it('callReconBucketScanStatus reports `upstream_status` (with the status) on 500', async () => {
 		const { callReconBucketScanStatus } = await import('../src/lib/recon-binding');
-		expect(await callReconBucketScanStatus(binding({}, 500), 'tok', 'scan_1')).toBeNull();
+		expect(await callReconBucketScanStatus(binding({}, 500), 'tok', 'scan_1')).toEqual({
+			ok: false,
+			reason: 'upstream_status',
+			status: 500,
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// The behavior change that motivated the discriminated ReconOutcome (#695):
+// a 404 on an async recon call is a DATA MISS (unknown/expired investigation or
+// scan id, or a poll racing its own *_start), not a binding failure. It used to
+// fall into `!resp.ok` and record `binding_5xx`, so every poll of an unknown id
+// fired a FALSE operator degradation alert.
+//
+// This is not a new contract, only a newly-honored one: the doc comment on
+// `BindingDegradationKind` in src/lib/binding-degradation.ts already states the
+// kind set "deliberately excludes ... the benign recon 404" — until now only
+// `callReconScan` (the sync path) actually honored it.
+// ---------------------------------------------------------------------------
+describe('recon async 404 is a silent data miss, not a degradation', () => {
+	it('returns not_found AND does NOT invoke the degradation sink or log a degradation', async () => {
+		const { callReconInvestigationStatus } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconInvestigationStatus(binding({ error: 'unknown id' }, 404), 'tok', 'expired_inv', undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'not_found', status: 404 });
+		expect(sink).not.toHaveBeenCalled();
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('binding_degradation');
+	});
+
+	it('holds for ALL six async entry points', async () => {
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		for (const { name, invoke } of await asyncCalls()) {
+			const out = await invoke(binding({ error: 'not found' }, 404), sink);
+			expect(out, name).toEqual({ ok: false, reason: 'not_found', status: 404 });
+		}
+		expect(sink).not.toHaveBeenCalled();
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('binding_degradation');
+	});
+});
+
+describe('ReconOutcome failure discriminants', () => {
+	it('unbound: absent binding is silent on ALL six entry points (BSL self-host, expected)', async () => {
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		for (const { name, invoke } of await asyncCalls()) {
+			expect(await invoke(undefined, sink), name).toEqual({ ok: false, reason: 'unbound' });
+		}
+		expect(sink).not.toHaveBeenCalled();
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('binding_degradation');
+	});
+
+	it('unauthorized: 401 records a degradation and carries the status', async () => {
+		const { callReconInvestigationReport } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconInvestigationReport(binding({ error: 'no' }, 401), 'bad-tok', 'inv_1', undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'unauthorized', status: 401 });
+		expect(sink).toHaveBeenCalledWith(expect.objectContaining({ degradationType: 'binding_5xx', component: 'recon' }));
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).toContain('binding_degradation');
+	});
+
+	it('unauthorized: 403 is the same discriminant as 401', async () => {
+		const { callReconBucketFindings } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconBucketFindings(binding({ error: 'forbidden' }, 403), 'bad-tok', 'scan_1', undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'unauthorized', status: 403 });
+		expect(sink).toHaveBeenCalledWith(expect.objectContaining({ degradationType: 'binding_5xx', component: 'recon' }));
+	});
+
+	it('upstream_status: a 502 records a degradation and carries the status', async () => {
+		const { callReconInvestigateStart } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconInvestigateStart(binding({ error: 'boom' }, 502), 'tok', 'username', 'someone', undefined, undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'upstream_status', status: 502 });
+		expect(sink).toHaveBeenCalledWith(expect.objectContaining({ degradationType: 'binding_5xx', component: 'recon' }));
+	});
+
+	it('malformed: a 200 whose body fails the schema is contract drift, NOT a degradation', async () => {
+		const { callReconInvestigateStart } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		const warn = vi.spyOn(console, 'log').mockImplementation(() => {});
+		// InvestigationStartSchema requires `investigationId`.
+		const out = await callReconInvestigateStart(binding({ status: 'running' }), 'tok', 'domain', 'example.com', undefined, undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'malformed', status: 200 });
+		// The upstream answered fine — this is neither an outage nor an auth failure,
+		// so recordReconDegradation is deliberately NOT called on this branch.
+		expect(sink).not.toHaveBeenCalled();
+		expect(warn.mock.calls.map((c) => String(c[0])).join('\n')).not.toContain('binding_degradation');
+	});
+
+	it('malformed: a 200 scalar body fails the opaque-object schema (rejects non-objects)', async () => {
+		const { callReconBucketScanStatus } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconBucketScanStatus(binding('not-an-object'), 'tok', 'scan_1', undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'malformed', status: 200 });
+		expect(sink).not.toHaveBeenCalled();
+	});
+
+	it('transport: a thrown fetch reports transport (no status) + binding_unavailable', async () => {
+		const { callReconInvestigationStatus } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconInvestigationStatus(throwingBinding(), 'tok', 'inv_1', undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'transport' });
+		expect(out).not.toHaveProperty('status');
+		expect(sink).toHaveBeenCalledWith(expect.objectContaining({ degradationType: 'binding_unavailable', component: 'recon' }));
+	});
+
+	it('transport: a TimeoutError maps to binding_timeout but the same discriminant', async () => {
+		const { callReconBucketScanStart } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const out = await callReconBucketScanStart(throwingBinding('TimeoutError'), 'tok', { target: 'x.com' }, undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'transport' });
+		expect(sink).toHaveBeenCalledWith(expect.objectContaining({ degradationType: 'binding_timeout', component: 'recon' }));
+	});
+
+	it('malformed: a 200 with a non-JSON body is contract drift, NOT an outage', async () => {
+		// A 2xx whose body is not even JSON (HTML error page, truncated response) must be
+		// `malformed` and SILENT. `reconJson` guards `resp.json()` with `.catch(() => null)`,
+		// matching `callReconScan`; without that guard the parse throw escapes to the outer
+		// catch and is reported as `transport` WITH a `binding_unavailable` degradation — a
+		// false operator alert, the same defect class as the benign 404 (see above).
+		const { callReconInvestigationStatus } = await import('../src/lib/recon-binding');
+		const sink = vi.fn();
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const b = { fetch: vi.fn(async () => new Response('<html>not json</html>', { status: 200 })) };
+		const out = await callReconInvestigationStatus(b, 'tok', 'inv_1', undefined, sink);
+		expect(out).toEqual({ ok: false, reason: 'malformed', status: 200 });
+		expect(sink).not.toHaveBeenCalled();
+	});
+
+	it('a thrown sink never breaks the fail-soft contract on the async path', async () => {
+		const { callReconInvestigationStatus } = await import('../src/lib/recon-binding');
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+		const sink = vi.fn(() => {
+			throw new Error('sink boom');
+		});
+		expect(await callReconInvestigationStatus(binding({}, 500), 'tok', 'inv_1', undefined, sink)).toEqual({
+			ok: false,
+			reason: 'upstream_status',
+			status: 500,
+		});
+	});
+});
+
+describe('isRetryableReconFailure', () => {
+	it('is true only for the transient reasons (upstream_status, transport, not_found)', async () => {
+		const { isRetryableReconFailure } = await import('../src/lib/recon-binding');
+		const expected: Record<ReconFailureReason, boolean> = {
+			unbound: false,
+			not_found: true,
+			unauthorized: false,
+			upstream_status: true,
+			malformed: false,
+			transport: true,
+		};
+		for (const [reason, want] of Object.entries(expected) as [ReconFailureReason, boolean][]) {
+			expect(isRetryableReconFailure(reason), reason).toBe(want);
+		}
 	});
 });

--- a/test/recon-binding.spec.ts
+++ b/test/recon-binding.spec.ts
@@ -154,7 +154,9 @@ describe('callReconScan degradation telemetry', () => {
 		vi.spyOn(console, 'log').mockImplementation(() => {});
 		const binding = bindingReturning({ error: 'boom' }, 502);
 		const out = await callReconBucketScanStatus(binding, 'tok', 'scan-123', undefined, sink);
-		expect(out).toBeNull();
+		// The async calls return a discriminated ReconOutcome (not `T | null`); the
+		// degradation contract is unchanged for a genuine upstream failure.
+		expect(out).toEqual({ ok: false, reason: 'upstream_status', status: 502 });
 		expect(sink).toHaveBeenCalledWith(expect.objectContaining({ degradationType: 'binding_5xx', component: 'recon' }));
 	});
 });

--- a/test/typecheck-baseline.json
+++ b/test/typecheck-baseline.json
@@ -1,8 +1,8 @@
 {
-	"$comment": "Ratchet baseline for `npm run typecheck:tests` (issue #645). Per-file tsc error counts for the test trees, which no other gate typechecks. An INCREASE fails CI; a decrease is reported and should be banked by re-running with `-- --update`. Regenerate deliberately — never to silence a new error.",
+	"$comment": "Ratchet baseline for `npm run typecheck:tests` (issue #645). Per-file tsc error counts for the test trees, which no other gate typechecks. An INCREASE fails CI; a decrease is reported and should be banked by re-running with `-- --update`. Regenerate deliberately \u2014 never to silence a new error.",
 	"generatedBy": "scripts/ci/typecheck-tests.mjs --update",
 	"typescript": "6.0.3",
-	"total": 1066,
+	"total": 1061,
 	"projects": {
 		"test/tsconfig.json": {
 			"packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts": 4,
@@ -171,7 +171,7 @@
 			"test/rate-limiter-kv-reset.test.ts": 2,
 			"test/rate-limiter-quota-batch.spec.ts": 6,
 			"test/rate-limiter.spec.ts": 19,
-			"test/recon-binding-async.spec.ts": 5,
+			"test/recon-binding-async.spec.ts": 0,
 			"test/recon-binding.spec.ts": 3,
 			"test/registrar-portfolio.spec.ts": 1,
 			"test/registrar-retry.test.ts": 6,


### PR DESCRIPTION
Closes the root cause left open by #695. The visible symptom — unavailable lanes reporting `passed: true, score: 100` — shipped in 3.53.0 (#697/#698/#699). This fixes the layer underneath it.

## The problem

`callRecon*` mapped six distinct conditions onto one `null`:

| Condition | Before |
|---|---|
| No `BV_RECON` binding (BSL self-host) | `null`, silent — correct |
| `404` — unknown/expired id, or a poll racing its own `*_start` | `null` + degradation `binding_5xx` |
| `401`/`403` — credential rejected | `null` + `binding_5xx` |
| `5xx` — real upstream outage | `null` + `binding_5xx` |
| `2xx` with a body failing schema validation | `null` |
| Fetch threw | `null` + `binding_unavailable` |

Callers could not tell them apart, so they used the *presence of the binding* as a proxy. `osint-investigate.ts` said so in a comment: the cases "cannot be told apart here and must not be pretended to."

The information loss had a second-order cost. Because the caller couldn't distinguish a 404 from a 5xx, neither could the **telemetry** — so every poll of an unknown, expired, or not-yet-registered id fed the 15-minute binding-degradation cron alert. `binding-degradation.ts` already documents that the kind set "deliberately excludes … the benign recon 404"; only `callReconScan` honored it.

## The change

The six async client functions return a discriminated `ReconOutcome<T>`:

```ts
type ReconFailureReason = 'unbound' | 'not_found' | 'unauthorized' | 'upstream_status' | 'malformed' | 'transport';
type ReconOutcome<T> = { ok: true; data: T } | { ok: false; reason: ReconFailureReason; status?: number };
```

`callReconScan` deliberately keeps `T | null` — four call sites that only ask "did I get intel?", and it already resolved its one meaningful distinction internally.

### Three false operator alerts removed

- **Benign 404 → silent.** Extends to the async path the rule `callReconScan` already followed and `binding-degradation.ts` already documented.
- **`2xx` with a non-JSON body → `malformed`, silent.** An HTML error page or truncated response threw inside `resp.json()`, escaped to the outer catch, and recorded `binding_unavailable` — an outage claim for what is contract drift. `callReconScan` had guarded this with `.catch(() => null)` all along; the async path had not. *(Found by the subagent writing the tests, against my implementation.)*
- **`401`/`403` is now distinguishable from a 5xx**, and surfaces as `reconFailureReason` / `reconUpstreamStatus` in finding metadata so an operator can see it is a credential problem, not an outage.

### A third unmeasured marker

`not_found` carries a new `upstreamNotFound` marker rather than reusing `upstreamUnavailable`. Both withhold the verdict; only one claims the service failed. Reporting a benign data miss as an outage is the same class of dishonesty #695 was about, and it would over-count on any dashboard tallying upstream failures.

This is a one-line addition to `UNMEASURED_MARKERS` because `stripReservedMarkers` and `test/audits/unmeasured-marker-scope.audit.test.ts` both **derive** their sets from that constant — so the new marker is automatically protected against upstream forgery and automatically barred from reaching a scored category.

### Hardening (second commit)

Builders now spread caller metadata first and set the reserved marker **last**, so `meta` cannot overwrite the control channel. Every `meta` at these call sites is locally constructed today, so this is defence in depth, not a live hole — it makes the invariant structural rather than conventional.

## Judgement calls worth a reviewer's eye

1. **`not_found` is unmeasured, not measured.** A definitive upstream answer about the *record* is still not a measurement of the *domain*, so it must not present as a scored pass. It keeps `partial: true` (uncached) so a client that raced its own `*_start` self-heals on the next poll.
2. **`not_found` on a `*_start` route means something different** — no id exists yet, so a 404 there indicates the recon service doesn't expose that investigation type (route/contract drift). Prose differs per call site accordingly.
3. **Telemetry routing is deliberately unchanged** beyond the two silences. `unauthorized` still records `binding_5xx`. Re-tuning alert routing is an operator-visible decision and is not bundled here.

## Verification

- `npx tsc --noEmit -p tsconfig.json` → 0 errors
- Affected specs + audits → **73 passed**; recon-adjacent surfaces → **135 passed**
- Full audit suite (`test/audits/`) → **439 passed**, 1 skipped
- `npm run typecheck:tests` ratchet → OK. `test/recon-binding-async.spec.ts` improved 5 → 0 and is banked. The other 14 files reported as improved were **not** banked: they improved because `wrangler types` regenerated `worker-configuration.d.ts` locally, which may differ from CI's, and tightening their baselines on an environment artifact could turn CI red.
- `prettier --check` + `eslint` clean on every changed file. `CHANGELOG.md` is left unformatted — it was already non-conforming on `main`, and formatting it would sweep the entire historical changelog into this diff.

## Test coverage added

13 tests, including a sweep asserting **all six** async entry points stay silent on 404 and on an absent binding, one covering each discriminant, and an exhaustive `Record<ReconFailureReason, boolean>` for `isRetryableReconFailure` so a future reason cannot compile without a decision.

Refs #695
