### PR TITLE
chore: release 3.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [Unreleased]
 
+## [3.55.0] - 2026-08-19
+
 **No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0 and `@blackveil/dns-checks` stays 1.19.0 — no weight, tier, grade band, severity penalty or profile rule moved, and no score changes. `recordPresent`/`controlPresent` are score-neutral by construction; only the `map_compliance` reporting surface reads them.
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.54.0",
+	"version": "3.55.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.54.0",
+			"version": "3.55.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.54.0",
+	"version": "3.55.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.54.0",
+  "version": "3.55.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Cuts 3.55.0 from the three fixes on main since 3.54.0.

## Contents

- **#705** — `map_compliance` no longer reports a control as PASS when its record was never published, and withholds a verdict for a category the scan itself declared not-applicable.
- **#708** — every Analytics Engine alerting query was rejected with **HTTP 422**: `CASE WHEN`, `GREATEST()` and `COUNT(*)` are not in AE's ClickHouse subset. This had disabled the **entire** alerting pipeline for 610 consecutive cron ticks — the full observability retention window — with only the watchdog surviving. Fixed and already verified live in prod.
- **#709** — each analytics query now runs in its own lane, so one failing query can no longer blind every other alert. This was the structural cause of #708's blast radius.

**No scoring-model change.** `SCORING_MODEL_VERSION` stays 1.10.0, `@blackveil/dns-checks` stays 1.19.0 — no weight, tier, grade band, severity penalty or profile rule moved.

## Why minor, not patch

This repo's own convention: 3.54.0 was likewise a fix-only release cut as a minor (`### Fixed` + `### Changed`), while 3.51.1 and 3.51.2 were `Changed`-only patches. This set is three substantial fixes, matching the 3.54.0 shape.

## Version surfaces

`publish.yml`'s `version-bump` job is a **read-only gate** — it fails the release if any surface disagrees with the tag. All synced:

| Surface | Value |
| --- | --- |
| `package.json` | 3.55.0 |
| `package-lock.json` (root + `packages['']`) | 3.55.0 |
| `server.json` (top-level) | 3.55.0 |
| `CHANGELOG.md` heading | `## [3.55.0] - 2026-08-19` |

`SERVER_VERSION` auto-derives from `package.json` — not hand-edited. `server.json` is remotes-only, so the `packages[0].version` two-field footgun does not apply.

## Verification

- `npm run typecheck` — clean
- `npm run lint` — clean
- Full suite: **7368 passed**, 1 flake, 13 skipped

The flake is `queue-batch-analytics.spec.ts` failing on a **15005ms timeout** alongside **18 workerd segfaults** in the run — the documented pool-instability signature, not a regression. It passes in isolation (3/3). `wasm-integration.test.ts` fails identically on clean `origin/main` — pre-existing and unrelated.

## Release ordering

After merge: tag the squash commit → `publish.yml` → `npm run deploy:prod` → verify `serverInfo.version` on prod → **only then** `mcp-publisher publish`. Registry-ahead-of-prod is a false public liveness claim; registry-behind-prod is benign.
