### PR TITLE
chore: release 3.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [3.54.0] - 2026-08-19
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.19.0 — no weight, tier, grade band, severity penalty or profile rule moved. No score changes. The recon tools this release touches are all `scanIncluded: false`, so nothing here reaches a scored category; `test/audits/unmeasured-marker-scope.audit.test.ts` enforces that boundary.
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.53.0",
+	"version": "3.54.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.53.0",
+			"version": "3.54.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.53.0",
+	"version": "3.54.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.53.0",
+  "version": "3.54.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Release cut for **3.54.0**. Ships #703 (merged in `d92e34e7`).

## Version surfaces — all four pre-bumped

| Surface | Value |
|---|---|
| `package.json` | 3.54.0 |
| `package-lock.json` | 3.54.0 |
| `server.json` (top-level; remotes-only, no `packages` stanza) | 3.54.0 |
| `CHANGELOG.md` heading | `## [3.54.0] - 2026-08-19` |

`SERVER_VERSION` is **not** in that list — it auto-derives from `pkg.version` and is deliberately untouched.

`publish.yml`'s `version-bump` job is a read-only gate: it fails the release with a per-surface `::error::` if any of these disagrees with the tag. Pre-bumping is what makes it pass, not a formality — the auto-bump it replaced silently half-failed releases 3.40.0 through 3.42.0.

`server.json` was edited by **exact-line substitution**, not a JSON round-trip. `git diff --numstat` confirms 1 insertion / 1 deletion. A `JSON.stringify` reindent is precisely what defeated the byte-level idempotency guard in those three broken releases.

## Contents

**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0, `@blackveil/dns-checks` stays 1.19.0. No weight, tier, grade band, severity penalty or profile rule moved, and no score changes. Every tool touched by #703 is `scanIncluded: false`, so nothing reaches a scored category — enforced by `test/audits/unmeasured-marker-scope.audit.test.ts`.

#703 fixed the root cause left open by #695: `callRecon*` collapsed six distinct conditions onto one `null`. It now returns a discriminated `ReconOutcome`, which also closed three false operator alerts feeding the 15-minute binding-degradation cron — a benign 404, a `2xx` with a non-JSON body, and a rejected credential were all indistinguishable from an upstream outage.

## Verification on this branch

- `mcp-publisher validate` → `server.json is valid`
- `npm run typecheck` → 0 errors
- `test/audits/` → **439 passed**, 1 skipped

## Post-merge sequence

1. Tag `v3.54.0` at the squashed merge commit (not this branch tip).
2. `npm -w packages/dns-checks run build && npm run deploy:prod` from an isolated worktree at the tag — `deploy:prod` uploads the **working tree**, and the shared checkout holds a concurrent agent's uncommitted work.
3. Verify prod `serverInfo.version` + a live scan.
4. **Then** `mcp-publisher publish` from that same worktree. Registry ahead of prod is the stale-prod foot-gun; behind is benign. Last release published 3.52.0 by mistake because it was run from the stale checkout — `mcp-publisher` reads `server.json` from the CWD.
5. Cancel the parked tag runs: both `publish.yml` **and** `deploy-prod.yml` trigger on `v*`, so every tag arms two approval-gated rollbacks.