### PR TITLE
fix(sanitize): stop mangling legitimate finding prose in the MCP serializer

### DIFF
--- a/packages/dns-checks/src/checks/ns-analysis.ts
+++ b/packages/dns-checks/src/checks/ns-analysis.ts
@@ -152,7 +152,8 @@ export function getSoaValidationFindings(soaValues: ParsedSoaValues): Finding[] 
 				'ns',
 				'SOA expire too short',
 				'medium',
-				`SOA expire value is ${soaValues.expire}s (< 604800s / 1 week). If secondary nameservers cannot reach the primary for this duration, they will stop serving the zone.`,
+				// #807: no bare `<` — the createFinding() sanitizer strips it and garbles the prose.
+				`SOA expire value is ${soaValues.expire}s, below the recommended 604800s (1 week). If secondary nameservers cannot reach the primary for this duration, they will stop serving the zone.`,
 			),
 		);
 	}

--- a/packages/dns-checks/src/scoring/metadata-sanitize.ts
+++ b/packages/dns-checks/src/scoring/metadata-sanitize.ts
@@ -65,9 +65,10 @@ const CONTROL_BYTES = /[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g;
 const UNICODE_STEALTH = /[\u061C\u200B-\u200F\u202A-\u202E\u2060-\u206F\uFEFF]/g;
 
 /**
- * Markdown / HTML injection characters. Mirrors `DNS_DATA_UNSAFE` in
+ * Markdown / HTML injection characters. Mirrors `MARKDOWN_SYNTAX` in
  * `src/lib/output-sanitize.ts` (backtick code fences, headings, list/quote/table
- * markers, link brackets, angle brackets). `_` and `()` are deliberately left
+ * markers, link brackets, angle brackets) — parity pinned by
+ * `test/output-sanitize.spec.ts` (#807). `_` and `()` are deliberately left
  * intact — they appear in legitimate DNS labels (`_dmarc`) and prose.
  */
 const MARKDOWN_UNSAFE = /[`*#[\]>|<]/g;

--- a/src/lib/output-sanitize.ts
+++ b/src/lib/output-sanitize.ts
@@ -3,7 +3,16 @@
 import { sanitizeStructuredString } from '@blackveil/dns-checks/scoring';
 import { sanitizeInput } from './sanitize';
 
-const MARKDOWN_SYNTAX = /[`*_#[\]()>|<]/g;
+/**
+ * Markdown / HTML injection characters (F7/LLM01 guards: code fences, emphasis,
+ * headings, link brackets, tables, HTML tags). MUST mirror `MARKDOWN_UNSAFE` in
+ * `packages/dns-checks/src/scoring/metadata-sanitize.ts` — parity is pinned by
+ * `test/output-sanitize.spec.ts`. `_` and `()` are deliberately NOT stripped
+ * (#807): they appear in legitimate DNS labels (`_dmarc`, `_25._tcp`) and prose
+ * ("(1024 bits)"), a bare underscore/paren is not markdown in GFM's common
+ * cases, and the `[`/`]` stripping already defeats markdown links.
+ */
+const MARKDOWN_SYNTAX = /[`*#[\]>|<]/g;
 
 /**
  * Sanitize DNS-sourced data before it enters finding detail strings.

--- a/src/tools/check-zone-hygiene.ts
+++ b/src/tools/check-zone-hygiene.ts
@@ -92,7 +92,8 @@ export async function checkZoneHygiene(domain: string, dnsOptions?: QueryDnsOpti
 								'zone_hygiene',
 								'SOA expire value is short',
 								'low',
-								`The SOA expire value (${soa.expire}s) is less than 1 week (604800s). If the primary NS becomes unreachable, secondaries will stop serving the zone sooner than recommended.`,
+								// #807: keep this wording consistent with the ns-analysis SOA-expire templates (no bare `<`).
+								`SOA expire value is ${soa.expire}s, below the recommended 604800s (1 week). If the primary NS becomes unreachable, secondaries will stop serving the zone sooner than recommended.`,
 								{ expire: soa.expire },
 							),
 						);

--- a/src/tools/ns-analysis.ts
+++ b/src/tools/ns-analysis.ts
@@ -138,7 +138,8 @@ export function getSoaValidationFindings(soaValues: ParsedSoaValues): Finding[] 
 				'ns',
 				'SOA expire too short',
 				'medium',
-				`SOA expire value is ${soaValues.expire}s (< 604800s / 1 week). If secondary nameservers cannot reach the primary for this duration, they will stop serving the zone.`,
+				// #807: no bare `<` — the createFinding() sanitizer strips it and garbles the prose.
+				`SOA expire value is ${soaValues.expire}s, below the recommended 604800s (1 week). If secondary nameservers cannot reach the primary for this duration, they will stop serving the zone.`,
 			),
 		);
 	}

--- a/test/check-zone-hygiene.spec.ts
+++ b/test/check-zone-hygiene.spec.ts
@@ -206,6 +206,10 @@ describe('checkZoneHygiene', () => {
 		expect(shortExpire).toBeDefined();
 		expect(shortExpire!.severity).toBe('low');
 		expect(shortExpire!.metadata?.expire).toBe(86400);
+		// #807: template must not use a bare `<` — createFinding()'s markdown
+		// sanitizer strips it and garbles the prose.
+		expect(shortExpire!.detail).toContain('SOA expire value is 86400s, below the recommended 604800s (1 week).');
+		expect(shortExpire!.detail).not.toContain('<');
 	});
 
 	it('should handle missing SOA record', async () => {

--- a/test/explain-finding.spec.ts
+++ b/test/explain-finding.spec.ts
@@ -439,7 +439,7 @@ describe('explainFinding', () => {
 
 	it('falls back to default for NS medium severity (no NS_MEDIUM entry)', async () => {
 		const { explainFinding } = await getModule();
-		const result = explainFinding('NS', 'medium', 'SOA expire value is 1800s (< 604800s / 1 week)');
+		const result = explainFinding('NS', 'medium', 'SOA expire value is 1800s, below the recommended 604800s (1 week)');
 		expect(result.title).toBe('Security Check Complete');
 	});
 

--- a/test/format-scan-report.spec.ts
+++ b/test/format-scan-report.spec.ts
@@ -91,7 +91,7 @@ describe('format-scan-report', () => {
 		expect(report).toContain('Overall Score: 72/100 (C)');
 		expect(report).toContain('Grade: C');
 		expect(report).toContain('Takeover Verification: potential');
-		expect(report).toContain('Proof Required: authorized proof of control');
+		expect(report).toContain('Proof Required: authorized_proof_of_control'); // #807: sanitizer now preserves underscores in the token
 		expect(report).toContain('Confidence: heuristic');
 		expect(report).toContain('Results served from cache');
 	});

--- a/test/ns-analysis.spec.ts
+++ b/test/ns-analysis.spec.ts
@@ -41,6 +41,11 @@ describe('ns-analysis', () => {
 			'SOA expire too short',
 			'SOA negative cache TTL too long',
 		]);
+		// #807: template must not use a bare `<` — createFinding()'s markdown
+		// sanitizer strips it and garbles the prose ("300s ( 604800s / 1 week)").
+		const expire = findings.find((finding) => finding.title === 'SOA expire too short');
+		expect(expire!.detail).toContain('SOA expire value is 300s, below the recommended 604800s (1 week).');
+		expect(expire!.detail).not.toContain('<');
 	});
 
 	it('returns null for malformed SOA strings', () => {

--- a/test/output-sanitize.spec.ts
+++ b/test/output-sanitize.spec.ts
@@ -319,18 +319,26 @@ describe('sanitizeOutputText', () => {
 		expect(sanitizeOutputText('a|b')).not.toContain('|');
 	});
 
-	it('replaces underscore with space (MARKDOWN_SYNTAX includes underscore)', async () => {
+	it('preserves underscores (#807 — DNS labels like _25._tcp, _dmarc are legitimate prose)', async () => {
 		const { sanitizeOutputText } = await import('../src/lib/output-sanitize');
-		// sanitizeOutputText uses MARKDOWN_SYNTAX which includes `_`
-		// This is intentional: it is stricter than sanitizeDnsData for display output
-		expect(sanitizeOutputText('_italic_')).not.toContain('_');
+		// #807: MARKDOWN_SYNTAX used to include `_`, mangling DNS labels in finding
+		// prose (`_25._tcp` → `25. tcp`). It now matches the dns-checks
+		// MARKDOWN_UNSAFE class, which deliberately preserves `_` — a bare
+		// underscore is not emphasis in GFM's common cases, and `[`/`]` stripping
+		// already defeats markdown links.
+		expect(sanitizeOutputText('_25._tcp')).toBe('_25._tcp');
+		expect(sanitizeOutputText('_443._tcp')).toBe('_443._tcp');
+		expect(sanitizeOutputText('default._bimi')).toBe('default._bimi');
+		expect(sanitizeOutputText('_dmarc.example.com')).toBe('_dmarc.example.com');
 	});
 
-	it('replaces parentheses with space (MARKDOWN_SYNTAX includes parentheses)', async () => {
+	it('preserves parentheses (#807 — natural-language detail like "(1024 bits)")', async () => {
 		const { sanitizeOutputText } = await import('../src/lib/output-sanitize');
-		// sanitizeOutputText uses MARKDOWN_SYNTAX which includes `(` and `)`
-		expect(sanitizeOutputText('func(arg)')).not.toContain('(');
-		expect(sanitizeOutputText('func(arg)')).not.toContain(')');
+		// #807: MARKDOWN_SYNTAX used to include `(` and `)`, space-padding prose
+		// punctuation ("(1024 bits)." → "1024 bits ."). A bare paren is not a
+		// markdown link once `[`/`]` are stripped.
+		expect(sanitizeOutputText('weak DKIM key (1024 bits).')).toBe('weak DKIM key (1024 bits).');
+		expect(sanitizeOutputText('func(arg)')).toBe('func(arg)');
 	});
 
 	// --- Truncation ---
@@ -420,18 +428,18 @@ describe('sanitizeOutputText', () => {
 // ---------------------------------------------------------------------------
 
 describe('sanitizeDnsData vs sanitizeOutputText — differing contracts', () => {
-	it('sanitizeDnsData preserves underscores; sanitizeOutputText does not', async () => {
+	it('both preserve underscores (#807 — classes realigned on `_`)', async () => {
 		const { sanitizeDnsData, sanitizeOutputText } = await import('../src/lib/output-sanitize');
 		const input = '_dmarc.example.com';
 		expect(sanitizeDnsData(input)).toContain('_');
-		expect(sanitizeOutputText(input)).not.toContain('_');
+		expect(sanitizeOutputText(input)).toContain('_');
 	});
 
-	it('sanitizeDnsData preserves parentheses; sanitizeOutputText does not', async () => {
+	it('both preserve parentheses (#807 — classes realigned on `()`)', async () => {
 		const { sanitizeDnsData, sanitizeOutputText } = await import('../src/lib/output-sanitize');
 		const input = 'see RFC (7208)';
 		expect(sanitizeDnsData(input)).toContain('(');
-		expect(sanitizeOutputText(input)).not.toContain('(');
+		expect(sanitizeOutputText(input)).toContain('(');
 	});
 
 	it('sanitizeDnsData does not truncate; sanitizeOutputText truncates at 240 by default', async () => {
@@ -448,5 +456,95 @@ describe('sanitizeDnsData vs sanitizeOutputText — differing contracts', () => 
 		// sanitizeOutputText still loses ESC during sanitizeInput().
 		expect(sanitizeDnsData(ansi)).not.toContain('\x1b');
 		expect(sanitizeOutputText(ansi)).not.toContain('\x1b');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #807 drift guard: worker MARKDOWN_SYNTAX vs dns-checks MARKDOWN_UNSAFE
+// ---------------------------------------------------------------------------
+//
+// The two stacked injection guards — `createFinding()`'s auto-sanitize
+// (MARKDOWN_UNSAFE, packages/dns-checks/src/scoring/metadata-sanitize.ts) and
+// the MCP prose serializer (MARKDOWN_SYNTAX, src/lib/output-sanitize.ts) —
+// silently diverged: the worker class grew `_`, `(`, `)` and mangled
+// legitimate DNS labels (`_25._tcp` → `25. tcp`) and prose punctuation.
+// This suite pins the two character classes to identical strip/preserve
+// behaviour, per character, so they cannot drift apart again.
+
+describe('#807 sanitizer character-class parity (worker ↔ dns-checks)', () => {
+	// F7/LLM01 injection characters — BOTH layers must strip every one of these
+	// (code fences, emphasis, headings, links, tables, HTML tags).
+	const MUST_STRIP = ['`', '*', '#', '[', ']', '>', '|', '<'] as const;
+	// Legitimate DNS-label / prose characters — BOTH layers must preserve these
+	// (`_dmarc`, `_25._tcp`, parenthesized prose like "(1024 bits)").
+	const MUST_PRESERVE = ['_', '(', ')'] as const;
+
+	it('both layers strip every markdown/HTML injection character', async () => {
+		const { sanitizeOutputText } = await import('../src/lib/output-sanitize');
+		const { sanitizeStructuredString } = await import('@blackveil/dns-checks/scoring');
+		for (const ch of MUST_STRIP) {
+			const probe = `a${ch}b`;
+			expect(sanitizeStructuredString(probe), `dns-checks must strip ${JSON.stringify(ch)}`).not.toContain(ch);
+			expect(sanitizeOutputText(probe), `worker must strip ${JSON.stringify(ch)}`).not.toContain(ch);
+		}
+	});
+
+	it('both layers preserve underscore and parentheses', async () => {
+		const { sanitizeOutputText } = await import('../src/lib/output-sanitize');
+		const { sanitizeStructuredString } = await import('@blackveil/dns-checks/scoring');
+		for (const ch of MUST_PRESERVE) {
+			const probe = `a${ch}b`;
+			expect(sanitizeStructuredString(probe), `dns-checks must preserve ${JSON.stringify(ch)}`).toContain(ch);
+			expect(sanitizeOutputText(probe), `worker must preserve ${JSON.stringify(ch)}`).toContain(ch);
+		}
+	});
+
+	it('the layers agree on every printable ASCII punctuation character', async () => {
+		const { sanitizeOutputText } = await import('../src/lib/output-sanitize');
+		const { sanitizeStructuredString } = await import('@blackveil/dns-checks/scoring');
+		// Full printable-ASCII punctuation sweep: any future edit that widens or
+		// narrows ONE class without the other fails here, naming the character.
+		for (let code = 0x21; code <= 0x7e; code++) {
+			const ch = String.fromCharCode(code);
+			if (/[a-zA-Z0-9]/.test(ch)) continue;
+			const probe = `a${ch}b`;
+			const pkgKeeps = sanitizeStructuredString(probe).includes(ch);
+			const workerKeeps = sanitizeOutputText(probe).includes(ch);
+			expect(workerKeeps, `classes drifted on ${JSON.stringify(ch)} (dns-checks keeps: ${pkgKeeps})`).toBe(pkgKeeps);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// #807 SOA-expire template survives both sanitizer layers intact
+// ---------------------------------------------------------------------------
+//
+// The old template "SOA expire value is 1800s (< 604800s / 1 week)." was
+// garbled in sequence: createFinding() stripped the bare `<`, then the prose
+// serializer stripped `()`, yielding "1800s 604800s / 1 week ." with orphaned
+// punctuation. The reworded template must round-trip both layers byte-for-byte.
+
+describe('#807 SOA-expire finding prose round-trips both sanitizer layers', () => {
+	it('worker + package ns-analysis template is unchanged by both layers', async () => {
+		const { sanitizeOutputText } = await import('../src/lib/output-sanitize');
+		const { sanitizeStructuredString } = await import('@blackveil/dns-checks/scoring');
+		const detail =
+			'SOA expire value is 1800s, below the recommended 604800s (1 week). If secondary nameservers cannot reach the primary for this duration, they will stop serving the zone.';
+		const afterLayer1 = sanitizeStructuredString(detail);
+		expect(afterLayer1).toBe(detail);
+		const afterLayer2 = sanitizeOutputText(afterLayer1, 500);
+		expect(afterLayer2).toBe(detail);
+		// No orphaned punctuation from stripped characters
+		expect(afterLayer2).not.toMatch(/\s[.,]/);
+	});
+
+	it('zone-hygiene template is unchanged by both layers', async () => {
+		const { sanitizeOutputText } = await import('../src/lib/output-sanitize');
+		const { sanitizeStructuredString } = await import('@blackveil/dns-checks/scoring');
+		const detail =
+			'SOA expire value is 86400s, below the recommended 604800s (1 week). If the primary NS becomes unreachable, secondaries will stop serving the zone sooner than recommended.';
+		const afterBoth = sanitizeOutputText(sanitizeStructuredString(detail), 500);
+		expect(afterBoth).toBe(detail);
+		expect(afterBoth).not.toMatch(/\s[.,]/);
 	});
 });

--- a/test/tool-formatters.spec.ts
+++ b/test/tool-formatters.spec.ts
@@ -99,7 +99,7 @@ describe('tool-formatters', () => {
 
 		const text = formatCheckResult(result);
 		expect(text).toContain('Takeover Verification: potential');
-		expect(text).toContain('Proof Required: authorized proof of control');
+		expect(text).toContain('Proof Required: authorized_proof_of_control'); // #807: sanitizer now preserves underscores in the token
 		expect(text).toContain('Confidence: heuristic');
 	});
 


### PR DESCRIPTION
## Symptom

Two byte-for-byte-reproduced manglings of legitimate finding prose (#807):

- **A — garbled SOA-expire message**: `SOA expire value is 1800s (< 604800s / 1 week).` rendered as `SOA expire value is 1800s 604800s / 1 week .` — orphaned ` .` included — on google.com and every domain with a short SOA expire. The mangled text flows into branded client PDF/DOCX deliverables.
- **B — underscores stripped from DNS labels, punctuation space-padded** (systematic, MCP prose surface): `_25._tcp` → `25. tcp`, `default._bimi` → `default. bimi`, `(1024 bits).` → `1024 bits .`, `p=,` → `p= ,`.

## Root cause

Two stacked markdown-stripping injection guards whose character classes silently drifted apart:

1. `createFinding()` auto-sanitize — `MARKDOWN_UNSAFE` in `packages/dns-checks/src/scoring/metadata-sanitize.ts`, which **deliberately** preserves `_` and `()` (its comment cites `_dmarc`).
2. The MCP prose serializer — `MARKDOWN_SYNTAX` in `src/lib/output-sanitize.ts`, which had grown into a superset adding `_`, `(`, `)`, while its sibling's doc comment still claimed the classes mirrored each other.

Symptom A is the two layers in sequence: layer 1 strips the template's bare `<`, layer 2 strips the `()`. Symptom B is entirely layer 2's extra `_`/`()` members.

## Fix

- **Narrow `MARKDOWN_SYNTAX`** to match the dns-checks class: drop `_`, `(`, `)`. The F7/LLM01 injection guards are **unchanged** — backtick, `*`, `#`, `[`, `]`, `>`, `|`, `<` are all still stripped (code fences, links, headings, tables, HTML). A bare paren cannot form a markdown link once `[`/`]` are stripped, and a bare underscore is not emphasis in GFM's common cases.
- **Reword the three SOA-expire templates** (`packages/dns-checks/src/checks/ns-analysis.ts`, `src/tools/ns-analysis.ts`, `src/tools/check-zone-hygiene.ts`) to `SOA expire value is ${expire}s, below the recommended 604800s (1 week).` — no bare `<` for the deeper sanitizer to strip; the three copies now share a consistent first sentence.
- **Drift guard**: new parity suite in `test/output-sanitize.spec.ts` pins the worker (`MARKDOWN_SYNTAX`) and package (`MARKDOWN_UNSAFE`) classes to identical strip/preserve behaviour — per named injection character, per preserved character, and across a full printable-ASCII punctuation sweep — so the classes cannot silently diverge again.
- Fixed the stale `DNS_DATA_UNSAFE` cross-reference in the dns-checks doc comment.

## Tests updated (pinned-mangled-text sweep)

- `test/output-sanitize.spec.ts` — the two tests that deliberately pinned the buggy stripping of `_` and `()` are **inverted** to assert preservation (`_25._tcp`, `_443._tcp`, `default._bimi`, `(1024 bits)` all round-trip verbatim), and the "differing contracts" section now asserts both sanitizers preserve `_`/`()`. New end-to-end tests assert the reworded SOA templates survive **both** sanitizer layers byte-for-byte with no orphaned punctuation.
- `test/tool-formatters.spec.ts` + `test/format-scan-report.spec.ts` — both asserted the mangled rendering `Proof Required: authorized proof of control` (underscores stripped from the `authorized_proof_of_control` token); now assert the verbatim token. No injection assertion was weakened — all `not.toContain` checks for backticks/brackets/headings/ANSI stand as-is.
- `test/ns-analysis.spec.ts` + `test/check-zone-hygiene.spec.ts` — added detail assertions pinning the new `<`-free template at source.
- `test/explain-finding.spec.ts` — an incidental input string using the old template wording updated for consistency (asserts fallback behaviour; not wording-dependent).

## Test evidence

- `npx vitest run` on all 11 touched/affected worker specs (output-sanitize, format-scan-report, ns-analysis, check-ns, check-zone-hygiene, tool-formatters, format-report, format-report-na-reconciliation, brand-audit-markdown, discover-subdomains-coverage, explain-finding): **307/307 passed**
- `npx vitest run --root packages/dns-checks`: **883/883 passed**
- `npm run typecheck`: clean (rc=0) · `npm run lint`: clean
- TDD: the new/inverted assertions were written first and observed failing (8 red) against the old regex and templates before the fix.

Fixes #807

🤖 Generated with [Claude Code](https://claude.com/claude-code)
