### PR TITLE
fix(discovery): stop a degraded sweep scoring as a healthy one (#734, #735)

### DIFF
--- a/src/lib/ct-coverage.ts
+++ b/src/lib/ct-coverage.ts
@@ -45,7 +45,15 @@
  */
 
 /** Per-source health outcome, shared with the tool's `ct_source` health log. */
-export type CtSourceOutcome = 'ok' | 'empty' | 'http_error' | 'timeout' | 'error';
+/**
+ * `rate_limited` is split out from `http_error` on purpose (#735). A 429 is the
+ * one upstream failure where the correct caller response is the OPPOSITE of the
+ * usual one: retrying extends the lockout and burns a quota shared with every
+ * other domain scanned next. Measured 2026-08-21 — after Certspotter 504s on a
+ * large estate it 429s the same unauthenticated caller, and the lockout outlived
+ * a 75-second wait.
+ */
+export type CtSourceOutcome = 'ok' | 'empty' | 'http_error' | 'rate_limited' | 'timeout' | 'error';
 
 /**
  * How much of CT history a source can see AT ALL, independent of whether we

--- a/src/tools/discover-brand-domains.ts
+++ b/src/tools/discover-brand-domains.ts
@@ -472,6 +472,20 @@ export function signalCouldNotComplete(status: string | undefined): boolean {
 	return status === 'failed' || status === 'error' || status === 'timeout' || status === 'rate_limited';
 }
 
+/**
+ * Signals without which a sweep is not a brand discovery at all.
+ *
+ * Certificate SANs are the highest-yield channel by a wide margin: the other
+ * signals corroborate candidates, but SAN is what SUPPLIES most of them. A run
+ * that loses SAN does not return a smaller answer, it returns a different and
+ * much emptier question — and because the score falls out of how many findings
+ * were surfaced, an emptier question scores BETTER (#734).
+ *
+ * Kept as a named set rather than inlined so the all-failed gate (#670) and the
+ * primary-degradation gate below cannot drift apart about which signals matter.
+ */
+export const PRIMARY_DISCOVERY_SIGNALS: readonly DiscoverSignal[] = ['san', 'san_recursive'];
+
 function isGeneratedSeedSignal(signal: DiscoverSignal): boolean {
 	return signal === 'markov_gen' || signal === 'active_lookalike';
 }
@@ -1662,6 +1676,17 @@ export async function discoverBrandDomains(
 	const degradedNote =
 		degradedSignals.length > 0 ? ` degraded=[${degradedSignals.map((s) => `${s}:${signalStatus[s]?.status}`).join(', ')}]` : '';
 
+	// #734 — the subset of degraded signals that this category cannot do without.
+	// Narrower than `degradedSignals` on purpose: a degraded *corroborating* signal
+	// (ns, mx_overlap, ...) costs precision and is worth naming in the text, but a
+	// degraded PRIMARY signal costs the answer itself and must stop the run being
+	// scored. `signalCouldNotComplete` is reused rather than re-spelled so this and
+	// the all-failed gate (#670) draw exactly the same line — `budget_exceeded` and
+	// `partial` are NOT failures here, they are a smaller-but-real measurement.
+	const degradedPrimarySignals = signals.filter(
+		(s) => PRIMARY_DISCOVERY_SIGNALS.includes(s) && signalCouldNotComplete(signalStatus[s]?.status),
+	);
+
 	// Always emit a summary finding so the formatter has something to print.
 	const summary = createFinding(
 		'brand_discovery',
@@ -1683,10 +1708,34 @@ export async function discoverBrandDomains(
 				dropped: dropCounts,
 				sources: universe.stats.sources,
 			},
+			...(degradedPrimarySignals.length > 0
+				? { inconclusive: true, errorKind: 'dns_error' as const, degradedPrimarySignals }
+				: {}),
 		},
 	);
 
-	return buildCheckResult('brand_discovery', [summary, ...candidateFindings]);
+	const result = buildCheckResult('brand_discovery', [summary, ...candidateFindings]);
+
+	// #734 — a sweep that lost a PRIMARY signal did not measure what this category
+	// claims to measure, so it must be EXCLUDED from scoring rather than scored on
+	// a partial view. #670 already does this for the all-signals-failed case; the
+	// `.every()` there means a partial loss fell through to normal scoring, where
+	// the score is derived from how many candidates surfaced — so a crippled sweep
+	// outscored a healthy one. Measured 2026-08-21: `meta.com` with `san: error`
+	// surfaced 1 of >=152 real apexes and returned passed:true/score:95, while a
+	// healthy `facebook.com` sweep surfacing 27 returned passed:false/score:0.
+	//
+	// The candidate findings are deliberately RETAINED: whatever the surviving
+	// signals found is still useful to a caller, and throwing it away would trade
+	// one wrong answer for another. `checkStatus: 'error'` is what makes the
+	// scoring engine skip the category; `partial: true` keeps a transient upstream
+	// outage (crt.sh was returning 502/404 for hours when this was found) out of
+	// the 5-minute cache so the next call re-measures instead of replaying it.
+	if (degradedPrimarySignals.length > 0) {
+		return { ...result, score: 0, passed: false, checkStatus: 'error' as const, partial: true };
+	}
+
+	return result;
 }
 
 /** Format a discoverBrandDomains CheckResult as human-readable text. */

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -797,6 +797,21 @@ function logCtSource(domain: string, source: string, outcome: CtSourceOutcome): 
 	}
 }
 
