### PR TITLE
fix(alerting): stop paging critical on a single probe call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged and `@blackveil/dns-checks` stays at **1.23.0** — no check, weight, threshold or grade band moves, and no domain is re-graded. This is operator alerting only; no scan output changes.
+
+### Fixed
+
+- **The error-rate alert no longer pages `critical` on a single probe call.** The `anomalies` lane computed a percentage over whatever the 15m window happened to hold, guarded only by `total_calls > 0`. At the measured traffic (~11 tool calls/hour) that window holds ~3 calls, so one error is 33% and a lone call is 100% — both past `errorThreshold * 2`, hence `critical`. Live off the alert board: `Error rate 100.0% / error_count: 1 / total_calls: 1`, `50.0% over 2`, `45.5% over 11`. The lane now abstains below `ALERT_MIN_ERROR_SAMPLES` (default **20**, derived rather than round: at the 5% ceiling it is the smallest denominator at which one error cannot trip the alert, since 1/20 = 5.0% is not > 5%) and logs the abstention at `info` so a permanently-quiet lane stays greppable. This is the same floor the latency lane gained in #729 and that `queryErrorRate` already carried as `HAVING total > 10`; the alerting error lane was the one rate estimator with no denominator guard at all.
+- **The alert judges real errors instead of counting fuzz traffic as an outage.** `error_pct` conflates pre-dispatch arg-validation rejections (`blob4='none'` — the request never reached a tool) with errors from tools that actually executed. `queryErrorRate` split those apart precisely because that floor of probe traffic inflated low-volume tools (`check_mx` read ~16% but was ~0% real failures) — but the query that PAGES kept reading the conflated column. `queryRecentAnomalies` now emits `input_error_count` / `real_error_count` / `real_error_pct`, and the lane thresholds on `real_error_pct`. The `p95_ms: 0` on both 100% alerts is the fingerprint of exactly this: no tool work ran. A row without the split falls back to the conflated value rather than reading 0%, so an older reader over-reports rather than hiding an outage.
+- **The alert title now carries its own denominator** — `Error rate 45.5% — 5 of 11 calls` rather than `Error rate 45.5%`. The reader sees the title first, and every alert on the reported board omitted the sample size from it. The suppressed `input_error_count` is reported in the metrics block so an operator comparing against a raw Analytics Engine query can reconcile the two numbers.
+
+### Notes
+
+- Abstaining deliberately makes the lane quiet on a low-traffic deploy. That is the correct trade rather than a coverage gap: below the floor a "100% error rate" is genuinely indistinguishable from one bad probe, so no threshold separates them. Low-volume incidents stay covered by the lanes that alert on **absolute counts** (tail exceptions, binding degradation, queue failures — all threshold 1), which do not depend on rate inference. Rate detectors abstain; count detectors cover.
+
 ## [3.63.0] - 2026-08-21
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged — no check, weight, threshold or grade band moves, and no domain is re-graded. `@blackveil/dns-checks` stays at **1.23.0** (untouched this release).

--- a/src/lib/analytics-queries.ts
+++ b/src/lib/analytics-queries.ts
@@ -209,14 +209,34 @@ GROUP BY tier
 ORDER BY request_count DESC`;
 }
 
-/** Anomaly detection query for alerting. Returns error rate and p95 latency for the last N minutes. */
+/**
+ * Anomaly detection query for alerting. Returns error rate and p95 latency for the
+ * last N minutes.
+ *
+ * Carries the SAME input-vs-real error split as {@link queryErrorRate}, and for the
+ * same reason — except here it is load-bearing rather than diagnostic, because this
+ * is the query that PAGES. `input_error_count` (blob4='none') is a request rejected
+ * at pre-dispatch arg validation: no tool ran, nothing was measured, and the caller
+ * is overwhelmingly a fuzzer or a probe hitting the public endpoint. `real_error_count`
+ * (blob4!='none') is a tool that actually executed and failed — the only class of
+ * error that means the service is unhealthy.
+ *
+ * `error_pct` is retained (unused by the alert, kept for back-compat with any reader
+ * that selects it) but MUST NOT be what the alert judges: at low volume a single
+ * unauthenticated fuzz call is 100% of the window. See the `anomalies` lane in
+ * `scheduled.ts` for the sample floor that guards the denominator.
+ */
 export function queryRecentAnomalies(minutes: string, dataset?: string): string {
 	minutes = safeInterval(minutes);
 	return `SELECT
   SUM(_sample_interval) AS total_calls,
   SUM(if(blob3 = 'error', _sample_interval, 0)) AS error_count,
