### PR TITLE
chore(dns-checks): bump package + parity corpus to 1.24.0 for the scoring-model-1.13.0 re-vendor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5163,7 +5163,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.23.0",
+			"version": "1.24.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.23.0",
+	"version": "1.24.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.23.0';
+export const PARITY_CORPUS_VERSION = '1.24.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):


### PR DESCRIPTION
## Summary

Lockstep version bump preceding the bv-web-prod re-vendor: `packages/dns-checks` **1.23.0 → 1.24.0** and `PARITY_CORPUS_VERSION` moved together in one commit (the lockstep law from the `bv-mcp-scoring` skill; precedent #667). Root `package-lock.json` refreshed.

This cuts the version that gets packed into `vendor/blackveil-dns-checks-1.24.0.tgz` for bv-web-prod, shipping scoring model **1.13.0** (#775) plus the 1.22.0→1.23.0 delta bv-web-prod hasn't vendored yet. `DNS_CHECKS_PACKAGE_VERSION` derives from `PARITY_CORPUS_VERSION`, so no other surface changes.

## Verification

- `npm run build --workspace=packages/dns-checks` clean
- `parity-corpus.contract.test.ts` + `scoring-version.spec.ts` + `scan-version-stamps.spec.ts` — 80/80
- `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)