### PR TITLE
fix(ci): re-enable npm + registry publish and make failure loud (#719)

### DIFF
--- a/.claude/skills/bv-mcp-release/SKILL.md
+++ b/.claude/skills/bv-mcp-release/SKILL.md
@@ -45,7 +45,7 @@ Two transferable lessons:
 
 ## Current publish reality (verify, don't assume)
 
-- **npm publish is gated** (`NPM_TOKEN` not configured) — the hosted npm step won't run. The 3.3.x line is **not on npm**.
+- **npm publish and registry publish are NO LONGER gated** (#719 removed the `if: false` both carried since an `NPM_TOKEN` rotation). While gated, the jobs reported `skipped` — which is GREEN — so npm rotted for ~46 minor versions: `blackveil-dns` sat at **2.13.0** and `@blackveil/dns-checks` at **1.3.12** against a repo at 3.59.0 / 1.22.0. Both jobs now fail loudly on a missing or non-authenticating `NPM_TOKEN`, skip a version already on the registry (re-run safe), and verify against `registry.npmjs.org` after publishing. ⚠️ **The next tagged release will fail its npm job unless a live `NPM_TOKEN` with publish rights to BOTH packages is in the `production` environment** — that is intended: loud beats silent.
 - **MCP Registry IS publishable locally** via `mcp-publisher publish` with `MCP_PUBLISHER_KEY` (in `.dev.vars`) + DNS-TXT auth for `com.blackveilsecurity/*`. Registry liveness-checks npm versions, so the server entry is **remotes-only**.
 - Verify what's live: query the registry with `?version=latest`.
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -159,22 +159,34 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    # Gated off while the production `NPM_TOKEN` is being rotated. The hosted
-    # token returned 404 on `npm publish` for v2.24.0 (npm reports 404 for
-    # auth-shaped misses). Re-enable by deleting this `if:` line once a fresh
-    # token with publish rights to both `blackveil-dns` and
-    # `@blackveil/dns-checks` is in the production env. Releases are running
-    # via the manual fallback in the meantime.
-    if: false
+    # This job was gated off with `if: false` during an `NPM_TOKEN` rotation and
+    # stayed off for ~46 minor versions (#719). The rot was invisible because a
+    # skipped job is GREEN: the release workflow reported success while npm went
+    # stale. Every failure mode below is therefore made LOUD — a missing or
+    # invalid token fails the job before any build work, and nothing here
+    # warn-and-skips. Do not reintroduce a silent gate; if npm publishing must be
+    # paused, delete the job or fail it explicitly with a reason.
     steps:
-      - name: Check npm token
+      # Fails BEFORE checkout/build so a missing secret costs seconds, not a
+      # full release build, and the error is the first thing in the log.
+      - name: Preflight — NPM_TOKEN is present
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ -z "$NPM_TOKEN" ]; then
-            echo "::error::NPM_TOKEN not configured in production environment"
+            echo "::error title=NPM_TOKEN missing::NPM_TOKEN is not set in the 'production' environment. Create an npm automation token with publish rights to BOTH 'blackveil-dns' and '@blackveil/dns-checks', then: gh secret set NPM_TOKEN --env production"
             exit 1
           fi
+          # Automation tokens are opaque, but a value carrying whitespace or a
+          # quote is a paste accident that would otherwise surface as an
+          # inscrutable 404 at publish time (npm answers 404 for auth misses).
+          case "$NPM_TOKEN" in
+            *[[:space:]]* | *\"* | *\'*)
+              echo "::error title=NPM_TOKEN malformed::NPM_TOKEN contains whitespace or quote characters — re-set it without surrounding quotes or a trailing newline."
+              exit 1
+              ;;
+          esac
+          echo "NPM_TOKEN is present (${#NPM_TOKEN} chars)."
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -186,6 +198,20 @@ jobs:
           cache: npm
           registry-url: 'https://registry.npmjs.org'
 
+      # Presence is not validity. A rotated-away token authenticates as nobody
+      # and npm reports the resulting publish miss as a 404, which reads like a
+      # package-name problem rather than an auth problem. Prove the token
+      # resolves to a user here, where the error message can say so.
+      - name: Preflight — NPM_TOKEN authenticates
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          if ! WHO=$(npm whoami --registry=https://registry.npmjs.org/ 2>&1); then
+            echo "::error title=NPM_TOKEN invalid::npm whoami failed — the token is expired, revoked, or lacks read access. Response: ${WHO}"
+            exit 1
+          fi
+          echo "Authenticated to npm as: ${WHO}"
+
       - run: npm ci
 
       - name: Build workspace package
@@ -193,15 +219,61 @@ jobs:
 
       - run: npm run build
 
-      - name: Publish
-        run: npm publish --provenance --access public
+      # Idempotent by design: a release can half-publish (root succeeds, the
+      # workspace package fails) and the retry must not die on
+      # `EPUBLISHCONFLICT` for the half that already landed. An ALREADY-PRESENT
+      # version is logged and skipped; any other publish failure still fails the
+      # job. This never overwrites a published version — npm forbids that.
+      - name: Publish blackveil-dns
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          VERSION: ${{ needs.version-bump.outputs.version }}
+        run: |
+          if npm view "blackveil-dns@${VERSION}" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+            echo "::notice title=blackveil-dns already published::blackveil-dns@${VERSION} is already on the registry — skipping publish (re-run safe)."
+          else
+            npm publish --provenance --access public
+          fi
 
       - name: Publish @blackveil/dns-checks
-        run: npm -w packages/dns-checks publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          # The workspace package versions independently of the root release
+          # tag, so read its own manifest rather than reusing $VERSION.
+          PKG_VERSION=$(node -p "require('./packages/dns-checks/package.json').version")
+          if npm view "@blackveil/dns-checks@${PKG_VERSION}" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+            echo "::notice title=@blackveil/dns-checks already published::@blackveil/dns-checks@${PKG_VERSION} is already on the registry — skipping publish (re-run safe)."
+          else
+            npm -w packages/dns-checks publish --provenance --access public
+          fi
+
+      - name: Verify published versions
+        env:
+          VERSION: ${{ needs.version-bump.outputs.version }}
+        run: |
+          # Assert against the REGISTRY, not against a green step (#719
+          # acceptance criterion). npm's read path is CDN-cached, so allow a
+          # short settle before failing.
+          PKG_VERSION=$(node -p "require('./packages/dns-checks/package.json').version")
+          fail=0
+          for spec in "blackveil-dns@${VERSION}" "@blackveil/dns-checks@${PKG_VERSION}"; do
+            ok=0
+            for _ in 1 2 3 4 5 6; do
+              if npm view "$spec" version --registry=https://registry.npmjs.org/ >/dev/null 2>&1; then
+                ok=1
+                break
+              fi
+              sleep 10
+            done
+            if [ "$ok" -eq 1 ]; then
+              echo "Verified on registry: $spec"
+            else
+              echo "::error title=Publish not visible::${spec} is not resolvable on registry.npmjs.org after publish."
+              fail=1
+            fi
+          done
+          [ "$fail" -eq 0 ]
 
   # NOTE (#718): this workflow deliberately has NO Cloudflare deploy job.
   #
@@ -249,11 +321,14 @@ jobs:
     needs: [validate, version-bump]
     runs-on: ubuntu-latest
     environment: production
-    # Gated off in lockstep with publish-npm. The MCP Registry validates that
-    # the npm package version exists before publishing, so this job cascades to
-    # `NPM package 'blackveil-dns' not found (status: 404)` whenever npm is
-    # stale. Re-enable together with publish-npm once `NPM_TOKEN` is rotated.
-    if: false
+    # Was gated off in lockstep with publish-npm (#719) and re-enabled with it.
+    #
+    # It does NOT depend on publish-npm: `server.json` is remotes-only, so the
+    # registry's npm-existence check ("NPM package 'blackveil-dns' not found
+    # (status: 404)") does not apply to this listing. The two publishes are
+    # independent and a failure in one must not silently withhold the other.
+    # ⚠️ If an npm `packages` stanza is ever re-added to server.json, that check
+    # returns and this job must then `needs: publish-npm`.
     steps:
       - name: Check publisher key
         env:


### PR DESCRIPTION
Resolves the workflow half of #719. **Leave #719 open** until a tagged release actually publishes and `npm view blackveil-dns version` matches the tag (this repo keeps issues open past merge for exactly this reason — see #725).

## Version drift (measured, not assumed)

| Package | Published on npm | This repo | Behind by |
|---|---|---|---|
| `blackveil-dns` | **2.13.0** (`time.modified` 2026-05-30) | **3.59.0** | one major + ~46 minor releases, ~2.5 months |
| `@blackveil/dns-checks` | **1.3.12** (2026-06-01) | **1.22.0** | ~19 minor releases |

Anyone running `npm i blackveil-dns` today gets a scanner from May.

The **MCP Registry listing is unaffected**: `server.json` is remotes-only (single top-level `version`, no `packages` stanza), so the registry's npm-existence check does not apply and the listing tracks prod, not npm. Confirmed by reading `server.json` — the two publishes are genuinely independent.

## What was wrong

Both `publish-npm` and `publish-registry` carried `if: false`, added during an `NPM_TOKEN` rotation and never removed. **The real defect is not the `if: false` — it is that a skipped job is GREEN.** Every tagged release since reported success while npm went stale, and nothing anywhere said so. Both jobs were gated, not just one.

## What changed (`.github/workflows/publish.yml`)

- **Removed both `if: false` gates** and the rotation scaffolding comments, replaced with a note explaining why a silent gate must not be reintroduced (pause by deleting or explicitly failing the job, never by skipping it).
- **Preflight 1 — presence, before checkout/build.** Missing `NPM_TOKEN` fails in seconds with the exact remediation command, not after a full release build. Also rejects a value carrying whitespace/quotes, which is a paste accident that would otherwise surface as an inscrutable 404 (npm answers 404 for auth misses).
- **Preflight 2 — validity.** Presence is not validity: a rotated-away token authenticates as nobody and the publish 404s, which reads like a package-name problem. `npm whoami` now proves the token resolves to a user, and the error says "token expired/revoked".
- **Idempotent publish.** A version already on the registry is logged via `::notice` and skipped instead of dying on `EPUBLISHCONFLICT`, so a half-published release (root ok, workspace package failed) can be re-run. It never overwrites — npm forbids that. `@blackveil/dns-checks` versions independently of the release tag, so its check reads its own manifest rather than reusing `$VERSION`.
- **Post-publish verification against the registry** (with a short CDN-settle retry) — the #719 acceptance criterion is `registry.npmjs.org`, not a green job.
- `publish-registry` deliberately does **not** gain `needs: publish-npm`; a comment records that this flips if an npm `packages` stanza ever returns to `server.json`.

Also updated the stale "npm publish is gated" claim in `.claude/skills/bv-mcp-release/SKILL.md`.

No version bump, no tag, no publish performed here — this is the workflow definition only.

## Verification

```
$ actionlint 1.7.12 — .github/workflows/publish.yml → exit 0, no findings
$ bash -n over all 24 run blocks: OK
$ YAML parse: publish-npm | if: <none>   publish-registry | if: <none>
$ npm run lint  → eslint . → exit 0
$ npx vitest run test/audits/workflow-permissions.audit.test.ts \
    test/audits/workflow-secret-check.audit.test.ts \
    test/audits/infra-probe-wrangler.audit.test.ts \
    test/release-integrity.spec.ts
  Test Files  4 passed (4)   Tests  47 passed (47)
```

## ⚠️ OPERATOR ACTION REQUIRED

**The next tagged release will FAIL its npm job unless a live `NPM_TOKEN` is in the `production` environment. That is intended** — loud beats the silent skip that caused this. Do this before tagging:

1. Create an npm **automation** (granular, CI-usable) token with **publish** rights to BOTH `blackveil-dns` and `@blackveil/dns-checks` at https://www.npmjs.com/settings/~/tokens
2. Set it — **in a real terminal**, this cannot run from an agent harness (no TTY; it would hang on the prompt):
   ```bash
   printf %s "$YOUR_TOKEN" | gh secret set NPM_TOKEN --env production --repo MadaBurns/bv-mcp
   ```
   (Pipe on stdin — never pass the token as `--body`, which lands it in shell history and `ps`. `printf %s`, not `echo`, or a trailing newline is stored as part of the secret.)
3. Confirm it authenticates locally before relying on CI:
   ```bash
   NODE_AUTH_TOKEN="$YOUR_TOKEN" npm whoami --registry=https://registry.npmjs.org/
   ```
4. **Decide and record: backfill vs publish-forward.** Recommend **publish forward only** — 46 skipped versions are not independently verifiable now, and backfilling would republish untested historical trees. Publishing 3.59.0 (or the next release) as `latest` closes the user-facing gap immediately.
5. Then tag as usual (`npm run deploy:prod` order per the release skill), and verify against the registry, not the job:
   ```bash
   npm view blackveil-dns version
   npm view @blackveil/dns-checks version
   ```
6. Only when both match the release should #719 be closed.
