### PR TITLE
fix(m365): lead sample-only tool descriptions with the disclosure (#417)

### DIFF
--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -756,7 +756,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	query_signins: {
 		description:
-			'Query Microsoft Entra sign-in logs for a tenant. Optionally filter by user principal name, failure status, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent. A `representative: true` field in the response marks sample (non-live) data until live Graph reads land.',
+			'SAMPLE DATA ONLY — this tool has no live Microsoft Graph read path yet, so every response is illustrative and must NOT be used to investigate a real incident or answer a question about actual tenant activity; the `representative: true` field marks it on each response. Query Microsoft Entra sign-in logs for a tenant. Optionally filter by user principal name, failure status, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
 		schema: QuerySigninsArgs,
 		group: 'identity_secops',
 		tier: 'protective',
@@ -764,7 +764,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	query_ual: {
 		description:
-			'Query the Microsoft 365 Unified Audit Log for a tenant. Optionally filter by operation type, user, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent. A `representative: true` field in the response marks sample (non-live) data until live Graph reads land.',
+			'SAMPLE DATA ONLY — this tool has no live read path and may never gain one (Microsoft Graph exposes no direct Unified Audit Log equivalent; see issue #759), so every response is illustrative and must NOT be used to investigate a real incident; the `representative: true` field marks it on each response. Query the Microsoft 365 Unified Audit Log for a tenant. Optionally filter by operation type, user, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
 		schema: QueryUalArgs,
 		group: 'identity_secops',
 		tier: 'protective',
@@ -780,7 +780,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	assess_coverage: {
 		description:
-			'Assess Conditional Access coverage gaps for a Microsoft Entra tenant — identifies users and apps not protected by any enforced policy. Requires m365Proxy service binding; returns { unprovisioned: true } when absent. A `representative: true` field in the response marks sample (non-live) data until live Graph reads land.',
+			'SAMPLE DATA ONLY — this tool has no live Microsoft Graph read path yet, so the gaps it reports are illustrative and must NOT be treated as a real assessment of a tenant\'s Conditional Access posture; the `representative: true` field marks it on each response. Assess Conditional Access coverage gaps for a Microsoft Entra tenant — identifies users and apps not protected by any enforced policy. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
 		schema: AssessCoverageArgs,
 		group: 'identity_secops',
 		tier: 'protective',

--- a/test/contracts/m365-tool-seam-wiring.contract.test.ts
+++ b/test/contracts/m365-tool-seam-wiring.contract.test.ts
@@ -128,6 +128,38 @@ describe('M365 seam — the contracted tool set is derived from the registry', (
 	});
 });
 
+/**
+ * Tools with NO live Graph read path in bv-web-prod's `m365-handler.server.ts`.
+ * Verified 2026-08-21: its dispatch gates the live branch on `tool === 'get-ca-policies'`
+ * alone, so these three reach the representative seam on EVERY call.
+ */
+const SAMPLE_ONLY_TOOLS = ['query_signins', 'query_ual', 'assess_coverage'] as const;
+
+describe('M365 seam — sample-only tools disclose it in the description, not just the response', () => {
+	// `representative: true` in the payload is only read AFTER a call is made, and
+	// only by a client that looks. The description is what an LLM weighs when
+	// DECIDING to call — so for a tool that can only ever answer with sample data,
+	// the disclosure has to lead there too. Dropping it is a truthfulness
+	// regression that no payload assertion above can see.
+	for (const name of SAMPLE_ONLY_TOOLS) {
+		it(`${name} leads its description with the sample-data disclosure`, () => {
+			const def = TOOLS.find((t) => t.name === name);
+			expect(def).toBeDefined();
+			expect(def!.description.startsWith('SAMPLE DATA ONLY')).toBe(true);
+			expect(def!.description).toContain('representative: true');
+		});
+	}
+
+	it('get_ca_policies does NOT carry the blanket disclosure — it has a live path', () => {
+		// The inverse guard: `get_ca_policies` CAN return live Entra data once a
+		// tenant is connected and keyed, so labelling it sample-only would be the
+		// same class of lie in the other direction.
+		const def = TOOLS.find((t) => t.name === 'get_ca_policies');
+		expect(def!.description.startsWith('SAMPLE DATA ONLY')).toBe(false);
+		expect(def!.description).toContain('`false` once a live Microsoft Graph read succeeded');
+	});
+});
+
 // ───────────────────────────────────────────────────────────────────────────────
 // OUTBOUND: what bv-mcp promises to send bv-web-prod, driven through the registry.
 // ───────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Part of the #417 split. Scope: **bv-mcp-side interim mitigation only** — no live Graph work (that is upstream in bv-web-prod and operator-gated).

## Why

`query_signins`, `query_ual` and `assess_coverage` have **no live Microsoft Graph read path**. Verified 2026-08-21 in `bv-web-prod/app/lib/mcp/m365-handler.server.ts`: the live dispatch is gated on `tool === 'get-ca-policies'` alone, so these three hit the representative seam on every call. A live probe against production 3.61.0 with an owner key returned `representative: true` for all four.

The disclosure already existed — as `representative: true` in the payload, and as a sentence at the **end** of each description behind binding boilerplate. But a payload flag is read *after* a call, and only by a client that looks; the description is what an LLM weighs when *deciding* to call. Same class as #725: a security tool that looks like it is answering when it is not.

## What changed

Three descriptions now **lead** with `SAMPLE DATA ONLY — …must NOT be used to investigate a real incident…`, keeping the `representative: true` pointer. `query_ual` additionally names #759 (Graph has no direct UAL equivalent, so it may never gain a live path).

`get_ca_policies` is **deliberately untouched** — it can return live Entra data once a tenant is connected and keyed, so a blanket sample-only label would be the same untruth inverted.

## Verification

- New contract block in `test/contracts/m365-tool-seam-wiring.contract.test.ts` pins **both** directions: the three sample-only tools must lead with the disclosure, and `get_ca_policies` must **not**.
- **Mutation-proven** — removing the prefix from `assess_coverage` reddens exactly that test (`1 failed | 23 passed`), then restored.
- `typecheck` 0 errors, `lint` clean, `40 passed` across the two M365 contract suites + tool-selection steering.

No scoring value, no tool behaviour, and no request/response shape changes — description text and one test file.