### PR TITLE
feat(m365)!: disable client-tenant reads by default (fail-closed kill switch)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import {
 	FREE_TOOL_DAILY_LIMITS,
 	MAX_REQUEST_BODY_BYTES,
 	isContractFlagGateEnabled,
+	m365ProxyBindings,
 	parseCacheTtl,
 	parseGlobalDailyLimit,
 	parsePerCheckTimeout,
@@ -142,6 +143,13 @@ type BvMcpEnv = Env & {
 	OWNER_ALLOW_IPS?: string;
 	BV_WEB?: Fetcher;
 	BV_WEB_INTERNAL_KEY?: string;
+	/**
+	 * Enables M365 client-tenant reads (`identity_secops` tools). Fail-closed:
+	 * only the exact string `'true'` wires the `BV_WEB` M365 proxy + its bearer.
+	 * Unset ⇒ those tools degrade to `unprovisioned` and no customer tenant is
+	 * ever authenticated into. See `isM365TenantReadEnabled` in lib/config.ts.
+	 */
+	M365_TENANT_READS_ENABLED?: string;
 	ALLOWED_ORIGINS?: string;
 	PROVIDER_SIGNATURES_URL?: string;
 	PROVIDER_SIGNATURES_ALLOWED_HOSTS?: string;
@@ -872,8 +880,7 @@ app.post('/mcp', async (c) => {
 					reconAuthToken: c.env.BV_RECON_KEY,
 					tlsProbeBinding: c.env.BV_TLS_PROBE,
 					tlsProbeAuthToken: c.env.BV_TLS_PROBE_KEY,
-					m365Proxy: c.env.BV_WEB,
-					m365ProxyAuthToken: c.env.BV_WEB_INTERNAL_KEY,
+					...m365ProxyBindings(c.env),
 					bvWebBenchmark: c.env.BV_WEB,
 					bvWebBenchmarkAuthToken: c.env.BV_WEB_INTERNAL_KEY,
 					infraProbe: c.env.BV_INFRA_PROBE,
@@ -976,8 +983,7 @@ app.post('/mcp', async (c) => {
 		reconAuthToken: c.env.BV_RECON_KEY,
 		tlsProbeBinding: c.env.BV_TLS_PROBE,
 		tlsProbeAuthToken: c.env.BV_TLS_PROBE_KEY,
-		m365Proxy: c.env.BV_WEB,
-		m365ProxyAuthToken: c.env.BV_WEB_INTERNAL_KEY,
+		...m365ProxyBindings(c.env),
 		bvWebBenchmark: c.env.BV_WEB,
 		bvWebBenchmarkAuthToken: c.env.BV_WEB_INTERNAL_KEY,
 		infraProbe: c.env.BV_INFRA_PROBE,
@@ -1164,8 +1170,7 @@ app.post('/mcp/messages', async (c) => {
 				reconAuthToken: c.env.BV_RECON_KEY,
 				tlsProbeBinding: c.env.BV_TLS_PROBE,
 				tlsProbeAuthToken: c.env.BV_TLS_PROBE_KEY,
-				m365Proxy: c.env.BV_WEB,
-				m365ProxyAuthToken: c.env.BV_WEB_INTERNAL_KEY,
+				...m365ProxyBindings(c.env),
 				bvWebBenchmark: c.env.BV_WEB,
 				bvWebBenchmarkAuthToken: c.env.BV_WEB_INTERNAL_KEY,
 				infraProbe: c.env.BV_INFRA_PROBE,

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -684,6 +684,47 @@ export function isAuthRequiredTool(toolName: string): boolean {
 	return AUTH_REQUIRED_TOOLS.has(toolName);
 }
 
+/**
+ * Kill switch for M365 CLIENT-TENANT reads (the `identity_secops` tools).
+ *
+ * These are the ONLY tools whose data path requires authenticating into a
+ * CUSTOMER's Microsoft 365 / Entra tenant. bv-mcp itself holds no tenant
+ * credential — it forwards over the `BV_WEB` service binding carrying the
+ * trusted internal bearer, and bv-web-prod exchanges an owner-consented,
+ * encrypted OAuth token for a Microsoft Graph read.
+ *
+ * DEFAULT: DISABLED (fail-closed). Absent/any-other value ⇒ no tenant read is
+ * possible on ANY path (public `/mcp`, `/internal/tools/*`, service binding),
+ * because the binding and its bearer are never wired into the runtime options.
+ * Only the exact string `'true'` re-enables it.
+ *
+ * Degradation is the EXISTING, documented fail-soft: `callM365Proxy` receives
+ * no proxy and returns `{ ok: false, unprovisioned: true }`, exactly as on a
+ * BSL self-host where `BV_WEB` is unbound. No new response shape, no new error
+ * class, and every auth/quota gate around these tools stays in force — this
+ * removes the capability, it does not weaken a control.
+ *
+ * Re-enable with `M365_TENANT_READS_ENABLED = "true"` as a Worker var.
+ */
+export function isM365TenantReadEnabled(env: { M365_TENANT_READS_ENABLED?: string }): boolean {
+	return env.M365_TENANT_READS_ENABLED === 'true';
+}
+
+/**
+ * Runtime-option fragment wiring the M365 proxy, or `{}` when tenant reads are
+ * disabled. Spread at every call site so the binding and the internal bearer
+ * are dropped together — wiring one without the other is the dangerous state.
+ */
+export function m365ProxyBindings(env: { BV_WEB?: Fetcher; BV_WEB_INTERNAL_KEY?: string; M365_TENANT_READS_ENABLED?: string }): {
+	m365Proxy?: Fetcher;
+	m365ProxyAuthToken?: string;
+} {
+	if (!isM365TenantReadEnabled(env)) {
+		return {};
+	}
+	return { m365Proxy: env.BV_WEB, m365ProxyAuthToken: env.BV_WEB_INTERNAL_KEY };
+}
+
 /** Tools intentionally governed by per-IP rate limits only (no per-tool free-tier quota). Audited by test/audits/tool-quota-coverage.audit.test.ts. */
 export const INTENTIONALLY_UNLIMITED_TOOLS: ReadonlySet<string> = new Set<string>();
 

--- a/test/m365-tenant-read-killswitch.spec.ts
+++ b/test/m365-tenant-read-killswitch.spec.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * M365 client-tenant read kill switch.
+ *
+ * The four `identity_secops` tools are the only surface whose data path
+ * requires authenticating into a CUSTOMER's Microsoft 365 / Entra tenant.
+ * bv-mcp holds no tenant credential itself: it forwards over the `BV_WEB`
+ * service binding carrying the trusted internal bearer, and bv-web-prod
+ * exchanges an owner-consented OAuth token for a Graph read.
+ *
+ * The capability is withdrawn by never WIRING that binding, so no tenant read
+ * is possible on any path (public `/mcp`, `/internal/tools/*`, service
+ * binding). These tests pin the two properties that make that safe:
+ *
+ *   1. fail-closed — absent/garbage/`'false'` config ⇒ disabled;
+ *   2. all-or-nothing — the binding and its bearer are dropped TOGETHER
+ *      (wiring a bearer without a proxy, or vice versa, is the dangerous
+ *      half-state this helper exists to make unrepresentable).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isM365TenantReadEnabled, m365ProxyBindings } from '../src/lib/config';
+
+const FAKE_BINDING = { fetch: async () => new Response('{}') } as unknown as Fetcher;
+
+describe('isM365TenantReadEnabled — fail-closed', () => {
+	it('is disabled when the var is absent (the production default)', () => {
+		expect(isM365TenantReadEnabled({})).toBe(false);
+	});
+
+	it.each(['false', 'FALSE', 'True', '1', 'yes', 'on', '', ' true', 'true ', 'enabled'])(
+		'is disabled for the non-canonical value %o',
+		(value) => {
+			expect(isM365TenantReadEnabled({ M365_TENANT_READS_ENABLED: value })).toBe(false);
+		},
+	);
+
+	it('is enabled ONLY for the exact string "true"', () => {
+		expect(isM365TenantReadEnabled({ M365_TENANT_READS_ENABLED: 'true' })).toBe(true);
+	});
+});
+
+describe('m365ProxyBindings — the capability is withdrawn by not wiring it', () => {
+	it('wires NEITHER the proxy nor the internal bearer when disabled', () => {
+		const wired = m365ProxyBindings({ BV_WEB: FAKE_BINDING, BV_WEB_INTERNAL_KEY: 'internal-secret' });
+		expect(wired.m365Proxy).toBeUndefined();
+		expect(wired.m365ProxyAuthToken).toBeUndefined();
+	});
+
+	it('does not leak the internal bearer even when the binding is present', () => {
+		// The bearer is the credential bv-web-prod trusts. Dropping the proxy but
+		// forwarding the token would hand a trusted secret to a disabled path.
+		const wired = m365ProxyBindings({
+			BV_WEB: FAKE_BINDING,
+			BV_WEB_INTERNAL_KEY: 'internal-secret',
+			M365_TENANT_READS_ENABLED: 'false',
+		});
+		expect(Object.values(wired)).not.toContain('internal-secret');
+		expect(Object.keys(wired)).toHaveLength(0);
+	});
+
+	it('wires BOTH the proxy and the bearer when explicitly enabled', () => {
+		const wired = m365ProxyBindings({
+			BV_WEB: FAKE_BINDING,
+			BV_WEB_INTERNAL_KEY: 'internal-secret',
+			M365_TENANT_READS_ENABLED: 'true',
+		});
+		expect(wired.m365Proxy).toBe(FAKE_BINDING);
+		expect(wired.m365ProxyAuthToken).toBe('internal-secret');
+	});
+
+	it('stays unwired when enabled on a self-host that has no BV_WEB binding', () => {
+		const wired = m365ProxyBindings({ M365_TENANT_READS_ENABLED: 'true' });
+		expect(wired.m365Proxy).toBeUndefined();
+	});
+});


### PR DESCRIPTION
Disables every bv-mcp surface that requires authenticating into a **client's Microsoft 365 / Entra tenant** — the four `identity_secops` tools (`query_signins`, `query_ual`, `get_ca_policies`, `assess_coverage`).

## Scope: what actually requires client-tenant auth

Verified by search, not assumption: bv-mcp holds **no tenant credential at all** — there is no `M365_TOKEN_KEY`, no refresh token, no Graph client in this repo. It forwards over the `BV_WEB` service binding carrying the trusted internal bearer; bv-web-prod exchanges the owner-consented, encrypted OAuth token for the Graph read.

So `identity_secops` is the entire surface. The bv-recon and brand-tier bindings authenticate to **our own** infrastructure, not a customer tenant, and are untouched.

## Mechanism: withdraw by not wiring, not by refusing

`m365ProxyBindings(env)` returns `{}` unless `M365_TENANT_READS_ENABLED === 'true'`, and is spread at all three wiring sites in `src/index.ts`. No tenant read is possible on **any** path — public `/mcp`, `/internal/tools/*`, or service binding — because the binding never enters the runtime options.

- **Fail-closed**: the var is absent in production, so this ships disabled with no config change. Only the exact string `'true'` re-enables.
- **All-or-nothing**: the binding and its bearer drop together. Wiring a bearer without a proxy would hand a trusted credential to a disabled path; the helper makes that half-state unrepresentable.
- **Existing degradation**: `callM365Proxy` receives no proxy and returns `{ ok: false, unprovisioned: true }` — exactly the documented BSL self-host behaviour. No new response shape, no new error class, no client-visible error string to allowlist.

## This removes a capability; it does not weaken a control

Every surrounding gate is untouched and still proven by its own suite — the 401 `AUTH_REQUIRED_TOOLS` gate, the no-principal hard reject, tier quotas, and the proxy envelope contract all still pass, because those tests inject their own proxy through `runtimeOptions` rather than the Worker env. Deleting or loosening those tests would have been the wrong way to do this.

## Verification

- `npm run typecheck` → **0 errors**; `npm run lint` → clean; `typecheck:tests` ratchet → OK.
- M365 + auth-gate suites: **89 passed** across 6 files.
- **Mutation-proven**: flipping the default to fail-open (`!== 'false'`) reddens **11 of 16** new tests; restored, `git diff` clean.

## Re-enabling

Set the Worker var `M365_TENANT_READS_ENABLED = "true"`.

Refs #417, #759.