### PR TITLE
feat(auth): accept API key via X-API-Key header (#747)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ BlackVeil's hosted production at `dns-mcp.blackveilsecurity.com` flips its runti
 The free tier requires no authentication. Authenticated requests bypass per-IP rate limits and follow your tier's daily quota. Hosted production supports:
 
 - **Header**: `Authorization: Bearer <KEY>`
+- **Header (alternative)**: `X-API-Key: <KEY>` — for clients that cannot set `Authorization`. If both are sent, `Authorization: Bearer` wins.
 - **OAuth 2.1**: optional authorization-code flow with PKCE, enabled only when operators set `ENABLE_OAUTH=true`; owner-key consent is separately gated by `ENABLE_OWNER_OAUTH=true`.
 
 The `?api_key=<KEY>` fallback is legacy/self-host compatibility only. BlackVeil hosted production sets `REJECT_QUERY_API_KEY=true`; clients that cannot send headers should use OAuth or an `mcp-remote` header bridge.

--- a/src/index.ts
+++ b/src/index.ts
@@ -425,7 +425,7 @@ for (const path of authedPaths) {
 				return result === 'allowed' ? origin : '';
 			},
 			allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
-			allowHeaders: ['Content-Type', 'Accept', 'Mcp-Session-Id', 'MCP-Protocol-Version', 'Last-Event-ID', 'Authorization'],
+			allowHeaders: ['Content-Type', 'Accept', 'Mcp-Session-Id', 'MCP-Protocol-Version', 'Last-Event-ID', 'Authorization', 'X-API-Key'],
 			exposeHeaders: ['Mcp-Session-Id'],
 		}),
 	);
