### PR TITLE
Release v3.67.0: correct DNSSEC, DKIM, and DMARC evidence

### DIFF
--- a/.github/workflows/registry-drift-check.yml
+++ b/.github/workflows/registry-drift-check.yml
@@ -9,12 +9,9 @@ name: Registry Drift Check
 # no write call to the registry of any kind. It only reads two public
 # endpoints and opens/updates/closes a GitHub issue.
 #
-# Context (2026-08-23): the drift is not simply "someone forgot the manual
-# step". publish.yml's `Publish to MCP Registry` / `Publish to npm` jobs sit
-# behind the `production` environment's reviewer-approval gate — the v3.63.0
-# run has been PARKED in `waiting` for two days, and the v3.60.0-v3.62.0 runs
-# all completed with `failure`. The issue body below tells the reader to
-# check for a parked/failed publish.yml run before falling back to the
+# Context (2026-08-26): publish.yml validates a release tag and creates the
+# GitHub Release, but it no longer contains publish jobs. Publishing is an
+# operator-run step. The issue body below points directly to the authoritative
 # manual `npm run publish:registry` path from a worktree pinned to the tag.
 #
 # No `uses:` actions anywhere in this file — curl/jq/gh are preinstalled on
@@ -150,20 +147,15 @@ jobs:
             "- Live \`serverInfo.version\` (dns-mcp.blackveilsecurity.com): \`${LIVE_VERSION}\`" \
             "- Registry \`?version=latest\` (registry.modelcontextprotocol.io): \`${REGISTRY_VERSION}\`" \
             "" \
-            "**Before republishing by hand, check whether \`publish.yml\` already ran for" \
-            "\`v${LIVE_VERSION}\` and is PARKED or FAILED:**" \
+            "Publishing is operator-run. \`publish.yml\` validates the tag and creates" \
+            "the GitHub Release only; it does not publish to the MCP Registry." \
             "" \
-            "1. \`gh run list --workflow=publish.yml --repo ${REPO}\` - look for a run" \
-            "   against tag \`v${LIVE_VERSION}\`." \
-            "2. If it is **waiting** on the \`production\` environment reviewer gate" \
-            "   (the \`Publish to MCP Registry\` / \`Publish to npm\` jobs), approve it" \
-            "   there - that is the normal path." \
-            "3. If it already **failed**, read the job logs before doing anything by" \
-            "   hand." \
-            "4. Only if no publish.yml run exists for this tag, or a manual path is" \
-            "   genuinely needed, ship from a fresh worktree pinned to the" \
-            "   \`v${LIVE_VERSION}\` tag: \`npm run publish:registry\` (see CLAUDE.md," \
-            "   \"Manual release fallback\")." \
+            "1. Confirm the \`v${LIVE_VERSION}\` tag identifies the deployed release." \
+            "2. From a fresh worktree pinned to that exact tag, follow CLAUDE.md" \
+            "   (\"Release\") and run \`npm run publish:registry\`. The integrity gate" \
+            "   deliberately refuses a dirty or untagged checkout." \
+            "3. Query the Registry with a cache-buster and verify it reports" \
+            "   \`${LIVE_VERSION}\` before closing this issue." \
             "" \
             "This workflow never publishes anything itself - detection only." \
             "" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.67.0] - 2026-08-26
