### PR TITLE
chore: release 3.60.0

### DIFF
--- a/.claude/skills/bv-mcp-release/SKILL.md
+++ b/.claude/skills/bv-mcp-release/SKILL.md
@@ -55,9 +55,9 @@ Two transferable lessons:
 
 **Rule: deploy to prod first, then publish the registry. Never the reverse.**
 
-- Correct order: merge bump → tag (→ `publish.yml` cuts the GH Release; its Cloudflare deploy ends `cancelled`, registry `skipped`) → **`npm run deploy:prod`** → verify `serverInfo.version` + scoring footer on prod → **only then `mcp-publisher publish`** → verify `?version=latest` shows `isLatest=true`.
+- Correct order (**changed by #719** — see the warning below): merge bump → **`npm run deploy:prod`** → verify `serverInfo.version` + scoring footer on prod → **only then tag**. `publish.yml` cuts the GH Release and now also publishes to the registry, so the tag must come after the deploy.
 - Registry **behind** prod (published 3.8.0 while prod serves 3.9.0) is **benign** — it just means "not yet bumped," and is the safe state to pause in if the deploy is deferred. Registry **ahead** of prod is the foot-gun.
-- The tag pipeline itself is ordering-safe: per the job table it does the GH Release but **skips** the registry, so tagging advertises nothing to the registry. Only the manual `mcp-publisher` step does — keep it last.
+- ⚠️ **The tag pipeline is NO LONGER ordering-safe.** It used to be — `publish-registry` carried `if: false`, so tagging advertised nothing and the manual `mcp-publisher` step was the only publisher. #719 re-enabled that job, and `publish.yml` deliberately has **no** Cloudflare deploy job (#718), so a tag pushed before `npm run deploy:prod` now advertises the new version to the registry while prod still serves the old one — the same stale-prod class as the v2.10.2–v2.10.6 incidents. **Deploy prod before tagging.** The manual `mcp-publisher publish` remains the fallback when the job cannot run.
 - "Formalize the release" (version surfaces + tag + GH Release) and "deploy + publish" are separable. Deploy and registry publish are outward-facing — confirm before each unless told to run the whole sequence.
 
 Publish steps (key never echoed): `mcp-publisher validate` → `login dns --domain blackveilsecurity.com --private-key "$KEY"` (read `$KEY` from `.dev.vars`, ed25519) → `publish` → `logout`. Verify: `?search=com.blackveilsecurity/dns&version=latest` → expect `version=X.Y.Z status=active isLatest=true` (search endpoint sometimes returns an empty body — retry a few times).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.60.0] - 2026-08-21
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` goes to **1.23.0** for new exports only (additive; no existing export changes shape).
+
+### Fixed
+
+- **The robots gate now records which branch decided a scan.** `withRobotsGate` fails open when `robots.txt` is unreachable or times out, so a scan of the same domain could be scored from a real policy read or from a guess with nothing in the result to tell them apart — reproducibility silently depended on the target's uptime during a 3s window. An opt-in `onRobotsResolution` callback now reports every branch (`allowed` / `disallowed` / `no_policy` / `unreachable` / `timeout`) plus `failOpen`, and `check_ssl` and `check_http_security` stamp it at `CheckResult.metadata.robotsResolution`. **The fail-open policy itself is unchanged** and no finding is added, removed or reweighted — this is metadata only, so no score can move. `CheckStatus` is deliberately NOT widened: two bv-web-prod consumers switch exhaustively over that union. (#745)
+- **A scan abstention is now self-describing instead of prose-only**, so a downstream consumer can tell "we were asked not to scan" from "we scanned and found nothing" without parsing English. (#743)
+- **A blanket `User-agent: *` block is no longer reported as naming our scanner.** The attribution said the target had specifically disallowed us when it had simply disallowed everyone. (#742)
+- **Rate limits: a new tool can no longer inherit the partner-tier daily limit silently.** `TOOL_DEFS` entries without an explicit per-tool limit fell through to the flat partner default with nothing recording that as a decision. An explicit `INTENTIONALLY_PARTNER_FLAT_TOOLS` set plus audit assertions now force the choice to be made and written down. **No limit value changed** — this is a guard, not a re-tuning. (#746)
+- **`npm test` no longer depends on a masked Node-compat injection.** Nine audit suites that shell out with Node built-ins were being collected into the Workers pool, which only worked because `@cloudflare/vitest-pool-workers` < 0.21.2 injected `nodejs_compat_v2` unconditionally; 0.21.2+ resolves Node compat from `wrangler.jsonc` and correctly refused them. Vitest now runs two projects (`workers` + `node`) off a shared file list. No audit was weakened, skipped or deleted, and `src/` is untouched. (#711, #752)
+- **Local pushes are no longer blocked by GitHub's own squash-merge trailers.** GitHub writes bot sign-off and co-author trailers into every squash merge it performs server-side, where local hooks never run; those messages then reached the push-range scanner the first time a branch merged `main` and failed the push under the `real-email` rule for history the developer did not author. The allowlist is exact-address plus GitHub's noreply co-author domain — **not** the `github.com` domain, so a genuine address in source is still flagged.
+
+### Changed
+
+- **npm and MCP Registry publishing are no longer gated off.** Both jobs carried `if: false` since an `NPM_TOKEN` rotation and reported `skipped`, which is GREEN — so npm rotted undetected: `blackveil-dns` sat at **2.13.0** and `@blackveil/dns-checks` at **1.3.12** against a repo at 3.59.0 / 1.22.0. Both now fail loudly on a missing or non-authenticating token, skip a version already published (re-run safe), and verify against `registry.npmjs.org` afterwards. ⚠️ **A tagged release will fail its npm job until a live `NPM_TOKEN` with publish rights to both packages is set in the `production` environment** — intended: loud beats silent. (#719)
+
 ## [3.59.0] - 2026-08-21
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` and `@blackveil/dns-checks` are unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.59.0",
+	"version": "3.60.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.59.0",
+			"version": "3.60.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"
@@ -5163,7 +5163,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.22.0",
+			"version": "1.23.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.59.0",
+	"version": "3.60.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.22.0",
+	"version": "1.23.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.22.0';
+export const PARITY_CORPUS_VERSION = '1.23.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
     "url": "https://github.com/MadaBurns/bv-mcp",
     "source": "github"
   },
