### PR TITLE
fix(discover-subdomains): read the cache BEFORE spending CT quota

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1681,8 +1681,11 @@ export async function handleToolsCall(
 						deadlineMs: Date.now() + DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS,
 						...(forceRefresh && { forceRefresh }),
 						...(runtimeOptions?.certspotterToken && { certspotterToken: runtimeOptions.certspotterToken }),
-						// Last-known-good resilience cache: a clean enumeration is stored here
-						// and re-served (marked stale) when every live CT source is down.
+						// Subdomain cache, doing two jobs off one entry: inside the fresh
+						// window it answers the call outright (marked `cached`, no upstream
+						// query — this is what keeps us inside CertSpotter's 10/hr
+						// full-domain quota); past it, it is the last-known-good net
+						// re-served (marked `stale`) when every live CT source is down.
 						...(scanCacheKV && { cacheKv: scanCacheKV }),
 						...(runtimeOptions?.waitUntil && { waitUntil: runtimeOptions.waitUntil }),
 					});
@@ -1692,6 +1695,10 @@ export async function handleToolsCall(
 						issues: result.issues.length,
 						sourceUnavailable: result.sourceUnavailable ?? false,
 						stale: result.stale ?? false,
+						// Cache-hit rate is the metric this quota fix is judged on — without
+						// it in tail there is no way to tell a working fresh-read cache from
+						// one that silently never hits.
+						cached: result.cached ?? false,
 						// #573: an under-reported enumeration must be visible in tail, not
 						// just in the payload — a rising truncated-rate is the alarm for a
 						// CT source that has quietly started capping us.
@@ -1705,7 +1712,7 @@ export async function handleToolsCall(
 						// consulted — is now visible in tail, not just in the payload.
 						coverageDegraded: result.coverage?.degraded ?? false,
 						...(result.sources ? { sources: result.sources.join(',') } : {}),
-						...(result.stale ? { cacheAgeMinutes: result.cacheAgeMinutes ?? 0 } : {}),
+						...(result.stale || result.cached ? { cacheAgeMinutes: result.cacheAgeMinutes ?? 0 } : {}),
 					};
 					// A CT-source outage (sourceUnavailable) is NOT a clean "0 subdomains found" — for a
 					// security tool the two are dangerously indistinguishable. Surface it as a failed/

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -10,11 +10,15 @@
  * certificate issuance.
  *
  * Source resilience (a CT outage must not read as "no subdomains"):
+ *   0. fresh KV cache hit, returned marked `cached` — no upstream call at all,
+ *      because a recent enumeration is the answer rather than a fallback and
+ *      re-querying only spends scarce provider quota, then
  *   1. bv-certstream-worker binding (fast, cached) when present, then
  *   2. direct public sources in order — crt.sh → Certspotter — each with a
  *      bounded retry and a per-source `ct_source` health log, then
  *   3. last-known-good KV cache, returned marked `stale` with its age.
  * Only when all of the above are exhausted do we report `sourceUnavailable`.
+ * Steps 0 and 3 read the SAME entry; only its age decides which job it does.
  *
  * COMPLETENESS HONESTY (this is a SAMPLE, never an inventory):
  * The result carries a `coverage` record whose `basis` is the literal
@@ -102,6 +106,29 @@ const CT_SOURCE_MAX_BODY_BYTES = 5 * 1024 * 1024;
  */
 const SUBDOMAIN_LKG_KEY_PREFIX = 'cache:subdomains-lkg:';
 const SUBDOMAIN_LKG_TTL_SECONDS = 7 * 24 * 60 * 60;
+
+/**
+ * Fresh-read window: how long a cached enumeration is served DIRECTLY, with no
+ * live CT query at all.
+ *
+ * The same KV entry backs two different jobs. Beyond this window it is only an
+ * outage net (served `stale`, above). Inside it, it is the answer — because
+ * re-querying is a pure quota spend for information that has not changed.
+ *
+ * Why this matters more than it looks: CertSpotter's free "Small" tier meters
+ * full-domain queries (`include_subdomains=true`) at **10 per HOUR per account**,
+ * and that account is shared with bv2-certstream, which already consumes ~6/hr
+ * on its 10-minute cron. Before this window existed, every repeat scan of the
+ * same domain spent one of the remaining ~4 — so a handful of re-scans could
+ * exhaust discovery for the whole estate while returning identical data.
+ *
+ * One hour is chosen against the data's own update rate, not arbitrarily: CT
+ * logs lag issuance by minutes to hours (a CA's SCT merge delay), so a shorter
+ * window mostly re-reads the same snapshot at full quota cost. `force_refresh`
+ * bypasses this entirely for a caller that needs a guaranteed-live read, and the
+ * outage fallback is unaffected.
+ */
+const SUBDOMAIN_FRESH_TTL_SECONDS = 60 * 60;
 
 /**
  * Maximum subdomains carried in the STRUCTURED result (CT logs can contain
@@ -282,7 +309,21 @@ export interface SubdomainDiscoveryResult {
 	 * judge freshness. `sourceUnavailable` stays false here (we DO have data).
 	 */
 	stale?: boolean;
-	/** Age of a `stale` result in whole minutes since it was cached. */
+	/**
+	 * True when this result was served from a cache entry that is still inside the
+	 * fresh-read window ({@link SUBDOMAIN_FRESH_TTL_SECONDS}) — no live CT source
+	 * was consulted on this call, and none needed to be.
+	 *
+	 * DISTINCT from {@link stale} on purpose. `stale` means "every live source was
+	 * unreachable and this is the best we have", i.e. a degraded answer a consumer
+	 * may want to warn about. `cached` is a healthy hit on current data. Folding
+	 * the two into one boolean would make every quota-saving hit read as an
+	 * outage — the same class of mistake as reporting an unmeasured signal as a
+	 * measured `false`. Pair with {@link cacheAgeMinutes} to judge freshness, and
+	 * note {@link coverage} describes the call that CACHED the data, not this one.
+	 */
+	cached?: boolean;
+	/** Age of a `stale` or `cached` result in whole minutes since it was cached. */
 	cacheAgeMinutes?: number;
 	/**
 	 * True when this result is NOT the whole story — either the returned
@@ -436,6 +477,15 @@ export async function discoverSubdomains(
 	// this the orchestrator forgets the fast path ran at all, and `buildCtCoverage`
 	// reports the dead binding as "not consulted on this call" (#738).
 	const certstreamAttempts: CtSourceAttempt[] = [];
+
+	// Fresh-read cache, BEFORE any upstream call — including the certstream
+	// binding. A recent enumeration is the answer, not a fallback, so re-querying
+	// spends scarce CertSpotter full-domain quota (10/hr/account, shared with
+	// bv2-certstream) for data we already hold. `force_refresh` opts out.
+	if (!options?.forceRefresh) {
+		const cached = await readFreshCache(domain, options);
+		if (cached) return cached;
+	}
 
 	// Fast path: certstream service binding (bv-certstream-worker; itself
 	// multi-source + short-cached). On a clean result, prime the LKG cache.
@@ -1126,7 +1176,7 @@ function subdomainLkgKey(domain: string): string {
 
 /** Strip transient/served-state flags so the cached copy is a clean answer. */
 function stripTransientFlags(result: SubdomainDiscoveryResult): SubdomainDiscoveryResult {
-	const { stale: _stale, cacheAgeMinutes: _age, sourceUnavailable: _unavail, partial: _partial, ...clean } = result;
+	const { stale: _stale, cached: _cached, cacheAgeMinutes: _age, sourceUnavailable: _unavail, partial: _partial, ...clean } = result;
 	return clean;
 }
 
@@ -1137,7 +1187,10 @@ function stripTransientFlags(result: SubdomainDiscoveryResult): SubdomainDiscove
  */
 async function cacheSuccess(domain: string, result: SubdomainDiscoveryResult, options?: DiscoverSubdomainsOptions): Promise<void> {
 	if (!options?.cacheKv) return;
-	if (result.sourceUnavailable || result.partial || result.stale) return;
+	// `cached` joins this list so a cache hit can never be written back over
+	// itself, which would refresh `cachedAt` without a live read and let one
+	// enumeration be served as "fresh" indefinitely.
+	if (result.sourceUnavailable || result.partial || result.stale || result.cached) return;
 	// An empty enumeration is a worthless fallback: re-serving "0 subdomains
 	// (stale)" during an outage tells the caller nothing the explicit outage
 	// error doesn't, and invites reading it as a confirmed empty.
@@ -1156,6 +1209,24 @@ async function cacheSuccess(domain: string, result: SubdomainDiscoveryResult, op
  * is no cache / KV is absent / the read fails.
  */
 async function readLastKnownGood(domain: string, options?: DiscoverSubdomainsOptions): Promise<SubdomainDiscoveryResult | null> {
+	const loaded = await loadCacheEntry(domain, options);
+	if (!loaded) return null;
+	return {
+		...stripTransientFlags(loaded.result),
+		stale: true,
+		cacheAgeMinutes: Math.floor(loaded.ageMs / 60_000),
+	};
+}
+
+/**
+ * Load and age the cache entry, or null when KV is absent / empty / unreadable.
+ * Shared by the fresh-read and last-known-good paths so they cannot disagree
+ * about the stored shape or about how age is computed.
+ */
+async function loadCacheEntry(
+	domain: string,
+	options?: DiscoverSubdomainsOptions,
+): Promise<{ result: SubdomainDiscoveryResult; ageMs: number } | null> {
 	if (!options?.cacheKv) return null;
 	let entry: SubdomainLkgEntry | undefined;
 	try {
@@ -1165,11 +1236,26 @@ async function readLastKnownGood(domain: string, options?: DiscoverSubdomainsOpt
 	}
 	if (!entry || !entry.result) return null;
 	const cachedAt = typeof entry.cachedAt === 'number' ? entry.cachedAt : Date.now();
-	const ageMs = Math.max(0, Date.now() - cachedAt);
+	return { result: entry.result, ageMs: Math.max(0, Date.now() - cachedAt) };
+}
+
+/**
+ * Read a cache entry that is still inside the fresh window, so the call can be
+ * answered without spending a live CT query. Returns null when there is no
+ * entry, KV is absent, or the entry has aged past {@link
+ * SUBDOMAIN_FRESH_TTL_SECONDS} — in which case the caller proceeds to the live
+ * sources and the entry survives as the outage net.
+ *
+ * Marked `cached`, never `stale`: this is current data, not a degraded fallback.
+ */
+async function readFreshCache(domain: string, options?: DiscoverSubdomainsOptions): Promise<SubdomainDiscoveryResult | null> {
+	const loaded = await loadCacheEntry(domain, options);
+	if (!loaded) return null;
+	if (loaded.ageMs > SUBDOMAIN_FRESH_TTL_SECONDS * 1000) return null;
 	return {
-		...stripTransientFlags(entry.result),
-		stale: true,
-		cacheAgeMinutes: Math.floor(ageMs / 60_000),
+		...stripTransientFlags(loaded.result),
+		cached: true,
+		cacheAgeMinutes: Math.floor(loaded.ageMs / 60_000),
 	};
 }
 
@@ -1625,6 +1711,7 @@ export function formatSubdomainDiscovery(result: SubdomainDiscoveryResult, forma
 	// something visibly went wrong is the same false confidence in a new place.
 	banners.push(sampleBanner(result));
 	if (result.stale) banners.push(staleBanner(result));
+	else if (result.cached) banners.push(cachedBanner(result));
 	// Distinct from `stale` (served from the last-known-good cache): `partial`
 	// here means a live source answered but timed out mid-query, so the data
 	// shown is real but the enumeration may be incomplete. Skip when `stale`
@@ -1648,6 +1735,19 @@ function sampleBanner(result: SubdomainDiscoveryResult): string {
 		return `ℹ️ CT SAMPLE — NOT AN INVENTORY: ${result.totalSubdomains} is a LOWER BOUND. A host that has never had a publicly-logged certificate does not appear in Certificate Transparency at all.`;
 	}
 	return `ℹ️ CT SAMPLE — NOT AN INVENTORY: ${result.coverage.caveat}\n${formatCoverageLine(result.coverage)}`;
+}
+
+/**
+ * Cache notice for a result served inside the fresh-read window.
+ *
+ * Deliberately NOT the staleness banner: nothing is degraded here and no source
+ * is down, so the wording must not imply an outage. What the caller does need to
+ * know is that this is a snapshot with an age, and how to force a live read.
+ */
+function cachedBanner(result: SubdomainDiscoveryResult): string {
+	const age = result.cacheAgeMinutes ?? 0;
+	const ageText = age < 1 ? 'less than a minute' : `${age} minute${age === 1 ? '' : 's'}`;
+	return `ℹ️ CACHED (${ageText} old): served from a recent Certificate Transparency enumeration rather than a new query. Pass \`force_refresh\` for a guaranteed-live read.`;
 }
 
 /** Staleness notice prepended when a result came from the last-known-good cache. */

--- a/test/discover-subdomains-resilience.spec.ts
+++ b/test/discover-subdomains-resilience.spec.ts
@@ -19,9 +19,9 @@ const { restore } = setupFetchMock();
 afterEach(() => restore());
 
 /**
- * Minimal in-memory KV mock (get/put/delete) sufficient for the LKG cache.
- * Cast to KVNamespace at the call site (codebase idiom) to avoid depending on
- * the ambient worker-types resolution in this spec file.
+ * Minimal in-memory KV mock (get/put/delete) sufficient for the subdomain cache.
+ * The module under test uses only those three methods; `list` and
+ * `getWithMetadata` are deliberately not implemented.
  */
 function makeKv() {
 	const store = new Map<string, string>();
@@ -39,6 +39,18 @@ function makeKv() {
 			store.delete(key);
 		},
 	};
+}
+
+/**
+ * Widen the mock to the full `KVNamespace` surface for the call sites.
+ *
+ * Done ONCE here rather than at each call site: this file previously carried 10
+ * standing TS2739 errors from passing the bare mock, tracked by the
+ * `typecheck:tests` ratchet. One documented widening in one place drops that
+ * count to zero instead of growing it with every new spec.
+ */
+function asKv(kv: ReturnType<typeof makeKv>): KVNamespace {
+	return kv as unknown as KVNamespace;
 }
 
 /**
@@ -167,7 +179,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			if (s.includes('crt.sh')) return Response.json([crtEntry('api.example.com'), crtEntry('vpn.example.com')], { status: 200 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		const fresh = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const fresh = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 		expect(fresh.subdomains.map((s) => s.subdomain).sort()).toEqual(['api.example.com', 'vpn.example.com']);
 		expect(kv.store.size).toBeGreaterThan(0);
 
@@ -181,7 +193,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		const stale = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const stale = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(stale.stale).toBe(true);
 		expect(stale.sourceUnavailable).toBeFalsy();
@@ -198,7 +210,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
 
-		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(result.sourceUnavailable).toBe(true);
 		expect(result.stale).toBeFalsy();
@@ -253,14 +265,14 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			if (s.includes('crt.sh')) return Response.json([crtEntry('api.example.com')], { status: 200 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
 			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
 			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv, forceRefresh: true });
+		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv), forceRefresh: true });
 
 		expect(result.stale).toBe(true);
 		expect(result.subdomains.map((s) => s.subdomain)).toEqual(['api.example.com']);
@@ -302,7 +314,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			if (s.includes('crt.sh')) return Response.json([crtEntry('api.example.com')], { status: 200 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		// Past the fresh window, so the entry is an outage net rather than the
 		// answer — otherwise the fresh-read path would satisfy this call before the
@@ -311,7 +323,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 
 		// Budget already blown (e.g. the certstream fast path consumed all of it):
 		// a KV read is still affordable, so we must return data, not an error.
-		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv, deadlineMs: Date.now() - 1 });
+		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv), deadlineMs: Date.now() - 1 });
 
 		expect(result.stale).toBe(true);
 		expect(result.partial).toBe(true);
@@ -352,7 +364,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
 
-		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const result = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(result.sourceUnavailable).toBeFalsy();
 		// An empty result is a weak fallback: re-serving "0 subdomains (stale)" is no
@@ -370,7 +382,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			if (s.includes('crt.sh')) return Response.json([crtEntry('api.example.com')], { status: 200 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 		const afterSeed = kv.store.get([...kv.store.keys()][0]);
 
 		// Outage: must NOT clobber the cached good set with an empty/unavailable one.
@@ -379,7 +391,7 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(kv.store.get([...kv.store.keys()][0])).toBe(afterSeed);
 	});
@@ -457,7 +469,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 			if (s.includes('crt.sh')) return Response.json([crtEntry('api.example.com'), crtEntry('vpn.example.com')], { status: 200 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
-		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 		expect(kv.store.size).toBeGreaterThan(0);
 	}
 
@@ -475,7 +487,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 		});
 		globalThis.fetch = spy;
 
-		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(ctFetchCount(spy)).toBe(0);
 		expect(hit.subdomains.map((s) => s.subdomain).sort()).toEqual(['api.example.com', 'vpn.example.com']);
@@ -486,7 +498,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 		const kv = makeKv();
 		await prime(kv);
 
-		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		// `stale` is documented as "every live CT source was unreachable". A healthy
 		// cache hit is not an outage, and a consumer branching on `stale` to warn
@@ -510,7 +522,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 		});
 		globalThis.fetch = spy;
 
-		const refreshed = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const refreshed = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(ctFetchCount(spy)).toBeGreaterThan(0);
 		expect(refreshed.cached).toBeFalsy();
@@ -530,7 +542,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 		});
 		globalThis.fetch = spy;
 
-		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(ctFetchCount(spy)).toBe(0);
 		expect(hit.cached).toBe(true);
@@ -548,7 +560,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 		});
 		globalThis.fetch = spy;
 
-		const forced = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv, forceRefresh: true });
+		const forced = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv), forceRefresh: true });
 
 		expect(ctFetchCount(spy)).toBeGreaterThan(0);
 		expect(forced.cached).toBeFalsy();
@@ -587,7 +599,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 		});
 		globalThis.fetch = spy;
 
-		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv, deadlineMs: Date.now() - 1 });
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv), deadlineMs: Date.now() - 1 });
 
 		expect(ctFetchCount(spy)).toBe(0);
 		expect(hit.cached).toBe(true);
@@ -608,7 +620,7 @@ describe('discoverSubdomains — fresh-read cache', () => {
 		});
 		globalThis.fetch = spy;
 
-		const other = await discoverSubdomains('other.com', undefined, undefined, { cacheKv: kv });
+		const other = await discoverSubdomains('other.com', undefined, undefined, { cacheKv: asKv(kv) });
 
 		expect(ctFetchCount(spy)).toBeGreaterThan(0);
 		expect(other.cached).toBeFalsy();

--- a/test/discover-subdomains-resilience.spec.ts
+++ b/test/discover-subdomains-resilience.spec.ts
@@ -41,6 +41,39 @@ function makeKv() {
 	};
 }
 
+/**
+ * Mirror of `SUBDOMAIN_FRESH_TTL_SECONDS` in the module under test. Kept as a
+ * local literal ON PURPOSE: importing the constant would make these specs agree
+ * with the implementation by construction, so a bad TTL edit could never fail
+ * them. If this drifts, the `honours the configured fresh window` test fails —
+ * which is the intended alarm, not a nuisance.
+ */
+const FRESH_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Backdate every cached entry by `ms`, simulating the passage of time without
+ * fake timers (which fight the async fetch mocks in this suite). Operates on the
+ * raw JSON so it stays honest about the on-disk shape.
+ */
+function advanceCacheAge(kv: ReturnType<typeof makeKv>, ms: number) {
+	for (const [key, raw] of kv.store) {
+		const entry = JSON.parse(raw) as { cachedAt?: number };
+		if (typeof entry.cachedAt === 'number') {
+			entry.cachedAt -= ms;
+			kv.store.set(key, JSON.stringify(entry));
+		}
+	}
+}
+
+/** Count CT-source fetches only — the suite's mock also answers DoH lookups. */
+function ctFetchCount(mock: ReturnType<typeof vi.fn>): number {
+	return mock.mock.calls.filter((c) => {
+		const u = c[0];
+		const s = typeof u === 'string' ? u : u instanceof URL ? u.toString() : String((u as Request)?.url ?? '');
+		return s.includes('crt.sh') || s.includes('certspotter.com');
+	}).length;
+}
+
 /** A crt.sh JSON entry for one cert. */
 function crtEntry(name: string) {
 	return { name_value: name, issuer_name: "CN=R3, O=Let's Encrypt", not_before: '2026-02-01', not_after: '2026-05-01' };
@@ -48,7 +81,13 @@ function crtEntry(name: string) {
 
 /** A Certspotter issuance object (expand=dns_names,issuer). */
 function certspotterEntry(names: string[]) {
-	return { id: '1', dns_names: names, not_before: '2026-02-01', not_after: '2026-05-01', issuer: { name: "C=US, O=Let's Encrypt, CN=R11" } };
+	return {
+		id: '1',
+		dns_names: names,
+		not_before: '2026-02-01',
+		not_after: '2026-05-01',
+		issuer: { name: "C=US, O=Let's Encrypt, CN=R11" },
+	};
 }
 
 describe('discoverSubdomains — multi-source resilience', () => {
@@ -62,7 +101,8 @@ describe('discoverSubdomains — multi-source resilience', () => {
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
 			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
 			if (s.includes('crt.sh')) return Response.json({}, { status: 500 });
-			if (s.includes('certspotter.com')) return Response.json([certspotterEntry(['api.example.com', 'secure.example.com'])], { status: 200 });
+			if (s.includes('certspotter.com'))
+				return Response.json([certspotterEntry(['api.example.com', 'secure.example.com'])], { status: 200 });
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
 
@@ -130,6 +170,10 @@ describe('discoverSubdomains — multi-source resilience', () => {
 		const fresh = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
 		expect(fresh.subdomains.map((s) => s.subdomain).sort()).toEqual(['api.example.com', 'vpn.example.com']);
 		expect(kv.store.size).toBeGreaterThan(0);
+
+		// Age the entry out of the fresh-read window, or the second call would be
+		// served from cache and never reach the (failing) sources this test is about.
+		advanceCacheAge(kv, FRESH_TTL_MS + 60_000);
 
 		// Second call: every source fails → must serve the cached set marked stale.
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
@@ -229,7 +273,9 @@ describe('discoverSubdomains — multi-source resilience', () => {
 				domain: 'example.com',
 				totalSubdomains: 1,
 				totalCertificates: 1,
-				subdomains: [{ subdomain: 'api.example.com', firstSeen: '', lastSeen: '', issuer: '', certCount: 1, isWildcard: false, isExpired: false }],
+				subdomains: [
+					{ subdomain: 'api.example.com', firstSeen: '', lastSeen: '', issuer: '', certCount: 1, isWildcard: false, isExpired: false },
+				],
 				wildcardCerts: 0,
 				expiredCerts: 0,
 				uniqueIssuers: [],
@@ -257,6 +303,11 @@ describe('discoverSubdomains — multi-source resilience', () => {
 			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
 		});
 		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+
+		// Past the fresh window, so the entry is an outage net rather than the
+		// answer — otherwise the fresh-read path would satisfy this call before the
+		// deadline gate is ever reached (covered separately below).
+		advanceCacheAge(kv, FRESH_TTL_MS + 60_000);
 
 		// Budget already blown (e.g. the certstream fast path consumed all of it):
 		// a KV read is still affordable, so we must return data, not an error.
@@ -313,7 +364,6 @@ describe('discoverSubdomains — multi-source resilience', () => {
 		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
 		const kv = makeKv();
 
-
 		// Seed cache with a good result.
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
 			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
@@ -360,6 +410,10 @@ describe('discover_subdomains handler — LKG cache wiring', () => {
 		expect(fresh.isError).toBeFalsy();
 		expect(kv.store.size).toBeGreaterThan(0);
 
+		// Past the fresh-read window, so this exercises the outage path and not
+		// the cache-hit path (which has its own coverage below).
+		advanceCacheAge(kv, FRESH_TTL_MS + 60_000);
+
 		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
 			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
 			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
@@ -372,5 +426,192 @@ describe('discover_subdomains handler — LKG cache wiring', () => {
 		const payload = stale.structuredContent as Record<string, unknown> | undefined;
 		expect(payload?.stale).toBe(true);
 		expect(payload?.sourceUnavailable).toBeFalsy();
+	});
+});
+
+/**
+ * Fresh-read cache (quota conservation).
+ *
+ * The LKG cache was written on every success but READ only on total-outage or
+ * deadline-trip, so a repeat scan of the same domain always spent a live query.
+ * On CertSpotter's free "Small" tier that bucket is 10 full-domain queries/HOUR,
+ * shared account-wide with bv2-certstream — so five scans of one domain could
+ * exhaust half the estate's daily discovery budget for zero new information.
+ *
+ * These specs pin the fix: inside the fresh window a cached answer is served
+ * with ZERO upstream CT calls, and it is labelled `cached` (never `stale`, which
+ * means "every live source was unreachable" and would misreport a healthy hit
+ * as an outage).
+ */
+describe('discoverSubdomains — fresh-read cache', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	/** Prime the cache with one successful crt.sh enumeration. */
+	async function prime(kv: ReturnType<typeof makeKv>) {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([crtEntry('api.example.com'), crtEntry('vpn.example.com')], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+		expect(kv.store.size).toBeGreaterThan(0);
+	}
+
+	it('serves a repeat scan from cache without spending ANY upstream CT query', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		await prime(kv);
+
+		// Any CT call in this window is a quota spend the fix exists to prevent,
+		// so the sources are wired to throw rather than merely to fail.
+		const spy = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) throw new Error('quota spent on a cache-hit path');
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		globalThis.fetch = spy;
+
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+
+		expect(ctFetchCount(spy)).toBe(0);
+		expect(hit.subdomains.map((s) => s.subdomain).sort()).toEqual(['api.example.com', 'vpn.example.com']);
+	});
+
+	it('labels a cache hit `cached` and NOT `stale`, with an age', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		await prime(kv);
+
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+
+		// `stale` is documented as "every live CT source was unreachable". A healthy
+		// cache hit is not an outage, and a consumer branching on `stale` to warn
+		// about degraded data must not fire here.
+		expect(hit.cached).toBe(true);
+		expect(hit.stale).toBeFalsy();
+		expect(hit.sourceUnavailable).toBeFalsy();
+		expect(typeof hit.cacheAgeMinutes).toBe('number');
+	});
+
+	it('honours the configured fresh window — an older entry goes back to the network', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		await prime(kv);
+		advanceCacheAge(kv, FRESH_TTL_MS + 60_000);
+
+		const spy = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([crtEntry('new.example.com')], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		globalThis.fetch = spy;
+
+		const refreshed = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+
+		expect(ctFetchCount(spy)).toBeGreaterThan(0);
+		expect(refreshed.cached).toBeFalsy();
+		expect(refreshed.subdomains.map((s) => s.subdomain)).toEqual(['new.example.com']);
+	});
+
+	it('an entry just INSIDE the window is still served from cache (boundary control)', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		await prime(kv);
+		advanceCacheAge(kv, FRESH_TTL_MS - 60_000);
+
+		const spy = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) throw new Error('should not be reached');
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		globalThis.fetch = spy;
+
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv });
+
+		expect(ctFetchCount(spy)).toBe(0);
+		expect(hit.cached).toBe(true);
+	});
+
+	it('force_refresh bypasses the fresh cache and queries live sources', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		await prime(kv);
+
+		const spy = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([crtEntry('forced.example.com')], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		globalThis.fetch = spy;
+
+		const forced = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv, forceRefresh: true });
+
+		expect(ctFetchCount(spy)).toBeGreaterThan(0);
+		expect(forced.cached).toBeFalsy();
+		expect(forced.subdomains.map((s) => s.subdomain)).toEqual(['forced.example.com']);
+	});
+
+	it('without a cacheKv every call still queries live sources (control)', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const spy = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([crtEntry('api.example.com')], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		globalThis.fetch = spy;
+
+		await discoverSubdomains('example.com');
+		const first = ctFetchCount(spy);
+		await discoverSubdomains('example.com');
+
+		expect(first).toBeGreaterThan(0);
+		expect(ctFetchCount(spy)).toBeGreaterThan(first);
+	});
+
+	it('a fresh cache hit answers even when the deadline has already tripped', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		await prime(kv);
+
+		// A blown budget is a reason to AVOID the network, not a reason to degrade
+		// the answer: a KV read costs milliseconds. The result must be the accurate
+		// `cached`, not `stale`/`partial` — nothing is stale and nothing was skipped.
+		const spy = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) throw new Error('should not be reached');
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		globalThis.fetch = spy;
+
+		const hit = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: kv, deadlineMs: Date.now() - 1 });
+
+		expect(ctFetchCount(spy)).toBe(0);
+		expect(hit.cached).toBe(true);
+		expect(hit.stale).toBeFalsy();
+		expect(hit.partial).toBeFalsy();
+		expect(hit.subdomains.map((s) => s.subdomain).sort()).toEqual(['api.example.com', 'vpn.example.com']);
+	});
+
+	it('does not serve one domain’s cache entry for another domain', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+		await prime(kv);
+
+		const spy = vi.fn(async (url: string | URL | Request) => {
+			const s = typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+			if (s.includes('crt.sh')) return Response.json([crtEntry('api.other.com')], { status: 200 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+		globalThis.fetch = spy;
+
+		const other = await discoverSubdomains('other.com', undefined, undefined, { cacheKv: kv });
+
+		expect(ctFetchCount(spy)).toBeGreaterThan(0);
+		expect(other.cached).toBeFalsy();
+		expect(other.subdomains.map((s) => s.subdomain)).toEqual(['api.other.com']);
 	});
 });

--- a/test/typecheck-baseline.json
+++ b/test/typecheck-baseline.json
@@ -108,7 +108,7 @@
 			"test/decide-retry-enqueue.test.ts": 4,
 			"test/discover-brand-domains-corroboration.test.ts": 3,
 			"test/discover-brand-domains.spec.ts": 4,
-			"test/discover-subdomains-resilience.spec.ts": 10,
+			"test/discover-subdomains-resilience.spec.ts": 0,
 			"test/dmarc-impersonation-escalation.spec.ts": 1,
 			"test/dns-transport.spec.ts": 1,
 			"test/format-report.spec.ts": 9,


### PR DESCRIPTION
## The defect

The subdomain cache was **written on every success but read only on a total source outage or a deadline trip** (`readLastKnownGood` had exactly two call sites). It was outage insurance and never quota relief: a repeat scan of the same domain always spent a live CT query for data already held.

That is expensive now that we are authenticated. CertSpotter's free **Small** tier meters full-domain queries (`include_subdomains=true`) at **10 per hour per ACCOUNT**, and since `CERTSPOTTER_TOKEN` was provisioned that account is shared with `bv2-certstream`, which already consumes ~6/hr on its 10-minute cron. Five re-scans of one domain could exhaust discovery for the whole estate while returning identical data.

## The fix

A **fresh-read window (1h)** checked ahead of every upstream call, including the certstream binding. Same KV entry, same write path — only its age decides which job it does:

| Age | Role | Label |
|---|---|---|
| ≤ 1h | the answer; **zero** upstream calls | `cached` |
| > 1h | last-known-good outage net | `stale` |

**Why `cached` and not `stale`.** `stale` is documented as *"every live CT source was unreachable"*. Reusing it would make every quota-saving hit read as an outage to any consumer branching on it — the same class of error as reporting an unmeasured signal as a measured `false`. The rendered banner is likewise distinct: the stale banner asserts sources are down, which is false on a healthy hit.

`force_refresh` bypasses the window. The outage fallback and the coverage/honesty contract are untouched — a cache-served result still carries the **caching** call's coverage, following the precedent already set at the deadline path.

`cacheSuccess` now also refuses to store a `cached` result, so a hit can never be written back over itself; that would refresh `cachedAt` without a live read and let one enumeration be served as fresh indefinitely.

## Why the TTL is 1h

Chosen against the data's update rate, not arbitrarily: CT logs lag issuance by minutes to hours (SCT merge delay), so a shorter window mostly re-reads the same snapshot at full quota cost. It is a single named constant.

## Tests — mutation-proven

8 new specs. Each mutation below was applied to the implementation and the suite confirmed RED, then restored GREEN:

| Mutation | Result |
|---|---|
| Remove the fresh-read call (revert the fix) | **4 failed** |
| Widen TTL 1h → 24h | **4 failed** |
| Label the hit `stale` instead of `cached` | **3 failed** |

The TTL is mirrored as a **local literal** in the spec on purpose — importing the constant would make the specs agree with the implementation by construction, so a bad TTL edit could never fail them.

Two pre-existing specs now age the entry past the window. That is a real behaviour change, not papering over: both did *call 1 succeeds → call 2 all-sources-fail → expect stale*, which the fresh cache would now satisfy from cache without reaching the network. Aging the entry keeps them exercising the outage path they are named for, and a **new** spec covers the fresh-hit/deadline interaction (a blown budget is a reason to avoid the network, not to degrade the answer).

## Verification

- `npm test` — **7667 passed**, 0 failed. `test/wasm-integration.test.ts` fails in *any* worktree (`crates/*/pkg` is gitignored) and is unrelated.
- `npm run typecheck` — RC 0 · `npm run lint` — RC 0

## Known limitation (deliberately out of scope)

`cacheSuccess` still refuses to store a **zero-subdomain** enumeration, so a domain with genuinely no CT-logged subdomains keeps spending a query per scan. That guard exists to stop an outage-era empty poisoning the fallback net; changing it would alter outage semantics and belongs in its own change.