### PR TITLE
chore: release 3.63.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.63.0] - 2026-08-21
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` stays at **1.23.0** (untouched this release).
+
+### Changed
+
+- **The four `identity_secops` tools are withdrawn from the public catalog** (#764). `query_signins`, `query_ual`, `get_ca_policies` and `assess_coverage` join `INTERNAL_ONLY_TOOLS`: they no longer appear in `tools/list`, and a public `tools/call` returns the same unknown-tool result a typo produces. The advertised public tool count drops **80 → 76** (README, `server.json`, `smithery.yaml`, `docs/github-settings.md`, the VS Code extension); every audit formula is `TOOL_DEFS.length − INTERNAL_ONLY_TOOLS.size`, so the count tripwires updated themselves. They remain registered in `TOOL_DEFS` **deliberately** — the auth gate, the Layer-2 no-principal reject and the M365 seam contracts are all derived from the registry, so deleting the entries would delete those tripwires with them; re-listing is the exact inverse of this diff.
+- ⚠️ **The internal-only gate shadows the `AUTH_REQUIRED_TOOLS` 401 path.** It short-circuits in `handleToolsCall` *before* tier branching, so an unauthenticated public caller now receives the unknown-tool result rather than a `401`. The auth gate itself is intact and still pinned — it simply can no longer be exercised through the public path. The resulting property is strictly stronger: the M365 proxy is unreachable from the public surface at **any** privilege level (asserted with a proxy actually bound, so "never reached" is measured rather than vacuous), and every tier receives a **byte-identical** response, so an unprivileged caller cannot infer that the tools exist. A new invariant pins `AUTH_REQUIRED_TOOLS ⊆ INTERNAL_ONLY_TOOLS`, so a tool can never be re-listed without its auth gate coming back with it. The Layer-2 registry tests (no-principal reject, `keyHash` forwarding) are untouched and still pass.
+
 ## [3.62.0] - 2026-08-21
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` stays at **1.23.0** (untouched this release).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.62.0",
+	"version": "3.63.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.62.0",
+			"version": "3.63.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.62.0",
+	"version": "3.63.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.62.0",
+	"version": "3.63.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Release 3.63.0.

**Contents:** #764 — the four `identity_secops` tools are withdrawn from the public catalog via `INTERNAL_ONLY_TOOLS`. Public tool count 80 → 76.

**Minor, not major:** no tool is deleted from `TOOL_DEFS`, no schema or wire shape changes. A public `tools/call` for these names returns the same unknown-tool result a typo produces.

⚠️ The internal-only gate short-circuits before tier branching, so it now shadows the `AUTH_REQUIRED_TOOLS` 401 path. The resulting property is stronger (proxy unreachable at any privilege level; byte-identical responses across tiers, so no existence leak), and `AUTH_REQUIRED_TOOLS ⊆ INTERNAL_ONLY_TOOLS` is now pinned.

`@blackveil/dns-checks` stays at **1.23.0** — verified untouched.

**Gates:** build 0 · typecheck 0 · typecheck:tests OK · lint 0 · 35 targeted tests pass.