### PR TITLE
chore: release 3.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.62.0] - 2026-08-21
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` stays at **1.23.0** (untouched this release).
+
+### Changed
+
+- **Client-tenant reads are now disabled by default (fail-closed).** The four `identity_secops` tools (`query_signins`, `query_ual`, `get_ca_policies`, `assess_coverage`) are the only tools that reach into a customer's Microsoft 365 / Entra tenant. They now require the Worker var `M365_TENANT_READS_ENABLED = "true"`; absent it, `m365ProxyBindings()` returns `{}` and neither the `BV_WEB` proxy nor `BV_WEB_INTERNAL_KEY` is wired into runtime options at any of the three call sites (`/mcp`, `/internal/tools/*`, service binding). Every path therefore returns the already-documented `{ unprovisioned: true }` degradation — **no new response shape and no new error class**. The withdrawal is by *not wiring*, not by a refusal branch, so a tenant read is unreachable rather than merely refused, and the binding and its bearer can never be half-wired (a bearer without a proxy would hand a trusted credential to a disabled path). bv-mcp holds no tenant credential of its own — no `M365_TOKEN_KEY`, no refresh tokens — it only proxies, so this closes the entire tenant-auth surface from this repo. The bv-recon and brand-tier bindings authenticate to **our own** infrastructure, not a customer tenant, and are deliberately untouched. Existing auth-gate and seam tests (89 across 6 files) are unchanged and still pass: the capability is removed without weakening a control. Marked `feat!` for the behaviour change; released as a **minor** because no tool is removed from `TOOL_DEFS`, no schema or wire shape changes, and the resulting response is a path the contract already documented. (#762)
+
+### Fixed
+
+- **Sample-only M365 tool descriptions now lead with the disclosure.** `query_signins`, `query_ual` and `assess_coverage` mentioned `representative: true` only after the binding boilerplate, so a client choosing a tool saw the capability first and the caveat last. Each now opens with `SAMPLE DATA ONLY — … must NOT be used to investigate a real incident`. `get_ca_policies` deliberately does **not** carry that prefix — it has a live Graph path and a blanket sample-only label would be the same untruth inverted; a contract test pins both directions. (#417, #760)
+
 ## [3.61.0] - 2026-08-21
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` stays at **1.23.0** (untouched this release).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.61.0",
+	"version": "3.62.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.61.0",
+			"version": "3.62.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.61.0",
+	"version": "3.62.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -1,16 +1,16 @@
 {
-  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "com.blackveilsecurity/dns",
-  "description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
-  "repository": {
-    "url": "https://github.com/MadaBurns/bv-mcp",
-    "source": "github"
-  },
-  "version": "3.61.0",
-  "remotes": [
-    {
-      "type": "streamable-http",
-      "url": "https://dns-mcp.blackveilsecurity.com/mcp"
-    }
-  ]
+	"$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+	"name": "com.blackveilsecurity/dns",
+	"description": "DNS and email security scanner with 80 MCP tools for SPF, DMARC, DNSSEC, SSL, and brand audits.",
+	"repository": {
+		"url": "https://github.com/MadaBurns/bv-mcp",
+		"source": "github"
+	},
+	"version": "3.62.0",
+	"remotes": [
+		{
+			"type": "streamable-http",
+			"url": "https://dns-mcp.blackveilsecurity.com/mcp"
+		}
+	]
 }


### PR DESCRIPTION
Release 3.62.0.

**Headline:** client-tenant reads (the four `identity_secops` tools) are **disabled by default, fail-closed** (#762). Also folds in the sample-only description disclosure (#417/#760) — #761 was closed so this ships as one tag rather than deploying twice.

- `@blackveil/dns-checks` stays **1.23.0** — verified untouched (`git diff v3.61.0..HEAD -- packages/dns-checks` = 0 files), so `PARITY_CORPUS_VERSION` needs no change.
- No scoring change; no schema or wire-shape change.
- Minor, not major, despite the `feat!` marker: no tool removed from `TOOL_DEFS`, and `{ unprovisioned: true }` is a path the contract already documents.

Gates: build 0 · typecheck 0 · typecheck:tests OK · lint 0 · 45 targeted tests pass. Full suite passed on this content at #762 (660 files / 7797 tests).