### PR TITLE
fix(http-security,ssl): treat no-content 2xx (204/205) as unmeasured, not a scored page

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/http-security-no-content.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/http-security-no-content.test.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Issue #806, package half.
+ *
+ * A terminal 204/205 (no-content 2xx) satisfies `response.ok`, so before the guard it
+ * flowed straight into `analyzeSecurityHeaders()` and produced the ENTIRE confident
+ * missing-header slate — fully scored, no `inconclusive`, no `checkStatus` — from a
+ * response that by definition carried no page (observed live: google.com scored
+ * "No X-Frame-Options" off an anomalous 204 that google never serves).
+ *
+ * The pinned contract: a no-content terminal response is UNMEASURED, routed to the same
+ * shape as the WAF-blocked/never-completed-probe branches (issue #638 lineage):
+ *   - NO missing-header findings, and NEVER `missingControl` (that flag asserts
+ *     "we measured and it's absent" — a 204 measured nothing);
+ *   - one `inconclusive: true` finding with `errorKind`/`confidence` markers;
+ *   - score 0 / passed false, with `checkStatus: 'error'` so the scoring engine
+ *     EXCLUDES the category (transient-failure renormalization) rather than scoring it.
+ *
+ * Imports the SOURCE module, not the built `@blackveil/dns-checks` — meaningful without
+ * a dist rebuild.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkHTTPSecurity } from '../../checks/check-http-security';
+import type { FetchFunction } from '../../types';
+
+function expectUnmeasuredNoContent(result: Awaited<ReturnType<typeof checkHTTPSecurity>>) {
+	// No confident missing-header slate may be derived from a bodyless response…
+	expect(result.findings.some((f) => f.title.startsWith('No '))).toBe(false);
+	// …and absolutely no claim of absence.
+	expect(result.findings.some((f) => f.metadata?.missingControl === true)).toBe(false);
+	// One honest unmeasured finding with the transient-exclusion markers.
+	const marker = result.findings.find((f) => f.metadata?.inconclusive === true);
+	expect(marker).toBeDefined();
+	expect(marker!.metadata?.errorKind).toBe('no_content');
+	expect(marker!.metadata?.confidence).toBe('heuristic');
+	// Unmeasured must never read as a PASS, and the category is EXCLUDED, not zeroed.
+	expect(result.score).toBe(0);
+	expect(result.passed).toBe(false);
+	expect(result.checkStatus).toBe('error');
+}
+
+describe('checkHTTPSecurity — a no-content 2xx is unmeasured, not a missing-header slate (issue #806)', () => {
+	it('terminal 204 on the direct HEAD path', async () => {
+		const fetchFn: FetchFunction = async () => new Response(null, { status: 204 });
+		expectUnmeasuredNoContent(await checkHTTPSecurity('example.com', fetchFn));
+	});
+
+	it('terminal 205 on the direct HEAD path', async () => {
+		const fetchFn: FetchFunction = async () => new Response(null, { status: 205 });
+		expectUnmeasuredNoContent(await checkHTTPSecurity('example.com', fetchFn));
+	});
+
+	it('204 reached via a redirect chain (301 → 204)', async () => {
+		let calls = 0;
+		const fetchFn: FetchFunction = async () => {
+			calls++;
+			if (calls === 1) {
+				return new Response(null, { status: 301, headers: { location: 'https://www.example.com/' } });
+			}
+			return new Response(null, { status: 204 });
+		};
+		expectUnmeasuredNoContent(await checkHTTPSecurity('example.com', fetchFn));
+	});
+
+	it('204 returned by the GET fallback after a 405 HEAD', async () => {
+		const fetchFn: FetchFunction = async (_url, init) => {
+			if (init?.method === 'GET') return new Response(null, { status: 204 });
+			return new Response(null, { status: 405 });
+		};
+		expectUnmeasuredNoContent(await checkHTTPSecurity('example.com', fetchFn));
+	});
+
+	it('a real headerless 200 is UNCHANGED — still analyzed as a measured page', async () => {
+		// The guard is scoped to 204/205: a 200 with no security headers is a genuine
+		// measurement of a served page, and its missing-header findings stay confident.
+		const fetchFn: FetchFunction = async () => new Response('<html></html>', { status: 200 });
+		const result = await checkHTTPSecurity('example.com', fetchFn);
+		expect(result.checkStatus).toBeUndefined();
+		expect(result.findings.some((f) => f.title === 'No Content-Security-Policy')).toBe(true);
+	});
+});