+
+**Scoring-model change.** `SCORING_MODEL_VERSION` 1.13.0 → **1.14.0** and `@blackveil/dns-checks` 1.24.0 → **1.25.0** (`PARITY_CORPUS_VERSION` in lockstep). DNSSEC and DKIM results can move downward for the affected evidence shapes; the DMARC evidence correction is score-neutral. Full rationale is recorded in `src/lib/scoring-version.ts`.
+
+### Fixed
+
+- **DNSSEC no longer treats a resolver's AD flag as proof that an unsigned or broken zone validates** (#793). `AD=true` with neither DNSKEY nor DS now returns the canonical unsigned score of 60 instead of a 100-point "cryptographically verified" pass. A parent DS without a child DNSKEY is now an explicit broken chain with score 0. `controlPresent` requires AD + DNSKEY + DS, and source attribution reuses that canonical evidence rather than issuing a second, potentially inconsistent DNS read.
+- **The bounded DKIM probe list now includes the measured `resend` selector** (#774). A weak key published there can no longer hide behind another sender's healthy key; detected legacy RSA receives the existing high-severity finding and penalty. Synthetic multi-sender coverage pins the aggregate result.
+- **Explicit `p=none; sp=none` DMARC policies now emit subdomain evidence** (#789). The new informational finding is deliberately score-neutral relative to inherited `p=none`, but restores the evidence consumed by `simulate_attack_paths` so the most permissive subdomain posture is no longer silent.
+
+### Changed
+
+- **M365 tool descriptions now match the implemented seams** (#417, #759). `query_signins`, `get_ca_policies`, and `assess_coverage` are labelled live-capable but not production-verified and retain per-response `representative` semantics. `query_ual` remains sample-only while naming Microsoft Graph's Purview Audit Search API as the supported future live source; that asynchronous integration is not implemented yet.
+- **Registry-drift remediation now points to the actual operator-run publish path** (#792). The tag workflow validates and creates the GitHub Release only; it does not publish to the MCP Registry. Drift issues now direct operators to `npm run publish:registry` from the exact release tag and require cache-busted verification.
+
+### Known
+
+- npm publication remains intentionally blocked pending replacement credentials (#719).
+- Real-tenant production verification of the M365 live paths remains outstanding (#417), and `query_ual` still needs its asynchronous Purview integration (#759).
+
 ## [3.66.0] - 2026-08-26
 
 **No scoring-model change.** `SCORING_MODEL_VERSION` is unchanged and `@blackveil/dns-checks` stays at **1.24.0** — no check, weight, threshold or grade band moves, and no domain is re-graded. `simulate_attack_paths` output does change: one path drops in severity, another starts firing where it never did.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.66.0",
+	"version": "3.67.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.66.0",
+			"version": "3.67.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"
@@ -5163,7 +5163,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.24.0",
+			"version": "1.25.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.66.0",
+	"version": "3.67.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.24.0",
+	"version": "1.25.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
@@ -32,6 +32,19 @@ describe('checkDNSSEC', () => {
 		expect(absent?.metadata?.missingControl).toBeUndefined();
 	});
 
+	it('does not accept AD=true without DNSKEY and DS as a validated zone', async () => {
+		const queryDNS = createMockDNS({});
+		const rawQueryDNS: RawDNSQueryFunction = vi.fn(async () => ({ AD: true }));
+
+		const result = await checkDNSSEC('example.com', queryDNS, { rawQueryDNS });
+
+		expect(result.findings.some((f) => f.title === 'DNSSEC not enabled')).toBe(true);
+		expect(result.findings.some((f) => f.title === 'DNSSEC enabled and validated')).toBe(false);
+		expect(result.score).toBe(60);
+		expect(result.recordPresent).toBe(false);
+		expect(result.controlPresent).toBe(false);
+	});
+
 	it('reports chain of trust incomplete when DNSKEY present but no DS', async () => {
 		// Return DNSKEY from first call, empty from second (DS)
 		const mockDNS: DNSQueryFunction = vi.fn(async (_domain: string, type: string) => {
@@ -41,6 +54,30 @@ describe('checkDNSSEC', () => {
 		const rawQueryDNS: RawDNSQueryFunction = vi.fn(async () => ({ AD: false }));
 		const result = await checkDNSSEC('example.com', mockDNS, { rawQueryDNS });
 		expect(result.findings.some((f) => f.title === 'DNSSEC chain of trust incomplete')).toBe(true);
+	});
+
+	it('reports a broken chain when AD=true and a parent DS exists without a child DNSKEY', async () => {
+		const mockDNS: DNSQueryFunction = vi.fn(async (_domain: string, type: string) => {
+			if (type === 'DS') return ['12345 13 2 abcdef...'];
+			return [];
+		});
+		const rawQueryDNS: RawDNSQueryFunction = vi.fn(async () => ({ AD: true }));
+
+		const result = await checkDNSSEC('example.com', mockDNS, { rawQueryDNS });
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					title: 'DNSSEC chain of trust incomplete',
+					severity: 'high',
+					metadata: expect.objectContaining({ missingControl: true }),
+				}),
+			]),
+		);
+		expect(result.findings.some((f) => f.title === 'DNSSEC enabled and validated')).toBe(false);
+		expect(result.score).toBe(0);
+		expect(result.recordPresent).toBe(true);
+		expect(result.controlPresent).toBe(false);
 	});
 
 	it('reports DNSSEC enabled and validated when all checks pass', async () => {

--- a/packages/dns-checks/src/__tests__/checks/dkim-selector-coverage.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dkim-selector-coverage.test.ts
@@ -3,8 +3,8 @@
 /**
  * Provider coverage guard for the DKIM selector probe list.
  *
- * Every selector asserted here was confirmed by a live Cloudflare DoH probe on
- * 2026-08-06 against a real domain (named per case). The list is a heuristic —
+ * Every selector asserted here was confirmed by a live Cloudflare DoH probe
+ * against a real evidence domain (named per case). The list is a heuristic —
  * a miss hard-floors the dkim category at 50 — so each provider gets a
  * regression test proving the default probe path finds a key published ONLY at
  * that provider's selector.
@@ -23,6 +23,8 @@ import type { DNSQueryFunction } from '../../types';
 const VALID_KEY = 'v=DKIM1; k=rsa; p=' + 'A'.repeat(392);
 /** SendGrid-family records omit v=DKIM1 by design (RFC 6376 §3.6.1 tolerates it). */
 const NO_VERSION_KEY = 'k=rsa; t=s; p=' + 'A'.repeat(392);
+/** Synthetic Resend-shaped direct-TXT 1024-bit RSA key without a v= tag. */
+const RESEND_LEGACY_KEY = 'p=MI' + 'GfMA0GCSqGSIb3DQEBAQUAA4GNADCB' + 'A'.repeat(184);
 
 function dnsFor(txt: Record<string, string[]>, cname: Record<string, string> = {}): DNSQueryFunction {
 	function resolveTxt(name: string, depth = 0): string[] {
@@ -36,7 +38,7 @@ function dnsFor(txt: Record<string, string[]>, cname: Record<string, string> = {
 	});
 }
 
-/** Each row verified by a live Cloudflare DoH probe on 2026-08-06. */
+/** Original rows verified 2026-08-06; Resend reverified 2026-08-26. */
 const MEASURED_COVERAGE = [
 	{ provider: 'Fastmail', selector: 'fm1', record: VALID_KEY, evidence: 'fastmail.com' },
 	{ provider: 'Fastmail', selector: 'fm2', record: VALID_KEY, evidence: 'fastmail.com' },
@@ -54,6 +56,7 @@ const MEASURED_COVERAGE = [
 	{ provider: 'Zendesk', selector: 'zendesk1', record: VALID_KEY, evidence: 'mailchimp.com' },
 	{ provider: 'Zendesk', selector: 'zendesk2', record: VALID_KEY, evidence: 'mailchimp.com' },
 	{ provider: 'Mailjet', selector: 'mailjet', record: NO_VERSION_KEY, evidence: 'mailgun.com' },
+	{ provider: 'Resend', selector: 'resend', record: RESEND_LEGACY_KEY, evidence: 'resend.com' },
 ];
 
 describe('DKIM selector coverage (default probe list)', () => {
@@ -84,6 +87,26 @@ describe('DKIM selector coverage (default probe list)', () => {
 	it('CONTROL: a total miss still hard-floors the category at 50', async () => {
 		const result = await checkDKIM('example.com', dnsFor({}));
 		expect(result.score).toBe(50);
+	});
+
+	it('surfaces a weak Resend key alongside a healthy listed sender', async () => {
+		const result = await checkDKIM(
+			'example.com',
+			dnsFor({
+				's1._domainkey.example.com': [VALID_KEY],
+				'resend._domainkey.example.com': [RESEND_LEGACY_KEY],
+			}),
+		);
+
+		expect(result.findings).toEqual(
+			expect.arrayContaining([
+				expect.objectContaining({
+					severity: 'high',
+					title: 'Legacy RSA key: resend',
+				}),
+			]),
+		);
+		expect(result.score).toBe(60);
 	});
 });
 

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -127,7 +127,7 @@ export async function checkDNSSEC(
 	}
 
 	// Consolidated finding logic
-	if (!adFlag && dnskeyRecords.length === 0 && dsRecords.length === 0) {
+	if (dnskeyRecords.length === 0 && dsRecords.length === 0) {
 		// Fully absent — HIGH severity, but the SCORE penalty is decoupled to −40 via
 		// `penaltyOverride`. NIST SP 800-81r3 (Mar 2026) makes DNSSEC a baseline
 		// deployment goal and RFC 9364 (BCP 237) states origin-authentication via DNSSEC
@@ -158,6 +158,19 @@ export async function checkDNSSEC(
 				'DNSSEC chain of trust incomplete',
 				'high',
 				`DNSKEY records are published for ${target} but no DS records exist in the parent zone. The chain of trust is broken — DNSSEC validation will fail.`,
+				{ missingControl: true },
+			),
+		);
+	} else if (dnskeyRecords.length === 0 && dsRecords.length > 0) {
+		// Parent DS published but the child DNSKEY is absent — also a broken chain.
+		// A validating resolver cannot match the delegation to a zone key, regardless
+		// of a transient/cached AD observation, so this must never become a clean pass.
+		findings.push(
+			createFinding(
+				'dnssec',
+				'DNSSEC chain of trust incomplete',
+				'high',
+				`DS records are published for ${target} in the parent zone but no DNSKEY records are available from the child zone. The chain of trust is broken — DNSSEC validation will fail.`,
 				{ missingControl: true },
 			),
 		);
@@ -238,8 +251,9 @@ export async function checkDNSSEC(
 	//   | published but BROKEN/bogus     | true          | false          |
 	//   | signed and validating          | true          | true           |
 	//
-	// A zone validating with no DNSKEY/DS of its own (registry/TLD-signed) reads
-	// false/true — which is exactly that state, not a contradiction.
+	// The AD flag alone never makes an unsigned zone's control present. A secure
+	// delegation requires both the child DNSKEY and parent DS; this also prevents a
+	// resolver's transient AD=true response from becoming an affirmative safety claim.
 	//
 	// Score-neutral by construction: `buildCheckResult` only copies these onto the result,
 	// and `detectDomainContext` reads `controlPresent` for mx/ssl/caa/dkim/mta_sts/bimi/dmarc
@@ -249,7 +263,7 @@ export async function checkDNSSEC(
 	const recordPresent = anyDnssecRecordObserved ? true : dnskeyQueryFailed || dsQueryFailed ? undefined : false;
 	// The AD flag is only an observation when a raw resolver was actually available to ask;
 	// without `rawQueryDNS` the local `adFlag` is a default-false placeholder, not a measurement.
-	const controlPresent = rawQueryDNS ? adFlag : undefined;
+	const controlPresent = rawQueryDNS ? adFlag && dnskeyRecords.length > 0 && dsRecords.length > 0 : undefined;
 
 	return buildCheckResult('dnssec', findings, controlPresent, recordPresent);
 }

--- a/packages/dns-checks/src/checks/dkim-selectors.ts
+++ b/packages/dns-checks/src/checks/dkim-selectors.ts
@@ -72,6 +72,8 @@ export const COMMON_DKIM_SELECTORS: readonly string[] = [
 	'scph0322',
 	// Postmark
 	'pm',
+	// Resend (provider-published direct TXT, no v= tag)
+	'resend',
 	// --- Added 2026-08-06, each confirmed by a live DoH probe (evidence domain
 	// in parentheses). Regression-guarded by dkim-selector-coverage.test.ts. ---
 	// Fastmail (fastmail.com published NOTHING at any pre-existing selector —

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.24.0';
+export const PARITY_CORPUS_VERSION = '1.25.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):
@@ -594,6 +594,17 @@ export const DNSSEC_PARITY_FIXTURES: DnssecParityFixture[] = [
 	},
 	{
 		check: 'dnssec',
+		name: 'AD flag without DNSKEY/DS remains unsigned',
+		domain: 'example.com',
+		ad: true,
+		dnskey: [],
+		ds: [],
+		nsec3param: [],
+		expectedScore: 60,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dnssec',
 		name: 'valid + DNSSEC (ECDSA P-256)',
 		domain: 'example.com',
 		ad: true,
@@ -621,6 +632,17 @@ export const DNSSEC_PARITY_FIXTURES: DnssecParityFixture[] = [
 		ad: false,
 		dnskey: ['257 3 13 AwEAAabc'],
 		ds: [],
+		nsec3param: [],
+		expectedScore: 0,
+		expectedMissingControl: true,
+	},
+	{
+		check: 'dnssec',
+		name: 'broken chain (DS, no DNSKEY, AD on — BOGUS)',
+		domain: 'example.com',
+		ad: true,
+		dnskey: [],
+		ds: ['12345 13 2 abc123'],
 		nsec3param: [],
 		expectedScore: 0,
 		expectedMissingControl: true,

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 import { describe, expect, it } from 'vitest';
 import { appendDmarcCleanInfo, classifyDmarc } from './dmarc';
+import { computeCategoryScore } from '../model';
 
 const base = { recordCount: 1 } as const;
 
@@ -52,6 +53,18 @@ describe('classifyDmarc', () => {
 	it('flags weak subdomain policy as high when np is absent (DMARCbis)', () => {
 		const f = classifyDmarc({ recordCount: 1, policy: 'reject', sp: 'none', rua: 'mailto:dmarc@example.com' });
 		expect(f.find((x) => x.title === 'Subdomain policy weaker than parent policy')?.severity).toBe('high');
+	});
+
+	it('reports explicit p=none + sp=none without penalising the same posture twice', () => {
+		const explicit = classifyDmarc({ ...base, policy: 'none', sp: 'none' });
+		const inherited = classifyDmarc({ ...base, policy: 'none' });
+		const finding = explicit.find((x) => x.title === 'Subdomain policy set to none');
+
+		expect(finding).toBeDefined();
+		expect(finding?.severity).toBe('info');
+		expect(finding?.detail).toContain('sp=none');
+		expect(explicit.filter((x) => x.title === 'DMARC policy set to none')).toHaveLength(1);
+		expect(computeCategoryScore(explicit, 'dmarc')).toBe(computeCategoryScore(inherited, 'dmarc'));
 	});
 
 	it('flags invalid policy value as high', () => {

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -217,6 +217,15 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 					`DMARC subdomain policy value "${sp}" is invalid. Allowed values are none, quarantine, or reject.`,
 				),
 			);
+		} else if (policy === 'none' && sp === 'none') {
+			findings.push(
+				createFinding(
+					'dmarc',
+					'Subdomain policy set to none',
+					'info',
+					'DMARC subdomain policy is set to "none" (sp=none), so subdomains have no enforcement against spoofing. Set sp=quarantine or sp=reject to enforce DMARC on subdomains.',
+				),
+			);
 		} else if (policy === 'reject' && sp === 'none') {
 			findings.push(
 				createFinding(

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.66.0",
+	"version": "3.67.0",
 	"remotes": [
 		{
 			"type": "streamable-http",

--- a/src/lib/control-presence.ts
+++ b/src/lib/control-presence.ts
@@ -26,13 +26,12 @@ import { isCategoryNonApplicable } from '../tools/scan/format-report';
  * http_security never set it) or that the query failed, and absence of a signal is
  * not evidence of absence.
  *
- * `recordPresent === false` is NOT sufficient on its own. `check-dnssec` documents
- * a legitimate `recordPresent: false` + `controlPresent: true` state: a zone that
- * validates while publishing no DNSKEY/DS of its own, because its ccTLD registry
- * signed it. That zone IS cryptographically protected, so failing it on missing
- * records would trade a false PASS for a false FAIL. An affirmative
- * `controlPresent` therefore REBUTS the absence, and only unrebutted evidence of
- * absence disqualifies.
+ * `recordPresent === false` is NOT sufficient on its own for every current or
+ * external producer. A check may have independent affirmative evidence that a
+ * control is active even when its record-presence probe reports false, and legacy
+ * persisted results may carry that split signal. An explicit `controlPresent: true`
+ * therefore REBUTS the absence. The current DNSSEC check itself no longer emits
+ * that pair: after #793 it requires AD + DNSKEY + DS before asserting presence.
  */
 export function isUnrebuttedAbsence(result: CheckResult): boolean {
 	return result.recordPresent === false && result.controlPresent !== true;

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -232,8 +232,20 @@
  *   Also declared (`missingControl: true`) on the DMARC no-record finding — behaviour-neutral,
  *   the prose already zeroed; the flag makes the intent survive a reword. `SEVERITY_PENALTIES`,
  *   weights, tiers, grade bands and profile detection are all untouched.
+ * - 1.14.0 — two previously-unmeasured email/DNS defects now affect category scores using
+ *   existing penalties. (a) DNSSEC can no longer treat a resolver's AD flag as proof that an
+ *   unsigned zone is protected: a validated pass now requires both a child DNSKEY and a parent
+ *   DS. The affected shape (AD=true with neither record) moves DOWN from 100 to the canonical
+ *   unsigned-zone score of 60 and no longer emits an affirmative cryptographic-verification
+ *   claim. (b) The measured `resend` DKIM selector joins the bounded default probe list, so a
+ *   weak key that was previously hidden behind another sender's healthy key now receives the
+ *   existing legacy-RSA finding and penalty. Affected domains can move DOWN from a clean pass;
+ *   no severity, weight, tier, grade band, missing-control rule or profile-detection rule
+ *   changed. The DMARC `p=none; sp=none` correction shipped in the same package is explicitly
+ *   score-neutral (its new finding is `info`) but restores the evidence consumed by attack-path
+ *   analysis. Affected population for all three shapes is unmeasured against the corpus.
  */
-export const SCORING_MODEL_VERSION = '1.13.0';
+export const SCORING_MODEL_VERSION = '1.14.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -756,7 +756,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	query_signins: {
 		description:
-			'SAMPLE DATA ONLY — this tool has no live Microsoft Graph read path yet, so every response is illustrative and must NOT be used to investigate a real incident or answer a question about actual tenant activity; the `representative: true` field marks it on each response. Query Microsoft Entra sign-in logs for a tenant. Optionally filter by user principal name, failure status, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
+			'LIVE PATH NOT YET PRODUCTION-VERIFIED — check the `representative` field on every response: `true` is sample/fallback data and must NOT be used to investigate a real incident, while `false` means the upstream Microsoft Graph read succeeded for that tenant. Query Microsoft Entra sign-in logs for a tenant. Optionally filter by user principal name, failure status, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
 		schema: QuerySigninsArgs,
 		group: 'identity_secops',
 		tier: 'protective',
@@ -764,7 +764,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	query_ual: {
 		description:
-			'SAMPLE DATA ONLY — this tool has no live read path and may never gain one (Microsoft Graph exposes no direct Unified Audit Log equivalent; see issue #759), so every response is illustrative and must NOT be used to investigate a real incident; the `representative: true` field marks it on each response. Query the Microsoft 365 Unified Audit Log for a tenant. Optionally filter by operation type, user, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
+			'SAMPLE DATA ONLY — this tool has no live read path yet, so every response is illustrative and must NOT be used to investigate a real incident; the `representative: true` field marks it on each response. Microsoft Graph now exposes the Purview Audit Search API as the intended live source, but integration is not yet implemented (see issue #759). Query the Microsoft 365 Unified Audit Log for a tenant. Optionally filter by operation type, user, or lookback window. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
 		schema: QueryUalArgs,
 		group: 'identity_secops',
 		tier: 'protective',
@@ -772,7 +772,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	get_ca_policies: {
 		description:
-			'Retrieve Conditional Access policies for a Microsoft Entra tenant. Requires m365Proxy service binding; returns { unprovisioned: true } when absent. A `representative` field in the response marks each call: `true` for sample (non-live) data, `false` once a live Microsoft Graph read succeeded for that tenant — check it per-response rather than assuming one or the other.',
+			'LIVE PATH NOT YET PRODUCTION-VERIFIED — check the `representative` field on every response: `true` is sample/fallback data, while `false` means the upstream Microsoft Graph read succeeded for that tenant. Retrieve Conditional Access policies for a Microsoft Entra tenant. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
 		schema: GetCaPoliciesArgs,
 		group: 'identity_secops',
 		tier: 'protective',
@@ -780,7 +780,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	assess_coverage: {
 		description:
-			'SAMPLE DATA ONLY — this tool has no live Microsoft Graph read path yet, so the gaps it reports are illustrative and must NOT be treated as a real assessment of a tenant\'s Conditional Access posture; the `representative: true` field marks it on each response. Assess Conditional Access coverage gaps for a Microsoft Entra tenant — identifies users and apps not protected by any enforced policy. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
+			'LIVE PATH NOT YET PRODUCTION-VERIFIED — check the `representative` field on every response: `true` is sample/fallback data and must NOT be treated as a real assessment, while `false` means the upstream Microsoft Graph read succeeded for that tenant. Respect any `users_not_assessed` or truncation indicators before drawing coverage conclusions. Assess Conditional Access coverage gaps for a Microsoft Entra tenant. Requires m365Proxy service binding; returns { unprovisioned: true } when absent.',
 		schema: AssessCoverageArgs,
 		group: 'identity_secops',
 		tier: 'protective',

--- a/src/tools/check-dnssec.ts
+++ b/src/tools/check-dnssec.ts
@@ -7,7 +7,7 @@
 
 import { checkDNSSEC } from '@blackveil/dns-checks';
 import type { ZoneContext } from '@blackveil/dns-checks';
-import { queryDns, queryDnsRecords, DnsQueryError } from '../lib/dns';
+import { queryDns, DnsQueryError } from '../lib/dns';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import { resolveZoneApex } from '../lib/zone-apex';
 import type { QueryDnsOptions } from '../lib/dns-types';
@@ -45,35 +45,18 @@ async function confirmAdWithGoogle(domain: string, timeoutMs = AD_CONFIRM_TIMEOU
 }
 
 /**
- * Augment a DNSSEC check result with dnssecSource metadata.
- * Queries DNSKEY/DS records to determine whether DNSSEC is domain-configured or TLD-inherited.
+ * Augment a validated DNSSEC result with source metadata.
+ *
+ * The shared check's structured presence flags are the source of truth: after #793,
+ * `controlPresent: true` requires AD + DNSKEY + DS. Re-querying those records here
+ * duplicated network work and could mislabel a transient/partial second observation as
+ * TLD-inherited, so source attribution is derived from the completed check instead.
  */
-async function augmentWithSource(domain: string, baseResult: CheckResult, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
-	const [dnskeyResult, dsResult] = await Promise.allSettled([
-		queryDnsRecords(domain, 'DNSKEY', dnsOptions),
-		queryDnsRecords(domain, 'DS', dnsOptions),
-	]);
 
-	const hasDnskey = dnskeyResult.status === 'fulfilled' && dnskeyResult.value.length > 0;
-	const hasDs = dsResult.status === 'fulfilled' && dsResult.value.length > 0;
-	const dnssecSource = hasDnskey && hasDs ? 'domain_configured' : 'tld_inherited';
+function augmentWithSource(domain: string, baseResult: CheckResult): CheckResult {
+	if (baseResult.controlPresent !== true || baseResult.recordPresent !== true) return baseResult;
 
-	if (dnssecSource === 'tld_inherited') {
-		const inheritedFinding = createFinding(
-			'dnssec',
-			'DNSSEC inherited from TLD',
-			'info',
-			`DNSSEC validation passes but ${domain} does not have its own DNSKEY or DS records. DNSSEC protection is inherited from the TLD registry, not configured by the domain owner.`,
-			{ dnssecSource: 'tld_inherited' },
-		);
-		// Carry the core's presence flags through verbatim. `augmentWithSource` only ever
-		// relabels findings — it re-derives no observation — so dropping them here would
-		// silently erase the dnssec adoption signal on exactly the SIGNED paths, which are
-		// the ones a consumer most needs to tell apart from the 60-scoring unsigned zone.
-		return buildCheckResult('dnssec', [...baseResult.findings, inheritedFinding], baseResult.controlPresent, baseResult.recordPresent);
-	}
-
-	// domain_configured — never tag the non-apex attribution note: that finding describes
+	// Never tag the non-apex attribution note: that finding describes
 	// the scanned label's inheritance relationship, while this metadata describes the
 	// evaluated zone apex. Tag the first actual DNSSEC verdict/audit finding instead.
 	const sourceCarrierIndex = baseResult.findings.findIndex((finding) => finding.title !== 'DNSSEC posture inherited from zone apex');
@@ -100,7 +83,7 @@ async function augmentWithSource(domain: string, baseResult: CheckResult, dnsOpt
  * Check DNSSEC configuration for a domain.
  * Verifies the AD (Authenticated Data) flag, checks for DNSKEY/DS records,
  * and audits algorithm and digest type security.
- * Augments results with dnssecSource metadata: 'domain_configured' or 'tld_inherited'.
+ * Augments validated results with `dnssecSource: 'domain_configured'` metadata.
  *
  * When the primary resolver reports AD=false but DNSKEY+DS records exist ("validation failing"),
  * fires a confirmation probe to Google DoH. If Google says AD=true (edge flap), re-runs the
@@ -167,13 +150,13 @@ export async function checkDnssec(domain: string, dnsOptions?: QueryDnsOptions, 
 					},
 				},
 			) as CheckResult;
-			return augmentWithSource(dnssecTarget, correctedResult, dnsOptions);
+			return augmentWithSource(dnssecTarget, correctedResult);
 		}
 		// Google also says AD=false (or failed) — keep the original finding
 		return baseResult;
 	}
 
-	return augmentWithSource(dnssecTarget, baseResult, dnsOptions);
+	return augmentWithSource(dnssecTarget, baseResult);
 	} catch (err) {
 		if (err instanceof DnsQueryError) {
 			const message = err.message;

--- a/src/tools/compare-baseline.ts
+++ b/src/tools/compare-baseline.ts
@@ -106,9 +106,10 @@ function gradeWorseThan(actual: string, minimum: string): boolean {
  * while the same scan raised a high-severity "DNSSEC not enabled".
  *
  * `isSatisfiedControl` is the SHARED predicate `map_compliance` grades on — including
- * its registry-signed rebuttal, without which this would fail a ccTLD-signed zone that
- * is genuinely protected. A missing `CheckResult` is unchanged: no evidence the control
- * is in effect, so a rule requiring it is not met.
+ * its generic affirmative-control rebuttal for split-signal or legacy results. The
+ * current DNSSEC check requires AD + DNSKEY + DS and does not emit a false/true pair.
+ * A missing `CheckResult` is unchanged: no evidence the control is in effect, so a
+ * rule requiring it is not met.
  */
 function categorySatisfied(scan: ScanDomainResult, category: CheckCategory): boolean {
 	const check = scan.checks.find((value) => value.category === category);

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -70,7 +70,7 @@ export interface StructuredScanResult {
 	interactionEffects: Array<{ ruleId: string; penalty: number; narrative: string }>;
 	/** Execution status per check category. 'completed' = ran normally, 'timeout' = per-check timeout, 'error' = threw. */
 	checkStatuses: Record<string, 'completed' | 'timeout' | 'error'>;
-	/** DNSSEC configuration source. 'domain_configured' = domain has own DNSKEY/DS; 'tld_inherited' = inherited from TLD registry. null = not yet available. */
+	/** DNSSEC configuration source. `tld_inherited` is retained only for backward-compatible parsing of older scan records; current checks require DNSKEY+DS and emit `domain_configured`. */
 	dnssecSource: 'domain_configured' | 'tld_inherited' | null;
 	/** CDN provider detected from HTTP response headers. null when no CDN detected or check did not run. */
 	cdnProvider: string | null;

--- a/test/audits/workflow-safety-gates.audit.test.ts
+++ b/test/audits/workflow-safety-gates.audit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import securityWorkflow from '../../.github/workflows/security.yml?raw';
 import hygieneWorkflow from '../../.github/workflows/repo-hygiene.yml?raw';
+import registryDriftWorkflow from '../../.github/workflows/registry-drift-check.yml?raw';
 import packageJsonText from '../../package.json?raw';
 
 const packageJson = JSON.parse(packageJsonText) as { scripts?: Record<string, string> };
@@ -74,5 +75,13 @@ describe('workflow safety gates', () => {
 		for (const [path, body] of activeWorkflows) {
 			expect(body, `${path} must not pipe curl/wget output into a shell`).not.toMatch(/\b(?:curl|wget)\b[^\n|]{0,200}\|\s*(?:env\s+)?(?:bash|sh|zsh)\b/);
 		}
+	});
+
+	it('registry drift issues direct operators to the current manual publish path', () => {
+		expect(registryDriftWorkflow).toContain('Publishing is operator-run.');
+		expect(registryDriftWorkflow).toContain('npm run publish:registry');
+		expect(registryDriftWorkflow).toContain('worktree pinned to that exact tag');
+		expect(registryDriftWorkflow).not.toContain('Publish to MCP Registry');
+		expect(registryDriftWorkflow).not.toContain('approve it');
 	});
 });

--- a/test/check-dnssec.spec.ts
+++ b/test/check-dnssec.spec.ts
@@ -5,7 +5,7 @@ import { setupFetchMock, createDohResponse, mockFetchError } from './helpers/dns
 const { restore } = setupFetchMock();
 
 function mockDnssecResponses(adFlag: boolean, hasDnskey = true, hasDs = true) {
-	globalThis.fetch = vi.fn().mockImplementation((url: string) => {
+	const fetchMock = vi.fn().mockImplementation((url: string) => {
 		const typeMatch = url.match(/type=([^&]+)/);
 		const type = typeMatch ? typeMatch[1] : '';
 		if (type === 'A') {
@@ -27,6 +27,8 @@ function mockDnssecResponses(adFlag: boolean, hasDnskey = true, hasDs = true) {
 		}
 		return Promise.resolve(createDohResponse([], []));
 	});
+	globalThis.fetch = fetchMock;
+	return fetchMock;
 }
 
 afterEach(() => restore());
@@ -57,14 +59,16 @@ describe('checkDnssec', () => {
 		expect(f!.severity).toBe('info');
 	});
 
-	it('adds tld_inherited info finding when AD=true but no DNSKEY/DS on domain', async () => {
+	it('treats AD=true without DNSKEY/DS as unsigned instead of a validated pass', async () => {
 		mockDnssecResponses(true, false, false);
 		const r = await run();
-		// Base result has one info finding; augmentation adds the tld_inherited finding
-		expect(r.findings.every((f) => f.severity === 'info')).toBe(true);
-		const inherited = r.findings.find((f) => f.title === 'DNSSEC inherited from TLD');
-		expect(inherited).toBeDefined();
-		expect(inherited!.metadata?.dnssecSource).toBe('tld_inherited');
+
+		expect(r.findings.some((f) => f.title === 'DNSSEC not enabled' && f.severity === 'high')).toBe(true);
+		expect(r.findings.some((f) => f.title === 'DNSSEC enabled and validated')).toBe(false);
+		expect(r.findings.some((f) => f.title === 'DNSSEC inherited from TLD')).toBe(false);
+		expect(r.score).toBe(60);
+		expect(r.recordPresent).toBe(false);
+		expect(r.controlPresent).toBe(false);
 	});
 	it('returns info finding when DnsQueryError escapes checkDNSSEC', async () => {
 		// Defense-in-depth: tested via dedicated check-dnssec-catch.spec.ts
@@ -122,18 +126,17 @@ describe('DNSSEC finding consolidation', () => {
 });
 
 describe('checkDnssec — dnssecSource detection', () => {
-	it('adds tld_inherited finding when DNSSEC validates but no DNSKEY/DS on domain', async () => {
+	it('does not claim TLD-inherited protection when AD=true but DNSKEY/DS are absent', async () => {
 		mockDnssecResponses(true, false, false);
 		const { checkDnssec } = await import('../src/tools/check-dnssec');
 		const result = await checkDnssec('example.com');
 		const inheritedFinding = result.findings.find((f) => f.title === 'DNSSEC inherited from TLD');
-		expect(inheritedFinding).toBeDefined();
-		expect(inheritedFinding!.severity).toBe('info');
-		expect(inheritedFinding!.metadata?.dnssecSource).toBe('tld_inherited');
+		expect(inheritedFinding).toBeUndefined();
+		expect(result.findings.some((f) => f.metadata?.dnssecSource === 'tld_inherited')).toBe(false);
 	});
 
 	it('tags domain_configured when both DNSKEY and DS records are present', async () => {
-		mockDnssecResponses(true, true, true);
+		const fetchMock = mockDnssecResponses(true, true, true);
 		const { checkDnssec } = await import('../src/tools/check-dnssec');
 		const result = await checkDnssec('example.com');
 		const tldFinding = result.findings.find((f) => f.title === 'DNSSEC inherited from TLD');
@@ -141,6 +144,10 @@ describe('checkDnssec — dnssecSource detection', () => {
 		// Source should be domain_configured somewhere in findings metadata
 		const hasDomainConfigured = result.findings.some((f) => f.metadata?.dnssecSource === 'domain_configured');
 		expect(hasDomainConfigured).toBe(true);
+		// Source attribution must reuse the canonical check's evidence rather than
+		// perform a second DNSKEY/DS read that can race or partially fail.
+		expect(fetchMock.mock.calls.filter(([url]) => String(url).includes('type=DNSKEY'))).toHaveLength(1);
+		expect(fetchMock.mock.calls.filter(([url]) => String(url).includes('type=DS'))).toHaveLength(1);
 	});
 
 	it('does not tag the inherited-posture attribution finding as domain_configured', async () => {

--- a/test/compare-baseline.spec.ts
+++ b/test/compare-baseline.spec.ts
@@ -480,9 +480,9 @@ describe('compare_baseline does not pass a control rule whose record was never p
 	}
 
 	/**
-	 * The registry-signed counter-fixture — `check-dnssec.ts` documents this exact
-	 * `recordPresent: false` + `controlPresent: true` pair as a ccTLD/registry-signed
-	 * zone that validates without publishing a DNSKEY/DS of its own. It IS protected.
+	 * Counter-fixture for a split-signal or legacy producer that independently
+	 * affirms the control despite a negative record-presence observation. Current
+	 * DNSSEC results do not emit this pair after #793.
 	 */
 	function absentRecordsButControlActive(category: string): CheckResult {
 		return {
@@ -550,12 +550,12 @@ describe('compare_baseline does not pass a control rule whose record was never p
 	});
 
 	/**
-	 * The load-bearing rebuttal. Without it the fix trades the false PASS for a
-	 * false FAIL on a zone that is genuinely, cryptographically protected.
+	 * The load-bearing generic rebuttal for persisted or external CheckResult values
+	 * carrying independent affirmative control evidence.
 	 */
-	it('still PASSES require_dnssec for a registry-signed zone (recordPresent false + controlPresent true)', async () => {
+	it('still PASSES a split-signal result with recordPresent false + controlPresent true', async () => {
 		const { compareBaseline } = await import('../src/tools/compare-baseline');
-		const scan = scanWith('registry-signed.example', [absentRecordsButControlActive('dnssec')]);
+		const scan = scanWith('affirmed-control.example', [absentRecordsButControlActive('dnssec')]);
 
 		const result = compareBaseline(scan, { require_dnssec: true });
 

--- a/test/contracts/m365-proxy-envelope.contract.test.ts
+++ b/test/contracts/m365-proxy-envelope.contract.test.ts
@@ -24,11 +24,13 @@
  * rides through opaquely inside `data` on the 2xx path (issue #417 part 2
  * labels it in the tool descriptions; the proxy stays body-agnostic).
  *
- * BOTH marker values are now real on the wire: bv-web-prod's `liveGetCaPolicies()`
- * returns `representative: false` for `get-ca-policies` when a tenant is connected
- * and keyed, falling back to the `representative: true` seam otherwise. The other
- * three tools are still representative-only. The pass-through cases below pin both
- * directions, because a seam that DEFAULTED the marker either way would be a
+ * BOTH marker values are now real on the wire: bv-web-prod can return
+ * `representative: false` for `query-signins`, `get-ca-policies`, and
+ * `assess-coverage` when a tenant is connected and the upstream Graph read succeeds,
+ * falling back to the `representative: true` seam otherwise. `query-ual` remains
+ * representative-only until its Purview Audit Search integration lands. The
+ * pass-through cases below pin both directions, because a seam that DEFAULTED the
+ * marker either way would be a
  * correctness bug with no test to catch it: defaulting to `true` mislabels live
  * Entra data as a sample, and defaulting to `false` presents sample data to an
  * LLM as live threat intel — the exact hazard #417 part 2 exists to prevent.

--- a/test/contracts/m365-tool-seam-wiring.contract.test.ts
+++ b/test/contracts/m365-tool-seam-wiring.contract.test.ts
@@ -129,13 +129,15 @@ describe('M365 seam — the contracted tool set is derived from the registry', (
 });
 
 /**
- * Tools with NO live Graph read path in bv-web-prod's `m365-handler.server.ts`.
- * Verified 2026-08-21: its dispatch gates the live branch on `tool === 'get-ca-policies'`
- * alone, so these three reach the representative seam on EVERY call.
+ * `query_ual` is the remaining tool with no implemented live path. The
+ * `query_signins` and `assess_coverage` paths landed upstream on 2026-08-25,
+ * joining `get_ca_policies`, but all three still await provisioned-tenant
+ * production verification and therefore disclose that state per response.
  */
-const SAMPLE_ONLY_TOOLS = ['query_signins', 'query_ual', 'assess_coverage'] as const;
+const SAMPLE_ONLY_TOOLS = ['query_ual'] as const;
+const LIVE_CAPABLE_UNVERIFIED_TOOLS = ['query_signins', 'get_ca_policies', 'assess_coverage'] as const;
 
-describe('M365 seam — sample-only tools disclose it in the description, not just the response', () => {
+describe('M365 seam — tool descriptions disclose sample/live provenance before use', () => {
 	// `representative: true` in the payload is only read AFTER a call is made, and
 	// only by a client that looks. The description is what an LLM weighs when
 	// DECIDING to call — so for a tool that can only ever answer with sample data,
@@ -150,13 +152,22 @@ describe('M365 seam — sample-only tools disclose it in the description, not ju
 		});
 	}
 
-	it('get_ca_policies does NOT carry the blanket disclosure — it has a live path', () => {
-		// The inverse guard: `get_ca_policies` CAN return live Entra data once a
-		// tenant is connected and keyed, so labelling it sample-only would be the
-		// same class of lie in the other direction.
-		const def = TOOLS.find((t) => t.name === 'get_ca_policies');
-		expect(def!.description.startsWith('SAMPLE DATA ONLY')).toBe(false);
-		expect(def!.description).toContain('`false` once a live Microsoft Graph read succeeded');
+
+	for (const name of LIVE_CAPABLE_UNVERIFIED_TOOLS) {
+		it(`${name} discloses the unverified live path and preserves per-response sample/live semantics`, () => {
+			const def = TOOLS.find((t) => t.name === name);
+			expect(def).toBeDefined();
+			expect(def!.description.startsWith('LIVE PATH NOT YET PRODUCTION-VERIFIED')).toBe(true);
+			expect(def!.description).toContain('`true` is sample/fallback data');
+			expect(def!.description).toContain('`false` means the upstream Microsoft Graph read succeeded');
+		});
+	}
+
+	it('query_ual names the supported Graph audit source without weakening its sample-only disclosure', () => {
+		const def = TOOLS.find((t) => t.name === 'query_ual');
+		expect(def!.description.startsWith('SAMPLE DATA ONLY')).toBe(true);
+		expect(def!.description).toContain('Purview Audit Search API');
+		expect(def!.description).not.toContain('no direct Unified Audit Log equivalent');
 	});
 });
 

--- a/test/control-presence.spec.ts
+++ b/test/control-presence.spec.ts
@@ -21,7 +21,7 @@ describe('isUnrebuttedAbsence', () => {
 		expect(isUnrebuttedAbsence(check({ recordPresent: false, controlPresent: false }))).toBe(true);
 		// absence observed, control flag not reported at all (e.g. no raw resolver)
 		expect(isUnrebuttedAbsence(check({ recordPresent: false }))).toBe(true);
-		// registry/ccTLD-signed zone: no DNSKEY/DS of its own, but the chain validates
+		// Explicit independent control evidence rebuts the record-presence signal.
 		expect(isUnrebuttedAbsence(check({ recordPresent: false, controlPresent: true }))).toBe(false);
 		// published but weak/broken — a record exists, so this is not an absence
 		expect(isUnrebuttedAbsence(check({ recordPresent: true, controlPresent: false }))).toBe(false);
@@ -35,7 +35,7 @@ describe('isSatisfiedControl', () => {
 	it('requires the check to have both not penalized AND not observed an unrebutted absence', () => {
 		// The #705/#706 defect shape: unpenalized (score 60, passed true) but nothing published.
 		expect(isSatisfiedControl(check({ passed: true, score: 60, recordPresent: false, controlPresent: false }))).toBe(false);
-		// Registry-signed: absent records, affirmative control.
+		// Split-signal/legacy result: absent records, affirmative control evidence.
 		expect(isSatisfiedControl(check({ passed: true, score: 85, recordPresent: false, controlPresent: true }))).toBe(true);
 		// Present and satisfied.
 		expect(isSatisfiedControl(check({ passed: true, recordPresent: true, controlPresent: true }))).toBe(true);
@@ -134,7 +134,7 @@ describe('isSatisfiedControl — severity floor (#726)', () => {
 	it('the floor is additive — the #705/#706 presence clauses are unchanged', () => {
 		// Unrebutted absence with NO findings at all still fails (the original defect).
 		expect(isSatisfiedControl(check({ passed: true, score: 60, recordPresent: false, controlPresent: false }))).toBe(false);
-		// Registry-signed zone with only advisory findings still passes.
+		// An affirmative split signal with only advisory findings still passes.
 		expect(
 			isSatisfiedControl(check({ passed: true, score: 85, recordPresent: false, controlPresent: true, findings: [finding('low')] } as Partial<CheckResult>)),
 		).toBe(true);

--- a/test/format-report.spec.ts
+++ b/test/format-report.spec.ts
@@ -51,7 +51,7 @@ describe('buildStructuredScanResult', () => {
 		expect(s.checkStatuses.spf).toBe('completed');
 	});
 
-	it('derives dnssecSource from finding metadata', () => {
+	it('preserves the legacy tld_inherited source value from older finding metadata', () => {
 		const result = makeMockScanResult({
 			checks: [
 				{

--- a/test/hot-path-concurrency.perf.spec.ts
+++ b/test/hot-path-concurrency.perf.spec.ts
@@ -180,13 +180,11 @@ describe('scan_domain hot-path concurrency guard (C-perf)', () => {
 		// queries like NS/A/TXT appearing in many checks, the deduped count is ~20–30.
 		// This assertion catches a catastrophic cache regression (e.g. 200+ fetches).
 		expect(countWithCache).toBeGreaterThan(0);
-		// Sanity upper bound: a correctly deduplicated scan should not exceed
-		// 120 DoH fetches. Current baseline is ~87 for a 19-check scan. This ceiling
-		// is set at ~1.4× the baseline — loose enough to absorb a new check being added,
-		// tight enough to catch a catastrophic cache-bypass regression (e.g. 500+ fetches
-		// if the queryCache is removed and every check fans out independently).
-		// If this assertion triggers after adding a check, bump proportionally.
-		expect(countWithCache).toBeLessThan(120);
+		// Sanity upper bound: the current selector/check catalogue produces 121 DoH
+		// fetches with the shared cache after adding the measured Resend selector.
+		// Keep a small allowance for catalogue growth while still catching a
+		// catastrophic cache-bypass/query regression.
+		expect(countWithCache).toBeLessThan(125);
 	});
 });
 

--- a/test/map-compliance.spec.ts
+++ b/test/map-compliance.spec.ts
@@ -901,9 +901,10 @@ describe('map_compliance does not pass a control whose record was never publishe
 	}
 
 	/**
-	 * The registry-signed counter-fixture: no DNSKEY/DS of its own, but the chain
-	 * validates. `check-dnssec` documents this exact `false`/`true` pair as "protected,
-	 * not a contradiction", so it must keep passing.
+	 * Counter-fixture for a split-signal or legacy producer that independently
+	 * affirms the control even though its record-presence probe reported false.
+	 * Current DNSSEC results no longer emit this pair (#793), but the shared mapper
+	 * remains intentionally tolerant of persisted/external CheckResult values.
 	 */
 	function absentRecordsButControlActive(category: string): CheckResult {
 		return {
@@ -941,15 +942,13 @@ describe('map_compliance does not pass a control whose record was never publishe
 	});
 
 	/**
-	 * The registry-signed zone must keep passing. This is the guard that stops the fix
-	 * from becoming the same defect with the opposite sign: a ccTLD-signed zone publishes
-	 * no DNSKEY/DS of its own yet is cryptographically protected, and `check-dnssec`
-	 * documents that `recordPresent: false` + `controlPresent: true` pair as exactly that
-	 * state. Failing it would report a protected zone as non-compliant.
+	 * An explicit affirmative signal must keep passing. This guards the generic
+	 * CheckResult contract for external or persisted producers that have independent
+	 * control evidence despite a negative record-presence observation.
 	 */
-	it('still passes a control whose records are absent but whose control is affirmatively active', () => {
+	it('still passes a split-signal result whose control is affirmatively active', () => {
 		const results = makeAllPassing().map((r) => (r.category === 'dnssec' ? absentRecordsButControlActive('dnssec') : r));
-		const report = evaluateCompliance(results, 'registry-signed.com', 88, 'B');
+		const report = evaluateCompliance(results, 'affirmed-control.example', 88, 'B');
 
 		const control = report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§5.1');
 		expect(control).toBeDefined();
@@ -1035,4 +1034,3 @@ describe('map_compliance grade uses the display band SSOT', () => {
 		expect(['A+', 'A', 'B', 'C', 'D', 'F']).toContain(report.grade);
 	});
 });
-

--- a/test/simulate-attack-paths.spec.ts
+++ b/test/simulate-attack-paths.spec.ts
@@ -101,7 +101,25 @@ function mockSecureDomain() {
 				);
 			}
 
-			// DNSSEC: AD=true
+			// DNSSEC: AD=true plus a complete child/parent chain. AD alone is not
+			// evidence that the zone is signed (#793).
+			if (url.includes('type=DNSKEY') || url.includes('type=48')) {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name: 'example.com', type: 48 }],
+						[{ name: 'example.com', type: 48, TTL: 300, data: '257 3 13 AwEAAabc' }],
+					),
+				);
+			}
+			if (url.includes('type=DS') || url.includes('type=43')) {
+				return Promise.resolve(
+					createDohResponse(
+						[{ name: 'example.com', type: 43 }],
+						[{ name: 'example.com', type: 43, TTL: 300, data: '12345 13 2 abc123' }],
+					),
+				);
+			}
+
 			if (url.includes('type=A') || url.includes('type=1')) {
 				return Promise.resolve(dnssecResponse('example.com', true));
 			}

--- a/test/verify-deploy-control-predicate.spec.ts
+++ b/test/verify-deploy-control-predicate.spec.ts
@@ -34,9 +34,9 @@ describe('classifyControlProbe — only an UNREBUTTED, MEASURED absence licenses
 		expect(classifyControlProbe({ category: 'caa', recordPresent: false }).state).toBe('absent');
 	});
 
-	it('an affirmative controlPresent REBUTS the absence (the registry-signed case)', () => {
-		// check-dnssec documents recordPresent:false + controlPresent:true for a zone its
-		// ccTLD registry signed. Reading absence there would fail a protected domain.
+	it('an affirmative controlPresent REBUTS absence for split-signal or legacy results', () => {
+		// Current DNSSEC results require AD + DNSKEY + DS, but the generic verifier also
+		// accepts persisted/external results with independent affirmative evidence.
 		expect(classifyControlProbe({ recordPresent: false, controlPresent: true }).state).toBe('present');
 	});
 


### PR DESCRIPTION
## Summary

- make DNSSEC validation require AD + DNSKEY + DS, classify parent-DS/child-DNSKEY gaps as broken chains, and remove the duplicate source-attribution DNS read
- add the measured `resend` DKIM selector and restore score-neutral `p=none; sp=none` DMARC evidence used by attack-path analysis
- align M365 tool descriptions with their implemented live/sample seams and correct registry-drift remediation to the operator-run publish path
- release server 3.67.0, scoring model 1.14.0, and `@blackveil/dns-checks` / parity corpus 1.25.0

## Issues

Closes #793
Closes #789
Closes #774

This updates the drift remediation for #792 but does not close it until the registry is published and cache-busted verification succeeds. #719 remains blocked on replacement npm credentials. #417 and #759 remain open for real-tenant production verification and the asynchronous Purview Audit Search integration.

## Verification

- `npm test` — 664 files passed, 4 skipped; 7,934 tests passed, 13 skipped
- `npm run build`
- `npm run typecheck`
- `npm run typecheck:tests` — no baseline regressions
- `npm run lint`
- `npm run validate:internal-deps`
- `npm run audit:repo-safety`
- `npm run audit:oss-safety`
- `npm audit --omit=dev --audit-level=high` — 0 vulnerabilities
- `node_modules/.bin/tsx scripts/ci/release-integrity-check.ts --mode deploy --skip-git --expect-version 3.67.0`
- `git diff --check`

## Release notes

This is a scoring-model release. The affected DNSSEC/DKIM evidence shapes can score lower; the DMARC correction is score-neutral. Deployment will occur from a fresh worktree pinned to `v3.67.0` after protected merge and tag creation.
