### PR TITLE
chore(release): prepare 3.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,49 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.68.0] - 2026-08-27
+
+**No scoring-model change.** `SCORING_MODEL_VERSION` remains **1.14.0** and
+`@blackveil/dns-checks` remains **1.25.0** — no check, weight, threshold, grade
+band, or domain score changes in this release.
+
+### Security
+
+- **Authenticated session identity is now authoritative across every internal
+  trust boundary** (#803). OAuth mint/revoke, tool delegation, Brand Watch
+  cleanup and webhook delivery, tenant operations, M365, TLS, recon, grade
+  probes, and internal web calls use distinct capabilities and fail closed on
+  missing, ambiguous, or mismatched caller identity.
+- **OAuth and quota state transitions are atomic and bounded** (#803).
+  Registration and token flows enforce exact redirect parsing, PKCE, issuer,
+  lifetime, generation, and revocation contracts; trial, anonymous, tenant, and
+  reservation limits are principal-scoped and cannot be bypassed by concurrent
+  requests.
+- **Untrusted network input is bounded before allocation and decode** (#803).
+  HTTP redirects and bodies, DNS and raw TCP exchanges, SSE streams, cache
+  cardinality, ancillary destinations, and WHOIS connect/open/write/read phases
+  now have explicit budgets, sanitized failure categories, and safe unread-body
+  disposal.
+- **Brand Watch delivery is replay-safe** (#803). Parent, target, and outbox
+  state is committed transactionally; retry identifiers are deterministic; and
+  failed deliveries remain persisted for controlled replay instead of being
+  silently lost.
+
+### Changed
+
+- `query_ual` remains a deprecated, local compatibility tombstone: it still
+  applies validation and authorization gates, returns `query_ual_deprecated`,
+  and never proxies to M365. The three active M365 tools use the dedicated M365
+  bearer and discriminated principal identity (#803).
+
+### Operations
+
+- Full rollout requires the documented distinct caller/validator secrets and
+  `scripts/brand-audit/sql/0001_watch_webhook_outbox.sql` before the MCP
+  producer is published. Deploy WHOIS and infrastructure-probe satellites
+  first, and keep M365 tenant reads disabled until both sides of the capability
+  pair are verified (#803).
+
 ## [3.67.0] - 2026-08-26
 
 **Scoring-model change.** `SCORING_MODEL_VERSION` 1.13.0 → **1.14.0** and `@blackveil/dns-checks` 1.24.0 → **1.25.0** (`PARITY_CORPUS_VERSION` in lockstep). DNSSEC and DKIM results can move downward for the affected evidence shapes; the DMARC evidence correction is score-neutral. Full rationale is recorded in `src/lib/scoring-version.ts`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ## [3.68.0] - 2026-08-27
 
-**No scoring-model change.** `SCORING_MODEL_VERSION` remains **1.14.0** and
-`@blackveil/dns-checks` remains **1.25.0** — no check, weight, threshold, grade
-band, or domain score changes in this release.
+**No scoring-policy change.** `SCORING_MODEL_VERSION` remains **1.14.0** — no
+weight, threshold, severity penalty, profile-selection rule, or grade band
+moves. `@blackveil/dns-checks` moves **1.25.0 → 1.26.0**, with
+`PARITY_CORPUS_VERSION` in lockstep, because the core package's network and
+response-boundary behavior changed. This intentionally cold-starts scan caches.
+Results at oversized, slow, redirecting, or robots-gated network edges can now
+become explicitly inconclusive instead of consuming an unbounded response; no
+new scoring rule is introduced.
 
 ### Security
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.67.0",
+	"version": "3.68.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.67.0",
+			"version": "3.68.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5156,7 +5156,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.25.0",
+			"version": "1.26.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.67.0",
+	"version": "3.68.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.25.0",
+	"version": "1.26.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -38,7 +38,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.25.0';
+export const PARITY_CORPUS_VERSION = '1.26.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.67.0",
+	"version": "3.68.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Summary

Prepare the protected MCP `3.68.0` release from the exact merge commit of #803.

- synchronize `package.json`, `package-lock.json`, and `server.json` at `3.68.0` through the repository version lifecycle;
- add release notes for the trust-boundary hardening shipped by #803;
- keep scoring policy `1.14.0` unchanged while advancing `@blackveil/dns-checks` and `PARITY_CORPUS_VERSION` together from `1.25.0` to `1.26.0` for the core network-boundary changes.

## Validation

- `npm ci` — 0 vulnerabilities
- `node_modules/.bin/tsx scripts/ci/release-integrity-check.ts --mode deploy --skip-git --expect-version 3.68.0` — all version surfaces match
- `npm -w packages/dns-checks run build` — passed at `1.26.0`
- `npx vitest run packages/dns-checks` — 48 files / 911 tests passed
- cache-key, scan-version, and parity contracts — 3 files / 86 tests passed
- `npm run build:wasm && npm test` — 680 files passed, 4 skipped; 8,210 tests passed, 13 skipped
- production/test-tree typechecks, ESLint, and internal dependency policy — passed
- `git diff --check` — clean
- repo-safety and Gitleaks commit hooks — clean

## Release sequence after merge

1. tag the exact merged `main` commit as `v3.68.0`;
2. wait for the tag validation/GitHub Release workflow;
3. build the provenance-stamped `@blackveil/dns-checks` `1.26.0` tarball and re-vendor it into bv-web-prod before that consumer ships;
4. deploy satellites, MCP producer, and consumers from clean worktrees pinned to their reviewed commits;
5. verify live `serverInfo.version` and security behavior;
6. publish and cache-bust verify the MCP Registry only after production is proven.

Production secret provisioning and D1 migrations remain separately operator-gated. This PR performs no production write or deployment.
