### PR TITLE
fix(robots): make a scan abstention self-describing instead of prose-only

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/check-bimi-robots.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-bimi-robots.test.ts
@@ -24,4 +24,33 @@ describe('checkBIMI — robots.txt disallow', () => {
 		expect(logoFinding!.severity).toBe('info');
 		expect(result.findings.some((f) => f.title === 'BIMI logo fetch failed')).toBe(false);
 	});
+
+	it('does not accuse a site of naming us when its robots.txt blocks every crawler', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'blanket');
+		};
+		const result = await checkBIMI('example.com', queryDNS, { fetchFn });
+		const logoFinding = result.findings.find((f) => f.title.includes('robots.txt'))!;
+		expect(logoFinding.detail).not.toContain('BlackVeil-Security-Scanner');
+		expect(logoFinding.detail).toContain('all automated crawlers');
+	});
+
+	it('says so plainly when a site does name us', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'named');
+		};
+		const result = await checkBIMI('example.com', queryDNS, { fetchFn });
+		const logoFinding = result.findings.find((f) => f.title.includes('robots.txt'))!;
+		expect(logoFinding.detail).toContain('BlackVeil-Security-Scanner');
+	});
+
+	it('records the abstention machine-readably rather than only in prose', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'blanket');
+		};
+		const result = await checkBIMI('example.com', queryDNS, { fetchFn });
+		const logoFinding = result.findings.find((f) => f.title.includes('robots.txt'))!;
+		expect(logoFinding.metadata?.notAssessedReason).toBe('robots_disallowed');
+		expect(logoFinding.metadata?.robotsScope).toBe('blanket');
+	});
 });

--- a/packages/dns-checks/src/__tests__/checks/check-http-security-robots.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-http-security-robots.test.ts
@@ -15,4 +15,33 @@ describe('checkHTTPSecurity — robots.txt disallow', () => {
 		expect(result.findings[0]!.detail).toContain('robots.txt');
 		expect(result.findings[0]!.severity).toBe('info');
 	});
+
+	it('does not accuse a site of naming us when its robots.txt blocks every crawler', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'blanket');
+		};
+		const result = await checkHTTPSecurity('crt.sh', fetchFn);
+		const detail = result.findings[0]!.detail;
+		expect(detail).not.toContain('BlackVeil-Security-Scanner');
+		expect(detail).toContain('all automated crawlers');
+	});
+
+	it('says so plainly when a site does name us', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'named');
+		};
+		const result = await checkHTTPSecurity('example.com', fetchFn);
+		expect(result.findings[0]!.detail).toContain('BlackVeil-Security-Scanner');
+	});
+
+	it('records the abstention machine-readably rather than only in prose', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'blanket');
+		};
+		const result = await checkHTTPSecurity('crt.sh', fetchFn);
+		const meta = result.findings[0]!.metadata ?? {};
+		expect(meta.notAssessedReason).toBe('robots_disallowed');
+		expect(meta.robotsScope).toBe('blanket');
+		expect(meta.confidence).toBe('deterministic');
+	});
 });

--- a/packages/dns-checks/src/__tests__/checks/check-ssl-robots.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-ssl-robots.test.ts
@@ -17,6 +17,39 @@ describe('checkSSL — robots.txt disallow', () => {
 		expect(result.controlPresent).toBeUndefined();
 	});
 
