### PR TITLE
chore: release 3.61.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.61.1] - 2026-08-21
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` stays at **1.23.0** (untouched this release). No tool behaviour, argument or response shape changes: this release alters tool *description* text only.
+
+### Changed
+
+- **The three sample-only M365 `identity_secops` tools now lead with their disclosure** (#417). `query_signins`, `query_ual` and `assess_coverage` have no live Microsoft Graph path — they return representative sample data flagged `representative: true` in the response. Their descriptions did carry that caveat, but only after a sentence of binding boilerplate, so a client listing tools saw the capability first and the caveat last. Each now opens with `SAMPLE DATA ONLY — …must NOT be used to investigate a real incident…`, which is what a caller sees *before* choosing the tool rather than a flag in a payload they may never surface. `get_ca_policies` is deliberately excluded: it has a live Entra path, so labelling it sample-only would be the same untruth inverted. Both directions are pinned by contract tests.
+
 ## [3.61.0] - 2026-08-21
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` stays at **1.23.0** (untouched this release).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.61.0",
+	"version": "3.61.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.61.0",
+			"version": "3.61.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.61.0",
+	"version": "3.61.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "com.blackveilsecurity/dns",
-  "description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
-  "repository": {
-    "url": "https://github.com/MadaBurns/bv-mcp",
-    "source": "github"
-  },
-  "version": "3.61.0",
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://dns-mcp.blackveilsecurity.com/mcp"
-    }
-  ]
+	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+	"name": "com.blackveilsecurity/dns",
+	"description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"repository": {
+		"url": "https://github.com/MadaBurns/bv-mcp",
+		"source": "github"
+	},
+	"version": "3.61.1",
+	"remotes": [
+		{
+			"type": "streamable-http",
+			"url": "https://dns-mcp.blackveilsecurity.com/mcp"
+		}
+	]
 }


### PR DESCRIPTION
Patch release — **tool description text only**, no behaviour, argument or response-shape change.

## What ships

**#417** — `query_signins`, `query_ual` and `assess_coverage` have no live Microsoft Graph path; they return sample data flagged `representative: true`. Their descriptions carried that caveat only *after* binding boilerplate, so a client listing tools saw the capability first and the caveat last. Each now opens with `SAMPLE DATA ONLY — …must NOT be used to investigate a real incident…`.

`get_ca_policies` is deliberately **excluded** — it has a live Entra path, so a blanket sample-only label would be the same untruth inverted. Both directions are pinned by contract tests (merged in #760).

## Why deploy

Verified against live prod at 3.61.0: all three tools still bury the disclosure. The mitigation only reduces real exposure once deployed.

## Version surfaces

| surface | value |
|---|---|
| package.json / lock / server.json | 3.61.1 |
| CHANGELOG heading | [3.61.1] |
| @blackveil/dns-checks | 1.23.0 (unchanged — zero files touched since v3.61.0) |

## Verification

- `build` 0 · `typecheck` 0 · `typecheck:tests` OK (no file exceeds baseline) · `lint` 0
- `scan-version-stamps` + `m365-tool-seam-wiring.contract` → 29 passed
- Full suite ran green on this content at #760 (659 files / 7781 tests)

No scoring-model change. `SCORING_MODEL_VERSION` unchanged; no domain is re-graded.