### PR TITLE
fix(compliance): stop reporting a control as PASS when its record was never published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.19.0 — no weight, tier, grade band, severity penalty or profile rule moved, and no score changes. `recordPresent`/`controlPresent` are score-neutral by construction; only the `map_compliance` reporting surface reads them.
+
+### Fixed
+
+- `map_compliance` no longer reports a control as PASS when the control's record was never published. It graded on `CheckResult.passed`, which records whether a check PENALIZED the domain rather than whether the control exists — so an absent-but-unpenalized control still read as compliant. Measured 2026-08-19: `davidhf.com` was reported **100% passing on both NIST 800-177 and PCI DSS 4.0** while the same scan raised a high-severity "DNSSEC not enabled" and a medium "No CAA records" against it; NIST §5.1 (DNSSEC Validation) and §5.2 (CAA) returned `pass` on every domain tested, signed or not, so neither control ever discriminated. Verdicts now additionally require that the check did not observe a definitive absence.
+- A control whose mapped category the scan itself declared NOT APPLICABLE is now `not_assessed` rather than being failed on that absence. Without this, the presence rule above would newly report "NIST §4.4 MTA-STS — FAIL" against a `web_only` domain that accepts no mail — trading a false PASS for a false FAIL. Applicability is not re-derived: `isCategoryNonApplicable` (the single source `categoryScores` and `notApplicableCategories` both come from) is now exported and reused.
+- `map_compliance` renders the same grade letter as every other surface. It passed `ScanScore.grade` — the engine's canonical NINE-band letter — straight through instead of the six-band display band, so the same domain at the same score read `B+` here and `B` in `scan_domain` (measured on `codewithbullet.com` at 82, and `davidhf.com` at 92 reporting `A+`, a band that requires ≥ 95 on the display scale). It now uses `displayGradeFor`, the display SSOT.
+
+### Notes
+
+- A zone that validates while publishing no DNSKEY/DS of its own — the registry/ccTLD-signed case `check-dnssec` documents as the legitimate `recordPresent: false` + `controlPresent: true` state — still passes §5.1. An affirmative `controlPresent` rebuts absence, so a protected zone is never reported as non-compliant.
+- The `map_compliance` "healthy baseline" test fixture published no MX, DNSKEY/DS or TLSA while mocking every mail control. It only read as healthy because the mapper graded on `passed`; it now publishes the records it claims, so it exercises a genuinely compliant domain.
+
 ## [3.54.0] - 2026-08-19
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.19.0 — no weight, tier, grade band, severity penalty or profile rule moved. No score changes. The recon tools this release touches are all `scanIncluded: false`, so nothing here reaches a scored category; `test/audits/unmeasured-marker-scope.audit.test.ts` enforces that boundary.

--- a/src/tools/map-compliance.ts
+++ b/src/tools/map-compliance.ts
@@ -11,7 +11,8 @@ import { scanDomain } from './scan-domain';
 import type { ScanRuntimeOptions } from './scan/post-processing';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
-import { formatScoreGrade, hasCompletedEvidence, isCompletedCheck, UNGRADED_DISPLAY } from '../lib/ungraded-display';
+import { displayGradeFor, formatScoreGrade, hasCompletedEvidence, isCompletedCheck, UNGRADED_DISPLAY } from '../lib/ungraded-display';
+import { isCategoryNonApplicable } from './scan/format-report';
 
 export type ComplianceFramework = 'nist_800_177' | 'pci_dss_4' | 'soc2' | 'cis_controls';
 
