### PR TITLE
chore: release 3.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.57.0] - 2026-08-21
+
+**No scoring-model change.** This release touches operator alerting only — no check, finding, weight or grade moves. `SCORING_MODEL_VERSION` and `@blackveil/dns-checks` are unchanged, so cached scans are NOT invalidated and no domain is re-graded.
+
+### Fixed
+
+- **The `P95 latency` cron alert paged `critical` for behaviour working exactly as designed** (#729). A live example: `P95 latency 22612ms (last 15m)`, `total_calls: 35`, severity **critical** — nothing was wrong. Three independent defects compounded, so fixing any one alone would have left it firing.
+
+  1. **No volume floor.** The only guard was `total_calls > 0`. At the measured rate (~11 tool calls/hour) a 15m window holds ~3 calls, and `quantileExactWeighted(0.95)` over a handful of samples converges on the **maximum** — the alert was reporting the slowest single call in the window and labelling it a percentile.
+  2. **No workload class.** Enumeration tools were pooled with `scan_domain` against one 10s ceiling. Measured over 7 days against the live dataset, **exactly four** tools have a p95 above 10s: `discover_brand_domains` (25,715ms), `batch_scan` (25,000ms — its own documented `budgetMs` is 25s), `compare_domains` (22,612ms, the tool behind the reported page) and `discover_subdomains` (11,711ms). `discover_brand_domains` could not run without paging **critical**, because 25,715 > 10,000 × 2.
+  3. **Threshold below the design envelope.** `scan_domain` is ~90% of interactive volume (6,124 of 6,762 calls) and is built to run to a 15s `SCAN_TIMEOUT_MS`; its measured p95 is 9,059ms, ~10% under the old 10s ceiling, so ordinary upper-normal scan latency was one blip from paging.
+
+  Latency now leaves the 15m `anomalies` lane for its own lane with its own 6h window and per-class ceilings — interactive 15s (= `SCAN_TIMEOUT_MS`, so the ceiling derives from the dominant tool's own budget rather than a round number), batch 30s. `p95_ms` remains on the error-rate payload as context: removing the alert must not remove the datum.
+
+  Verified against live Analytics Engine with the new query rather than reasoned about: over 7 days batch p95 = 25,000 and interactive p95 = 8,952, both under their new ceilings; over the last 6h, interactive p95 = 3,579 across 28 calls. The lane goes quiet without going dead.
+
+  The lane evaluates only on a **non-overlapping window boundary**. A 6h lookback read every 15m would re-report the same slow window up to 24 times — one true finding becoming 24 pages, this same failure with the sign flipped. The trade-off is explicit: a missed cron tick skips that window entirely, which for a trend alert is the right way to be wrong.
+
+  Below `ALERT_MIN_LATENCY_SAMPLES` the lane **abstains and logs** rather than paging on a percentile it cannot support — logged, so a permanently-quiet lane stays greppable instead of indistinguishable from a healthy one. An unrecognised workload class inherits the **stricter** ceiling, so an unmapped tool can never quietly buy itself a 30s allowance.
+
+- **A whole-pipeline alerting outage could be downgraded to a warning.** The `LANE_COUNT = 5` constant is replaced by a counter of lanes actually attempted. Because the new latency lane runs only on a window boundary, a hardcoded total would have reported a genuine 5-of-5 outage as "5 of 6 degraded" and lost the single loud page. Counting also removes the bump-me-when-you-add-a-lane drift hazard the constant carried.
+
+### Changed
+
+- `ALERT_P95_THRESHOLD` moves `10000` → `15000` in `wrangler.jsonc`, and three knobs are added: `ALERT_BATCH_P95_THRESHOLD` (30000), `ALERT_LATENCY_LOOKBACK_MINUTES` (360) and `ALERT_MIN_LATENCY_SAMPLES` (20). These are public vars, not secrets — they ship with the deploy and need no environment provisioning.
+
+- `queryLatencyByWorkloadClass` **defaults** its tool list from `LONG_RUNNING_TOOLS` rather than requiring it. Not ergonomics: `analytics-queries-ae-dialect.spec.ts` calls every exported builder with a single argument, so a required parameter would have made this the one builder whose SQL that audit never dialect-checked.
+
+- A `CLAUDE.md` count that was **already stale before this release** is corrected: the webhook resolver was documented as wired into "all 4 alert-dispatch sites" while `scheduled.ts` holds 10. De-numeralized rather than re-numbered, since that count has now demonstrably drifted once.
+
 ## [3.56.0] - 2026-08-21
 
 **This release DOES change scores.** One entry in this block — the lame-delegation escalation under *Changed* — moves a severity, stamps a confidence and raises a per-profile importance, and it lowers the grade of an affected domain: measured **97 (A+) → 82 (B+)**. Everything else here remains score-neutral and is proven so: the CAA-parameter and cert-validity-window additions emit nothing scored, the BIMI corrections are prose-only with the `bimi` category pinned byte-identical, and the `compare_baseline` fix touches a reporting surface the scorer does not read. `recordPresent`/`controlPresent` likewise remain score-neutral by construction; nothing in the scoring path reads them.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.56.0",
+	"version": "3.57.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.56.0",
+			"version": "3.57.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.56.0",
+	"version": "3.57.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.56.0",
+  "version": "3.57.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Version bump only — all four surfaces pre-bumped so `publish.yml`'s read-only `version-bump` gate passes.

| Surface | Value |
|---|---|
| `package.json` + `package-lock.json` | 3.57.0 |
| `server.json` (top-level, remotes-only) | 3.57.0 |
| `CHANGELOG.md` heading | `[3.57.0] - 2026-08-21` |

`SERVER_VERSION` auto-derives from `pkg.version` — not hand-edited.

**No scoring-model change.** Operator alerting only: `SCORING_MODEL_VERSION` and `@blackveil/dns-checks` are unchanged, so `PARITY_CORPUS_VERSION` does not move, cached scans are **not** invalidated, and no domain is re-graded. That is the deliberate contrast with 3.56.0, which did move grades.

Carries #729 (merged in #732).

`npx vitest run test/audits/` — 442 passed | 1 skipped, including the version-sync and `server-json-tool-count` gates. The `package-lock.json` diff is version-only (2 lines), no dependency tree change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)