+	it('does not accuse a site of naming us when its robots.txt blocks every crawler', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'blanket');
+		};
+		const result = await checkSSL('crt.sh', fetchFn);
+		const detail = result.findings[0]!.detail;
+		expect(detail).not.toContain('BlackVeil-Security-Scanner');
+		expect(detail).toContain('all automated crawlers');
+	});
+
+	it('says so plainly when a site does name us', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'named');
+		};
+		const result = await checkSSL('example.com', fetchFn);
+		expect(result.findings[0]!.detail).toContain('BlackVeil-Security-Scanner');
+	});
+
+	it('records the abstention machine-readably rather than only in prose', async () => {
+		const fetchFn = async (url: string) => {
+			throw new RobotsDisallowedError(url, 'blanket');
+		};
+		const result = await checkSSL('crt.sh', fetchFn);
+		const meta = result.findings[0]!.metadata ?? {};
+		// A consumer must be able to tell "we chose not to look" from "the probe broke"
+		// without string-matching the detail copy.
+		expect(meta.notAssessedReason).toBe('robots_disallowed');
+		expect(meta.robotsScope).toBe('blanket');
+		// Pinned explicitly so `inferFindingConfidence`'s prose keyword scan can never
+		// reclassify this finding as a side effect of a copy edit.
+		expect(meta.confidence).toBe('deterministic');
+	});
+
 	it('does not call the HTTP-redirect check when the HTTPS fetch was robots-disallowed', async () => {
 		let redirectFetchCalled = false;
 		const fetchFn = async (url: string) => {

--- a/packages/dns-checks/src/checks/check-bimi.ts
+++ b/packages/dns-checks/src/checks/check-bimi.ts
@@ -11,7 +11,7 @@
 
 import type { CheckResult, DNSQueryFunction, FetchFunction, Finding } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
-import { RobotsDisallowedError } from '../robots-gate';
+import { RobotsDisallowedError, describeRobotsScope, robotsAbstentionMetadata } from '../robots-gate';
 import { isNoSendPolicy } from './spf-analysis';
 
 /** BIMI logo fetch timeout (ms). */
@@ -162,7 +162,8 @@ async function validateBimiSvg(logoUrl: string, fetchFn: FetchFunction, timeout:
 					'bimi',
 					'BIMI logo not independently validated (robots.txt)',
 					'info',
-					`${logoUrl} could not be fetched: the domain's robots.txt disallows BlackVeil-Security-Scanner. The BIMI record itself is still validated from DNS; only the logo file's own contents were not checked.`,
+					`${logoUrl} could not be fetched: the domain's robots.txt ${describeRobotsScope(err.scope)}. The BIMI record itself is still validated from DNS; only the logo file's own contents were not checked.`,
+					robotsAbstentionMetadata(err.scope),
 				),
 			);
 			return findings;

--- a/packages/dns-checks/src/checks/check-http-security.ts
+++ b/packages/dns-checks/src/checks/check-http-security.ts
@@ -5,7 +5,12 @@
 import type { CheckResult, FetchFunction, Finding } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
 import { analyzeSecurityHeaders } from './http-security-analysis';
-import { SCANNER_USER_AGENT, RobotsDisallowedError } from '../robots-gate';
+import {
+	SCANNER_USER_AGENT,
+	RobotsDisallowedError,
+	describeRobotsScope,
+	robotsAbstentionMetadata,
+} from '../robots-gate';
 
 /** Default HTTPS timeout (ms) */
 const HTTPS_TIMEOUT_MS = 4_000;
@@ -219,7 +224,8 @@ export async function checkHTTPSecurity(
 					'http_security',
 					'HTTP security check skipped (robots.txt)',
 					'info',
-					`${domain}'s robots.txt disallows BlackVeil-Security-Scanner, so HTTP security headers could not be independently verified. Not scored — see https://www.blackveilsecurity.com/bot-policy.`,
+					`${domain}'s robots.txt ${describeRobotsScope(err.scope)}, so HTTP security headers could not be independently verified. Not scored — see https://www.blackveilsecurity.com/bot-policy.`,
+					robotsAbstentionMetadata(err.scope),
 				),
 			);
 		} else {

--- a/packages/dns-checks/src/checks/check-ssl.ts
+++ b/packages/dns-checks/src/checks/check-ssl.ts
@@ -121,7 +121,7 @@ async function checkHttps(
 	} catch (err) {
 		if (err instanceof RobotsDisallowedError) {
 			return {
-				findings: [getRobotsDisallowedFinding(domain)],
+				findings: [getRobotsDisallowedFinding(domain, err.scope)],
 				reachable: undefined,
 				robotsDisallowed: true,
 			};

--- a/packages/dns-checks/src/checks/ssl-analysis.ts
+++ b/packages/dns-checks/src/checks/ssl-analysis.ts
@@ -10,6 +10,8 @@
 
 import type { Finding } from '../types';
 import { createFinding } from '../check-utils';
+import type { RobotsDisallowScope } from '../robots-gate';
+import { describeRobotsScope, robotsAbstentionMetadata } from '../robots-gate';
 
 export function getHttpsFindings(domain: string, responseUrl: string | undefined, hstsHeader: string | null): Finding[] {
 	const findings: Finding[] = [];
@@ -89,12 +91,13 @@ export function getHttpsErrorFinding(domain: string, message: string): Finding {
  * scanner — distinct from `getHttpsErrorFinding`, which implies a real
  * connectivity/certificate problem. This is never a security weakness.
  */
-export function getRobotsDisallowedFinding(domain: string): Finding {
+export function getRobotsDisallowedFinding(domain: string, scope: RobotsDisallowScope = 'blanket'): Finding {
 	return createFinding(
 		'ssl',
 		'HTTPS check skipped (robots.txt)',
 		'info',
-		`${domain}'s robots.txt disallows BlackVeil-Security-Scanner, so HTTPS/HSTS could not be independently verified. Not scored — see https://www.blackveilsecurity.com/bot-policy.`,
+		`${domain}'s robots.txt ${describeRobotsScope(scope)}, so HTTPS/HSTS could not be independently verified. Not scored — see https://www.blackveilsecurity.com/bot-policy.`,
+		robotsAbstentionMetadata(scope),
 	);
 }
 

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -38,7 +38,13 @@ export { isGraded } from './scoring/engine';
 export { createFinding, buildCheckResult, computeCategoryScore, inferFindingConfidence, sanitizeDnsData } from './check-utils';
 
 // Robot policy
-export { SCANNER_USER_AGENT, RobotsDisallowedError, withRobotsGate } from './robots-gate';
+export {
+	SCANNER_USER_AGENT,
+	RobotsDisallowedError,
+	withRobotsGate,
+	describeRobotsScope,
+	robotsAbstentionMetadata,
+} from './robots-gate';
 export type { RobotsDisallowScope } from './robots-gate';
 
 // DKIM selector probe list. Exported so downstream consumers can assert provider

--- a/packages/dns-checks/src/robots-gate.ts
+++ b/packages/dns-checks/src/robots-gate.ts
@@ -46,6 +46,39 @@ export class RobotsDisallowedError extends Error {
 	}
 }
 
+/**
+ * The clause a finding uses to describe WHO a robots.txt block applies to.
+ * Kept here, next to the scope it renders, so the three checks that abstain on
+ * a robots block cannot drift into three different accounts of the same fact.
+ */
+export function describeRobotsScope(scope: RobotsDisallowScope): string {
+	return scope === 'named'
+		? 'disallows BlackVeil-Security-Scanner by name'
+		: 'disallows all automated crawlers';
+}
+
+/**
+ * Metadata stamped on every finding produced by a robots.txt abstention.
+ *
+ * `notAssessedReason` exists because `checkStatus` cannot express this: its
+ * union is `'completed' | 'timeout' | 'error'`, so a deliberate, polite
+ * abstention is reported with the same token as a probe that genuinely broke.
+ * Widening that union is a breaking change for downstream consumers (which
+ * compare it by equality and cast it into their own unions), so the
+ * distinction is carried additively here instead.
+ *
+ * `confidence` is pinned rather than left to `inferFindingConfidence`, whose
+ * fallback classifies a finding by keyword-scanning its own title and detail —
+ * a copy edit must never be able to silently reclassify an abstention.
+ */
+export function robotsAbstentionMetadata(scope: RobotsDisallowScope): {
+	notAssessedReason: 'robots_disallowed';
+	robotsScope: RobotsDisallowScope;
+	confidence: 'deterministic';
+} {
+	return { notAssessedReason: 'robots_disallowed', robotsScope: scope, confidence: 'deterministic' };
+}
+
 interface RobotsRule {
 	path: string;
 	allow: boolean;


### PR DESCRIPTION
> **Stacked on #742.** Base is `fix/robots-blanket-vs-named-attribution`, not `main` — retarget to `main` after #742 merges.

## What

Three checks abstain when a target's robots.txt blocks us — `ssl`, `http_security`, `bimi`. Each said, verbatim, that the site "disallows BlackVeil-Security-Scanner", and each carried nothing a consumer could read except that sentence. Two problems follow.

### 1. The copy inherited the misattribution #742 fixes

These strings are what reach a customer-facing report, so a site with an ordinary blanket `User-agent: *` policy was described there as having singled out BlackVeil. All three now render `describeRobotsScope(err.scope)`.

### 2. The abstention was not machine-readable

`CheckStatus` is `'completed' | 'timeout' | 'error'`. There is no member meaning *"we deliberately did not look"*, so a polite opt-out is reported with the same token as a probe that genuinely broke — a consumer cannot tell them apart without string-matching the detail copy.

Widening that union is a **breaking change for downstream consumers**, so this PR does not do it:

| Consumer | Code | Why widening breaks it |
|---|---|---|
| bv-web-prod `shared/lib/scan/scan-engine.server.ts:406` | `(r.checkStatus ?? 'completed') as ScanCheckStatus` | casts an unknown member straight into its own union |
| bv-web-prod `shared/lib/mcp-scan/score.ts:45` | `if (r.checkStatus === 'error' ...)` | equality test — a new member silently slips past |

Instead the distinction is recorded **additively**: `metadata.notAssessedReason: 'robots_disallowed'` and `metadata.robotsScope`. Scoring is untouched — the category is still excluded via `checkStatus`, and `isCheckMeasured` remains an allowlist (`undefined || 'completed'`), so nothing new can slip into a score.

## Also: `confidence` is now pinned, not inferred

`inferFindingConfidence`'s fallback classifies a finding by **keyword-scanning its own title and detail**. An abstention's classification must not be a function of its wording — this repo has already shipped one defect where finding prose outranked structured metadata. These findings now declare `confidence` explicitly, so a copy edit cannot silently reclassify them.

The shared clause and metadata live in `robots-gate.ts` next to the scope they describe, so the three call sites cannot drift into three accounts of one fact.

## Verification

- `packages/dns-checks`: **840/840 green** (9 new tests, all written failing first — 6 failed for the right reasons before the fix).
- `tsc --noEmit` clean; `eslint` clean on all six changed source files.
- Root suite (run against built `dist/`, per this repo's two-test-tree split): 643 passed, **2 failed — both pre-existing and unrelated**:
  - `test/wasm-integration.test.ts` — needs `crates/bv-wasm-core/pkg`, gitignored at `.gitignore:18` and therefore absent from any fresh worktree.
  - `test/queue-batch-analytics.spec.ts` — times out under full-suite parallelism, **passes 3/3 in isolation**.
  - Neither file references `robots`, `checkSSL`, `checkHTTPSecurity`, or `checkBIMI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)