### PR TITLE
fix(scanner): five findings-accuracy defects (#779–#783)

### DIFF
--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -268,7 +268,9 @@ async function detectWildcardParents(parentDomains: string[]): Promise<Set<strin
  * Returns only domains that have NS records (i.e., are registered),
  * along with their normalized NS record data for ownership comparison.
  */
-async function filterByNsExistence(domains: string[]): Promise<{ registered: string[]; nsMap: Map<string, Set<string>> }> {
+async function filterByNsExistence(
+	domains: string[],
+): Promise<{ registered: string[]; nsMap: Map<string, Set<string>>; unresolved: number }> {
 	const nsMap = new Map<string, Set<string>>();
 	const results = await Promise.allSettled(
 		domains.map(async (domain) => {
@@ -282,7 +284,15 @@ async function filterByNsExistence(domains: string[]): Promise<{ registered: str
 	const registered = results
 		.filter((r): r is PromiseFulfilledResult<{ domain: string; hasNs: boolean }> => r.status === 'fulfilled' && r.value.hasNs)
 		.map((r) => r.value.domain);
-	return { registered, nsMap };
+	// A REJECTED NS lookup is not "unregistered" — it is UNKNOWN, and dropping it
+	// silently is the primary source of run-to-run variance (#781). This phase
+	// gates everything downstream, so a timed-out NS query makes a registered
+	// domain vanish from the result set entirely, with nothing in the response
+	// distinguishing that from a deregistration. Measured on openclaw.ai: three
+	// `force_refresh` runs minutes apart returned 12, 10 and 13 candidates, with
+	// three names appearing only in the third.
+	const unresolved = results.filter((r) => r.status === 'rejected').length;
+	return { registered, nsMap, unresolved };
 }
 
 /**
@@ -616,7 +626,7 @@ async function checkLookalikesCore(
 		queryPrimaryNs(domain),
 		queryPrimaryMx(domain),
 	]);
-	const { registered: registeredPerms, nsMap: lookalikeNsMap } = nsResult;
+	const { registered: registeredPerms, nsMap: lookalikeNsMap, unresolved: nsUnresolved } = nsResult;
 
 	if (registeredPerms.length === 0) {
 		findings.push(
@@ -666,6 +676,23 @@ async function checkLookalikesCore(
 			results.push(result.value);
 		}
 	}
+	// Second silent-drop site (#781): a candidate already KNOWN registered, whose
+	// infrastructure probe failed, disappears here.
+	const probeUnresolved = probeResults.filter((r) => r.status === 'rejected').length;
+	/**
+	 * Enumeration coverage for this run.
+	 *
+	 * `complete: false` means the candidate set is a SAMPLE, not a census — so a
+	 * consumer diffing consecutive runs must not read a shrinking set as a
+	 * deregistration, and a report must not present the list as exhaustive.
+	 */
+	const enumeration = {
+		permutationsGenerated: permutations.length,
+		permutationsProbed: permsToProbe.length,
+		candidatesResolved: results.length,
+		unresolvedCount: nsUnresolved + probeUnresolved,
+		complete: nsUnresolved + probeUnresolved === 0,
+	};
 
 	// Enrichment (Defect L / issue #264): for each non-defensively-registered
 	// lookalike with mail or web infrastructure, gather corroborating signals
@@ -753,6 +780,23 @@ async function checkLookalikesCore(
 	const highDomains: string[] = [];
 	/** Their ownership verdicts — always non-owned, since owned candidates never reach the counter. */
 	const highVerdicts = new Set<OwnershipVerdict>();
+	/**
+	 * EVERY non-owned candidate with a working mail host — a strictly WIDER set
+	 * than `highDomains`, which additionally requires a #264 corroborator.
+	 *
+	 * Tracked separately because the summary finding used to be TITLED for this
+	 * set ("N lookalike domains with mail capability detected") while being
+	 * COUNTED from the narrower one (#779). Measured on openclaw.ai the title
+	 * said 2 while six candidates in the SAME response carried `hasMX: true`;
+	 * on openclaw.org it said 1 against 3. A three-fold undercount, in the one
+	 * finding a consumer is most likely to read without expanding the per-domain
+	 * detail — and it propagated into a client-facing report.
+	 *
+	 * A domain with working mail AND a live website is not the safer case: the
+	 * site lends the mail credibility. Excluding it from a count labelled "mail
+	 * capability" was the wrong direction to be wrong in.
+	 */
+	const mailCapableDomains: string[] = [];
 	for (const result of results) {
 		const ownership: OwnershipAssessment = ownershipByDomain.get(result.domain) ?? {
 			verdict: 'unattributed',
@@ -954,6 +998,10 @@ async function checkLookalikesCore(
 				brandHeld !== undefined,
 			),
 		);
+		// `hasMX` is already false for an RFC 7505 null MX (`0 .`), which is the
+		// explicit way a domain declines mail — so this counts real mail hosts,
+		// not merely "an MX record exists".
+		if (result.hasMX) mailCapableDomains.push(result.domain);
 		if (result.hasMX && severity === 'high') {
 			highCount++;
 			highDomains.push(result.domain);
@@ -968,17 +1016,74 @@ async function checkLookalikesCore(
 		findings.push(
 			createFinding(
 				'lookalikes',
-				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} with mail capability detected`,
+				// TITLE NAMES THE PREDICATE IT COUNTS (#779). It used to say "with
+				// mail capability", which is a strictly wider set than the
+				// mail-infra-PLUS-corroborator matrix this count applies — so the
+				// headline under-reported threefold against its own per-domain
+				// evidence. The staging subset is the right thing to lead with; it
+				// just has to be named as the subset it is, with the wider
+				// mail-capable figure alongside rather than implied.
+				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} showing pre-phishing staging signals`,
 				'high',
-				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging. ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
+				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging.${
+					mailCapableDomains.length > highCount
+						? ` A further ${mailCapableDomains.length - highCount} confusable domain${mailCapableDomains.length - highCount > 1 ? 's' : ''} also ${mailCapableDomains.length - highCount > 1 ? 'have' : 'has'} a working mail host without those additional signals — ${mailCapableDomains.length} can send mail in total.`
+						: ''
+				} ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
 				{
 					lookalikeDomainCount: highCount,
 					lookalikeDomains: highDomains,
+					// BOTH numbers, so a consumer never has to re-derive either from
+					// the per-domain findings — which is what the old shape forced,
+					// and what nobody did.
+					mailCapableCount: mailCapableDomains.length,
+					mailCapableDomains,
+					enumeration,
+					// Set-level claim, so its confidence tracks ENUMERATION coverage,
+					// not per-domain measurement quality (#781). Each row remains
+					// deterministic about its own domain; what is uncertain when a
+					// lookup was dropped is whether the SET is complete — and this
+					// finding is the one making a claim about the set.
+					confidence: enumeration.complete ? 'deterministic' : 'heuristic',
 					// Present whenever the counted set shares one verdict (the realistic
 					// case — a non-owned registered candidate is always `third_party`).
 					// Omitted rather than fabricated for a mixed set; either way it can
 					// never be `owned_by_seed`, since owned candidates never reach here.
 					...(highVerdicts.size === 1 ? { ownershipVerdict: [...highVerdicts][0] } : {}),
+					findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+				},
+			),
+		);
+	} else if (mailCapableDomains.length > 0) {
+		// The other half of #779. When mail-capable candidates exist but none
+		// carries a #264 corroborator, the old code emitted NO summary at all —
+		// so an estate with several confusable domains that can send mail
+		// produced an aggregate view saying nothing, and a consumer reading only
+		// summaries concluded there was no mail-capable lookalike exposure.
+		//
+		// MEDIUM, not high: mail capability alone is a real observation but not
+		// evidence of staging, and the severity has to stay honest about which
+		// of the two it is.
+		const n = mailCapableDomains.length;
+		findings.push(
+			createFinding(
+				'lookalikes',
+				`${n} lookalike domain${n > 1 ? 's' : ''} with a working mail host`,
+				'medium',
+				`${n} confusable domain${n > 1 ? 's' : ''} of ${domain} ${n > 1 ? 'have' : 'has'} a working mail host, so ${n > 1 ? 'they are' : 'it is'} capable of sending mail that resembles ${domain}. No additional corroborating signal of pre-phishing staging was observed, and ${n > 1 ? 'none appears' : 'it does not appear'} to belong to the scanned organisation — this is an infrastructure observation, not an allegation. Enforcing DMARC p=reject on ${domain} is what makes receivers reject mail forging that name.`,
+				{
+					mailCapableCount: n,
+					mailCapableDomains,
+					enumeration,
+					confidence: enumeration.complete ? 'deterministic' : 'heuristic',
+					// Names what it observed — invariant 4, asserted by
+					// `assertAxisInvariants`: every threat_observation must identify
+					// its subject. Omitting this made the first draft of this finding
+					// anonymous, and the existing suite caught it.
+					lookalikeDomains: mailCapableDomains,
+					// Deliberately no `lookalikeDomainCount`: nothing reached the
+					// staging threshold, and reusing that key would let a consumer
+					// read this as the staging count.
 					findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
 				},
 			),
@@ -992,8 +1097,34 @@ async function checkLookalikesCore(
 				'lookalikes',
 				'No active lookalike domains detected',
 				'info',
-				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations with DNS or mail infrastructure detected.`,
-				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
+				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations with DNS or mail infrastructure detected.${
+					enumeration.complete
+						? ''
+						: ` ⚠️ ${enumeration.unresolvedCount} lookup${enumeration.unresolvedCount > 1 ? 's' : ''} did not resolve, so this is not a conclusive "none".`
+				}`,
+				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis, enumeration },
+			),
+		);
+	}
+
+	// PARTIAL COVERAGE (#781). Emitted as its own finding, not only as metadata,
+	// because a consumer reading findings — which is most of them — otherwise
+	// has no way to learn the candidate set is a SAMPLE. Without it, repeat runs
+	// returning different sets look like real-world change: monitoring built on
+	// diffing consecutive runs raises false "new lookalike registered" alerts for
+	// names merely missed last time, and misses real ones enumerated before.
+	if (!enumeration.complete) {
+		findings.push(
+			createFinding(
+				'lookalikes',
+				'Lookalike enumeration was incomplete — treat this list as a sample',
+				'info',
+				`${enumeration.unresolvedCount} of ${enumeration.permutationsProbed} candidate lookup${enumeration.permutationsProbed > 1 ? 's' : ''} for ${domain} did not resolve (DNS timeout or rate limiting), so those permutations could be neither confirmed nor ruled out. The ${enumeration.candidatesResolved} domain${enumeration.candidatesResolved === 1 ? '' : 's'} reported here are observed examples, not a complete inventory — do not read a smaller set on a later run as a domain having been deregistered, and re-run before relying on the count.`,
+				{
+					findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
+					enumeration,
+					confidence: 'heuristic',
+				},
 			),
 		);
 	}

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -122,7 +122,16 @@ export const FALLBACK_RDAP_SERVERS: Record<string, string> = {
 	tools: 'https://rdap.identitydigital.services/rdap/',
 	// Identity Digital ccTLDs / TLD operators
 	io: 'https://rdap.identitydigital.services/rdap/',
-	ai: 'https://rdap.nic.ai/',
+	// ⚠️ `.ai` is Identity Digital, NOT `rdap.nic.ai` (#780). That host has NO A
+	// RECORD — it does not resolve and never answered. Because `probeRdap`
+	// fail-softs to `EMPTY_RDAP_PROBE`, every `.ai` lookup silently produced
+	// `registrationDays: null` while `.org`/`.com` populated correctly, so the
+	// "recently registered" signal — the highest-value thing lookalike triage
+	// surfaces — was dead for the whole TLD with no error raised anywhere.
+	// Verified against IANA's authoritative bootstrap (data.iana.org/rdap/dns.json
+	// maps ai → identitydigital) and by live probe: openclaw.ai returns 200 with
+	// a registration event. Do NOT "restore" rdap.nic.ai.
+	ai: 'https://rdap.identitydigital.services/rdap/',
 	sh: 'https://rdap.identitydigital.services/rdap/',
 	// auDA
 	au: 'https://rdap.cctld.au/rdap/',

--- a/src/tools/intelligence.ts
+++ b/src/tools/intelligence.ts
@@ -30,10 +30,33 @@ export interface TrendSummary {
 	snapshots: TrendSnapshot[];
 }
 
+/**
+ * Why a benchmark read came back `unavailable`.
+ *
+ * A bare `unavailable` is unactionable (#783): a caller's three sensible
+ * responses — retry, fall back, or record a permanent limitation — cannot be
+ * chosen between without knowing which happened. Measured 2026-08-24: the
+ * `mail_enabled` profile returned `unavailable` while `enterprise_mail`
+ * succeeded in the same window, which reads as "this profile has no cohort".
+ * It was a 500ms timeout on the BUSIEST profile (1.47M scans vs 46k); the
+ * identical call succeeded minutes later. Recorded in a client document as a
+ * permanent scope limitation before it was caught.
+ *
+ * - `not_configured` — the DO binding is absent. Permanent for this deployment.
+ * - `timeout` — the shard did not answer inside the budget. Retryable, and the
+ *   likeliest reason on a large profile.
+ * - `upstream_error` — the shard answered non-2xx. Retryable.
+ */
+export type BenchmarkUnavailableReason = 'not_configured' | 'timeout' | 'upstream_error';
+
 /** Benchmark response from the DO. */
 export interface BenchmarkResult {
 	status: 'ok' | 'insufficient_data' | 'unavailable';
 	profile: string;
+	/** Set only when `status === 'unavailable'`. See {@link BenchmarkUnavailableReason}. */
+	reason?: BenchmarkUnavailableReason;
+	/** Set only when `status === 'unavailable'`. `false` means do not re-probe. */
+	retryable?: boolean;
 	totalScans?: number;
 	minimumRequired?: number;
 	meanScore?: number;
@@ -51,6 +74,10 @@ export interface ProviderInsightsResult {
 	status: 'ok' | 'no_data' | 'unavailable';
 	provider: string;
 	profile: string;
+	/** Set only when `status === 'unavailable'`. See {@link BenchmarkUnavailableReason}. */
+	reason?: BenchmarkUnavailableReason;
+	/** Set only when `status === 'unavailable'`. `false` means do not re-probe. */
+	retryable?: boolean;
 	totalScans?: number;
 	emaOverallScore?: number;
 	topFailingCategories?: string[];
@@ -84,7 +111,7 @@ export async function getBenchmark(
 	shardMode: AccumulatorShardMode = 'global',
 ): Promise<BenchmarkResult> {
 	if (!accumulator) {
-		return { status: 'unavailable', profile };
+		return { status: 'unavailable', profile, reason: 'not_configured', retryable: false };
 	}
 
 	try {
@@ -93,13 +120,26 @@ export async function getBenchmark(
 		const url = new URL('https://do/benchmark');
 		url.searchParams.set('profile', profile);
 
-		const response = await Promise.race([
-			stub.fetch(url.toString(), { method: 'GET' }),
-			new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), INTELLIGENCE_FETCH_TIMEOUT_MS)),
-		]);
+		// ONE retry on timeout (#783). The measured failure was the busiest
+		// profile missing a 500ms budget while a smaller sibling answered — a
+		// blip, not a capability gap, but indistinguishable from one at the call
+		// site. Retrying only the timeout path keeps the worst case at two
+		// budgets and leaves a genuine upstream error to surface immediately.
+		let response: Response | undefined;
+		for (let attempt = 0; attempt < 2; attempt++) {
+			try {
+				response = await Promise.race([
+					stub.fetch(url.toString(), { method: 'GET' }),
+					new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), INTELLIGENCE_FETCH_TIMEOUT_MS)),
+				]);
+				break;
+			} catch {
+				if (attempt === 1) return { status: 'unavailable', profile, reason: 'timeout', retryable: true };
+			}
+		}
 
-		if (!response.ok) {
-			return { status: 'unavailable', profile };
+		if (!response || !response.ok) {
+			return { status: 'unavailable', profile, reason: 'upstream_error', retryable: true };
 		}
 
 		const benchmarkData = (await response.json()) as BenchmarkResult;
@@ -135,7 +175,9 @@ export async function getBenchmark(
 
 		return benchmarkData;
 	} catch {
-		return { status: 'unavailable', profile };
+		// Shard resolution / JSON parse failed rather than the fetch — retryable,
+		// but not a timeout, so it is reported as an upstream problem.
+		return { status: 'unavailable', profile, reason: 'upstream_error', retryable: true };
 	}
 }
 
@@ -159,7 +201,7 @@ export async function getProviderInsights(
 	shardMode: AccumulatorShardMode = 'global',
 ): Promise<ProviderInsightsResult> {
 	if (!accumulator) {
-		return { status: 'unavailable', provider, profile };
+		return { status: 'unavailable', provider, profile, reason: 'not_configured', retryable: false };
 	}
 
 	try {
@@ -169,18 +211,29 @@ export async function getProviderInsights(
 		url.searchParams.set('provider', provider);
 		url.searchParams.set('profile', profile);
 
-		const response = await Promise.race([
-			stub.fetch(url.toString(), { method: 'GET' }),
-			new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), INTELLIGENCE_FETCH_TIMEOUT_MS)),
-		]);
+		// Same one-retry-on-timeout as `getBenchmark` — this reads the same DO
+		// under the same budget, so it has the same blip-vs-gap ambiguity (#783).
+		let response: Response | undefined;
+		for (let attempt = 0; attempt < 2; attempt++) {
+			try {
+				response = await Promise.race([
+					stub.fetch(url.toString(), { method: 'GET' }),
+					new Promise<never>((_, reject) => setTimeout(() => reject(new Error('timeout')), INTELLIGENCE_FETCH_TIMEOUT_MS)),
+				]);
+				break;
+			} catch {
+				if (attempt === 1) return { status: 'unavailable', provider, profile, reason: 'timeout', retryable: true };
+			}
+		}
 
-		if (!response.ok) {
-			return { status: 'unavailable', provider, profile };
+		if (!response || !response.ok) {
+			return { status: 'unavailable', provider, profile, reason: 'upstream_error', retryable: true };
 		}
 
 		return (await response.json()) as ProviderInsightsResult;
 	} catch {
-		return { status: 'unavailable', provider, profile };
+		// Shard resolution / JSON parse failed rather than the fetch.
+		return { status: 'unavailable', provider, profile, reason: 'upstream_error', retryable: true };
 	}
 }
 

--- a/src/tools/simulate-attack-paths.ts
+++ b/src/tools/simulate-attack-paths.ts
@@ -159,11 +159,39 @@ function isDaneMissing(findings: Finding[]): boolean {
 	});
 }
 
-/** Check if CAA records are missing. */
+/**
+ * Findings that exist ONLY on a zone which already publishes CAA.
+ *
+ * `issuewild` and `iodef` are OPTIONAL sub-tags of an EXISTING CAA RRset — a
+ * zone with three `issue` tags and no `iodef` is a zone WITH CAA, and the
+ * finding says exactly that. Their titles ("No CAA iodef tag") nonetheless
+ * contain the substring "no caa", which is what the old predicate matched.
+ */
+const CAA_SUBTAG_FINDING = /\b(issuewild|iodef|issuemail)\b/;
+
+/**
+ * Does the zone publish NO CAA records at all?
+ *
+ * ⚠️ #782 — this used to substring-match `"no caa"` against any non-info `caa`
+ * finding, so *"No CAA issuewild tag"* and *"No CAA iodef tag"* both matched.
+ * Measured on openclaw.org: the zone publishes THREE `issue` tags
+ * (sectigo.com, letsencrypt.org, pki.goog), `check_caa` scored it 90 and
+ * reported only the two optional sub-tags as absent — while the simulator, in
+ * the SAME run, emitted a `cert_misissuance` path whose stated prerequisite was
+ * "No CAA records restrict certificate issuance".
+ *
+ * That is a report contradicting itself: a CAA section listing three issuers,
+ * and an attack-path section asserting there are none. A path whose
+ * prerequisite is checkably false is worse than no path — a competent reader
+ * checks it, and then distrusts everything else in the document.
+ *
+ * A title naming a sub-tag is therefore EXCLUDING evidence: it proves the RRset
+ * exists rather than that it is absent.
+ */
 function isCaaMissing(findings: Finding[]): boolean {
-	return hasFindings(findings, (f) => {
-		if (f.category !== 'caa') return false;
-		if (f.severity === 'info') return false;
+	const caaFindings = findings.filter((f) => f.category === 'caa' && f.severity !== 'info');
+	if (caaFindings.some((f) => CAA_SUBTAG_FINDING.test(f.title.toLowerCase()))) return false;
+	return caaFindings.some((f) => {
 		const t = f.title.toLowerCase();
 		return t.includes('no caa') || t.includes('missing') || t.includes('not configured');
 	});
@@ -181,22 +209,41 @@ function isCspWeakOrMissing(findings: Finding[]): boolean {
 }
 
 /** Check if X-Frame-Options is missing and CSP frame-ancestors is missing. */
-function isClickjackingVulnerable(findings: Finding[]): boolean {
+/**
+ * Which framing control is actually absent.
+ *
+ * ⚠️ #782 — the condition is an OR (`XFO missing` OR `CSP missing`) but the
+ * path's `prerequisites` asserted BOTH unconditionally. Measured on
+ * openclaw.org: `www` sends `X-Frame-Options: SAMEORIGIN` and publishes no CSP,
+ * so only the CSP arm matched — and the emitted path still stated
+ * "X-Frame-Options header missing", which `check_http_security` in the same run
+ * correctly did not report, because the header is present.
+ *
+ * Returning WHICH arm fired lets the path state only what it observed. A path
+ * that names a control the reader can see is present is a checkable falsehood,
+ * and it discredits the paths that are correct.
+ */
+function clickjackingGaps(findings: Finding[]): { frameOptions: boolean; csp: boolean } {
 	const httpFindings = findings.filter((f) => f.category === 'http_security' && f.severity !== 'info');
-	if (httpFindings.length === 0) return false;
+	if (httpFindings.length === 0) return { frameOptions: false, csp: false };
 
-	const hasFrameOptionsMissing = httpFindings.some((f) => {
+	const frameOptions = httpFindings.some((f) => {
 		const t = f.title.toLowerCase();
 		return t.includes('x-frame-options') || t.includes('frame-options');
 	});
 
-	// Also check if CSP is missing entirely (no frame-ancestors possible without CSP)
-	const hasCspMissing = httpFindings.some((f) => {
+	// CSP missing entirely — no frame-ancestors is possible without a CSP.
+	const csp = httpFindings.some((f) => {
 		const t = f.title.toLowerCase();
 		return t.includes('no content-security-policy') || t.includes('missing csp');
 	});
 
-	return hasFrameOptionsMissing || hasCspMissing;
+	return { frameOptions, csp };
+}
+
+function isClickjackingVulnerable(findings: Finding[]): boolean {
+	const gaps = clickjackingGaps(findings);
+	return gaps.frameOptions || gaps.csp;
 }
 
 /** Check if DKIM key is weak (< 2048 bits). */
@@ -241,7 +288,15 @@ interface AttackPathDefinition {
 	severity: 'critical' | 'high' | 'medium' | 'low';
 	feasibility: 'trivial' | 'moderate' | 'difficult';
 	condition: (findings: Finding[]) => boolean;
-	prerequisites: string[];
+	/**
+	 * The conditions the path depends on.
+	 *
+	 * A FUNCTION when the path's condition is a disjunction, so the emitted list
+	 * names only the arm that actually fired (#782). A static array asserts every
+	 * listed prerequisite holds — which is false for an OR, and produced a path
+	 * claiming "X-Frame-Options header missing" about a host that sends it.
+	 */
+	prerequisites: string[] | ((findings: Finding[]) => string[]);
 	steps: string[];
 	impact: string;
 	mitigations: string[];
@@ -364,7 +419,14 @@ const ATTACK_PATH_DEFINITIONS: AttackPathDefinition[] = [
 		severity: 'medium',
 		feasibility: 'moderate',
 		condition: (findings) => isClickjackingVulnerable(findings),
-		prerequisites: ['X-Frame-Options header missing', 'No CSP frame-ancestors directive'],
+		// Derived, not asserted — see `clickjackingGaps` (#782).
+		prerequisites: (findings) => {
+			const gaps = clickjackingGaps(findings);
+			const out: string[] = [];
+			if (gaps.frameOptions) out.push('X-Frame-Options header missing');
+			if (gaps.csp) out.push('No CSP frame-ancestors directive');
+			return out;
+		},
 		steps: [
 			'Embed target page in hidden iframe on attacker site',
 			'Overlay transparent page over decoy UI',
@@ -493,7 +555,8 @@ export function evaluateAttackPathsFromFindings(findings: Finding[]): AttackPath
 				name: def.name,
 				severity: def.severity,
 				feasibility: def.feasibility,
-				prerequisites: def.prerequisites,
+				prerequisites:
+					typeof def.prerequisites === 'function' ? def.prerequisites(findings) : def.prerequisites,
 				steps: def.steps,
 				impact: def.impact,
 				mitigations: def.mitigations,

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -1735,6 +1735,151 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 		});
 	}
 
+	/**
+	 * #779 — the summary finding's TITLE named a strictly wider predicate than
+	 * its COUNT applied. It said "N lookalike domains with mail capability
+	 * detected" while N counted only mail-infra PLUS a #264 corroborator.
+	 *
+	 * Measured on real estates before the fix: openclaw.ai's rollup said 2 while
+	 * six candidates in the SAME response carried `hasMX: true`; openclaw.org
+	 * said 1 against 3. A consumer reading only the summary — which is what a
+	 * summary is for — got a three-fold undercount, and it propagated into a
+	 * client-facing report.
+	 */
+	describe('#779 summary finding: title matches the predicate it counts', () => {
+		it('does not claim "mail capability" for the corroborated-staging subset', async () => {
+			mockPrePhishingFixture();
+			const result = await run('testco.com');
+			const summary = result.findings.find((f) => f.metadata?.lookalikeDomainCount !== undefined);
+			expect(summary).toBeDefined();
+			expect(
+				summary!.title,
+				'the title must not name a wider set than the count applies',
+			).not.toMatch(/mail capability/i);
+			expect(summary!.title).toMatch(/pre-phishing staging signals/i);
+		});
+
+		it('exposes the wider mail-capable count alongside, so nobody re-derives it', async () => {
+			mockPrePhishingFixture();
+			const result = await run('testco.com');
+			const summary = result.findings.find((f) => f.metadata?.lookalikeDomainCount !== undefined);
+			// Both numbers present. Forcing consumers to re-derive the wider figure
+			// from per-domain findings is what nobody did, and why the undercount
+			// went unnoticed.
+			expect(summary!.metadata?.mailCapableCount).toBeDefined();
+			expect(summary!.metadata?.mailCapableDomains).toContain('twstco.com');
+			expect(summary!.metadata?.mailCapableCount as number).toBeGreaterThanOrEqual(
+				summary!.metadata?.lookalikeDomainCount as number,
+			);
+		});
+
+		it('a null-MX candidate is not counted as mail-capable', async () => {
+			// RFC 7505 `0 .` is the explicit way a domain DECLINES mail. A naive
+			// MX-record count reads it as capability — the opposite of its meaning.
+			globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+				const { name, type } = parseDohQuery(input);
+				if (name === 'testco.com' && (type === 'NS' || type === '2')) {
+					return Promise.resolve(
+						createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]),
+					);
+				}
+				if (name === 'twstco.com') {
+					if (type === 'NS' || type === '2') {
+						return Promise.resolve(
+							createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]),
+						);
+					}
+					if (type === 'MX' || type === '15') {
+						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '0 .' }]));
+					}
+				}
+				return Promise.resolve(createDohResponse([], []));
+			});
+			const result = await run('testco.com');
+			for (const f of result.findings) {
+				expect(f.metadata?.mailCapableDomains ?? []).not.toContain('twstco.com');
+			}
+		});
+	});
+
+	/**
+	 * #781 — repeat `force_refresh` runs returned different candidate SETS with
+	 * nothing in the response saying so, while every finding claimed
+	 * `confidence: "deterministic"`. Measured on openclaw.ai: 12, then 10, then
+	 * 13 candidates minutes apart, three names appearing only in the third run.
+	 *
+	 * Cause: a REJECTED NS lookup in `filterByNsExistence` was treated as
+	 * "unregistered" and dropped. That phase gates everything downstream, so one
+	 * timed-out query removed a registered domain from the results entirely.
+	 */
+	describe('#781 enumeration coverage is reported, not silently dropped', () => {
+		it('reports complete coverage when every lookup resolves', async () => {
+			mockPrePhishingFixture();
+			const result = await run('testco.com');
+			const withEnum = result.findings.find((f) => f.metadata?.enumeration !== undefined);
+			expect(withEnum).toBeDefined();
+			const e = withEnum!.metadata!.enumeration as { complete: boolean; unresolvedCount: number };
+			expect(e.complete).toBe(true);
+			expect(e.unresolvedCount).toBe(0);
+			// No partial-coverage warning when nothing was dropped.
+			expect(result.findings.some((f) => /enumeration was incomplete/i.test(f.title))).toBe(false);
+		});
+
+		it('emits a partial-coverage finding, and stops claiming deterministic, when a lookup fails', async () => {
+			// A rejected NS query is UNKNOWN, not "unregistered".
+			globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+				const { name, type } = parseDohQuery(input);
+				if (name === 'testco.com' && (type === 'NS' || type === '2')) {
+					return Promise.resolve(
+						createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]),
+					);
+				}
+				if (name === 'twstco.com') {
+					if (type === 'NS' || type === '2') {
+						return Promise.resolve(
+							createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]),
+						);
+					}
+					if (type === 'MX' || type === '15') {
+						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mx.mailgun.org.' }]));
+					}
+				}
+				// Every other permutation's lookup FAILS rather than answering empty.
+				return Promise.reject(new Error('DNS timeout'));
+			});
+
+			const result = await run('testco.com');
+			const warning = result.findings.find((f) => /enumeration was incomplete/i.test(f.title));
+			expect(warning, 'a consumer reading only findings must still learn the set is a sample').toBeDefined();
+			expect(warning!.severity).toBe('info');
+			expect(warning!.detail).toMatch(/observed examples, not a complete inventory/i);
+
+			const e = warning!.metadata!.enumeration as { complete: boolean; unresolvedCount: number };
+			expect(e.complete).toBe(false);
+			expect(e.unresolvedCount).toBeGreaterThan(0);
+
+			// Set-level claims must not still say "deterministic" about a set that
+			// was not exhaustively enumerated.
+			for (const f of result.findings) {
+				if (f.metadata?.enumeration && (f.metadata.enumeration as { complete: boolean }).complete === false) {
+					expect(f.metadata.confidence).not.toBe('deterministic');
+				}
+			}
+		});
+
+		it('per-domain findings stay deterministic — only the SET is uncertain', async () => {
+			mockPrePhishingFixture();
+			const result = await run('testco.com');
+			const perDomain = result.findings.filter((f) => f.metadata?.lookalikeDomain !== undefined);
+			expect(perDomain.length).toBeGreaterThan(0);
+			for (const f of perDomain) {
+				// Each row is a real measurement of a real domain; incomplete
+				// enumeration says nothing about the rows that DID resolve.
+				expect(f.metadata?.confidence).toBe('deterministic');
+			}
+		});
+	});
+
 	it('6(a) emits BOTH axes for a live third-party typosquat: attribution capped at info, threat at the calibrated HIGH', async () => {
 		mockPrePhishingFixture();
 		const result = await run('testco.com');
@@ -1768,10 +1913,15 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 		expect(result.score).toBeLessThanOrEqual(75);
 	});
 
