### PR TITLE
test: salvage three orphaned audits before deleting their branches

### DIFF
--- a/test/audits/completed-predicate-agreement.audit.test.ts
+++ b/test/audits/completed-predicate-agreement.audit.test.ts
@@ -1,0 +1,113 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * The completed-check predicate has THREE deliberate spellings, in modules that
+ * cannot import each other:
+ *
+ *   1. `packages/dns-checks/src/scoring/evidence.ts` (`computeScanEvidence`) —
+ *      `checkStatus === undefined || checkStatus === 'completed'` (the package
+ *      cannot depend on Worker code);
+ *   2. `src/lib/ungraded-display.ts` (`isCompletedCheck`/`hasCompletedEvidence`)
+ *      — the zero-import leaf every `src/tools/` formatter shares;
+ *   3. `src/tools/map-compliance.ts` — the NEGATIVE spelling
+ *      `checkStatus !== 'timeout' && checkStatus !== 'error'`, at both the
+ *      per-control filter and the report-level `assessed` computation.
+ *
+ * Spellings 1–2 name the statuses that COUNT; spelling 3 names the statuses
+ * that DON'T. They agree today only because `CheckStatus` has exactly three
+ * members. Add a fourth (say `'skipped'`) and the two styles silently diverge:
+ * the positive spellings call it not-completed while the negative one calls it
+ * completed — the evidence gate would abstain on a scan whose compliance report
+ * confidently grades the very same checks. This audit iterates EVERY
+ * `CheckStatus` union member (parsed from the type declaration itself, so a new
+ * member joins automatically) through all three shipped code paths and fails on
+ * the first disagreement.
+ */
+
+import { describe, it, expect } from 'vitest';
+import type { CheckResult, CheckStatus } from '../../src/lib/scoring';
+
+// The union is a TYPE — erased at runtime — so the member list is recovered from
+// the declaration source itself (same import.meta.glob raw mechanism as
+// `ungraded-representation.audit.test.ts`; the Workers pool has no `fs`). A
+// fourth member added to the union is therefore in the iteration set with no
+// edit to this file.
+const TYPES_SOURCE = import.meta.glob('../../packages/dns-checks/src/types.ts', {
+	eager: true,
+	query: '?raw',
+	import: 'default',
+}) as Record<string, string>;
+
+function parseCheckStatusMembers(): string[] {
+	const source = Object.values(TYPES_SOURCE)[0] ?? '';
+	const match = source.match(/export type CheckStatus\s*=\s*([^;]+);/);
+	if (!match) return [];
+	return match[1]
+		.split('|')
+		.map((m) => m.trim().replace(/^'|'$/g, ''))
+		.filter((m) => m.length > 0);
+}
+
+/** A minimal but valid CheckResult carrying the status under test. */
+function dmarcResult(status: string | undefined): CheckResult {
+	return {
+		category: 'dmarc',
+		passed: false,
+		score: 0,
+		findings: [{ category: 'dmarc', title: 'DMARC finding', severity: 'high', detail: 'x' }],
+		...(status === undefined ? {} : { checkStatus: status as CheckStatus }),
+	} as CheckResult;
+}
+
+describe('completed-predicate agreement across the three spellings', () => {
+	it('parsed the CheckStatus union non-vacuously', () => {
+		const members = parseCheckStatusMembers();
+		// If parsing breaks (the declaration moves or is reformatted), fail loudly
+		// rather than iterating an empty set and passing on nothing.
+		expect(members).toEqual(expect.arrayContaining(['completed', 'timeout', 'error']));
+		expect(members.length).toBeGreaterThanOrEqual(3);
+	});
+
+	it('every CheckStatus member (and the absent-status legacy shape) classifies identically in all three modules', async () => {
+		const { computeScanEvidence } = await import('@blackveil/dns-checks/scoring');
+		const { isCompletedCheck, hasCompletedEvidence } = await import('../../src/lib/ungraded-display');
+		const { evaluateCompliance } = await import('../../src/tools/map-compliance');
+
+		const statuses: Array<string | undefined> = [...parseCheckStatusMembers(), undefined];
+		expect(statuses.length).toBeGreaterThanOrEqual(4);
+
+		for (const status of statuses) {
+			const result = dmarcResult(status);
+			const label = `checkStatus: ${status ?? '(absent)'}`;
+
+			// Spelling 1 — the package's evidence accounting.
+			const byEvidence = computeScanEvidence([result]).completed === 1;
+			// Spelling 2 — the shared leaf predicate (single-check and some() forms).
+			const byLeaf = isCompletedCheck(result);
+			const byLeafSome = hasCompletedEvidence([result]);
+			// Spelling 3a — map_compliance's report-level `assessed` (:~367).
+			const report = evaluateCompliance([result], 'predicate-agreement.example', null, null);
+			const byComplianceAssessed = report.assessed;
+			// Spelling 3b — map_compliance's per-control transient partition (:~272).
+			// NIST 800-177 §4.3.3 maps solely to `dmarc`: with `passed: false` a
+			// completed result grades it `fail`; a non-completed one must abstain
+			// to `not_assessed`. Either graded verdict means "counted as completed".
+			const control = report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§4.3.3');
+			expect(control, `${label}: NIST §4.3.3 control missing — fixture no longer reaches the per-control filter`).toBeDefined();
+			const byComplianceControl = control!.status !== 'not_assessed';
+
+			expect(byLeaf, `${label}: ungraded-display vs dns-checks evidence`).toBe(byEvidence);
+			expect(byLeafSome, `${label}: hasCompletedEvidence vs isCompletedCheck`).toBe(byEvidence);
+			expect(byComplianceAssessed, `${label}: map_compliance assessed vs dns-checks evidence`).toBe(byEvidence);
+			expect(byComplianceControl, `${label}: map_compliance per-control filter vs dns-checks evidence`).toBe(byEvidence);
+		}
+
+		// Known-value anchors: agreement alone would also hold if every spelling
+		// drifted the same wrong way. Pin the semantics for the three current
+		// members plus the legacy absent-status shape.
+		expect(computeScanEvidence([dmarcResult(undefined)]).completed).toBe(1);
+		expect(computeScanEvidence([dmarcResult('completed')]).completed).toBe(1);
+		expect(computeScanEvidence([dmarcResult('timeout')]).completed).toBe(0);
+		expect(computeScanEvidence([dmarcResult('error')]).completed).toBe(0);
+	});
+});

