### PR TITLE
fix(discovery): a CT source that FAILED is no longer reported as never-asked (#738)

### DIFF
--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -426,11 +426,17 @@ export async function discoverSubdomains(
 ): Promise<SubdomainDiscoveryResult> {
 	// Fast path: certstream service binding (bv-certstream-worker; itself
 	// multi-source + short-cached). On a clean result, prime the LKG cache.
+	// Attempts made by the fast path before it gave up. Threaded into every
+	// downstream path so a certstream FAILURE is reported as a failure — without
+	// this the orchestrator forgets the fast path ran at all, and `buildCtCoverage`
+	// reports the dead binding as "not consulted on this call" (#738).
+	const certstreamAttempts: CtSourceAttempt[] = [];
 	if (certstream) {
-		const result = await queryCertstream(domain, certstream, certstreamAuthToken, options);
-		if (result) {
-			await cacheSuccess(domain, result, options);
-			return result;
+		const fastPath = await queryCertstream(domain, certstream, certstreamAuthToken, options);
+		if (fastPath.attempt) certstreamAttempts.push(fastPath.attempt);
+		if (fastPath.result) {
+			await cacheSuccess(domain, fastPath.result, options);
+			return fastPath.result;
 		}
 		// Fall through to the direct public sources if the binding failed.
 	}
@@ -441,7 +447,10 @@ export async function discoverSubdomains(
 	// milliseconds, unlike the 10s fetch we no longer have budget for.
 	if (deadlineExceeded(options)) {
 		const staleOnDeadline = await readLastKnownGood(domain, options);
-		return staleOnDeadline ? { ...staleOnDeadline, partial: true } : emptyResult(domain, true, true);
+		// A stale result keeps the coverage of the call that CACHED it — that record
+		// describes its own provenance and would be a lie about this call. Staleness
+		// is signalled by `stale`/`partial` instead.
+		return staleOnDeadline ? { ...staleOnDeadline, partial: true } : emptyResult(domain, true, true, { attempts: certstreamAttempts });
 	}
 
 	// Direct public CT sources, tried in order with per-source health logging
@@ -451,7 +460,8 @@ export async function discoverSubdomains(
 		const meta: EnumerationMeta = {
 			sources: direct.sources,
 			sourceIndexExhausted: direct.sourceIndexExhausted,
-			attempts: direct.attempts,
+			// Attempt order: the fast path ran first.
+			attempts: [...certstreamAttempts, ...direct.attempts],
 		};
 		const result =
 			direct.entries.length > 0 ? buildResultFromEntries(domain, direct.entries, meta) : emptyResult(domain, false, false, meta);
@@ -465,7 +475,7 @@ export async function discoverSubdomains(
 	const stale = await readLastKnownGood(domain, options);
 	if (stale) return stale;
 
-	return emptyResult(domain, true, false, { attempts: direct.attempts });
+	return emptyResult(domain, true, false, { attempts: [...certstreamAttempts, ...direct.attempts] });
 }
 
 /**
@@ -1169,9 +1179,11 @@ async function queryCertstream(
 	certstream: { fetch: typeof fetch },
 	certstreamAuthToken?: string,
 	options?: DiscoverSubdomainsOptions,
-): Promise<SubdomainDiscoveryResult | null> {
+): Promise<CertstreamFastPath> {
 	if (deadlineExceeded(options)) {
-		return emptyResult(domain, true, true);
+		// Budget gone before a single request was issued, so the source genuinely was
+		// NOT consulted. No attempt is recorded and `notConsulted` stays truthful.
+		return { result: emptyResult(domain, true, true) };
 	}
 
 	const enumerate = await queryCertstreamEndpoint<CertstreamEnumerateResponse>(
@@ -1181,48 +1193,104 @@ async function queryCertstream(
 		certstreamAuthToken,
 		options,
 	);
-	const enumerateOk = Boolean(enumerate) && !enumerate?.error && Array.isArray(enumerate?.subdomains);
-	if (enumerateOk && enumerate) {
-		if (!enumerate.timedOut) {
-			return buildCertstreamResult(domain, enumerate.subdomains, enumerate.certificateCount);
+	const enumerateOk = Boolean(enumerate.data) && !enumerate.data?.error && Array.isArray(enumerate.data?.subdomains);
+	// A 200 carrying an `error` body or the wrong shape is not a healthy answer;
+	// only the transport succeeded.
+	let outcome: CtSourceOutcome = enumerate.outcome === 'ok' && !enumerateOk ? 'error' : enumerate.outcome;
+
+	if (enumerateOk && enumerate.data) {
+		const data = enumerate.data;
+		if (!data.timedOut) {
+			return { result: buildCertstreamResult(domain, data.subdomains, data.certificateCount), attempt: certstreamAttempt('ok', true) };
 		}
 		// #575's partial semantics, now also carrying #573's upstream metadata so the
 		// timed-out enumeration is reported incomplete rather than merely `partial`.
-		if (enumerate.subdomains.length > 0) {
+		if (data.subdomains.length > 0) {
 			return {
-				...buildCertstreamResult(domain, enumerate.subdomains, enumerate.certificateCount, { timedOut: true }),
-				partial: true,
+				result: { ...buildCertstreamResult(domain, data.subdomains, data.certificateCount, { timedOut: true }), partial: true },
+				attempt: certstreamAttempt('ok', true),
 			};
 		}
 		// timedOut:true with an empty list — fall through to /sans below rather
-		// than accepting an incomplete measurement as a confident zero.
+		// than accepting an incomplete measurement as a confident zero. The source
+		// DID answer, so the recorded outcome is a timeout, never "never asked".
+		outcome = 'timeout';
 	}
 
 	// Deadline gate: if we already burned the budget on /enumerate, skip /sans
-	// and let the orchestrator decide whether to fall through to crt.sh.
+	// and let the orchestrator decide whether to fall through to crt.sh. One
+	// request HAS been issued by now, so the attempt is recorded either way.
 	if (deadlineExceeded(options)) {
-		return emptyResult(domain, true, true);
+		return { result: emptyResult(domain, true, true), attempt: certstreamAttempt(outcome, false) };
 	}
 
 	const sans = await queryCertstreamEndpoint<CertstreamSansResponse>('sans', domain, certstream, certstreamAuthToken, options);
 	// `/sans` reports its own upstream truncation — read it (declared and silently
 	// discarded before #573) so an incomplete SAN sweep is never served as a
 	// complete enumeration. Layered over #575's timed-out control flow.
-	const sansOk = Boolean(sans) && !sans?.error && Array.isArray(sans?.names);
-	if (!sansOk || !sans) return null;
-	if (!sans.timedOut) {
-		return buildCertstreamResult(domain, sans.names, sans.certificateCount, { truncated: sans.truncated });
-	}
-	if (sans.names.length > 0) {
+	const sansOk = Boolean(sans.data) && !sans.data?.error && Array.isArray(sans.data?.names);
+	outcome = worstCertstreamOutcome(outcome, sans.outcome === 'ok' && !sansOk ? 'error' : sans.outcome);
+
+	if (!sansOk || !sans.data) return { result: null, attempt: certstreamAttempt(outcome, false) };
+	const data = sans.data;
+	if (!data.timedOut) {
 		return {
-			...buildCertstreamResult(domain, sans.names, sans.certificateCount, { truncated: sans.truncated, timedOut: true }),
-			partial: true,
+			result: buildCertstreamResult(domain, data.names, data.certificateCount, { truncated: data.truncated }),
+			attempt: certstreamAttempt('ok', true),
 		};
 	}
-	// timedOut:true with an empty list — return null so the orchestrator falls
+	if (data.names.length > 0) {
+		return {
+			result: { ...buildCertstreamResult(domain, data.names, data.certificateCount, { truncated: data.truncated, timedOut: true }), partial: true },
+			attempt: certstreamAttempt('ok', true),
+		};
+	}
+	// timedOut:true with an empty list — no result so the orchestrator falls
 	// through to the direct public sources (crt.sh → Certspotter) instead of
 	// treating this as a confident zero.
-	return null;
+	return { result: null, attempt: certstreamAttempt('timeout', false) };
+}
+
+/** One certstream endpoint call: the parsed body (when healthy) and why, if not. */
+interface CertstreamEndpointOutcome<T> {
+	data: T | null;
+	outcome: CtSourceOutcome;
+}
+
+/**
+ * The certstream fast path's answer AND its coverage attempt (#738).
+ *
+ * `attempt` is present whenever at least one request was ISSUED — including
+ * every failure. It is absent only when the deadline tripped before any request
+ * went out, which is the one case where "not consulted" is literally true.
+ *
+ * This pairing is the fix: `queryCertstream` used to return a bare `null` on
+ * failure, so `buildCtCoverage` — which derives `notConsulted` as "known sources
+ * minus ATTEMPTED" — could not distinguish a source that failed from one never
+ * asked, and reported a hard outage as a benign "not consulted on this call".
+ */
+interface CertstreamFastPath {
+	result: SubdomainDiscoveryResult | null;
+	attempt?: CtSourceAttempt;
+}
+
+function certstreamAttempt(outcome: CtSourceOutcome, contributed: boolean): CtSourceAttempt {
+	return { source: 'certstream', outcome, contributed };
+}
+
+/**
+ * Most-actionable-wins when `/enumerate` and `/sans` fail differently.
+ *
+ * Ordered by what the caller must DO, not by severity: a 429 is the one outcome
+ * whose correct response is the opposite of the usual one (back off — retrying
+ * extends a lockout on a quota shared with the next domain), so it must never be
+ * masked by a subsequent generic error. Timeout ranks next because it is
+ * deterministic per-domain (#735) and tells the caller not to retry identically.
+ */
+const CERTSTREAM_OUTCOME_PRECEDENCE: readonly CtSourceOutcome[] = ['rate_limited', 'timeout', 'http_error', 'error', 'empty', 'ok'];
+
+function worstCertstreamOutcome(a: CtSourceOutcome, b: CtSourceOutcome): CtSourceOutcome {
+	return CERTSTREAM_OUTCOME_PRECEDENCE.indexOf(a) <= CERTSTREAM_OUTCOME_PRECEDENCE.indexOf(b) ? a : b;
 }
 
 async function queryCertstreamEndpoint<T>(
@@ -1231,7 +1299,7 @@ async function queryCertstreamEndpoint<T>(
 	certstream: { fetch: typeof fetch },
 	certstreamAuthToken?: string,
 	options?: DiscoverSubdomainsOptions,
-): Promise<T | null> {
+): Promise<CertstreamEndpointOutcome<T>> {
 	const composed = composeAbortSignal(CT_SOURCE_TIMEOUT_MS, options?.signal);
 
 	try {
@@ -1242,11 +1310,14 @@ async function queryCertstreamEndpoint<T>(
 		});
 		if (!response.ok) {
 			await disposeUnreadResponseBody(response);
-			return null;
+			return { data: null, outcome: httpFailureOutcome(response.status) };
 		}
-		return (await response.json()) as T;
+		return { data: (await response.json()) as T, outcome: 'ok' };
 	} catch {
-		return null;
+		// An abort is the inner CT timeout or the caller's deadline; either way the
+		// source did not answer in time, which is a materially different remediation
+		// from an upstream error (see `ctFailureGuidance`).
+		return { data: null, outcome: composed.signal.aborted ? 'timeout' : 'error' };
 	} finally {
 		composed.cleanup();
 	}

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -424,13 +424,14 @@ export async function discoverSubdomains(
 	certstreamAuthToken?: string,
 	options?: DiscoverSubdomainsOptions,
 ): Promise<SubdomainDiscoveryResult> {
-	// Fast path: certstream service binding (bv-certstream-worker; itself
-	// multi-source + short-cached). On a clean result, prime the LKG cache.
 	// Attempts made by the fast path before it gave up. Threaded into every
 	// downstream path so a certstream FAILURE is reported as a failure — without
 	// this the orchestrator forgets the fast path ran at all, and `buildCtCoverage`
 	// reports the dead binding as "not consulted on this call" (#738).
 	const certstreamAttempts: CtSourceAttempt[] = [];
+
+	// Fast path: certstream service binding (bv-certstream-worker; itself
+	// multi-source + short-cached). On a clean result, prime the LKG cache.
 	if (certstream) {
 		const fastPath = await queryCertstream(domain, certstream, certstreamAuthToken, options);
 		if (fastPath.attempt) certstreamAttempts.push(fastPath.attempt);
@@ -1286,11 +1287,23 @@ function certstreamAttempt(outcome: CtSourceOutcome, contributed: boolean): CtSo
  * extends a lockout on a quota shared with the next domain), so it must never be
  * masked by a subsequent generic error. Timeout ranks next because it is
  * deterministic per-domain (#735) and tells the caller not to retry identically.
+ *
+ * Deliberately a `Record` over the union and NOT an array + `indexOf`: `indexOf`
+ * returns -1 for a member missing from the list, which compares as the MOST
+ * actionable rank, so adding a seventh `CtSourceOutcome` would silently make it
+ * beat a real 429. As a `Record` the same omission is a compile error.
  */
-const CERTSTREAM_OUTCOME_PRECEDENCE: readonly CtSourceOutcome[] = ['rate_limited', 'timeout', 'http_error', 'error', 'empty', 'ok'];
+const CERTSTREAM_OUTCOME_PRECEDENCE: Record<CtSourceOutcome, number> = {
+	rate_limited: 0,
+	timeout: 1,
+	http_error: 2,
+	error: 3,
+	empty: 4,
+	ok: 5,
+};
 
 function worstCertstreamOutcome(a: CtSourceOutcome, b: CtSourceOutcome): CtSourceOutcome {
-	return CERTSTREAM_OUTCOME_PRECEDENCE.indexOf(a) <= CERTSTREAM_OUTCOME_PRECEDENCE.indexOf(b) ? a : b;
+	return CERTSTREAM_OUTCOME_PRECEDENCE[a] <= CERTSTREAM_OUTCOME_PRECEDENCE[b] ? a : b;
 }
 
 async function queryCertstreamEndpoint<T>(

--- a/test/discover-subdomains-coverage.spec.ts
+++ b/test/discover-subdomains-coverage.spec.ts
@@ -154,6 +154,79 @@ describe('discover_subdomains — per-source coverage record', () => {
 		expect(result.coverage?.notConsulted).toContain('certspotter');
 	});
 
+	// #738 item 4. Measured in production 2026-08-21: `BV_CERTSTREAM` was bound to a
+	// worker that 404s every CT route, so the fast path was entered and failed on
+	// EVERY call — 13/13 requests, confirmed by Cloudflare observability — while the
+	// payload said "Not consulted on this call: certstream".
+	//
+	// `queryCertstreamEndpoint` returned `null` on `!response.ok` without recording an
+	// attempt, and `buildCtCoverage` derives `notConsulted` as "known sources minus
+	// ATTEMPTED", so a source that failed was indistinguishable from one never asked.
+	// That inverts the meaning this module exists to protect (`ct-coverage.ts`: "sources
+	// that were never consulted are named explicitly, so a fast-path single-source answer
+	// cannot masquerade as a multi-source consensus"), and it hides a hard outage as a
+	// benign configuration note — the operator sees "not consulted" and concludes the
+	// binding is absent, when it is present and broken.
+	describe('a certstream fast path that FAILED is never reported as never-asked', () => {
+		// Every distinct way the fast path can fail. The bug was NOT specific to 404 —
+		// it swallowed the whole `!response.ok` branch plus every throw — so the lock is
+		// the INVARIANT across failure modes, not one literal status.
+		const failureModes: Array<{ label: string; respond: () => Promise<Response>; outcome: string }> = [
+			{ label: '404 (wrong worker deployed at that name)', respond: async () => Response.json({ error: 'Not found' }, { status: 404 }), outcome: 'http_error' },
+			{ label: '500 (upstream fault)', respond: async () => Response.json({ error: 'boom' }, { status: 500 }), outcome: 'http_error' },
+			{ label: '429 (quota spent)', respond: async () => Response.json({ error: 'rate limited' }, { status: 429 }), outcome: 'rate_limited' },
+		];
+
+		for (const mode of failureModes) {
+			it(`records certstream as attempted-and-failed on ${mode.label}`, async () => {
+				const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+				const certstreamFetch = vi.fn(mode.respond);
+				globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+					const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+					if (s.includes('crt.sh')) return Response.json({}, { status: 502 });
+					if (s.includes('certspotter.com')) return Response.json([issuance(1, ['api.example.com'])], { status: 200 });
+					return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+				});
+
+				const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch });
+
+				// The binding WAS exercised — assert the premise, so this test cannot pass
+				// by the fast path silently never running.
+				expect(certstreamFetch).toHaveBeenCalled();
+
+				// The defect, stated directly.
+				expect(result.coverage?.notConsulted).not.toContain('certstream');
+
+				const certstream = result.coverage?.perSource.find((s) => s.source === 'certstream');
+				expect(certstream).toBeDefined();
+				expect(certstream?.outcome).toBe(mode.outcome);
+				expect(certstream?.contributed).toBe(false);
+				expect(result.coverage?.unavailable).toContain('certstream');
+
+				// The prose a human actually reads must not call it never-asked either.
+				expect(result.coverage?.caveat).not.toMatch(/Not consulted on this call:[^.]*certstream/);
+			});
+		}
+
+		it('still reports certstream as notConsulted when the binding is genuinely absent', async () => {
+			// The control. Unbinding restored a TRUE statement, and the fix must not
+			// destroy it — otherwise "not consulted" becomes unreachable and the field
+			// stops discriminating at all.
+			const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+			globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+				const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+				if (s.includes('crt.sh')) return Response.json({}, { status: 502 });
+				if (s.includes('certspotter.com')) return Response.json([issuance(1, ['api.example.com'])], { status: 200 });
+				return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+			});
+
+			const result = await discoverSubdomains('example.com');
+
+			expect(result.coverage?.notConsulted).toContain('certstream');
+			expect(result.coverage?.perSource.find((s) => s.source === 'certstream')).toBeUndefined();
+		});
+	});
+
 	it('labels each source with the slice of CT history it can even see', async () => {
 		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {

--- a/test/discover-subdomains-coverage.spec.ts
+++ b/test/discover-subdomains-coverage.spec.ts
@@ -208,6 +208,33 @@ describe('discover_subdomains — per-source coverage record', () => {
 			});
 		}
 
+		it('keeps the 429 when /enumerate is rate-limited and /sans then fails generically', async () => {
+			// The fast path is a two-endpoint ladder, so the two calls can fail
+			// differently. A 429 must survive: it is the one outcome whose correct
+			// response is the OPPOSITE of the usual one — back off, because retrying
+			// extends a lockout on a quota shared with the next domain scanned (#735).
+			// Letting the later 500 win would tell the caller "retry, may be transient".
+			const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+			const certstreamFetch = vi.fn(async (input: RequestInfo | URL) => {
+				const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+				return url.includes('/enumerate')
+					? Response.json({ error: 'rate limited' }, { status: 429 })
+					: Response.json({ error: 'boom' }, { status: 500 });
+			});
+			globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+				const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+				if (s.includes('crt.sh')) return Response.json({}, { status: 502 });
+				if (s.includes('certspotter.com')) return Response.json([issuance(1, ['api.example.com'])], { status: 200 });
+				return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+			});
+
+			const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch });
+
+			// Both endpoints were exercised — otherwise this passes vacuously.
+			expect(certstreamFetch).toHaveBeenCalledTimes(2);
+			expect(result.coverage?.perSource.find((s) => s.source === 'certstream')?.outcome).toBe('rate_limited');
+		});
+
 		it('still reports certstream as notConsulted when the binding is genuinely absent', async () => {
 			// The control. Unbinding restored a TRUE statement, and the fix must not
 			// destroy it — otherwise "not consulted" becomes unreachable and the field


### PR DESCRIPTION
Phase 0 of the CT-source plan. Closes item 4 of #738.

## The defect

`queryCertstreamEndpoint` returned a bare `null` on `!response.ok` and on every throw, recording no attempt. `buildCtCoverage` derives `notConsulted` as *known sources minus **attempted***, so a source that was queried and failed was indistinguishable from one never asked. Every affected result said:

> Not consulted on this call: certstream.

That inverts the exact guarantee `ct-coverage.ts` exists to provide — *"sources that were never consulted are named explicitly, so a fast-path single-source answer cannot masquerade as a multi-source consensus"* — and it hides a hard outage as a benign configuration note. An operator reading "not consulted" concludes the binding is **absent**, when it is **present and broken**.

## Measured, not inferred

Production, 2026-08-21. `BV_CERTSTREAM` was bound to a worker that 404s every CT route, so the fast path was entered and failed on *every* call — **13/13 requests, HTTP 404**, confirmed via Cloudflare Workers observability — while all four sampled `discover_subdomains` results reported certstream as not consulted.

The binding has since been reverted, which makes the message accidentally true again. **The bug is unchanged**: it fires for any certstream failure — timeout, 5xx, 429, malformed body.

## Changes

- `queryCertstreamEndpoint` returns `{data, outcome}`. `!response.ok` routes through the existing `httpFailureOutcome` (429 → `rate_limited`); an abort → `timeout`; any other throw → `error`. A 200 carrying an `error` body or the wrong shape is downgraded to `error` rather than counted healthy.
- `queryCertstream` returns `{result, attempt?}`. `attempt` is present whenever a request was **issued** — absent only when the deadline tripped before any request went out, the one case where "not consulted" is literally true.
- `discoverSubdomains` threads the fast-path attempt into every fall-through path, in attempt order.
- `worstCertstreamOutcome` keeps the most **actionable** outcome when `/enumerate` and `/sans` fail differently: a 429 must never be masked by a later generic error, because its correct response is the opposite of the usual one (#735).

Stale/cached results deliberately keep the coverage of the call that cached them — that record describes its own provenance, and overwriting it would be a lie in the other direction.

## Testing

Failure modes are table-driven (**404 / 500 / 429**) because the bug swallowed the entire `!response.ok` branch plus every throw — the lock is the **invariant**, not one literal status. Each test asserts the binding was actually exercised, so none can pass by the fast path silently never running.

A **control** locks the true case: a genuinely absent binding must still report `notConsulted: ['certstream']`. Without it, a fix could make the field unreachable and stop discriminating entirely.

**Mutation-proven** — suppressing the attempt push turns exactly the 3 failure-mode tests red and leaves the control green.

Full suite: **7,655 passed**, 13 skipped. `test/wasm-integration.test.ts` fails identically on an unmodified tree (gitignored `crates/*/pkg` is absent in a worktree) — verified by stashing the diff and re-running.

Typecheck and lint clean.

## Why this is Phase 0

While CT failures are recorded as non-attempts, source health cannot be measured honestly — so the remaining phases (authenticating Certspotter, then choosing a tier on evidence) would be tuned blind. This is a prerequisite, not cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
