### PR TITLE
fix(robots): a blanket `User-agent: *` block is no longer reported as naming us

### DIFF
--- a/packages/dns-checks/src/__tests__/robots-gate.test.ts
+++ b/packages/dns-checks/src/__tests__/robots-gate.test.ts
@@ -171,6 +171,38 @@ describe('withRobotsGate', () => {
 		await expect(gated('https://example.com/robots.txt')).resolves.toBeInstanceOf(Response);
 	});
 
+	it('attributes a blanket `User-agent: *` disallow to all crawlers, not to us by name', async () => {
+		const inner = vi.fn(async (url: string) => {
+			// The real crt.sh robots.txt: blocks every crawler, names nobody.
+			if (url.endsWith('/robots.txt')) return textResponse('User-agent: *\nDisallow: /\n');
+			return textResponse('should not be reached');
+		});
+		const gated = withRobotsGate(inner);
+		const err = await gated('https://crt.sh/').catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(RobotsDisallowedError);
+		expect((err as RobotsDisallowedError).scope).toBe('blanket');
+		expect((err as RobotsDisallowedError).message).not.toContain('BlackVeil-Security-Scanner');
+	});
+
+	it('attributes a disallow in a group naming our UA as a named block', async () => {
+		const inner = vi.fn(async (url: string) => {
+			if (url.endsWith('/robots.txt')) {
+				return textResponse('User-agent: BlackVeil-Security-Scanner\nDisallow: /\n');
+			}
+			return textResponse('should not be reached');
+		});
+		const gated = withRobotsGate(inner);
+		const err = await gated('https://example.com/').catch((e: unknown) => e);
+		expect(err).toBeInstanceOf(RobotsDisallowedError);
+		expect((err as RobotsDisallowedError).scope).toBe('named');
+		expect((err as RobotsDisallowedError).message).toContain('BlackVeil-Security-Scanner');
+	});
+
+	it('defaults to the non-accusatory `blanket` scope when the caller supplies none', () => {
+		// Conservative default: never claim a site singled us out without evidence it did.
+		expect(new RobotsDisallowedError('https://example.com/').scope).toBe('blanket');
+	});
+
 	it('selects the named UA group over the wildcard group', async () => {
 		const inner = vi.fn(async (url: string) => {
 			if (url.endsWith('/robots.txt')) {

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -39,6 +39,7 @@ export { createFinding, buildCheckResult, computeCategoryScore, inferFindingConf
 
 // Robot policy
 export { SCANNER_USER_AGENT, RobotsDisallowedError, withRobotsGate } from './robots-gate';
+export type { RobotsDisallowScope } from './robots-gate';
 
 // DKIM selector probe list. Exported so downstream consumers can assert provider
 // coverage without re-declaring the list (a second copy would drift and, because

--- a/packages/dns-checks/src/robots-gate.ts
+++ b/packages/dns-checks/src/robots-gate.ts
@@ -15,10 +15,33 @@ export const SCANNER_USER_AGENT =
 
 const ROBOTS_FETCH_TIMEOUT_MS = 3_000;
 
+/**
+ * Which robots.txt group produced the disallow.
+ * - `blanket` — a `User-agent: *` group. The site blocks EVERY crawler and has
+ *   said nothing about us specifically. This is the overwhelmingly common case.
+ * - `named`  — a group whose `User-agent` list contains our own product token,
+ *   i.e. the operator deliberately singled this scanner out.
+ *
+ * The distinction is user-visible: attributing a blanket block to us by name
+ * misrepresents an ordinary site-wide no-crawl policy as a targeted one.
+ */
+export type RobotsDisallowScope = 'blanket' | 'named';
+
 /** Thrown by a `withRobotsGate`-wrapped fetch when the target's robots.txt disallows our UA for the requested path. */
 export class RobotsDisallowedError extends Error {
-	constructor(public readonly url: string) {
-		super(`robots.txt disallows BlackVeil-Security-Scanner for ${url}`);
+	constructor(
+		public readonly url: string,
+		/**
+		 * Defaults to `blanket`, the non-accusatory reading: absent positive
+		 * evidence that a site named this scanner, never claim that it did.
+		 */
+		public readonly scope: RobotsDisallowScope = 'blanket'
+	) {
+		super(
+			scope === 'named'
+				? `robots.txt names and disallows BlackVeil-Security-Scanner for ${url}`
+				: `robots.txt disallows all crawlers (User-agent: *) for ${url}`
+		);
 		this.name = 'RobotsDisallowedError';
 	}
 }
@@ -70,11 +93,18 @@ export function parseRobotsGroups(text: string): RobotsGroup[] {
 	return groups;
 }
 
+/** A selected group plus how it was selected — see {@link RobotsDisallowScope}. */
+interface SelectedGroup {
+	group: RobotsGroup;
+	scope: RobotsDisallowScope;
+}
+
 /** Most-specific group for `userAgentToken` (an exact agent-token match beats the `*` fallback). Null = no group applies. */
-function selectGroup(groups: RobotsGroup[], userAgentToken: string): RobotsGroup | null {
+function selectGroup(groups: RobotsGroup[], userAgentToken: string): SelectedGroup | null {
 	const named = groups.find((g) => g.agents.includes(userAgentToken));
-	if (named) return named;
-	return groups.find((g) => g.agents.includes('*')) ?? null;
+	if (named) return { group: named, scope: 'named' };
+	const wildcard = groups.find((g) => g.agents.includes('*'));
+	return wildcard ? { group: wildcard, scope: 'blanket' } : null;
 }
 
 /** Convert a robots.txt path pattern (`*` wildcard, trailing `$` end-anchor) into a prefix-matching RegExp. */
@@ -129,9 +159,9 @@ export function withRobotsGate(
 	const userAgent = opts.userAgent ?? SCANNER_USER_AGENT;
 	const productToken = userAgent.split('/')[0]!.toLowerCase();
 	const timeoutMs = opts.timeoutMs ?? ROBOTS_FETCH_TIMEOUT_MS;
-	const groupCache = new Map<string, Promise<RobotsGroup | null>>();
+	const groupCache = new Map<string, Promise<SelectedGroup | null>>();
 
-	async function resolveGroup(host: string): Promise<RobotsGroup | null> {
+	async function resolveGroup(host: string): Promise<SelectedGroup | null> {
 		let pending = groupCache.get(host);
 		if (!pending) {
 			pending = (async () => {
@@ -162,9 +192,9 @@ export function withRobotsGate(
 		const nextInit: RequestInit = { ...init, headers };
 
 		if (parsed.pathname !== '/robots.txt') {
-			const group = await resolveGroup(parsed.hostname);
-			if (isPathDisallowed(group, parsed.pathname)) {
-				throw new RobotsDisallowedError(url);
+			const selected = await resolveGroup(parsed.hostname);
+			if (selected && isPathDisallowed(selected.group, parsed.pathname)) {
+				throw new RobotsDisallowedError(url, selected.scope);
 			}
 		}
 


### PR DESCRIPTION
## What

`RobotsDisallowedError`'s message was a fixed string:

```ts
super(`robots.txt disallows BlackVeil-Security-Scanner for ${url}`);
```

thrown identically whether a site named this scanner or simply blocks every crawler. The second case is overwhelmingly the common one, so the copy misrepresented an ordinary site-wide no-crawl policy as a targeted block against BlackVeil.

## How it surfaced

Scanning `crt.sh` returned `checkStatus: 'error'` for both `ssl` and `http_security`, with a finding saying crt.sh "disallows BlackVeil-Security-Scanner". Its robots.txt is 26 bytes and has not changed since 2019-12-05:

```
User-agent: *
Disallow: /
```

It names nobody. `selectGroup` correctly fell back to the `*` group per RFC 9309 §2.2.1 — the parse was right, the attribution was not. That text reaches a scan finding and therefore a customer-facing report, where it reads as a site having singled us out.

## Change

- `selectGroup` now returns the matched group **and how it matched** (`SelectedGroup { group, scope }`).
- `RobotsDisallowedError` carries `scope: 'blanket' | 'named'` and picks its message accordingly.
- The parameter defaults to `'blanket'` — absent positive evidence that a site named us, never claim it did.
- `RobotsDisallowScope` is exported for downstream consumers.

**No behaviour change to what is or isn't fetched.** The gate allows and blocks exactly the same requests; only the attribution changes.

## Verification

- `packages/dns-checks`: **831/831 → all green** (3 new tests, written failing first — they failed on `scope` being `undefined` before the fix).
- `tsc --noEmit` clean, `eslint` clean on changed files.
- Only one production construct site exists, and bv-web-prod does not reference `RobotsDisallowedError` at all, so the signature change is contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)