### PR TITLE
fix(attack-paths): two evidence-fidelity defects in simulate_attack_paths (#787, #788)

### DIFF
--- a/src/tools/simulate-attack-paths.ts
+++ b/src/tools/simulate-attack-paths.ts
@@ -105,28 +105,133 @@ function isDmarcWeakOrMissing(findings: Finding[]): boolean {
 	});
 }
 
-/** Check if DMARC has no subdomain policy (sp=) or sp=none. */
+/**
+ * Check if DMARC leaves subdomains unprotected.
+ *
+ * ⚠️ #788 — the mirror image of #782. That bug matched prose meaning the
+ * opposite; this one FAILED to match for the same reason. The old third clause
+ * was `!d.includes('sp=') && d.includes('p=none')`, and check_dmarc's detail for
+ * a MISSING subdomain policy reads:
+ *
+ *   "No subdomain policy (sp=) specified. Subdomains inherit the "none" policy,
+ *    which provides no protection against spoofing."
+ *
+ * `sp=` appears as a substring precisely BECAUSE the tag is absent, so
+ * `!d.includes('sp=')` was always false and the clause could never fire. The
+ * literal `p=none` is not in the detail either — the policy is named as
+ * `"none"`. Measured 2026-08-26: `email_spoof_subdomain` fired for 0 of 16
+ * domains, including moonshot.ai, whose own finding says subdomains have "no
+ * protection against spoofing".
+ *
+ * THE DISCRIMINATOR IS THE INHERITED POLICY, not whether an `sp=` tag exists.
+ * Inheriting `reject` is fine; inheriting `none` is not. Both cases emit the
+ * same "No subdomain policy (sp=)" prose, so keying on the tag cannot separate
+ * them — only the named policy can.
+ *
+ * Deliberately conservative: a domain with `p=none` but NO subdomain finding at
+ * all (huggingface.co on the same sweep) does not fire here. That evidence state
+ * is indistinguishable from `p=none` + an explicit strong `sp=`, and inventing a
+ * finding from an absence is the failure mode this family of fixes exists to
+ * stop. If that gap matters it belongs in check_dmarc, which owns the evidence.
+ */
+const SUBDOMAIN_POLICY_IS_NONE: RegExp[] = [
+	// Explicit tags. Word-anchored so `aspf=`/`adkim=` cannot match.
+	/\bsp=none\b/,
+	/\bnp=none\b/,
+	// `p=quarantine|reject` + `sp=none` (existing subdomains).
+	/subdomain polic\w*\s+is set to "none"/,
+	// `p=none` + no `sp=` — subdomains inherit the org policy, which is none.
+	/subdomains inherit p=none/,
+	/subdomains inherit the "none"/,
+];
+
 function isDmarcSubdomainWeak(findings: Finding[]): boolean {
 	return hasFindings(findings, (f) => {
 		if (f.category !== 'dmarc') return false;
-		const d = f.detail.toLowerCase();
-		const t = f.title.toLowerCase();
-		// Missing DMARC entirely means no subdomain policy either
-		if (t.includes('no dmarc') || t.includes('missing')) return true;
-		// Explicit sp=none
-		if (d.includes('sp=none')) return true;
-		// No sp= tag and p=none
-		if (!d.includes('sp=') && d.includes('p=none')) return true;
-		return false;
+		const haystack = `${f.title} ${f.detail}`.toLowerCase();
+		// Missing DMARC entirely means no subdomain policy either.
+		if (f.title.toLowerCase().includes('no dmarc') || f.title.toLowerCase().includes('missing')) {
+			return true;
+		}
+		// Otherwise the path fires only where the policy that APPLIES TO SUBDOMAINS
+		// is literally `none`. `sp=quarantine` under `p=reject` is weaker than the
+		// parent but still enforcing, so it is deliberately NOT a match here.
+		return SUBDOMAIN_POLICY_IS_NONE.some((re) => re.test(haystack));
 	});
+}
+
+/**
+ * The `subdomain_takeover` findings that actually support a takeover path.
+ *
+ * ⚠️ #787 — everything below exists because this set is NOT homogeneous.
+ * `check_subdomain_takeover` emits two quite different things under one
+ * category, and the path used to treat them identically:
+ *
+ *   [high]   Subdomain possible takeover signal <provider>   ← claimable service
+ *   [medium] Dangling CNAME operational drift : a → b        ← just doesn't resolve
+ *
+ * Measured on openai.com (2026-08-26): `blog.openai.com` CNAMEs to
+ * `d2b532lzynlqb7.cloudfront.net`, which returns NOERROR/NODATA on two
+ * independent public resolvers (Cloudflare and Google) — a deleted
+ * distribution, genuinely dangling. But a CloudFront distribution ID is
+ * assigned by AWS and cannot be chosen by an attacker, so that name is NOT
+ * re-registrable. The scanner encodes exactly that distinction in the severity
+ * it assigns; the simulator threw it away.
+ */
+function subdomainTakeoverEvidence(findings: Finding[]): Finding[] {
+	return findings.filter(
+		(f) =>
+			f.category === 'subdomain_takeover' &&
+			(f.severity === 'critical' || f.severity === 'high' || f.severity === 'medium'),
+	);
 }
 
 /** Check if subdomain takeover findings exist with severity >= medium. */
 function hasSubdomainTakeoverRisk(findings: Finding[]): boolean {
-	return hasFindings(
-		findings,
-		(f) => f.category === 'subdomain_takeover' && (f.severity === 'critical' || f.severity === 'high' || f.severity === 'medium'),
-	);
+	return subdomainTakeoverEvidence(findings).length > 0;
+}
+
+/**
+ * Severity of the takeover path = severity of its STRONGEST supporting finding.
+ *
+ * ⚠️ #787 — this was hardcoded `critical`. Because `overallRisk` is simply the
+ * most severe feasible path, a single MEDIUM operational-drift finding rendered
+ * the entire domain **critical**. On the 16-domain AI-provider sweep that
+ * produced the only `critical` verdict in the whole run, on a dangling CNAME
+ * nobody can claim. A severity a reader can check and disagree with discredits
+ * the paths that are correct.
+ */
+function subdomainTakeoverSeverity(findings: Finding[]): 'critical' | 'high' | 'medium' {
+	const evidence = subdomainTakeoverEvidence(findings);
+	if (evidence.some((f) => f.severity === 'critical')) return 'critical';
+	if (evidence.some((f) => f.severity === 'high')) return 'high';
+	return 'medium';
+}
+
+/**
+ * Prerequisites naming what was OBSERVED, never what would be convenient.
+ *
+ * ⚠️ #787 — the static list said "Dangling CNAME pointing to unclaimed
+ * resource". "Unclaimed" is an assertion of attacker-registrability, and a
+ * drift finding establishes only that the target stopped resolving. Those are
+ * different claims with different remediation urgency, and only one of them is
+ * supported by a NODATA answer.
+ */
+function subdomainTakeoverPrerequisites(findings: Finding[]): string[] {
+	const evidence = subdomainTakeoverEvidence(findings);
+	const out: string[] = [];
+	if (evidence.some((f) => f.title.toLowerCase().includes('takeover'))) {
+		out.push('Subdomain CNAME resolves to a service with a known takeover signature');
+	}
+	if (evidence.some((f) => /dangling|drift/.test(f.title.toLowerCase()))) {
+		out.push('Dangling CNAME to a resource that no longer resolves (attacker registrability not established)');
+	}
+	// Never emit a path that can name nothing it rests on — an unreviewable
+	// finding is the failure mode this whole family of fixes exists to stop.
+	if (out.length === 0 && evidence.length > 0) {
+		out.push('Subdomain takeover signal reported by check_subdomain_takeover');
+	}
+	return out;
 }
 
 /** Check if DNSSEC is not enabled. */