+/**
+ * Classify a non-OK HTTP response from a CT source (#735).
+ *
+ * 429 is separated from the generic `http_error` because it inverts the correct
+ * caller response. Every other upstream failure is worth retrying; a 429 means
+ * the unauthenticated quota is already spent, and retrying extends the lockout
+ * on a quota SHARED with whatever domain is scanned next. Measured 2026-08-21:
+ * once Certspotter 504s on a large estate it 429s the same caller, and the
+ * lockout survived a 75-second wait — so an eager retry loop converts one slow
+ * domain into a sweep-wide outage.
+ */
+function httpFailureOutcome(status: number): CtSourceOutcome {
+	return status === 429 ? 'rate_limited' : 'http_error';
+}
+
 /** Fetch + parse crt.sh into normalized entries. Bounded body, no throw. */
 async function fetchCrtShEntries(domain: string, signal: AbortSignal): Promise<SourceResult> {
 	try {
@@ -806,7 +821,7 @@ async function fetchCrtShEntries(domain: string, signal: AbortSignal): Promise<S
 		});
 		if (!response.ok) {
 			await disposeUnreadResponseBody(response);
-			return { outcome: 'http_error', entries: [] };
+			return { outcome: httpFailureOutcome(response.status), entries: [] };
 		}
 		const declaredLength = Number(response.headers.get('content-length'));
 		if (Number.isFinite(declaredLength) && declaredLength > CT_SOURCE_MAX_BODY_BYTES) {
@@ -875,7 +890,7 @@ async function fetchCertspotterEntries(domain: string, signal: AbortSignal, opti
 
 			if (!response.ok) {
 				await disposeUnreadResponseBody(response);
-				if (pagesRead === 0) return { outcome: 'http_error', entries: [] };
+				if (pagesRead === 0) return { outcome: httpFailureOutcome(response.status), entries: [] };
 				stopIncomplete();
 				break;
 			}
@@ -1455,13 +1470,19 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false,
 function ctFailureGuidance(coverage: CtCoverage | undefined): string {
 	const perSource = coverage?.perSource ?? [];
 	const timedOut = perSource.filter((s) => s.outcome === 'timeout').map((s) => s.source);
+	const limited = perSource.filter((s) => s.outcome === 'rate_limited').map((s) => s.source);
 	const errored = perSource.filter((s) => s.outcome === 'http_error' || s.outcome === 'error').map((s) => s.source);
 	const never = coverage?.notConsulted ?? [];
 
 	const parts: string[] = [];
 	if (timedOut.length > 0) {
 		parts.push(
-			`${timedOut.join(', ')} timed out — for a domain with a large certificate population this is deterministic, not transient, so an identical retry will time out again; narrow the query or page the source.`,
+			`${timedOut.join(', ')} timed out — this is deterministic for this domain, not transient, so an identical retry will time out again. Page size is NOT the lever: limit=10, limit=100 and after=0 were measured returning the same HTTP 504.`,
+		);
+	}
+	if (limited.length > 0) {
+		parts.push(
+			`${limited.join(', ')} rate-limited this caller (HTTP 429) — the unauthenticated quota is spent. Back off; retrying extends the lockout and the quota is shared with the next domain scanned.`,
 		);
 	}
 	if (errored.length > 0) {

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -1435,6 +1435,46 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false,
 	};
 }
 
+/**
+ * Remediation prose for a total CT failure, split by WHY each source failed.
+ *
+ * The banner used to end "retry shortly" unconditionally. That is correct for an
+ * upstream outage and actively misleading for a timeout: Certspotter returns
+ * HTTP 504 `{"code":"timeout"}` for domains with a large certificate population
+ * ("domains with a huge number of sub-domains or certificates" — its own words)
+ * while answering smaller domains in the same window. Measured 2026-08-21:
+ * `meta.com` timed out repeatedly; `anthropic.com` returned 200 / 43 KB. So the
+ * timeout is a deterministic property of the DOMAIN under an unpaginated query,
+ * not a transient property of the SOURCE — telling the caller to retry sends
+ * them into a loop that cannot terminate, on precisely the largest estates.
+ *
+ * `notConsulted` is reported separately because it is not a failure at all: the
+ * source was never asked (typically unbound in this deployment). Folding it into
+ * "unavailable" implies three sources were tried when only two were (#735).
+ */
+function ctFailureGuidance(coverage: CtCoverage | undefined): string {
+	const perSource = coverage?.perSource ?? [];
+	const timedOut = perSource.filter((s) => s.outcome === 'timeout').map((s) => s.source);
+	const errored = perSource.filter((s) => s.outcome === 'http_error' || s.outcome === 'error').map((s) => s.source);
+	const never = coverage?.notConsulted ?? [];
+
+	const parts: string[] = [];
+	if (timedOut.length > 0) {
+		parts.push(
+			`${timedOut.join(', ')} timed out — for a domain with a large certificate population this is deterministic, not transient, so an identical retry will time out again; narrow the query or page the source.`,
+		);
+	}
+	if (errored.length > 0) {
+		parts.push(`${errored.join(', ')} returned an upstream error, which may be transient — a retry is worthwhile.`);
+	}
+	if (never.length > 0) {
+		parts.push(`${never.join(', ')} was never consulted (not configured in this deployment), so no fallback source remained.`);
+	}
+	// Only reachable if a source failed with an outcome outside the known set.
+	if (parts.length === 0) return 'Retry shortly.';
+	return parts.join(' ');
+}
+
 /** Format subdomain discovery result as human-readable text. */
 export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, format: OutputFormat = 'full'): string {
 	// Both zero-ish branches carry the per-source coverage line: "which source
@@ -1442,7 +1482,7 @@ export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, forma
 	const coverageLine = result.coverage ? `\n${formatCoverageLine(result.coverage)}` : '';
 
 	if (result.sourceUnavailable) {
-		return `Subdomain Discovery: ${result.domain} — Certificate Transparency source unavailable (the CT log endpoint returned an error or was unreachable); could not enumerate subdomains. This does not mean the domain has no subdomains — retry shortly.${coverageLine}`;
+		return `Subdomain Discovery: ${result.domain} — Certificate Transparency source unavailable; could not enumerate subdomains. This does not mean the domain has no subdomains. ${ctFailureGuidance(result.coverage)}${coverageLine}`;
 	}
 	if (result.totalSubdomains === 0) {
 		// A STALE empty set is not a confident "none found" — say so, or the

--- a/test/discover-brand-domains.spec.ts
+++ b/test/discover-brand-domains.spec.ts
@@ -248,6 +248,74 @@ describe('discoverBrandDomains', () => {
 		expect(candidates).toHaveLength(0);
 	});
 
+	it('reports a PARTIAL sweep that lost a primary signal as UNMEASURED, not as a passing score (#734)', async () => {
+		// #670 closed the all-signals-failed case with `.every()`. A run where the
+		// primary certificate channel dies but secondary signals answer therefore
+		// fell straight through to normal scoring — and normal scoring rewards
+		// surfacing FEWER candidates, so a crippled sweep outscored a healthy one.
+		//
+		// Measured against production 2026-08-21: seed `meta.com` with `san: error`
+		// plus four degraded signals surfaced 1 of >=152 real Meta apexes (0.7%) and
+		// returned `passed: true, score: 95`, while a healthy `facebook.com` sweep
+		// that surfaced 27 returned `passed: false, score: 0`. Score moved inversely
+		// to measurement success. That is the #662/#670 false-green shape.
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const deps = makeDeps({
+			// Primary channel dies...
+			correlateSans: vi.fn().mockResolvedValue({
+				seedDomain: 'example.com',
+				coOwnedDomains: [],
+				certIds: [],
+				queryStatus: 'timeout',
+			} satisfies SanCorrelationResult),
+			// ...while secondary signals answer cleanly, so `allFailed` is false.
+			// Two corroborating signals, because a single-signal candidate is dropped
+			// by the corroboration gate and we need one to actually SURVIVE to prove
+			// the degraded path still returns what it found.
+			correlateNs: vi.fn().mockResolvedValue(okNs([{ domain: 'sister.example', confidence: 1 }])),
+			mineDmarcRua: vi.fn().mockResolvedValue(okRua(['sister.example'])),
+		});
+
+		const result = await discoverBrandDomains('example.com', { signals: ['san', 'ns', 'dmarc_rua'] }, deps);
+
+		// The sweep did not measure what it claims to measure, so the category must
+		// be EXCLUDED from scoring rather than scored on a partial view.
+		expect(result.checkStatus).toBe('error');
+		expect(result.passed).toBe(false);
+		// `partial` keeps a transient upstream outage out of the 5-minute cache so
+		// the next call re-measures instead of replaying a degraded sweep.
+		expect(result.partial).toBe(true);
+
+		// Whatever the surviving signals DID find is still worth returning to the
+		// caller — degrading the score must not throw away real candidates.
+		const candidates = result.findings.filter((f) => f.metadata?.candidate);
+		expect(candidates.length).toBeGreaterThan(0);
+
+		// And the degradation must be legible in the output, not inferable only by
+		// cross-reading signalStatus.
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.inconclusive).toBe(true);
+		expect(summary?.metadata?.degradedPrimarySignals).toEqual(['san']);
+	});
+
+	it('scores a sweep normally when every primary signal completed (#734 control)', async () => {
+		// The discriminating half: same shape, primary signal HEALTHY. If this ever
+		// starts returning checkStatus 'error' too, the guard above has over-fired
+		// and made the category permanently unmeasurable.
+		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
+		const deps = makeDeps({
+			correlateSans: vi.fn().mockResolvedValue(okSan([])),
+			correlateNs: vi.fn().mockResolvedValue(okNs([{ domain: 'sister.example', confidence: 1 }])),
+		});
+
+		const result = await discoverBrandDomains('example.com', { signals: ['san', 'ns'] }, deps);
+
+		expect(result.checkStatus).toBeUndefined();
+		expect(result.partial).toBeFalsy();
+		const summary = result.findings.find((f) => f.metadata?.summary === true);
+		expect(summary?.metadata?.degradedPrimarySignals).toBeUndefined();
+	});
+
 	it('reports an all-signals-failed sweep as UNMEASURED, never as "control absent" (#670)', async () => {
 		const { discoverBrandDomains } = await import('../src/tools/discover-brand-domains');
 		const deps = makeDeps({

--- a/test/discover-subdomains-coverage.spec.ts
+++ b/test/discover-subdomains-coverage.spec.ts
@@ -331,6 +331,14 @@ describe('discover_subdomains — rendered text always states the sample caveat'
 			expect(output).toMatch(/retry/i);
 		});
 
+		it('tells a rate-limited caller to BACK OFF, never that a retry is worthwhile', async () => {
+			const output = await renderUnavailable([{ source: 'certspotter', outcome: 'rate_limited' }]);
+			expect(output).toMatch(/certspotter/);
+			expect(output).toMatch(/back off|backoff|quota/i);
+			// The dangerous wording: retrying is what EXTENDS a 429 lockout.
+			expect(output).not.toMatch(/retry is worthwhile|retry shortly/i);
+		});
+
 		it('says the deployment has no configured fallback when the last source was never consulted', async () => {
 			const output = await renderUnavailable(
 				[

--- a/test/discover-subdomains-coverage.spec.ts
+++ b/test/discover-subdomains-coverage.spec.ts
@@ -289,4 +289,60 @@ describe('discover_subdomains — rendered text always states the sample caveat'
 		expect(output).toContain('crtsh');
 		expect(output).toContain('certspotter');
 	});
+
+	// #735 — the total-failure banner told EVERY caller to "retry shortly".
+	//
+	// That is right for an upstream outage and wrong for a timeout. Measured
+	// 2026-08-21: certspotter returned HTTP 504 {"code":"timeout"} for meta.com
+	// ("domains with a huge number of sub-domains or certificates") while
+	// answering anthropic.com with HTTP 200 in the same window. So the timeout is
+	// a deterministic property of the domain's certificate population under an
+	// unpaginated query, not a transient blip — retrying is guaranteed to fail
+	// again, forever, on exactly the largest and most interesting estates.
+	describe('total-failure banner distinguishes transient from deterministic (#735)', () => {
+		async function renderUnavailable(perSource: Array<{ source: string; outcome: string }>, notConsulted: string[] = []) {
+			const { formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+			const { buildCtCoverage } = await import('../src/lib/ct-coverage');
+			const coverage = buildCtCoverage(
+				perSource.map((s) => ({ source: s.source, outcome: s.outcome as never, contributed: false })),
+			);
+			return formatSubdomainDiscovery(
+				{
+					domain: 'meta.com',
+					subdomains: [],
+					totalSubdomains: 0,
+					sourceUnavailable: true,
+					coverage: { ...coverage, notConsulted },
+				} as never,
+				'full',
+			);
+		}
+
+		it('does NOT tell the caller to retry when the source timed out', async () => {
+			const output = await renderUnavailable([{ source: 'certspotter', outcome: 'timeout' }]);
+			expect(output).not.toMatch(/retry shortly/i);
+			// and it must say WHY retrying will not help
+			expect(output).toMatch(/certspotter/);
+			expect(output).toMatch(/deterministic|too large|not transient/i);
+		});
+
+		it('still offers a retry when the failure was an upstream error', async () => {
+			const output = await renderUnavailable([{ source: 'crtsh', outcome: 'http_error' }]);
+			expect(output).toMatch(/retry/i);
+		});
+
+		it('says the deployment has no configured fallback when the last source was never consulted', async () => {
+			const output = await renderUnavailable(
+				[
+					{ source: 'crtsh', outcome: 'http_error' },
+					{ source: 'certspotter', outcome: 'timeout' },
+				],
+				['certstream'],
+			);
+			expect(output).toMatch(/certstream/);
+			expect(output).toMatch(/not configured|no configured fallback|never consulted/i);
+			// The mixed case must not silently drop the deterministic warning.
+			expect(output).toMatch(/deterministic|too large|not transient/i);
+		});
+	});
 });

--- a/test/discover-subdomains-resilience.spec.ts
+++ b/test/discover-subdomains-resilience.spec.ts
@@ -168,7 +168,6 @@ describe('discoverSubdomains — multi-source resilience', () => {
 		// the caller a retry is worthwhile — which extends the lockout and poisons
 		// the shared quota for every OTHER domain scanned next.
 		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
-		const kv = makeKv();
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
 			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
 			if (s.includes('crt.sh') || s.includes('certspotter.com')) {
@@ -177,7 +176,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
 
-		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const result = await discoverSubdomains('example.com');
 
 		expect(result.sourceUnavailable).toBe(true);
 		const outcomes = (result.coverage?.perSource ?? []).map((s) => s.outcome);
@@ -189,14 +188,13 @@ describe('discoverSubdomains — multi-source resilience', () => {
 		// Discriminating half: 503 must NOT be swept into the new bucket, or the
 		// retry guidance disappears for the one case where retrying is correct.
 		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
-		const kv = makeKv();
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
 			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
 			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
 
-		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const result = await discoverSubdomains('example.com');
 		const outcomes = (result.coverage?.perSource ?? []).map((s) => s.outcome);
 		expect(outcomes).toContain('http_error');
 		expect(outcomes).not.toContain('rate_limited');

--- a/test/discover-subdomains-resilience.spec.ts
+++ b/test/discover-subdomains-resilience.spec.ts
@@ -161,6 +161,47 @@ describe('discoverSubdomains — multi-source resilience', () => {
 		expect(result.subdomains).toEqual([]);
 	});
 
+	it('records HTTP 429 as rate_limited, not as a generic http_error (#735)', async () => {
+		// Measured 2026-08-21: after certspotter 504s on a large estate it starts
+		// returning 429 to the SAME unauthenticated caller, and the lockout outlived
+		// a 75-second wait. Collapsing that into `http_error` makes the banner tell
+		// the caller a retry is worthwhile — which extends the lockout and poisons
+		// the shared quota for every OTHER domain scanned next.
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) {
+				return Response.json({ code: 'rate_limited' }, { status: 429 });
+			}
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+
+		expect(result.sourceUnavailable).toBe(true);
+		const outcomes = (result.coverage?.perSource ?? []).map((s) => s.outcome);
+		expect(outcomes).toContain('rate_limited');
+		expect(outcomes).not.toContain('http_error');
+	});
+
+	it('still records a non-429 upstream failure as http_error (#735 control)', async () => {
+		// Discriminating half: 503 must NOT be swept into the new bucket, or the
+		// retry guidance disappears for the one case where retrying is correct.
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const outcomes = (result.coverage?.perSource ?? []).map((s) => s.outcome);
+		expect(outcomes).toContain('http_error');
+		expect(outcomes).not.toContain('rate_limited');
+	});
+
 	it('still serves stale on total failure even when force_refresh is set', async () => {
 		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
 		const kv = makeKv();


### PR DESCRIPTION
Closes #734. Closes #735.

Both defects were found while running a third-party estate sweep (Meta) from bv-web-prod on 2026-08-21, and both are the same shape the #662/#670 work exists to remove: **an unmeasured condition presented to the caller as an affirmative healthy result.**

## #734 — `brand_discovery` scored a partial signal failure as a pass

#670 added the unmeasured gate, but keyed it on `.every()`:

```ts
const allFailed = signals.length > 0 && signals.every((s) => signalCouldNotComplete(signalStatus[s]?.status));
```

so it fires **only on total failure**. A run that loses the primary certificate channel while secondary signals still answer falls through to normal scoring — and the score derives from how many candidates surfaced, so **a crippled sweep outscores a healthy one**.

Measured, same tool, same session:

| seed | signalStatus | surfaced | result |
|---|---|---|---|
| `meta.com` | `san: error` + 4 degraded | **1** | `passed: true`, **`score: 95`** |
| `facebook.com` | `san: error`, rest ok | **27** | `passed: false`, `score: 0` |

Ground truth: Meta owns **at least 152** apex domains, established independently of this tool by testing candidates for in-bailiwick NS delegation to `a-d.ns.facebook.com`. The tool surfaced **1 of ≥152 (0.7%)** and returned a 95/pass. A caller enforcing a minimum grade in CI therefore passes on a scan that measured almost nothing.

**Fix.** Adds `PRIMARY_DISCOVERY_SIGNALS` (`san`, `san_recursive`) and excludes the category from scoring (`checkStatus: 'error'`, `passed: false`, `partial: true`) when any primary signal could not complete.

Two deliberate choices worth review:

- **Candidate findings are retained.** The degraded path still returns what the surviving signals found. Discarding them would trade one wrong answer for another; the caller gets the data plus an explicit `inconclusive` marker, and only the *score* is withheld.
- **`budget_exceeded` and `partial` are not failures here.** `signalCouldNotComplete` is reused rather than re-spelled, so this gate and #670's draw exactly the same line and cannot drift.

## #735 — the total-CT-failure banner told everyone to "retry shortly"

Right for an upstream outage, wrong for a timeout. Certspotter returns `HTTP 504 {"code":"timeout"}` on domains with a large certificate population, while answering smaller domains in the same window — `meta.com` timed out repeatedly, `anthropic.com` returned 200/43 KB. The timeout is a **deterministic property of the domain** under an unpaginated query, not a transient property of the source, so "retry" sends the caller into a loop that cannot terminate on precisely the largest and most interesting estates.

Splits the guidance by per-source outcome, and reports `notConsulted` separately — an unbound source was never asked, and folding it into "unavailable" implies three sources were tried when only two were.

## #735 follow-up — the "real fix" was measured and is NOT pagination

The first commit split the failure messaging. I then went after the root cause I had proposed on #735 — paginating certspotter — and **measurement disproved it**:

- Pagination already exists (#573/#577). The failure is on **page 1**, which has no cursor.
- Page size is not the lever: `meta.com` returns **HTTP 504 at ~15.6s** with no `limit`, `limit=100`, `limit=10`, and `after=0` alike. `&limit=` is ignored without an API key, so the cost is the upstream subdomain scan.
- It is not a size threshold: **`facebook.com` (a larger estate) answers in 1.45s** while `meta.com` times out on 4 consecutive attempts.
- A narrowing fallback (drop `include_subdomains`) does make `meta.com` answer in 3.3s — and is **deliberately not shipped**, because it yields `unique dns_names: 2`, the only subdomain being the wildcard `*.meta.com`.

What the measurement *did* surface is a genuine defect. After the 504, certspotter **429s the same caller** and the lockout outlived a 75-second wait:

```
attempt 1: http=504 code=timeout
attempt 2: http=429 code=rate_limited
attempt 3: http=429 code=rate_limited
```

**429 was handled nowhere** — it fell into the generic `!response.ok` → `http_error` branch. Combined with this PR's own messaging fix, the tool would have told the caller *"a retry is worthwhile"* on a 429, extending the lockout on a quota **shared with the next domain scanned**. One slow domain becomes a sweep-wide outage.

So the second commit adds `rate_limited` as a distinct `CtSourceOutcome` with back-off guidance, routed through a `httpFailureOutcome(status)` classifier on both CT sources' page-1 path. A control test keeps 503 on the retry path, so the new bucket cannot swallow the case where retrying *is* correct.

**Residual, deliberately not code.** Certspotter cannot serve certain large domains without an API key. That is an upstream capability limit; the fixes are procurement or a bound `BV_CERTSTREAM`. I have not opened an issue for it — it is a spend decision, not an engineering one.

## Testing

```
Full suite: 7651 passed | 13 skipped   (7648 before; +3 new tests)
tsc --noEmit: 0 errors (after `wrangler types`)
```

`test/wasm-integration.test.ts` fails on the known gitignored `crates/*/pkg` worktree baseline (`No such module … bv_wasm_core_bg.wasm`). This diff touches no wasm files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