--- a/test/audits/scanscore-fixture-evidence.audit.test.ts
+++ b/test/audits/scanscore-fixture-evidence.audit.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Hand-built `ScanScore` test literals must carry the `evidence` field.
+ *
+ * `ScanScore.evidence` is REQUIRED by the type — but `test/` is excluded from
+ * `tsconfig.json`, so an `{ ... } as ScanScore` literal in a spec is never
+ * typechecked and silently drops the field. During the evidence-gate slice,
+ * 21+ fixture sites were found (by grep) feeding evidence-less scores into
+ * formatters and comparators — fixtures that no longer model what production
+ * produces, exercising code against a shape the engine cannot emit. The cast
+ * can't enforce the contract, so this audit does.
+ *
+ * Rules:
+ *   - `{ ... } as ScanScore` — the literal must contain an `evidence:` key, or
+ *     a spread (`...`) that can carry one from an audited-elsewhere source.
+ *   - `as unknown as ScanScore` — the DOCUMENTED escape hatch for fixtures
+ *     that are deliberately malformed (defensive-handling tests). Skipped, on
+ *     the same logic as an eslint-disable: the double cast is a visible,
+ *     greppable declaration of intent where a plain cast is an accident.
+ *   - `as ScanScore['...']` (indexed access) and identifier casts
+ *     (`value as ScanScore`, no closing brace before the cast) are not object
+ *     literals and are skipped.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+// The Workers pool has no `fs`; the corpus is inlined at build time (same
+// mechanism as `ungraded-representation.audit.test.ts`). BOTH un-typechecked
+// test trees: `test/**` (excluded by root tsconfig) and the vendored core's
+// `__tests__/**` (excluded by the package tsconfig).
+const SOURCES = import.meta.glob(['../**/*.ts', '../../packages/dns-checks/src/__tests__/**/*.ts'], {
+	eager: true,
+	query: '?raw',
+	import: 'default',
+}) as Record<string, string>;
+
+/** This file names the pattern it hunts, so it must not scan itself. */
+const SELF = '../audits/scanscore-fixture-evidence.audit.test.ts';
+
+/**
+ * Given the index of the closing `}` of an object literal, walk backwards to
+ * the matching `{` and return the literal's text. Depth counting only — good
+ * enough for test fixtures, where braces inside strings are balanced or absent.
+ */
+function extractLiteralEndingAt(source: string, closeBraceIndex: number): string | null {
+	let depth = 0;
+	for (let i = closeBraceIndex; i >= 0; i--) {
+		const ch = source[i];
+		if (ch === '}') depth++;
+		else if (ch === '{') {
+			depth--;
+			if (depth === 0) return source.slice(i, closeBraceIndex + 1);
+		}
+	}
+	return null;
+}
+
+describe('ScanScore fixture evidence audit', () => {
+	it('every plain `as ScanScore` object literal in the un-typechecked test trees carries `evidence`', () => {
+		const CAST = /\bas\s+(unknown\s+as\s+)?ScanScore\b(?!\s*\[)/g;
+		const offenders: string[] = [];
+		let literalsChecked = 0;
+		let escapeHatches = 0;
+
+		for (const [path, source] of Object.entries(SOURCES)) {
+			if (path === SELF) continue;
+			for (const match of source.matchAll(CAST)) {
+				if (match[1] !== undefined) {
+					// `as unknown as ScanScore` — deliberate malformed fixture.
+					escapeHatches++;
+					continue;
+				}
+				// Find the last non-whitespace char before the cast; only a `}`
+				// means the cast is applied to an object literal.
+				let i = match.index - 1;
+				while (i >= 0 && /\s/.test(source[i])) i--;
+				if (i < 0 || source[i] !== '}') continue;
+
+				const literal = extractLiteralEndingAt(source, i);
+				const line = source.slice(0, match.index).split('\n').length;
+				if (literal === null) {
+					offenders.push(`${path}:${line} — unbalanced braces before \`as ScanScore\` (audit could not extract the literal)`);
+					continue;
+				}
+				literalsChecked++;
+				if (!/\bevidence\s*:/.test(literal) && !literal.includes('...')) {
+					offenders.push(
+						`${path}:${line} — \`as ScanScore\` literal without an \`evidence\` field. ` +
+							`Add \`evidence: { attempted, completed, ratio }\` (or \`computeScanEvidence(checks)\`); ` +
+							`use \`as unknown as ScanScore\` ONLY for a deliberately malformed fixture.`,
+					);
+				}
+			}
+		}
+
+		// Non-vacuity: the corpus and both branches of the classifier must have
+		// real work to do, or every assertion above passes on nothing.
+		expect(Object.keys(SOURCES).length).toBeGreaterThan(250);
+		expect(literalsChecked).toBeGreaterThanOrEqual(10);
+		expect(escapeHatches).toBeGreaterThanOrEqual(1);
+
+		expect(offenders).toEqual([]);
+	});
+});

--- a/test/tenants/scan-persistence.integration.test.ts
+++ b/test/tenants/scan-persistence.integration.test.ts
@@ -1,0 +1,261 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * End-to-end regression tests for tenant scan persistence.
+ *
+ * These deliberately do NOT `vi.mock('../../src/handlers/tools')`. Every other
+ * tenant suite mocks `handleToolsCall` and fires `resultCapture` itself, so they
+ * all passed while production captured nothing: `resultCapture` was only invoked
+ * on the `TOOL_REGISTRY` dispatch path, and `scan_domain` is dispatched from the
+ * `switch` in `handlers/tools.ts` instead. Every tenant scan row therefore
+ * persisted `score: null, grade: null` with zero findings, which made the
+ * `/report/:cycle_id` `mean_score` and `grade_dist` aggregates meaningless.
+ *
+ * Driving the REAL `handleToolsCall` (with DNS mocked at the fetch layer) is the
+ * only way to catch that wiring gap, so these tests assert on the values actually
+ * bound to the `scans` INSERT.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { env, createExecutionContext, waitOnExecutionContext } from 'cloudflare:test';
+import { resetTenantResolverCache } from '../../src/tenants/tenant-resolver';
+import { setupFetchMock, createDohResponse, txtResponse, nsResponse, caaResponse, dnssecResponse, httpResponse } from '../helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => {
+	restore();
+	resetTenantResolverCache();
+});
+
+const TEST_TENANT_ID = 'tenant-1';
+const TEST_TENANT_BINDING = 'TENANT_DB_TENANT_1';
+const TEST_INTERNAL_KEY = 'tenant-orchestrator-internal-key';
+const TEST_DOMAIN = 'example.com';
+const REGISTRY_LOOKUP_SQL = 'SELECT id, super_tenant_id, d1_db_id, routing_mode, active FROM sub_tenants WHERE id = ? LIMIT 1';
+const SCANS_INSERT_SQL =
+	'INSERT INTO scans (id, domain, scan_at, score, grade, maturity_stage, finding_count, result_json, cycle_id) ' +
+	'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
+
+/** Bind positions of the `scans` INSERT above. */
+const DOMAIN_BIND = 1;
+const SCORE_BIND = 3;
+const GRADE_BIND = 4;
+const FINDING_COUNT_BIND = 6;
+const RESULT_JSON_BIND = 7;
+
+/** A scan-wide DNS/HTTP mock: enough signal that the domain scores above zero. */
+function mockScannableDomain() {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+		if (url.includes('cloudflare-dns.com')) {
+			if (url.includes('type=TXT') || url.includes('type=16')) {
+				if (url.includes('_dmarc.')) return Promise.resolve(txtResponse(`_dmarc.${TEST_DOMAIN}`, ['v=DMARC1; p=reject']));
+				if (url.includes('_domainkey.')) return Promise.resolve(txtResponse(`default._domainkey.${TEST_DOMAIN}`, ['v=DKIM1; k=rsa; p=MIGf']));
+				return Promise.resolve(txtResponse(TEST_DOMAIN, ['v=spf1 include:_spf.google.com -all']));
+			}
+			if (url.includes('type=NS') || url.includes('type=2')) {
+				return Promise.resolve(nsResponse(TEST_DOMAIN, ['ns1.example.com.', 'ns2.example.com.']));
+			}
+			if (url.includes('type=CAA') || url.includes('type=257')) {
+				return Promise.resolve(caaResponse(TEST_DOMAIN, ['0 issue "letsencrypt.org"']));
+			}
+			if (url.includes('type=A') || url.includes('type=1')) {
+				return Promise.resolve(dnssecResponse(TEST_DOMAIN, true));
+			}
+			return Promise.resolve(createDohResponse([], []));
+		}
+
+		if (url.startsWith('https://')) return Promise.resolve({ ...httpResponse('OK'), url });
+		return Promise.resolve(httpResponse('OK'));
+	});
+}
+
+type RecordedCall = { sql: string; binds: unknown[] };
+
+function makeMockD1(rowsBySql: Record<string, unknown[]> = {}) {
+	const calls: RecordedCall[] = [];
+	const db: D1Database = {
+		prepare(sql: string) {
+			let binds: unknown[] = [];
+			const stmt = {
+				bind(...args: unknown[]) {
+					binds = args;
+					return stmt;
+				},
+				async first<T = unknown>(): Promise<T | null> {
+					calls.push({ sql, binds });
+					return ((rowsBySql[sql] ?? [])[0] as T | undefined) ?? null;
+				},
+				async all<T = unknown>() {
+					calls.push({ sql, binds });
+					return { results: (rowsBySql[sql] ?? []) as T[], success: true, meta: {} } as unknown as D1Result<T>;
+				},
+				async run() {
+					calls.push({ sql, binds });
+					return {
+						success: true,
+						meta: { changes: 1, last_row_id: 0, duration: 0, rows_read: 0, rows_written: 1, size_after: 0 },
+					} as unknown as D1Response;
+				},
+				async raw() {
+					calls.push({ sql, binds });
+					return [] as unknown[];
+				},
+			};
+			return stmt as unknown as D1PreparedStatement;
+		},
+		async batch<T = unknown>(stmts: D1PreparedStatement[]): Promise<D1Result<T>[]> {
+			const out: D1Result<T>[] = [];
+			for (const s of stmts) out.push((await (s as unknown as { run: () => Promise<unknown> }).run()) as D1Result<T>);
+			return out;
+		},
+		async exec() {
+			return { count: 0, duration: 0 } as unknown as D1ExecResult;
+		},
+		dump() {
+			throw new Error('not implemented');
+		},
+		withSession() {
+			throw new Error('not implemented');
+		},
+	} as unknown as D1Database;
+	return { db, calls };
+}
+
+function buildEnv(rowsBySql: Record<string, unknown[]> = {}) {
+	const registry = makeMockD1({
+		[REGISTRY_LOOKUP_SQL]: [{ id: TEST_TENANT_ID, super_tenant_id: 'super-tenant-1', d1_db_id: 'fake-d1-uuid', active: 1 }],
+	});
+	const tenant = makeMockD1(rowsBySql);
+	const customEnv = {
+		...env,
+		BV_WEB_INTERNAL_KEY: TEST_INTERNAL_KEY,
+		REQUIRE_INTERNAL_AUTH: 'true',
+		TENANT_REGISTRY_DB: registry.db,
+		[TEST_TENANT_BINDING]: tenant.db,
+	} as typeof env & Record<string, unknown>;
+	return { customEnv, tenantCalls: tenant.calls };
+}
+
+/**
+ * Assert a `scans` row carries a genuine score/grade rather than the nulls production wrote.
+ *
+ * `domain` is asserted on the COLUMN (bind 1), not inside `result_json`:
+ * `TenantScanSnapshot` (`src/tenants/scan-snapshot.ts`) is a deliberate compact
+ * projection of `score`/`grade`/`maturityStage`/`findings` and carries no
+ * `domain` key, because the column already holds it. This test originally
+ * asserted `parsed.domain` against a pre-`scanResultCapture` snapshot shape
+ * that no longer exists.
+ */
+function expectRealScoreRow(binds: unknown[]) {
+	expect(typeof binds[SCORE_BIND]).toBe('number');
+	expect(binds[SCORE_BIND]).toBeGreaterThan(0);
+	expect(typeof binds[GRADE_BIND]).toBe('string');
+	expect(binds[GRADE_BIND]).not.toBe('');
+	// result_json must round-trip the aggregate the fingerprint pre-flight re-reads.
+	expect(typeof binds[RESULT_JSON_BIND]).toBe('string');
+	const parsed = JSON.parse(binds[RESULT_JSON_BIND] as string) as { score?: unknown; grade?: unknown };
+	expect(parsed.score).toBe(binds[SCORE_BIND]);
+	expect(parsed.grade).toBe(binds[GRADE_BIND]);
+	expect(binds[DOMAIN_BIND]).toBe(TEST_DOMAIN);
+}
+
+describe('tenant scan persistence (real handleToolsCall)', () => {
+	it('persists a real score and grade via the queue consumer', async () => {
+		mockScannableDomain();
+		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
+		const { customEnv, tenantCalls } = buildEnv();
+		const ctx = createExecutionContext();
+
+		const outcome = await processScanMessage(
+			{ cycle_id: 'cycle_persist_q', sub_tenant_id: TEST_TENANT_ID, domain: TEST_DOMAIN },
+			1,
+			customEnv,
+			{ waitUntil: (p: Promise<unknown>) => ctx.waitUntil(p) },
+		);
+		await waitOnExecutionContext(ctx);
+		expect(outcome).toBe('ack');
+
+		const scanInserts = tenantCalls.filter((c) => c.sql === SCANS_INSERT_SQL);
+		expect(scanInserts.length).toBe(1);
+		expectRealScoreRow(scanInserts[0]!.binds);
+	});
+
+	it('persists a real score and grade via the sync POST /internal/tenants/scan route', async () => {
+		mockScannableDomain();
+		const worker = (await import('../../src')).default;
+		const { customEnv, tenantCalls } = buildEnv();
+
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tenants/scan', {
+			method: 'POST',
+			headers: {
+				'Content-Type': 'application/json',
+				Authorization: `Bearer ${TEST_INTERNAL_KEY}`,
+				'X-Tenant': TEST_TENANT_ID,
+			},
+			body: JSON.stringify({ domains: [TEST_DOMAIN] }),
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, customEnv, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(res.status).toBe(200);
+
+		const scanInserts = tenantCalls.filter((c) => c.sql === SCANS_INSERT_SQL);
+		expect(scanInserts.length).toBe(1);
+		expectRealScoreRow(scanInserts[0]!.binds);
+	});
+
+	it('persists the scan findings so finding_count is not stuck at zero', async () => {
+		mockScannableDomain();
+		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
+		const { customEnv, tenantCalls } = buildEnv();
+		const ctx = createExecutionContext();
+
+		await processScanMessage(
+			{ cycle_id: 'cycle_persist_findings', sub_tenant_id: TEST_TENANT_ID, domain: TEST_DOMAIN },
+			1,
+			customEnv,
+			{ waitUntil: (p: Promise<unknown>) => ctx.waitUntil(p) },
+		);
+		await waitOnExecutionContext(ctx);
+
+		const scanInsert = tenantCalls.find((c) => c.sql === SCANS_INSERT_SQL);
+		const findingCount = scanInsert!.binds[FINDING_COUNT_BIND] as number;
+		expect(findingCount).toBeGreaterThan(0);
+
+		// A non-zero finding_count must be matched by actual findings rows, or the
+		// cycle alert sweep (which reads the findings table) sees an empty scan.
+		const findingInserts = tenantCalls.filter((c) => c.sql.startsWith('INSERT INTO findings'));
+		expect(findingInserts.length).toBeGreaterThan(0);
+		const persistedFindings = findingInserts.reduce((n, c) => n + c.binds.length / 8, 0);
+		expect(persistedFindings).toBe(findingCount);
+	});
+
+	it('reports a non-zero mean_score once rows carry real scores', async () => {
+		const worker = (await import('../../src')).default;
+		// Rows shaped like the ones the fixed persistence path now writes.
+		const { customEnv } = buildEnv({
+			'SELECT score, grade FROM scans WHERE cycle_id = ?': [
+				{ score: 80, grade: 'B' },
+				{ score: 90, grade: 'A' },
+			],
+		});
+
+		const req = new Request<unknown, IncomingRequestCfProperties>('http://example.com/internal/tenants/report/cycle_persist_q', {
+			method: 'GET',
+			headers: { Authorization: `Bearer ${TEST_INTERNAL_KEY}`, 'X-Tenant': TEST_TENANT_ID },
+		});
+		const ctx = createExecutionContext();
+		const res = await worker.fetch(req, customEnv, ctx);
+		await waitOnExecutionContext(ctx);
+		expect(res.status).toBe(200);
+
+		const body = (await res.json()) as { summary: { mean_score: number; grade_dist: Record<string, number> } };
+		expect(body.summary.mean_score).toBe(85);
+		// Before the fix every row was null → grade_dist was always `{ unknown: N }`.
+		expect(body.summary.grade_dist).toEqual({ B: 1, A: 1 });
+		expect(body.summary.grade_dist.unknown).toBeUndefined();
+	});
+});

