### PR TITLE
fix(discovery): make the Certspotter failover reachable and correct the CT timeout guidance (#738)

### DIFF
--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -56,9 +56,6 @@ import { disposeUnreadResponseBody, readBoundedOrNull } from '../lib/response-bo
  */
 export const DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS = 24_000;
 
-/** Per-attempt timeout for a direct public CT source request (ms). */
-const CT_SOURCE_TIMEOUT_MS = 10_000;
-
 /**
  * Per-ATTEMPT timeout for the Certspotter fallback (ms) — this bounds the whole
  * paginated run, not one page: `queryDirectSources` composes ONE abort signal per
@@ -76,7 +73,43 @@ const CT_SOURCE_TIMEOUT_MS = 10_000;
  * caller's budget stays authoritative and the stop is non-fatal (pages already
  * read are kept, `enumerationComplete: false`).
  */
-const CERTSPOTTER_TIMEOUT_MS = 14_000;
+export const CERTSPOTTER_TIMEOUT_MS = 14_000;
+
+/**
+ * Slack left over after crt.sh and a FULL Certspotter attempt have both been
+ * budgeted for, covering the work that is not a CT fetch: the fresh-cache read,
+ * the certstream fast-path check, JSON parsing of a multi-MB crt.sh body, and
+ * the ~500ms retry backoff.
+ *
+ * Without it the two per-source timeouts sum to exactly the handler budget, and
+ * `hasBudgetFor(CERTSPOTTER_TIMEOUT_MS)` — an all-or-nothing gate — is then false
+ * for ANY non-zero elapsed time, which is every real call.
+ */
+export const CT_FAILOVER_HEADROOM_MS = 2_000;
+
+/**
+ * Per-attempt timeout for the crt.sh CT source (ms).
+ *
+ * ⚠️ DERIVED, not chosen: it is whatever the handler budget has left once a full
+ * Certspotter attempt and {@link CT_FAILOVER_HEADROOM_MS} are reserved. This is
+ * the fix for #738 item 3. It was a hardcoded 10_000, which made the Certspotter
+ * fallback STRUCTURALLY UNREACHABLE whenever crt.sh consumed its whole timeout:
+ * `queryDirectSources` refuses to start a source it cannot finish
+ * (`hasBudgetFor(options, source.timeoutMs)`), and 24_000 − 10_000 = 14_000 is
+ * exactly `CERTSPOTTER_TIMEOUT_MS`, so the gate failed on every real call.
+ * Measured live on v3.58.0: `crtsh=timeout, certspotter=not-consulted` for both
+ * `meta.com` and `anthropic.com` — while Certspotter answered `anthropic.com`
+ * directly in HTTP 200 / 43 KB. The multi-source failover built in #573 was inert
+ * in exactly the scenario it exists for.
+ *
+ * The trade is deliberate: a cold crt.sh query that would have landed between 8s
+ * and 10s is now abandoned in favour of actually asking the second source. Nothing
+ * here is scored — `discover_subdomains` is not a `scan_domain` category and emits
+ * no `CheckResult`/findings — so this moves recall, never a grade.
+ *
+ * Pinned by `test/discover-subdomains-failover-budget.spec.ts`.
+ */
+export const CT_SOURCE_TIMEOUT_MS = DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS - CERTSPOTTER_TIMEOUT_MS - CT_FAILOVER_HEADROOM_MS;
 
 /**
  * Retry PASSES over the whole source list on a transient outcome (timeout / 5xx
@@ -1656,6 +1689,11 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false,
  * source was never asked (typically unbound in this deployment). Folding it into
  * "unavailable" implies three sources were tried when only two were (#735).
  */
+/** Subject-verb agreement for a source list ("certstream was" / "a, b were"). */
+function wasWere(sources: readonly string[]): string {
+	return sources.length === 1 ? 'was' : 'were';
+}
+
 function ctFailureGuidance(coverage: CtCoverage | undefined): string {
 	const perSource = coverage?.perSource ?? [];
 	const timedOut = perSource.filter((s) => s.outcome === 'timeout').map((s) => s.source);
@@ -1665,9 +1703,26 @@ function ctFailureGuidance(coverage: CtCoverage | undefined): string {
 
 	const parts: string[] = [];
 	if (timedOut.length > 0) {
-		parts.push(
-			`${timedOut.join(', ')} timed out — this is deterministic for this domain, not transient, so an identical retry will time out again. Page size is NOT the lever: limit=10, limit=100 and after=0 were measured returning the same HTTP 504.`,
-		);
+		// The pagination measurement is CERTSPOTTER'S (#738 item 1). crt.sh does not
+		// take `limit=`/`after=` in that form and its 504 was never measured, so
+		// printing that clause for a crtsh timeout states a falsehood — which, while
+		// crt.sh was the source timing out, was every call. Each source now gets the
+		// claim that was actually measured for it, and the crt.sh clause names the
+		// knob that really binds it: this tool's own per-source CT budget, not the
+		// whole-scan SCAN_TIMEOUT_MS (which does not apply — `discover_subdomains` is
+		// not a `scan_domain` category).
+		const upstreamCapped = timedOut.filter((s) => s === 'certspotter');
+		const budgetCapped = timedOut.filter((s) => s !== 'certspotter');
+		if (upstreamCapped.length > 0) {
+			parts.push(
+				`${upstreamCapped.join(', ')} timed out upstream — this is deterministic for this domain, not transient, so an identical retry will time out again. Page size is NOT the lever: limit=10, limit=100 and after=0 were measured returning the same HTTP 504.`,
+			);
+		}
+		if (budgetCapped.length > 0) {
+			parts.push(
+				`${budgetCapped.join(', ')} did not answer inside this tool's ${CT_SOURCE_TIMEOUT_MS / 1000}s per-source CT budget (CT_SOURCE_TIMEOUT_MS — the knob that bounds this source; SCAN_TIMEOUT_MS does not apply here). Why it was slow was not measured, so a retry may or may not help.`,
+			);
+		}
 	}
 	if (limited.length > 0) {
 		parts.push(
@@ -1678,7 +1733,19 @@ function ctFailureGuidance(coverage: CtCoverage | undefined): string {
 		parts.push(`${errored.join(', ')} returned an upstream error, which may be transient — a retry is worthwhile.`);
 	}
 	if (never.length > 0) {
-		parts.push(`${never.join(', ')} was never consulted (not configured in this deployment), so no fallback source remained.`);
+		// Two different reasons wear the same label (#738 item 2). `certstream` is the
+		// only source gated on a binding, so "not configured in this deployment" is a
+		// TRUE statement about it and a false one about a public API that needs no
+		// configuration at all — telling an operator to go configure Certspotter sends
+		// them after something that does not exist.
+		const unbound = never.filter((s) => s === 'certstream');
+		const unspent = never.filter((s) => s !== 'certstream');
+		if (unbound.length > 0) parts.push(`${unbound.join(', ')} ${wasWere(unbound)} never consulted: not configured in this deployment.`);
+		if (unspent.length > 0) {
+			parts.push(
+				`${unspent.join(', ')} ${wasWere(unspent)} never consulted: no budget remained after the earlier source(s), so no fallback source was reached. This is a budget outcome, not a configuration one — ${unspent.join(', ')} needs no binding.`,
+			);
+		}
 	}
 	// Only reachable if a source failed with an outcome outside the known set.
 	if (parts.length === 0) return 'Retry shortly.';

--- a/test/discover-subdomains-failover-budget.spec.ts
+++ b/test/discover-subdomains-failover-budget.spec.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+// #738 item 3 — the Certspotter fallback was STRUCTURALLY UNREACHABLE.
+//
+// `queryDirectSources` refuses to start a source it cannot finish inside the
+// caller's deadline (`hasBudgetFor(options, source.timeoutMs)`), an all-or-
+// nothing gate. With crt.sh at a hardcoded 10s out of the 24s handler budget,
+// the remainder was 24_000 - 10_000 = 14_000 = exactly `CERTSPOTTER_TIMEOUT_MS`,
+// so ANY elapsed time at all (cache read, fast-path check, JSON parse) made the
+// gate false and Certspotter was never asked. Measured live on v3.58.0:
+// `crtsh=timeout, certspotter=not-consulted` for meta.com AND anthropic.com,
+// while Certspotter answered anthropic.com directly in HTTP 200 / 43 KB.
+//
+// These are assertions against the real constants, not comments: any future
+// bump of one timeout that re-closes the failover window fails here.
+
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import {
+	CERTSPOTTER_TIMEOUT_MS,
+	CT_FAILOVER_HEADROOM_MS,
+	CT_SOURCE_TIMEOUT_MS,
+	DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS,
+	discoverSubdomains,
+} from '../src/tools/discover-subdomains';
+
+describe('CT failover budget invariant (#738)', () => {
+	it('leaves a FULL Certspotter attempt inside the handler budget after crt.sh burns its whole timeout', () => {
+		expect(CT_SOURCE_TIMEOUT_MS + CERTSPOTTER_TIMEOUT_MS).toBeLessThanOrEqual(DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS);
+		// Strictly less: equality is the pre-fix state, where the gate fails on any
+		// non-zero elapsed time.
+		expect(DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS - CT_SOURCE_TIMEOUT_MS - CERTSPOTTER_TIMEOUT_MS).toBeGreaterThanOrEqual(
+			CT_FAILOVER_HEADROOM_MS,
+		);
+	});
+
+	it('keeps crt.sh a useful primary rather than trimming it to nothing', () => {
+		expect(CT_SOURCE_TIMEOUT_MS).toBeGreaterThanOrEqual(5_000);
+	});
+
+	it('still consults Certspotter after crt.sh consumes its entire timeout', async () => {
+		const consulted: string[] = [];
+		vi.stubGlobal('fetch', async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input instanceof Request ? input.url : input);
+			if (url.includes('crt.sh')) {
+				consulted.push('crtsh');
+				// crt.sh hangs until its per-source abort signal fires — the exact
+				// production shape that used to consume the whole budget.
+				return await new Promise<Response>((_resolve, reject) => {
+					init?.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+				});
+			}
+			if (url.includes('certspotter.com')) {
+				consulted.push('certspotter');
+				return Response.json([{ id: '1', dns_names: ['api.example.com'], not_before: '', not_after: '' }], { status: 200 });
+			}
+			return Response.json({}, { status: 404 });
+		});
+
+		// The real handler deadline. Elapsed time is non-zero by the time crt.sh
+		// aborts, which is precisely what the pre-fix arithmetic could not absorb.
+		const result = await discoverSubdomains('example.com', undefined, undefined, {
+			deadlineMs: Date.now() + DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS,
+		});
+
+		expect(consulted).toEqual(['crtsh', 'certspotter']);
+		expect(result.coverage?.notConsulted ?? []).not.toContain('certspotter');
+		expect(result.totalSubdomains).toBe(1);
+	}, 30_000);
+
+	afterEach(() => {
+		vi.unstubAllGlobals();
+	});
+});


### PR DESCRIPTION
Closes the two remaining items of #738 (item 4 shipped in v3.59.0 and is untouched).

## What the code actually showed vs the issue's framing

The prompt/issue framing named `CRTSH_TIMEOUT_MS` (~8000ms) being killed by `scan_domain`'s 8s `PER_CHECK_TIMEOUT_MS`. **Neither exists on this path.** `discover_subdomains` is *not* a `scan_domain` category (`CHECK_DISPATCH` has no `certificate_transparency` key, `discoverSubdomains` has exactly one caller: `handlers/tools.ts`), so `safeCheck` and `PER_CHECK_TIMEOUT_MS` never touch it. The real constants:

| constant | before | after |
|---|---|---|
| `DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS` | 24_000 | 24_000 (unchanged) |
| `CT_SOURCE_TIMEOUT_MS` (crt.sh) | 10_000 (hardcoded) | 8_000 (derived) |
| `CERTSPOTTER_TIMEOUT_MS` | 14_000 | 14_000 (unchanged) |
| `CT_FAILOVER_HEADROOM_MS` | — | 2_000 (new, named) |

The defect is real, with a different mechanism than described: `queryDirectSources` refuses to **start** a source it cannot finish (`hasBudgetFor(options, source.timeoutMs)`), and `24_000 - 10_000 = 14_000` is *exactly* `CERTSPOTTER_TIMEOUT_MS`. Any non-zero elapsed time (cache read, fast-path check, JSON parse) made that gate false, so a crt.sh that burned its full timeout guaranteed `certspotter=not-consulted` — matching the live v3.58.0 output on meta.com and anthropic.com.

## Changes

- `CT_SOURCE_TIMEOUT_MS` is now **derived** — budget − full Certspotter attempt − `CT_FAILOVER_HEADROOM_MS` — so the failover window cannot be closed again by a future edit without failing the test.
- Timeout guidance is source-aware: Certspotter keeps the pagination measurement that was actually made for it; crt.sh gets a clause naming the knob that really binds it (`CT_SOURCE_TIMEOUT_MS`), explicitly *not* `SCAN_TIMEOUT_MS`, which does not apply here (issue item 1).
- `not configured in this deployment` is now only said of `certstream`, the one binding-gated source; an unconsulted Certspotter is reported as the budget outcome it is. Subject-verb agreement fixed (issue item 2).

`createFetchBudget`/`fetchBudgetFor` was considered and **rejected**: it is for a check whose sequential fetches overrun `PER_CHECK_TIMEOUT_MS` under `safeCheck`, which this path never runs under; and per CLAUDE.md's warning, this check's failure semantics are already deadline-aware and honest (`sourceUnavailable` / `partial` / `unconfirmed_zero`) — a second budget layer would only add a way to turn "slow" into "absent".

## No scoring value moved

`discover_subdomains` emits no `CheckResult` and no findings, is not in `CHECK_DISPATCH`, and no weight, severity, threshold or grade band is touched.

## Verification

- `npm run typecheck` → rc=0 · `npm run lint` → rc=0
- `npx vitest run test/discover-subdomains*.spec.ts test/scan-domain.spec.ts test/tools-scan-timeouts.spec.ts` → **8 files, 158 tests passed**
- New `test/discover-subdomains-failover-budget.spec.ts` pins the invariant against the real constants (`CT_SOURCE_TIMEOUT_MS + CERTSPOTTER_TIMEOUT_MS + headroom <= DISCOVER_SUBDOMAINS_SYNC_BUDGET_MS`) plus a live-behaviour test that hangs crt.sh until abort and asserts Certspotter is still consulted.
- Mutation-proven: restoring `CT_SOURCE_TIMEOUT_MS = 10_000` reddens exactly the two new invariant tests (`expected 0 to be greater than or equal to 2000`, `expected [ 'crtsh' ] to deeply equal [ 'crtsh', 'certspotter' ]`) and leaves the third green.