@@ -286,6 +391,15 @@ interface AttackPathDefinition {
 	id: string;
 	name: string;
 	severity: 'critical' | 'high' | 'medium' | 'low';
+	/**
+	 * Derives the emitted severity from the evidence, overriding `severity`.
+	 *
+	 * Present only where one `condition` accepts findings of DIFFERENT severities
+	 * (#787). A static `severity` then reports the worst case for every match,
+	 * and since `overallRisk` is the most severe feasible path, that promotes the
+	 * whole domain on the strength of the weakest qualifying finding.
+	 */
+	severityFrom?: (findings: Finding[]) => 'critical' | 'high' | 'medium' | 'low';
 	feasibility: 'trivial' | 'moderate' | 'difficult';
 	condition: (findings: Finding[]) => boolean;
 	/**
@@ -341,10 +455,13 @@ const ATTACK_PATH_DEFINITIONS: AttackPathDefinition[] = [
 	{
 		id: 'subdomain_takeover',
 		name: 'Subdomain Takeover via Dangling CNAME',
+		// Ceiling only — the emitted value is derived (#787).
 		severity: 'critical',
+		severityFrom: (findings) => subdomainTakeoverSeverity(findings),
 		feasibility: 'moderate',
 		condition: (findings) => hasSubdomainTakeoverRisk(findings),
-		prerequisites: ['Dangling CNAME pointing to unclaimed resource'],
+		// Derived, not asserted — see `subdomainTakeoverPrerequisites` (#787).
+		prerequisites: (findings) => subdomainTakeoverPrerequisites(findings),
 		steps: [
 			'Identify dangling CNAME record pointing to deprovisioned cloud resource',
 			'Register the unclaimed resource on the cloud provider',
@@ -553,7 +670,7 @@ export function evaluateAttackPathsFromFindings(findings: Finding[]): AttackPath
 			feasiblePaths.push({
 				id: def.id,
 				name: def.name,
-				severity: def.severity,
+				severity: def.severityFrom ? def.severityFrom(findings) : def.severity,
 				feasibility: def.feasibility,
 				prerequisites:
 					typeof def.prerequisites === 'function' ? def.prerequisites(findings) : def.prerequisites,

--- a/test/simulate-attack-paths.spec.ts
+++ b/test/simulate-attack-paths.spec.ts
@@ -1118,3 +1118,176 @@ describe('#782 a path never states a prerequisite the findings contradict', () =
 		}
 	});
 });
+
+/**
+ * #787 — `subdomain_takeover` asserted a hardcoded CRITICAL severity and an
+ * "unclaimed resource" prerequisite regardless of what the evidence said.
+ *
+ * Measured 2026-08-26 on openai.com during a 16-domain AI-provider sweep.
+ * `check_subdomain_takeover` emitted exactly two findings:
+ *
+ *   [high]   Subdomain possible takeover signal Azure CDN
+ *   [medium] Dangling CNAME operational drift : blog.openai.com
+ *                                              → d2b532lzynlqb7.cloudfront.net
+ *
+ * The simulator turned that into a CRITICAL path whose prerequisite read
+ * "Dangling CNAME pointing to unclaimed resource", which drove the whole
+ * domain's `overallRisk` to **critical** — the only critical verdict in the
+ * entire sweep.
+ *
+ * Two separate over-claims:
+ *
+ *  1. SEVERITY. `hasSubdomainTakeoverRisk` accepts medium|high|critical, but
+ *     the path is hardcoded `severity: 'critical'`. A MEDIUM "operational
+ *     drift" finding is therefore promoted two full levels, and because
+ *     `overallRisk` is just the most severe path, one medium finding renders
+ *     the domain critical.
+ *
+ *  2. PREREQUISITE. "unclaimed resource" asserts the target is REGISTRABLE by
+ *     an attacker. Verified against DNS: `d2b532lzynlqb7.cloudfront.net`
+ *     returns NOERROR/NODATA (a deleted distribution) on two independent
+ *     public resolvers — genuinely dangling. But CloudFront distribution IDs are
+ *     assigned by AWS and cannot be chosen, so the resource is NOT claimable.
+ *     The scanner knew this: it rated that finding MEDIUM and titled it
+ *     "operational drift", not "takeover".
+ *
+ * Same family as #782 — a path stating more than its own evidence supports.
+ */
+describe('#787 subdomain_takeover severity and prerequisites follow the evidence', () => {
+	async function paths(findings: unknown[]) {
+		const { evaluateAttackPathsFromFindings } = await import('../src/tools/simulate-attack-paths');
+		return evaluateAttackPathsFromFindings(findings as never);
+	}
+
+	const DRIFT_ONLY = [
+		{
+			category: 'subdomain_takeover',
+			title: 'Dangling CNAME operational drift : blog.openai.com → d2b532lzynlqb7.cloudfront.net',
+			severity: 'medium',
+			detail: 'CNAME target does not resolve.',
+		},
+	];
+
+	const REAL_OPENAI = [
+		{
+			category: 'subdomain_takeover',
+			title: 'Subdomain possible takeover signal Azure CDN',
+			severity: 'high',
+			detail: 'Azure CDN endpoint signature observed.',
+		},
+		...DRIFT_ONLY,
+	];
+
+	it('does not promote a medium operational-drift finding to a critical path', async () => {
+		const path = (await paths(DRIFT_ONLY)).find((p) => p.id === 'subdomain_takeover');
+		expect(path, 'the path should still be reported').toBeDefined();
+		expect(path!.severity, 'a medium finding must not render the domain critical').toBe('medium');
+	});
+
+	it('does not claim the resource is unclaimed when only drift was observed', async () => {
+		const path = (await paths(DRIFT_ONLY)).find((p) => p.id === 'subdomain_takeover');
+		expect(
+			path!.prerequisites,
+			'"unclaimed" asserts attacker-registrability, which a drift finding does not establish',
+		).not.toContain('Dangling CNAME pointing to unclaimed resource');
+		expect(path!.prerequisites.length).toBeGreaterThan(0);
+	});
+
+	it('caps the real openai.com evidence set at high, not critical', async () => {
+		const path = (await paths(REAL_OPENAI)).find((p) => p.id === 'subdomain_takeover');
+		expect(path!.severity, 'strongest underlying finding was high').toBe('high');
+	});
+
+	it('still reports critical when the evidence itself is critical', async () => {
+		// Control: the fix must not disarm a genuine critical takeover.
+		const path = (
+			await paths([
+				{
+					category: 'subdomain_takeover',
+					title: 'Subdomain takeover confirmed',
+					severity: 'critical',
+					detail: 'Target bucket is unregistered and claimable.',
+				},
+			])
+		).find((p) => p.id === 'subdomain_takeover');
+		expect(path!.severity).toBe('critical');
+	});
+});
+
+/**
+ * #788 — `email_spoof_subdomain` is a DEAD path: it fired for 0 of 16 domains,
+ * including the two whose org policy is `p=none`.
+ *
+ * Mirror image of #782. That bug matched prose that meant the opposite; this
+ * one FAILS to match for the same reason. `isDmarcSubdomainWeak`'s third clause
+ * is `!d.includes('sp=') && d.includes('p=none')`, and check_dmarc's detail for
+ * a MISSING subdomain policy reads:
+ *
+ *   "No subdomain policy (sp=) specified. Subdomains inherit the "none" policy,
+ *    which provides no protection against spoofing."
+ *
+ * `sp=` occurs as a substring precisely BECAUSE the tag is absent, so
+ * `!d.includes('sp=')` is false and the clause can never fire. The literal
+ * `p=none` is not in the detail either — the policy is named as `"none"`.
+ *
+ * Measured 2026-08-26 on moonshot.ai (DMARC p=none, spoofability 59): the
+ * scanner said subdomains have "no protection against spoofing" and the
+ * simulator reported no subdomain-spoofing path at all. A missing HIGH finding
+ * on the most spoofable domain in the sweep.
+ *
+ * The discriminator is the INHERITED POLICY, not the presence of the sp= tag:
+ * inheriting "reject" is fine, inheriting "none" is not.
+ */
+describe('#788 email_spoof_subdomain fires on an inherited none policy', () => {
+	async function paths(findings: unknown[]) {
+		const { evaluateAttackPathsFromFindings } = await import('../src/tools/simulate-attack-paths');
+		return evaluateAttackPathsFromFindings(findings as never);
+	}
+
+	it('fires when subdomains inherit a none policy (real moonshot.ai finding)', async () => {
+		const result = await paths([
+			{
+				category: 'dmarc',
+				title: 'Subdomains inherit p=none policy',
+				severity: 'info',
+				detail:
+					'No subdomain policy (sp=) specified. Subdomains inherit the "none" policy, which provides no protection against spoofing.',
+			},
+		]);
+		expect(
+			result.find((p) => p.id === 'email_spoof_subdomain'),
+			'subdomains inheriting p=none are spoofable',
+		).toBeDefined();
+	});
+
+	it('does NOT fire when subdomains inherit an enforcing policy (real openai.com finding)', async () => {
+		// Control: the same "No subdomain policy (sp=)" prose, but inheriting reject.
+		const result = await paths([
+			{
+				category: 'dmarc',
+				title: 'No subdomain policy',
+				severity: 'low',
+				detail:
+					'No subdomain policy (sp=) specified. Subdomains inherit the main policy ("reject"), but explicitly setting sp= is recommended.',
+			},
+		]);
+		expect(
+			result.find((p) => p.id === 'email_spoof_subdomain'),
+			'inheriting reject is not a subdomain weakness',
+		).toBeUndefined();
+	});
+
+	it('still fires on an explicit sp=none', async () => {
+		const result = await paths([
+			{ category: 'dmarc', title: 'Subdomain policy is none', severity: 'medium', detail: 'Record sets sp=none.' },
+		]);
+		expect(result.find((p) => p.id === 'email_spoof_subdomain')).toBeDefined();
+	});
+
+	it('still fires when DMARC is absent entirely', async () => {
+		const result = await paths([
+			{ category: 'dmarc', title: 'No DMARC record', severity: 'high', detail: 'No DMARC record published.' },
+		]);
+		expect(result.find((p) => p.id === 'email_spoof_subdomain')).toBeDefined();
+	});
+});


### PR DESCRIPTION
Closes #787. Closes #788.

Both are the **#782 family** — a path whose emitted claim does not match the findings it reasons from — and neither is covered by `0638d28d`. Both reproduce on `origin/main`. Found while sweeping 16 large AI providers with the full tool set.

## #787 — `subdomain_takeover` over-claimed, twice

**Severity was hardcoded `critical`** while `hasSubdomainTakeoverRisk` accepts `medium|high|critical`. `overallRisk` is just the most severe feasible path, so **one medium finding rendered a whole domain critical**. On `openai.com` the `[medium] Dangling CNAME operational drift` finding produced the only `critical` verdict in the entire 16-domain run.

**The prerequisite asserted the target was "unclaimed"** — i.e. registrable by an attacker. `blog.openai.com` → `d2b532lzynlqb7.cloudfront.net` returns NOERROR/NODATA on two independent public resolvers, so it *is* genuinely dangling. But CloudFront distribution IDs are assigned by AWS and cannot be chosen, so it is **not claimable**. The scanner already encoded that distinction in the severity it assigned; the simulator discarded it.

## #788 — `email_spoof_subdomain` never fired, on any of 16 domains

The clause was `!d.includes('sp=') && d.includes('p=none')`. `check_dmarc`'s detail for a *missing* subdomain policy is:

> `No subdomain policy (sp=) specified. Subdomains inherit the "none" policy, ...`

`sp=` is present as a substring **precisely because the tag is absent**, so the clause could never fire. It only ever matched by accident via the unrelated `np=none` finding — which is what kept the #564 test green.

`moonshot.ai` publishes a bare `v=DMARC1; p=none;`. Its own finding says subdomains have *"no protection against spoofing"*, and no path was emitted.

The discriminator is **the policy subdomains inherit**, not whether an `sp=` tag exists — both of these emit identical `"No subdomain policy (sp=)"` prose:

| record | inherited | spoofable? |
|---|---|---|
| `p=reject` (no `sp=`) | reject | no |
| `p=none` (no `sp=`) | none | **yes** |

## Verification

- **8 new tests.** 4 are RED on `origin/main` before the change and green after. The other 4 are **controls** — a genuinely `critical` takeover still reports `critical`; inheriting `reject` does not fire; explicit `sp=none` fires; absent DMARC fires — and are green *both* before and after, so neither fix simply disarms its path.
- The **#564 and #782 regression tests stay green**; #564 now matches on the intended evidence rather than by accident.
- **Replayed over the real captured findings for all 16 domains:** `openai.com` `critical` → `high`; `moonshot.ai` gains `email_spoof_subdomain` and is the only one that does; `cert_misissuance` fires on exactly the 9 domains with no CAA RRset and none of the 7 with one, matching `dig CAA` on two independent resolvers.
- Full `npm test`: **7925 passed, 13 skipped, 0 failed.** `tsc --noEmit` and `eslint` clean.

> ⚠️ `npm test` needs `npm run build` first — the root `test/` tree runs the built `dist/`, and a stale `dist` fails 12 scoring/version-stamp specs unrelated to this change.

## Out of scope

- **#786** — production runs a build older than the #782 fix. Every live CAA/XFO false positive traces to that, not to code. Needs a deploy.
- **#789** — `check_dmarc` emits no subdomain finding *at all* for `p=none` + `sp=none` (`huggingface.co`, the worst spoofability in the sweep at 73). The fix lands in the vendored scoring SSOT and would shift grades, break the parity contracts in bv-web-prod and need a `SCORING_MODEL_VERSION` bump — filed for adjudication, deliberately not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)