-  "version": "3.59.0",
+  "version": "3.60.0",
   "remotes": [
     {
       "type": "streamable-http",


### PR DESCRIPTION
Release 3.60.0. Ships the four issue fixes merged today plus the dependabot backlog.

## Version surfaces
- `package.json` + `package-lock.json` 3.59.0 -> **3.60.0** (`SERVER_VERSION` auto-derives)
- `server.json` (remotes-only, single `version`) -> 3.60.0
- `CHANGELOG.md` `[3.60.0]` heading
- `@blackveil/dns-checks` 1.22.0 -> **1.23.0** — mandatory, #745/#743 add new public exports (`createRobotsGroupCache`, `describeRobotsScope`, resolution types) and npm publish is no longer gated
- `PARITY_CORPUS_VERSION` -> 1.23.0 — a hand-maintained literal version-locked to the dns-checks manifest by `parity-corpus.contract.test.ts`; missing it fails `test/scan-version-stamps.spec.ts`

**No scoring-model change.** `SCORING_MODEL_VERSION` untouched; no check, weight, threshold or band moves.

## Also corrects the release skill
`#719` re-enabled `publish-registry`, and `publish.yml` deliberately has **no** Cloudflare deploy job (#718). The skill still claimed the tag pipeline "skips the registry" and is "ordering-safe" — that was only true because of the `if: false`. Tagging now advertises to the registry while prod still serves the old build, the same stale-prod class as v2.10.2-v2.10.6. Corrected to **deploy prod before pushing the tag**.

## Verification
- `npm run typecheck` + `typecheck:tests`: 0 errors
- `npm test`: **654 files / 7755 tests passed**. One environmental failure, `test/wasm-integration.test.ts` — the gitignored `crates/bv-wasm-core/pkg` artifact is not built in a fresh worktree; it passes in the main checkout and CI builds WASM explicitly.

## Operator note
The tag will fail its `publish-npm` job until a live `NPM_TOKEN` with publish rights to both packages is set in the `production` environment. That is #719 working as designed (loud beats silent), not a release regression. Published npm is currently 2.13.0 / 1.3.12.