### PR TITLE
fix(check-rbl): drop dead SORBS zone from RBL coverage

### DIFF
--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -527,7 +527,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	check_rbl: {
 		description:
-			'Check MX server IP reputation against 7 DNS-based Real-time Blocklists (SpamCop, UCEProtect, Mailspike, Barracuda, PSBL, SORBS). Resolves MX hosts to IPs first.',
+			'Check MX server IP reputation against 6 DNS-based Real-time Blocklists (SpamCop, UCEProtect, Mailspike, Barracuda, PSBL). Resolves MX hosts to IPs first.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/tools/check-rbl.ts
+++ b/src/tools/check-rbl.ts
@@ -2,7 +2,7 @@
 
 /**
  * Real-time Blocklist (RBL) check tool.
- * Resolves MX IPs for a domain and checks against 7 DNS-based blocklists.
+ * Resolves MX IPs for a domain and checks against 6 DNS-based blocklists.
  *
  * Spamhaus ZEN is intentionally NOT in the provider set. bv-mcp queries via
  * shared public resolvers, where ZEN returns rate-limit/refused codes
@@ -10,6 +10,13 @@
  * reliable ZEN query path (its secondary-resolver token only drives
  * empty-result confirmation, it does not reroute the ZEN lookup). ZEN is
  * therefore dropped unconditionally: neither queried nor counted.
+ *
+ * SORBS is also excluded — the entire sorbs.net domain NXDOMAINs (SORBS shut
+ * down mid-2024, confirmed cross-resolver). A dead zone NXDOMAINs every
+ * query, so "not listed" is indistinguishable from "the list is gone" and
+ * cannot support a deterministic clean verdict (#814). Do not re-add it
+ * without a liveness sentinel (e.g. querying its 127.0.0.2 test point) to
+ * confirm the zone actually answers.
  */
 
 import { queryDnsRecords, queryMxRecords } from '../lib/dns';
@@ -30,7 +37,10 @@ const RBL_ZONES: RblZone[] = [
 	{ name: 'Mailspike', zone: 'bl.mailspike.net' },
 	{ name: 'Barracuda', zone: 'b.barracudacentral.org' },
 	{ name: 'PSBL', zone: 'psbl.surriel.com' },
-	{ name: 'SORBS', zone: 'dnsbl.sorbs.net' },
+	// SORBS (dnsbl.sorbs.net) removed: SORBS shut down mid-2024 and the whole
+	// sorbs.net domain NXDOMAINs cross-resolver, so "not listed" there is
+	// unfalsifiable, not a measurement (#814). See module header — do not
+	// re-add without a liveness sentinel.
 ];
 
 const CATEGORY = 'rbl' as CheckCategory;
@@ -43,10 +53,10 @@ function isMailspikePositive(ip: string): boolean {
 }
 
 /**
- * Check MX server IPs against 7 DNS-based Real-time Blocklists.
+ * Check MX server IPs against 6 DNS-based Real-time Blocklists.
  * Falls back to domain A records if no MX records exist.
  *
- * Spamhaus ZEN is excluded from the provider set — see the module header.
+ * Spamhaus ZEN and SORBS are excluded from the provider set — see the module header.
  */
 export async function checkRbl(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
 	const findings: ReturnType<typeof createFinding>[] = [];

--- a/test/check-rbl.spec.ts
+++ b/test/check-rbl.spec.ts
@@ -33,20 +33,19 @@ function emptyResponse(name: string) {
 }
 
 /**
- * The 7 RBL zones used by check_rbl. Spamhaus ZEN is intentionally excluded —
+ * The 6 RBL zones used by check_rbl. Spamhaus ZEN is intentionally excluded —
  * bv-mcp has no reliable ZEN query path, so it is never queried or counted.
  * `zen.spamhaus.org` is kept in this fixture list ONLY so the mock can assert
  * it is never queried.
+ *
+ * SORBS (dnsbl.sorbs.net) was removed in #814 — the whole sorbs.net domain
+ * NXDOMAINs (SORBS shut down mid-2024), so a "not listed" verdict there is
+ * unfalsifiable, not a measurement.
  */
-const RBL_ZONES = [
-	'bl.spamcop.net',
-	'dnsbl-1.uceprotect.net',
-	'dnsbl-2.uceprotect.net',
-	'bl.mailspike.net',
-	'b.barracudacentral.org',
-	'psbl.surriel.com',
-	'dnsbl.sorbs.net',
-];
+const RBL_ZONES = ['bl.spamcop.net', 'dnsbl-1.uceprotect.net', 'dnsbl-2.uceprotect.net', 'bl.mailspike.net', 'b.barracudacentral.org', 'psbl.surriel.com'];
+
+/** Dead zone — must NEVER appear in a query. Tracked separately from RBL_ZONES (#814). */
+const SORBS_ZONE = 'dnsbl.sorbs.net';
 
 /** ZEN zone — must NEVER appear in a query. Tracked separately from RBL_ZONES. */
 const ZEN_ZONE = 'zen.spamhaus.org';
@@ -135,7 +134,7 @@ describe('checkRbl', () => {
 		return checkRbl(domain, dnsOptions);
 	}
 
-	it('NEVER queries Spamhaus ZEN — it is dropped unconditionally (neither queried nor counted)', async () => {
+	it('NEVER queries Spamhaus ZEN or SORBS — both are dropped unconditionally (neither queried nor counted)', async () => {
 		const queriedZones = new Set<string>();
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
@@ -152,6 +151,11 @@ describe('checkRbl', () => {
 				queriedZones.add(ZEN_ZONE);
 				return Promise.resolve(aResponse(name, ['127.0.0.2']));
 			}
+			if (name.endsWith(`.${SORBS_ZONE}`)) {
+				// SORBS must NEVER be queried (#814) — record it so the assertion below fails if it is.
+				queriedZones.add(SORBS_ZONE);
+				return Promise.resolve(emptyResponse(name));
+			}
 			for (const zone of RBL_ZONES) {
 				if (name.endsWith(`.${zone}`)) {
 					queriedZones.add(zone);
@@ -161,17 +165,21 @@ describe('checkRbl', () => {
 			return Promise.resolve(emptyResponse('unknown'));
 		});
 
-		const result = await run(); // ZEN is dropped regardless of dnsOptions
+		const result = await run(); // ZEN and SORBS are dropped regardless of dnsOptions
 		// ZEN never queried.
 		expect(queriedZones.has(ZEN_ZONE)).toBe(false);
+		// SORBS never queried (#814 — dead zone, NXDOMAINs cross-resolver since mid-2024).
+		expect(queriedZones.has(SORBS_ZONE)).toBe(false);
 		// No ZEN/Spamhaus verdict emitted (no high listing, no quota finding).
 		expect(result.findings.some((f) => /spamhaus/i.test(f.title) || /spamhaus/i.test(f.detail))).toBe(false);
 		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
-		// Clean message counts only the 7 active (non-ZEN) zones.
+		// Clean message counts only the 6 active (non-ZEN, non-SORBS) zones.
 		const cleanFinding = result.findings.find((f) => /clean|not listed/i.test(f.title));
 		expect(cleanFinding).toBeDefined();
-		expect(cleanFinding!.detail).toContain('7 RBLs');
+		expect(cleanFinding!.detail).toContain('6 RBLs');
 		expect((cleanFinding!.metadata?.zones as string[]) ?? []).not.toContain(ZEN_ZONE);
+		expect((cleanFinding!.metadata?.zones as string[]) ?? []).not.toContain(SORBS_ZONE);
+		expect((cleanFinding!.metadata?.zones as string[]) ?? []).toEqual(RBL_ZONES);
 	});
 
 	it('NEVER queries Spamhaus ZEN even when a secondary-resolver token is supplied', async () => {
@@ -273,7 +281,7 @@ describe('checkRbl', () => {
 			rblAnswers: {
 				'1.113.0.203.bl.spamcop.net': ['127.0.0.2'],
 			},
-			dnsErrors: new Set(['dnsbl.sorbs.net']),
+			dnsErrors: new Set(['psbl.surriel.com']),
 		});
 
 		const result = await run();


### PR DESCRIPTION
## Symptom

`check_rbl` claims *"All checked IPs for `<domain>` are clean on 7 RBLs"* with `metadata.zones` including `dnsbl.sorbs.net` and `confidence: deterministic`.

## Evidence (from #814)

SORBS shut down mid-2024 — the entire `sorbs.net` domain NXDOMAINs, cross-resolver:

```
dns.google        2.0.0.127.dnsbl.sorbs.net A   → Status 3 (universal test point NOT listed)
dns.google        dnsbl.sorbs.net SOA          → Status 3
dns.google        sorbs.net NS                 → Status 3 (whole domain NXDOMAIN)
cloudflare-dns.com 2.0.0.127.dnsbl.sorbs.net A  → Status 3 (confirmed cross-resolver)
```

Live zones from the same vantage point (spamcop, psbl, barracuda, uceprotect-1/-2, mailspike) all answer their test points correctly. A dead zone NXDOMAINs every query, so "not listed on dnsbl.sorbs.net" is indistinguishable from "the list no longer exists" — it cannot support a `deterministic` clean verdict. Effective coverage was 6 live zones, not the advertised 7.

## Fix

- Removed `dnsbl.sorbs.net` from `RBL_ZONES` in `src/tools/check-rbl.ts`, with a dated comment (`SORBS shutdown 2024, #814`) so it isn't re-added without a liveness check.
- The "clean on N RBLs" prose derives from `RBL_ZONES.length`, so it self-corrected to 6 with no separate edit needed.
- Updated the hardcoded "7" in the `check_rbl` tool description in `src/schemas/tool-definitions.ts` to 6, and dropped SORBS from the parenthetical provider list.
- Updated module/function doc comments in `check-rbl.ts` from "7" to "6" DNS-based blocklists.

## Tests

`test/check-rbl.spec.ts`:
- Zone fixture list (`RBL_ZONES`) no longer includes `dnsbl.sorbs.net`; added a separate `SORBS_ZONE` constant (mirroring the existing `ZEN_ZONE` pattern) tracked outside the active zone list.
- Extended the "never queries Spamhaus ZEN" test to also assert SORBS is **never queried**, that the clean-verdict text now reads `"6 RBLs"`, and that `metadata.zones` excludes both ZEN and SORBS and equals the expected 6-zone list exactly.
- Retargeted the DNS-error test (previously errored on `dnsbl.sorbs.net`) to a still-live zone (`psbl.surriel.com`) so it keeps exercising the partial-failure path.
- All pre-existing listed/clean/fallback/Mailspike-positive-reputation cases still pass unmodified.

Verification run in this branch:
```
npx vitest run test/check-rbl.spec.ts        # 10/10 passed
npm run typecheck                            # clean
npm run lint                                 # clean
npm run check:tool-surface                   # "76 public tools, 35 check_* tools" — unchanged, as expected
```

## Follow-up (not in this PR)

The issue also proposes a liveness sentinel (querying each zone's `127.0.0.2` test point before trusting a "not listed" result as clean) as an alternative to outright removal. That's a larger behavioral change deliberately deferred here — removal is the minimal fix for the immediate false-assurance problem. A sentinel would also cover the adjacent, currently-unadjudicable case the issue records: `bl.mailspike.net` SERVFAILs via Google DoH while answering cleanly via Cloudflare, so which answer the scanner's resolver path actually received can't be observed from outside. Worth a dedicated follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)