### PR TITLE
fix(rdap): 5 TLDs silently returned null registration data; split check-lookalikes.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"audit:repo-safety": "node scripts/repo-safety/scan-sensitive-surface.mjs",
 		"audit:licenses": "node scripts/license-check.mjs",
 		"audit:rate-limits": "tsx scripts/audits/tool-rate-limit-inventory.ts",
+		"audit:rdap-fallback": "tsx scripts/audits/rdap-fallback-reconcile.ts",
 		"audit:oss-safety": "node scripts/vitest-filter-workerd.mjs run test/audits/oss-fixture-safety.audit.test.ts test/audits/no-tracked-secrets.audit.test.ts test/audits/npm-publish-surface.audit.test.ts test/audits/busl-positioning.audit.test.ts test/audits/readme-tool-surface.audit.test.ts test/audits/infra-probe-wrangler.audit.test.ts test/audits/repo-safety-policy.audit.test.ts test/audits/repo-safety-scanner.audit.test.ts test/audits/hook-coverage.audit.test.ts test/audits/workflow-safety-gates.audit.test.ts test/audits/repo-safety-docs.audit.test.ts && node scripts/vitest-filter-workerd.mjs run --config vitest.node.config.mts test/audits/repo-safety-push-range-scanner.audit.test.ts test/audits/license-headers.audit.test.ts test/audits/dependency-license.audit.test.ts test/audits/workflow-cost.audit.test.ts test/audits/dns-checks-runtime-agnostic.node.test.ts && npm run audit:licenses",
 		"generate-report": "bash scripts/generate-report.sh",
 		"report:qa": "node scripts/audits/brand-report-qa.mjs",

