### PR TITLE
fix(resolver-consistency): normalize DoH TXT presentation quoting

### DIFF
--- a/src/lib/dns-multi-resolver.ts
+++ b/src/lib/dns-multi-resolver.ts
@@ -65,13 +65,66 @@ function buildUrl(endpoint: string, domain: string, type: RecordTypeName): strin
  * reports SPLIT_HORIZON across virtually the whole internet (#811). Collapse
  * both representations to the same bare logical string before comparing.
  * Non-TXT types are unaffected.
+ *
+ * LIMITATION (deliberate, reviewed under #811): this is textual normalization
+ * for the two observed DoH conventions, NOT an RFC 1035 presentation-format
+ * unescaper — a full parser is out of scope here. A TXT value that itself
+ * contains a literal `"` is presented with a backslash escape (`\"`); this
+ * function strips the outer quote pair but does not unescape interior
+ * `\"` sequences, so an escaped-quote payload can still compare unequal
+ * across resolvers (safe direction: a spurious SPLIT_HORIZON, never a false
+ * collapse of genuinely different values into CONSISTENT — see
+ * `dns-multi-resolver.spec.ts`'s "escaped-quote" case).
+ *
+ * The outer-pair strip below is additionally guarded to only fire when BOTH
+ * the first and last characters are unescaped `"` and the interior has no
+ * unescaped `"`, which prevents asymmetric or interior-quoted values from
+ * being mis-stripped. That guard does NOT close every gap: if one resolver's
+ * raw answer is byte-for-byte identical to `"<the other resolver's wrapped
+ * value>"` (i.e. a bare resolver's real content happens to itself look like
+ * a quoted string), the two raw inputs are indistinguishable by any
+ * per-answer textual heuristic and will still normalize to the same value
+ * (pinned, not fixed, by the "contrived collision" test) — resolving that
+ * would require passing resolver identity into this function to apply
+ * per-resolver stripping rules, deliberately not done here.
  */
 function normalizeAnswerData(data: string, type: RecordTypeName): string {
 	const stripped = data.replace(/\.$/, '');
 	if (type !== 'TXT') return stripped.toLowerCase();
 	const joined = stripped.replace(/"\s+"/g, ''); // collapse multi-string segment separators
-	const unquoted = joined.replace(/^"|"$/g, ''); // strip the remaining outer quote pair, if present
-	return unquoted.toLowerCase();
+	return stripOuterQuotePairIfUnambiguous(joined).toLowerCase();
+}
+
+/** True if the character at index `i` in `s` is preceded by an odd number of
+ * consecutive backslashes (i.e. is a `\"`-escaped quote, not a literal one). */
+function isEscapedAt(s: string, i: number): boolean {
+	let backslashes = 0;
+	let j = i - 1;
+	while (j >= 0 && s[j] === '\\') {
+		backslashes++;
+		j--;
+	}
+	return backslashes % 2 === 1;
+}
+
+/**
+ * Strip a matching outer `"..."` pair only when it is unambiguous: both the
+ * first and last characters are unescaped quotes, and no unescaped quote
+ * remains in the interior. Otherwise returns `s` unchanged. See the
+ * LIMITATION note on {@link normalizeAnswerData} for what this does and does
+ * not protect against.
+ */
+function stripOuterQuotePairIfUnambiguous(s: string): string {
+	if (s.length < 2 || s[0] !== '"' || s[s.length - 1] !== '"' || isEscapedAt(s, s.length - 1)) {
+		return s;
+	}
+	const interior = s.slice(1, -1);
+	for (let i = 0; i < interior.length; i++) {
+		if (interior[i] === '"' && !isEscapedAt(interior, i)) {
+			return s;
+		}
+	}
+	return interior;
 }
 
 /** Fetch a DoH response from a single resolver with timeout. */

--- a/src/lib/dns-multi-resolver.ts
+++ b/src/lib/dns-multi-resolver.ts
@@ -52,6 +52,28 @@ function buildUrl(endpoint: string, domain: string, type: RecordTypeName): strin
 	return `${endpoint}?${params.toString()}`;
 }
 
+/**
+ * Normalize a single DoH answer's `data` field for cross-resolver comparison.
+ *
+ * TXT answers arrive in RFC 1035 presentation format, but DoH providers
+ * disagree on whether the JSON encodes that quoting literally: Cloudflare's
+ * DoH wraps each TXT character-string in `"..."` and joins a multi-string
+ * record's segments with a `" "` separator (e.g. `"part1" "part2"`), while
+ * Google's DoH returns the bare, unquoted value. Left unnormalized, comparing
+ * Cloudflare's `"\"MS=ms123\""` against Google's `"MS=ms123"` never matches
+ * for ANY domain that has TXT records, so the consistency check structurally
+ * reports SPLIT_HORIZON across virtually the whole internet (#811). Collapse
+ * both representations to the same bare logical string before comparing.
+ * Non-TXT types are unaffected.
+ */
+function normalizeAnswerData(data: string, type: RecordTypeName): string {
+	const stripped = data.replace(/\.$/, '');
+	if (type !== 'TXT') return stripped.toLowerCase();
+	const joined = stripped.replace(/"\s+"/g, ''); // collapse multi-string segment separators
+	const unquoted = joined.replace(/^"|"$/g, ''); // strip the remaining outer quote pair, if present
+	return unquoted.toLowerCase();
+}
+
 /** Fetch a DoH response from a single resolver with timeout. */
 async function fetchResolver(resolverName: string, endpoint: string, domain: string, type: RecordTypeName): Promise<ResolverAnswer> {
 	const controller = new AbortController();
@@ -79,7 +101,7 @@ async function fetchResolver(resolverName: string, endpoint: string, domain: str
 		const typeCode = RecordType[type];
 		const answers = (data.Answer ?? [])
 			.filter((a: DnsAnswer) => a.type === typeCode)
-			.map((a: DnsAnswer) => a.data.replace(/\.$/, '').toLowerCase())
+			.map((a: DnsAnswer) => normalizeAnswerData(a.data, type))
 			.sort();
 
 		const ttl = data.Answer?.[0]?.TTL;

--- a/test/dns-multi-resolver.spec.ts
+++ b/test/dns-multi-resolver.spec.ts
@@ -34,6 +34,24 @@ function mockSplitResolvers() {
 	});
 }
 
+/**
+ * Mock resolvers with per-resolver TXT `data` payloads, keyed by whether the
+ * request URL identifies as Cloudflare or Google. Lets a fixture send the
+ * SAME logical TXT value dressed in two different DoH presentation styles.
+ */
+function mockPerResolverTxt(cloudflareData: string[], googleData: string[]) {
+	globalThis.fetch = vi.fn().mockImplementation((url: string | URL) => {
+		const urlStr = typeof url === 'string' ? url : url.toString();
+		const isCloudflare = urlStr.includes('cloudflare');
+		const u = new URL(urlStr);
+		const name = u.searchParams.get('name') ?? 'example.com';
+		const type = Number(u.searchParams.get('type') ?? '16');
+		const data = isCloudflare ? cloudflareData : googleData;
+		const answers = data.map((d) => ({ name, type: 16, TTL: 300, data: d }));
+		return Promise.resolve(createDohResponse([{ name, type }], answers));
+	});
+}
+
 describe('queryMultiResolver', () => {
 	it('returns CONSISTENT when all resolvers agree', async () => {
 		mockConsistentResolvers([{ name: 'example.com', type: 1, TTL: 300, data: '93.184.216.34' }]);
@@ -113,6 +131,43 @@ describe('queryMultiResolver', () => {
 		for (const [, init] of vi.mocked(globalThis.fetch).mock.calls) {
 			expect(init?.redirect).toBe('manual');
 		}
+	});
+
+	// #811: Cloudflare's DoH JSON wraps TXT strings in RFC 1035 presentation
+	// quotes; Google's does not. The two must normalize to the same logical
+	// value so identical TXT records don't get misreported as SPLIT_HORIZON.
+	describe('TXT quote normalization (#811)', () => {
+		it('treats a quote-wrapped Cloudflare TXT value as CONSISTENT with Google’s bare value', async () => {
+			mockPerResolverTxt(['"MS=ms70274184"'], ['MS=ms70274184']);
+
+			const result = await queryMultiResolver('example.com', 'TXT');
+
+			expect(result.status).toBe('CONSISTENT');
+			expect(result.detail).toContain('identical');
+			// The displayed evidence must match what was actually compared.
+			for (const ra of result.resolverAnswers) {
+				if (ra.status === 'ok') {
+					expect(ra.answers).toEqual(['ms=ms70274184']);
+				}
+			}
+		});
+
+		it('still reports SPLIT_HORIZON when the underlying TXT values genuinely differ', async () => {
+			mockPerResolverTxt(['"MS=ms70274184"'], ['MS=some-other-value']);
+
+			const result = await queryMultiResolver('example.com', 'TXT');
+
+			expect(result.status).toBe('SPLIT_HORIZON');
+		});
+
+		it('joins a multi-string TXT record’s quoted segments before comparing', async () => {
+			// Cloudflare-style: two adjacent quoted segments of one logical record.
+			mockPerResolverTxt(['"part1" "part2"'], ['part1part2']);
+
+			const result = await queryMultiResolver('example.com', 'TXT');
+
+			expect(result.status).toBe('CONSISTENT');
+		});
 	});
 });
 

--- a/test/dns-multi-resolver.spec.ts
+++ b/test/dns-multi-resolver.spec.ts
@@ -137,7 +137,7 @@ describe('queryMultiResolver', () => {
 	// quotes; Google's does not. The two must normalize to the same logical
 	// value so identical TXT records don't get misreported as SPLIT_HORIZON.
 	describe('TXT quote normalization (#811)', () => {
-		it('treats a quote-wrapped Cloudflare TXT value as CONSISTENT with Google’s bare value', async () => {
+		it("treats a quote-wrapped Cloudflare TXT value as CONSISTENT with Google's bare value", async () => {
 			mockPerResolverTxt(['"MS=ms70274184"'], ['MS=ms70274184']);
 
 			const result = await queryMultiResolver('example.com', 'TXT');
@@ -160,12 +160,49 @@ describe('queryMultiResolver', () => {
 			expect(result.status).toBe('SPLIT_HORIZON');
 		});
 
-		it('joins a multi-string TXT record’s quoted segments before comparing', async () => {
+		it("joins a multi-string TXT record's quoted segments before comparing", async () => {
 			// Cloudflare-style: two adjacent quoted segments of one logical record.
 			mockPerResolverTxt(['"part1" "part2"'], ['part1part2']);
 
 			const result = await queryMultiResolver('example.com', 'TXT');
 
+			expect(result.status).toBe('CONSISTENT');
+		});
+
+		// Follow-up review finding on #811: normalizeAnswerData() does textual
+		// quote-stripping, not RFC 1035 unescaping, so a TXT value containing a
+		// literal/escaped quote is only partially handled. Pin the SAFE direction
+		// here: Cloudflare's escaped-quote form and Google's bare form must never
+		// collapse to CONSISTENT when their content differs after only an outer
+		// unwrap (a spurious SPLIT_HORIZON is acceptable; a false CONSISTENT is not).
+		it('reports SPLIT_HORIZON (never a false CONSISTENT) for a TXT value containing an escaped quote', async () => {
+			// Real content: he said "hi" — Cloudflare wraps + backslash-escapes the
+			// interior quotes; Google returns the bare value with real quote chars.
+			mockPerResolverTxt(['"he said \\"hi\\""'], ['he said "hi"']);
+
+			const result = await queryMultiResolver('example.com', 'TXT');
+
+			expect(result.status).toBe('SPLIT_HORIZON');
+		});
+
+		// Contrived dangerous-direction case flagged in review: a resolver's bare
+		// (unwrapped) TXT content can itself be byte-for-byte identical to what
+		// wrapping produces for a DIFFERENT real value on another resolver — e.g.
+		// Cloudflare's real value `foo` is wrapped to the raw string `"foo"`, and
+		// Google's real value happens to BE the 5-byte string `"foo"` (quotes as
+		// literal content). The two raw DoH answers are then byte-identical, so
+		// no per-answer textual heuristic (including the outer-quote-pair guard
+		// added here) can tell them apart — this is pinned as a known, inherent
+		// limitation (see the LIMITATION note on normalizeAnswerData), NOT
+		// silently treated as fixed. Resolving it would require passing resolver
+		// identity into the normalizer, which is deliberately out of scope.
+		it("KNOWN LIMITATION: cannot distinguish a bare value that collides byte-for-byte with another resolver's wrapped value", async () => {
+			mockPerResolverTxt(['"foo"'], ['"foo"']);
+
+			const result = await queryMultiResolver('example.com', 'TXT');
+
+			// Pinning current (inherent, documented) behavior — not asserting this
+			// is correct or desirable, only that it is understood and unchanged.
 			expect(result.status).toBe('CONSISTENT');
 		});
 	});


### PR DESCRIPTION
## Symptom

`check_resolver_consistency` reported *"TXT records differ between resolvers — likely GeoDNS or CDN steering"* (`SPLIT_HORIZON`) for essentially every domain with TXT records, including google.com and cloudflare.com, driving a false -15 hit on the resolver score. Ground truth: both resolvers returned identical TXT record sets — the only difference was presentational.

## Root cause

`src/lib/dns-multi-resolver.ts:82` normalized each DoH answer's `data` field by stripping the trailing dot and lowercasing, but never accounted for RFC 1035 presentation quoting:

- Cloudflare's DoH JSON wraps each TXT character-string in literal quotes (`"\"MS=ms123\""`) and joins multi-string records with a `" "` segment separator.
- Google's DoH returns the bare, unquoted value (`"MS=ms123"`).

`classifyConsistency` then compared `JSON.stringify`'d answer sets, which never matched for identical TXT data across the two DoH providers — a structural false positive on virtually the whole internet, not a per-zone finding.

## Fix

Added `normalizeAnswerData()` in `src/lib/dns-multi-resolver.ts`: for TXT-type answers only, it collapses adjacent quoted segments (`"part1" "part2"` → `part1part2`) and strips the remaining outer quote pair, before lowercasing. Non-TXT record types are unaffected. Because this replaces the single mapping call that populates `resolverAnswers`, the normalized form also flows into the finding's displayed evidence, so what's shown matches what was actually compared.

## Tests

Added three cases to `test/dns-multi-resolver.spec.ts` under `TXT quote normalization (#811)`:
- Cloudflare quote-wrapped vs Google bare value, same logical TXT string → `CONSISTENT` (previously `SPLIT_HORIZON`; verified failing pre-fix via `git stash`).
- A genuinely differing TXT value across resolvers → still `SPLIT_HORIZON` (control, unaffected by the fix — passes both before and after).
- A multi-string TXT record (`"part1" "part2"` vs bare `part1part2`) → `CONSISTENT`.

All 21 tests in `test/dns-multi-resolver.spec.ts` + `test/check-resolver-consistency.spec.ts` pass. `npm run typecheck` and `npm run lint` both clean.

## Out of scope

The issue's secondary observation — Quad9 `timeout` / OpenDNS `error` making the advertised 4-resolver comparison effectively 2-resolver in production — is a telemetry/reachability question, not addressed here. Left open per the issue for an operator to check prod telemetry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)