@@ -232,19 +233,55 @@ const FRAMEWORK_LABELS: Record<ComplianceFramework, string> = {
 };
 
 /**
+ * Does this completed check actually satisfy the control it is mapped to?
+ *
+ * `passed` alone is NOT the answer, and reading it as one was the defect this predicate
+ * closes. `passed` records whether the check PENALIZED the domain; a control that is
+ * absent but carries no penalty under the active profile still returns `passed: true`.
+ * Mapping that onto a compliance verdict published "NIST 800-177 §5.1 DNSSEC — PASS"
+ * for domains with no DNSSEC at all, alongside the same scan's own high-severity
+ * "DNSSEC not enabled" finding.
+ *
+ * `recordPresent` is the observational answer to "was the artifact published at all",
+ * and is documented as score-neutral precisely so a consumer like this one can read it
+ * without perturbing scoring. Only an explicit `false` counts: `undefined` means the
+ * check does not report the signal (spf, dkim, ssl, ns and http_security never set it)
+ * or that the query failed, and absence of a signal is not evidence of absence.
+ *
+ * `recordPresent === false` is NOT sufficient on its own. `check-dnssec` documents a
+ * legitimate `recordPresent: false` + `controlPresent: true` state: a zone that
+ * validates while publishing no DNSKEY/DS of its own, because its ccTLD registry signed
+ * it. That zone IS cryptographically protected, so failing it on missing records would
+ * trade the false PASS this fixes for a false FAIL. An affirmative `controlPresent`
+ * therefore wins, and only unrebutted evidence of absence disqualifies.
+ */
+function isSatisfiedControl(result: CheckResult): boolean {
+	if (!result.passed) return false;
+	return !(result.recordPresent === false && result.controlPresent !== true);
+}
+
+/**
  * Evaluate compliance control status from check results (pure function).
  * Exported for direct unit testing without needing to mock scanDomain.
+ *
+ * `notApplicableCategories` comes from the scan's own applicability pass — see
+ * `isCategoryNonApplicable` in `scan/format-report.ts`, the single source that
+ * `categoryScores` and `notApplicableCategories` both derive from. Callers that omit it
+ * get the previous behaviour for every category.
  */
 export function evaluateCompliance(
 	checkResults: CheckResult[],
 	domain: string,
 	score: number | null,
 	grade: string | null,
+	notApplicableCategories: readonly string[] = [],
 ): ComplianceReport {
 	const resultsByCategory = new Map<string, CheckResult>();
 	for (const r of checkResults) {
 		resultsByCategory.set(r.category, r);
 	}
+
+	const notApplicable = new Set(notApplicableCategories);
 
 	const frameworkMappings = new Map<ComplianceFramework, ComplianceMapping[]>();
 	for (const fw of FRAMEWORK_ORDER) {
@@ -257,11 +294,22 @@ export function evaluateCompliance(
 		let status: ComplianceStatus;
 		const relatedFindings: string[] = [];
 
-		if (matchedResults.length === 0) {
+		// A category the SCAN itself declared not-applicable carries no verdict for this
+		// control. Dropping it here (rather than letting it fall through to the presence
+		// rule below) is what stops a `web_only` domain — which legitimately publishes no
+		// MTA-STS record — from newly reading "NIST §4.4 — FAIL". The applicability
+		// decision is NOT re-derived here: `isCategoryNonApplicable` in
+		// `scan/format-report.ts` is the single source `categoryScores` and
+		// `notApplicableCategories` both come from, and its verdict is passed in.
+		const applicableResults = matchedResults.filter((r) => !notApplicable.has(r.category));
+		const notApplicableCount = matchedResults.length - applicableResults.length;
+
+		if (applicableResults.length === 0) {
 			// No check data for ANY mapped category — there is no evidence either way,
 			// so this control has no verdict. It used to be reported as `fail`, which
 			// made an unmeasured domain (NXDOMAIN / broken zone — `checks: []`) render
-			// as a complete framework-by-framework compliance failure.
+			// as a complete framework-by-framework compliance failure. The same reasoning
+			// covers a control whose every mapped category was declared inapplicable.
 			status = 'not_assessed';
 		} else {
 			// A matched result whose check never COMPLETED (checkStatus 'timeout'/'error')
@@ -270,15 +318,15 @@ export function evaluateCompliance(
 			// partition on `checkStatus` here. `isCompletedCheck` is the single SSOT
 			// spelling of "absent or 'completed' means the check ran normally" — see
 			// `test/audits/*evidence*` for the ban on re-deriving this locally.
-			const completed = matchedResults.filter(isCompletedCheck);
+			const completed = applicableResults.filter(isCompletedCheck);
 
 			if (completed.length === 0) {
 				// Every matched category was measured-AT but never measured — one slow
 				// resolver must not turn into "DMARC Policy — FAIL" on a healthy domain.
 				status = 'not_assessed';
 			} else {
-				const passingCount = completed.filter((r) => r.passed).length;
-				const failingResults = completed.filter((r) => !r.passed);
+				const passingCount = completed.filter(isSatisfiedControl).length;
+				const failingResults = completed.filter((r) => !isSatisfiedControl(r));
 
 				// Collect finding titles from failing categories — completed ones only, so a
 				// transient check's "check error"/"timed out" title never reads as a graded
@@ -301,8 +349,8 @@ export function evaluateCompliance(
 				// and `totalCategories >= completed.length` always holds — the all-transient
 				// case (denominator hitting 0) already short-circuited to `not_assessed`
 				// before this line, so no separate zero-check is needed here.
-				const transientCount = matchedResults.length - completed.length;
-				const totalCategories = control.categories.length - transientCount;
+				const transientCount = applicableResults.length - completed.length;
+				const totalCategories = control.categories.length - transientCount - notApplicableCount;
 
 				if (control.requirePass) {
 					// All mapped categories must pass (and be present)
@@ -377,7 +425,20 @@ export function evaluateCompliance(
 export async function mapCompliance(domain: string, kv?: KVNamespace, runtimeOptions?: ScanRuntimeOptions): Promise<ComplianceReport> {
 	const scanResult = await scanDomain(domain, kv, runtimeOptions);
 
-	return evaluateCompliance(scanResult.checks, domain, scanResult.score.overall, scanResult.score.grade);
+	// Mirror the scan's own applicability pass so a category it nulled cannot be graded
+	// here. Same predicate, same profile default as `formatScanReport` — not a second
+	// opinion on applicability.
+	const profile = scanResult.context?.profile ?? 'mail_enabled';
+	const categoryScores: Record<string, number> = scanResult.score.categoryScores ?? {};
+	const notApplicableCategories = scanResult.checks
+		.filter((check) => isCompletedCheck(check) && isCategoryNonApplicable(check, check.category, profile, categoryScores[check.category]))
+		.map((check) => check.category);
+
+	// `ScanScore.grade` is the engine's canonical NINE-band letter. Every DISPLAY surface
+	// renders the six-band scale via `displayGradeFor`, so passing the raw grade through
+	// made this tool disagree with `scan_domain` on the same score (82 → "B+" here, "B"
+	// there). One band scale, one helper.
+	return evaluateCompliance(scanResult.checks, domain, scanResult.score.overall, displayGradeFor(scanResult.score), notApplicableCategories);
 }
 
 /**

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -196,7 +196,7 @@ const EMAIL_CATEGORIES_HEURISTIC_NA = new Set<string>(['spf', 'dmarc', 'dkim', '
  * score for, so it never produces this shape); a hand-built `categoryScores`/`checks`
  * pair from an external caller could reach it.
  */
-function isCategoryNonApplicable(check: CheckResult | undefined, category: string, profile: string, score: number | undefined): boolean {
+export function isCategoryNonApplicable(check: CheckResult | undefined, category: string, profile: string, score: number | undefined): boolean {
 	const isNonMailProfile = profile === 'non_mail' || profile === 'web_only';
 	if (!isNonMailProfile) return false;
 

--- a/test/map-compliance.spec.ts
+++ b/test/map-compliance.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import type { CheckResult } from '../src/lib/scoring';
 import { evaluateCompliance, formatCompliance, UNASSESSED_COMPLIANCE_CAVEAT, buildAllTransientCaveat } from '../src/tools/map-compliance';
 import type { ComplianceReport } from '../src/tools/map-compliance';
-import { setupFetchMock, createDohResponse, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse } from './helpers/dns-mock';
+import { setupFetchMock, createDohResponse, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse, tlsaResponse } from './helpers/dns-mock';
 
 /** Helper to build a minimal CheckResult for compliance mapping tests. */
 function makeCheckResult(category: string, passed: boolean, findings: Array<{ title: string; severity: string }> = []): CheckResult {
@@ -308,8 +308,35 @@ describe('map_compliance treats a never-completed check as not_assessed, not fai
 				}
 				if (url.includes('type=NS') || url.includes('type=2'))
 					return Promise.resolve(nsResponse(domain, [`ns1.${domain}.`, `ns2.${domain}.`]));
+				// This fixture mocks SPF, DKIM, DMARC, MTA-STS and TLS-RPT — i.e. it intends a
+				// healthy MAIL domain — but published no MX, so `detectDomainContext` classified
+				// it `web_only` and the scan declared every mail-only category NOT APPLICABLE.
+				// That made the block comment below ("every other NIST category completed and
+				// passed") false. Publishing MX restores the profile the fixture was written for.
+				if (url.includes('type=MX') || url.includes('type=15'))
+					return Promise.resolve(
+						createDohResponse([{ name: domain, type: 15 }], [{ name: domain, type: 15, TTL: 300, data: `10 mail.${domain}.` }]),
+					);
+				// Publishing MX makes NIST §4.5 (DANE for SMTP) applicable, so the healthy
+				// baseline has to actually publish TLSA to satisfy it.
+				if (url.includes('type=TLSA') || url.includes('type=52'))
+					return Promise.resolve(
+						tlsaResponse(`_25._tcp.mail.${domain}`, [{ usage: 3, selector: 1, matchingType: 1, certData: 'abc123' }]),
+					);
 				if (url.includes('type=CAA') || url.includes('type=257'))
 					return Promise.resolve(caaResponse(domain, ['0 issue "letsencrypt.org"']));
+				// A signed zone publishes DNSKEY/DS as well as setting AD. Without these the
+				// fixture claimed "healthy by default" while modelling an UNSIGNED zone
+				// (`recordPresent: false`), which only read as healthy because the mapper was
+				// grading on `passed` — the very defect under test elsewhere in this file.
+				if (url.includes('type=DNSKEY') || url.includes('type=48'))
+					return Promise.resolve(
+						createDohResponse([{ name: domain, type: 48 }], [{ name: domain, type: 48, TTL: 300, data: '257 3 13 mdsswUyr3DPW...' }]),
+					);
+				if (url.includes('type=DS') || url.includes('type=43'))
+					return Promise.resolve(
+						createDohResponse([{ name: domain, type: 43 }], [{ name: domain, type: 43, TTL: 300, data: '12345 13 2 abc123...' }]),
+					);
 				if (url.includes('type=A') || url.includes('type=1')) return Promise.resolve(dnssecResponse(domain, true));
 				return Promise.resolve(createDohResponse([], []));
 			}
@@ -707,5 +734,174 @@ describe('formatCompliance', () => {
 		const spfLine = output.split('\n').find((l) => l.includes('§4.3.1'));
 		expect(spfLine).toBeDefined();
 		expect(spfLine).not.toContain(' — ');
+	});
+});
+
+/**
+ * A control must not be reported as PASS on the strength of a check that observed no
+ * published record.
+ *
+ * `passed` answers "did this check penalize the domain", NOT "does the control exist".
+ * A check for an absent-but-unpenalized control still returns `passed: true` — that is
+ * the documented reason `recordPresent` exists (see `CheckResult.recordPresent`, which
+ * is explicitly score-neutral so that nothing in the scoring path reads it). This mapper
+ * was reading `passed`, so a domain with NO DNSSEC and NO CAA was reported as passing
+ * NIST 800-177 §5.1 and §5.2 — a published compliance claim the same scan simultaneously
+ * contradicted with a high-severity "DNSSEC not enabled" finding.
+ *
+ * Measured 2026-08-19 against three live domains: cloudflare.com (DNSSEC signed,
+ * `recordPresent: true`) correctly passed §5.1, while davidhf.com and codewithbullet.com
+ * (both `recordPresent: false`, both carrying a HIGH "DNSSEC not enabled") ALSO passed it.
+ * The control never discriminated.
+ */
+describe('map_compliance does not pass a control whose record was never published', () => {
+	/**
+	 * A check that COMPLETED, was not penalized, but published nothing.
+	 *
+	 * The flag pair is the shape MEASURED from production on 2026-08-19, not one invented
+	 * in the mapper's own vocabulary: `check_dnssec` on davidhf.com and `check_caa` on the
+	 * same domain both returned `passed: true` with `controlPresent: false` and
+	 * `recordPresent: false` alongside a high/medium "not enabled" finding.
+	 */
+	function absentButUnpenalized(category: string, title: string, severity: string): CheckResult {
+		return {
+			category,
+			passed: true,
+			score: 60,
+			controlPresent: false,
+			recordPresent: false,
+			findings: [{ category, title, severity, detail: '' }],
+		} as CheckResult;
+	}
+
+	/**
+	 * The registry-signed counter-fixture: no DNSKEY/DS of its own, but the chain
+	 * validates. `check-dnssec` documents this exact `false`/`true` pair as "protected,
+	 * not a contradiction", so it must keep passing.
+	 */
+	function absentRecordsButControlActive(category: string): CheckResult {
+		return {
+			category,
+			passed: true,
+			score: 85,
+			controlPresent: true,
+			recordPresent: false,
+			findings: [{ category, title: 'DNSSEC is registry-managed', severity: 'medium', detail: '' }],
+		} as CheckResult;
+	}
+
+	it('does not pass NIST §5.1 when the DNSSEC check observed no published record', () => {
+		const results = makeAllPassing().map((r) =>
+			r.category === 'dnssec' ? absentButUnpenalized('dnssec', 'DNSSEC not enabled', 'high') : r,
+		);
+		const report = evaluateCompliance(results, 'no-dnssec.com', 82, 'B');
+
+		const control = report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§5.1');
+		expect(control).toBeDefined();
+		expect(control!.status).not.toBe('pass');
+	});
+
+	it('does not pass NIST §5.2 when the CAA check observed no published record', () => {
+		const results = makeAllPassing().map((r) => (r.category === 'caa' ? absentButUnpenalized('caa', 'No CAA records', 'medium') : r));
+		const report = evaluateCompliance(results, 'no-caa.com', 82, 'B');
+
+		const control = report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§5.2');
+		expect(control).toBeDefined();
+		expect(control!.status).not.toBe('pass');
+	});
+
+	/**
+	 * The registry-signed zone must keep passing. This is the guard that stops the fix
+	 * from becoming the same defect with the opposite sign: a ccTLD-signed zone publishes
+	 * no DNSKEY/DS of its own yet is cryptographically protected, and `check-dnssec`
+	 * documents that `recordPresent: false` + `controlPresent: true` pair as exactly that
+	 * state. Failing it would report a protected zone as non-compliant.
+	 */
+	it('still passes a control whose records are absent but whose control is affirmatively active', () => {
+		const results = makeAllPassing().map((r) => (r.category === 'dnssec' ? absentRecordsButControlActive('dnssec') : r));
+		const report = evaluateCompliance(results, 'registry-signed.com', 88, 'B');
+
+		const control = report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§5.1');
+		expect(control).toBeDefined();
+		expect(control!.status).toBe('pass');
+	});
+
+	/**
+	 * Over-correction guard. `recordPresent: undefined` means "this check does not report
+	 * the signal" (spf, dkim, ssl, ns, http_security never set it) or "the query failed".
+	 * Neither is evidence of absence, so behaviour must be unchanged for those.
+	 */
+	it('still passes a control whose check does not report the presence signal at all', () => {
+		const results = makeAllPassing(); // no recordPresent anywhere
+		const report = evaluateCompliance(results, 'silent-signal.com', 95, 'A');
+
+		for (const control of report.frameworks.nist_800_177.mappings) {
+			expect(control.status).toBe('pass');
+		}
+	});
+
+	/**
+	 * The second over-correction guard, and the reason this fix is not a one-line
+	 * predicate swap. On a `web_only`/`non_mail` domain the scan already declares the
+	 * mail-only categories NOT APPLICABLE and nulls their scores. Those categories also
+	 * report `recordPresent: false` (there genuinely is no MTA-STS record), so failing on
+	 * absence alone would newly report "NIST §4.4 MTA-STS — FAIL" against a domain that
+	 * accepts no mail. That trades a false PASS for a false FAIL: the same defect wearing
+	 * the opposite sign. A control the scan declared inapplicable has no verdict to give.
+	 */
+	it('reports a not-applicable category as not_assessed rather than failing it on absence', () => {
+		const results = makeAllPassing().map((r) =>
+			r.category === 'mta_sts' ? absentButUnpenalized('mta_sts', 'No MTA-STS or TLS-RPT records found', 'low') : r,
+		);
+		const report = evaluateCompliance(results, 'web-only.com', 82, 'B', ['mta_sts']);
+
+		const control = report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§4.4');
+		expect(control).toBeDefined();
+		expect(control!.status).toBe('not_assessed');
+		// And it must leave the denominator, not sit in it as a silent zero.
+		expect(report.frameworks.nist_800_177.notAssessed).toBeGreaterThan(0);
+	});
+});
+
+/**
+ * `map_compliance` must render the SAME letter as every other rating surface.
+ *
+ * `ScanScore.grade` carries the engine's canonical NINE-band grade (A+/A/B+/B/C+/…);
+ * the display SSOT is `displayGradeFor`, which `format-report.ts` uses for
+ * `scan_domain`. This tool passed the raw nine-band value straight through, so the same
+ * domain at the same score rendered `B+` here and `B` in `scan_domain` — measured
+ * 2026-08-19 on codewithbullet.com (82 → "B+" vs "B") and davidhf.com (92 → "A+" vs "A",
+ * where A+ additionally means ≥95 on the display scale).
+ */
+describe('map_compliance grade uses the display band SSOT', () => {
+	const { restore } = setupFetchMock();
+	afterEach(() => restore());
+
+	it('never emits a letter outside the six-band display scale', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			const domain = 'band-ssot.com';
+			if (url.includes('cloudflare-dns.com')) {
+				if (url.includes('type=TXT') || url.includes('type=16')) {
+					if (url.includes('_dmarc.')) return Promise.resolve(txtResponse(`_dmarc.${domain}`, ['v=DMARC1; p=quarantine']));
+					if (url.includes('_domainkey.')) return Promise.resolve(createDohResponse([], []));
+					return Promise.resolve(txtResponse(domain, ['v=spf1 include:_spf.google.com ~all']));
+				}
+				if (url.includes('type=NS') || url.includes('type=2')) return Promise.resolve(nsResponse(domain, [`ns1.${domain}.`]));
+				if (url.includes('type=CAA') || url.includes('type=257')) return Promise.resolve(createDohResponse([], []));
+				if (url.includes('type=A') || url.includes('type=1')) return Promise.resolve(dnssecResponse(domain, false));
+				return Promise.resolve(createDohResponse([], []));
+			}
+			return Promise.resolve(httpResponse('OK'));
+		});
+
+		const { mapCompliance } = await import('../src/tools/map-compliance');
+		const { nistScoreToGrade } = await import('@blackveil/dns-checks/scoring');
+		const report = await mapCompliance('band-ssot.com');
+
+		// Fixture-reachability guard: a null score would make the assertions vacuous.
+		expect(report.score).not.toBeNull();
+		expect(report.grade).toBe(nistScoreToGrade(report.score!));
+		expect(['A+', 'A', 'B', 'C', 'D', 'F']).toContain(report.grade);
 	});
 });


### PR DESCRIPTION
## What

`map_compliance` graded controls on `CheckResult.passed`, which records whether a check **penalized** the domain — not whether the control exists. An absent-but-unpenalized control still returns `passed: true`, so the tool published compliance claims the same scan contradicted.

## Evidence

Found while using our own tooling for a vendor assessment. `map_compliance` reported **`davidhf.com` as 100% passing on both NIST 800-177 and PCI DSS 4.0**, while `scan_domain` simultaneously raised a *high*-severity "DNSSEC not enabled" and a *medium* "No CAA records" on that same domain.

A known-good/known-bad pair confirmed the control never discriminates:

| Domain | `check_dnssec` | `recordPresent` | `map_compliance` §5.1 |
|---|---|---|---|
| cloudflare.com | Signed, ECDSA P-256, score 100 | `true` | pass — correct |
| davidhf.com | Not enabled, **High**, score 60 | `false` | **pass — wrong** |
| codewithbullet.com | Not enabled, **High**, score 60 | `false` | **pass — wrong** |

§5.2 (CAA) behaved identically: all three domains publish no CAA records, all three returned `pass`.

The risk is a customer being shown "NIST 800-177: 100% compliant" on a domain the same platform flags with a high-severity finding — a published compliance claim the evidence does not support.

## Changes

1. **Grade on presence, not penalty.** A completed check disqualifies its control when it observed a definitive absence. `recordPresent` alone is *not* sufficient — `check-dnssec` documents `recordPresent: false` + `controlPresent: true` as the registry/ccTLD-signed zone, which **is** protected — so an affirmative `controlPresent` rebuts absence.
2. **Honour the scan's own applicability pass.** Without this, change 1 would newly report "NIST §4.4 MTA-STS — FAIL" against a `web_only` domain that accepts no mail: the same defect with the opposite sign. `isCategoryNonApplicable` is exported and reused, so `categoryScores`, `notApplicableCategories` and compliance share one applicability decision rather than re-deriving it.
3. **Use the display band SSOT.** `ScanScore.grade` is the engine's canonical **nine**-band letter; every display surface renders six bands via `displayGradeFor`. Passing the raw grade through made this tool print `B+` where `scan_domain` printed `B` for the same score, and `A+` at 92 — a band that requires ≥ 95.

## Scoring impact

**None.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.19.0. No weight, tier, grade band, severity penalty or profile rule moved. Both presence flags are score-neutral by construction — nothing in the scoring path reads them.

## Tests

Written first, each watched fail for the right reason before the fix:

- NIST §5.1 does not pass when DNSSEC published no record
- NIST §5.2 does not pass when CAA published no record
- a registry-signed zone (`recordPresent: false` + `controlPresent: true`) **still passes** — the over-correction guard
- a check that does not report the signal at all (`undefined`) is unchanged
- a not-applicable category is `not_assessed`, not failed, and leaves the denominator
- the grade never falls outside the six-band scale (failed non-vacuously at `C+` vs `C`)

Fixtures use the wire shape **measured from production**, not one invented in the mapper's vocabulary.

The `map_compliance` "healthy baseline" fixture turned out to publish no MX, DNSKEY/DS or TLSA while mocking every mail control — it read as healthy only because the mapper graded on `passed`. It now publishes the records it claims, so it exercises a genuinely compliant domain rather than pinning the bug.

## Verification

- `test/map-compliance.spec.ts` — 31/31 pass
- Full suite — **7355 passed, 0 failed** (628 files). The one suite-level failure on a fresh worktree is `test/wasm-integration.test.ts` missing the gitignored `crates/bv-wasm-core/pkg` artifact; it passes 4/4 once that artifact is present.
- `npm run typecheck` clean · `npm run typecheck:tests` within baseline · `eslint` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)