--- a/packages/dns-checks/src/__tests__/checks/ssl-no-content.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/ssl-no-content.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Issue #806, ssl half.
+ *
+ * `getHttpRedirectFindings` has a catch-all "No HTTP to HTTPS redirect (status N)"
+ * finding for any non-3xx status. A 204/205 from the plain-HTTP probe is a no-content
+ * response that measured nothing about redirect posture (observed live: google.com's
+ * real http:// answer is a 301, yet a scan emitted "status 204") — so the sub-probe is
+ * SKIPPED (no finding), matching the check's existing silent-skip posture for a failed
+ * HTTP probe. Real statuses (200, 4xx, 3xx→http) keep their current behavior.
+ *
+ * Imports the SOURCE module, not the built `@blackveil/dns-checks`.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { getHttpRedirectFindings } from '../../checks/ssl-analysis';
+
+describe('getHttpRedirectFindings — no-content HTTP probe responses are unmeasured (issue #806)', () => {
+	it.each([[204], [205]])('status %d emits NO redirect finding', (status) => {
+		expect(getHttpRedirectFindings('example.com', status, null)).toEqual([]);
+	});
+
+	it.each([[200], [404], [418]])('a real non-redirect status %d still emits the finding', (status) => {
+		const findings = getHttpRedirectFindings('example.com', status, null);
+		expect(findings).toHaveLength(1);
+		expect(findings[0].title).toBe('No HTTP to HTTPS redirect');
+		expect(findings[0].severity).toBe('medium');
+	});
+
+	it('an http:// downgrade redirect still emits its finding', () => {
+		const findings = getHttpRedirectFindings('example.com', 301, 'http://example.com/');
+		expect(findings).toHaveLength(1);
+		expect(findings[0].title).toBe('HTTP does not redirect to HTTPS');
+	});
+
+	it('an https:// redirect stays clean', () => {
+		expect(getHttpRedirectFindings('example.com', 301, 'https://example.com/')).toEqual([]);
+	});
+});

--- a/packages/dns-checks/src/checks/check-http-security.ts
+++ b/packages/dns-checks/src/checks/check-http-security.ts
@@ -19,6 +19,36 @@ const HTTPS_TIMEOUT_MS = 4_000;
 const MAX_REDIRECT_HOPS = 3;
 
 /**
+ * No-content 2xx statuses (issue #806). A terminal 204/205 satisfies `response.ok`
+ * but by definition delivered no page, so its (typically empty) header set must never
+ * be analyzed as the site's — doing so manufactured the entire confident
+ * missing-header slate from a response that measured nothing (observed live on
+ * google.com via an egress anomaly: the real answer is a 301/200 chain carrying
+ * `x-frame-options`, yet the scan reported "No X-Frame-Options"). WAF detection
+ * cannot rescue this case — it requires status >= 400 or a body signature — so the
+ * guard routes it to the same unmeasured shape as the WAF-blocked/never-completed
+ * probe branches below.
+ */
+const NO_CONTENT_STATUSES = new Set([204, 205]);
+
+/**
+ * The one honest finding for a no-content terminal response (issue #806).
+ * No `missingControl` — that flag asserts "we measured and the control is absent",
+ * and a 204 measured nothing (issue #638 law). `inconclusive` + `errorKind` are the
+ * honest unmeasured markers; the score-0/passed-false shape is applied by the caller
+ * via `unmeasuredZero`, exactly like the blocked-probe branches.
+ */
+function noContentFinding(domain: string, status: number): Finding {
+	return createFinding(
+		'http_security',
+		'HTTP response carried no content',
+		'info',
+		`https://${domain} answered the scanner with HTTP ${status} (no content). No page was delivered, so security headers could not be verified — the response may be an egress anomaly or challenge rather than the site.`,
+		{ inconclusive: true, confidence: 'heuristic', errorKind: 'no_content' },
+	);
+}
+
+/**
  * Follow redirects manually to get the final response with security headers.
  * Redirect responses (e.g., nist.gov → www.nist.gov) typically lack security
  * headers, causing false negatives if we analyze the 301 instead of the 200.
@@ -144,7 +174,16 @@ export async function checkHTTPSecurity(
 		// Follow redirects to get the final destination's headers
 		response = await followRedirects(response, fetchFn, timeoutMs);
 
-		if (response.ok) {
+		if (NO_CONTENT_STATUSES.has(response.status)) {
+			// Issue #806 — the terminal response is accepted here, so the no-content guard
+			// runs BEFORE any header-read branch (it also structurally shields the still-3xx
+			// branch below, where a 204/205 can never appear). `checkStatus: 'error'` makes
+			// the scoring engine EXCLUDE the category (transient-failure renormalization)
+			// rather than score the 0 — so the transient-zero retry can fire.
+			inconclusive = 'error';
+			unmeasuredZero = true;
+			findings.push(noContentFinding(domain, response.status));
+		} else if (response.ok) {
 			// 200-299: analyze headers normally
 			findings.push(...analyzeSecurityHeaders(response.headers));
 		} else if (response.status === 0 || response.status >= 500) {
@@ -165,7 +204,15 @@ export async function checkHTTPSecurity(
 			const getResponse = await tryGetFallback(`https://${domain}`, fetchFn, timeoutMs);
 			if (getResponse && (getResponse.ok || (getResponse.status >= 300 && getResponse.status < 400))) {
 				const followed = await followRedirects(getResponse, fetchFn, timeoutMs);
-				findings.push(...analyzeSecurityHeaders(followed.headers));
+				if (NO_CONTENT_STATUSES.has(followed.status)) {
+					// Issue #806 — the GET fallback's terminal response is accepted here, so the
+					// same no-content guard applies before analysis.
+					inconclusive = 'error';
+					unmeasuredZero = true;
+					findings.push(noContentFinding(domain, followed.status));
+				} else {
+					findings.push(...analyzeSecurityHeaders(followed.headers));
+				}
 				// GET fallback returns a real body we never read (followRedirects only
 				// cancels it when it redirects); release it so workerd doesn't cancel a
 				// stalled stream.

--- a/packages/dns-checks/src/checks/ssl-analysis.ts
+++ b/packages/dns-checks/src/checks/ssl-analysis.ts
@@ -102,6 +102,17 @@ export function getRobotsDisallowedFinding(domain: string, scope: RobotsDisallow
 }
 
 export function getHttpRedirectFindings(domain: string, status: number, location: string | null): Finding[] {
+	// Issue #806: a no-content 2xx (204/205) on the plain-HTTP probe delivered no page
+	// and measured nothing about redirect posture (observed live: google.com's real
+	// http:// answer is a 301, yet an egress anomaly produced "No HTTP to HTTPS
+	// redirect (status 204)"). Skip the sub-probe as unmeasured — matching
+	// checkHttpRedirect's silent-skip posture for a failed HTTP probe — instead of
+	// letting the catch-all below emit a scored claim. Real statuses (200, 4xx,
+	// 3xx→http) keep their behavior.
+	if (status === 204 || status === 205) {
+		return [];
+	}
+
 	if (status >= 300 && status < 400 && location?.startsWith('https://')) {
 		return [];
 	}

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -889,3 +889,32 @@ describe('checkHttpSecurity — WAF-inconclusive prose must not overclaim (issue
 		expect(finding.detail).toMatch(/\bmay\b/i);
 	});
 });
+
+describe('checkHttpSecurity — a no-content 2xx is unmeasured, not a missing-header slate (issue #806)', () => {
+	async function run(domain = 'example.com') {
+		const { checkHttpSecurity } = await import('../src/tools/check-http-security');
+		return checkHttpSecurity(domain);
+	}
+
+	it.each([[204], [205]])('terminal %d: no missing-header findings, inconclusive/excluded shape', async (status) => {
+		// A 204/205 satisfies `response.ok` but carries no page; before the guard it flowed
+		// into analyzeSecurityHeaders() and produced the full confident missing-header slate
+		// (observed live on google.com — issue #806). WAF detection cannot rescue it:
+		// detectWafEvent requires status >= 400 or a body signature.
+		globalThis.fetch = vi.fn().mockResolvedValue({
+			ok: true,
+			status,
+			type: 'basic',
+			headers: new Headers(),
+		});
+		const result = await run();
+		expect(result.findings.some((f) => f.title.startsWith('No '))).toBe(false);
+		expect(result.findings.some((f) => f.metadata?.missingControl === true)).toBe(false);
+		const marker = result.findings.find((f) => f.metadata?.inconclusive === true);
+		expect(marker).toBeDefined();
+		expect(marker!.metadata?.errorKind).toBe('no_content');
+		expect(result.score).toBe(0);
+		expect(result.passed).toBe(false);
+		expect(result.checkStatus).toBe('error');
+	});
+});

--- a/test/check-ssl.spec.ts
+++ b/test/check-ssl.spec.ts
@@ -189,4 +189,30 @@ describe('checkSsl', () => {
 		expect(finding).toBeDefined();
 		expect(finding!.severity).toBe('medium');
 	});
+
+	it('should NOT emit a redirect finding when the plain-HTTP probe returns a no-content 204 (issue #806)', async () => {
+		// A 204 carried no page and measured nothing about redirect posture (observed live:
+		// google.com's real http:// answer is a 301, yet a scan emitted "status 204").
+		// The sub-probe is skipped, matching the silent-skip posture for a failed HTTP probe.
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.startsWith('https://')) {
+				return Promise.resolve({
+					url: 'https://example.com/',
+					ok: true,
+					status: 200,
+					headers: new Headers({ 'strict-transport-security': 'max-age=31536000; includeSubDomains' }),
+				});
+			}
+			// Anomalous no-content answer on the http:// probe
+			return Promise.resolve({
+				ok: true,
+				status: 204,
+				headers: new Headers(),
+			});
+		});
+		const result = await run();
+		const finding = result.findings.find((f) => f.title === 'No HTTP to HTTPS redirect');
+		expect(finding).toBeUndefined();
+	});
 });


### PR DESCRIPTION
## Symptom

`scan_domain google.com` (scanner validation sweep 2026-08-28, dns-checks 1.25.0) emitted two confident false findings from one anomalous upstream 204:

- http_security: *"No X-Frame-Options header and no CSP frame-ancestors directive found"* — false; every hop of google.com's real chain carries `x-frame-options: SAMEORIGIN`.
- ssl: *"No HTTP to HTTPS redirect (status 204)"* — false; `http://google.com` really answers `301 → https://www.google.com/`.

## Root cause

Nothing between fetch and analysis asked "did we actually get a page?":

- `packages/dns-checks/src/checks/check-http-security.ts` — a terminal 204/205 satisfies `response.ok`, so its empty header set flowed into `analyzeSecurityHeaders()` and produced the entire confident missing-header slate: fully scored, no `inconclusive`, no `checkStatus`, KV-cached 5 min. WAF detection cannot intercept it (`detectWafEvent` requires status ≥ 400 or a body signature, so 204 → `null`).
- `packages/dns-checks/src/checks/ssl-analysis.ts` `getHttpRedirectFindings` — any non-3xx status, including a no-content 204, fell into the catch-all *"No HTTP to HTTPS redirect (status N)"* scored finding.

Not a redirect-hop bug — #782 already discarded that hypothesis; both layers follow redirects correctly.

## Fix

- **check-http-security (package)**: guard where the terminal response is accepted, before any header-read branch — the direct/redirect-followed path (which also structurally shields the still-3xx branch) and the GET-fallback path. A 204/205 routes to the existing unmeasured shape used by the WAF-blocked/never-completed-probe branches: one `inconclusive: true` finding with `errorKind: 'no_content'` + `confidence: 'heuristic'`, score 0 / passed false via `unmeasuredZero`, and `checkStatus: 'error'` so the scoring engine EXCLUDES the category (transient-failure renormalization) and the transient-zero retry can fire. Never `missingControl` — a 204 measured nothing (#638 law). The worker wrapper's synthetic-response path (`src/tools/check-http-security.ts`) feeds the same package function, so `scan_domain` is covered too, and its `isUnanalyzable` gate already skips CDN annotation on `checkStatus: 'error'`.
- **ssl-analysis (package)**: `getHttpRedirectFindings` skips the redirect sub-probe on 204/205 (unmeasured), matching `checkHttpRedirect`'s silent-skip posture for a failed HTTP probe. Real statuses (200, 4xx, 3xx→http, 3xx→https) are byte-for-byte unchanged and pinned by tests.

Out of scope (per issue): fetch-budget intermediate-hop analysis, the `usable[0]`/`primary` header-status mismatch, package versions.

## Test evidence (TDD — new tests written first, observed failing)

New tests:
- `packages/dns-checks/src/__tests__/checks/http-security-no-content.test.ts` — direct 204/205, 301→204 chain, 405→GET-204 fallback (all asserting no missing-header slate, no `missingControl`, the inconclusive/excluded shape), plus a headerless-200-unchanged guard.
- `packages/dns-checks/src/__tests__/checks/ssl-no-content.test.ts` — 204/205 emit no redirect finding; 200/404/418, http-downgrade, and https-redirect behavior pinned unchanged.
- Worker-path cases appended to `test/check-http-security.spec.ts` (204/205 through the dual-fetch → synthetic-response path) and `test/check-ssl.spec.ts` (http-probe 204 → no redirect finding).

Runs (all green):
- `npx vitest run` in `packages/dns-checks` — 49 files, 895 tests passed (includes the #638 WAF/unmeasured suite and both robots suites).
- `npx vitest run test/check-http-security.spec.ts test/check-ssl.spec.ts` — 2 files, 63 tests passed (existing WAF/redirect/#664 tests untouched and green).
- `npm run typecheck` — clean. `npm run lint` — clean.

No parity/scoring fixtures moved — the guard only fires on 204/205, which no existing fixture exercised (the issue verified no test anywhere covered a 204).

Fixes #806

🤖 Generated with [Claude Code](https://claude.com/claude-code)