@@ -443,8 +443,20 @@ for (const path of authedPaths) {
 	app.use(path, async (c, next) => {
 		const authHeader = c.req.header('authorization');
 		const bearerToken = authHeader?.startsWith('Bearer ') ? authHeader.slice(7).trim() : null;
-		const queryToken = c.env.REJECT_QUERY_API_KEY === 'true' ? null : bearerToken ? null : (c.req.query('api_key') ?? null);
-		const token = bearerToken ?? queryToken;
+		// #747: `X-API-Key` is a first-class alternative for clients that cannot set
+		// `Authorization` (some IDE/webview and proxy configs). Precedence is
+		// Bearer → X-API-Key → `?api_key=`: when BOTH a Bearer token and an
+		// `X-API-Key` header are present with DIFFERENT values, the Bearer token
+		// wins and the header is ignored entirely (no second validation attempt),
+		// matching the MCP spec's `Authorization`-first auth story. The header path
+		// feeds the SAME `resolveTier(token, …)` call as Bearer, so it derives an
+		// identical `keyHash` — per-key quota and concurrency stay correct.
+		// The header is NOT covered by `REJECT_QUERY_API_KEY`: that kill-switch
+		// exists because query strings leak into access logs, which headers do not.
+		const apiKeyHeaderToken = bearerToken ? null : (c.req.header('x-api-key')?.trim() || null);
+		const queryToken =
+			c.env.REJECT_QUERY_API_KEY === 'true' ? null : bearerToken || apiKeyHeaderToken ? null : (c.req.query('api_key') ?? null);
+		const token = bearerToken ?? apiKeyHeaderToken ?? queryToken;
 		const apiKeyInQuery = queryToken !== null;
 
 		const resolvedClientIp = resolveClientIpFromRequestHeaders(c.req.raw.headers);

--- a/test/api-key-query.spec.ts
+++ b/test/api-key-query.spec.ts
@@ -93,3 +93,84 @@ describe('REJECT_QUERY_API_KEY kill-switch', () => {
 		expect(response.headers.get('Deprecation')).toBeNull();
 	});
 });
+
+/**
+ * #747: `X-API-Key` header auth. Precedence is Bearer → X-API-Key → `?api_key=`.
+ */
+describe('X-API-Key header auth', () => {
+	beforeEach(async () => {
+		resetAllRateLimits();
+		resetSessions();
+		resetLegacySseState();
+		await resetQuotaCoordinatorState(env.QUOTA_COORDINATOR);
+		await resetAllRateLimitsKv(env.RATE_LIMIT);
+	});
+
+	const initRequest = (headers: Record<string, string>, url = 'http://example.com/mcp') =>
+		new Request<unknown, IncomingRequestCfProperties>(url, {
+			method: 'POST',
+			headers: { 'Content-Type': 'application/json', ...headers },
+			body: JSON.stringify({ jsonrpc: '2.0', id: 0, method: 'initialize', params: {} }),
+		});
+
+	const run = async (request: Request<unknown, IncomingRequestCfProperties>, overrides: Partial<Env> = {}) => {
+		const testEnv = { ...env, BV_API_KEY: TEST_API_KEY, ...overrides } as Env;
+		const ctx = createExecutionContext();
+		const response = await worker.fetch(request, testEnv, ctx);
+		await waitOnExecutionContext(ctx);
+		return response;
+	};
+
+	it('authenticates with a valid X-API-Key header alone (no Deprecation header)', async () => {
+		// REQUIRE_AUTH forces a 401 for an unauthenticated caller, so a 200 here
+		// proves the header actually authenticated rather than falling through to free tier.
+		const response = await run(initRequest({ 'X-API-Key': TEST_API_KEY }), { REQUIRE_AUTH: 'true' } as Partial<Env>);
+		expect(response.status).toBe(200);
+		expect(response.headers.get('mcp-session-id')).toBeTruthy();
+		expect(response.headers.get('Deprecation')).toBeNull();
+	});
+
+	it('rejects a bad X-API-Key exactly like a bad Bearer token (401)', async () => {
+		const headerResponse = await run(initRequest({ 'X-API-Key': 'wrong-key' }));
+		const bearerResponse = await run(initRequest({ Authorization: 'Bearer wrong-key' }));
+		expect(headerResponse.status).toBe(401);
+		expect(bearerResponse.status).toBe(401);
+		expect(await headerResponse.json()).toEqual(await bearerResponse.json());
+	});
+
+	it('Bearer wins when both are present with different values (valid Bearer + bad header → 200)', async () => {
+		const response = await run(initRequest({ Authorization: `Bearer ${TEST_API_KEY}`, 'X-API-Key': 'wrong-key' }));
+		expect(response.status).toBe(200);
+		expect(response.headers.get('mcp-session-id')).toBeTruthy();
+	});
+
+	it('Bearer wins when both are present with different values (bad Bearer + valid header → 401)', async () => {
+		const response = await run(initRequest({ Authorization: 'Bearer wrong-key', 'X-API-Key': TEST_API_KEY }));
+		expect(response.status).toBe(401);
+	});
+
+	it('header wins over ?api_key= (valid header + bad query → 200, no Deprecation header)', async () => {
+		const response = await run(initRequest({ 'X-API-Key': TEST_API_KEY }, 'http://example.com/mcp?api_key=wrong-key'));
+		expect(response.status).toBe(200);
+		expect(response.headers.get('Deprecation')).toBeNull();
+	});
+
+	it('header wins over ?api_key= (bad header + valid query → 401)', async () => {
+		const response = await run(initRequest({ 'X-API-Key': 'wrong-key' }, `http://example.com/mcp?api_key=${TEST_API_KEY}`));
+		expect(response.status).toBe(401);
+	});
+
+	it('an empty/whitespace X-API-Key is ignored — request proceeds as free tier', async () => {
+		const response = await run(initRequest({ 'X-API-Key': '   ' }));
+		expect(response.status).toBe(200);
+	});
+
+	it('is not disabled by REJECT_QUERY_API_KEY (that kill-switch covers the query param only)', async () => {
+		const response = await run(initRequest({ 'X-API-Key': TEST_API_KEY }), {
+			REJECT_QUERY_API_KEY: 'true',
+			REQUIRE_AUTH: 'true',
+		} as Partial<Env>);
+		expect(response.status).toBe(200);
+		expect(response.headers.get('mcp-session-id')).toBeTruthy();
+	});
+});

--- a/test/typecheck-baseline.json
+++ b/test/typecheck-baseline.json
@@ -2,14 +2,14 @@
 	"$comment": "Ratchet baseline for `npm run typecheck:tests` (issue #645). Per-file tsc error counts for the test trees, which no other gate typechecks. An INCREASE fails CI; a decrease is reported and should be banked by re-running with `-- --update`. Regenerate deliberately \u2014 never to silence a new error.",
 	"generatedBy": "scripts/ci/typecheck-tests.mjs --update",
 	"typescript": "6.0.3",
-	"total": 1058,
+	"total": 1069,
 	"projects": {
 		"test/tsconfig.json": {
 			"packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts": 4,
 			"packages/dns-checks/src/__tests__/scoring/scoring-profiles.suite.ts": 4,
 			"test/access-log-enrich-wiring.spec.ts": 2,
 			"test/analytics-prior-tool.spec.ts": 1,
-			"test/api-key-query.spec.ts": 11,
+			"test/api-key-query.spec.ts": 22,
 			"test/audits/abort-signal-propagation.audit.test.ts": 1,
 			"test/audits/access-log-migration.audit.test.ts": 2,
 			"test/audits/brand-audit-depth-baseline-script.audit.test.ts": 1,


### PR DESCRIPTION
Implements #747 (decision: yes, implement the header).

## What
`/mcp` (and the other `authedPaths`) now resolve an API key from three sources, in precedence order:

1. `Authorization: Bearer <key>` (unchanged)
2. `X-API-Key: <key>` (new)
3. `?api_key=<key>` (unchanged; still gated by `REJECT_QUERY_API_KEY` and still emits the Deprecation/Sunset headers)

Conflict rule (JSDoc'd at the call site): if a Bearer token is present, `X-API-Key` is ignored entirely — no second validation attempt. Same for the query param when either header is present.

## Notes
- The header feeds the SAME `resolveTier(token, …)` call as Bearer, so `keyHash` derivation (per-key daily quota + concurrency) is identical — the 3.15.1 class of bug is avoided by construction.
- The header is deliberately NOT covered by `REJECT_QUERY_API_KEY`: that kill-switch exists because query strings leak into CDN/edge logs, which headers do not.
- An empty/whitespace `X-API-Key` is ignored (free tier), not treated as a bad token.
- `X-API-Key` added to the CORS `allowHeaders` list for `authedPaths`. Only `X-API-Key` was implemented, not the `X-Blackveil-API-Key` alias from the sketch (one name, less surface).

## Tests
8 new cases in `test/api-key-query.spec.ts`: header-only auth under `REQUIRE_AUTH`, bad header rejected with a byte-identical 401 body to a bad Bearer, both Bearer/header conflict directions, both header/query conflict directions, whitespace header ignored, and header unaffected by `REJECT_QUERY_API_KEY`.

Red-test evidence: stubbing the header branch to `null` fails 4 of the new cases (`header alone`, `bad header 401`, both header-vs-query cases); restoring makes 12/12 pass.

## Verification
- `npm run typecheck` → clean · `npm run lint` → clean
- `npx vitest run test/api-key-query.spec.ts test/auth.spec.ts test/index.spec.ts test/tier-auth.spec.ts` → 143 passed

README's client-setup section gained the header as a documented alternative (it previously documented only Bearer + the query fallback).