### PR TITLE
feat(rate-limits): force an explicit partner-tier decision per tool (#746)

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
 		"validate:internal-deps": "node scripts/maintenance/validate-internal-deps.mjs",
 		"audit:repo-safety": "node scripts/repo-safety/scan-sensitive-surface.mjs",
 		"audit:licenses": "node scripts/license-check.mjs",
+		"audit:rate-limits": "tsx scripts/audits/tool-rate-limit-inventory.ts",
 		"audit:oss-safety": "node scripts/vitest-filter-workerd.mjs run test/audits/oss-fixture-safety.audit.test.ts test/audits/no-tracked-secrets.audit.test.ts test/audits/npm-publish-surface.audit.test.ts test/audits/busl-positioning.audit.test.ts test/audits/readme-tool-surface.audit.test.ts test/audits/infra-probe-wrangler.audit.test.ts test/audits/repo-safety-policy.audit.test.ts test/audits/repo-safety-scanner.audit.test.ts test/audits/hook-coverage.audit.test.ts test/audits/workflow-safety-gates.audit.test.ts test/audits/repo-safety-docs.audit.test.ts && node scripts/vitest-filter-workerd.mjs run --config vitest.node.config.mts test/audits/repo-safety-push-range-scanner.audit.test.ts test/audits/license-headers.audit.test.ts test/audits/dependency-license.audit.test.ts test/audits/workflow-cost.audit.test.ts test/audits/dns-checks-runtime-agnostic.node.test.ts && npm run audit:licenses",
 		"generate-report": "bash scripts/generate-report.sh",
 		"report:qa": "node scripts/audits/brand-report-qa.mjs",

--- a/scripts/audits/tool-rate-limit-inventory.ts
+++ b/scripts/audits/tool-rate-limit-inventory.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Rate-limit inventory audit (#746).
+//
+// Emits, for every entry in TOOL_DEFS, the rate-limit decision surface:
+//   name, group, tier, scanIncluded, auth-required, internal-only,
+//   gated-paid-only, free-tier daily quota, partner-tier effective daily limit,
+//   and whether that partner limit is EXPLICIT (an entry in
+//   TIER_TOOL_DAILY_LIMITS.partner) or INHERITED (the flat TIER_DAILY_LIMITS.partner).
+//
+// Usage:
+//   npx tsx scripts/audits/tool-rate-limit-inventory.ts            # table
+//   npx tsx scripts/audits/tool-rate-limit-inventory.ts --json     # machine-readable
+//   npx tsx scripts/audits/tool-rate-limit-inventory.ts --inherited-only
+//
+// The DURABLE guard is test/audits/tool-quota-coverage.audit.test.ts (it fails
+// when a TOOL_DEFS entry carries no explicit partner-tier decision). This script
+// is the human-readable companion used to make those decisions.
+
+import { TOOLS } from '../../src/schemas/tool-definitions';
+import {
+	TIER_DAILY_LIMITS,
+	TIER_TOOL_DAILY_LIMITS,
+	FREE_TOOL_DAILY_LIMITS,
+	INTENTIONALLY_UNLIMITED_TOOLS,
+	INTENTIONALLY_PARTNER_FLAT_TOOLS,
+	INTERNAL_ONLY_TOOLS,
+	AUTH_REQUIRED_TOOLS,
+	GATED_PAID_ONLY_TOOLS,
+} from '../../src/lib/config';
+
+interface Row {
+	name: string;
+	group: string;
+	tier: string;
+	scanIncluded: boolean;
+	internalOnly: boolean;
+	authRequired: boolean;
+	gatedPaidOnly: boolean;
+	freeDaily: number | 'unlimited' | 'none';
+	partnerDaily: number;
+	partnerSource: 'explicit' | 'inherited';
+	partnerFlatDeclared: boolean;
+}
+
+const partnerOverrides = TIER_TOOL_DAILY_LIMITS.partner ?? {};
+
+const rows: Row[] = TOOLS.map((tool) => {
+	const explicit = Object.prototype.hasOwnProperty.call(partnerOverrides, tool.name);
+	const free = Object.prototype.hasOwnProperty.call(FREE_TOOL_DAILY_LIMITS, tool.name)
+		? FREE_TOOL_DAILY_LIMITS[tool.name]
+		: INTENTIONALLY_UNLIMITED_TOOLS.has(tool.name)
+			? ('unlimited' as const)
+			: ('none' as const);
+	return {
+		name: tool.name,
+		group: tool.group,
+		tier: tool.tier ?? '—',
+		scanIncluded: tool.scanIncluded,
+		internalOnly: INTERNAL_ONLY_TOOLS.has(tool.name),
+		authRequired: AUTH_REQUIRED_TOOLS.has(tool.name),
+		gatedPaidOnly: GATED_PAID_ONLY_TOOLS.has(tool.name),
+		freeDaily: free,
+		partnerDaily: explicit ? partnerOverrides[tool.name] : TIER_DAILY_LIMITS.partner,
+		partnerSource: explicit ? 'explicit' : 'inherited',
+		partnerFlatDeclared: INTENTIONALLY_PARTNER_FLAT_TOOLS.has(tool.name),
+	};
+});
+
+const args = new Set(process.argv.slice(2));
+const shown = args.has('--inherited-only') ? rows.filter((r) => r.partnerSource === 'inherited') : rows;
+
+if (args.has('--json')) {
+	console.log(JSON.stringify(shown, null, 2));
+} else {
+	const header = ['tool', 'group', 'tier', 'scan', 'auth', 'gated', 'free/day', 'partner/day', 'source', 'flat-declared'];
+	const table = shown.map((r) => [
+		r.name + (r.internalOnly ? ' (internal)' : ''),
+		r.group,
+		r.tier,
+		r.scanIncluded ? 'y' : '',
+		r.authRequired ? 'y' : '',
+		r.gatedPaidOnly ? 'y' : '',
+		String(r.freeDaily),
+		String(r.partnerDaily),
+		r.partnerSource,
+		r.partnerFlatDeclared ? 'y' : '',
+	]);
+	const widths = header.map((h, i) => Math.max(h.length, ...table.map((row) => row[i].length)));
+	const fmt = (row: string[]) => row.map((cell, i) => cell.padEnd(widths[i])).join('  ');
+	console.log(fmt(header));
+	console.log(widths.map((w) => '-'.repeat(w)).join('  '));
+	for (const row of table) console.log(fmt(row));
+
+	const inherited = rows.filter((r) => r.partnerSource === 'inherited');
+	const undecided = inherited.filter((r) => !r.partnerFlatDeclared && !r.internalOnly);
+	console.log(
+		`\ntotals: ${rows.length} tools · explicit ${rows.length - inherited.length} · inherited ${inherited.length}` +
+			` (declared-flat ${inherited.length - undecided.length - inherited.filter((r) => r.internalOnly).length}, UNDECIDED ${undecided.length})`,
+	);
+	if (undecided.length) console.log(`UNDECIDED: ${undecided.map((r) => r.name).join(', ')}`);
+
+	// Alias keys in the partner block that are not TOOL_DEFS names (e.g. `scan`).
+	const toolNames = new Set(TOOLS.map((t) => t.name));
+	const aliasKeys = Object.keys(partnerOverrides).filter((k) => !toolNames.has(k));
+	if (aliasKeys.length) console.log(`alias keys in TIER_TOOL_DAILY_LIMITS.partner (not TOOL_DEFS): ${aliasKeys.join(', ')}`);
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -688,6 +688,103 @@ export function isAuthRequiredTool(toolName: string): boolean {
 export const INTENTIONALLY_UNLIMITED_TOOLS: ReadonlySet<string> = new Set<string>();
 
 /**
+ * Tools where the FLAT partner-tier limit (TIER_DAILY_LIMITS.partner) is the
+ * deliberate answer, i.e. they intentionally carry no
+ * TIER_TOOL_DAILY_LIMITS.partner override (#746).
+ *
+ * Background: `TIER_TOOL_DAILY_LIMITS[tier]?.[tool] ?? TIER_DAILY_LIMITS[tier]`
+ * (src/mcp/execute.ts) makes ABSENCE indistinguishable from an intentional flat
+ * limit, so 45 of 81 tools inherited 100k/day with no record of anyone choosing
+ * it — and the set grew with every new tool. This set forces the decision to be
+ * explicit: the tool-quota-coverage audit fails when a TOOL_DEFS entry appears
+ * in NEITHER the partner override block NOR here (and when it appears in both).
+ *
+ * Membership rule: a tool belongs here when 100k/day of it is genuinely
+ * acceptable — cheap DoH-only checks, local computation, and status/report
+ * pollers (whose cost was already paid by the throttled *_start that created
+ * the job). A tool that fans out to an EXTERNAL METERED service does NOT belong
+ * here on cost grounds; several such tools are listed below only because
+ * lowering a live paid-tier limit is an operator/product decision, not a code
+ * cleanup — those carry a NEEDS-PRODUCT-DECISION comment and must not be
+ * silently retuned.
+ */
+export const INTENTIONALLY_PARTNER_FLAT_TOOLS: ReadonlySet<string> = new Set<string>([
+	// ── Cheap DoH-only checks. Same cost class as the 500k check_* siblings; the
+	// 100k flat is lower, so it is safe, and RAISING to 500k for parity is a
+	// product call (see NEEDS PRODUCT DECISION, #746).
+	'check_dane_https',
+	'check_svcb_https',
+	'check_nsec_walkability',
+	'check_dnssec_chain',
+	'check_agent_discovery',
+	'check_dnskey_strength',
+	'check_subdomain_takeover',
+	'check_authoritative_dns_infra',
+	'check_root_server_set',
+	'check_resolver_consistency',
+	'resolve_spf_chain',
+
+	// ── Local computation / no external fan-out beyond DoH already counted.
+	'generate',
+	'get_domain_rank',
+	'get_benchmark',
+	'get_provider_insights',
+	'assess_spoofability',
+	'analyze_drift',
+	'validate_fix',
+	'map_compliance',
+	'prioritize_csc_leads',
+	'simulate_attack_paths',
+	'map_csc_products', // INTERNAL_ONLY_TOOLS — not public-callable; flat limit is moot but recorded
+
+	// ── Multi-domain orchestrators. Bounded by their own budget/concurrency
+	// (batch_scan: budgetMs 25s, concurrency 3), so the daily count is not the
+	// binding constraint.
+	'batch_scan',
+	'compare_domains',
+
+	// ── Async pollers. The expensive work is metered at the *_start tool; the
+	// poll is a KV/D1 read, so a flat 100k is correct and must NOT be lowered to
+	// match its start sibling (that would strand in-flight jobs).
+	'discover_brand_domains_status',
+	'discover_brand_domains_findings',
+	'scan_buckets_status',
+	'scan_buckets_findings',
+	'osint_investigation_status',
+	'osint_investigation_report',
+
+	// ── Externally metered via BV_RECON / third-party feeds. 100k is very likely
+	// too permissive versus the deliberately-throttled 50k siblings
+	// (check_mx_reputation, check_lookalikes, check_shadow_domains,
+	// discover_brand_domains). Listed here to record the CURRENT effective value,
+	// NOT to endorse it — lowering a live partner-tier limit is user-visible and
+	// needs an operator decision (#746 "NEEDS PRODUCT DECISION").
+	'check_dbl',
+	'check_rbl',
+	'cymru_asn',
+	'rdap_lookup',
+	'check_fast_flux',
+	'discover_subdomains',
+	'map_supply_chain',
+	'check_realtime_threat_feed',
+	'discover_brand_domains_start',
+	'scan_buckets_start',
+	'osint_investigate_domain_start',
+	'osint_investigate_infrastructure_start',
+	'osint_investigate_supply_chain_start',
+	'osint_investigate_username_start',
+	'osint_investigate_email_start',
+]);
+
+/**
+ * Keys in TIER_TOOL_DAILY_LIMITS that are NOT TOOL_DEFS names and are therefore
+ * exempt from the "must be a real tool" audit. `scan` is the accepted alias for
+ * `scan_domain` in tools/call; normalizeToolName() runs BEFORE the limit lookup
+ * in some paths and after in others, so the alias needs its own entry.
+ */
+export const RATE_LIMIT_ALIAS_KEYS: ReadonlySet<string> = new Set<string>(['scan']);
+
+/**
  * Tools whose OWN documented budget exceeds {@link DEFAULT_P95_THRESHOLD}, so a
  * latency alert must not judge them against the interactive threshold (#729).
  *

--- a/test/audits/tool-quota-coverage.audit.test.ts
+++ b/test/audits/tool-quota-coverage.audit.test.ts
@@ -12,7 +12,15 @@
 
 import { describe, it, expect } from 'vitest';
 import { TOOLS } from '../../src/schemas/tool-definitions';
-import { FREE_TOOL_DAILY_LIMITS, INTENTIONALLY_UNLIMITED_TOOLS, INTERNAL_ONLY_TOOLS } from '../../src/lib/config';
+import {
+	FREE_TOOL_DAILY_LIMITS,
+	INTENTIONALLY_UNLIMITED_TOOLS,
+	INTERNAL_ONLY_TOOLS,
+	INTENTIONALLY_PARTNER_FLAT_TOOLS,
+	RATE_LIMIT_ALIAS_KEYS,
+	TIER_TOOL_DAILY_LIMITS,
+	TIER_DAILY_LIMITS,
+} from '../../src/lib/config';
 
 const IDENTITY_SECOPS_TOOLS = ['query_signins', 'query_ual', 'get_ca_policies', 'assess_coverage'] as const;
 
@@ -48,6 +56,80 @@ describe('tool-quota-coverage audit', () => {
 		for (const tool of IDENTITY_SECOPS_TOOLS) {
 			expect(FREE_TOOL_DAILY_LIMITS[tool], `${tool}: public free quota decision`).toBe(0);
 			expect(INTENTIONALLY_UNLIMITED_TOOLS.has(tool), `${tool}: must not be intentionally unlimited`).toBe(false);
+		}
+	});
+});
+
+// #746 — partner-tier decision coverage. `TIER_TOOL_DAILY_LIMITS[tier]?.[tool]
+// ?? TIER_DAILY_LIMITS[tier]` (src/mcp/execute.ts) makes ABSENCE
+// indistinguishable from an intentional flat-limit decision, so 45 of 81 tools
+// silently inherited 100k/day. Every TOOL_DEFS entry must now record the
+// decision in exactly one place.
+describe('partner-tier rate-limit decision coverage audit (#746)', () => {
+	const partnerOverrides = TIER_TOOL_DAILY_LIMITS.partner ?? {};
+
+	it('every TOOL_DEFS entry has an explicit partner-tier decision (override XOR intentional-flat)', () => {
+		const missing: string[] = [];
+		const both: string[] = [];
+
+		for (const tool of TOOLS) {
+			const hasOverride = Object.prototype.hasOwnProperty.call(partnerOverrides, tool.name);
+			const isFlat = INTENTIONALLY_PARTNER_FLAT_TOOLS.has(tool.name);
+			if (!hasOverride && !isFlat) missing.push(tool.name);
+			if (hasOverride && isFlat) both.push(tool.name);
+		}
+
+		expect(
+			missing,
+			`tools with NO partner-tier decision (add a TIER_TOOL_DAILY_LIMITS.partner override, or list in INTENTIONALLY_PARTNER_FLAT_TOOLS): ${missing.join(', ')}`,
+		).toEqual([]);
+		expect(both, `tools with BOTH an override and an intentional-flat declaration (pick one): ${both.join(', ')}`).toEqual([]);
+	});
+
+	it('INTENTIONALLY_PARTNER_FLAT_TOOLS membership is a subset of TOOL_DEFS names (catches renames)', () => {
+		const validNames = new Set(TOOLS.map((t) => t.name));
+		const stale = [...INTENTIONALLY_PARTNER_FLAT_TOOLS].filter((name) => !validNames.has(name));
+		expect(stale, `INTENTIONALLY_PARTNER_FLAT_TOOLS contains names not in TOOL_DEFS: ${stale.join(', ')}`).toEqual([]);
+	});
+
+	// The partner block legitimately carries the `scan` alias key, which is not a
+	// TOOL_DEFS name (tools/call accepts `scan` for `scan_domain`). Any OTHER
+	// non-tool key is a typo or a stale rename and must fail.
+	it('TIER_TOOL_DAILY_LIMITS keys are TOOL_DEFS names or allowlisted aliases', () => {
+		const validNames = new Set(TOOLS.map((t) => t.name));
+		for (const [tier, overrides] of Object.entries(TIER_TOOL_DAILY_LIMITS)) {
+			const stale = Object.keys(overrides ?? {}).filter((k) => !validNames.has(k) && !RATE_LIMIT_ALIAS_KEYS.has(k));
+			expect(stale, `TIER_TOOL_DAILY_LIMITS.${tier} has keys that are neither tools nor aliases: ${stale.join(', ')}`).toEqual([]);
+		}
+	});
+
+	it('the scan alias tracks its scan_domain target at every tier', () => {
+		for (const [tier, overrides] of Object.entries(TIER_TOOL_DAILY_LIMITS)) {
+			const o = overrides ?? {};
+			if (!('scan' in o) && !('scan_domain' in o)) continue;
+			expect(o.scan, `TIER_TOOL_DAILY_LIMITS.${tier}: scan alias must match scan_domain`).toBe(o.scan_domain);
+		}
+	});
+
+	// Guards the direction that actually costs money: a tool declared "flat is
+	// fine" must not thereby end up MORE permissive than the flat tier limit.
+	it('intentional-flat tools resolve to exactly the flat partner limit', () => {
+		for (const name of INTENTIONALLY_PARTNER_FLAT_TOOLS) {
+			const effective = partnerOverrides[name] ?? TIER_DAILY_LIMITS.partner;
+			expect(effective, `${name}: effective partner limit`).toBe(TIER_DAILY_LIMITS.partner);
+		}
+	});
+});
+
+describe('legacy identity-secops quota expectations', () => {
+	// These four proxy Microsoft Graph reads through bv-web and are auth-required
+	// (unauthenticated callers get 401 before dispatch), so their cost bound is
+	// the explicit per-principal cap — they must never fall back to the flat
+	// 100k partner limit.
+	it('identity-secops tools keep explicit paid-tier caps (never flat-inherited)', () => {
+		for (const tool of IDENTITY_SECOPS_TOOLS) {
+			expect(TIER_TOOL_DAILY_LIMITS.partner?.[tool], `${tool}: explicit partner cap`).toBe(2_000);
+			expect(INTENTIONALLY_PARTNER_FLAT_TOOLS.has(tool), `${tool}: must not be declared flat`).toBe(false);
 		}
 	});
 });


### PR DESCRIPTION
Closes #746 (steps 1–2; step 3 deliberately deferred — see NEEDS PRODUCT DECISION).

## The defect

`src/mcp/execute.ts:1197`

```ts
const dailyLimit = TIER_TOOL_DAILY_LIMITS[tier]?.[toolName] ?? TIER_DAILY_LIMITS[tier];
```

ABSENCE is indistinguishable from an intentional flat-limit decision, so **45 of 81** `TOOL_DEFS`
entries inherited `TIER_DAILY_LIMITS.partner = 100_000` with no record that anyone chose it — and the
set grows with every new tool (11 when first noticed in 2026-05, 45 today).

## What this PR changes

**No limit VALUE changes.** This is the durable guard plus the recorded decisions.

1. `INTENTIONALLY_PARTNER_FLAT_TOOLS` in `src/lib/config.ts` — the tools where the flat partner limit
   is the deliberate answer, grouped and justified by cost class in comments.
2. `RATE_LIMIT_ALIAS_KEYS = {scan}` — allowlists the legitimate non-`TOOL_DEFS` key in the partner
   block (`tools/call` accepts `scan` for `scan_domain`), so the audit can reject every OTHER stale key.
3. `test/audits/tool-quota-coverage.audit.test.ts` — four new assertions (model: the exact-set pattern
   in `test/request-dedup-wiring.spec.ts`):
   - every `TOOL_DEFS` entry appears in **exactly one** of `TIER_TOOL_DAILY_LIMITS.partner` or
     `INTENTIONALLY_PARTNER_FLAT_TOOLS` (never neither → a new tool cannot quietly inherit; never both);
   - `INTENTIONALLY_PARTNER_FLAT_TOOLS` ⊆ `TOOL_DEFS` names (catches renames — the six `generate_*`
     tools consolidated into `generate` would have tripped this);
   - every key in every tier block is a tool name or an allowlisted alias;
   - `scan` tracks `scan_domain` at every tier; and a flat-declared tool must resolve to **exactly**
     `TIER_DAILY_LIMITS.partner` (so "flat is fine" can never mean "more permissive than flat").
   - the identity-secops assertion was tightened: those four must keep an EXPLICIT 2,000 cap and must
     never be flat-declared.
4. `scripts/audits/tool-rate-limit-inventory.ts` (`npm run audit:rate-limits`) — mechanical inventory
   generator; `--json` / `--inherited-only` supported. The table below is its output.

Rate-limit surfacing contract is untouched: no change to `mcp/execute.ts`, so 429 + JSON-RPC `-32029`
+ `retry-after` and the `Rate limit exceeded` message prefix are unaffected (`test/index.spec.ts` green).

## Inventory (npm run audit:rate-limits)

`81 tools · explicit 36 · inherited 45 · UNDECIDED 0` (was: UNDECIDED 45). No `partner/day` number moved.

| tool | group | free/day | partner/day | before | after |
|---|---|---|---|---|---|
| check_mx, check_spf, check_dmarc, check_dkim, check_dnssec, check_ssl, check_mta_sts, check_ns, check_caa, check_bimi, check_tlsrpt, check_http_security, check_dane, check_ptr, check_subdomailing, check_txt_hygiene, check_srv, check_zone_hygiene, explain_finding | email_auth / infrastructure / meta | 25–50 | 500,000 | explicit | explicit |
| scan_domain (+ `scan` alias) | meta | 25 | 2,500,000 | explicit | explicit |
| compare_baseline | meta | 10 | 100,000 | explicit | explicit |
| check_lookalikes, check_shadow_domains, check_mx_reputation, discover_brand_domains | brand_threats / email_auth / discovery | 0–5 | 50,000 | explicit | explicit |
| brand_audit_single, brand_audit_batch_start | discovery | 0 | 200 | explicit | explicit |
| brand_audit_status, brand_audit_get_report | discovery | 0 | 10,000 | explicit | explicit |
| list/register/delete_brand_audit_watch | discovery | 0 | 100 | explicit | explicit |
| query_signins, query_ual, get_ca_policies, assess_coverage | identity_secops | 0 | 2,000 | explicit | explicit |
| check_dane_https, check_svcb_https, check_nsec_walkability, check_dnssec_chain, check_agent_discovery, check_dnskey_strength, check_subdomain_takeover, check_authoritative_dns_infra, check_root_server_set, check_resolver_consistency, resolve_spf_chain | infrastructure / intelligence | 10–25 | 100,000 | **inherited** | **flat-declared** (cheap DoH-only) |
| generate, get_domain_rank, get_benchmark, get_provider_insights, assess_spoofability, analyze_drift, validate_fix, map_compliance, prioritize_portfolio_leads, simulate_attack_paths, map_registrar_products (internal-only) | remediation / intelligence | 0–25 | 100,000 | **inherited** | **flat-declared** (local computation) |
| batch_scan, compare_domains | meta | 0 | 100,000 | **inherited** | **flat-declared** (bounded by own budget/concurrency) |
| discover_brand_domains_status/_findings, scan_buckets_status/_findings, osint_investigation_status/_report | discovery / intelligence | 0–25 | 100,000 | **inherited** | **flat-declared** (poller — cost metered at `*_start`) |
| check_dbl, check_rbl, cymru_asn, rdap_lookup, check_fast_flux, discover_subdomains, map_supply_chain, check_realtime_threat_feed, discover_brand_domains_start, scan_buckets_start, osint_investigate_{domain,infrastructure,supply_chain,username,email}_start | intelligence / discovery | 0–5 | 100,000 | **inherited** | **flat-declared, FLAGGED** — see below |

Full table: `npm run audit:rate-limits`.

## Classification notes

- **Pollers are NOT the same cost class as their `*_start`.** `scan_buckets_status`, `osint_investigation_report`,
  `discover_brand_domains_findings` etc. read an already-created job (KV/D1); throttling them to match
  their start sibling would strand in-flight jobs. Flat is correct.
- **identity_secops (`query_signins`, `query_ual`, `get_ca_policies`, `assess_coverage`) was left alone by design.**
  They are `AUTH_REQUIRED_TOOLS` (unauthenticated callers get 401 before dispatch), pinned to 0 on
  free/agent, and carry explicit 2,000/day caps on developer/enterprise/partner to bound Microsoft Graph
  cost. Nothing to fix; now pinned by a test so it can't drift.
- `map_registrar_products` is `INTERNAL_ONLY_TOOLS` (not public-callable) — recorded as flat for completeness.

## NEEDS PRODUCT DECISION (not shipped here)

Lowering a live partner-tier limit is a user-visible behaviour change that can break existing partner
integrations, so these are flagged, not applied. Each is recorded at its CURRENT effective value with a
`NEEDS-PRODUCT-DECISION` comment in `config.ts`.

1. **Externally-metered tools sit at 2× their deliberately-throttled siblings.** `check_mx_reputation`,
   `check_lookalikes`, `check_shadow_domains`, `discover_brand_domains` were explicitly throttled to
   **50,000**. These same-cost-class tools inherit **100,000**:
   `check_dbl`, `check_rbl`, `cymru_asn`, `rdap_lookup`, `check_fast_flux`, `discover_subdomains`,
   `map_supply_chain`, `check_realtime_threat_feed` (BV_RECON), `scan_buckets_start`,
   `osint_investigate_{domain,infrastructure,supply_chain,username,email}_start`.
   Proposed: **50,000** to match. Needs operator sign-off (paid-tier limit reduction).
2. **`discover_brand_domains_start` (100,000) is the async door to `discover_brand_domains` (50,000).**
   The sync form is capped at half its async twin — the async path is the cheaper one to abuse. Proposed:
   align the start tool at 50,000. Same operator sign-off.
3. **13 `check_*` tools at 100,000 vs 17 siblings at 500,000** (`check_dane_https`, `check_svcb_https`,
   `check_nsec_walkability`, `check_dnssec_chain`, `check_agent_discovery`, `check_dnskey_strength`,
   `check_subdomain_takeover`, `check_authoritative_dns_infra`, `check_root_server_set`,
   `check_resolver_consistency`, `resolve_spf_chain`). This asymmetry is in the SAFE direction (more
   restrictive), so nothing is at risk; RAISING them to 500,000 for parity is a product call about what
   partners are entitled to, not a defect fix.

## Verification

```
$ npx vitest run test/audits/tool-quota-coverage.audit.test.ts
 ✓ test/audits/tool-quota-coverage.audit.test.ts (9 tests) 3ms
 Test Files  1 passed (1)      Tests  9 passed (9)

$ npm run typecheck        # clean
$ npm run lint             # eslint . — clean
$ npm test                 # 7672 passed | 13 skipped (7686); 643/658 files
```

Two failures in the full run are pre-existing/environmental, not from this change:
`test/wasm-integration.test.ts` (`No such module .../crates/bv-wasm-core/pkg/bv_wasm_core_bg.wasm` — the
wasm artifact is not built in a fresh worktree) and `test/internal-analytics-forensics.spec.ts` (15s
timeout under parallel load; **passes in isolation: 2 passed**).

**The guard is proven to fail red.** Temporarily removing `check_dbl` from `INTENTIONALLY_PARTNER_FLAT_TOOLS`:

```
 × every TOOL_DEFS entry has an explicit partner-tier decision (override XOR intentional-flat)
AssertionError: tools with NO partner-tier decision (add a TIER_TOOL_DAILY_LIMITS.partner override,
or list in INTENTIONALLY_PARTNER_FLAT_TOOLS): check_dbl: expected [ 'check_dbl' ] to deeply equal []
```

(entry restored; the other 8 assertions stayed green, so the failure is precisely scoped.)