--- a/test/typecheck-baseline.json
+++ b/test/typecheck-baseline.json
@@ -2,7 +2,7 @@
 	"$comment": "Ratchet baseline for `npm run typecheck:tests` (issue #645). Per-file tsc error counts for the test trees, which no other gate typechecks. An INCREASE fails CI; a decrease is reported and should be banked by re-running with `-- --update`. Regenerate deliberately \u2014 never to silence a new error.",
 	"generatedBy": "scripts/ci/typecheck-tests.mjs --update",
 	"typescript": "6.0.3",
-	"total": 1061,
+	"total": 1058,
 	"projects": {
 		"test/tsconfig.json": {
 			"packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts": 4,
@@ -23,6 +23,7 @@
 			"test/audits/busl-positioning.audit.test.ts": 14,
 			"test/audits/completed-evidence-cross-package-parity.audit.test.ts": 1,
 			"test/audits/completed-evidence-predicate-ssot.audit.test.ts": 1,
+			"test/audits/completed-predicate-agreement.audit.test.ts": 1,
 			"test/audits/cron-dispatch-coverage.audit.test.ts": 1,
 			"test/audits/dependency-license.audit.test.ts": 7,
 			"test/audits/deploy-pipeline.audit.test.ts": 2,
@@ -56,6 +57,7 @@
 			"test/audits/repo-safety-push-range-scanner.audit.test.ts": 5,
 			"test/audits/repo-safety-scanner.audit.test.ts": 4,
 			"test/audits/scan-timeout-ssot.audit.test.ts": 1,
+			"test/audits/scanscore-fixture-evidence.audit.test.ts": 1,
 			"test/audits/score-stability-chaos-script.node.test.ts": 3,
 			"test/audits/server-json-tool-count.audit.test.ts": 7,
 			"test/audits/sidecar-bucket-separation.audit.test.ts": 1,
@@ -197,6 +199,7 @@
 			"test/tenants/queue-consumer.integration.test.ts": 2,
 			"test/tenants/queue-producer.integration.test.ts": 6,
 			"test/tenants/routes.integration.test.ts": 23,
+			"test/tenants/scan-persistence.integration.test.ts": 5,
 			"test/tenants/scheduled-handlers.integration.test.ts": 3,
 			"test/tenants/tenant-scope-bola.integration.test.ts": 3,
 			"test/tenants/tenant-scope-coverage.audit.test.ts": 1,


### PR DESCRIPTION
Salvage step of the orphaned-branch cleanup. Five remote branches carried no open PR; this lands the only content among them that `main` does not already have, so all five can be deleted without losing coverage.

## Why content-level review, not `git cherry`

Every one of the five was squash-merged or rebased, so `git cherry` reports false "not in main" for **all** of them. Verdicts were reached by comparing trees and symbols:

| Branch | Unique content vs main | Verdict |
|---|---|---|
| `fix/robots-abstention-finding-provenance` | none (0 files, 0 symbols) | delete — landed via #742/#751 |
| `refactor/maintainability-audit` | none — tip tree byte-identical to a main ancestor (`c3f59f7c`) | delete |
| `chore/bump-workers-toolchain-audit` | none — wanted `vitest-pool-workers ^0.18.8`; main has `^0.21.3` via #752 | delete |
| `claude/jolly-pascal-ik79my` | 1 integration test | delete after salvage |
| `claude/hopeful-meitner-ubnz4k` | 2 audit tests (73 commits' src already on main) | delete after salvage |

## What lands

- **`completed-predicate-agreement.audit.test.ts`** — pins the three deliberate spellings of the completed-check predicate against each other (`computeScanEvidence`, `isCompletedCheck`/`hasCompletedEvidence`, and `map_compliance`'s *negative* spelling). They agree only because `CheckStatus` has exactly three members; a fourth would silently diverge the positive and negative styles, so the evidence gate would abstain on a scan whose compliance report confidently grades the same checks. Union members are parsed from the type declaration, so a new one joins automatically.
- **`scanscore-fixture-evidence.audit.test.ts`** — fails any plain `as ScanScore` literal missing `evidence`; carries its own non-vacuity floors.
- **`scan-persistence.integration.test.ts`** — drives the **real** `handleToolsCall` instead of mocking it, the only way to catch the `scan_domain` result-capture wiring gap that persisted `score: null` on every tenant scan row.

## What is deliberately NOT salvaged

`claude/jolly-pascal-ik79my`'s own fix (`src/lib/captured-result.ts`). Main fixed the same bug **better**, via a `scanResultCapture` hook carrying the full `ScanDomainResult` (`queue-consumer.ts:367`, `routes.ts:844`). Only the test was additive.

## Port required

The tenants test asserted `domain` inside `result_json` — a pre-`scanResultCapture` snapshot shape that no longer exists. `TenantScanSnapshot` is a deliberate projection of `score`/`grade`/`maturityStage`/`findings` and carries no `domain` key because the column already holds it, so the assertion moved to the column bind.

## Verification

- All three pass on `main`: 8 tests, real score 90 / grade A.
- **Proven red**: reverting `scanResultCapture` → `resultCapture` in `queue-consumer.ts` reproduces the original bug signature (score not a number, `finding_count` 0). `src/` restored clean — no source change in this PR.
- `npm run typecheck` 0 errors, `npm run lint` clean, `typecheck:tests` gate green.

## Baseline note

The 7 new `typecheck-baseline.json` errors are the ambient-typing class every sibling file already carries (`cloudflare:test` exports, `Request<>` type args, `import.meta.glob`) — not vacuity. Banked **only** these three files by hand rather than `-- --update`, which would also have banked unrelated decreases in oauth/wasm/dns-checks that may be environment-dependent. `total` was stale (1061 vs an actual entry sum of 1051); recomputed to 1058 = 1051 + 7. The gate reads per-file counts and recomputes the total, so the field is informational.

Test-only. No `src/` change.