### PR TITLE
docs(release): correct the pipeline description and flag the working-tree foot-guns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -280,7 +280,11 @@ git commit -am "chore: bump version to <X.Y.Z>" && git push origin main
 git tag v<X.Y.Z> && git push origin v<X.Y.Z>
 ```
 
-Pipeline: validate → version-verify (read-only gate) → npm publish (provenance) || Cloudflare deploy → MCP Registry → GH Release. Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in `production` env — fail-fast if absent. `wrangler d1 execute --remote --file=-` does NOT accept stdin; pass a real path.
+⚠️ **Deploy and publish are operator-run steps, not tag-triggered ones** — see *Manual release fallback* below. Several pipeline jobs are conditionally gated, so read `publish.yml` for what is actually enabled rather than assuming a stage ran.
+
+**A green Release run does not prove a deploy or publish happened.** Verify the result directly, every time: `serverInfo.version` on the live endpoint, and a **cache-busted** registry query (the registry read API is CDN-cached and can return a stale count and a fresh row in back-to-back requests).
+
+Requires `NPM_TOKEN`, `CLOUDFLARE_API_TOKEN`, `MCP_REGISTRY_TOKEN` in `production` env — fail-fast if absent. `wrangler d1 execute --remote --file=-` does NOT accept stdin; pass a real path.
 
 **Workflow secret-check audit** (`test/audits/workflow-secret-check.audit.test.ts`): every `[ -z "$*_TOKEN" ]` guard must `exit 1`; no warn-and-skip. Codifies v2.10.2–v2.10.6 silent prod-stale.
 
@@ -297,7 +301,11 @@ npm run deploy:prod
 mcp-publisher publish
 ```
 
-**`server.json` is currently remotes-only** — a single top-level `version` field (no `packages` stanza); sync just that field to the tag. (If an npm `packages` stanza is ever re-added, it reintroduces the two-field foot-gun — sync both then.)
+🚨 **Run these from a worktree pinned to the release commit — never from a shared or long-lived checkout.** BOTH shipping commands read the working tree: `deploy:prod` compiles it (`npm -w packages/dns-checks run build`), and `mcp-publisher publish` reads `./server.json` from **cwd**. Neither validates that the tree matches the tag, so a stale checkout ships whatever it happens to hold — and for the registry that means publishing the wrong version, silently and publicly. A fresh worktree also needs the gitignored `.dev/wrangler.deploy.jsonc` copied in (the injector fails closed without it) plus `npm ci`.
+
+**MCP Registry auth is DNS-based:** `mcp-publisher login dns --domain <domain> --private-key <hex>` — **hex**, not base64 or PEM. The public half lives in an apex TXT record `v=MCPv1; k=ed25519; p=<base64>`; changing it is a zone write, so it is operator-only. 🚨 **Never let the private key print to stdout** — it then persists in shell history, scrollback and any agent transcript, and must be discarded and rotated. Write it to a file and pass `--private-key "$(cat mcp.hex)"` so only the substitution is recorded. Keep the local `mcp-publisher` version matching CI's: a version skew moved the token store and invalidated the saved login.
+
+**`server.json` is currently remotes-only** — a single top-level `version` field (no `packages` stanza); sync just that field to the tag. (If an npm `packages` stanza is ever re-added, it reintroduces the two-field foot-gun — sync both then.) Remotes-only also means the registry's npm-existence check does not apply, so **the npm and registry publishes are independent** — do not treat them as one problem, in either direction.
 
 Approve gated deploys through GitHub's protected environment UI or an
 operator-only runbook.


### PR DESCRIPTION
Docs-only. Two changes to `CLAUDE.md`'s Release section.

## 1. The pipeline description was wrong

It listed npm publish, Cloudflare deploy and MCP-registry publish as tag-triggered stages. They are operator-run, so the text told operators the opposite of what a tag does — and invited reading a green Release run as proof that something shipped.

Replaced with a pointer to *Manual release fallback*, a note to read `publish.yml` for what is actually enabled, and what to verify instead: live `serverInfo.version`, plus a **cache-busted** registry query. That last one matters — the registry read API is CDN-cached and returned a stale count and a fresh row in two back-to-back requests during the last release.

## 2. Two undocumented hazards on the release path

- **Both shipping commands read the working tree** and neither checks it against the tag. `deploy:prod` compiles it (`npm -w packages/dns-checks run build`); `mcp-publisher publish` reads `./server.json` from **cwd**. A stale checkout therefore ships whatever it happens to hold — and for the registry that means publishing the wrong version, silently and publicly. Now says to run both from a worktree pinned to the release commit, and notes a fresh worktree needs `.dev/wrangler.deploy.jsonc` plus `npm ci`.
- **MCP registry auth is DNS-based** and takes the key as **hex** (not base64 or PEM), with the public half in an apex `v=MCPv1; k=ed25519; p=<base64>` TXT record. The private half must never reach stdout or it persists in shell history, scrollback and agent transcripts. Also notes to keep the local `mcp-publisher` version matching CI's — a skew moves the token store and invalidates the saved login.

## Notes

- Rebased onto `origin/main`, not onto a stale checkout: the first attempt was built on a tree behind `main` and would have silently reverted the `CLAUDE.md` changes from #680, #696 and #679. Diff is now 10 insertions / 2 deletions, confined to the two blocks above.
- `test/audits/busl-positioning.audit.test.ts` (which reads `CLAUDE.md`) passes 8/8.
- Docs-only, so `ci-docs.yml` handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
