### PR TITLE
docs(github-settings): the paid DNS action was replaced, not disabled

### DIFF
--- a/docs/github-settings.md
+++ b/docs/github-settings.md
@@ -35,7 +35,13 @@ Require branches to be up to date before merge, block force pushes, block branch
 
 The required checks must include gitleaks, the repo safety scanner, OSS fixture safety, npm publish surface audit, and BUSL positioning audit. Do not make workflow edits that remove these gates without replacing them with an equivalent required check.
 
-The paid `MadaBurns/blackveil-dns-action` workflow is intentionally disabled as `.github/workflows/dns-security.yml.disabled`. Do not re-enable it for push, pull request, or scheduled CI/CD unless an operator explicitly accepts the billing surface.
+## CI cost posture
+
+No workflow may introduce a billing surface — a self-hosted runner, a paid marketplace action, or any paid GitHub feature — without explicit operator approval of that specific surface. If the cost of a feature is unclear, leave it disabled rather than enabling it to find out.
+
+This is machine-enforced, not just documented: `test/audits/workflow-cost.audit.test.ts` (via `scripts/ci/check-workflow-cost.mjs`, part of `npm run audit:oss-safety`) fails CI on any self-hosted runner or paid marketplace action. Rationale and the full posture live in `docs/ci-cost-posture.md`.
+
+The paid `MadaBurns/blackveil-dns-action` was removed and **replaced** by `.github/workflows/dns-security.yml`, which runs a $0 dogfood scan of blackveilsecurity.com using this repo's own built scanner (`scripts/ci/dogfood-scan.mjs`, minimum grade B, advisory — not a required check). Do not reintroduce the paid action; extend the dogfood scan instead.
 
 ## Exposure Cleanup
 


### PR DESCRIPTION
## What

`docs/github-settings.md` still described the paid `MadaBurns/blackveil-dns-action` as sitting disabled at `.github/workflows/dns-security.yml.disabled`, not to be re-enabled.

That file does not exist. The paid action was removed and **replaced** by `.github/workflows/dns-security.yml`, which runs a $0 dogfood scan of blackveilsecurity.com with this repo's own built scanner (`scripts/ci/dogfood-scan.mjs`, min grade B, advisory). A reader following the old text goes looking for a `.disabled` file that isn't there and concludes the repo has no DNS scan in CI.

## Why this shape

The stale line stated a prohibition against one named vendor action. Replaced with a `CI cost posture` section that states the actual rule — no billing surface without explicit operator approval of that specific surface — and names the gate that **enforces** it:

- `test/audits/workflow-cost.audit.test.ts` via `scripts/ci/check-workflow-cost.mjs` (in `npm run audit:oss-safety`), which fails CI on any self-hosted runner or paid marketplace action
- full posture in `docs/ci-cost-posture.md`

A rule with a named enforcer survives the next reorganisation; the vendor-specific prose did not.

## Scope

Docs-only, 7 lines. The tool-count prose that `readme-tool-surface` asserts against is untouched.

Found while reviewing a 3-month-old stash (now discarded) that had drafted a billing-guardrail section for this same file. The stash is superseded; this is the part of it that is still true. The other two pieces of that stash were filed as #746 and #747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)