--- a/scripts/audits/rdap-fallback-reconcile.ts
+++ b/scripts/audits/rdap-fallback-reconcile.ts
@@ -1,0 +1,394 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// RDAP fallback-server reconciliation against IANA (#780).
+//
+// `FALLBACK_RDAP_SERVERS` in src/tools/check-rdap-lookup.ts is a hand-maintained
+// TLD → RDAP base URL table that DUPLICATES IANA's authoritative bootstrap at
+// https://data.iana.org/rdap/dns.json. A wrong or dead entry there degrades
+// SILENTLY: `probeRdap()` fail-softs, so every domain under that TLD returns
+// `registrationDays: null` — indistinguishable at every consumer from "old
+// domain, nothing notable". That is exactly how `.ai` pointed at
+// `https://rdap.nic.ai/` (a host with NO A record) for an unknown length of
+// time while `.com`/`.org` populated correctly.
+//
+// WHY THIS IS A SCRIPT AND NOT A UNIT TEST. test/rdap-fallback-server-map.spec.ts
+// states the reasoning and this script honours it: its structural assertions
+// (well-formed https base URL, lowercase key, trailing slash) would NOT have
+// caught #780 — `https://rdap.nic.ai/` is perfectly well-formed, it just does
+// not exist. Only a LIVE reconciliation catches the class, and a unit test that
+// fetched IANA would make the suite depend on someone else's uptime and fail
+// closed on a network blip. So the class-level guard lives here, out-of-band,
+// and is NOT wired into `npm test`.
+//
+// Usage:
+//   npx tsx scripts/audits/rdap-fallback-reconcile.ts                 # report
+//   npx tsx scripts/audits/rdap-fallback-reconcile.ts --json          # machine-readable
+//   npx tsx scripts/audits/rdap-fallback-reconcile.ts --list-missing  # list every TLD IANA covers that the table lacks
+//   npx tsx scripts/audits/rdap-fallback-reconcile.ts --probe         # additionally HTTP-probe each table host
+//
+// Exit codes — the whole point is that a failure can never read as "all clear":
+//   0  reconciled, no divergence and no dead host
+//   1  DEFECTS found (divergent entry, dead host, or a TLD IANA does not know)
+//   2  INCONCLUSIVE — the IANA fetch/parse failed, or a host's DNS status could
+//      not be established. NOTHING is asserted about the table in this case.
+//
+// It reports three classes, per the #780 post-mortem:
+//   (a) entries whose target disagrees with IANA (host and/or path);
+//   (b) entries whose host does not resolve (the #780 shape);
+//   (c) TLDs IANA covers that the table lacks.
+//
+// (c) is INFORMATIONAL, not a defect: the table is deliberately a failsafe
+// SUBSET consulted only when the live bootstrap is unavailable, so IANA's ~1.2k
+// TLDs will always dwarf it. It is reported as a count so a deliberate coverage
+// decision stays a decision.
+//
+// A FOURTH class falls out of the reconciliation and is deliberately NOT a
+// defect: a TLD the table pins that IANA does not publish at all (several
+// ccTLDs — co, me, io, sh, us). Its target cannot be checked against the
+// authority, which is precisely the case the fallback table exists to cover, so
+// as long as the host RESOLVES it is reported as a NOTICE. Making it red would
+// keep this script permanently red on legitimate entries and train the operator
+// to ignore it. Such an entry that ALSO fails to resolve is still caught — by
+// (b), where it belongs.
+
+import { Resolver } from 'node:dns/promises';
+// The LEAF module, not `check-rdap-lookup.ts`: this reads the SAME object the
+// runtime uses (never a copy — a copy would reconcile against itself), and the
+// leaf imports nothing, so a plain Node/tsx process can load it. Importing the
+// tool instead drags in the scoring → sanitize → punycode chain and dies.
+import { FALLBACK_RDAP_SERVERS, IANA_BOOTSTRAP_URL as DEFAULT_BOOTSTRAP_URL } from '../../src/tools/rdap-fallback-servers';
+
+/**
+ * Override for an IANA mirror — and the only way to exercise the fail-closed
+ * path on demand, which is how this script was proven to DISCRIMINATE rather
+ * than merely to pass: pointed at an unreachable host it must exit 2 with
+ * "INCONCLUSIVE", never at a green all-clear.
+ *   BV_RDAP_BOOTSTRAP_URL=https://data.iana.invalid/rdap/dns.json npx tsx …
+ */
+const IANA_BOOTSTRAP_URL = process.env.BV_RDAP_BOOTSTRAP_URL ?? DEFAULT_BOOTSTRAP_URL;
+
+const FETCH_TIMEOUT_MS = 20_000;
+const DNS_TIMEOUT_MS = 5_000;
+const PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Sanity floor on the parsed bootstrap. A 200 response carrying an unexpected
+ * shape would otherwise parse to an empty map, and an empty map makes EVERY
+ * table entry look like "IANA does not know this TLD" — a fabricated
+ * catastrophe. Below this floor we refuse to conclude anything (exit 2).
+ */
+const MIN_PLAUSIBLE_IANA_TLDS = 500;
+
+const args = new Set(process.argv.slice(2));
+const asJson = args.has('--json');
+const listMissing = args.has('--list-missing');
+const doProbe = args.has('--probe');
+
+/** How the table's target compares with IANA's. */
+type Verdict = 'match' | 'path-differs' | 'host-differs' | 'not-in-iana';
+
+/** DNS status of a table host. `unknown` is NOT "dead" — see the exit-code note. */
+type DnsStatus = 'resolves' | 'dead' | 'unknown';
+
+interface Row {
+	tld: string;
+	tableUrl: string;
+	ianaUrl: string | null;
+	verdict: Verdict;
+	host: string;
+	dns: DnsStatus;
+	/** Populated only when DNS could not be established — the raw resolver error codes. */
+	dnsDetail?: string;
+	/** Populated only with --probe: the HTTP status, or a transport-failure marker. */
+	probe?: string;
+}
+
+function die(message: string, code: 1 | 2): never {
+	if (asJson) {
+		console.log(JSON.stringify({ ok: false, inconclusive: code === 2, error: message }, null, 2));
+	} else {
+		console.error(`\n❌ ${message}`);
+		if (code === 2) {
+			console.error('   INCONCLUSIVE — nothing is asserted about FALLBACK_RDAP_SERVERS by this run.');
+		}
+	}
+	process.exit(code);
+}
+
+/**
+ * Fetch and parse IANA's bootstrap into a TLD → base-URL map, using the SAME
+ * "first URL wins" rule as `fetchBootstrap()` in check-rdap-lookup.ts, so this
+ * script compares like with like. Any failure is fatal and loud — never an
+ * empty map handed to the comparison.
+ */
+async function fetchIanaBootstrap(): Promise<Record<string, string>> {
+	let resp: Response;
+	try {
+		resp = await fetch(IANA_BOOTSTRAP_URL, {
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+			headers: { Accept: 'application/json' },
+		});
+	} catch (err) {
+		die(`Could not reach ${IANA_BOOTSTRAP_URL}: ${(err as Error).message}`, 2);
+	}
+	if (!resp.ok) {
+		die(`${IANA_BOOTSTRAP_URL} returned HTTP ${resp.status} ${resp.statusText}`, 2);
+	}
+
+	let data: { services?: unknown };
+	try {
+		data = (await resp.json()) as { services?: unknown };
+	} catch (err) {
+		die(`${IANA_BOOTSTRAP_URL} did not return parseable JSON: ${(err as Error).message}`, 2);
+	}
+
+	const services = data.services;
+	if (!Array.isArray(services)) {
+		die(`${IANA_BOOTSTRAP_URL} has no \`services\` array — bootstrap format changed?`, 2);
+	}
+
+	const map: Record<string, string> = {};
+	for (const service of services) {
+		if (!Array.isArray(service)) continue;
+		const [tlds, urls] = service as [unknown, unknown];
+		if (!Array.isArray(tlds) || !Array.isArray(urls) || urls.length === 0) continue;
+		const serverUrl = urls[0];
+		for (const tld of tlds) {
+			if (typeof tld === 'string' && typeof serverUrl === 'string') map[tld.toLowerCase()] = serverUrl;
+		}
+	}
+
+	if (Object.keys(map).length < MIN_PLAUSIBLE_IANA_TLDS) {
+		die(`IANA bootstrap parsed to only ${Object.keys(map).length} TLDs (< ${MIN_PLAUSIBLE_IANA_TLDS}) — refusing to reconcile against it.`, 2);
+	}
+	return map;
+}
+
+/** Normalise a base URL the way `probeRdap()` consumes it: lowercase host, exactly one trailing slash. */
+function normalizeBase(url: string): string {
+	try {
+		const parsed = new URL(url);
+		parsed.hostname = parsed.hostname.toLowerCase();
+		const path = parsed.pathname.endsWith('/') ? parsed.pathname : `${parsed.pathname}/`;
+		return `${parsed.protocol}//${parsed.host}${path}`;
+	} catch {
+		return url;
+	}
+}
+
+function hostOf(url: string): string {
+	try {
+		return new URL(url).hostname.toLowerCase();
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Establish whether a host resolves. Returns `dead` ONLY on an authoritative
+ * "no such name / no such record" for BOTH A and AAAA — a timeout or SERVFAIL
+ * is `unknown`, never `dead`. Reading a resolver timeout as a dead host is the
+ * inverse of the #780 defect and would send someone editing a working entry.
+ */
+async function resolveHost(resolver: Resolver, host: string): Promise<{ status: DnsStatus; detail?: string }> {
+	const AUTHORITATIVE_ABSENCE = new Set(['ENOTFOUND', 'ENODATA', 'NXDOMAIN', 'NOTFOUND']);
+	// allSettled, NOT an early return out of a loop: both lookups are started
+	// eagerly, so returning on the first success would leave the other promise's
+	// rejection unhandled and crash the process on Node's unhandled-rejection
+	// default — a script that dies mid-run is a script whose verdict you cannot
+	// read.
+	const settled = await Promise.allSettled([resolver.resolve4(host), resolver.resolve6(host)]);
+	const codes: string[] = [];
+	let sawAbsence = 0;
+	let sawRecords = false;
+
+	for (const outcome of settled) {
+		if (outcome.status === 'fulfilled') {
+			if (Array.isArray(outcome.value) && outcome.value.length > 0) {
+				sawRecords = true;
+				codes.push('OK');
+				continue;
+			}
+			// An empty array is an authoritative NODATA for this record type.
+			sawAbsence++;
+			codes.push('EMPTY');
+			continue;
+		}
+		const code = (outcome.reason as NodeJS.ErrnoException).code ?? (outcome.reason as Error).message;
+		codes.push(String(code));
+		if (AUTHORITATIVE_ABSENCE.has(String(code))) sawAbsence++;
+	}
+
+	if (sawRecords) return { status: 'resolves' };
+	if (sawAbsence === 2) return { status: 'dead', detail: codes.join('/') };
+	return { status: 'unknown', detail: codes.join('/') };
+}
+
+/** Optional live reachability probe of the RDAP base URL. Reports, never judges the HTTP status. */
+async function probeBase(url: string): Promise<string> {
+	try {
+		const resp = await fetch(url, {
+			method: 'GET',
+			redirect: 'manual',
+			signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+			headers: { Accept: 'application/rdap+json, application/json' },
+		});
+		void resp.body?.cancel();
+		return `HTTP ${resp.status}`;
+	} catch (err) {
+		return `TRANSPORT-FAIL (${(err as Error).message})`;
+	}
+}
+
+async function main(): Promise<void> {
+	const iana = await fetchIanaBootstrap();
+	const resolver = new Resolver({ timeout: DNS_TIMEOUT_MS, tries: 2 });
+
+	const tableTlds = Object.keys(FALLBACK_RDAP_SERVERS).sort();
+	const rows: Row[] = [];
+
+	// One DNS lookup per DISTINCT host — the table maps 20+ TLDs onto a handful
+	// of operators, so per-TLD lookups would be mostly duplicate queries.
+	const hosts = [...new Set(tableTlds.map((tld) => hostOf(FALLBACK_RDAP_SERVERS[tld])))].filter(Boolean);
+	const dnsByHost = new Map<string, { status: DnsStatus; detail?: string }>();
+	await Promise.all(hosts.map(async (host) => dnsByHost.set(host, await resolveHost(resolver, host))));
+
+	const probeByUrl = new Map<string, string>();
+	if (doProbe) {
+		const urls = [...new Set(tableTlds.map((tld) => normalizeBase(FALLBACK_RDAP_SERVERS[tld])))];
+		await Promise.all(urls.map(async (url) => probeByUrl.set(url, await probeBase(url))));
+	}
+
+	for (const tld of tableTlds) {
+		const tableUrl = normalizeBase(FALLBACK_RDAP_SERVERS[tld]);
+		const ianaRaw = iana[tld];
+		const ianaUrl = ianaRaw ? normalizeBase(ianaRaw) : null;
+		const host = hostOf(tableUrl);
+
+		let verdict: Verdict;
+		if (ianaUrl === null) verdict = 'not-in-iana';
+		else if (ianaUrl === tableUrl) verdict = 'match';
+		else if (hostOf(ianaUrl) !== host) verdict = 'host-differs';
+		else verdict = 'path-differs';
+
+		const dns = dnsByHost.get(host) ?? { status: 'unknown' as DnsStatus, detail: 'no-lookup' };
+		rows.push({
+			tld,
+			tableUrl,
+			ianaUrl,
+			verdict,
+			host,
+			dns: dns.status,
+			...(dns.status === 'resolves' ? {} : { dnsDetail: dns.detail }),
+			...(doProbe ? { probe: probeByUrl.get(tableUrl) } : {}),
+		});
+	}
+
+	const missingTlds = Object.keys(iana)
+		.filter((tld) => !(tld in FALLBACK_RDAP_SERVERS))
+		.sort();
+
+	const divergent = rows.filter((r) => r.verdict === 'host-differs' || r.verdict === 'path-differs');
+	const notInIana = rows.filter((r) => r.verdict === 'not-in-iana');
+	const dead = rows.filter((r) => r.dns === 'dead');
+	const unknownDns = rows.filter((r) => r.dns === 'unknown');
+	// `notInIana` is deliberately NOT counted here — see the fourth-class note in
+	// the header. An unpublished TLD whose host is dead is already in `dead`.
+	const defects = divergent.length + dead.length;
+
+	if (asJson) {
+		console.log(
+			JSON.stringify(
+				{
+					ok: defects === 0 && unknownDns.length === 0,
+					source: IANA_BOOTSTRAP_URL,
+					checkedAt: new Date().toISOString(),
+					ianaTldCount: Object.keys(iana).length,
+					tableTldCount: tableTlds.length,
+					rows,
+					divergent: divergent.map((r) => r.tld),
+					notInIana: notInIana.map((r) => r.tld),
+					deadHosts: [...new Set(dead.map((r) => r.host))],
+					unknownDnsHosts: [...new Set(unknownDns.map((r) => r.host))],
+					missingTldCount: missingTlds.length,
+					...(listMissing ? { missingTlds } : {}),
+				},
+				null,
+				2,
+			),
+		);
+	} else {
+		const header = ['tld', 'table target', 'verdict', 'dns', ...(doProbe ? ['probe'] : [])];
+		const table = rows.map((r) => [
+			r.tld,
+			r.tableUrl,
+			r.verdict === 'match' ? 'match' : `${r.verdict.toUpperCase()} → ${r.ianaUrl ?? '(absent from IANA)'}`,
+			r.dns === 'resolves' ? 'ok' : `${r.dns.toUpperCase()} (${r.dnsDetail ?? '?'})`,
+			...(doProbe ? [r.probe ?? ''] : []),
+		]);
+		const widths = header.map((h, i) => Math.max(h.length, ...table.map((row) => row[i].length)));
+		const fmt = (row: string[]) => row.map((cell, i) => cell.padEnd(widths[i])).join('  ');
+		console.log(`RDAP fallback reconciliation against ${IANA_BOOTSTRAP_URL}`);
+		console.log(`IANA covers ${Object.keys(iana).length} TLDs; the table pins ${tableTlds.length}.\n`);
+		console.log(fmt(header));
+		console.log(widths.map((w) => '-'.repeat(w)).join('  '));
+		for (const row of table) console.log(fmt(row));
+
+		console.log('\n--- (a) entries whose target disagrees with IANA [DEFECT] ---');
+		if (divergent.length === 0) {
+			console.log('none');
+		} else {
+			for (const r of divergent) console.log(`${r.tld}: table=${r.tableUrl}  IANA=${r.ianaUrl}  (${r.verdict})`);
+		}
+
+		console.log('\n--- (a2) entries IANA does not publish at all [NOTICE, not a defect] ---');
+		if (notInIana.length === 0) {
+			console.log('none');
+		} else {
+			console.log('Unverifiable against the authority — which is exactly the case this fallback table exists to cover.');
+			for (const r of notInIana) {
+				console.log(`${r.tld}: table=${r.tableUrl}  (host ${r.dns === 'resolves' ? 'resolves' : r.dns.toUpperCase()})`);
+			}
+		}
+
+		console.log('\n--- (b) entries whose host does not resolve (the #780 shape) ---');
+		if (dead.length === 0) {
+			console.log('none');
+		} else {
+			for (const r of dead) console.log(`${r.tld}: ${r.host} — ${r.dnsDetail}  (every ${r.tld} lookup silently returns registrationDays: null)`);
+		}
+		if (unknownDns.length > 0) {
+			console.log(`\n⚠️  DNS status could not be established for ${unknownDns.length} entr${unknownDns.length === 1 ? 'y' : 'ies'} —`);
+			console.log('   NOT reported as dead (a resolver timeout is not an authoritative absence):');
+			for (const r of unknownDns) console.log(`   ${r.tld}: ${r.host} — ${r.dnsDetail}`);
+		}
+
+		console.log('\n--- (c) TLDs IANA covers that the table lacks ---');
+		console.log(
+			`${missingTlds.length} of ${Object.keys(iana).length}. INFORMATIONAL: the table is a deliberate failsafe subset ` +
+				'consulted only when the live bootstrap is unavailable.',
+		);
+		if (listMissing) console.log(missingTlds.join(' '));
+		else if (missingTlds.length > 0) console.log('(re-run with --list-missing to enumerate)');
+
+		console.log(
+			`\ntotals: ${tableTlds.length} entries · match ${rows.filter((r) => r.verdict === 'match').length}` +
+				` · divergent ${divergent.length} · not-in-IANA ${notInIana.length} · dead ${dead.length} · dns-unknown ${unknownDns.length}`,
+		);
+	}
+
+	if (defects > 0) {
+		if (!asJson) console.error(`\n❌ ${defects} defect(s) found in FALLBACK_RDAP_SERVERS — see (a) and (b) above.`);
+		process.exit(1);
+	}
+	if (unknownDns.length > 0) {
+		if (!asJson) console.error(`\n⚠️  INCONCLUSIVE: ${unknownDns.length} host(s) had an unresolvable DNS status. This is NOT an all-clear.`);
+		process.exit(2);
+	}
+	if (!asJson) console.log('\n✅ FALLBACK_RDAP_SERVERS reconciles with IANA and every host resolves.');
+}
+
+void main().catch((err: unknown) => {
+	// A throw anywhere above is a failure to reconcile, never an all-clear.
+	die(`Unexpected failure during reconciliation: ${(err as Error).stack ?? String(err)}`, 2);
+});

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -5,506 +5,86 @@
  * Generates typosquat/lookalike domain permutations and checks for
  * active DNS registrations and mail infrastructure.
  * Standalone check — not included in scan_domain due to query volume.
+ *
+ * THIS FILE IS THE ORCHESTRATOR AND THE PUBLIC SURFACE. It sequences the
+ * pipeline and owns nothing else; each stage lives in a sibling module, split
+ * out of this file as a PURE EXTRACTION (no behaviour change):
+ *
+ *  - `lookalike-analysis.ts` / `markov-generator.ts` — candidate generation.
+ *  - `lookalike-dns.ts` — NS-existence filtering, wildcard-parent detection,
+ *    the adaptive-batching A/MX probe, and the two seed-side queries.
+ *  - `lookalike-enrichment.ts` — the RDAP + HEAD corroborator probes.
+ *  - `lookalike-attribution.ts` — the same-entity and brand-held predicates.
+ *  - `lookalike-severity.ts` — the #264 severity matrix.
+ *  - `lookalike-findings.ts` — the three-axis contract and the per-candidate
+ *    Finding builders. READ ITS MODULE JSDOC before touching any emission
+ *    site: it carries the four axis invariants `test/check-lookalikes.spec.ts`
+ *    pins, including invariant 4 (every `threat_observation` names its subject
+ *    via `lookalikeDomain`/`lookalikeDomains`).
+ *  - `lookalike-summary-findings.ts` — the aggregate and `scan_status`
+ *    Finding builders.
+ *
+ * Everything the tool exported before the split is still exported from HERE,
+ * unchanged, so `src/package.ts`, `src/handlers/tools.ts`,
+ * `discover-brand-domains.ts` and the test suite keep one import site.
  */
 
-import { queryDnsRecords, queryMxRecords } from '../lib/dns';
-import type { QueryDnsOptions } from '../lib/dns-types';
 import { callReconScan, isReconHit } from '../lib/recon-binding';
-import { safeFetch } from '../lib/safe-fetch';
 import type { ReconBinding, BindingDegradationSink, ReconScanResult } from '../lib/recon-binding';
 import type { CheckResult, Finding } from '../lib/scoring';
-import { buildCheckResult, createFinding } from '../lib/scoring';
+import { buildCheckResult } from '../lib/scoring';
 import { generateCognitiveLookalikes, generateCombosquats, generateLookalikes } from './lookalike-analysis';
-import { FALLBACK_RDAP_SERVERS, extractRegistrantOrg, findEntityByRole, isRedactedRegistrantOrg } from './check-rdap-lookup';
-import { evaluateDefensiveRegistration, type DefensiveReason } from '../lib/brand-defensive-registration';
-import { calibrateLookalikeSeverity, isDisposableMxHost, type LookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
-import {
-	buildNonOwnedGateFinding,
-	capAttributionSeverity,
-	classifyOwnership,
-	type OwnershipAssessment,
-	type OwnershipVerdict,
-} from '../lib/ownership-attribution';
+import { calibrateLookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
+import { classifyOwnership, type OwnershipAssessment, type OwnershipVerdict } from '../lib/ownership-attribution';
 import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 import { extractBrandName } from '../lib/public-suffix';
+import {
+	detectWildcardParents,
+	filterByNsExistence,
+	getParentDomain,
+	labelCount,
+	probeWithAdaptiveBatching,
+	queryPrimaryMx,
+	queryPrimaryNs,
+	type LookalikeResult,
+} from './lookalike-dns';
+import { EMPTY_RDAP_PROBE, enrichLookalikes, probePrimaryRegistration } from './lookalike-enrichment';
+import { computeSameEntityCandidates, isBrandHeldRegistration, isSameEntityOrgMatch } from './lookalike-attribution';
+import type { DefensiveReason } from '../lib/brand-defensive-registration';
+import {
+	applyOwnershipGate,
+	buildBrandHeldFinding,
+	buildOwnedBySeedFinding,
+	buildRawAttributionFinding,
+	buildSharedRegistrantOrgFinding,
+	buildThreatObservationFinding,
+	describeCorroborators,
+} from './lookalike-findings';
+import {
+	buildIncompleteEnumerationFinding,
+	buildMailCapableSummaryFinding,
+	buildNoActiveInfrastructureFinding,
+	buildNoPermutationsFinding,
+	buildNoRegisteredCandidatesFinding,
+	buildReconCandidateFinding,
+	buildReconScanStatusFinding,
+	buildStagingSummaryFinding,
+	buildTimeoutFinding,
+} from './lookalike-summary-findings';
 
-/**
- * TASK 7B TWO-AXIS SPLIT (human-partner ruling, 2026-07-27).
- *
- * This tool reports on TWO independent axes, and every finding it emits
- * declares which one it belongs to via `metadata.findingAxis`:
- *
- *  - `'attribution'` — WHO owns the candidate. Governed by
- *    `classifyOwnership()` + `capAttributionSeverity()`: every non-
- *    `owned_by_seed` verdict is capped at `info` with neutral wording
- *    (D4's load-bearing safety property — the scanner never claims someone
- *    else's domain is the customer's, and never demands the customer act on
- *    a domain it does not control). UNCHANGED by this task.
- *
- *  - `'threat_observation'` — WHAT the candidate is doing. Carries the #264
- *    calibrated severity from `calibrateLookalikeSeverity()`. Task 7 computed
- *    that severity and then capped it away, which made `highCount`, the HIGH
- *    summary finding, and every sub-100 `lookalikes` category score
- *    unreachable — a live typosquat with active MX on a disposable provider
- *    scored 100/passed. These findings assert NOTHING about ownership (they
- *    say explicitly that the domain does not appear to belong to the scanned
- *    organisation) and demand no action ON that domain; only defensive
- *    options on the scanned organisation's own side are suggested.
- *
- *  - `'scan_status'` — the RUN itself, not any candidate: the "no active
- *    lookalike domains detected" notices and the timeout notice. Always
- *    `info`. Split out in fix round 1 (F2) because forcing these into
- *    `'threat_observation'` made the threat-axis invariants below unstateable.
- *
- * INVARIANTS (true of this file, pinned by `test/check-lookalikes.spec.ts`, and
- * what Task 8's cross-cutting audit will key on):
- *   1. every finding carries one of the three literals;
- *   2. every `'scan_status'` finding is `info`;
- *   3. no `'threat_observation'` finding carries `ownershipVerdict ===
- *      'owned_by_seed'` — a threat observation is never about a domain the
- *      scanned organisation owns;
- *   4. every `'threat_observation'` finding names the candidate it observed via
- *      `lookalikeDomain` (per candidate, INCLUDING the named-candidate recon CT
- *      corroboration) or `lookalikeDomains` (the aggregate summary). Bare
- *      `domain` metadata (scoped to the scanned domain, not a candidate) only
- *      ever appears on the demoted `'scan_status'` finding emitted when recon
- *      names no specific candidate — never on a `'threat_observation'` finding.
- *
- * The axis marker is STRUCTURAL, not prose: downstream consumers (and Task
- * 8's cross-cutting audit) key on the exact literals, never on wording.
- */
-export type LookalikeFindingAxis = 'attribution' | 'threat_observation' | 'scan_status';
-
-/** Default and minimum batch sizes for adaptive batching */
-export const INITIAL_BATCH_SIZE = 10;
-export const MIN_BATCH_SIZE = 3;
-export const BACKOFF_DELAY_MS = 500;
-export const FAILURE_THRESHOLD = 2;
+// ---------------------------------------------------------------------------
+// PUBLIC SURFACE — re-exported from the modules the split moved them to, so no
+// consumer (or test) has to know where a symbol now lives. This list is the
+// tool's external contract; it is byte-identical to the pre-split one.
+// ---------------------------------------------------------------------------
+export { INITIAL_BATCH_SIZE, MIN_BATCH_SIZE, BACKOFF_DELAY_MS, FAILURE_THRESHOLD, WILDCARD_CANARY_LABEL, PHASE1_DNS_OPTS } from './lookalike-dns';
+export { probeHasWebContent } from './lookalike-enrichment';
+export { isBrandHeldRegistration, isSameEntityOrgMatch } from './lookalike-attribution';
+export { DEFENSIVE_REASON_PHRASES, type LookalikeFindingAxis } from './lookalike-findings';
 
 /** Maximum wall-clock time for the entire lookalike check (ms). */
 const LOOKALIKE_TIMEOUT_MS = 20_000;
 
-/** Canary label used for wildcard detection on parent domains */
-export const WILDCARD_CANARY_LABEL = '_bv-wc-probe';
-
-/** Lean DNS options for Phase 1 existence checks — fast, no retries, no secondary confirmation. */
-export const PHASE1_DNS_OPTS: QueryDnsOptions = {
-	timeoutMs: 2000,
-	retries: 0,
-	skipSecondaryConfirmation: true,
-};
-
-interface LookalikeResult {
-	domain: string;
-	hasA: boolean;
-	hasMX: boolean;
-	/** MX exchange hosts (lowercased, trailing-dot-stripped) — empty when no real MX. */
-	mxExchanges: string[];
-}
-
-/** Budgets for the Defect L enrichment probes. Both are intentionally tight so 12 candidates × (RDAP + HEAD) stays under LOOKALIKE_TIMEOUT_MS. */
-const RDAP_PROBE_TIMEOUT_MS = 2500;
-const WEB_PROBE_TIMEOUT_MS = 2500;
-
-/**
- * Cap on the number of medium/high-severity lookalikes for which we attempt
- * the same-entity (shared-registrant) RDAP correlation. RDAP registrant data
- * is already harvested from the single enrichment fetch per candidate
- * ({@link probeRdap}), so the cost is bounded by the enrichment set; this cap
- * is a defensive ceiling so a pathological permutation explosion can't widen
- * the RDAP fan-out beyond the lookalike check's wall-clock budget. Ordered by
- * severity (high before medium) so the most damaging false-positives are
- * corrected first when the cap binds.
- */
-const SAME_ENTITY_RDAP_CAP = 10;
-
-/**
- * IANA registrar IDs of BRAND-PROTECTION registrars — corporate registrars
- * that do not sell to the general public. Getting a domain registered through
- * one requires a corporate account and a contract; you cannot buy a name at
- * CSC or MarkMonitor the way you can at a retail registrar.
- *
- * WHY THIS IS DIFFERENT FROM THE REGISTRANT-ORG FIELD (and therefore why it is
- * allowed to corroborate ownership at all). Ruling A / F2 bars the registrant
- * org from influencing attribution because it is free text the REGISTRANT
- * types — forgeable with one form field, and collision-prone because half the
- * internet sits behind the same privacy services. The IANA registrar ID is
- * neither: it is assigned by ICANN and published by the REGISTRY as part of
- * the delegation record. A registrant cannot set it, and cannot move a domain
- * into a corporate registrar's accreditation without that registrar's consent.
- *
- * It is still NOT proof of common ownership — many brands share CSC — which is
- * why {@link isBrandHeldRegistration} requires the candidate's INFRASTRUCTURE
- * to be defensively shaped as well, and why nothing here can ever produce an
- * `owned_by_seed` verdict (that remains seed-side NS evidence only).
- *
- * RETAIL REGISTRARS MUST NEVER BE ADDED. GoDaddy (146), Namecheap (1068) and
- * friends are shared by millions of unrelated registrants, so a shared-retail-
- * registrar match carries no identity information whatsoever. A control test
- * pins that GoDaddy is not treated as evidence.
- */
-const BRAND_PROTECTION_REGISTRAR_IANA_IDS: ReadonlySet<string> = new Set([
-	'299', // CSC Corporate Domains, Inc.
-	'292', // MarkMonitor Inc.
-	'470', // Com Laude (Nom-IQ Ltd)
-	'447', // SafeNames Ltd
-	'1600', // Brandsight, Inc.
-	'106', // Ascio Technologies (corporate channel)
-	'1316', // Nameshield SAS
-	'1495', // EBRAND Services
-	'151', // Gandi SAS — corporate/enterprise channel
-	'1479', // In2net / brand-protection channel
-]);
-
-/**
- * Human phrasing for a {@link DefensiveReason} token. Internal enum values are
- * meaningless in a customer-facing report about a named organisation — the
- * same rule `UNKNOWN_REASON_PHRASES` exists for in `registration-state.ts`.
- *
- * WORDING CONSTRAINT: none of these may contain `missing`, `required`,
- * `not found`, or the `no <...> record` shape. `scoreIndicatesMissingControl()`
- * in the vendored scoring package matches finding TEXT, and a match on a
- * high-severity finding ZEROES the whole category score — the one way a
- * wording change in this file could move a number. Pinned by a boundary test.
- */
-export const DEFENSIVE_REASON_PHRASES: Record<DefensiveReason, string> = {
-	'redirect-to-target': 'its web root redirects back to the scanned domain',
-	'parked-ns': 'its nameservers are at a domain-parking provider',
-	'no-mx': 'it carries no active mail service',
-};
-
-/**
- * Check whether an MX record represents real mail infrastructure.
- *
- * RFC 7505 defines the canonical null MX as priority-0 with exchange `.` (root),
- * meaning "this domain does not accept mail". A legacy convention used by some
- * operators is `0 localhost.` (or `0 localhost`), which has the same intent —
- * mail is null-routed to the sender's own localhost and is functionally rejected.
- * Both patterns must be excluded from the "has mail infrastructure" signal to
- * avoid false-positive HIGH typosquat findings on domains that have applied the
- * recommended anti-spoofing posture.
- */
-function isRealMxRecord(data: string): boolean {
-	const trimmed = data.trim().toLowerCase();
-	// Format from queryDnsRecords is "<priority> <target>", possibly with trailing dot.
-	const match = trimmed.match(/^(\d+)[\s\t]+(.*?)\.?$/);
-	if (!match) return true;
-	const [, priority, target] = match;
-	if (priority !== '0') return true;
-	return target !== '' && target !== 'localhost';
-}
-
-/**
- * Extract the lowercase exchange host from an MX record `"<priority> <target>"`.
- * Returns `null` when the record fails to parse or is a null MX. Used to feed
- * the disposable-MX detector in {@link calibrateLookalikeSeverity}.
- */
-function extractMxExchange(raw: string): string | null {
-	const trimmed = raw.trim().toLowerCase();
-	const match = trimmed.match(/^(\d+)[\s\t]+(.*?)\.?$/);
-	if (!match) return null;
-	const [, , target] = match;
-	if (target === '' || target === 'localhost') return null;
-	return target;
-}
-
-/**
- * Check a single lookalike domain for DNS and MX records.
- * Filters out null MX records (RFC 7505) to avoid false positives.
- */
-async function probeLookalike(domain: string): Promise<LookalikeResult> {
-	const [aRecords, mxRecords] = await Promise.allSettled([queryDnsRecords(domain, 'A'), queryDnsRecords(domain, 'MX')]);
-
-	const realMxRecords = mxRecords.status === 'fulfilled' ? mxRecords.value.filter(isRealMxRecord) : [];
-	const mxExchanges = realMxRecords.map(extractMxExchange).filter((host): host is string => host !== null);
-
-	return {
-		domain,
-		hasA: aRecords.status === 'fulfilled' && aRecords.value.length > 0,
-		hasMX: realMxRecords.length > 0,
-		mxExchanges,
-	};
-}
-
-/**
- * Count the number of labels (dot-separated segments) in a domain.
- */
-function labelCount(domain: string): number {
-	return domain.split('.').length;
-}
-
-/**
- * Extract the parent domain from a dot-insertion permutation.
- * E.g., "blackve.ilsecurity.com" → "ilsecurity.com"
- */
-function getParentDomain(domain: string): string {
-	const parts = domain.split('.');
-	return parts.slice(1).join('.');
-}
-
-/**
- * Detect wildcard DNS on a set of parent domains by probing a canary subdomain.
- * Returns a Set of parent domains that have wildcard A records.
- */
-async function detectWildcardParents(parentDomains: string[]): Promise<Set<string>> {
-	const wildcardParents = new Set<string>();
-	const probes = parentDomains.map(async (parent) => {
-		try {
-			const canary = `${WILDCARD_CANARY_LABEL}.${parent}`;
-			const records = await queryDnsRecords(canary, 'A');
-			if (records.length > 0) {
-				wildcardParents.add(parent);
-			}
-		} catch {
-			// Query failed — not a wildcard
-		}
-	});
-	await Promise.allSettled(probes);
-	return wildcardParents;
-}
-
-/**
- * Phase 1: Fast NS existence check for all domains in parallel.
- * Returns only domains that have NS records (i.e., are registered),
- * along with their normalized NS record data for ownership comparison.
- */
-async function filterByNsExistence(
-	domains: string[],
-): Promise<{ registered: string[]; nsMap: Map<string, Set<string>>; unresolved: number }> {
-	const nsMap = new Map<string, Set<string>>();
-	const results = await Promise.allSettled(
-		domains.map(async (domain) => {
-			const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
-			if (ns.length > 0) {
-				nsMap.set(domain, normalizeNsSet(ns));
-			}
-			return { domain, hasNs: ns.length > 0 };
-		}),
-	);
-	const registered = results
-		.filter((r): r is PromiseFulfilledResult<{ domain: string; hasNs: boolean }> => r.status === 'fulfilled' && r.value.hasNs)
-		.map((r) => r.value.domain);
-	// A REJECTED NS lookup is not "unregistered" — it is UNKNOWN, and dropping it
-	// silently is the primary source of run-to-run variance (#781). This phase
-	// gates everything downstream, so a timed-out NS query makes a registered
-	// domain vanish from the result set entirely, with nothing in the response
-	// distinguishing that from a deregistration. Measured on openclaw.ai: three
-	// `force_refresh` runs minutes apart returned 12, 10 and 13 candidates, with
-	// three names appearing only in the third.
-	const unresolved = results.filter((r) => r.status === 'rejected').length;
-	return { registered, nsMap, unresolved };
-}
-
-/**
- * Normalize a set of NS record values for comparison.
- * Strips trailing dots, lowercases, and returns a Set.
- */
-function normalizeNsSet(nsRecords: string[]): Set<string> {
-	return new Set(nsRecords.map((ns) => ns.replace(/\.$/, '').toLowerCase()));
-}
-
-/**
- * Query NS records for the primary domain to use for ownership comparison.
- * Returns an empty set if the query fails.
- */
-async function queryPrimaryNs(domain: string): Promise<Set<string>> {
-	try {
-		const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
-		return normalizeNsSet(ns);
-	} catch {
-		return new Set<string>();
-	}
-}
-
-/**
- * Query MX records for the primary domain — the D4 (2026-07-26
- * correctness-defects design) MX-overlap corroboration signal for
- * `attributionConfidence()`. Fail-soft: an empty set just means the guard
- * falls back to "no corroboration" rather than throwing.
- */
-async function queryPrimaryMx(domain: string): Promise<Set<string>> {
-	try {
-		const mx = await queryMxRecords(domain, PHASE1_DNS_OPTS);
-		return new Set(mx.map((r) => r.exchange.toLowerCase().replace(/\.$/, '')));
-	} catch {
-		return new Set<string>();
-	}
-}
-
-/**
- * AXIS 1 (attribution) ONLY — Task 7b. This caps what the report may CLAIM
- * about ownership; it does not and must not cap what the report may say was
- * OBSERVED. The observed-threat severity now travels on a separate finding
- * built by {@link buildThreatObservationFinding}, so capping here no longer
- * makes `highCount`, the HIGH summary finding, and every sub-100 `lookalikes`
- * category score unreachable (the defect the opus review found in Task 7).
- *
- * D4 severity ceiling for a lookalike finding, mirroring `applyOwnershipGate()`
- * in `check-shadow-domains.ts` — see that file's JSDoc for the full rationale;
- * this is the same pattern reused for a second tool so the two stay
- * consistent for downstream consumers. The neutral-wording sentence and
- * metadata shape live in `buildNonOwnedGateFinding()`
- * (`src/lib/ownership-attribution.ts`), shared with `check-shadow-domains.ts`
- * (fix round 2, F1) — the two tools had already drifted apart within this
- * slice when each hand-rolled its own copy.
- *
- * `owned_by_seed` findings pass through unclamped — `checkLookalikesCore`'s
- * main loop already emits its own dedicated "likely owned by same entity"
- * finding for that verdict before this function is ever reached, so in
- * practice every call here receives a non-owned verdict. The passthrough
- * branch exists anyway so the invariant is explicit and enforced at this
- * chokepoint rather than merely assumed by the caller.
- *
- * DEMOTE, NEVER DELETE (binding ruling): this returns a `Finding`, never
- * `null`/`undefined` — a real measurement (an active registration with
- * MX/A records) is never suppressed, only its severity capped and its
- * wording made neutral. `attributionConfidence()` governs WORDING/CONFIDENCE
- * ONLY; it can never move the ceiling, which `capAttributionSeverity()`
- * derives from `ownership.verdict` alone.
- */
-function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, brand: string, corroborated: boolean): Finding {
-	const ceiling = capAttributionSeverity(ownership.verdict);
-	if (ceiling === 'unbounded') return finding;
-
-	// `calibrateLookalikeSeverity()` never returns `'info'`, so unlike
-	// `check-shadow-domains.ts` there is no local info-severity branch here —
-	// every candidate reaching this point goes through the shared non-owned
-	// rewrite. `postureNoun` MUST match `check-shadow-domains.ts`'s value
-	// byte-for-byte (parity pinned by `test/ownership-attribution.spec.ts`).
-	return buildNonOwnedGateFinding(finding, ownership, brand, corroborated, ceiling, {
-		category: 'lookalikes',
-		domainMetadataKey: 'lookalikeDomain',
-		postureNoun: 'DNS/mail posture',
-	});
-}
-
-/**
- * AXIS 2 — build the observed-threat finding for a NON-OWNED candidate
- * (Task 7b). Carries the #264 calibrated severity verbatim; the attribution
- * finding built by {@link applyOwnershipGate} carries the `info` cap.
- *
- * WORDING CONTRACT (customer-facing, legal-sensitive — BlackVeil names real
- * third-party organisations in reports). The text:
- *  - states only what was OBSERVED (MX/A presence, registration recency,
- *    disposable MX, absent web content) — no claim of intent.
- *    "Impersonation-shaped" / "consistent with pre-phishing staging" is the
- *    ceiling; the words "malicious"/"attacker" are deliberately absent;
- *  - says EXPLICITLY that the domain does not appear to belong to the scanned
- *    organisation, so no reader can mistake this for an ownership claim;
- *  - never uses "your", "shadow domain", or any ownership/control framing;
- *  - demands no action ON the observed domain. Only defensive options that
- *    need no access to it (monitor, block at the gateway, report for
- *    takedown) are offered.
- *
- * Pinned by `test/check-lookalikes.spec.ts`'s Task 7b block, which asserts
- * both the positive wording and the banned-framing negatives on title AND
- * detail (a split surface — right severity, ownership-framed prose — is the
- * failure mode that bit Task 6's first review pass).
- */
-function buildThreatObservationFinding(
-	candidateDomain: string,
-	seedDomain: string,
-	severity: LookalikeSeverity,
-	signals: LookalikeSignals,
-	ownership: OwnershipAssessment,
-	corroboratorReasons: string,
-	sharedRegistrantOrg: string | undefined,
-	/**
-	 * True when {@link isBrandHeldRegistration} corroborated that the candidate
-	 * is the scanned organisation's OWN defensive registration. Changes the
-	 * closing REMEDIATION sentence only — the observation and its calibrated
-	 * severity are emitted unchanged, per the F1 ruling that an attribution
-	 * signal may annotate the threat axis but never switch it off or discount
-	 * it. Telling a customer to report their own domain for takedown is not a
-	 * severity question; it is simply wrong advice.
-	 */
-	brandHeld = false,
-): Finding {
-	const infraPhrase = signals.hasMX
-		? `active mail infrastructure (MX records), so it is capable of sending mail that resembles ${seedDomain}`
-		: 'web infrastructure (A records) and no active mail infrastructure';
-	const observed = corroboratorReasons ? `${infraPhrase}; also observed: ${corroboratorReasons}` : infraPhrase;
-	// FIX ROUND 1 (F1): when the #263 correlation found a shared registrant-org
-	// string, it is RECORDED here — as an unverified observation — but it does
-	// NOT reduce the severity and does not suppress this finding. An org string
-	// anyone can type into a registrar form earns a sentence, not a discount.
-	const registrantNote = sharedRegistrantOrg
-		? ` Its RDAP registrant-organisation string matches the one published for ${seedDomain} ("${sharedRegistrantOrg}"); that field is self-declared, unverified by the registry, and frequently a shared privacy-service placeholder, so it is recorded but does not reduce what was observed here.`
-		: '';
-	// The attribution clause and the closing remediation clause both assume the
-	// candidate is an outside party's. When the registration record corroborates
-	// that it is the scanned organisation's OWN defensive registration, both are
-	// replaced — the observation itself and its calibrated severity are
-	// untouched, so nothing here moves a score.
-	const attributionClause = brandHeld
-		? `the registry publishes the same brand-protection registrar for it as for ${seedDomain}, so it is most likely the scanned organisation's own defensive registration`
-		: `${candidateDomain} does not appear to belong to the scanned organisation, this finding claims no control over it, and no change to it is requested`;
-	const remediationClause = brandHeld
-		? `Because this looks like your own defensive registration, treat it as portfolio hygiene rather than a threat: confirm it against your domain portfolio, and keep it parked with mail explicitly disabled so it cannot be used to send. Do NOT report it for takedown without confirming ownership first.`
-		: `Defensive options that need no access to ${candidateDomain}: monitor it, block or quarantine mail bearing that name at the gateway, and report it to its registrar or a takedown provider.`;
-	return createFinding(
-		'lookalikes',
-		`Impersonation-shaped ${signals.hasMX ? 'infrastructure' : 'web infrastructure'} observed: ${candidateDomain}`,
-		severity,
-		`${candidateDomain} is a confusable variant of ${seedDomain} and was observed with ${observed}. This is an infrastructure observation only: ${attributionClause}.${registrantNote} ${remediationClause}`,
-		{
-			...(brandHeld ? { brandHeldRegistration: true } : {}),
-			lookalikeDomain: candidateDomain,
-			hasA: signals.hasA,
-			hasMX: signals.hasMX,
-			registrationDays: signals.registrationDays,
-			mxOnDisposable: signals.mxOnDisposable,
-			hasWebContent: signals.hasWebContent,
-			findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
-			// The verdict travels on EVERY classified finding, threat axis
-			// included, so a consumer can read "high observed threat, NOT owned by
-			// the customer" off a single object rather than correlating two.
-			ownershipVerdict: ownership.verdict,
-			...(sharedRegistrantOrg ? { sharedRegistrantOrg } : {}),
-		},
-	);
-}
-
-/**
- * Run permutation probes with adaptive batch sizing and backoff.
- * Starts at INITIAL_BATCH_SIZE, halves on repeated failures (floor at MIN_BATCH_SIZE),
- * recovers on clean batches.
- */
-async function probeWithAdaptiveBatching(permutations: string[]): Promise<PromiseSettledResult<LookalikeResult>[]> {
-	const allResults: PromiseSettledResult<LookalikeResult>[] = [];
-	let batchSize = INITIAL_BATCH_SIZE;
-	let delayMs = 0;
-
-	for (let i = 0; i < permutations.length; i += batchSize) {
-		if (delayMs > 0) {
-			await new Promise((resolve) => setTimeout(resolve, delayMs));
-		}
-
-		const batch = permutations.slice(i, i + batchSize);
-		const batchResults = await Promise.allSettled(batch.map((d) => probeLookalike(d)));
-		allResults.push(...batchResults);
-
-		// Count failures in this batch
-		const failures = batchResults.filter((r) => r.status === 'rejected').length;
-		if (failures > FAILURE_THRESHOLD) {
-			// Back off: halve batch size (floor to MIN_BATCH_SIZE) and add delay
-			batchSize = Math.max(MIN_BATCH_SIZE, Math.floor(batchSize / 2));
-			delayMs = BACKOFF_DELAY_MS;
-		} else if (delayMs > 0 && failures === 0) {
-			// Recover: if a clean batch after backoff, try increasing again
-			batchSize = Math.min(INITIAL_BATCH_SIZE, batchSize + 2);
-			delayMs = 0;
-		}
-	}
-
-	return allResults;
-}
-
-/**
- * Detect registered lookalike/typosquat domains with DNS or mail infrastructure.
- * Generates domain permutations and checks for active registrations using adaptive batching.
- * Filters out false positives from wildcard DNS on parent domains and null MX records.
- */
 /**
  * Extract a specific candidate domain bv-recon's CT_LOOKALIKE hit names, if
  * any (fix round 1, F1). The check response schema's only extension point
@@ -525,6 +105,11 @@ export function extractReconMatchedDomain(reconResult: ReconScanResult, seedDoma
 	return normalized;
 }
 
+/**
+ * Detect registered lookalike/typosquat domains with DNS or mail infrastructure.
+ * Generates domain permutations and checks for active registrations using adaptive batching.
+ * Filters out false positives from wildcard DNS on parent domains and null MX records.
+ */
 export async function checkLookalikes(
 	domain: string,
 	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
@@ -533,15 +118,7 @@ export async function checkLookalikes(
 		checkLookalikesCore(domain, reconOptions),
 		new Promise<never>((_, reject) => setTimeout(() => reject(new Error('Lookalike check timed out')), LOOKALIKE_TIMEOUT_MS)),
 	]).catch(() => {
-		const result = buildCheckResult('lookalikes', [
-			createFinding(
-				'lookalikes',
-				'Lookalike check incomplete',
-				'info',
-				'Lookalike check did not complete within the time limit. Results may be incomplete — try again shortly.',
-				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
-			),
-		]);
+		const result = buildCheckResult('lookalikes', [buildTimeoutFinding()]);
 		// Mark as partial so callers can skip caching
 		result.partial = true;
 		return result;
@@ -573,15 +150,7 @@ async function checkLookalikesCore(
 	];
 
 	if (permutations.length === 0) {
-		findings.push(
-			createFinding(
-				'lookalikes',
-				'No active lookalike domains detected',
-				'info',
-				`No lookalike domain permutations could be generated for ${domain}.`,
-				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
-			),
-		);
+		findings.push(buildNoPermutationsFinding(domain));
 		return buildCheckResult('lookalikes', findings);
 	}
 
@@ -629,15 +198,7 @@ async function checkLookalikesCore(
 	const { registered: registeredPerms, nsMap: lookalikeNsMap, unresolved: nsUnresolved } = nsResult;
 
 	if (registeredPerms.length === 0) {
-		findings.push(
-			createFinding(
-				'lookalikes',
-				'No active lookalike domains detected',
-				'info',
-				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations detected.`,
-				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
-			),
-		);
+		findings.push(buildNoRegisteredCandidatesFinding(domain, permutations.length));
 		return buildCheckResult('lookalikes', findings);
 	}
 
@@ -808,21 +369,7 @@ async function checkLookalikesCore(
 
 		if (sameOwner) {
 			// Structurally owned by the seed — the customer's own domain.
-			findings.push(
-				createFinding(
-					'lookalikes',
-					`Lookalike domain likely owned by same entity: ${result.domain}`,
-					'info',
-					`The domain ${result.domain} is owned by the same organisation as ${domain} (${ownership.rationale}).${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
-					{
-						lookalikeDomain: result.domain,
-						hasA: result.hasA,
-						hasMX: result.hasMX,
-						ownershipVerdict: ownership.verdict,
-						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
-					},
-				),
-			);
+			findings.push(buildOwnedBySeedFinding(result, domain, ownership));
 			// Task 7b requirement 5: an `owned_by_seed` candidate gets NO
 			// threat-observation finding — the customer's own domain is not an
 			// impersonation threat to itself. This `continue` (together with the
@@ -853,127 +400,23 @@ async function checkLookalikesCore(
 		// Same-entity correlation (issue #263): the calibrated severity is a
 		// threat tier (low/medium/high), but if this lookalike's RDAP registrant
 		// org matches the scan domain's, it's PLAUSIBLY the org's own defensive /
-		// regional registration. Downgrade to an info finding instead of a
-		// threat. Only medium/high candidates are eligible (see
+		// regional registration. It is REPORTED as such — see
+		// `buildSharedRegistrantOrgFinding` — but the threat axis below is
+		// emitted regardless. Only medium/high candidates are eligible (see
 		// computeSameEntityCandidates); LOW web-only matches stay as-is (cheap,
 		// low-noise, not worth the fetch).
-		//
-		// F2 (2026-07-27 fix round 2): a RDAP registrant-org match is
-		// DELIBERATELY NOT fed into `classifyOwnership()` as an ownership
-		// signal — the org field is self-declared and unverified by most
-		// registries (the same attacker-influenceable class as the
-		// candidate-side declarations described in the OWNERSHIP RULE note
-		// on `ClassifyOwnershipInput`), so it must never be able to
-		// silently produce an `owned_by_seed` verdict. Every candidate reaching
-		// this branch therefore still carries the STRUCTURAL verdict computed
-		// earlier (`third_party` here — `sameOwner` above already filtered out
-		// `owned_by_seed`), and the verdict now travels on this finding too
-		// (`ownershipVerdict` in metadata) per the same "verdict travels on
-		// EVERY classified finding" invariant `check-shadow-domains.ts` states
-		// for its own emission sites. The title/prose no longer asserts common
-		// ownership outright — it's reworded to state plainly that this is a
-		// registrant-organisation SIGNAL, distinct from (and weaker than) the
-		// structural NS-based evidence, whose own finding is quoted verbatim.
 		const matchedOrg = sameEntityMatches.get(result.domain);
 		const brandHeld = brandHeldMatches.get(result.domain);
 		if (brandHeld !== undefined) {
-			// AXIS 1 — the registration record corroborates that this is the
-			// scanned organisation's OWN defensive registration. Emitted INSTEAD
-			// of the neutral D4 gate template, which would otherwise state
-			// positively that the domain "is registered to a different
-			// organisation" — a claim the nameserver evidence alone never
-			// supported and which is simply false here.
-			//
-			// SEVERITY IS `info`, EXACTLY AS `applyOwnershipGate()` WOULD HAVE
-			// CAPPED IT. This branch changes what the report SAYS, never what it
-			// SCORES: `capAttributionSeverity()` caps every non-`owned_by_seed`
-			// attribution finding at `info` regardless, so swapping the prose
-			// moves no penalty. Pinned by the boundary test in
-			// `test/ownership-attribution.spec.ts`.
-			const registrarLabel = brandHeld.registrarName
-				? `${brandHeld.registrarName} (IANA ${brandHeld.registrarIanaId})`
-				: `IANA registrar ${brandHeld.registrarIanaId}`;
-			findings.push(
-				createFinding(
-					'lookalikes',
-					`Confusable domain held at the same brand-protection registrar: ${result.domain}`,
-					'info',
-					`The domain ${result.domain} is a confusable variant of ${domain}, and the registry publishes the SAME brand-protection registrar for both (${registrarLabel}). Its infrastructure also has the shape of a defensive registration — ${DEFENSIVE_REASON_PHRASES[brandHeld.reason]}. Brand-protection registrars do not sell to the general public and the IANA registrar ID is published by the registry rather than declared by the registrant, so this corroborates that ${result.domain} is held by the scanned organisation itself; it is not proof, since one such registrar serves many brands. Nameserver evidence is separate and did not link the two: ${ownership.rationale} Confirm against your own domain portfolio before treating ${result.domain} as an outside party's.`,
-					{
-						lookalikeDomain: result.domain,
-						hasA: result.hasA,
-						hasMX: result.hasMX,
-						brandHeldRegistration: true,
-						sharedRegistrarIanaId: brandHeld.registrarIanaId,
-						defensiveReason: brandHeld.reason,
-						// Ruling A holds: registrar evidence never manufactures
-						// `owned_by_seed`. The STRUCTURAL verdict travels unchanged.
-						ownershipVerdict: ownership.verdict,
-						ownershipRationale: ownership.rationale,
-						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
-					},
-				),
-			);
+			findings.push(buildBrandHeldFinding(result, domain, ownership, brandHeld));
 		} else if (matchedOrg !== undefined) {
-			// AXIS 1 — the registrant-org observation REPLACES the neutral D4 gate
-			// template for this candidate (it is strictly more informative), but it
-			// is still an attribution statement capped at info.
-			findings.push(
-				createFinding(
-					'lookalikes',
-					`Lookalike domain shares registrant organisation with scanned domain: ${result.domain}`,
-					'info',
-					`The domain ${result.domain} shares the same RDAP registrant organisation as ${domain} ("${matchedOrg}"), which may indicate a defensive registration or regional presence by the same owner. This is a registrant-organisation signal, not structural ownership evidence — RDAP registrant fields are self-declared and not independently verified. Nameserver-based evidence: ${ownership.rationale}${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
-					{
-						lookalikeDomain: result.domain,
-						hasA: result.hasA,
-						hasMX: result.hasMX,
-						sharedRegistrantOrg: matchedOrg,
-						ownershipVerdict: ownership.verdict,
-						ownershipRationale: ownership.rationale,
-						findingAxis: 'attribution' satisfies LookalikeFindingAxis,
-					},
-				),
-			);
+			findings.push(buildSharedRegistrantOrgFinding(result, domain, ownership, matchedOrg));
 		} else {
-			// AXIS 1 — the ownership verdict caps the ATTRIBUTION finding's severity: a candidate
-			// with no ownership signal linking it to the scanned organisation can
-			// never surface above info, regardless of how threatening its raw
-			// infrastructure signals look. `attributionConfidence()` (fed the
-			// MX-overlap corroboration signal below) governs WORDING/CONFIDENCE
-			// only — see `applyOwnershipGate()`'s JSDoc.
+			// AXIS 1 — the ownership verdict caps the ATTRIBUTION finding's
+			// severity. `attributionConfidence()` (fed the MX-overlap
+			// corroboration signal below) governs WORDING/CONFIDENCE only.
 			const mxOverlapsPrimary = result.mxExchanges.some((ex) => primaryMx.has(ex));
-			const rawFinding = result.hasMX
-				? createFinding(
-						'lookalikes',
-						`Lookalike domain with mail infrastructure: ${result.domain}`,
-						severity,
-						`The domain ${result.domain} is registered with active mail servers (MX records), which could be used for phishing or email spoofing targeting ${domain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
-						{
-							lookalikeDomain: result.domain,
-							hasA: result.hasA,
-							hasMX: result.hasMX,
-							registrationDays: signals.registrationDays,
-							mxOnDisposable: signals.mxOnDisposable,
-							hasWebContent: signals.hasWebContent,
-							findingAxis: 'attribution' satisfies LookalikeFindingAxis,
-						},
-					)
-				: createFinding(
-						'lookalikes',
-						`Lookalike domain registered: ${result.domain}`,
-						severity,
-						`The domain ${result.domain} is registered (has web presence) but no mail infrastructure detected. It could still be used for phishing websites targeting ${domain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
-						{
-							lookalikeDomain: result.domain,
-							hasA: result.hasA,
-							hasMX: result.hasMX,
-							registrationDays: signals.registrationDays,
-							mxOnDisposable: signals.mxOnDisposable,
-							hasWebContent: signals.hasWebContent,
-							findingAxis: 'attribution' satisfies LookalikeFindingAxis,
-						},
-					);
+			const rawFinding = buildRawAttributionFinding(result, domain, severity, signals, corroboratorReasons);
 
 			// Attribution pushed FIRST so a consumer scanning for the ownership
 			// statement about a candidate finds it ahead of the threat observation.
@@ -1009,124 +452,19 @@ async function checkLookalikesCore(
 		}
 	}
 
-	// Summary finding for high-severity lookalikes (AXIS 2). Only fires when at
-	// least one NON-OWNED candidate reached HIGH under the issue #264 matrix
-	// (mail-infra + corroborator). Owned candidates never reach here.
 	if (highCount > 0) {
-		findings.push(
-			createFinding(
-				'lookalikes',
-				// TITLE NAMES THE PREDICATE IT COUNTS (#779). It used to say "with
-				// mail capability", which is a strictly wider set than the
-				// mail-infra-PLUS-corroborator matrix this count applies — so the
-				// headline under-reported threefold against its own per-domain
-				// evidence. The staging subset is the right thing to lead with; it
-				// just has to be named as the subset it is, with the wider
-				// mail-capable figure alongside rather than implied.
-				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} showing pre-phishing staging signals`,
-				'high',
-				`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging.${
-					mailCapableDomains.length > highCount
-						? ` A further ${mailCapableDomains.length - highCount} confusable domain${mailCapableDomains.length - highCount > 1 ? 's' : ''} also ${mailCapableDomains.length - highCount > 1 ? 'have' : 'has'} a working mail host without those additional signals — ${mailCapableDomains.length} can send mail in total.`
-						: ''
-				} ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
-				{
-					lookalikeDomainCount: highCount,
-					lookalikeDomains: highDomains,
-					// BOTH numbers, so a consumer never has to re-derive either from
-					// the per-domain findings — which is what the old shape forced,
-					// and what nobody did.
-					mailCapableCount: mailCapableDomains.length,
-					mailCapableDomains,
-					enumeration,
-					// Set-level claim, so its confidence tracks ENUMERATION coverage,
-					// not per-domain measurement quality (#781). Each row remains
-					// deterministic about its own domain; what is uncertain when a
-					// lookup was dropped is whether the SET is complete — and this
-					// finding is the one making a claim about the set.
-					confidence: enumeration.complete ? 'deterministic' : 'heuristic',
-					// Present whenever the counted set shares one verdict (the realistic
-					// case — a non-owned registered candidate is always `third_party`).
-					// Omitted rather than fabricated for a mixed set; either way it can
-					// never be `owned_by_seed`, since owned candidates never reach here.
-					...(highVerdicts.size === 1 ? { ownershipVerdict: [...highVerdicts][0] } : {}),
-					findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
-				},
-			),
-		);
+		findings.push(buildStagingSummaryFinding({ seedDomain: domain, highCount, highDomains, highVerdicts, mailCapableDomains, enumeration }));
 	} else if (mailCapableDomains.length > 0) {
-		// The other half of #779. When mail-capable candidates exist but none
-		// carries a #264 corroborator, the old code emitted NO summary at all —
-		// so an estate with several confusable domains that can send mail
-		// produced an aggregate view saying nothing, and a consumer reading only
-		// summaries concluded there was no mail-capable lookalike exposure.
-		//
-		// MEDIUM, not high: mail capability alone is a real observation but not
-		// evidence of staging, and the severity has to stay honest about which
-		// of the two it is.
-		const n = mailCapableDomains.length;
-		findings.push(
-			createFinding(
-				'lookalikes',
-				`${n} lookalike domain${n > 1 ? 's' : ''} with a working mail host`,
-				'medium',
-				`${n} confusable domain${n > 1 ? 's' : ''} of ${domain} ${n > 1 ? 'have' : 'has'} a working mail host, so ${n > 1 ? 'they are' : 'it is'} capable of sending mail that resembles ${domain}. No additional corroborating signal of pre-phishing staging was observed, and ${n > 1 ? 'none appears' : 'it does not appear'} to belong to the scanned organisation — this is an infrastructure observation, not an allegation. Enforcing DMARC p=reject on ${domain} is what makes receivers reject mail forging that name.`,
-				{
-					mailCapableCount: n,
-					mailCapableDomains,
-					enumeration,
-					confidence: enumeration.complete ? 'deterministic' : 'heuristic',
-					// Names what it observed — invariant 4, asserted by
-					// `assertAxisInvariants`: every threat_observation must identify
-					// its subject. Omitting this made the first draft of this finding
-					// anonymous, and the existing suite caught it.
-					lookalikeDomains: mailCapableDomains,
-					// Deliberately no `lookalikeDomainCount`: nothing reached the
-					// staging threshold, and reusing that key would let a consumer
-					// read this as the staging count.
-					findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
-				},
-			),
-		);
+		findings.push(buildMailCapableSummaryFinding({ seedDomain: domain, mailCapableDomains, enumeration }));
 	}
 
 	// If no active lookalikes found
 	if (findings.length === 0) {
-		findings.push(
-			createFinding(
-				'lookalikes',
-				'No active lookalike domains detected',
-				'info',
-				`Checked ${permutations.length} domain permutations of ${domain}. No active registrations with DNS or mail infrastructure detected.${
-					enumeration.complete
-						? ''
-						: ` ⚠️ ${enumeration.unresolvedCount} lookup${enumeration.unresolvedCount > 1 ? 's' : ''} did not resolve, so this is not a conclusive "none".`
-				}`,
-				{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis, enumeration },
-			),
-		);
+		findings.push(buildNoActiveInfrastructureFinding(domain, permutations.length, enumeration));
 	}
 
-	// PARTIAL COVERAGE (#781). Emitted as its own finding, not only as metadata,
-	// because a consumer reading findings — which is most of them — otherwise
-	// has no way to learn the candidate set is a SAMPLE. Without it, repeat runs
-	// returning different sets look like real-world change: monitoring built on
-	// diffing consecutive runs raises false "new lookalike registered" alerts for
-	// names merely missed last time, and misses real ones enumerated before.
 	if (!enumeration.complete) {
-		findings.push(
-			createFinding(
-				'lookalikes',
-				'Lookalike enumeration was incomplete — treat this list as a sample',
-				'info',
-				`${enumeration.unresolvedCount} of ${enumeration.permutationsProbed} candidate lookup${enumeration.permutationsProbed > 1 ? 's' : ''} for ${domain} did not resolve (DNS timeout or rate limiting), so those permutations could be neither confirmed nor ruled out. The ${enumeration.candidatesResolved} domain${enumeration.candidatesResolved === 1 ? '' : 's'} reported here are observed examples, not a complete inventory — do not read a smaller set on a later run as a domain having been deregistered, and re-run before relying on the count.`,
-				{
-					findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
-					enumeration,
-					confidence: 'heuristic',
-				},
-			),
-		);
+		findings.push(buildIncompleteEnumerationFinding(domain, enumeration));
 	}
 
 	// Recon enrichment: additive-only, fail-soft.
@@ -1170,429 +508,13 @@ async function checkLookalikesCore(
 				// customer's own domain gets no threat_observation finding — this
 				// enrichment is additive-only and adds nothing new for one.
 				if (reconOwnership.verdict !== 'owned_by_seed') {
-					findings.push(
-						createFinding('lookalikes', 'CT-observed lookalike corroboration', 'medium', detail, {
-							lookalikeDomain: matchedDomain,
-							reconEnriched: true,
-							findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
-							ownershipVerdict: reconOwnership.verdict,
-						}),
-					);
+					findings.push(buildReconCandidateFinding(matchedDomain, detail, reconOwnership));
 				}
 			} else {
-				// No specific candidate nameable — never fabricate one. A
-				// scan-level notice about the run's own CT signal, not a
-				// per-candidate threat claim, so it stays `info`/`scan_status`
-				// (DEMOTE, NEVER DELETE: the real signal is still surfaced).
-				findings.push(
-					createFinding(
-						'lookalikes',
-						'CT-observed lookalike corroboration (no specific candidate identified)',
-						'info',
-						`${detail} No specific confusable domain was identified by this signal, so no candidate-level claim is made.`,
-						{ domain, reconEnriched: true, findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
-					),
-				);
+				findings.push(buildReconScanStatusFinding(domain, detail));
 			}
 		}
 	}
 
 	return buildCheckResult('lookalikes', findings);
-}
-
-interface LookalikeCorroborators {
-	registrationDays: number | null;
-	mxOnDisposable: boolean;
-	hasWebContent: boolean;
-	/**
-	 * Normalised RDAP registrant org for this candidate, harvested from the same
-	 * single RDAP fetch as {@link registrationDays}. `null` when RDAP failed,
-	 * returned no registrant entity, or the org field was empty — in which case
-	 * the same-entity correlation fails soft (the calibrated threat severity
-	 * stands; a real threat is never suppressed on missing RDAP).
-	 */
-	registrantOrg: string | null;
-	/**
-	 * Registry-published IANA registrar ID for this candidate, harvested from
-	 * the same single RDAP fetch as everything else here. Feeds
-	 * {@link isBrandHeldRegistration}; `null` fails soft to "no evidence".
-	 */
-	registrarIanaId: string | null;
-	/** Registrar display name, for report prose only. */
-	registrarName: string | null;
-}
-
-/**
- * THE single predicate deciding whether two RDAP registrant-org strings may be
- * treated as the same entity (issue #263). Added in Task 7b fix round 1 for
- * review finding F1.
- *
- * The org field is free text the registrant TYPES and RDAP does not verify it.
- * Raw string equality was therefore both forgeable (one registrar form field)
- * and — far more damaging — trivially collision-prone: seed and candidate
- * sitting behind the SAME privacy service normalise equal for reasons that
- * carry zero identity information. Both sides are gated through
- * `isRedactedRegistrantOrg()`, so a redacted / proxy / generic value can never
- * produce a match.
- *
- * A surviving match is still only a WEAK, unverified signal: it earns a
- * sentence in the report, never a severity discount. The threat-observation
- * finding is emitted at its full calibrated severity regardless.
- *
- * EQUALITY-MATCHING INVARIANT — READ BEFORE CHANGING THE COMPARISON (fix round
- * 2, re-review residual). The final test is STRICT EQUALITY, and
- * `isRedactedRegistrantOrg()` is a pure function of its string. Therefore
- * whenever the two orgs are equal the predicate returns the SAME verdict for
- * both, and checking one side is currently EXACTLY equivalent to checking both.
- * That was verified by execution: mutating this function to gate the candidate
- * side only left the entire suite green, and no end-to-end fixture can
- * discriminate — for a one-sided gate to wrongly match, the two strings would
- * have to differ in redaction status while still being equal, which equality
- * matching makes impossible.
- *
- * The both-sides form is kept as DEFENCE IN DEPTH for the day that comparison
- * stops being equality. ANY change to fuzzy/containment/token-overlap/edit-
- * distance matching MUST (a) keep the gate on BOTH sides — under fuzzy matching
- * a redacted string can match a non-redacted one, so a one-sided gate becomes a
- * real hole — and (b) ship a fixture that discriminates one-sided from
- * two-sided, which only becomes constructible once equality is gone. Until
- * then the semantics are pinned directly by the unit tests on this function in
- * `test/check-lookalikes.spec.ts` (exported for exactly that purpose), not by
- * an end-to-end fixture that cannot tell the two implementations apart.
- */
-export function isSameEntityOrgMatch(primaryOrg: string | null, candidateOrg: string | null): boolean {
-	if (primaryOrg === null || candidateOrg === null) return false;
-	if (isRedactedRegistrantOrg(primaryOrg) || isRedactedRegistrantOrg(candidateOrg)) return false;
-	return primaryOrg === candidateOrg;
-}
-
-/**
- * Determine which lookalike candidates are eligible for the issue #263
- * same-entity (shared-registrant) downgrade. Eligibility mirrors the
- * classification loop's decision so we never fetch the primary's registrant
- * org speculatively: a candidate qualifies only when `ownershipByDomain`
- * does NOT already attribute it to the seed (`owned_by_seed` — CALL SITE 3
- * of the D4 2026-07-26 correctness-defects design's ownership gate) and has
- * mail/web infra. The result is sorted by calibrated severity, highest first,
- * and capped at {@link SAME_ENTITY_RDAP_CAP} so a permutation explosion can't
- * widen the RDAP fan-out unbounded.
- *
- * LOW-SEVERITY CANDIDATES ARE ELIGIBLE (changed — they used to be excluded as
- * "not worth the RDAP cost"). That exclusion was the mechanical cause of the
- * brand's-own-defensive-registration defect: a defensive registration is
- * PARKED, so it is web-only, aged and mail-less, and therefore calibrates
- * exactly `low`. The tool skipped the one fetch that would have told it who
- * held the domain, then asserted the domain "is registered to a different
- * organisation" and offered to report it for takedown — a positive
- * non-ownership CLAIM derived from evidence it declined to gather.
- *
- * Severity is a THREAT tier, so gating an ATTRIBUTION lookup on it was a
- * category error: the cheapest candidates to dismiss as low-threat are
- * precisely the ones most likely to be the customer's own.
- *
- * COST OF THE WIDENING IS ONE FETCH, MEASURED NOT ASSUMED. Candidate RDAP was
- * never gated on severity — `enrichLookalikes()` already fetches it for every
- * non-owned candidate with mail/web infra. The medium/high gate only decided
- * whether the SEED's single RDAP fetch happened. So widening to `low` adds at
- * most ONE request per scan, on scans that have a registered non-owned
- * candidate at all. `SAME_ENTITY_RDAP_CAP` still bounds the set; severity now
- * only decides ORDER within it, and `owned_by_seed` candidates are still
- * excluded outright, so the shared-NS short-circuit still pays no RDAP cost.
- */
-function computeSameEntityCandidates(
-	results: LookalikeResult[],
-	ownershipByDomain: Map<string, OwnershipAssessment>,
-	enrichment: Map<string, LookalikeCorroborators>,
-): string[] {
-	const SEVERITY_ORDER: Record<LookalikeSeverity, number> = { high: 0, medium: 1, low: 2 };
-	const eligible: Array<{ domain: string; severity: LookalikeSeverity }> = [];
-	for (const result of results) {
-		const sameOwner = ownershipByDomain.get(result.domain)?.verdict === 'owned_by_seed';
-		if (sameOwner) continue;
-		if (!result.hasMX && !result.hasA) continue;
-		const corroborators = enrichment.get(result.domain);
-		const severity = calibrateLookalikeSeverity({
-			hasA: result.hasA,
-			hasMX: result.hasMX,
-			registrationDays: corroborators?.registrationDays ?? null,
-			mxOnDisposable: corroborators?.mxOnDisposable ?? false,
-			hasWebContent: corroborators?.hasWebContent ?? true,
-		});
-		eligible.push({ domain: result.domain, severity });
-	}
-	eligible.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
-	return eligible.slice(0, SAME_ENTITY_RDAP_CAP).map((e) => e.domain);
-}
-
-/**
- * Run the Defect L enrichment probes (RDAP registration age + web HEAD probe)
- * for every candidate in parallel. Failure to enrich is fail-soft: missing
- * RDAP data becomes `registrationDays: null` (treated as "unknown — not recent")
- * and a probe error becomes `hasWebContent: true` to avoid synthesising HIGH
- * out of nothing. `mxOnDisposable` is derived synchronously from the already-
- * parsed MX exchanges, no extra DNS needed.
- */
-async function enrichLookalikes(candidates: LookalikeResult[]): Promise<Map<string, LookalikeCorroborators>> {
-	const map = new Map<string, LookalikeCorroborators>();
-	if (candidates.length === 0) return map;
-	await Promise.allSettled(
-		candidates.map(async (candidate) => {
-			const [rdap, hasWebContent] = await Promise.all([
-				probeRdap(candidate.domain),
-				candidate.hasA ? probeHasWebContent(candidate.domain) : Promise.resolve(true),
-			]);
-			const mxOnDisposable = candidate.mxExchanges.some(isDisposableMxHost);
-			map.set(candidate.domain, {
-				registrationDays: rdap.registrationDays,
-				mxOnDisposable,
-				hasWebContent,
-				registrantOrg: rdap.registrantOrg,
-				registrarIanaId: rdap.registrarIanaId,
-				registrarName: rdap.registrarName,
-			});
-		}),
-	);
-	return map;
-}
-
-/** Result of the single lightweight RDAP probe per candidate. */
-interface RdapProbeResult {
-	/** Age in days since the RDAP `registration` event, or `null` on any failure / missing data. */
-	registrationDays: number | null;
-	/** Normalised RDAP registrant org, or `null` on any failure / missing data. */
-	registrantOrg: string | null;
-	/**
-	 * Registry-published IANA registrar ID, or `null` on any failure / absence.
-	 * Distinct in kind from {@link registrantOrg}: assigned by ICANN, published
-	 * by the registry, and not settable by the registrant — see
-	 * {@link BRAND_PROTECTION_REGISTRAR_IANA_IDS}.
-	 */
-	registrarIanaId: string | null;
-	/** Registrar display name, for report prose only. Never compared. */
-	registrarName: string | null;
-}
-
-/** Empty probe result — used for early-outs and the catch path (fail-soft). */
-const EMPTY_RDAP_PROBE: RdapProbeResult = { registrationDays: null, registrantOrg: null, registrarIanaId: null, registrarName: null };
-
-/**
- * Pull the registrar's IANA ID and display name out of a parsed RDAP domain
- * response. Local to this file rather than imported because
- * `check-rdap-lookup.ts` keeps its vCard/publicId readers private; only
- * `findEntityByRole` is exported, so the traversal is reused and just the two
- * field reads are done here.
- *
- * Fail-soft in every branch — a non-conforming shape yields nulls, which the
- * brand-held predicate treats as "no evidence" (never as a match).
- */
-function extractRegistrar(rdapData: unknown): { ianaId: string | null; name: string | null } {
-	if (typeof rdapData !== 'object' || rdapData === null) return { ianaId: null, name: null };
-	const entities = (rdapData as { entities?: unknown }).entities;
-	if (!Array.isArray(entities)) return { ianaId: null, name: null };
-	const registrar = findEntityByRole(entities as Parameters<typeof findEntityByRole>[0], 'registrar');
-	if (!registrar) return { ianaId: null, name: null };
-
-	let ianaId: string | null = null;
-	const publicIds = (registrar as { publicIds?: unknown }).publicIds;
-	if (Array.isArray(publicIds)) {
-		for (const publicId of publicIds) {
-			if (typeof publicId !== 'object' || publicId === null) continue;
-			const { type, identifier } = publicId as { type?: unknown; identifier?: unknown };
-			if (typeof type === 'string' && /^IANA Registrar ID$/i.test(type.trim()) && typeof identifier === 'string' && identifier.trim()) {
-				ianaId = identifier.trim();
-				break;
-			}
-		}
-	}
-
-	let name: string | null = null;
-	const vcardArray = (registrar as { vcardArray?: unknown }).vcardArray;
-	if (Array.isArray(vcardArray) && vcardArray[0] === 'vcard' && Array.isArray(vcardArray[1])) {
-		for (const prop of vcardArray[1] as unknown[]) {
-			if (Array.isArray(prop) && prop[0] === 'fn' && typeof prop[3] === 'string' && prop[3].trim()) {
-				name = prop[3].trim();
-				break;
-			}
-		}
-	}
-	return { ianaId, name };
-}
-
-/**
- * THE predicate deciding whether a candidate is the scanned organisation's own
- * DEFENSIVE REGISTRATION rather than a third party's domain.
- *
- * Requires BOTH, and neither alone is sufficient:
- *
- *  1. REGISTRATION-RECORD corroboration — the candidate and the seed share an
- *     IANA registrar ID belonging to a brand-protection registrar
- *     ({@link BRAND_PROTECTION_REGISTRAR_IANA_IDS}). A shared RETAIL registrar
- *     is explicitly not evidence: millions of unrelated registrants share one.
- *
- *  2. DEFENSIVE INFRASTRUCTURE SHAPE — `evaluateDefensiveRegistration()`
- *     (`src/lib/brand-defensive-registration.ts`) agrees the candidate is a
- *     typo-close label parked with minimal infrastructure. An attacker who
- *     somehow reached the same corporate registrar but stood up live mail
- *     still fails this leg and gets the full threat treatment.
- *
- * WHAT THIS DELIBERATELY DOES NOT DO: it does not, and must not, produce an
- * `owned_by_seed` ownership verdict. `classifyOwnership()` stays driven by
- * seed-side nameserver evidence alone (Ruling A), and every finding about this
- * candidate keeps carrying its structural `third_party` verdict. What changes
- * is what the report CLAIMS and RECOMMENDS: it stops asserting the domain
- * "is registered to a different organisation" on evidence that never
- * addressed the question, and stops telling the customer to report their own
- * domain for takedown.
- *
- * NULL-GUARD NOTE — VERIFIED BY MUTATION, NOT ASSUMED (the same disclosure
- * `isSameEntityOrgMatch` above makes about its own both-sides gate). The
- * `=== null` guard on the first line is currently REDUNDANT: deleting it left
- * the entire suite green, because two `null` IDs pass the equality check and
- * are then rejected by `BRAND_PROTECTION_REGISTRAR_IANA_IDS.has(null)` anyway.
- * No fixture can discriminate the two implementations while membership is an
- * exact-set test, so none is shipped pretending to.
- *
- * It is kept as DEFENCE IN DEPTH and becomes load-bearing the moment that
- * membership test is relaxed — a name-based or fuzzy registrar comparison, or
- * an "any shared registrar" mode — at which point "both sides published
- * nothing" would read as a match and silently mark every RDAP-less candidate
- * as brand-held. Anyone relaxing it MUST keep this guard and ship a fixture
- * that discriminates it, which only becomes constructible then.
- */
-export function isBrandHeldRegistration(input: {
-	seedDomain: string;
-	candidateDomain: string;
-	seedRegistrarIanaId: string | null;
-	candidateRegistrarIanaId: string | null;
-	candidateMxExchanges: readonly string[];
-	candidateNsHosts: readonly string[];
-}): { brandHeld: false } | { brandHeld: true; registrarIanaId: string; reason: DefensiveReason } {
-	const { seedRegistrarIanaId, candidateRegistrarIanaId } = input;
-	if (seedRegistrarIanaId === null || candidateRegistrarIanaId === null) return { brandHeld: false };
-	if (seedRegistrarIanaId !== candidateRegistrarIanaId) return { brandHeld: false };
-	if (!BRAND_PROTECTION_REGISTRAR_IANA_IDS.has(candidateRegistrarIanaId)) return { brandHeld: false };
-
-	const shape = evaluateDefensiveRegistration({
-		candidateDomain: input.candidateDomain,
-		targetDomain: input.seedDomain,
-		// A concrete array (never `undefined`) — we DID look, via the Phase 2
-		// probe, so an empty set means "no mail", not "unknown". The heuristic
-		// abstains on `undefined`, which would silently disable this leg.
-		mxRecords: input.candidateMxExchanges,
-		nsHosts: input.candidateNsHosts,
-	});
-	if (!shape.defensive || shape.reason === undefined) return { brandHeld: false };
-	return { brandHeld: true, registrarIanaId: candidateRegistrarIanaId, reason: shape.reason };
-}
-
-/**
- * Lightweight RDAP lookup constrained for use inside the lookalike check.
- * Hits the hardcoded {@link FALLBACK_RDAP_SERVERS} map only (no IANA bootstrap),
- * single fetch, hard 2.5s timeout, no retries. From that single response it
- * derives BOTH the registration age (issue #264 corroborator) AND the registrant
- * org (issue #263 same-entity correlation) — no extra fetch for the org signal.
- * Any failure / missing data yields `null` for the affected field, which the
- * calibrator treats as "unknown" (never elevates severity) and the same-entity
- * check treats as "no match" (never suppresses a real threat).
- */
-async function probeRdap(domain: string): Promise<RdapProbeResult> {
-	const labels = domain.split('.');
-	const tld = labels[labels.length - 1]?.toLowerCase();
-	if (!tld) return EMPTY_RDAP_PROBE;
-	const serverUrl = FALLBACK_RDAP_SERVERS[tld];
-	if (!serverUrl) return EMPTY_RDAP_PROBE;
-	try {
-		const baseUrl = serverUrl.endsWith('/') ? serverUrl : `${serverUrl}/`;
-		const rdapUrl = `${baseUrl}domain/${domain}`;
-		// The RDAP host comes from the FALLBACK_RDAP_SERVERS map — not statically
-		// trusted as a class (the sibling fetchRdapResponse path derives the same
-		// host from the network-sourced IANA bootstrap), so route through safeFetch
-		// for parity: validateOutboundUrl() re-validates the destination host (SSRF
-		// gate) and manual redirect stops the worker chasing a server-supplied
-		// Location. safeFetch throws on a blocked host (matching native fetch error
-		// semantics); the surrounding try/catch degrades it to EMPTY_RDAP_PROBE
-		// exactly like any other probe failure (fail-soft, never throws out of the tool).
-		const resp = await safeFetch(rdapUrl, {
-			redirect: 'manual',
-			signal: AbortSignal.timeout(RDAP_PROBE_TIMEOUT_MS),
-			headers: { Accept: 'application/rdap+json, application/json' },
-		});
-		if (!resp.ok) {
-			void resp.body?.cancel();
-			return EMPTY_RDAP_PROBE;
-		}
-		const data = (await resp.json()) as { events?: Array<{ eventAction?: string; eventDate?: string }> };
-		const registration = Array.isArray(data.events) ? data.events.find((e) => e.eventAction === 'registration') : undefined;
-		let registrationDays: number | null = null;
-		if (registration?.eventDate) {
-			const creationTime = new Date(registration.eventDate).getTime();
-			if (Number.isFinite(creationTime)) {
-				registrationDays = Math.floor((Date.now() - creationTime) / (1000 * 60 * 60 * 24));
-			}
-		}
-		const registrar = extractRegistrar(data);
-		return {
-			registrationDays,
-			registrantOrg: extractRegistrantOrg(data),
-			registrarIanaId: registrar.ianaId,
-			registrarName: registrar.name,
-		};
-	} catch {
-		return EMPTY_RDAP_PROBE;
-	}
-}
-
-/**
- * Fetch the scan domain's own registration record — registrant org for the
- * same-entity correlation (issue #263) AND the registry-published registrar ID
- * for {@link isBrandHeldRegistration}. ONE fetch serves both; reuses
- * {@link probeRdap} and fails soft to {@link EMPTY_RDAP_PROBE}.
- */
-async function probePrimaryRegistration(domain: string): Promise<RdapProbeResult> {
-	return probeRdap(domain);
-}
-
-/**
- * HEAD probe the candidate domain to confirm web content is reachable.
- * Fail-soft: any error (connection refused, timeout, DNS miss, TLS error)
- * returns `true` so a flaky probe can't synthesise a HIGH severity via the
- * "no-web-content" corroborator. Parked-or-refused domains return `false`.
- *
- * 5xx responses also count as "has content" — we got reached the server,
- * the server just errored. Phishing infra rarely 5xx's; parked-page infra
- * usually 200's with adverts. The only consistent "no content" signal is a
- * hard transport failure.
- */
-export async function probeHasWebContent(domain: string): Promise<boolean> {
-	try {
-		// safeFetch + manual redirect: the candidate is attacker-influenced, so we
-		// MUST NOT auto-follow a 302 → internal/Cloudflare host (blind SSRF oracle,
-		// OWASP A10). safeFetch validates the destination hostname; manual redirect
-		// stops the worker from chasing an attacker-supplied Location. A 3xx still
-		// proves the host is reachable, so any response counts as "has content".
-		const resp = await safeFetch(`https://${domain}/`, {
-			method: 'HEAD',
-			redirect: 'manual',
-			signal: AbortSignal.timeout(WEB_PROBE_TIMEOUT_MS),
-		});
-		// Any HTTP response (incl. 3xx) means the host is reachable — content exists.
-		return Boolean(resp);
-	} catch {
-		// Transport failure (refused, timeout, DNS) — treat as no content (HIGH corroborator).
-		return false;
-	}
-}
-
-/**
- * Build a short human-readable list of corroborating signals for the finding
- * detail. Empty string when none apply (mail-infra-alone case).
- */
-function describeCorroborators(signals: LookalikeSignals): string {
-	const parts: string[] = [];
-	if (signals.registrationDays !== null && signals.registrationDays < 90) {
-		parts.push(`registered ${signals.registrationDays} day${signals.registrationDays === 1 ? '' : 's'} ago`);
-	}
-	if (signals.mxOnDisposable) parts.push('disposable MX provider');
-	if (!signals.hasWebContent) parts.push('no reachable web content');
-	return parts.join(', ');
 }

--- a/src/tools/check-rdap-lookup.ts
+++ b/src/tools/check-rdap-lookup.ts
@@ -9,6 +9,7 @@
 import { buildCheckResult, createFinding } from '../lib/scoring';
 import type { CheckResult, CheckCategory } from '../lib/scoring';
 import { safeFetch } from '../lib/safe-fetch';
+import { FALLBACK_RDAP_SERVERS, IANA_BOOTSTRAP_URL } from './rdap-fallback-servers';
 
 const CATEGORY = 'rdap' as CheckCategory;
 
@@ -84,80 +85,19 @@ export function deriveLockPosture(eppStatus: readonly string[]): LockPosture {
  */
 export const RDAP_LOOKUP_SYNC_BUDGET_MS = 24_000;
 
-/** RDAP bootstrap URL (IANA). */
-const IANA_BOOTSTRAP_URL = 'https://data.iana.org/rdap/dns.json';
-
 /**
- * Hardcoded RDAP server fallbacks for common TLDs. Used when the IANA bootstrap
- * fetch is unavailable (cold start, network blip). Snapshot from IANA's
- * canonical bootstrap; rarely changes — the audit test in Phase 6 of the
- * registrar-coverage TDD plan pins the coverage list. URLs that change at the
- * registry level get corrected when IANA bootstrap comes back online.
+ * The fallback table and the IANA bootstrap URL now live in the LEAF module
+ * `./rdap-fallback-servers` — it imports nothing, so the out-of-band
+ * reconciliation script (`scripts/audits/rdap-fallback-reconcile.ts`) can read
+ * the SAME object under plain Node/tsx instead of re-declaring it, which is the
+ * one thing that would make the reconciliation worthless. This file's import
+ * chain (scoring → sanitize → punycode) is workerd-shaped and will not load
+ * there.
+ *
+ * Re-exported so every existing import site — including
+ * `test/rdap-fallback-server-map.spec.ts` — is unchanged.
  */
-export const FALLBACK_RDAP_SERVERS: Record<string, string> = {
-	// Verisign-operated
-	com: 'https://rdap.verisign.com/com/v1/',
-	net: 'https://rdap.verisign.com/net/v1/',
-	// Public Interest Registry
-	org: 'https://rdap.publicinterestregistry.org/rdap/',
-	// Identity Digital (formerly Afilias / Donuts)
-	info: 'https://rdap.identitydigital.services/rdap/',
-	biz: 'https://rdap.nic.biz/',
-	us: 'https://rdap.identitydigital.services/rdap/',
-	tech: 'https://rdap.identitydigital.services/rdap/',
-	online: 'https://rdap.identitydigital.services/rdap/',
-	email: 'https://rdap.identitydigital.services/rdap/',
-	global: 'https://rdap.identitydigital.services/rdap/',
-	group: 'https://rdap.identitydigital.services/rdap/',
-	life: 'https://rdap.identitydigital.services/rdap/',
-	live: 'https://rdap.identitydigital.services/rdap/',
-	media: 'https://rdap.identitydigital.services/rdap/',
-	news: 'https://rdap.identitydigital.services/rdap/',
-	services: 'https://rdap.identitydigital.services/rdap/',
-	software: 'https://rdap.identitydigital.services/rdap/',
-	solutions: 'https://rdap.identitydigital.services/rdap/',
-	support: 'https://rdap.identitydigital.services/rdap/',
-	systems: 'https://rdap.identitydigital.services/rdap/',
-	technology: 'https://rdap.identitydigital.services/rdap/',
-	tools: 'https://rdap.identitydigital.services/rdap/',
-	// Identity Digital ccTLDs / TLD operators
-	io: 'https://rdap.identitydigital.services/rdap/',
-	// ⚠️ `.ai` is Identity Digital, NOT `rdap.nic.ai` (#780). That host has NO A
-	// RECORD — it does not resolve and never answered. Because `probeRdap`
-	// fail-softs to `EMPTY_RDAP_PROBE`, every `.ai` lookup silently produced
-	// `registrationDays: null` while `.org`/`.com` populated correctly, so the
-	// "recently registered" signal — the highest-value thing lookalike triage
-	// surfaces — was dead for the whole TLD with no error raised anywhere.
-	// Verified against IANA's authoritative bootstrap (data.iana.org/rdap/dns.json
-	// maps ai → identitydigital) and by live probe: openclaw.ai returns 200 with
-	// a registration event. Do NOT "restore" rdap.nic.ai.
-	ai: 'https://rdap.identitydigital.services/rdap/',
-	sh: 'https://rdap.identitydigital.services/rdap/',
-	// auDA
-	au: 'https://rdap.cctld.au/rdap/',
-	// Traficom
-	fi: 'https://rdap.fi/rdap/rdap/',
-	// .CO Internet
-	co: 'https://rdap.nic.co/',
-	// ME Registry
-	me: 'https://rdap.nic.me/',
-	// Google Registry — pubapi is the canonical RDAP endpoint; www.registry.google returns 404.
-	app: 'https://pubapi.registry.google/rdap/',
-	dev: 'https://pubapi.registry.google/rdap/',
-	// XYZ.COM LLC
-	xyz: 'https://rdap.nic.xyz/',
-	// ccTLDs reachable via IANA bootstrap — hardcoded here as failsafe for when
-	// the bootstrap fetch is negative-cached (transient data.iana.org outage).
-	ca: 'https://rdap.ca.fury.ca/rdap/',
-	cz: 'https://rdap.nic.cz/',
-	fr: 'https://rdap.nic.fr/',
-	in: 'https://rdap.nixiregistry.in/rdap/',
-	nl: 'https://rdap.sidn.nl/',
-	no: 'https://rdap.norid.no/',
-	pl: 'https://rdap.dns.pl/',
-	sg: 'https://rdap.sgnic.sg/rdap/',
-	uk: 'https://rdap.nominet.uk/uk/',
-};
+export { FALLBACK_RDAP_SERVERS };
 
 /** TTL for a successful IANA bootstrap fetch (6h). */
 const BOOTSTRAP_TTL_MS = 6 * 60 * 60 * 1000;

--- a/src/tools/lookalike-attribution.ts
+++ b/src/tools/lookalike-attribution.ts
@@ -1,0 +1,240 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Attribution predicates for the lookalike check — the "whose domain is this"
+ * corroboration layer (issue #263 same-entity correlation, and the brand-held
+ * defensive-registration signal).
+ *
+ * Extracted VERBATIM from `check-lookalikes.ts` (pure split, no behaviour
+ * change). These are AXIS 1 (attribution) inputs only: nothing here may move a
+ * threat severity, and — Ruling A — nothing here may produce an `owned_by_seed`
+ * ownership verdict, which stays driven by seed-side nameserver evidence in
+ * `classifyOwnership()` alone.
+ */
+
+import { evaluateDefensiveRegistration, type DefensiveReason } from '../lib/brand-defensive-registration';
+import type { OwnershipAssessment } from '../lib/ownership-attribution';
+import { isRedactedRegistrantOrg } from './check-rdap-lookup';
+import type { LookalikeResult } from './lookalike-dns';
+import type { LookalikeCorroborators } from './lookalike-enrichment';
+import { calibrateLookalikeSeverity, type LookalikeSeverity } from './lookalike-severity';
+
+/**
+ * Cap on the number of medium/high-severity lookalikes for which we attempt
+ * the same-entity (shared-registrant) RDAP correlation. RDAP registrant data
+ * is already harvested from the single enrichment fetch per candidate
+ * (`probeRdap`), so the cost is bounded by the enrichment set; this cap
+ * is a defensive ceiling so a pathological permutation explosion can't widen
+ * the RDAP fan-out beyond the lookalike check's wall-clock budget. Ordered by
+ * severity (high before medium) so the most damaging false-positives are
+ * corrected first when the cap binds.
+ */
+const SAME_ENTITY_RDAP_CAP = 10;
+
+/**
+ * IANA registrar IDs of BRAND-PROTECTION registrars — corporate registrars
+ * that do not sell to the general public. Getting a domain registered through
+ * one requires a corporate account and a contract; you cannot buy a name at
+ * CSC or MarkMonitor the way you can at a retail registrar.
+ *
+ * WHY THIS IS DIFFERENT FROM THE REGISTRANT-ORG FIELD (and therefore why it is
+ * allowed to corroborate ownership at all). Ruling A / F2 bars the registrant
+ * org from influencing attribution because it is free text the REGISTRANT
+ * types — forgeable with one form field, and collision-prone because half the
+ * internet sits behind the same privacy services. The IANA registrar ID is
+ * neither: it is assigned by ICANN and published by the REGISTRY as part of
+ * the delegation record. A registrant cannot set it, and cannot move a domain
+ * into a corporate registrar's accreditation without that registrar's consent.
+ *
+ * It is still NOT proof of common ownership — many brands share CSC — which is
+ * why {@link isBrandHeldRegistration} requires the candidate's INFRASTRUCTURE
+ * to be defensively shaped as well, and why nothing here can ever produce an
+ * `owned_by_seed` verdict (that remains seed-side NS evidence only).
+ *
+ * RETAIL REGISTRARS MUST NEVER BE ADDED. GoDaddy (146), Namecheap (1068) and
+ * friends are shared by millions of unrelated registrants, so a shared-retail-
+ * registrar match carries no identity information whatsoever. A control test
+ * pins that GoDaddy is not treated as evidence.
+ */
+const BRAND_PROTECTION_REGISTRAR_IANA_IDS: ReadonlySet<string> = new Set([
+	'299', // CSC Corporate Domains, Inc.
+	'292', // MarkMonitor Inc.
+	'470', // Com Laude (Nom-IQ Ltd)
+	'447', // SafeNames Ltd
+	'1600', // Brandsight, Inc.
+	'106', // Ascio Technologies (corporate channel)
+	'1316', // Nameshield SAS
+	'1495', // EBRAND Services
+	'151', // Gandi SAS — corporate/enterprise channel
+	'1479', // In2net / brand-protection channel
+]);
+
+/**
+ * THE single predicate deciding whether two RDAP registrant-org strings may be
+ * treated as the same entity (issue #263). Added in Task 7b fix round 1 for
+ * review finding F1.
+ *
+ * The org field is free text the registrant TYPES and RDAP does not verify it.
+ * Raw string equality was therefore both forgeable (one registrar form field)
+ * and — far more damaging — trivially collision-prone: seed and candidate
+ * sitting behind the SAME privacy service normalise equal for reasons that
+ * carry zero identity information. Both sides are gated through
+ * `isRedactedRegistrantOrg()`, so a redacted / proxy / generic value can never
+ * produce a match.
+ *
+ * A surviving match is still only a WEAK, unverified signal: it earns a
+ * sentence in the report, never a severity discount. The threat-observation
+ * finding is emitted at its full calibrated severity regardless.
+ *
+ * EQUALITY-MATCHING INVARIANT — READ BEFORE CHANGING THE COMPARISON (fix round
+ * 2, re-review residual). The final test is STRICT EQUALITY, and
+ * `isRedactedRegistrantOrg()` is a pure function of its string. Therefore
+ * whenever the two orgs are equal the predicate returns the SAME verdict for
+ * both, and checking one side is currently EXACTLY equivalent to checking both.
+ * That was verified by execution: mutating this function to gate the candidate
+ * side only left the entire suite green, and no end-to-end fixture can
+ * discriminate — for a one-sided gate to wrongly match, the two strings would
+ * have to differ in redaction status while still being equal, which equality
+ * matching makes impossible.
+ *
+ * The both-sides form is kept as DEFENCE IN DEPTH for the day that comparison
+ * stops being equality. ANY change to fuzzy/containment/token-overlap/edit-
+ * distance matching MUST (a) keep the gate on BOTH sides — under fuzzy matching
+ * a redacted string can match a non-redacted one, so a one-sided gate becomes a
+ * real hole — and (b) ship a fixture that discriminates one-sided from
+ * two-sided, which only becomes constructible once equality is gone. Until
+ * then the semantics are pinned directly by the unit tests on this function in
+ * `test/check-lookalikes.spec.ts` (re-exported from `check-lookalikes.ts` for
+ * exactly that purpose), not by an end-to-end fixture that cannot tell the two
+ * implementations apart.
+ */
+export function isSameEntityOrgMatch(primaryOrg: string | null, candidateOrg: string | null): boolean {
+	if (primaryOrg === null || candidateOrg === null) return false;
+	if (isRedactedRegistrantOrg(primaryOrg) || isRedactedRegistrantOrg(candidateOrg)) return false;
+	return primaryOrg === candidateOrg;
+}
+
+/**
+ * Determine which lookalike candidates are eligible for the issue #263
+ * same-entity (shared-registrant) downgrade. Eligibility mirrors the
+ * classification loop's decision so we never fetch the primary's registrant
+ * org speculatively: a candidate qualifies only when `ownershipByDomain`
+ * does NOT already attribute it to the seed (`owned_by_seed` — CALL SITE 3
+ * of the D4 2026-07-26 correctness-defects design's ownership gate) and has
+ * mail/web infra. The result is sorted by calibrated severity, highest first,
+ * and capped at {@link SAME_ENTITY_RDAP_CAP} so a permutation explosion can't
+ * widen the RDAP fan-out unbounded.
+ *
+ * LOW-SEVERITY CANDIDATES ARE ELIGIBLE (changed — they used to be excluded as
+ * "not worth the RDAP cost"). That exclusion was the mechanical cause of the
+ * brand's-own-defensive-registration defect: a defensive registration is
+ * PARKED, so it is web-only, aged and mail-less, and therefore calibrates
+ * exactly `low`. The tool skipped the one fetch that would have told it who
+ * held the domain, then asserted the domain "is registered to a different
+ * organisation" and offered to report it for takedown — a positive
+ * non-ownership CLAIM derived from evidence it declined to gather.
+ *
+ * Severity is a THREAT tier, so gating an ATTRIBUTION lookup on it was a
+ * category error: the cheapest candidates to dismiss as low-threat are
+ * precisely the ones most likely to be the customer's own.
+ *
+ * COST OF THE WIDENING IS ONE FETCH, MEASURED NOT ASSUMED. Candidate RDAP was
+ * never gated on severity — `enrichLookalikes()` already fetches it for every
+ * non-owned candidate with mail/web infra. The medium/high gate only decided
+ * whether the SEED's single RDAP fetch happened. So widening to `low` adds at
+ * most ONE request per scan, on scans that have a registered non-owned
+ * candidate at all. `SAME_ENTITY_RDAP_CAP` still bounds the set; severity now
+ * only decides ORDER within it, and `owned_by_seed` candidates are still
+ * excluded outright, so the shared-NS short-circuit still pays no RDAP cost.
+ */
+export function computeSameEntityCandidates(
+	results: LookalikeResult[],
+	ownershipByDomain: Map<string, OwnershipAssessment>,
+	enrichment: Map<string, LookalikeCorroborators>,
+): string[] {
+	const SEVERITY_ORDER: Record<LookalikeSeverity, number> = { high: 0, medium: 1, low: 2 };
+	const eligible: Array<{ domain: string; severity: LookalikeSeverity }> = [];
+	for (const result of results) {
+		const sameOwner = ownershipByDomain.get(result.domain)?.verdict === 'owned_by_seed';
+		if (sameOwner) continue;
+		if (!result.hasMX && !result.hasA) continue;
+		const corroborators = enrichment.get(result.domain);
+		const severity = calibrateLookalikeSeverity({
+			hasA: result.hasA,
+			hasMX: result.hasMX,
+			registrationDays: corroborators?.registrationDays ?? null,
+			mxOnDisposable: corroborators?.mxOnDisposable ?? false,
+			hasWebContent: corroborators?.hasWebContent ?? true,
+		});
+		eligible.push({ domain: result.domain, severity });
+	}
+	eligible.sort((a, b) => SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity]);
+	return eligible.slice(0, SAME_ENTITY_RDAP_CAP).map((e) => e.domain);
+}
+
+/**
+ * THE predicate deciding whether a candidate is the scanned organisation's own
+ * DEFENSIVE REGISTRATION rather than a third party's domain.
+ *
+ * Requires BOTH, and neither alone is sufficient:
+ *
+ *  1. REGISTRATION-RECORD corroboration — the candidate and the seed share an
+ *     IANA registrar ID belonging to a brand-protection registrar
+ *     ({@link BRAND_PROTECTION_REGISTRAR_IANA_IDS}). A shared RETAIL registrar
+ *     is explicitly not evidence: millions of unrelated registrants share one.
+ *
+ *  2. DEFENSIVE INFRASTRUCTURE SHAPE — `evaluateDefensiveRegistration()`
+ *     (`src/lib/brand-defensive-registration.ts`) agrees the candidate is a
+ *     typo-close label parked with minimal infrastructure. An attacker who
+ *     somehow reached the same corporate registrar but stood up live mail
+ *     still fails this leg and gets the full threat treatment.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO: it does not, and must not, produce an
+ * `owned_by_seed` ownership verdict. `classifyOwnership()` stays driven by
+ * seed-side nameserver evidence alone (Ruling A), and every finding about this
+ * candidate keeps carrying its structural `third_party` verdict. What changes
+ * is what the report CLAIMS and RECOMMENDS: it stops asserting the domain
+ * "is registered to a different organisation" on evidence that never
+ * addressed the question, and stops telling the customer to report their own
+ * domain for takedown.
+ *
+ * NULL-GUARD NOTE — VERIFIED BY MUTATION, NOT ASSUMED (the same disclosure
+ * `isSameEntityOrgMatch` above makes about its own both-sides gate). The
+ * `=== null` guard on the first line is currently REDUNDANT: deleting it left
+ * the entire suite green, because two `null` IDs pass the equality check and
+ * are then rejected by `BRAND_PROTECTION_REGISTRAR_IANA_IDS.has(null)` anyway.
+ * No fixture can discriminate the two implementations while membership is an
+ * exact-set test, so none is shipped pretending to.
+ *
+ * It is kept as DEFENCE IN DEPTH and becomes load-bearing the moment that
+ * membership test is relaxed — a name-based or fuzzy registrar comparison, or
+ * an "any shared registrar" mode — at which point "both sides published
+ * nothing" would read as a match and silently mark every RDAP-less candidate
+ * as brand-held. Anyone relaxing it MUST keep this guard and ship a fixture
+ * that discriminates it, which only becomes constructible then.
+ */
+export function isBrandHeldRegistration(input: {
+	seedDomain: string;
+	candidateDomain: string;
+	seedRegistrarIanaId: string | null;
+	candidateRegistrarIanaId: string | null;
+	candidateMxExchanges: readonly string[];
+	candidateNsHosts: readonly string[];
+}): { brandHeld: false } | { brandHeld: true; registrarIanaId: string; reason: DefensiveReason } {
+	const { seedRegistrarIanaId, candidateRegistrarIanaId } = input;
+	if (seedRegistrarIanaId === null || candidateRegistrarIanaId === null) return { brandHeld: false };
+	if (seedRegistrarIanaId !== candidateRegistrarIanaId) return { brandHeld: false };
+	if (!BRAND_PROTECTION_REGISTRAR_IANA_IDS.has(candidateRegistrarIanaId)) return { brandHeld: false };
+
+	const shape = evaluateDefensiveRegistration({
+		candidateDomain: input.candidateDomain,
+		targetDomain: input.seedDomain,
+		// A concrete array (never `undefined`) — we DID look, via the Phase 2
+		// probe, so an empty set means "no mail", not "unknown". The heuristic
+		// abstains on `undefined`, which would silently disable this leg.
+		mxRecords: input.candidateMxExchanges,
+		nsHosts: input.candidateNsHosts,
+	});
+	if (!shape.defensive || shape.reason === undefined) return { brandHeld: false };
+	return { brandHeld: true, registrarIanaId: candidateRegistrarIanaId, reason: shape.reason };
+}

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -1,0 +1,238 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * DNS resolution layer for the lookalike check.
+ *
+ * Extracted VERBATIM from `check-lookalikes.ts` (pure split, no behaviour
+ * change): everything here is the "does this candidate exist, and what
+ * infrastructure does it carry" question — NS existence filtering, the
+ * wildcard-parent canary probe, the adaptive-batching A/MX detail probe, and
+ * the two seed-side queries (`NS` for the ownership verdict, `MX` for the D4
+ * overlap corroboration signal).
+ *
+ * Nothing in this module builds a Finding, decides a severity, or makes an
+ * ownership claim — it only measures. The tuning constants live here rather
+ * than in the orchestrator because they are properties of the query plane, and
+ * `test/check-lookalikes.spec.ts` pins their exact values through the tool's
+ * re-export.
+ */
+
+import { queryDnsRecords, queryMxRecords } from '../lib/dns';
+import type { QueryDnsOptions } from '../lib/dns-types';
+
+/** Default and minimum batch sizes for adaptive batching */
+export const INITIAL_BATCH_SIZE = 10;
+export const MIN_BATCH_SIZE = 3;
+export const BACKOFF_DELAY_MS = 500;
+export const FAILURE_THRESHOLD = 2;
+
+/** Canary label used for wildcard detection on parent domains */
+export const WILDCARD_CANARY_LABEL = '_bv-wc-probe';
+
+/** Lean DNS options for Phase 1 existence checks — fast, no retries, no secondary confirmation. */
+export const PHASE1_DNS_OPTS: QueryDnsOptions = {
+	timeoutMs: 2000,
+	retries: 0,
+	skipSecondaryConfirmation: true,
+};
+
+export interface LookalikeResult {
+	domain: string;
+	hasA: boolean;
+	hasMX: boolean;
+	/** MX exchange hosts (lowercased, trailing-dot-stripped) — empty when no real MX. */
+	mxExchanges: string[];
+}
+
+/**
+ * Check whether an MX record represents real mail infrastructure.
+ *
+ * RFC 7505 defines the canonical null MX as priority-0 with exchange `.` (root),
+ * meaning "this domain does not accept mail". A legacy convention used by some
+ * operators is `0 localhost.` (or `0 localhost`), which has the same intent —
+ * mail is null-routed to the sender's own localhost and is functionally rejected.
+ * Both patterns must be excluded from the "has mail infrastructure" signal to
+ * avoid false-positive HIGH typosquat findings on domains that have applied the
+ * recommended anti-spoofing posture.
+ */
+function isRealMxRecord(data: string): boolean {
+	const trimmed = data.trim().toLowerCase();
+	// Format from queryDnsRecords is "<priority> <target>", possibly with trailing dot.
+	const match = trimmed.match(/^(\d+)[\s\t]+(.*?)\.?$/);
+	if (!match) return true;
+	const [, priority, target] = match;
+	if (priority !== '0') return true;
+	return target !== '' && target !== 'localhost';
+}
+
+/**
+ * Extract the lowercase exchange host from an MX record `"<priority> <target>"`.
+ * Returns `null` when the record fails to parse or is a null MX. Used to feed
+ * the disposable-MX detector in `calibrateLookalikeSeverity`.
+ */
+function extractMxExchange(raw: string): string | null {
+	const trimmed = raw.trim().toLowerCase();
+	const match = trimmed.match(/^(\d+)[\s\t]+(.*?)\.?$/);
+	if (!match) return null;
+	const [, , target] = match;
+	if (target === '' || target === 'localhost') return null;
+	return target;
+}
+
+/**
+ * Check a single lookalike domain for DNS and MX records.
+ * Filters out null MX records (RFC 7505) to avoid false positives.
+ */
+async function probeLookalike(domain: string): Promise<LookalikeResult> {
+	const [aRecords, mxRecords] = await Promise.allSettled([queryDnsRecords(domain, 'A'), queryDnsRecords(domain, 'MX')]);
+
+	const realMxRecords = mxRecords.status === 'fulfilled' ? mxRecords.value.filter(isRealMxRecord) : [];
+	const mxExchanges = realMxRecords.map(extractMxExchange).filter((host): host is string => host !== null);
+
+	return {
+		domain,
+		hasA: aRecords.status === 'fulfilled' && aRecords.value.length > 0,
+		hasMX: realMxRecords.length > 0,
+		mxExchanges,
+	};
+}
+
+/**
+ * Count the number of labels (dot-separated segments) in a domain.
+ */
+export function labelCount(domain: string): number {
+	return domain.split('.').length;
+}
+
+/**
+ * Extract the parent domain from a dot-insertion permutation.
+ * E.g., "blackve.ilsecurity.com" → "ilsecurity.com"
+ */
+export function getParentDomain(domain: string): string {
+	const parts = domain.split('.');
+	return parts.slice(1).join('.');
+}
+
+/**
+ * Detect wildcard DNS on a set of parent domains by probing a canary subdomain.
+ * Returns a Set of parent domains that have wildcard A records.
+ */
+export async function detectWildcardParents(parentDomains: string[]): Promise<Set<string>> {
+	const wildcardParents = new Set<string>();
+	const probes = parentDomains.map(async (parent) => {
+		try {
+			const canary = `${WILDCARD_CANARY_LABEL}.${parent}`;
+			const records = await queryDnsRecords(canary, 'A');
+			if (records.length > 0) {
+				wildcardParents.add(parent);
+			}
+		} catch {
+			// Query failed — not a wildcard
+		}
+	});
+	await Promise.allSettled(probes);
+	return wildcardParents;
+}
+
+/**
+ * Phase 1: Fast NS existence check for all domains in parallel.
+ * Returns only domains that have NS records (i.e., are registered),
+ * along with their normalized NS record data for ownership comparison.
+ */
+export async function filterByNsExistence(
+	domains: string[],
+): Promise<{ registered: string[]; nsMap: Map<string, Set<string>>; unresolved: number }> {
+	const nsMap = new Map<string, Set<string>>();
+	const results = await Promise.allSettled(
+		domains.map(async (domain) => {
+			const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
+			if (ns.length > 0) {
+				nsMap.set(domain, normalizeNsSet(ns));
+			}
+			return { domain, hasNs: ns.length > 0 };
+		}),
+	);
+	const registered = results
+		.filter((r): r is PromiseFulfilledResult<{ domain: string; hasNs: boolean }> => r.status === 'fulfilled' && r.value.hasNs)
+		.map((r) => r.value.domain);
+	// A REJECTED NS lookup is not "unregistered" — it is UNKNOWN, and dropping it
+	// silently is the primary source of run-to-run variance (#781). This phase
+	// gates everything downstream, so a timed-out NS query makes a registered
+	// domain vanish from the result set entirely, with nothing in the response
+	// distinguishing that from a deregistration. Measured on openclaw.ai: three
+	// `force_refresh` runs minutes apart returned 12, 10 and 13 candidates, with
+	// three names appearing only in the third.
+	const unresolved = results.filter((r) => r.status === 'rejected').length;
+	return { registered, nsMap, unresolved };
+}
+
+/**
+ * Normalize a set of NS record values for comparison.
+ * Strips trailing dots, lowercases, and returns a Set.
+ */
+function normalizeNsSet(nsRecords: string[]): Set<string> {
+	return new Set(nsRecords.map((ns) => ns.replace(/\.$/, '').toLowerCase()));
+}
+
+/**
+ * Query NS records for the primary domain to use for ownership comparison.
+ * Returns an empty set if the query fails.
+ */
+export async function queryPrimaryNs(domain: string): Promise<Set<string>> {
+	try {
+		const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
+		return normalizeNsSet(ns);
+	} catch {
+		return new Set<string>();
+	}
+}
+
+/**
+ * Query MX records for the primary domain — the D4 (2026-07-26
+ * correctness-defects design) MX-overlap corroboration signal for
+ * `attributionConfidence()`. Fail-soft: an empty set just means the guard
+ * falls back to "no corroboration" rather than throwing.
+ */
+export async function queryPrimaryMx(domain: string): Promise<Set<string>> {
+	try {
+		const mx = await queryMxRecords(domain, PHASE1_DNS_OPTS);
+		return new Set(mx.map((r) => r.exchange.toLowerCase().replace(/\.$/, '')));
+	} catch {
+		return new Set<string>();
+	}
+}
+
+/**
+ * Run permutation probes with adaptive batch sizing and backoff.
+ * Starts at INITIAL_BATCH_SIZE, halves on repeated failures (floor at MIN_BATCH_SIZE),
+ * recovers on clean batches.
+ */
+export async function probeWithAdaptiveBatching(permutations: string[]): Promise<PromiseSettledResult<LookalikeResult>[]> {
+	const allResults: PromiseSettledResult<LookalikeResult>[] = [];
+	let batchSize = INITIAL_BATCH_SIZE;
+	let delayMs = 0;
+
+	for (let i = 0; i < permutations.length; i += batchSize) {
+		if (delayMs > 0) {
+			await new Promise((resolve) => setTimeout(resolve, delayMs));
+		}
+
+		const batch = permutations.slice(i, i + batchSize);
+		const batchResults = await Promise.allSettled(batch.map((d) => probeLookalike(d)));
+		allResults.push(...batchResults);
+
+		// Count failures in this batch
+		const failures = batchResults.filter((r) => r.status === 'rejected').length;
+		if (failures > FAILURE_THRESHOLD) {
+			// Back off: halve batch size (floor to MIN_BATCH_SIZE) and add delay
+			batchSize = Math.max(MIN_BATCH_SIZE, Math.floor(batchSize / 2));
+			delayMs = BACKOFF_DELAY_MS;
+		} else if (delayMs > 0 && failures === 0) {
+			// Recover: if a clean batch after backoff, try increasing again
+			batchSize = Math.min(INITIAL_BATCH_SIZE, batchSize + 2);
+			delayMs = 0;
+		}
+	}
+
+	return allResults;
+}

--- a/src/tools/lookalike-enrichment.ts
+++ b/src/tools/lookalike-enrichment.ts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Enrichment probes for the lookalike check (Defect L / issue #264 + #263).
+ *
+ * Extracted VERBATIM from `check-lookalikes.ts` (pure split, no behaviour
+ * change). One RDAP fetch and at most one HEAD probe per candidate, both on
+ * tight budgets, yielding the corroborating signals the severity calibrator and
+ * the attribution predicates consume:
+ *
+ *  - `registrationDays` — the "recently registered" corroborator (#264);
+ *  - `registrantOrg` — the same-entity correlation input (#263);
+ *  - `registrarIanaId` / `registrarName` — the brand-held-registration input;
+ *  - `hasWebContent` — the "parked / unreachable" corroborator.
+ *
+ * EVERY path here is FAIL-SOFT and the direction of each failure default is
+ * load-bearing: a missing RDAP field becomes `null` ("unknown", never elevates
+ * severity and never suppresses a threat), and a failed HEAD probe becomes
+ * `true` ("has content", so a flaky probe cannot synthesise a HIGH). Nothing in
+ * this module throws out of the tool.
+ */
+
+import { safeFetch } from '../lib/safe-fetch';
+import { extractRegistrantOrg, findEntityByRole } from './check-rdap-lookup';
+import { FALLBACK_RDAP_SERVERS } from './rdap-fallback-servers';
+import { isDisposableMxHost } from './lookalike-severity';
+import type { LookalikeResult } from './lookalike-dns';
+
+/** Budgets for the Defect L enrichment probes. Both are intentionally tight so 12 candidates × (RDAP + HEAD) stays under LOOKALIKE_TIMEOUT_MS. */
+const RDAP_PROBE_TIMEOUT_MS = 2500;
+const WEB_PROBE_TIMEOUT_MS = 2500;
+
+export interface LookalikeCorroborators {
+	registrationDays: number | null;
+	mxOnDisposable: boolean;
+	hasWebContent: boolean;
+	/**
+	 * Normalised RDAP registrant org for this candidate, harvested from the same
+	 * single RDAP fetch as {@link registrationDays}. `null` when RDAP failed,
+	 * returned no registrant entity, or the org field was empty — in which case
+	 * the same-entity correlation fails soft (the calibrated threat severity
+	 * stands; a real threat is never suppressed on missing RDAP).
+	 */
+	registrantOrg: string | null;
+	/**
+	 * Registry-published IANA registrar ID for this candidate, harvested from
+	 * the same single RDAP fetch as everything else here. Feeds
+	 * `isBrandHeldRegistration`; `null` fails soft to "no evidence".
+	 */
+	registrarIanaId: string | null;
+	/** Registrar display name, for report prose only. */
+	registrarName: string | null;
+}
+
+/**
+ * Run the Defect L enrichment probes (RDAP registration age + web HEAD probe)
+ * for every candidate in parallel. Failure to enrich is fail-soft: missing
+ * RDAP data becomes `registrationDays: null` (treated as "unknown — not recent")
+ * and a probe error becomes `hasWebContent: true` to avoid synthesising HIGH
+ * out of nothing. `mxOnDisposable` is derived synchronously from the already-
+ * parsed MX exchanges, no extra DNS needed.
+ */
+export async function enrichLookalikes(candidates: LookalikeResult[]): Promise<Map<string, LookalikeCorroborators>> {
+	const map = new Map<string, LookalikeCorroborators>();
+	if (candidates.length === 0) return map;
+	await Promise.allSettled(
+		candidates.map(async (candidate) => {
+			const [rdap, hasWebContent] = await Promise.all([
+				probeRdap(candidate.domain),
+				candidate.hasA ? probeHasWebContent(candidate.domain) : Promise.resolve(true),
+			]);
+			const mxOnDisposable = candidate.mxExchanges.some(isDisposableMxHost);
+			map.set(candidate.domain, {
+				registrationDays: rdap.registrationDays,
+				mxOnDisposable,
+				hasWebContent,
+				registrantOrg: rdap.registrantOrg,
+				registrarIanaId: rdap.registrarIanaId,
+				registrarName: rdap.registrarName,
+			});
+		}),
+	);
+	return map;
+}
+
+/** Result of the single lightweight RDAP probe per candidate. */
+export interface RdapProbeResult {
+	/** Age in days since the RDAP `registration` event, or `null` on any failure / missing data. */
+	registrationDays: number | null;
+	/** Normalised RDAP registrant org, or `null` on any failure / missing data. */
+	registrantOrg: string | null;
+	/**
+	 * Registry-published IANA registrar ID, or `null` on any failure / absence.
+	 * Distinct in kind from {@link registrantOrg}: assigned by ICANN, published
+	 * by the registry, and not settable by the registrant — see
+	 * `BRAND_PROTECTION_REGISTRAR_IANA_IDS` in `lookalike-attribution.ts`.
+	 */
+	registrarIanaId: string | null;
+	/** Registrar display name, for report prose only. Never compared. */
+	registrarName: string | null;
+}
+
+/** Empty probe result — used for early-outs and the catch path (fail-soft). */
+export const EMPTY_RDAP_PROBE: RdapProbeResult = { registrationDays: null, registrantOrg: null, registrarIanaId: null, registrarName: null };
+
+/**
+ * Pull the registrar's IANA ID and display name out of a parsed RDAP domain
+ * response. Local to the lookalike surface rather than imported because
+ * `check-rdap-lookup.ts` keeps its vCard/publicId readers private; only
+ * `findEntityByRole` is exported, so the traversal is reused and just the two
+ * field reads are done here.
+ *
+ * Fail-soft in every branch — a non-conforming shape yields nulls, which the
+ * brand-held predicate treats as "no evidence" (never as a match).
+ */
+function extractRegistrar(rdapData: unknown): { ianaId: string | null; name: string | null } {
+	if (typeof rdapData !== 'object' || rdapData === null) return { ianaId: null, name: null };
+	const entities = (rdapData as { entities?: unknown }).entities;
+	if (!Array.isArray(entities)) return { ianaId: null, name: null };
+	const registrar = findEntityByRole(entities as Parameters<typeof findEntityByRole>[0], 'registrar');
+	if (!registrar) return { ianaId: null, name: null };
+
+	let ianaId: string | null = null;
+	const publicIds = (registrar as { publicIds?: unknown }).publicIds;
+	if (Array.isArray(publicIds)) {
+		for (const publicId of publicIds) {
+			if (typeof publicId !== 'object' || publicId === null) continue;
+			const { type, identifier } = publicId as { type?: unknown; identifier?: unknown };
+			if (typeof type === 'string' && /^IANA Registrar ID$/i.test(type.trim()) && typeof identifier === 'string' && identifier.trim()) {
+				ianaId = identifier.trim();
+				break;
+			}
+		}
+	}
+
+	let name: string | null = null;
+	const vcardArray = (registrar as { vcardArray?: unknown }).vcardArray;
+	if (Array.isArray(vcardArray) && vcardArray[0] === 'vcard' && Array.isArray(vcardArray[1])) {
+		for (const prop of vcardArray[1] as unknown[]) {
+			if (Array.isArray(prop) && prop[0] === 'fn' && typeof prop[3] === 'string' && prop[3].trim()) {
+				name = prop[3].trim();
+				break;
+			}
+		}
+	}
+	return { ianaId, name };
+}
+
+/**
+ * Lightweight RDAP lookup constrained for use inside the lookalike check.
+ * Hits the hardcoded {@link FALLBACK_RDAP_SERVERS} map only (no IANA bootstrap),
+ * single fetch, hard 2.5s timeout, no retries. From that single response it
+ * derives BOTH the registration age (issue #264 corroborator) AND the registrant
+ * org (issue #263 same-entity correlation) — no extra fetch for the org signal.
+ * Any failure / missing data yields `null` for the affected field, which the
+ * calibrator treats as "unknown" (never elevates severity) and the same-entity
+ * check treats as "no match" (never suppresses a real threat).
+ *
+ * ⚠️ A DEAD ENTRY IN THAT MAP DEGRADES SILENTLY (#780) — a host that does not
+ * resolve is indistinguishable here from "old domain, nothing notable". The
+ * class-level guard is `scripts/audits/rdap-fallback-reconcile.ts`, which
+ * reconciles the table against IANA's authoritative bootstrap out-of-band.
+ */
+async function probeRdap(domain: string): Promise<RdapProbeResult> {
+	const labels = domain.split('.');
+	const tld = labels[labels.length - 1]?.toLowerCase();
+	if (!tld) return EMPTY_RDAP_PROBE;
+	const serverUrl = FALLBACK_RDAP_SERVERS[tld];
+	if (!serverUrl) return EMPTY_RDAP_PROBE;
+	try {
+		const baseUrl = serverUrl.endsWith('/') ? serverUrl : `${serverUrl}/`;
+		const rdapUrl = `${baseUrl}domain/${domain}`;
+		// The RDAP host comes from the FALLBACK_RDAP_SERVERS map — not statically
+		// trusted as a class (the sibling fetchRdapResponse path derives the same
+		// host from the network-sourced IANA bootstrap), so route through safeFetch
+		// for parity: validateOutboundUrl() re-validates the destination host (SSRF
+		// gate) and manual redirect stops the worker chasing a server-supplied
+		// Location. safeFetch throws on a blocked host (matching native fetch error
+		// semantics); the surrounding try/catch degrades it to EMPTY_RDAP_PROBE
+		// exactly like any other probe failure (fail-soft, never throws out of the tool).
+		const resp = await safeFetch(rdapUrl, {
+			redirect: 'manual',
+			signal: AbortSignal.timeout(RDAP_PROBE_TIMEOUT_MS),
+			headers: { Accept: 'application/rdap+json, application/json' },
+		});
+		if (!resp.ok) {
+			void resp.body?.cancel();
+			return EMPTY_RDAP_PROBE;
+		}
+		const data = (await resp.json()) as { events?: Array<{ eventAction?: string; eventDate?: string }> };
+		const registration = Array.isArray(data.events) ? data.events.find((e) => e.eventAction === 'registration') : undefined;
+		let registrationDays: number | null = null;
+		if (registration?.eventDate) {
+			const creationTime = new Date(registration.eventDate).getTime();
+			if (Number.isFinite(creationTime)) {
+				registrationDays = Math.floor((Date.now() - creationTime) / (1000 * 60 * 60 * 24));
+			}
+		}
+		const registrar = extractRegistrar(data);
+		return {
+			registrationDays,
+			registrantOrg: extractRegistrantOrg(data),
+			registrarIanaId: registrar.ianaId,
+			registrarName: registrar.name,
+		};
+	} catch {
+		return EMPTY_RDAP_PROBE;
+	}
+}
+
+/**
+ * Fetch the scan domain's own registration record — registrant org for the
+ * same-entity correlation (issue #263) AND the registry-published registrar ID
+ * for `isBrandHeldRegistration`. ONE fetch serves both; reuses
+ * {@link probeRdap} and fails soft to {@link EMPTY_RDAP_PROBE}.
+ */
+export async function probePrimaryRegistration(domain: string): Promise<RdapProbeResult> {
+	return probeRdap(domain);
+}
+
+/**
+ * HEAD probe the candidate domain to confirm web content is reachable.
+ * Fail-soft: any error (connection refused, timeout, DNS miss, TLS error)
+ * returns `true` so a flaky probe can't synthesise a HIGH severity via the
+ * "no-web-content" corroborator. Parked-or-refused domains return `false`.
+ *
+ * 5xx responses also count as "has content" — we got reached the server,
+ * the server just errored. Phishing infra rarely 5xx's; parked-page infra
+ * usually 200's with adverts. The only consistent "no content" signal is a
+ * hard transport failure.
+ */
+export async function probeHasWebContent(domain: string): Promise<boolean> {
+	try {
+		// safeFetch + manual redirect: the candidate is attacker-influenced, so we
+		// MUST NOT auto-follow a 302 → internal/Cloudflare host (blind SSRF oracle,
+		// OWASP A10). safeFetch validates the destination hostname; manual redirect
+		// stops the worker from chasing an attacker-supplied Location. A 3xx still
+		// proves the host is reachable, so any response counts as "has content".
+		const resp = await safeFetch(`https://${domain}/`, {
+			method: 'HEAD',
+			redirect: 'manual',
+			signal: AbortSignal.timeout(WEB_PROBE_TIMEOUT_MS),
+		});
+		// Any HTTP response (incl. 3xx) means the host is reachable — content exists.
+		return Boolean(resp);
+	} catch {
+		// Transport failure (refused, timeout, DNS) — treat as no content (HIGH corroborator).
+		return false;
+	}
+}

--- a/src/tools/lookalike-findings.ts
+++ b/src/tools/lookalike-findings.ts
@@ -1,0 +1,382 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * PER-CANDIDATE finding construction for the lookalike check — one module per
+ * emitted Finding shape, extracted VERBATIM from `check-lookalikes.ts` (pure
+ * split, no behaviour change). Run-level (summary / `scan_status`) findings
+ * live in `lookalike-summary-findings.ts`.
+ *
+ * TASK 7B TWO-AXIS SPLIT (human-partner ruling, 2026-07-27).
+ *
+ * The lookalike tool reports on TWO independent axes, and every finding it
+ * emits declares which one it belongs to via `metadata.findingAxis`:
+ *
+ *  - `'attribution'` — WHO owns the candidate. Governed by
+ *    `classifyOwnership()` + `capAttributionSeverity()`: every non-
+ *    `owned_by_seed` verdict is capped at `info` with neutral wording
+ *    (D4's load-bearing safety property — the scanner never claims someone
+ *    else's domain is the customer's, and never demands the customer act on
+ *    a domain it does not control). UNCHANGED by this task.
+ *
+ *  - `'threat_observation'` — WHAT the candidate is doing. Carries the #264
+ *    calibrated severity from `calibrateLookalikeSeverity()`. Task 7 computed
+ *    that severity and then capped it away, which made `highCount`, the HIGH
+ *    summary finding, and every sub-100 `lookalikes` category score
+ *    unreachable — a live typosquat with active MX on a disposable provider
+ *    scored 100/passed. These findings assert NOTHING about ownership (they
+ *    say explicitly that the domain does not appear to belong to the scanned
+ *    organisation) and demand no action ON that domain; only defensive
+ *    options on the scanned organisation's own side are suggested.
+ *
+ *  - `'scan_status'` — the RUN itself, not any candidate: the "no active
+ *    lookalike domains detected" notices and the timeout notice. Always
+ *    `info`. Split out in fix round 1 (F2) because forcing these into
+ *    `'threat_observation'` made the threat-axis invariants below unstateable.
+ *
+ * INVARIANTS (true of this module and its summary sibling, pinned by
+ * `test/check-lookalikes.spec.ts`, and what Task 8's cross-cutting audit keys
+ * on):
+ *   1. every finding carries one of the three literals;
+ *   2. every `'scan_status'` finding is `info`;
+ *   3. no `'threat_observation'` finding carries `ownershipVerdict ===
+ *      'owned_by_seed'` — a threat observation is never about a domain the
+ *      scanned organisation owns;
+ *   4. every `'threat_observation'` finding names the candidate it observed via
+ *      `lookalikeDomain` (per candidate, INCLUDING the named-candidate recon CT
+ *      corroboration) or `lookalikeDomains` (the aggregate summary). Bare
+ *      `domain` metadata (scoped to the scanned domain, not a candidate) only
+ *      ever appears on the demoted `'scan_status'` finding emitted when recon
+ *      names no specific candidate — never on a `'threat_observation'` finding.
+ *
+ * The axis marker is STRUCTURAL, not prose: downstream consumers (and Task
+ * 8's cross-cutting audit) key on the exact literals, never on wording.
+ */
+
+import type { DefensiveReason } from '../lib/brand-defensive-registration';
+import { buildNonOwnedGateFinding, capAttributionSeverity, type OwnershipAssessment } from '../lib/ownership-attribution';
+import type { Finding } from '../lib/scoring';
+import { createFinding } from '../lib/scoring';
+import type { LookalikeResult } from './lookalike-dns';
+import type { LookalikeSeverity, LookalikeSignals } from './lookalike-severity';
+
+export type LookalikeFindingAxis = 'attribution' | 'threat_observation' | 'scan_status';
+
+/**
+ * Human phrasing for a {@link DefensiveReason} token. Internal enum values are
+ * meaningless in a customer-facing report about a named organisation — the
+ * same rule `UNKNOWN_REASON_PHRASES` exists for in `registration-state.ts`.
+ *
+ * WORDING CONSTRAINT: none of these may contain `missing`, `required`,
+ * `not found`, or the `no <...> record` shape. `scoreIndicatesMissingControl()`
+ * in the vendored scoring package matches finding TEXT, and a match on a
+ * high-severity finding ZEROES the whole category score — the one way a
+ * wording change in this file could move a number. Pinned by a boundary test.
+ */
+export const DEFENSIVE_REASON_PHRASES: Record<DefensiveReason, string> = {
+	'redirect-to-target': 'its web root redirects back to the scanned domain',
+	'parked-ns': 'its nameservers are at a domain-parking provider',
+	'no-mx': 'it carries no active mail service',
+};
+
+/**
+ * Build a short human-readable list of corroborating signals for the finding
+ * detail. Empty string when none apply (mail-infra-alone case).
+ */
+export function describeCorroborators(signals: LookalikeSignals): string {
+	const parts: string[] = [];
+	if (signals.registrationDays !== null && signals.registrationDays < 90) {
+		parts.push(`registered ${signals.registrationDays} day${signals.registrationDays === 1 ? '' : 's'} ago`);
+	}
+	if (signals.mxOnDisposable) parts.push('disposable MX provider');
+	if (!signals.hasWebContent) parts.push('no reachable web content');
+	return parts.join(', ');
+}
+
+/**
+ * AXIS 1 — the candidate is STRUCTURALLY owned by the seed (the customer's own
+ * domain). Emitted instead of, never alongside, a threat observation: Task 7b
+ * requirement 5 is that an `owned_by_seed` candidate gets no threat finding at
+ * all, since the customer's own domain is not an impersonation threat to itself.
+ */
+export function buildOwnedBySeedFinding(result: LookalikeResult, seedDomain: string, ownership: OwnershipAssessment): Finding {
+	return createFinding(
+		'lookalikes',
+		`Lookalike domain likely owned by same entity: ${result.domain}`,
+		'info',
+		`The domain ${result.domain} is owned by the same organisation as ${seedDomain} (${ownership.rationale}).${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
+		{
+			lookalikeDomain: result.domain,
+			hasA: result.hasA,
+			hasMX: result.hasMX,
+			ownershipVerdict: ownership.verdict,
+			findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+		},
+	);
+}
+
+/**
+ * AXIS 1 — the registration record corroborates that this is the scanned
+ * organisation's OWN defensive registration. Emitted INSTEAD of the neutral D4
+ * gate template, which would otherwise state positively that the domain "is
+ * registered to a different organisation" — a claim the nameserver evidence
+ * alone never supported and which is simply false here.
+ *
+ * SEVERITY IS `info`, EXACTLY AS {@link applyOwnershipGate} WOULD HAVE CAPPED
+ * IT. This branch changes what the report SAYS, never what it SCORES:
+ * `capAttributionSeverity()` caps every non-`owned_by_seed` attribution finding
+ * at `info` regardless, so swapping the prose moves no penalty. Pinned by the
+ * boundary test in `test/ownership-attribution.spec.ts`.
+ */
+export function buildBrandHeldFinding(
+	result: LookalikeResult,
+	seedDomain: string,
+	ownership: OwnershipAssessment,
+	brandHeld: { registrarIanaId: string; registrarName: string | null; reason: DefensiveReason },
+): Finding {
+	const registrarLabel = brandHeld.registrarName
+		? `${brandHeld.registrarName} (IANA ${brandHeld.registrarIanaId})`
+		: `IANA registrar ${brandHeld.registrarIanaId}`;
+	return createFinding(
+		'lookalikes',
+		`Confusable domain held at the same brand-protection registrar: ${result.domain}`,
+		'info',
+		`The domain ${result.domain} is a confusable variant of ${seedDomain}, and the registry publishes the SAME brand-protection registrar for both (${registrarLabel}). Its infrastructure also has the shape of a defensive registration — ${DEFENSIVE_REASON_PHRASES[brandHeld.reason]}. Brand-protection registrars do not sell to the general public and the IANA registrar ID is published by the registry rather than declared by the registrant, so this corroborates that ${result.domain} is held by the scanned organisation itself; it is not proof, since one such registrar serves many brands. Nameserver evidence is separate and did not link the two: ${ownership.rationale} Confirm against your own domain portfolio before treating ${result.domain} as an outside party's.`,
+		{
+			lookalikeDomain: result.domain,
+			hasA: result.hasA,
+			hasMX: result.hasMX,
+			brandHeldRegistration: true,
+			sharedRegistrarIanaId: brandHeld.registrarIanaId,
+			defensiveReason: brandHeld.reason,
+			// Ruling A holds: registrar evidence never manufactures
+			// `owned_by_seed`. The STRUCTURAL verdict travels unchanged.
+			ownershipVerdict: ownership.verdict,
+			ownershipRationale: ownership.rationale,
+			findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+		},
+	);
+}
+
+/**
+ * AXIS 1 — the registrant-org observation REPLACES the neutral D4 gate
+ * template for this candidate (it is strictly more informative), but it
+ * is still an attribution statement capped at info.
+ *
+ * F2 (2026-07-27 fix round 2): a RDAP registrant-org match is DELIBERATELY NOT
+ * fed into `classifyOwnership()` as an ownership signal — the org field is
+ * self-declared and unverified by most registries, so it must never be able to
+ * silently produce an `owned_by_seed` verdict. Every candidate reaching this
+ * branch therefore still carries the STRUCTURAL verdict computed earlier
+ * (`third_party` here), and the verdict travels on this finding too
+ * (`ownershipVerdict` in metadata) per the same "verdict travels on EVERY
+ * classified finding" invariant `check-shadow-domains.ts` states for its own
+ * emission sites. The title/prose does not assert common ownership outright —
+ * it states plainly that this is a registrant-organisation SIGNAL, distinct
+ * from (and weaker than) the structural NS-based evidence, whose own finding is
+ * quoted verbatim.
+ */
+export function buildSharedRegistrantOrgFinding(
+	result: LookalikeResult,
+	seedDomain: string,
+	ownership: OwnershipAssessment,
+	matchedOrg: string,
+): Finding {
+	return createFinding(
+		'lookalikes',
+		`Lookalike domain shares registrant organisation with scanned domain: ${result.domain}`,
+		'info',
+		`The domain ${result.domain} shares the same RDAP registrant organisation as ${seedDomain} ("${matchedOrg}"), which may indicate a defensive registration or regional presence by the same owner. This is a registrant-organisation signal, not structural ownership evidence — RDAP registrant fields are self-declared and not independently verified. Nameserver-based evidence: ${ownership.rationale}${result.hasMX ? ' Has active mail infrastructure.' : ''}${result.hasA ? ' Has web presence.' : ''}`,
+		{
+			lookalikeDomain: result.domain,
+			hasA: result.hasA,
+			hasMX: result.hasMX,
+			sharedRegistrantOrg: matchedOrg,
+			ownershipVerdict: ownership.verdict,
+			ownershipRationale: ownership.rationale,
+			findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+		},
+	);
+}
+
+/**
+ * AXIS 1 — the UNGATED attribution finding for a candidate with no
+ * registrar/registrant corroboration. Always routed through
+ * {@link applyOwnershipGate} before emission: the ownership verdict caps its
+ * severity, so a candidate with no ownership signal linking it to the scanned
+ * organisation can never surface above info, regardless of how threatening its
+ * raw infrastructure signals look. `attributionConfidence()` governs
+ * WORDING/CONFIDENCE only — see {@link applyOwnershipGate}'s JSDoc.
+ */
+export function buildRawAttributionFinding(
+	result: LookalikeResult,
+	seedDomain: string,
+	severity: LookalikeSeverity,
+	signals: LookalikeSignals,
+	corroboratorReasons: string,
+): Finding {
+	return result.hasMX
+		? createFinding(
+				'lookalikes',
+				`Lookalike domain with mail infrastructure: ${result.domain}`,
+				severity,
+				`The domain ${result.domain} is registered with active mail servers (MX records), which could be used for phishing or email spoofing targeting ${seedDomain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
+				{
+					lookalikeDomain: result.domain,
+					hasA: result.hasA,
+					hasMX: result.hasMX,
+					registrationDays: signals.registrationDays,
+					mxOnDisposable: signals.mxOnDisposable,
+					hasWebContent: signals.hasWebContent,
+					findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+				},
+			)
+		: createFinding(
+				'lookalikes',
+				`Lookalike domain registered: ${result.domain}`,
+				severity,
+				`The domain ${result.domain} is registered (has web presence) but no mail infrastructure detected. It could still be used for phishing websites targeting ${seedDomain}.${corroboratorReasons ? ` Corroborating signals: ${corroboratorReasons}.` : ''}`,
+				{
+					lookalikeDomain: result.domain,
+					hasA: result.hasA,
+					hasMX: result.hasMX,
+					registrationDays: signals.registrationDays,
+					mxOnDisposable: signals.mxOnDisposable,
+					hasWebContent: signals.hasWebContent,
+					findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+				},
+			);
+}
+
+/**
+ * AXIS 1 (attribution) ONLY — Task 7b. This caps what the report may CLAIM
+ * about ownership; it does not and must not cap what the report may say was
+ * OBSERVED. The observed-threat severity now travels on a separate finding
+ * built by {@link buildThreatObservationFinding}, so capping here no longer
+ * makes `highCount`, the HIGH summary finding, and every sub-100 `lookalikes`
+ * category score unreachable (the defect the opus review found in Task 7).
+ *
+ * D4 severity ceiling for a lookalike finding, mirroring `applyOwnershipGate()`
+ * in `check-shadow-domains.ts` — see that file's JSDoc for the full rationale;
+ * this is the same pattern reused for a second tool so the two stay
+ * consistent for downstream consumers. The neutral-wording sentence and
+ * metadata shape live in `buildNonOwnedGateFinding()`
+ * (`src/lib/ownership-attribution.ts`), shared with `check-shadow-domains.ts`
+ * (fix round 2, F1) — the two tools had already drifted apart within this
+ * slice when each hand-rolled its own copy.
+ *
+ * `owned_by_seed` findings pass through unclamped — `checkLookalikesCore`'s
+ * main loop already emits its own dedicated "likely owned by same entity"
+ * finding for that verdict before this function is ever reached, so in
+ * practice every call here receives a non-owned verdict. The passthrough
+ * branch exists anyway so the invariant is explicit and enforced at this
+ * chokepoint rather than merely assumed by the caller.
+ *
+ * DEMOTE, NEVER DELETE (binding ruling): this returns a `Finding`, never
+ * `null`/`undefined` — a real measurement (an active registration with
+ * MX/A records) is never suppressed, only its severity capped and its
+ * wording made neutral. `attributionConfidence()` governs WORDING/CONFIDENCE
+ * ONLY; it can never move the ceiling, which `capAttributionSeverity()`
+ * derives from `ownership.verdict` alone.
+ */
+export function applyOwnershipGate(finding: Finding, ownership: OwnershipAssessment, brand: string, corroborated: boolean): Finding {
+	const ceiling = capAttributionSeverity(ownership.verdict);
+	if (ceiling === 'unbounded') return finding;
+
+	// `calibrateLookalikeSeverity()` never returns `'info'`, so unlike
+	// `check-shadow-domains.ts` there is no local info-severity branch here —
+	// every candidate reaching this point goes through the shared non-owned
+	// rewrite. `postureNoun` MUST match `check-shadow-domains.ts`'s value
+	// byte-for-byte (parity pinned by `test/ownership-attribution.spec.ts`).
+	return buildNonOwnedGateFinding(finding, ownership, brand, corroborated, ceiling, {
+		category: 'lookalikes',
+		domainMetadataKey: 'lookalikeDomain',
+		postureNoun: 'DNS/mail posture',
+	});
+}
+
+/**
+ * AXIS 2 — build the observed-threat finding for a NON-OWNED candidate
+ * (Task 7b). Carries the #264 calibrated severity verbatim; the attribution
+ * finding built by {@link applyOwnershipGate} carries the `info` cap.
+ *
+ * WORDING CONTRACT (customer-facing, legal-sensitive — BlackVeil names real
+ * third-party organisations in reports). The text:
+ *  - states only what was OBSERVED (MX/A presence, registration recency,
+ *    disposable MX, absent web content) — no claim of intent.
+ *    "Impersonation-shaped" / "consistent with pre-phishing staging" is the
+ *    ceiling; the words "malicious"/"attacker" are deliberately absent;
+ *  - says EXPLICITLY that the domain does not appear to belong to the scanned
+ *    organisation, so no reader can mistake this for an ownership claim;
+ *  - never uses "your", "shadow domain", or any ownership/control framing;
+ *  - demands no action ON the observed domain. Only defensive options that
+ *    need no access to it (monitor, block at the gateway, report for
+ *    takedown) are offered.
+ *
+ * Pinned by `test/check-lookalikes.spec.ts`'s Task 7b block, which asserts
+ * both the positive wording and the banned-framing negatives on title AND
+ * detail (a split surface — right severity, ownership-framed prose — is the
+ * failure mode that bit Task 6's first review pass).
+ */
+export function buildThreatObservationFinding(
+	candidateDomain: string,
+	seedDomain: string,
+	severity: LookalikeSeverity,
+	signals: LookalikeSignals,
+	ownership: OwnershipAssessment,
+	corroboratorReasons: string,
+	sharedRegistrantOrg: string | undefined,
+	/**
+	 * True when `isBrandHeldRegistration` corroborated that the candidate
+	 * is the scanned organisation's OWN defensive registration. Changes the
+	 * closing REMEDIATION sentence only — the observation and its calibrated
+	 * severity are emitted unchanged, per the F1 ruling that an attribution
+	 * signal may annotate the threat axis but never switch it off or discount
+	 * it. Telling a customer to report their own domain for takedown is not a
+	 * severity question; it is simply wrong advice.
+	 */
+	brandHeld = false,
+): Finding {
+	const infraPhrase = signals.hasMX
+		? `active mail infrastructure (MX records), so it is capable of sending mail that resembles ${seedDomain}`
+		: 'web infrastructure (A records) and no active mail infrastructure';
+	const observed = corroboratorReasons ? `${infraPhrase}; also observed: ${corroboratorReasons}` : infraPhrase;
+	// FIX ROUND 1 (F1): when the #263 correlation found a shared registrant-org
+	// string, it is RECORDED here — as an unverified observation — but it does
+	// NOT reduce the severity and does not suppress this finding. An org string
+	// anyone can type into a registrar form earns a sentence, not a discount.
+	const registrantNote = sharedRegistrantOrg
+		? ` Its RDAP registrant-organisation string matches the one published for ${seedDomain} ("${sharedRegistrantOrg}"); that field is self-declared, unverified by the registry, and frequently a shared privacy-service placeholder, so it is recorded but does not reduce what was observed here.`
+		: '';
+	// The attribution clause and the closing remediation clause both assume the
+	// candidate is an outside party's. When the registration record corroborates
+	// that it is the scanned organisation's OWN defensive registration, both are
+	// replaced — the observation itself and its calibrated severity are
+	// untouched, so nothing here moves a score.
+	const attributionClause = brandHeld
+		? `the registry publishes the same brand-protection registrar for it as for ${seedDomain}, so it is most likely the scanned organisation's own defensive registration`
+		: `${candidateDomain} does not appear to belong to the scanned organisation, this finding claims no control over it, and no change to it is requested`;
+	const remediationClause = brandHeld
+		? `Because this looks like your own defensive registration, treat it as portfolio hygiene rather than a threat: confirm it against your domain portfolio, and keep it parked with mail explicitly disabled so it cannot be used to send. Do NOT report it for takedown without confirming ownership first.`
+		: `Defensive options that need no access to ${candidateDomain}: monitor it, block or quarantine mail bearing that name at the gateway, and report it to its registrar or a takedown provider.`;
+	return createFinding(
+		'lookalikes',
+		`Impersonation-shaped ${signals.hasMX ? 'infrastructure' : 'web infrastructure'} observed: ${candidateDomain}`,
+		severity,
+		`${candidateDomain} is a confusable variant of ${seedDomain} and was observed with ${observed}. This is an infrastructure observation only: ${attributionClause}.${registrantNote} ${remediationClause}`,
+		{
+			...(brandHeld ? { brandHeldRegistration: true } : {}),
+			lookalikeDomain: candidateDomain,
+			hasA: signals.hasA,
+			hasMX: signals.hasMX,
+			registrationDays: signals.registrationDays,
+			mxOnDisposable: signals.mxOnDisposable,
+			hasWebContent: signals.hasWebContent,
+			findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+			// The verdict travels on EVERY classified finding, threat axis
+			// included, so a consumer can read "high observed threat, NOT owned by
+			// the customer" off a single object rather than correlating two.
+			ownershipVerdict: ownership.verdict,
+			...(sharedRegistrantOrg ? { sharedRegistrantOrg } : {}),
+		},
+	);
+}

--- a/src/tools/lookalike-summary-findings.ts
+++ b/src/tools/lookalike-summary-findings.ts
@@ -1,0 +1,245 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * RUN-LEVEL finding construction for the lookalike check — the aggregate
+ * summaries (AXIS 2, `threat_observation`) and the `scan_status` notices about
+ * the run itself. Extracted VERBATIM from `check-lookalikes.ts` (pure split, no
+ * behaviour change); per-candidate builders live in `lookalike-findings.ts`,
+ * whose module JSDoc carries the three-axis contract and its four invariants.
+ *
+ * INVARIANT 4 APPLIES HERE TOO, and this is where it has actually been broken:
+ * every `threat_observation` must NAME its subject. The mail-capable summary
+ * below sets `lookalikeDomains` for exactly that reason — the first draft set
+ * only `mailCapableDomains` and was anonymous, which
+ * `test/check-lookalikes.spec.ts`'s `assertAxisInvariants` caught. Do not
+ * "simplify" that key away.
+ */
+
+import type { Finding } from '../lib/scoring';
+import { createFinding } from '../lib/scoring';
+import type { OwnershipAssessment, OwnershipVerdict } from '../lib/ownership-attribution';
+import type { LookalikeFindingAxis } from './lookalike-findings';
+
+/**
+ * Enumeration coverage for one run.
+ *
+ * `complete: false` means the candidate set is a SAMPLE, not a census — so a
+ * consumer diffing consecutive runs must not read a shrinking set as a
+ * deregistration, and a report must not present the list as exhaustive.
+ */
+export interface LookalikeEnumeration {
+	permutationsGenerated: number;
+	permutationsProbed: number;
+	candidatesResolved: number;
+	unresolvedCount: number;
+	complete: boolean;
+}
+
+/**
+ * `scan_status` — the run timed out. Emitted by the `checkLookalikes` wrapper's
+ * race, alongside `partial: true` on the CheckResult so callers skip caching.
+ */
+export function buildTimeoutFinding(): Finding {
+	return createFinding(
+		'lookalikes',
+		'Lookalike check incomplete',
+		'info',
+		'Lookalike check did not complete within the time limit. Results may be incomplete — try again shortly.',
+		{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
+	);
+}
+
+/** `scan_status` — no permutation could be generated at all for this seed. */
+export function buildNoPermutationsFinding(seedDomain: string): Finding {
+	return createFinding(
+		'lookalikes',
+		'No active lookalike domains detected',
+		'info',
+		`No lookalike domain permutations could be generated for ${seedDomain}.`,
+		{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
+	);
+}
+
+/** `scan_status` — permutations were probed, but Phase 1 found no registered candidate. */
+export function buildNoRegisteredCandidatesFinding(seedDomain: string, permutationCount: number): Finding {
+	return createFinding(
+		'lookalikes',
+		'No active lookalike domains detected',
+		'info',
+		`Checked ${permutationCount} domain permutations of ${seedDomain}. No active registrations detected.`,
+		{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
+	);
+}
+
+/**
+ * `scan_status` — registered candidates existed but none carried DNS or mail
+ * infrastructure, so nothing was classified. Carries the enumeration block so a
+ * partial run's "none" is explicitly hedged rather than read as conclusive.
+ */
+export function buildNoActiveInfrastructureFinding(
+	seedDomain: string,
+	permutationCount: number,
+	enumeration: LookalikeEnumeration,
+): Finding {
+	return createFinding(
+		'lookalikes',
+		'No active lookalike domains detected',
+		'info',
+		`Checked ${permutationCount} domain permutations of ${seedDomain}. No active registrations with DNS or mail infrastructure detected.${
+			enumeration.complete
+				? ''
+				: ` ⚠️ ${enumeration.unresolvedCount} lookup${enumeration.unresolvedCount > 1 ? 's' : ''} did not resolve, so this is not a conclusive "none".`
+		}`,
+		{ findingAxis: 'scan_status' satisfies LookalikeFindingAxis, enumeration },
+	);
+}
+
+/**
+ * AXIS 2 — summary finding for high-severity lookalikes. Only fires when at
+ * least one NON-OWNED candidate reached HIGH under the issue #264 matrix
+ * (mail-infra + corroborator). Owned candidates never reach here.
+ */
+export function buildStagingSummaryFinding(input: {
+	seedDomain: string;
+	highCount: number;
+	highDomains: string[];
+	highVerdicts: Set<OwnershipVerdict>;
+	mailCapableDomains: string[];
+	enumeration: LookalikeEnumeration;
+}): Finding {
+	const { seedDomain: domain, highCount, highDomains, highVerdicts, mailCapableDomains, enumeration } = input;
+	return createFinding(
+		'lookalikes',
+		// TITLE NAMES THE PREDICATE IT COUNTS (#779). It used to say "with
+		// mail capability", which is a strictly wider set than the
+		// mail-infra-PLUS-corroborator matrix this count applies — so the
+		// headline under-reported threefold against its own per-domain
+		// evidence. The staging subset is the right thing to lead with; it
+		// just has to be named as the subset it is, with the wider
+		// mail-capable figure alongside rather than implied.
+		`${highCount} lookalike domain${highCount > 1 ? 's' : ''} showing pre-phishing staging signals`,
+		'high',
+		`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging.${
+			mailCapableDomains.length > highCount
+				? ` A further ${mailCapableDomains.length - highCount} confusable domain${mailCapableDomains.length - highCount > 1 ? 's' : ''} also ${mailCapableDomains.length - highCount > 1 ? 'have' : 'has'} a working mail host without those additional signals — ${mailCapableDomains.length} can send mail in total.`
+				: ''
+		} ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
+		{
+			lookalikeDomainCount: highCount,
+			lookalikeDomains: highDomains,
+			// BOTH numbers, so a consumer never has to re-derive either from
+			// the per-domain findings — which is what the old shape forced,
+			// and what nobody did.
+			mailCapableCount: mailCapableDomains.length,
+			mailCapableDomains,
+			enumeration,
+			// Set-level claim, so its confidence tracks ENUMERATION coverage,
+			// not per-domain measurement quality (#781). Each row remains
+			// deterministic about its own domain; what is uncertain when a
+			// lookup was dropped is whether the SET is complete — and this
+			// finding is the one making a claim about the set.
+			confidence: enumeration.complete ? 'deterministic' : 'heuristic',
+			// Present whenever the counted set shares one verdict (the realistic
+			// case — a non-owned registered candidate is always `third_party`).
+			// Omitted rather than fabricated for a mixed set; either way it can
+			// never be `owned_by_seed`, since owned candidates never reach here.
+			...(highVerdicts.size === 1 ? { ownershipVerdict: [...highVerdicts][0] } : {}),
+			findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+		},
+	);
+}
+
+/**
+ * AXIS 2 — the other half of #779. When mail-capable candidates exist but none
+ * carries a #264 corroborator, the old code emitted NO summary at all — so an
+ * estate with several confusable domains that can send mail produced an
+ * aggregate view saying nothing, and a consumer reading only summaries
+ * concluded there was no mail-capable lookalike exposure.
+ *
+ * MEDIUM, not high: mail capability alone is a real observation but not
+ * evidence of staging, and the severity has to stay honest about which
+ * of the two it is.
+ */
+export function buildMailCapableSummaryFinding(input: {
+	seedDomain: string;
+	mailCapableDomains: string[];
+	enumeration: LookalikeEnumeration;
+}): Finding {
+	const { seedDomain: domain, mailCapableDomains, enumeration } = input;
+	const n = mailCapableDomains.length;
+	return createFinding(
+		'lookalikes',
+		`${n} lookalike domain${n > 1 ? 's' : ''} with a working mail host`,
+		'medium',
+		`${n} confusable domain${n > 1 ? 's' : ''} of ${domain} ${n > 1 ? 'have' : 'has'} a working mail host, so ${n > 1 ? 'they are' : 'it is'} capable of sending mail that resembles ${domain}. No additional corroborating signal of pre-phishing staging was observed, and ${n > 1 ? 'none appears' : 'it does not appear'} to belong to the scanned organisation — this is an infrastructure observation, not an allegation. Enforcing DMARC p=reject on ${domain} is what makes receivers reject mail forging that name.`,
+		{
+			mailCapableCount: n,
+			mailCapableDomains,
+			enumeration,
+			confidence: enumeration.complete ? 'deterministic' : 'heuristic',
+			// Names what it observed — invariant 4, asserted by
+			// `assertAxisInvariants`: every threat_observation must identify
+			// its subject. Omitting this made the first draft of this finding
+			// anonymous, and the existing suite caught it.
+			lookalikeDomains: mailCapableDomains,
+			// Deliberately no `lookalikeDomainCount`: nothing reached the
+			// staging threshold, and reusing that key would let a consumer
+			// read this as the staging count.
+			findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+		},
+	);
+}
+
+/**
+ * `scan_status` — PARTIAL COVERAGE (#781). Emitted as its own finding, not only
+ * as metadata, because a consumer reading findings — which is most of them —
+ * otherwise has no way to learn the candidate set is a SAMPLE. Without it,
+ * repeat runs returning different sets look like real-world change: monitoring
+ * built on diffing consecutive runs raises false "new lookalike registered"
+ * alerts for names merely missed last time, and misses real ones enumerated
+ * before.
+ */
+export function buildIncompleteEnumerationFinding(seedDomain: string, enumeration: LookalikeEnumeration): Finding {
+	return createFinding(
+		'lookalikes',
+		'Lookalike enumeration was incomplete — treat this list as a sample',
+		'info',
+		`${enumeration.unresolvedCount} of ${enumeration.permutationsProbed} candidate lookup${enumeration.permutationsProbed > 1 ? 's' : ''} for ${seedDomain} did not resolve (DNS timeout or rate limiting), so those permutations could be neither confirmed nor ruled out. The ${enumeration.candidatesResolved} domain${enumeration.candidatesResolved === 1 ? '' : 's'} reported here are observed examples, not a complete inventory — do not read a smaller set on a later run as a domain having been deregistered, and re-run before relying on the count.`,
+		{
+			findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
+			enumeration,
+			confidence: 'heuristic',
+		},
+	);
+}
+
+/**
+ * AXIS 2 — bv-recon named a SPECIFIC confusable candidate, so the CT
+ * corroboration is a per-candidate threat observation carrying that name
+ * (invariant 4) and the candidate's own ownership verdict (invariant 3).
+ */
+export function buildReconCandidateFinding(matchedDomain: string, detail: string, reconOwnership: OwnershipAssessment): Finding {
+	return createFinding('lookalikes', 'CT-observed lookalike corroboration', 'medium', detail, {
+		lookalikeDomain: matchedDomain,
+		reconEnriched: true,
+		findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,
+		ownershipVerdict: reconOwnership.verdict,
+	});
+}
+
+/**
+ * `scan_status` — bv-recon corroborated the seed's CT neighbourhood but named
+ * no specific candidate. Never fabricate one: this is a scan-level notice about
+ * the run's own CT signal, not a per-candidate threat claim, so it stays
+ * `info`/`scan_status` (DEMOTE, NEVER DELETE — the real signal is still
+ * surfaced).
+ */
+export function buildReconScanStatusFinding(seedDomain: string, detail: string): Finding {
+	return createFinding(
+		'lookalikes',
+		'CT-observed lookalike corroboration (no specific candidate identified)',
+		'info',
+		`${detail} No specific confusable domain was identified by this signal, so no candidate-level claim is made.`,
+		{ domain: seedDomain, reconEnriched: true, findingAxis: 'scan_status' satisfies LookalikeFindingAxis },
+	);
+}

--- a/src/tools/rdap-fallback-servers.ts
+++ b/src/tools/rdap-fallback-servers.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * The hand-maintained RDAP fallback server map, and the IANA bootstrap URL it
+ * duplicates.
+ *
+ * A LEAF MODULE ON PURPOSE — it imports NOTHING. `check-rdap-lookup.ts` pulls
+ * in the scoring/sanitize chain, which is workerd-shaped and cannot be loaded
+ * by a plain Node/tsx process; keeping the table here lets the out-of-band
+ * reconciliation script (`scripts/audits/rdap-fallback-reconcile.ts`) read the
+ * SAME object the runtime uses instead of re-declaring it, which is the one
+ * thing that would make the reconciliation worthless. Do not add an import to
+ * this file.
+ *
+ * `check-rdap-lookup.ts` re-exports `FALLBACK_RDAP_SERVERS`, so every existing
+ * consumer and `test/rdap-fallback-server-map.spec.ts` keep their import site.
+ */
+
+/** RDAP bootstrap URL (IANA). */
+export const IANA_BOOTSTRAP_URL = 'https://data.iana.org/rdap/dns.json';
+
+/**
+ * Hardcoded RDAP server fallbacks for common TLDs. Used when the IANA bootstrap
+ * fetch is unavailable (cold start, network blip). Snapshot from IANA's
+ * canonical bootstrap; rarely changes — the audit test in Phase 6 of the
+ * registrar-coverage TDD plan pins the coverage list. URLs that change at the
+ * registry level get corrected when IANA bootstrap comes back online.
+ *
+ * ⚠️ A WRONG OR DEAD ENTRY HERE DEGRADES SILENTLY (#780). `probeRdap()` in
+ * `lookalike-enrichment.ts` fail-softs, so a host that does not resolve yields
+ * `registrationDays: null` on EVERY domain under that TLD — indistinguishable
+ * from "old domain, nothing notable". `test/rdap-fallback-server-map.spec.ts`
+ * says plainly that its structural assertions cannot catch that class; the
+ * guard that can is `npx tsx scripts/audits/rdap-fallback-reconcile.ts`, which
+ * reconciles this table against {@link IANA_BOOTSTRAP_URL} live. Run it before
+ * adding or editing an entry.
+ */
+export const FALLBACK_RDAP_SERVERS: Record<string, string> = {
+	// Verisign-operated
+	com: 'https://rdap.verisign.com/com/v1/',
+	net: 'https://rdap.verisign.com/net/v1/',
+	// Public Interest Registry
+	org: 'https://rdap.publicinterestregistry.org/rdap/',
+	// Identity Digital (formerly Afilias / Donuts)
+	info: 'https://rdap.identitydigital.services/rdap/',
+	biz: 'https://rdap.nic.biz/',
+	us: 'https://rdap.identitydigital.services/rdap/',
+	// ⚠️ `.tech` and `.online` are Radix, NOT Identity Digital — same #780 shape,
+	// found by `npm run audit:rdap-fallback` reconciling this table against IANA.
+	// The host resolves and answers, so nothing errored; it just 404s every
+	// `.tech`/`.online` domain, which fail-softs to `registrationDays: null`.
+	// A REACHABLE-but-wrong operator is the nastier variant of #780: there is no
+	// DNS failure to notice. Measured 2026-08-25 — get.tech and radix.online both
+	// return 200 with a registration event from radix.host and 404 from
+	// identitydigital. IANA maps both to radix.host.
+	tech: 'https://rdap.radix.host/rdap/',
+	online: 'https://rdap.radix.host/rdap/',
+	email: 'https://rdap.identitydigital.services/rdap/',
+	global: 'https://rdap.identitydigital.services/rdap/',
+	group: 'https://rdap.identitydigital.services/rdap/',
+	life: 'https://rdap.identitydigital.services/rdap/',
+	live: 'https://rdap.identitydigital.services/rdap/',
+	media: 'https://rdap.identitydigital.services/rdap/',
+	news: 'https://rdap.identitydigital.services/rdap/',
+	services: 'https://rdap.identitydigital.services/rdap/',
+	software: 'https://rdap.identitydigital.services/rdap/',
+	solutions: 'https://rdap.identitydigital.services/rdap/',
+	support: 'https://rdap.identitydigital.services/rdap/',
+	systems: 'https://rdap.identitydigital.services/rdap/',
+	technology: 'https://rdap.identitydigital.services/rdap/',
+	tools: 'https://rdap.identitydigital.services/rdap/',
+	// Identity Digital ccTLDs / TLD operators
+	io: 'https://rdap.identitydigital.services/rdap/',
+	// ⚠️ `.ai` is Identity Digital, NOT `rdap.nic.ai` (#780). That host has NO A
+	// RECORD — it does not resolve and never answered. Because `probeRdap`
+	// fail-softs to `EMPTY_RDAP_PROBE`, every `.ai` lookup silently produced
+	// `registrationDays: null` while `.org`/`.com` populated correctly, so the
+	// "recently registered" signal — the highest-value thing lookalike triage
+	// surfaces — was dead for the whole TLD with no error raised anywhere.
+	// Verified against IANA's authoritative bootstrap (data.iana.org/rdap/dns.json
+	// maps ai → identitydigital) and by live probe: openclaw.ai returns 200 with
+	// a registration event. Do NOT "restore" rdap.nic.ai.
+	ai: 'https://rdap.identitydigital.services/rdap/',
+	sh: 'https://rdap.identitydigital.services/rdap/',
+	// auDA
+	au: 'https://rdap.cctld.au/rdap/',
+	// Traficom
+	fi: 'https://rdap.fi/rdap/rdap/',
+	// ⚠️ `.co` is DELIBERATELY ABSENT. It was `https://rdap.nic.co/`, a host with
+	// no A record (#780's exact shape). There is no replacement to point at: IANA's
+	// bootstrap does not publish `co` at all, and rdap.org, centralnic, verisign,
+	// godaddy and identitydigital were each probed on 2026-08-25 and none serve it.
+	// An entry that cannot answer is strictly worse than no entry — the result is
+	// the same `registrationDays: null`, but a dead host also spends a DNS failure
+	// and the probe timeout to get there. Do NOT re-add a guess; if `.co` RDAP
+	// appears, add it WITH a live probe showing a registration event.
+	// ME Registry is Identity Digital — `rdap.nic.me` also had no A record.
+	// Verified: google.me returns 200 with registration 2008-06-13.
+	me: 'https://rdap.identitydigital.services/rdap/',
+	// Google Registry — pubapi is the canonical RDAP endpoint; www.registry.google returns 404.
+	app: 'https://pubapi.registry.google/rdap/',
+	dev: 'https://pubapi.registry.google/rdap/',
+	// XYZ.COM LLC — served by CentralNic, not `rdap.nic.xyz` (no A record, #780
+	// shape). IANA maps xyz → rdap.centralnic.com/xyz/; verified 2026-08-25,
+	// google.xyz returns 200 with registration 2014-05-20.
+	xyz: 'https://rdap.centralnic.com/xyz/',
+	// ccTLDs reachable via IANA bootstrap — hardcoded here as failsafe for when
+	// the bootstrap fetch is negative-cached (transient data.iana.org outage).
+	ca: 'https://rdap.ca.fury.ca/rdap/',
+	cz: 'https://rdap.nic.cz/',
+	fr: 'https://rdap.nic.fr/',
+	in: 'https://rdap.nixiregistry.in/rdap/',
+	nl: 'https://rdap.sidn.nl/',
+	no: 'https://rdap.norid.no/',
+	pl: 'https://rdap.dns.pl/',
+	sg: 'https://rdap.sgnic.sg/rdap/',
+	uk: 'https://rdap.nominet.uk/uk/',
+};

--- a/test/audits/data/rdap-fallback-required-tlds.txt
+++ b/test/audits/data/rdap-fallback-required-tlds.txt
@@ -44,10 +44,25 @@ au
 # Traficom
 fi
 
-# .CO Internet
-co
+# .CO Internet — REMOVED 2026-08-25. A coverage REDUCTION, recorded rather than
+# quietly dropped.
+#
+# The entry that satisfied this line was `https://rdap.nic.co/`, a host with NO
+# A record (#780's shape). The coverage this list asserted therefore did not
+# exist: the audit was green while every `.co` lookup silently produced
+# `registrationDays: null`.
+#
+# There is nothing to point at. IANA's bootstrap does not publish `co` at all,
+# and rdap.org, centralnic, verisign, godaddy and identitydigital were each
+# probed live on 2026-08-25 — none serve it. Requiring an entry can only be
+# satisfied by a URL that does not answer, which is worse than absence: the same
+# null result, plus a DNS failure and the probe timeout to reach it.
+#
+# RESTORE this line the moment a `.co` RDAP server exists — with a live probe
+# showing a registration event, not merely a 200.
 
-# ME Registry
+# ME Registry — Identity Digital. `rdap.nic.me` also had no A record; corrected
+# 2026-08-25 (google.me returns 200 with registration 2008-06-13).
 me
 
 # Identity Digital ccTLD

--- a/test/rdap-bootstrap-cache.test.ts
+++ b/test/rdap-bootstrap-cache.test.ts
@@ -132,7 +132,12 @@ describe('RDAP bootstrap cache', () => {
 		// Use the exported constant directly so the audit test in Phase 6 can pin
 		// the snapshot. Phase 4 just asserts the minimum-viable coverage.
 		const fallback = mod.FALLBACK_RDAP_SERVERS;
-		for (const tld of ['com', 'net', 'org', 'info', 'io', 'biz', 'co', 'me', 'app', 'dev']) {
+		// `co` was dropped 2026-08-25: its entry was the non-resolving
+		// `rdap.nic.co`, no operator serves public RDAP for it, and IANA does not
+		// publish it — so asserting coverage here could only ever be satisfied by a
+		// URL that does not answer. Reason recorded in
+		// test/audits/data/rdap-fallback-required-tlds.txt.
+		for (const tld of ['com', 'net', 'org', 'info', 'io', 'biz', 'me', 'app', 'dev']) {
 			expect(fallback[tld], `expected fallback RDAP server for .${tld}`).toMatch(/^https:\/\//);
 		}
 	});

--- a/test/rdap-fallback-server-map.spec.ts
+++ b/test/rdap-fallback-server-map.spec.ts
@@ -25,8 +25,19 @@
  * (data.iana.org/rdap/dns.json), which is the authoritative mapping this table
  * duplicates. That belongs in a scheduled/live check, not a unit test — a unit
  * test that fetches it would make the suite depend on someone else's uptime and
- * would fail closed on a network blip. Until that exists, a dead entry for any
- * OTHER TLD would still degrade silently, exactly as `.ai` did.
+ * would fail closed on a network blip.
+ *
+ * ✅ THAT CHECK NOW EXISTS and is deliberately NOT wired into `npm test`:
+ *
+ *     npm run audit:rdap-fallback      # scripts/audits/rdap-fallback-reconcile.ts
+ *
+ * It fetches the live bootstrap and reports (a) entries whose target disagrees
+ * with IANA, (b) entries whose host does not resolve — the #780 shape — and
+ * (c) TLDs IANA covers that the table lacks. It exits 2 ("INCONCLUSIVE") rather
+ * than green whenever the fetch or a DNS status cannot be established, so a
+ * network blip can never read as an all-clear. Run it before adding or editing
+ * an entry in `FALLBACK_RDAP_SERVERS`; the assertions below stay structural on
+ * purpose and still cannot catch a dead host.
  */
 import { describe, it, expect } from 'vitest';
 import { FALLBACK_RDAP_SERVERS } from '../src/tools/check-rdap-lookup';
@@ -38,6 +49,35 @@ describe('FALLBACK_RDAP_SERVERS', () => {
 		// .io and .sh. `rdap.nic.ai` has no A record.
 		expect(FALLBACK_RDAP_SERVERS.ai).toBe('https://rdap.identitydigital.services/rdap/');
 		expect(FALLBACK_RDAP_SERVERS.ai).not.toMatch(/nic\.ai/);
+	});
+
+	it('pins the four entries the IANA reconciliation caught, and keeps .co absent', () => {
+		// Found 2026-08-25 by `npm run audit:rdap-fallback`. Every one was the #780
+		// failure — a silent `registrationDays: null` across a whole TLD — and each
+		// replacement below was confirmed by a LIVE probe returning a registration
+		// event, not merely by matching IANA.
+		//
+		// `.tech`/`.online` are the nastier variant: the old host resolved and
+		// answered, it just 404s every domain in those TLDs. No DNS error, nothing
+		// to notice — only a reconciliation against IANA finds that shape.
+		expect(FALLBACK_RDAP_SERVERS.xyz).toBe('https://rdap.centralnic.com/xyz/');
+		expect(FALLBACK_RDAP_SERVERS.tech).toBe('https://rdap.radix.host/rdap/');
+		expect(FALLBACK_RDAP_SERVERS.online).toBe('https://rdap.radix.host/rdap/');
+		expect(FALLBACK_RDAP_SERVERS.me).toBe('https://rdap.identitydigital.services/rdap/');
+
+		// None of the known-dead hosts may reappear anywhere in the table. Matched
+		// on the full HOST, not a substring: a bare /nic\.co/ also matches the
+		// legitimate `rdap.centralnic.com`, which is exactly the false positive
+		// this assertion tripped on first.
+		const hosts = Object.values(FALLBACK_RDAP_SERVERS).map((u) => new URL(u).hostname);
+		for (const dead of ['rdap.nic.xyz', 'rdap.nic.co', 'rdap.nic.me', 'rdap.nic.ai']) {
+			expect(hosts).not.toContain(dead);
+		}
+
+		// `.co` is deliberately ABSENT: no operator serves public RDAP for it and
+		// IANA does not publish it, so any entry would be a guess that fails slower
+		// than no entry at all.
+		expect(FALLBACK_RDAP_SERVERS.co).toBeUndefined();
 	});
 
 	it('routes .ai to the same operator as its sibling Identity Digital ccTLDs', () => {


### PR DESCRIPTION
Two pieces of residue from the #779–#783 wave. The RDAP half turned out to be a **live product-accuracy defect**, not housekeeping.

## The defect

#780 fixed `.ai`, whose fallback pointed at a host with no A record. Nothing reconciled the rest of the table against IANA, so any other dead entry failed identically: `probeRdap` fail-softs, so a bad host yields `registrationDays: null` for the **whole TLD, indefinitely, with no error anywhere** — and `null` is indistinguishable from "old domain, nothing notable" at every consumer. That kills the newly-registered signal, the highest-value output of lookalike triage.

**Five TLDs were affected.** Each replacement was confirmed by a live probe returning a registration event, not merely by matching IANA:

| TLD | was | status | now | proof |
|---|---|---|---|---|
| `xyz` | `rdap.nic.xyz` | no A record | `rdap.centralnic.com/xyz/` | google.xyz 2014-05-20 |
| `me` | `rdap.nic.me` | no A record | `identitydigital` | google.me 2008-06-13 |
| `tech` | `identitydigital` | **404s every domain** | `rdap.radix.host/rdap/` | get.tech 2016-09-22 |
| `online` | `identitydigital` | **404s every domain** | `rdap.radix.host/rdap/` | radix.online 200 |
| `co` | `rdap.nic.co` | no A record | **removed** | no server exists |

`.tech`/`.online` are the nastier variant of #780: the wrong host **resolves and answers**, it just 404s everything in those TLDs. There is no DNS failure to notice — only reconciliation against IANA finds that shape.

## The reconciliation

`npm run audit:rdap-fallback` — deliberately **not** in `npm test`. A unit test that fetches IANA would depend on someone else's uptime and fail closed on a network blip, exactly as `rdap-fallback-server-map.spec.ts` argued when it declined to add one.

It **fails loud**: unreachable host, non-JSON body, or a parse yielding <500 TLDs all exit `2 INCONCLUSIVE` rather than green; a DNS timeout/SERVFAIL reports `unknown`, never `dead`, so the inverse of #780 can't send someone editing a working entry. Proven by pointing `BV_RDAP_BOOTSTRAP_URL` at a dead host and at a 200-with-HTML.

`FALLBACK_RDAP_SERVERS` moved to a zero-import leaf module so the script reads the **same object** the runtime does — a re-declared copy would reconcile against itself.

Now exits 0: every entry agrees with IANA, every host resolves.

## `.co` is a recorded coverage reduction

Not quietly dropped. IANA does not publish `co` at all, and rdap.org, centralnic, verisign, godaddy and identitydigital were each probed — none serve it. The required-TLDs snapshot could only ever have been satisfied by a URL that does not answer, which is **worse than absence**: same null, plus a DNS failure and probe timeout to reach it. The audit was green on illusory coverage. Reason and restore-conditions recorded in `test/audits/data/rdap-fallback-required-tlds.txt`.

## The split

`check-lookalikes.ts` 1598 → 520 LOC across five siblings, all under the 600-LOC hook. Pure extraction — every prior export re-exported, so no import site changed. `assertAxisInvariants` intact, including the `lookalikeDomains` key a past change dropped while setting only `mailCapableDomains`.

## Verification

- Full suite matches the pre-edit baseline **exactly**: `663 passed / 7913 passed / 13 skipped`. Only `test/wasm-integration.test.ts` fails — it needs the gitignored `crates/*/pkg` and fails the same way on a clean checkout.
- `wrangler types && tsc --noEmit` → 0 errors.
- One transient `mcp-access-log.spec.ts` timeout appeared in a loaded run and did not reproduce (14/14 in isolation); flagging rather than hiding it.

## Not done

- **No scheduled workflow.** `registry-drift-check.yml` would fit, but scheduling it before this merges means it goes red on first run. Worth adding after.
- `check-rdap-lookup.ts` is still 1008 LOC and trips the size hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)