### PR TITLE
fix(spoofability): abstain on single-revoked-selector DKIM instead of scoring 0

### DIFF
--- a/src/tools/assess-spoofability.ts
+++ b/src/tools/assess-spoofability.ts
@@ -234,10 +234,28 @@ function assessDkim(result: CheckResult, noSendPolicy: boolean): ControlAssessme
 
 	const activeKey = result.controlPresent === true;
 
-	// `DKIM keys revoked (non-sending)` — every discovered selector publishes an
-	// empty `p=`, the documented posture of a domain that deliberately does not
-	// send. This is the shape that reported 100.
-	if (!activeKey && hasFindingTitled(result, 'DKIM keys revoked')) {
+	// Selectors were DISCOVERED but none carries a usable key — every published
+	// selector is revoked (empty `p=`), the documented posture of a domain that
+	// deliberately does not sign. Two check-side shapes express it (#808):
+	//
+	// - `DKIM keys revoked (non-sending)` — the check's plural consolidation,
+	//   which only fires for >1 discovered selector. This is the shape that
+	//   originally reported 100.
+	// - a singular `Revoked DKIM key: <selector>` with NO absence finding —
+	//   exactly one discovered selector, revoked (google.com's real shape). This
+	//   shape used to fall through to the hardcoded measured 0 below, scoring the
+	//   same posture 0 that scan_domain scored 85.
+	//
+	// Title-matching here is interim: the structural fact ("selectors found, none
+	// valid") is not exported on CheckResult — `controlPresent: false` conflates
+	// "no selector found" with "found but revoked". Exporting it is deferred with
+	// the check-side `> 1` consolidation cliff (an operator-gated scoring change).
+	// The absence-finding guard keeps a mixed hypothetical (a revoked selector
+	// recorded alongside a probe-miss absence claim) out of this branch.
+	const revokedOnly =
+		hasFindingTitled(result, 'DKIM keys revoked') ||
+		(hasFindingTitled(result, 'Revoked DKIM key') && !hasFindingTitled(result, 'No DKIM records found'));
+	if (!activeKey && revokedOnly) {
 		return {
 			score: null,
 			status: 'not_applicable',

--- a/test/assess-spoofability.spec.ts
+++ b/test/assess-spoofability.spec.ts
@@ -36,10 +36,18 @@ function mockEmailAuth(options: {
 	dkim?: boolean;
 	/** Publish REVOKED DKIM keys (empty p=) on every probed selector — the non-sending posture. */
 	dkimRevoked?: boolean;
+	/**
+	 * Publish a REVOKED key (empty p=) on EXACTLY this one selector; every other
+	 * probed selector gets an empty answer. This is google.com's real shape (#808):
+	 * one discoverable selector, revoked — unlike `dkimRevoked`, which answers on
+	 * all 46 probed selectors and so only ever exercises the plural
+	 * "DKIM keys revoked (non-sending)" consolidation branch.
+	 */
+	dkimRevokedSelector?: string;
 	/** Emit no MX records (a domain that receives no mail). */
 	noMx?: boolean;
 }) {
-	const { spf, dmarc, dkim = false, dkimRevoked = false, noMx = false } = options;
+	const { spf, dmarc, dkim = false, dkimRevoked = false, dkimRevokedSelector, noMx = false } = options;
 
 	globalThis.fetch = vi.fn().mockImplementation((url: string | URL) => {
 		const u = new URL(typeof url === 'string' ? url : url.toString());
@@ -63,7 +71,11 @@ function mockEmailAuth(options: {
 			}
 			if (name.includes('_domainkey')) {
 				const records: Array<{ name: string; type: number; TTL: number; data: string }> = [];
-				if (dkimRevoked) {
+				if (dkimRevokedSelector) {
+					if (name === `${dkimRevokedSelector}._domainkey.example.com`) {
+						records.push({ name, type: 16, TTL: 300, data: '"v=DKIM1; k=rsa; p="' });
+					}
+				} else if (dkimRevoked) {
 					records.push({ name, type: 16, TTL: 300, data: '"v=DKIM1; k=rsa; p="' });
 				} else if (dkim) {
 					records.push({ name, type: 16, TTL: 300, data: '"v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA"' });
@@ -218,6 +230,59 @@ describe('assessSpoofability', () => {
 				expect(text).not.toContain('null');
 				expect(text).toContain('not applicable');
 			}
+		});
+	});
+
+	/**
+	 * Issue #808: google.com's real shape — exactly ONE discoverable selector
+	 * (`20230601`), revoked (empty p=). `check_dkim` emits the SINGULAR
+	 * `Revoked DKIM key: <selector>` medium finding (the `foundSelectors.length > 1`
+	 * consolidation never fires, so no plural `DKIM keys revoked` info finding
+	 * exists), scores 85 and reports `controlPresent: false`. `assessDkim`'s
+	 * not_applicable gate matched only the PLURAL title, so this shape fell through
+	 * to the hardcoded `{ score: 0, status: 'measured' }` — DKIM 85 in scan_domain
+	 * vs 0 in assess_spoofability for the same domain on the same DNS, plus a
+	 * fabricated "Missing DKIM weakens DMARC alignment" composite bump.
+	 *
+	 * The pre-existing `dkimRevoked` mock answers revoked on EVERY `_domainkey`
+	 * query, so all 46 probed selectors "resolve" and only the plural branch was
+	 * ever exercised — which is why this went untested.
+	 */
+	describe('exactly one revoked selector (google.com shape, #808)', () => {
+		async function runSingleRevoked() {
+			mockEmailAuth({
+				spf: 'v=spf1 include:_spf.google.com ~all',
+				dmarc: 'v=DMARC1; p=reject; rua=mailto:d@example.com',
+				dkimRevokedSelector: '20230601',
+			});
+			const { assessSpoofability } = await import('../src/tools/assess-spoofability');
+			return assessSpoofability('example.com');
+		}
+
+		it('reproduces the check-side shape: singular revoked finding, no plural/absence finding, controlPresent false', async () => {
+			mockEmailAuth({
+				spf: 'v=spf1 include:_spf.google.com ~all',
+				dmarc: 'v=DMARC1; p=reject; rua=mailto:d@example.com',
+				dkimRevokedSelector: '20230601',
+			});
+			const { checkDkim } = await import('../src/tools/check-dkim');
+			const dkim = await checkDkim('example.com');
+			expect(dkim.controlPresent).toBe(false);
+			expect(dkim.findings.some((f) => f.title.startsWith('Revoked DKIM key:'))).toBe(true);
+			expect(dkim.findings.some((f) => f.title.startsWith('DKIM keys revoked'))).toBe(false);
+			expect(dkim.findings.some((f) => f.title.startsWith('No DKIM records found'))).toBe(false);
+		});
+
+		it('abstains on DKIM (not_applicable) instead of scoring a measured 0', async () => {
+			const result = await runSingleRevoked();
+			expect(result.controls.dkim.status).toBe('not_applicable');
+			expect(result.dkimProtection).toBeNull();
+			expect(result.controls.dkim.reason).toBeTruthy();
+		});
+
+		it('does not claim missing DKIM weakens DMARC alignment for a revoked-only domain', async () => {
+			const result = await runSingleRevoked();
+			expect(result.interactionEffects.some((e) => e.includes('Missing DKIM'))).toBe(false);
 		});
 	});
 


### PR DESCRIPTION
Fixes #808

## Symptom

For google.com, DKIM scored **85/100** in `scan_domain` but **0/100** in `assess_spoofability` — same domain, same DNS, same `CheckResult` from the same `checkDKIM`. The 0 then added a +5 composite spoofability bump and the prose "Missing DKIM weakens DMARC alignment" — for a domain with a published (revoked) selector.

## Root cause

`assessDkim`'s `not_applicable` gate matched only the finding title `DKIM keys revoked` — the plural consolidation `check-dkim.ts` emits solely from its `foundSelectors.length > 1` branch. A domain whose ONLY discoverable selector is revoked (empty `p=`, google.com's `20230601`) instead emits the singular `Revoked DKIM key: <selector>` medium finding, missed all four escape hatches, and hit the fallthrough `{ score: 0, status: 'measured' }` — contradicting the module's own contract ("DKIM reports the check's own score").

The regression mock in `test/assess-spoofability.spec.ts` answered a revoked record for EVERY `_domainkey` query, so all 46 probed selectors "resolved" and only the plural branch was ever exercised.

## Fix (mapping layer only)

`assessDkim` now recognizes both check-side shapes of "selectors discovered, none valid" as the same `not_applicable` revoked-only posture:

- the plural `DKIM keys revoked` info finding (unchanged behavior), OR
- a singular `Revoked DKIM key:` finding with no `No DKIM records found` absence finding (new)

both gated on `controlPresent !== true`. The revoked-only state therefore no longer feeds the `dkimScore === 0` interaction effect, so the "Missing DKIM weakens DMARC alignment" bump cannot fire for it.

An in-code comment notes the title-matching is interim: the structural fact ("selectors found, none valid") is not exported on `CheckResult` — `controlPresent: false` conflates absent with revoked — and exporting it is deferred alongside the check-side work below.

## Deliberately NOT changed (operator-gated)

`packages/dns-checks/src/checks/check-dkim.ts:364`'s `foundSelectors.length > 1` threshold is untouched: changing it moves customer `scan_domain` scores (1 revoked selector → 85 vs 2 revoked → 100 cliff) and is an operator-gated scoring decision per the repo's scoring-change rule. The cliff remains tracked on #808 as a follow-up.

## Tests

New `#808` describe block mocks EXACTLY ONE probed selector answering (revoked, empty `p=`) with empty answers for the rest — reproducing google.com's shape, unlike the pre-existing all-selectors-revoked mock:

- shape reproduction: singular revoked finding present, no plural/absence finding, `controlPresent: false`
- `controls.dkim.status === 'not_applicable'`, `dkimProtection === null` (previously 0/measured)
- no "Missing DKIM" interaction effect

`npx vitest run test/assess-spoofability.spec.ts`: 21/21 pass (both new behavioral cases failed before the fix; existing plural-branch no-send cases stay green). `npm run typecheck` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)