### PR TITLE
chore(deps): patch two high dev-tooling advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2663,9 +2663,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.8",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+			"version": "5.0.9",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+			"integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3890,9 +3890,9 @@
 			}
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.17",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-			"integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
Step 4 of the orphaned-branch cleanup. `chore/bump-workers-toolchain-audit` is being deleted as superseded (#752 took the Cloudflare toolchain further than that branch asked for), but the advisories that motivated it were still live on `main`. Fixing them here so deleting that branch loses nothing.

## The advisories

| Package | Bump | Advisory | Reached via |
|---|---|---|---|
| `brace-expansion` | 5.0.8 → 5.0.9 | [GHSA-rgw5-rvv9-x895](https://github.com/advisories/GHSA-rgw5-rvv9-x895) — DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation | `eslint → minimatch` |
| `nanoid` | 3.3.17 → 3.3.18 | [GHSA-2v37-7h3g-55p8](https://github.com/advisories/GHSA-2v37-7h3g-55p8) — custom generators can loop indefinitely when size is zero | `tsup` |

## Severity in context

Both are **dev-only**. `npm audit --omit=dev` reports **0 vulnerabilities**, and neither package reaches the Worker runtime. All three CI audit gates (`security.yml`, `ci-contract.yml`, `publish.yml`) run `--omit=dev` by documented policy, so neither advisory was blocking a merge or a release — this is hygiene, not a production exposure.

## Diff

Lockfile-only: two transitive patch bumps. No `package.json` change, no project version change. `npm audit` now reports 0 vulnerabilities (down from 2 high).

## Verification

- `npm ci` on the new lock, then `npm run typecheck` → clean.
- `npm test` → 654 files / **7755 tests pass**, 0 test failures.
- `test/wasm-integration.test.ts` fails as a suite in any fresh worktree until `npm run build:wasm` (`crates/bv-wasm-core/pkg` is gitignored); CI builds it explicitly, and it is unrelated to this lockfile change.