### PR TITLE
fix(dnssec-chain): score unsigned target zone as 60, not an accidental 100

### DIFF
--- a/src/tools/check-dnssec-chain.ts
+++ b/src/tools/check-dnssec-chain.ts
@@ -261,6 +261,31 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 		);
 	}
 
+	// Unsigned target zone (high severity, decoupled penalty). Mirrors check_dnssec's
+	// "DNSSEC not enabled" finding (packages/dns-checks/src/checks/check-dnssec.ts:130-151):
+	// the target has neither a DS in its parent nor a DNSKEY of its own, so the chain of
+	// trust terminates at the target and DNSSEC provides no origin authentication for it.
+	// The severity LABEL is `high` (per the same NIST SP 800-81r3 / RFC 9364 rationale as
+	// check_dnssec — DNSSEC is one of several integrity controls, not a sole baseline), but
+	// the SCORE penalty is decoupled to -40 via `penaltyOverride` (100-40=60) rather than the
+	// raw high-severity default, keeping this tool's unsigned verdict numerically aligned
+	// with scan_domain's dnssec category for the same domain (#810). We deliberately do NOT
+	// set `missingControl: true` (that would zero the score to 0 via buildCheckResult's
+	// `score: hasMissingControl ? 0 : score`) and the detail text avoids "no … record",
+	// "missing", "required", and "not found" so `scoreIndicatesMissingControl`
+	// (packages/dns-checks/src/scoring/model.ts:267-285) cannot auto-zero the finding.
+	if (reachedTarget && !targetSigned) {
+		findings.push(
+			createFinding(
+				CATEGORY,
+				'DNSSEC chain terminates unsigned',
+				'high',
+				`DNSSEC is not configured for ${domain}: the chain-of-trust walk found neither a DS at the parent zone nor a DNSKEY published by ${domain} itself, so the chain terminates here. Without DNSSEC, DNS responses for ${domain} are not cryptographically verified, leaving SPF, DMARC, and DKIM vulnerable to DNS-level manipulation.`,
+				{ zone: domain, linkage: 'no_ds', penaltyOverride: 40 },
+			),
+		);
+	}
+
 	// Weak algorithm finding (medium severity)
 	if (weakAlgsFound.length > 0) {
 		const uniqueWeak = [...new Set(weakAlgsFound)];

--- a/test/check-dnssec-chain.spec.ts
+++ b/test/check-dnssec-chain.spec.ts
@@ -152,6 +152,44 @@ describe('checkDnssecChain', () => {
 		expect(infoFinding!.detail).toMatch(/no DS|unsigned|not signed/i);
 	});
 
+	it('unsigned domain scores 60 with a real high finding (#810) — not an accidental 100 pass', async () => {
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			// example.com has no DS and no DNSKEY → unsigned
+			'example.com:DS': emptyDsResponse('example.com'),
+			'example.com:DNSKEY': emptyDnskeyResponse('example.com'),
+			'example.com:A': adResponse('example.com', false),
+		});
+
+		const result = await run();
+
+		// Mirrors check_dnssec's "DNSSEC not enabled" finding
+		// (packages/dns-checks/src/checks/check-dnssec.ts:143-151): a `high`-labelled
+		// finding whose penalty is decoupled to -40 via `penaltyOverride`, so the
+		// category lands at 60 rather than an accidental 100 (#810) or a zeroed 0.
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.metadata?.penaltyOverride).toBe(40);
+
+		// Must NOT be flagged as a missing control — that would force the returned
+		// score to 0 (buildCheckResult: `score: hasMissingControl ? 0 : score`)
+		// instead of the intended 60, per the CLAUDE.md scoring trap for this exact
+		// finding class ("missingControl = we MEASURED and the control is absent").
+		expect(highFinding!.metadata?.missingControl).toBeUndefined();
+
+		// Aligned with scan_domain's dnssec category for the same unsigned-domain
+		// shape (packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts:29-32):
+		// score 60, and — since 60 >= 50 and no finding sets missingControl — `passed`
+		// is true under this repo's documented `passed = score>=50 && !hasMissingControl`
+		// formula ("did not penalize", NOT "control exists"; see CLAUDE.md's `passed`-as-
+		// verdict trap). Forcing `passed: false` here would require missingControl,
+		// which would also zero the score to 0 — contradicting the 60 this fix targets.
+		expect(result.score).toBe(60);
+		expect(result.passed).toBe(true);
+	});
+
 	it('broken linkage (DS exists but no DNSKEY) produces high severity', async () => {
 		mockDnsFetch({
 			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),


### PR DESCRIPTION
## Symptom

`check_dnssec_chain` reports **score 100/100** for a provably unsigned domain (no DS, no DNSKEY at the target zone) — an accidental pass rather than an encoded verdict. `scan_domain` correctly scores the `dnssec` category **60/100** with a HIGH finding for the same domain shape.

## Root cause

The target-zone-unsigned state classifies as linkage `no_ds`, which `chainBroken` deliberately excludes (it isn't a *broken* chain — it's an *absent* one). The only finding emitted for that state was the info-severity chain summary. Info findings carry a zero score penalty, and `scoreIndicatesMissingControl` only gates on `critical`/`high` severity, so the category scored a clean 100 with no finding ever reflecting the actual state.

`check_dnssec` (the sibling tool, same underlying fact) already handles this correctly via a `high` finding decoupled from the score penalty with `penaltyOverride: 40` → 60.

## Fix

`src/tools/check-dnssec-chain.ts`: when the walk reaches the target domain and it has neither a DS in its parent nor a DNSKEY of its own (`reachedTarget && !targetSigned`), emit a real `high`-severity finding mirroring `check_dnssec`'s `"DNSSEC not enabled"` pattern (`packages/dns-checks/src/checks/check-dnssec.ts:130-151`):

- `severity: 'high'`, `penaltyOverride: 40` → category lands at 60/100 (not zeroed, not 100).
- `missingControl` is deliberately **not** set — that would force `buildCheckResult` to zero the returned score to 0 instead of 60.
- The detail/title wording avoids `MISSING_CONTROL_REGEX`'s triggers (`no … record`, `missing`, `required`, `not found`) — verified against the actual regex before writing the text, not just eyeballed.

Signed chains and genuinely broken chains (`no_dnskey`/`broken` linkage) are unchanged; only the previously-uncovered "reached the target and it's plainly unsigned" branch gains a real finding.

### A note on `passed`

`buildCheckResult`'s documented convention in this repo is `passed = score >= 50 && !hasMissingControl` — "did not penalize", not "control exists" (see CLAUDE.md's scoring traps, and the identical precedent for `check_dnssec` itself at `packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts:29-32`, which asserts `passed: true, score: 60` for the exact same unsigned-domain shape). Since our new finding does not set `missingControl` (by design — that's what keeps the score at 60 instead of 0), `passed` legitimately stays `true` post-fix, mirroring `check_dnssec` exactly. The `"✅ Passed"` label on that 60/100 result is the separate, broader formatter problem tracked in #809 (`result.passed` driving the badge for every `check_*` tool) — out of scope here.

## Blast radius

`check_dnssec_chain` is `scanIncluded: false` with an out-of-union `dnssec_chain` category (absent from `CheckCategory`/`CATEGORY_TIERS`), so `scan_domain` scoring is untouched by this change.

## Tests

Added `test/check-dnssec-chain.spec.ts`: *"unsigned domain scores 60 with a real high finding (#810) — not an accidental 100 pass"*, asserting:
- a `high` finding exists with `metadata.penaltyOverride === 40`
- `metadata.missingControl` is unset (proves the score isn't accidentally zeroed)
- `result.score === 60`
- `result.passed === true` (see note above)

All existing signed-chain / broken-chain / root-unverified / weak-algorithm cases in the same file are unchanged and stay green.

```
npx vitest run test/check-dnssec-chain.spec.ts   # 9 passed
npm run typecheck                                # clean
npm run lint                                     # clean
```

## Cross-references

- #809 — the formatter class-level issue (`"✅ Passed"` from `result.passed` for every `check_*` tool); separate PR, not touched here.
- #793 (closed) — the twin bug in `check_dnssec` itself (non-deterministic AD=true false-100), settled unsigned=60 as the precedent this PR aligns with.

🤖 Generated with [Claude Code](https://claude.com/claude-code)