### PR TITLE
chore: release 3.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [3.56.0] - 2026-08-21
 
 **This release DOES change scores.** One entry in this block — the lame-delegation escalation under *Changed* — moves a severity, stamps a confidence and raises a per-profile importance, and it lowers the grade of an affected domain: measured **97 (A+) → 82 (B+)**. Everything else here remains score-neutral and is proven so: the CAA-parameter and cert-validity-window additions emit nothing scored, the BIMI corrections are prose-only with the `bimi` category pinned byte-identical, and the `compare_baseline` fix touches a reporting surface the scorer does not read. `recordPresent`/`controlPresent` likewise remain score-neutral by construction; nothing in the scoring path reads them.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.55.0",
+	"version": "3.56.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.55.0",
+			"version": "3.56.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.55.0",
+	"version": "3.56.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.55.0",
+  "version": "3.56.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Version bump only — four surfaces (`package.json`, `package-lock.json`, `server.json`, `CHANGELOG.md`) to **3.56.0**, plus renaming the `[Unreleased]` CHANGELOG block to `[3.56.0] - 2026-08-21`.

`SERVER_VERSION` auto-derives from `pkg.version` and is deliberately not hand-edited. `server.json` was edited by targeted string replacement rather than a JSON round-trip — the diff is exactly 1 insertion / 1 deletion, avoiding the re-serialization that silently broke releases 3.40.0–3.42.0.

## ⚠️ This release changes scores and customer-visible verdicts

- **`SCORING_MODEL_VERSION` 1.10.0 → 1.12.0**, **dns-checks 1.19.0 → 1.22.0** (`PARITY_CORPUS_VERSION` in lockstep). That constant is folded into every scan cache key, so **the deploy invalidates cached scans** and the first post-deploy wave runs cold — expected.
- **Lame delegation → `critical`** (was `high`) with `verified` confidence, the Sitting Ducks hijack precondition. **Measured 97 (A+) → 82 (B+)**.
- **`compare_baseline`'s five `require_*` rules now violate where they previously passed** (#726 via #730). Customers with CI wired to them will see new failures.

Shipped under an explicit operator decision to release the scoring change together with the compliance fixes.

## Context

Prod has been serving 3.55.0 while `main` carried nine commits past that tag **under the same version string** — so this bump is what makes the deployed code distinguishable at `serverInfo.version`.

Deploy follows this merge: tag `v3.56.0` on the merge commit → `npm run deploy:prod` from a clean worktree pinned to the tag → verify → publish the MCP Registry last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)