### PR TITLE
fix(ci): create the drift labels before using them

### DIFF
--- a/.github/workflows/registry-drift-check.yml
+++ b/.github/workflows/registry-drift-check.yml
@@ -69,6 +69,21 @@ jobs:
           echo "Registry version: $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+      # `gh issue create --label X` FAILS if X does not already exist — it does
+      # not create labels implicitly, and the failure is fatal (the issue is not
+      # created at all). Creating them here keeps the workflow self-sufficient in
+      # a fresh fork or self-host rather than depending on repo state someone set
+      # up by hand. `--force` makes it idempotent: create if absent, update if not.
+      - name: Ensure drift labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh label create registry-drift --repo "$REPO" --force \
+            --color D93F0B --description "MCP Registry listing has drifted from live prod"
+          gh label create priority-high --repo "$REPO" --force \
+            --color B60205 --description "Escalated: needs attention now"
+
       - name: Compare versions and act
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
The first real run of `registry-drift-check` failed. It worked correctly right up to the last step — detected `live=3.63.0` vs `registry=3.62.0`, took the "first sighting" branch — then:

```
could not add label: 'registry-drift' not found
```

`gh issue create --label X` does not create `X` implicitly, and the failure is **fatal**: no issue is created at all. So the detector detected the drift and then reported nothing, which is the one outcome a detector must not have.

Neither `registry-drift` nor `priority-high` existed in the repo.

Creating them in the workflow rather than by hand keeps it self-sufficient in a fresh fork or self-host, instead of depending on repo state configured out of band. `--force` is idempotent — create if absent, update if present.

Verified: `workflow-permissions` 8/8, `workflow-cost` 2/2, still zero `uses:` lines, `bash -n` clean on the new block. The job already carries `issues: write`, which is what label creation needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)