-	it('un-deadens the summary path: the previously-unreachable HIGH "mail capability" summary finding fires again', async () => {
+	it('un-deadens the summary path: the previously-unreachable HIGH staging summary finding fires again', async () => {
 		mockPrePhishingFixture();
 		const result = await run('testco.com');
-		const summary = result.findings.find((f) => /lookalike domains? with mail capability detected/i.test(f.title));
+		// Retitled by #779: it used to say "with mail capability detected", a
+		// strictly WIDER predicate than the mail-infra-PLUS-corroborator matrix it
+		// actually counts. The count is unchanged; only the claim is now honest.
+		const summary = result.findings.find((f) =>
+			/lookalike domains? showing pre-phishing staging signals/i.test(f.title),
+		);
 		expect(summary).toBeDefined();
 		expect(summary!.severity).toBe('high');
 		expect(summary!.metadata?.findingAxis).toBe('threat_observation');
@@ -2089,7 +2239,7 @@ describe('checkLookalikes - Task 7b fix round 1 (RDAP org gating + scan_status a
 
 		// The aggregate summary specifically: it names the counted candidates and
 		// declares their (non-owned) verdict rather than leaving both blank.
-		const summary = result.findings.find((f) => /with mail capability detected/i.test(f.title));
+		const summary = result.findings.find((f) => /showing pre-phishing staging signals/i.test(f.title));
 		expect(summary).toBeDefined();
 		expect(summary!.metadata?.lookalikeDomains).toEqual(['twstco.com']);
 		expect(summary!.metadata?.ownershipVerdict).toBe('third_party');

--- a/test/intelligence.spec.ts
+++ b/test/intelligence.spec.ts
@@ -22,6 +22,45 @@ describe('getBenchmark', () => {
 		expect(result.profile).toBe('mail_enabled');
 	});
 
+	/**
+	 * #783 — a bare `unavailable` left a caller no way to choose between retry,
+	 * fall back, and record-a-permanent-limitation. Measured: `mail_enabled`
+	 * (1.47M scans) missed the 500ms budget while `enterprise_mail` (46k)
+	 * answered in the same window, which reads as "this profile has no cohort".
+	 * It was a blip — the identical call succeeded minutes later — but it had
+	 * already been written into a client document as a permanent limitation.
+	 */
+	describe('unavailable carries an actionable reason (#783)', () => {
+		it('an absent binding is NOT retryable — it is permanent for this deployment', async () => {
+			const result = await getBenchmark(undefined);
+			expect(result.reason).toBe('not_configured');
+			expect(result.retryable).toBe(false);
+		});
+
+		it('every unavailable result names a reason and a retry verdict', async () => {
+			// The invariant that makes the status actionable at all: no bare
+			// `unavailable` may escape this module.
+			const result = await getBenchmark(undefined);
+			expect(result.reason).toBeDefined();
+			expect(typeof result.retryable).toBe('boolean');
+		});
+
+		it('provider insights answers the same contract', async () => {
+			const result = await getProviderInsights(undefined, 'google');
+			expect(result.status).toBe('unavailable');
+			expect(result.reason).toBe('not_configured');
+			expect(result.retryable).toBe(false);
+		});
+
+		it('a successful read carries no reason — the fields are unavailable-only', async () => {
+			const result = await getBenchmark(env.PROFILE_ACCUMULATOR, 'non_mail');
+			if (result.status !== 'unavailable') {
+				expect(result.reason).toBeUndefined();
+				expect(result.retryable).toBeUndefined();
+			}
+		});
+	});
+
 	it('returns insufficient_data with few scans', async () => {
 		// non_mail profile has no data — should be insufficient
 		const result = await getBenchmark(env.PROFILE_ACCUMULATOR, 'non_mail');

--- a/test/rdap-fallback-server-map.spec.ts
+++ b/test/rdap-fallback-server-map.spec.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Guards `FALLBACK_RDAP_SERVERS` against the #780 failure shape: an entry that
+ * points at a host which does not exist.
+ *
+ * `.ai` was mapped to `https://rdap.nic.ai/`, a hostname with NO A RECORD. It
+ * never answered. `probeRdap` fail-softs to `EMPTY_RDAP_PROBE`, so the result
+ * was not an error but a silent `registrationDays: null` on EVERY `.ai` domain,
+ * indefinitely — while `.org` and `.com` populated correctly, which is what made
+ * it look like a per-TLD capability gap rather than a typo.
+ *
+ * The cost of that shape is why it deserves a test: `null` is indistinguishable
+ * from "old domain, nothing notable" at every consumer, so the newly-registered
+ * signal — the single highest-value output of lookalike triage — was dead for an
+ * entire TLD and no output anywhere said so.
+ *
+ * ⚠️ SCOPE, stated plainly so nobody reads more coverage into this than exists:
+ * the structural assertions below would NOT have caught #780. `https://rdap.nic.ai/`
+ * is a perfectly well-formed https base URL — it is simply a host that does not
+ * exist. Only the explicit `.ai` assertion pins the actual defect, and only for
+ * that one TLD.
+ *
+ * The class-level guard is a periodic reconciliation against IANA's bootstrap
+ * (data.iana.org/rdap/dns.json), which is the authoritative mapping this table
+ * duplicates. That belongs in a scheduled/live check, not a unit test — a unit
+ * test that fetches it would make the suite depend on someone else's uptime and
+ * would fail closed on a network blip. Until that exists, a dead entry for any
+ * OTHER TLD would still degrade silently, exactly as `.ai` did.
+ */
+import { describe, it, expect } from 'vitest';
+import { FALLBACK_RDAP_SERVERS } from '../src/tools/check-rdap-lookup';
+
+describe('FALLBACK_RDAP_SERVERS', () => {
+	it('maps .ai to Identity Digital, not the non-resolving rdap.nic.ai (#780)', () => {
+		// IANA's authoritative bootstrap (data.iana.org/rdap/dns.json) maps
+		// ai → https://rdap.identitydigital.services/rdap/, same operator as
+		// .io and .sh. `rdap.nic.ai` has no A record.
+		expect(FALLBACK_RDAP_SERVERS.ai).toBe('https://rdap.identitydigital.services/rdap/');
+		expect(FALLBACK_RDAP_SERVERS.ai).not.toMatch(/nic\.ai/);
+	});
+
+	it('routes .ai to the same operator as its sibling Identity Digital ccTLDs', () => {
+		// A cheap cross-check: if someone edits one of these three, the odd one
+		// out is visible rather than silently diverging.
+		expect(FALLBACK_RDAP_SERVERS.ai).toBe(FALLBACK_RDAP_SERVERS.io);
+		expect(FALLBACK_RDAP_SERVERS.ai).toBe(FALLBACK_RDAP_SERVERS.sh);
+	});
+
+	it.each(Object.entries(FALLBACK_RDAP_SERVERS))(
+		'%s is a well-formed https RDAP base URL',
+		(tld, url) => {
+			expect(tld, 'TLD keys are bare and lowercase').toMatch(/^[a-z0-9-]+$/);
+			const parsed = new URL(url);
+			expect(parsed.protocol, `${tld} must be https`).toBe('https:');
+			// A hostname with no dot cannot be a public RDAP server, and a trailing
+			// path is required because `probeRdap` appends `domain/<name>` to it.
+			expect(parsed.hostname).toContain('.');
+			expect(url.endsWith('/'), `${tld} must end in / so domain/<name> appends cleanly`).toBe(true);
+		},
+	);
+});

--- a/test/simulate-attack-paths.spec.ts
+++ b/test/simulate-attack-paths.spec.ts
@@ -1034,3 +1034,87 @@ describe('formatAttackPaths', () => {
 		expect(fullOutput).toContain('Overall Risk: LOW');
 	});
 });
+
+/**
+ * #782 — two paths were emitted whose stated PREREQUISITES the scan's own check
+ * results contradicted, in the same run, on openclaw.org:
+ *
+ *   cert_misissuance  "No CAA records restrict certificate issuance"
+ *                     …on a zone publishing THREE issue tags (check_caa: 90)
+ *   clickjacking      "X-Frame-Options header missing"
+ *                     …on a host sending XFO: SAMEORIGIN, which
+ *                     check_http_security correctly did NOT flag
+ *
+ * False positives of the worst kind: checkable ones. Attack-path prose is the
+ * part of a report that gets quoted, and a reader who verifies one failed
+ * prerequisite reasonably distrusts everything else in the document. Both had
+ * to be excluded by hand from a client deliverable.
+ */
+describe('#782 a path never states a prerequisite the findings contradict', () => {
+	async function paths(findings: unknown[]) {
+		const { evaluateAttackPathsFromFindings } = await import('../src/tools/simulate-attack-paths');
+		return evaluateAttackPathsFromFindings(findings as never);
+	}
+
+	it('does not claim CAA is absent when only the optional sub-tags are', async () => {
+		// The exact shape check_caa emits for a zone WITH CAA: `issue` tags
+		// present, optional `issuewild`/`iodef` absent. Both titles contain the
+		// substring "no caa", which is what the old predicate matched on.
+		const result = await paths([
+			{ category: 'caa', title: 'No CAA issuewild tag', severity: 'low', detail: 'No issuewild tag present.' },
+			{ category: 'caa', title: 'No CAA iodef tag', severity: 'low', detail: 'No iodef tag present.' },
+		]);
+		expect(
+			result.find((p) => p.id === 'cert_misissuance'),
+			'a zone publishing issue tags must not yield a "no CAA" path',
+		).toBeUndefined();
+	});
+
+	it('still fires when CAA really is absent', async () => {
+		// The control must not have been disabled by the fix.
+		const result = await paths([
+			{ category: 'caa', title: 'No CAA records found', severity: 'medium', detail: 'No CAA RRset published.' },
+		]);
+		const path = result.find((p) => p.id === 'cert_misissuance');
+		expect(path, 'the genuine no-CAA case must still be reported').toBeDefined();
+		expect(path!.prerequisites).toContain('No CAA records restrict certificate issuance');
+	});
+
+	it('names only the framing control that is actually missing', async () => {
+		// XFO present, CSP absent — only the CSP arm of the OR fires.
+		const result = await paths([
+			{
+				category: 'http_security',
+				title: 'No Content-Security-Policy header',
+				severity: 'medium',
+				detail: 'CSP is not set.',
+			},
+		]);
+		const path = result.find((p) => p.id === 'clickjacking');
+		expect(path).toBeDefined();
+		expect(
+			path!.prerequisites,
+			'the host sends X-Frame-Options; claiming it is missing is checkably false',
+		).not.toContain('X-Frame-Options header missing');
+		expect(path!.prerequisites).toContain('No CSP frame-ancestors directive');
+	});
+
+	it('names both when both are missing', async () => {
+		const result = await paths([
+			{ category: 'http_security', title: 'X-Frame-Options header missing', severity: 'medium', detail: 'Not set.' },
+			{ category: 'http_security', title: 'No Content-Security-Policy header', severity: 'medium', detail: 'Not set.' },
+		]);
+		const path = result.find((p) => p.id === 'clickjacking');
+		expect(path!.prerequisites).toEqual(['X-Frame-Options header missing', 'No CSP frame-ancestors directive']);
+	});
+
+	it('never emits a path with an empty prerequisite list', async () => {
+		// A path that fired but can name nothing it depends on is unreviewable.
+		const result = await paths([
+			{ category: 'http_security', title: 'X-Frame-Options header missing', severity: 'medium', detail: 'Not set.' },
+		]);
+		for (const p of result) {
+			expect(p.prerequisites.length, `${p.id} emitted no prerequisites`).toBeGreaterThan(0);
+		}
+	});
+});


### PR DESCRIPTION
Closes #779, #780, #781, #782, #783.

All five surfaced while running a real client assessment. Four share one shape: **a result that is wrong rather than missing**, in a place a consumer reads without expanding the detail. A false number or a checkably-false claim is worse than an absent one — it gets quoted, and then checked.

## #779 — the summary's title named a wider predicate than its count

Titled *"N lookalike domains with mail capability detected"*, counted only mail-infra **plus** a #264 corroborator.

| scanned | rollup said | per-domain `hasMX: true` |
|---|---|---|
| openclaw.ai | 2 | **6** |
| openclaw.org | 1 | **3** |

Retitled to *"N lookalike domains showing pre-phishing staging signals"* — the staging subset is the right thing to lead with, it just has to be named as the subset it is. `mailCapableCount` / `mailCapableDomains` now sit alongside so nobody re-derives the wider figure from per-domain findings (which nobody did, which is why this went unnoticed).

Also fixes the **other half**: when candidates could send mail but none reached the staging threshold, *no summary fired at all*. An estate with several mail-capable confusables produced an aggregate view saying nothing. That case now emits a MEDIUM finding — honest about being capability, not staging.

## #780 — my filed diagnosis was wrong; the real cause is one line

I supposed an RDAP-vs-whois gap for `.ai`. It isn't. `FALLBACK_RDAP_SERVERS` mapped `ai` to `https://rdap.nic.ai/` — **a host with no A record.** It has never resolved.

```
$ dig +short rdap.nic.ai A        # (empty)
$ curl https://rdap.nic.ai/domain/openclaw.ai      → http=000
$ curl https://rdap.identitydigital.services/rdap/domain/openclaw.ai
  → http=200, registration 2026-01-29T10:52:55Z
```

IANA's authoritative bootstrap maps `ai` → Identity Digital, same operator as the `.io`/`.sh` entries already in the table. Because `probeRdap` fail-softs, the symptom was a silent `registrationDays: null` across the entire TLD while `.org`/`.com` populated correctly — which is exactly what made it read as a per-TLD capability gap rather than a typo.

New spec pins it. **Its scope is stated honestly in the file**: the structural URL checks would *not* have caught this, because `https://rdap.nic.ai/` is well-formed — only the explicit `.ai` assertion does. The class-level guard is a periodic reconciliation against IANA's bootstrap, which belongs in a live check, not a unit test that would fail closed on a network blip. A dead entry for any *other* TLD would still degrade silently today.

## #781 — non-deterministic sets, labelled `deterministic`

Three `force_refresh` runs on openclaw.ai returned 12, 10 and 13 candidates, three names appearing only in the third.

Cause: a **rejected** NS lookup in `filterByNsExistence` was treated as *unregistered* and dropped. That phase gates everything downstream, so one timed-out query removed a registered domain from the results entirely, with nothing distinguishing that from a deregistration.

Both silent-drop sites are now counted and reported as `enumeration` metadata (`permutationsGenerated` / `permutationsProbed` / `candidatesResolved` / `unresolvedCount` / `complete`), plus an explicit partial-coverage finding — emitted as a **finding**, not only metadata, because a consumer reading findings otherwise has no way to learn the set is a sample.

`confidence` is downgraded on **set-level claims only**. Per-domain rows stay `deterministic`: incomplete enumeration says nothing about the rows that *did* resolve, and blanket-downgrading them would be noise.

## #782 — paths asserting what the same scan disproved

Two distinct bugs, both substring-matching on finding titles:

**CAA.** `isCaaMissing` matched `"no caa"` — which is what *"No CAA **issuewild** tag"* and *"No CAA **iodef** tag"* contain. Those findings only exist on a zone that **has** CAA. openclaw.org publishes three `issue` tags and `check_caa` scored it 90, while the simulator in the same run claimed *"No CAA records restrict certificate issuance"*. A report contradicting itself a few pages apart. Sub-tag findings are now *excluding* evidence.

**Clickjacking.** The condition is an OR (`XFO missing` **or** `CSP missing`) but `prerequisites` asserted **both** unconditionally. `www.openclaw.org` sends `X-Frame-Options: SAMEORIGIN` and has no CSP, so only the CSP arm fired — and the path still said the XFO header was missing, which `check_http_security` correctly did not report. Prerequisites now derive from the arm that actually matched.

> Correcting the record: issue #782 says the simulator "derives prerequisites independently of check results". That was my inference, and it's imprecise — it *does* read the findings, it just matched them badly. The fix is in the predicates, not the architecture.

## #783 — `unavailable` with no reason is unactionable

`mail_enabled` (1.47M scans) missed the 500ms budget while `enterprise_mail` (46k) answered in the same window. One profile failing while a sibling succeeds reads as *"this profile has no cohort"* — so "no benchmark available" went into a client document as a permanent scope limitation. The identical call succeeded minutes later.

Adds `reason` (`not_configured` | `timeout` | `upstream_error`) and `retryable`, plus **one** retry on the timeout path — the measured cause. Retrying only that path keeps the worst case at two budgets and lets a genuine upstream error surface immediately. Same treatment for `getProviderInsights`, which shares the DO and the budget.

## Verification

- `npm test` — **7913 passed**, 13 skipped. One failing suite: `test/wasm-integration.test.ts`, which needs `crates/*/pkg` — gitignored, so absent in any worktree. The main checkout has it, and none of these eight files touch wasm. Flagging rather than hiding it.
- `wrangler types && tsc --noEmit` — 0 errors. (Bare `tsc` reports 331 `Cannot find name 'D1Database'`-class errors until types are generated; that's the repo's normal flow, not a regression.)
- **Both #782 fixes proven to discriminate** — reverting the CAA sub-tag exclusion turns that test red; reverting the derived prerequisites turns the framing test red. Restored, green again.
- #780 verified against the live endpoint **and** IANA's bootstrap rather than assumed — which is how I found my own filed diagnosis was wrong.

## Note for review

`check-lookalikes.ts` is now ~1600 LOC and the repo's size hook flags it at >800. I did not split it in this PR — a structural refactor mixed into five behavioural fixes makes both harder to review. Worth its own issue.