+  SUM(if(blob3 = 'error' AND blob4 = 'none', _sample_interval, 0)) AS input_error_count,
+  SUM(if(blob3 = 'error' AND blob4 != 'none', _sample_interval, 0)) AS real_error_count,
   SUM(if(blob3 = 'error', _sample_interval, 0)) * 100.0
     / if(SUM(_sample_interval) > 0, SUM(_sample_interval), 1) AS error_pct,
+  SUM(if(blob3 = 'error' AND blob4 != 'none', _sample_interval, 0)) * 100.0
+    / if(SUM(_sample_interval) > 0, SUM(_sample_interval), 1) AS real_error_pct,
   quantileExactWeighted(0.95)(double1, _sample_interval) AS p95_ms
 FROM ${resolveAnalyticsDataset(dataset)}
 WHERE index1 = 'tool_call'

--- a/src/scheduled.ts
+++ b/src/scheduled.ts
@@ -7,8 +7,14 @@
  * Slack/Discord webhook alerts when thresholds are breached.
  *
  * Required env vars: CF_ACCOUNT_ID, CF_ANALYTICS_TOKEN, ALERT_WEBHOOK_URL
- * Optional env vars: ALERT_ERROR_THRESHOLD (default 5%), ALERT_P95_THRESHOLD (default 10000ms),
- *   ALERT_RATE_LIMIT_THRESHOLD (default 50 hits), ALERT_LOOKBACK_MINUTES (default 15)
+ * Optional env vars: ALERT_ERROR_THRESHOLD (default 5%), ALERT_MIN_ERROR_SAMPLES (default 20),
+ *   ALERT_P95_THRESHOLD (default 15000ms), ALERT_RATE_LIMIT_THRESHOLD (default 50 hits),
+ *   ALERT_LOOKBACK_MINUTES (default 15)
+ *
+ * Every RATE-based lane here pairs its threshold with a minimum-sample floor and
+ * abstains below it. A percentage over a handful of events is not a measurement, and
+ * a threshold cannot tell a real 100% from a single stray call. Absolute-count lanes
+ * (tail exceptions, binding degradation, queue failures) carry the low-volume case.
  */
 
 import {
@@ -36,7 +42,12 @@ import { resolveAlertWebhookUrl } from './lib/operator-webhook-binding';
 interface AnomalyRow {
 	total_calls?: number;
 	error_count?: number;
+	/** Pre-dispatch arg-validation rejections (blob4='none') — no tool ran. */
+	input_error_count?: number;
+	/** Errors from tools that actually EXECUTED (blob4!='none') — the honest signal. */
+	real_error_count?: number;
 	error_pct?: number;
+	real_error_pct?: number;
 	p95_ms?: number;
 }
 
@@ -90,6 +101,8 @@ export interface ScheduledEnv {
 	ALERT_LATENCY_LOOKBACK_MINUTES?: string;
 	/** Minimum tool calls in a class before its p95 is believed (default 20). Below this, p95 degenerates toward max. */
 	ALERT_MIN_LATENCY_SAMPLES?: string;
+	/** Minimum tool calls in the error-rate window before an error PERCENTAGE is believed (default 20). Below this the lane abstains — see DEFAULT_MIN_ERROR_SAMPLES. */
+	ALERT_MIN_ERROR_SAMPLES?: string;
 	ALERT_SPF_NULL_RATE_THRESHOLD?: string;
 	/** Min present-binding-degradation events in the lookback window to alert (default 1). */
 	ALERT_BINDING_DEGRADATION_THRESHOLD?: string;
@@ -255,6 +268,19 @@ const DEFAULT_LATENCY_LOOKBACK_MINUTES = 360;
  * says so in the log rather than paging on a number it cannot support.
  */
 const DEFAULT_MIN_LATENCY_SAMPLES = 20;
+/**
+ * Minimum tool calls in the error-rate window before a PERCENTAGE computed over it
+ * is believed. Not picked round — it is derived from the threshold it guards: at the
+ * default 5% ceiling, 20 is the smallest denominator at which ONE error cannot trip
+ * the alert (1/20 = 5.0%, which is not > 5%). Any smaller window is one stray call
+ * away from paging, which is exactly what happened: `error_count: 1 total_calls: 1`
+ * → 100% → `critical`, because 100 > 5 x 2.
+ *
+ * The same floor already guards the latency lane ({@link DEFAULT_MIN_LATENCY_SAMPLES})
+ * and the per-tool error query (`HAVING total > 10` in `queryErrorRate`). The alerting
+ * error lane was the one rate estimator with no denominator guard at all.
+ */
+const DEFAULT_MIN_ERROR_SAMPLES = 20;
 /** Cron cadence in minutes (the every-15-minutes trigger). Used to evaluate the latency lane once per NON-OVERLAPPING lookback window. */
 const CRON_INTERVAL_MINUTES = 15;
 /** A single present-binding failure (mis-rotated key, bv-recon 5xx) is worth surfacing. */
@@ -387,6 +413,8 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 	const latencyLookbackMinutes = Number.isFinite(parsedLatencyLookback) && parsedLatencyLookback > 0 ? parsedLatencyLookback : DEFAULT_LATENCY_LOOKBACK_MINUTES;
 	const parsedMinSamples = parseInt(env.ALERT_MIN_LATENCY_SAMPLES ?? '', 10);
 	const minLatencySamples = Number.isFinite(parsedMinSamples) && parsedMinSamples >= 0 ? parsedMinSamples : DEFAULT_MIN_LATENCY_SAMPLES;
+	const parsedMinErrorSamples = parseInt(env.ALERT_MIN_ERROR_SAMPLES ?? '', 10);
+	const minErrorSamples = Number.isFinite(parsedMinErrorSamples) && parsedMinErrorSamples >= 0 ? parsedMinErrorSamples : DEFAULT_MIN_ERROR_SAMPLES;
 
 	// EACH QUERY GETS ITS OWN try. Running all six inside a single try meant the
 	// FIRST rejection aborted the whole check, taking every later alert down with
@@ -454,23 +482,73 @@ export async function handleScheduled(env: ScheduledEnv): Promise<void> {
 		}
 
 		if (anomaly && anomaly.total_calls && anomaly.total_calls > 0) {
-			const errorPct = anomaly.error_pct ?? 0;
+			const totalCalls = anomaly.total_calls;
 			const p95Ms = anomaly.p95_ms ?? 0;
 
-			if (errorPct > errorThreshold) {
+			// JUDGE THE REAL ERROR RATE, NOT THE CONFLATED ONE.
+			//
+			// `error_pct` counts pre-dispatch arg-validation rejections (blob4='none') as
+			// service errors. Those are a fuzzer or a probe sending a bad/absent domain to a
+			// public endpoint — no tool ran, so nothing about the service was measured. The
+			// split already existed in `queryErrorRate` for the per-tool report (where it
+			// moved check_mx from ~16% to ~0%); the lane that actually PAGES was still
+			// reading the conflated number.
+			//
+			// `real_error_pct` is absent on a reader pinned to an older query shape, so fall
+			// back to the conflated value rather than silently reporting 0% — a fallback that
+			// over-reports is safe here; one that under-reports would hide an outage.
+			const errorPct = anomaly.real_error_pct ?? anomaly.error_pct ?? 0;
+			const realErrorCount = anomaly.real_error_count ?? anomaly.error_count ?? 0;
+
+			// ABSTAIN rather than page on a rate we cannot compute. A percentage over a
+			// handful of calls is not a rate — at the measured traffic (~11 tool calls/hour)
+			// a 15m window holds ~3 calls, so ONE stray error is 33%, and one call that is
+			// also the only call is 100%. Both paged `critical` against a 5% threshold.
+			//
+			// This deliberately makes the lane quiet on a low-traffic deploy, and that is the
+			// correct trade: at n < 20 a "100% error rate" is genuinely indistinguishable
+			// from one bad probe, so there is no threshold that separates them. A real
+			// low-volume incident is not left uncovered — the tail-exception, binding-
+			// degradation and queue-failure lanes all alert on ABSOLUTE counts (threshold 1)
+			// and so do not depend on rate inference at all. That division of labour is what
+			// makes the floor safe: rate detectors abstain, count detectors cover.
+			//
+			// Logged (never alerted) so a permanently-quiet lane is greppable rather than
+			// indistinguishable from a healthy one — same posture as the latency lane.
+			if (totalCalls < minErrorSamples) {
+				logEvent({
+					timestamp: new Date().toISOString(),
+					category: 'scheduled',
+					result: 'ok',
+					severity: 'info',
+					details: {
+						message: 'Error-rate lane abstained: too few calls for an error percentage to be meaningful.',
+						totalCalls,
+						realErrorCount,
+						minSamples: minErrorSamples,
+						lookbackMinutes: Number(lookback),
+					},
+				});
+			} else if (errorPct > errorThreshold) {
 				const severity = errorPct > errorThreshold * 2 ? 'critical' : 'warning';
 				await sendAlert(
 					webhookUrl,
 					buildAlertPayload({
-						title: `Error rate ${errorPct.toFixed(1)}% (last ${lookback}m)`,
+						// total_calls is in the TITLE, not just the metrics block: "5 of 11 calls"
+						// reads very differently from "45.5%", and the reader sees the title first.
+						// Same lesson as the latency lane (#729).
+						title: `Error rate ${errorPct.toFixed(1)}% — ${realErrorCount} of ${totalCalls} calls (last ${lookback}m)`,
 						severity,
 						metrics: {
-							error_pct: errorPct.toFixed(1) + '%',
-							error_count: anomaly.error_count,
-							total_calls: anomaly.total_calls,
+							real_error_pct: errorPct.toFixed(1) + '%',
+							real_error_count: realErrorCount,
+							// Reported so the reader can see how much of the raw error count was
+							// fuzz/probe noise that the alert deliberately did NOT judge.
+							input_error_count: anomaly.input_error_count ?? 0,
+							total_calls: totalCalls,
 							p95_ms: Math.round(p95Ms),
 						},
-						threshold: `error_pct > ${errorThreshold}%`,
+						threshold: `real_error_pct > ${errorThreshold}% over >= ${minErrorSamples} calls`,
 					}),
 					alertOptions(env),
 				);

--- a/test/error-rate-lane.spec.ts
+++ b/test/error-rate-lane.spec.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * THE ERROR-RATE ALERT PAGED `critical` ON A SINGLE PROBE CALL.
+ *
+ * Live examples off the operator alert board, all severity `critical`:
+ *
+ *   Error rate 100.0%  error_count: 1  total_calls: 1   p95_ms: 0
+ *   Error rate  50.0%  error_count: 1  total_calls: 2   p95_ms: 7174
+ *   Error rate  45.5%  error_count: 5  total_calls: 11  p95_ms: 3570
+ *
+ * Nothing was wrong. Two defects combined, and both had already been diagnosed and
+ * fixed ELSEWHERE in the same codebase without the alerting lane inheriting either:
+ *
+ *  1. NO DENOMINATOR FLOOR. The only guard was `total_calls > 0`, so a percentage was
+ *     computed over as little as one call. At the measured traffic (~11 tool calls per
+ *     hour) a 15m window holds ~3 calls, so a single error is 33% and the only call in
+ *     a window is 100% — both far past `errorThreshold * 2`, hence `critical`. The
+ *     latency lane learned this in #729 (`minLatencySamples`), and `queryErrorRate`
+ *     already carried `HAVING total > 10`; this lane had no floor at all.
+ *  2. CONFLATED ERROR CLASSES. `error_pct` counts pre-dispatch arg-validation
+ *     rejections (blob4='none' — no tool ran) as service errors. Those are fuzzers and
+ *     probes hitting a public endpoint. `queryErrorRate` split them out precisely
+ *     because that floor of noise inflated low-volume tools (check_mx read ~16% but was
+ *     ~0% real failures) — yet the query that PAGES kept reading the conflated number.
+ *     `p95_ms: 0` on the two 100% alerts is the fingerprint: no tool work ran at all.
+ *
+ * These tests pin the fix as INVARIANTS — abstain below the floor, judge only errors
+ * from tools that actually executed, keep the denominator in the title — so retuning a
+ * threshold does not require rewriting the guarantees.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const WEBHOOK = 'https://hooks.slack.com/test';
+const ENV = { CF_ACCOUNT_ID: 'a', CF_ANALYTICS_TOKEN: 't', ALERT_WEBHOOK_URL: WEBHOOK };
+
+interface Call {
+	url: string;
+	body: string;
+}
+
+/**
+ * Mock AE. `anomalyRow` is what the 15m anomalies query returns; every OTHER query
+ * returns data that does not trip its own threshold, so any alert observed came from
+ * the error-rate lane and nothing else.
+ */
+function mockAnalytics(anomalyRow: Record<string, unknown> | null): Call[] {
+	const calls: Call[] = [];
+	globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : (input as Request).url;
+		const body = (init?.body as string) ?? '';
+		calls.push({ url, body });
+
+		if (!url.includes('analytics_engine/sql')) return new Response('ok');
+		// The anomalies lane is the only tool_call query without a GROUP BY.
+		if (body.includes("index1 = 'tool_call'") && !body.includes('workload_class') && !body.includes('blob1 AS tool_name')) {
+			return Response.json({ data: anomalyRow ? [anomalyRow] : [] });
+		}
+		return Response.json({ data: [] });
+	}) as typeof fetch;
+	return calls;
+}
+
+async function run(anomalyRow: Record<string, unknown> | null): Promise<Call[]> {
+	const calls = mockAnalytics(anomalyRow);
+	const { handleScheduled } = await import('../src/scheduled');
+	await handleScheduled(ENV);
+	return calls;
+}
+
+function alertsSent(calls: Call[]): string {
+	return calls
+		.filter((c) => c.url.includes('hooks.slack.com'))
+		.map((c) => c.body)
+		.join('\n');
+}
+
+afterEach(() => {
+	vi.restoreAllMocks();
+	vi.resetModules();
+});
+
+describe('error-rate lane — denominator floor', () => {
+	it('does not page on a single errored call in the window (the reported incident)', async () => {
+		// Verbatim shape of the worst alert on the board: one call, one error, 100%.
+		const calls = await run({ total_calls: 1, error_count: 1, real_error_count: 1, error_pct: 100, real_error_pct: 100, p95_ms: 0 });
+
+		expect(alertsSent(calls)).not.toContain('Error rate');
+	});
+
+	it('does not page at 45.5% over 11 calls', async () => {
+		// The subtlest of the reported alerts — a real-looking rate that is still a
+		// sample too small to distinguish from noise.
+		const calls = await run({ total_calls: 11, error_count: 5, real_error_count: 5, error_pct: 45.5, real_error_pct: 45.5, p95_ms: 3570 });
+
+		expect(alertsSent(calls)).not.toContain('Error rate');
+	});
+
+	it('pages once the sample is large enough at the SAME error rate', async () => {
+		// NON-VACUOUSNESS: identical rate, only the call count differs. Without this,
+		// the tests above could be passing because the lane is dead rather than because
+		// it abstained.
+		const calls = await run({
+			total_calls: 200,
+			error_count: 91,
+			real_error_count: 91,
+			error_pct: 45.5,
+			real_error_pct: 45.5,
+			p95_ms: 3570,
+		});
+
+		expect(alertsSent(calls)).toContain('Error rate');
+	});
+
+	it('sits the floor exactly where one lone error cannot trip the default threshold', async () => {
+		// The floor is DERIVED from the 5% threshold it guards, not picked round:
+		// 1/20 = 5.0%, which is not > 5%. Pinning the relationship rather than the
+		// number keeps the derivation honest if either value is retuned.
+		const oneErrorAtFloor = await run({
+			total_calls: 20,
+			error_count: 1,
+			real_error_count: 1,
+			error_pct: 5,
+			real_error_pct: 5,
+			p95_ms: 100,
+		});
+		expect(alertsSent(oneErrorAtFloor)).not.toContain('Error rate');
+
+		// Two errors over the same window IS above threshold and is believed.
+		const twoErrorsAtFloor = await run({
+			total_calls: 20,
+			error_count: 2,
+			real_error_count: 2,
+			error_pct: 10,
+			real_error_pct: 10,
+			p95_ms: 100,
+		});
+		expect(alertsSent(twoErrorsAtFloor)).toContain('Error rate');
+	});
+});
+
+describe('error-rate lane — real vs input errors', () => {
+	it('does not page when every error was a pre-dispatch arg rejection', async () => {
+		// A fuzzer sending bad/absent domains to the public endpoint. Volume is well
+		// over the floor, so ONLY the class split can be what suppresses this.
+		const calls = await run({
+			total_calls: 200,
+			error_count: 120,
+			input_error_count: 120,
+			real_error_count: 0,
+			error_pct: 60,
+			real_error_pct: 0,
+			p95_ms: 0,
+		});
+
+		expect(alertsSent(calls)).not.toContain('Error rate');
+	});
+
+	it('pages when tools that actually executed are failing', async () => {
+		// Same volume, same raw error_count — the errors are just real this time.
+		const calls = await run({
+			total_calls: 200,
+			error_count: 120,
+			input_error_count: 0,
+			real_error_count: 120,
+			error_pct: 60,
+			real_error_pct: 60,
+			p95_ms: 4000,
+		});
+
+		expect(alertsSent(calls)).toContain('Error rate');
+	});
+
+	it('judges the real rate even when fuzz noise pushes the conflated rate over the line', async () => {
+		// The mixed case the split exists for: conflated 60% would page `critical`,
+		// real 2% is healthy. Judging the wrong column here is the whole defect.
+		const calls = await run({
+			total_calls: 200,
+			error_count: 120,
+			input_error_count: 116,
+			real_error_count: 4,
+			error_pct: 60,
+			real_error_pct: 2,
+			p95_ms: 800,
+		});
+
+		expect(alertsSent(calls)).not.toContain('Error rate');
+	});
+
+	it('falls back to the conflated rate when a reader returns no real_error_pct', async () => {
+		// FAIL-LOUD, not fail-silent. An older/pinned query shape omits the split; the
+		// lane must over-report rather than silently read 0% and hide an outage.
+		const calls = await run({ total_calls: 200, error_count: 120, error_pct: 60, p95_ms: 4000 });
+
+		expect(alertsSent(calls)).toContain('Error rate');
+	});
+});
+
+describe('error-rate lane — alert legibility', () => {
+	it('puts the error count and sample size in the alert TITLE, not only the metrics block', async () => {
+		// "45.5%" and "5 of 11 calls" are read very differently, and the reader sees the
+		// title first. Every alert on the reported board omitted the denominator from
+		// the title — the same omission the latency lane fixed in #729.
+		const calls = await run({
+			total_calls: 200,
+			error_count: 91,
+			input_error_count: 0,
+			real_error_count: 91,
+			error_pct: 45.5,
+			real_error_pct: 45.5,
+			p95_ms: 3570,
+		});
+
+		const title = (JSON.parse(alertsSent(calls)).text as string).split('\n')[0];
+		expect(title).toContain('Error rate');
+		expect(title).toContain('91');
+		expect(title).toContain('200');
+		expect(title).not.toContain('total_calls:');
+	});
+
+	it('reports the suppressed input-error count so the reader can see what was excluded', async () => {
+		// The alert must not silently drop the noise it declined to judge — an operator
+		// comparing against a raw AE query needs the two numbers to reconcile.
+		const calls = await run({
+			total_calls: 200,
+			error_count: 100,
+			input_error_count: 40,
+			real_error_count: 60,
+			error_pct: 50,
+			real_error_pct: 30,
+			p95_ms: 4000,
+		});
+
+		const sent = alertsSent(calls);
+		expect(sent).toContain('input_error_count');
+		expect(sent).toContain('40');
+		expect(sent).toContain('real_error_count');
+	});
+});
+
+describe('error-rate lane — query shape', () => {
+	it('selects the real/input error split the lane depends on', async () => {
+		// The lane reads `real_error_pct`; if the query stops emitting it, the fallback
+		// silently reverts to the conflated behaviour this fix removed. Pin the seam.
+		const calls = await run(null);
+		const sql = calls.find((c) => c.url.includes('analytics_engine/sql') && c.body.includes('real_error_pct'))?.body ?? '';
+
+		expect(sql).not.toBe('');
+		expect(sql).toContain("blob3 = 'error' AND blob4 != 'none'");
+		expect(sql).toContain("blob3 = 'error' AND blob4 = 'none'");
+		expect(sql).toContain('real_error_count');
+		expect(sql).toContain('input_error_count');
+		// Divide-by-zero guard must use if(), not GREATEST() — AE's SQL API 422s on the
+		// latter, which is what had every alert dead once before.
+		expect(sql).toContain('if(SUM(_sample_interval) > 0, SUM(_sample_interval), 1)');
+	});
+});


### PR DESCRIPTION
The `anomalies` lane computed an error PERCENTAGE over whatever the 15m window happened to hold, guarded only by `total_calls > 0`. At the measured traffic (~11 tool calls/hour) that window holds ~3 calls, so one error is 33% and a lone call is 100% — both past `errorThreshold * 2`, hence `critical`.

Live off the operator alert board, all severity `critical`, nothing wrong:

| Alert | error_count | total_calls | p95_ms |
| --- | --- | --- | --- |
| 100.0% | 1 | **1** | **0** |
| 100.0% | 1 | **1** | **0** |
| 50.0% | 1 | **2** | 7174 |
| 45.5% | 5 | **11** | 3570 |

Two defects, and both had already been diagnosed and fixed elsewhere in this codebase without the alerting lane inheriting either.

### 1. No denominator floor

The lane now abstains below `ALERT_MIN_ERROR_SAMPLES` (default **20**) and logs the abstention at `info` so a permanently-quiet lane stays greppable. The default is derived, not round: at the 5% ceiling, 20 is the smallest denominator at which one error cannot trip the alert, since 1/20 = 5.0% is not > 5%.

The latency lane gained this floor in #729 (`minLatencySamples`) and `queryErrorRate` already carried `HAVING total > 10`. The alerting error lane was the one rate estimator in the file with no denominator guard at all.

### 2. Conflated error classes

`error_pct` counts pre-dispatch arg-validation rejections (`blob4='none'` — the request never reached a tool, so nothing about the service was measured) as service errors. Those are fuzzers and probes on a public endpoint.

`queryErrorRate` split them out precisely because that noise floor inflated low-volume tools — its own comment records `check_mx` reading ~16% against ~0% real failures — yet the query that actually **pages** kept reading the conflated column. The `p95_ms: 0` on both 100% alerts is the fingerprint: no tool work ran.

`queryRecentAnomalies` now emits `input_error_count` / `real_error_count` / `real_error_pct`, and the lane thresholds on the real rate. A row without the split falls back to the conflated value rather than reading 0%, so an older reader over-reports rather than hiding an outage. The suppressed input-error count is reported in the payload so an operator can reconcile against a raw AE query.

### 3. Title carries its denominator

`Error rate 45.5% — 5 of 11 calls` rather than `Error rate 45.5%`. The reader sees the title first, and every alert on the board buried the sample size in the metrics block. Same omission the latency lane fixed in #729.

## The trade-off

This deliberately makes the lane quiet on low-traffic windows. That is the correct trade rather than a coverage gap: below the floor a "100% error rate" is genuinely indistinguishable from one bad probe, so no threshold separates them.

Low-volume incidents stay covered by the lanes that alert on **absolute counts** — tail exceptions, binding degradation, queue failures, all threshold 1 — which do not depend on rate inference. Rate detectors abstain; count detectors cover. `ALERT_MIN_ERROR_SAMPLES` is env-tunable if you want to trade noise back for sensitivity without shipping code.

## Verification

- 11 new regression tests in `test/error-rate-lane.spec.ts`. Every abstain case is paired with a non-vacuousness case (same rate, larger sample → still pages) so a passing abstain cannot be the lane simply being dead.
- Full suite: **7802 passed**. Two failures — `asset-discovery-integration` (a live-network test) and a Cloudflare cert-issuer path in `scan-post-processing` — fail identically on the clean base commit `36156d5`. Neither touches alerting.
- `typecheck`, the `typecheck:tests` ratchet, and `lint` all clean.

**No scoring-model change.** `SCORING_MODEL_VERSION` unchanged, `@blackveil/dns-checks` untouched at 1.23.0. Operator alerting only — no scan output changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q56zmS2TsAB8dTnk3sCcFQ