### PR TITLE
fix(handlers): stop formatCheckResult printing Passed for unsatisfied controls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,7 @@ Three-tier model (`computeScanScore`): **Core 70%** (DMARC 16, DKIM 10, SPF 10, 
 - ⚠️ **Measuring DNSSEC across a corpus: test `dnssec > 60`, NEVER `> 0`.** An unsigned zone sits at exactly 60 (fixed `penaltyOverride: 40`, not a zeroing) — `> 0` reports ~95–100% adoption against a true single-digit rate. Read `recordPresent`/`controlPresent` instead.
 - ⚠️ **`missingControl` = "we MEASURED and the control is absent"; `inconclusive` + `errorKind` = "the probe never reached the origin".** Never both on one finding — recording a blocked/cut probe as absence zeroes a category nobody measured.
 - ⚠️ **`SCORING_CONFIG.coreWeights` is INERT on the scan path** (parses, validates, changes no score — was live in prod undetected for months). Express overrides as `profileWeights.<profile>` (per-profile!). Any weight change re-grades every customer: an operator decision.
-- ⚠️ **`passed` = `score >= 50 && !hasMissingControl`** — "did not penalize", NOT "control exists". Three surfaces have misread it as a verdict.
+- ⚠️ **`passed` = `score >= 50 && !hasMissingControl`** — "did not penalize", NOT "control exists". Four surfaces have misread it as a verdict (map_compliance #705, compare_baseline #706, the deploy verifier #725, formatCheckResult's Status line #809).
 - **Grades — TWO scales by role**: canonical 9-band `scoreToGrade` internal; customer-facing 6-band NIST via the ONE chokepoint `displayGradeFor` (`src/lib/ungraded-display.ts`), which returns `null` for ungraded scans (never fabricate an F).
 - **Severity penalties**: C −40, H −25, M −15, L −5, Info 0.
 - **Adaptive weights**: EMA per profile+provider via `ProfileAccumulator` DO, blended past `MATURITY_THRESHOLD = 200`; falls back to static.

--- a/src/handlers/tool-formatters.ts
+++ b/src/handlers/tool-formatters.ts
@@ -4,6 +4,7 @@ import type { CheckResult } from '../lib/scoring';
 import type { OutputFormat } from './tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import { isCompletedCheck, UNGRADED_DISPLAY } from '../lib/ungraded-display';
+import { isSatisfiedControl } from '../lib/control-presence';
 import { resolveImpactNarrative } from '../tools/explain-finding';
 
 export interface McpContent {
@@ -139,7 +140,23 @@ export function formatCheckResult(result: CheckResult, format: OutputFormat = 'f
 	// The predicate MUST come from `isCompletedCheck`; re-deriving it here is banned by
 	// `test/audits/completed-evidence-predicate-ssot.audit.test.ts`.
 	if (isCompletedCheck(result)) {
-		lines.push(`**Status:** ${result.passed ? '✅ Passed' : '❌ Failed'}`);
+		// #809: `result.passed` means "did not penalize", not "the control exists" -- the same
+		// defect #705/#706/#725 closed on map_compliance/compare_baseline/the deploy verifier by
+		// routing through `isSatisfiedControl` (src/lib/control-presence.ts). This is the fourth
+		// and broadest surface: EVERY check_* tool's rendered Status line, via the generic
+		// dispatch in handlers/tools.ts. `!passed` still means Failed unambiguously. `passed` that
+		// also satisfies `isSatisfiedControl` (no unrebutted absence, no measured medium+ finding)
+		// keeps the plain "✅ Passed". `passed` that does NOT satisfy it -- a measured medium+
+		// finding survived under a profile that didn't penalize enough to flip `passed`, or an
+		// unrebutted absence -- gets a status that cannot be read as a control verdict: it is
+		// still "did not penalize" (not a fabricated Failed), but it must not say bare "Passed"
+		// either. Deliberately 🟡, NOT ⚠️/🔶/🔴/🚨/ℹ️ -- those are the per-finding severity icons
+		// rendered below, and `format: "compact"` is asserted (test/handlers-tools.spec.ts) to
+		// carry NONE of them in the Status line; reusing one here would make a compact-mode
+		// caller's "no severity icons" check see one that isn't describing a finding. The score
+		// line and structured/JSON channel are untouched -- this is display-only.
+		const statusLabel = result.passed ? (isSatisfiedControl(result) ? '✅ Passed' : '🟡 Passed with findings') : '❌ Failed';
+		lines.push(`**Status:** ${statusLabel}`);
 		lines.push(`**Score:** ${result.score}/100`);
 	} else {
 		lines.push(`**Status:** ${UNGRADED_DISPLAY}`);

--- a/test/handlers-tools.spec.ts
+++ b/test/handlers-tools.spec.ts
@@ -503,10 +503,17 @@ describe('formatCheckResult - via handleToolsCall', () => {
 		return handleToolsCall({ name, arguments: args });
 	}
 
-	it('passing check result contains "Passed" and score', async () => {
+	// #809: this fixture's mock TXT helper answers the `_spf.google.com` include lookup with
+	// the SAME record as the domain being checked, which the circular-include detector reads as
+	// a genuine self-reference -- a MEASURED high-severity finding. `score` (75) still clears the
+	// `passed` threshold, but `passed: true` alongside an unrebutted high finding is exactly the
+	// case `isSatisfiedControl` exists to catch, so the Status line can no longer say plain
+	// "Passed" for it -- that was the class of defect #809 fixed. Was `toContain('\u2705 Passed')`.
+	it('passing check result with a disqualifying finding gets the qualified verdict, not a plain "Passed"', async () => {
 		mockTxtRecords(['v=spf1 include:_spf.google.com -all']);
 		const result = await call('check_spf', { domain: 'example.com' });
-		expect(result.content[0].text).toContain('\u2705 Passed');
+		expect(result.content[0].text).toContain('\ud83d\udfe1 Passed with findings');
+		expect(result.content[0].text).not.toContain('\u2705 Passed');
 		expect(result.content[0].text).toContain('/100');
 	});
 

--- a/test/tool-formatters.spec.ts
+++ b/test/tool-formatters.spec.ts
@@ -77,6 +77,61 @@ describe('tool-formatters', () => {
 		expect(text).not.toContain('not measured');
 	});
 
+	// #809: `passed` alone means "did not penalize", not "the control exists" -- the same
+	// defect #705/#706/#725 fixed on map_compliance/compare_baseline/the deploy verifier, but
+	// missed here, the broadest surface (every check_* tool's rendered Status line). Routing
+	// through `isSatisfiedControl` (src/lib/control-presence.ts) closes it: a `passed: true`
+	// result that carries a MEASURED medium-or-worse finding (the severity floor) can no longer
+	// print a plain "✅ Passed" that reads as a control verdict nobody actually confirmed.
+	describe('formatCheckResult — passed-as-verdict (#809)', () => {
+		it('passed with only info findings still renders the plain Passed verdict', () => {
+			const result: CheckResult = {
+				category: 'spf',
+				passed: true,
+				score: 100,
+				checkStatus: 'completed',
+				findings: [{ category: 'spf', title: 'SPF record valid', severity: 'info', detail: 'Record ends in -all.' }],
+			};
+
+			const text = formatCheckResult(result);
+			expect(text).toContain('**Status:** ✅ Passed');
+		});
+
+		it('passed with a MEASURED medium finding cannot print a plain Passed verdict', () => {
+			const result: CheckResult = {
+				category: 'dnssec_chain',
+				passed: true,
+				score: 60,
+				checkStatus: 'completed',
+				findings: [
+					{
+						category: 'dnssec_chain',
+						title: 'DNSSEC not enabled',
+						severity: 'medium',
+						detail: 'No DS record found at the parent zone.',
+					},
+				],
+			};
+
+			const text = formatCheckResult(result);
+			expect(text).not.toContain('**Status:** ✅ Passed');
+			expect(text).toContain('**Status:** 🟡 Passed with findings');
+		});
+
+		it('!passed still renders Failed regardless of finding severity', () => {
+			const result: CheckResult = {
+				category: 'spf',
+				passed: false,
+				score: 20,
+				checkStatus: 'completed',
+				findings: [{ category: 'spf', title: 'Unsafe SPF policy', severity: 'high', detail: 'SPF record contains +all.' }],
+			};
+
+			const text = formatCheckResult(result);
+			expect(text).toContain('**Status:** ❌ Failed');
+		});
+	});
+
 	it('formatCheckResult renders takeover proof requirements when exploitability is not proven', () => {
 		const result: CheckResult = {
 			category: 'subdomain_takeover',


### PR DESCRIPTION
## Symptom

`check_dnssec_chain` (and every other `check_*` tool) can render `**Status:** ✅ Passed` for a domain whose control is provably absent or actively deficient — e.g. an unsigned zone (companion issue #810).

## Root cause

`result.passed` means `score >= 50 && !hasMissingControl` — "did not penalize", not "the control exists". `formatCheckResult` (`src/handlers/tool-formatters.ts:141-146`) printed `result.passed ? '✅ Passed' : '❌ Failed'` directly, for **every** `check_*` tool via the generic dispatch in `handlers/tools.ts`. This is the fourth surface to misread `passed` as a verdict — #705 (`map_compliance`), #706 (`compare_baseline`), and #725 (the deploy verifier) all had the same defect and were fixed by routing through `isSatisfiedControl` (`src/lib/control-presence.ts`); `tool-formatters.ts` imported nothing from that module.

## Fix

`formatCheckResult` now imports `isSatisfiedControl` and branches on it alongside `passed`:

- `!passed` → unchanged, `❌ Failed`
- `passed && isSatisfiedControl(result)` → unchanged, `✅ Passed`
- `passed && !isSatisfiedControl(result)` (an unrebutted absence, or a measured medium+ finding that survived under a profile that didn't penalize enough to flip `passed`) → `🟡 Passed with findings` — a status that cannot be read as a control verdict, without fabricating a `Failed` that never happened

Deliberately **not** reusing `⚠️`/`🔶`/`🔴`/`🚨`/`ℹ️` — those are the per-finding severity icons rendered in the body, and `format: "compact"` is asserted elsewhere to carry none of them in the Status line.

Display-only, per the scope ruling for this fix: the `**Score:**` line, the structured/JSON channel (`structuredContent` / `STRUCTURED_RESULT`), and `isSatisfiedControl`/`control-presence.ts` itself are all untouched.

Also updates CLAUDE.md's scoring section, which said "Three surfaces have misread it as a verdict" — stale by one; now names all four (#705/#706/#725/#809), per the issue's own closing housekeeping note.

## Tests (TDD)

Added a failing-first suite in `test/tool-formatters.spec.ts` (`formatCheckResult — passed-as-verdict (#809)`):
- passed + only info findings → plain `✅ Passed` (unchanged)
- passed + a measured medium finding → new `🟡 Passed with findings`
- `!passed` → `❌ Failed` (unchanged)

Swept the existing suite for the literal `✅ Passed`/`Passed'` string. One existing assertion in `test/handlers-tools.spec.ts` (`formatCheckResult - via handleToolsCall`) exercised a `check_spf` fixture whose mock TXT helper answers the `_spf.google.com` include lookup with the same record as the domain under test, which the circular-include detector reads as a genuine self-reference — a measured HIGH finding alongside `passed: true` (score 75). That is exactly the case `isSatisfiedControl` exists to catch, so the assertion was updated (with a `#809` comment) to expect `🟡 Passed with findings` instead of `✅ Passed`; no other assertion in that test was weakened.

- `npx vitest run test/tool-formatters.spec.ts test/handlers-tools.spec.ts` — 94/94 pass
- Full suite (`npm test`): 8202 passed, 7 failed, 13 skipped, 1 suite failed. All 8 failures are pre-existing and unrelated to this diff:
  - `test/wasm-integration.test.ts` — expected per repo convention (wasm module load error with 0 test failures)
  - 7 timeouts (`internal-analytics-erase`, `internal-analytics-forensics`, `internal-analytics-usage`, `legacy-session-validation`, `queue-batch-analytics`, `request-correlation-id`, `subdomain-takeover-cachekey`) — none of these files reference the Status line text this PR changes; re-ran two of them (`internal-analytics-usage`, `subdomain-takeover-cachekey`) in isolation and both passed, confirming full-suite WebSocket-teardown flake rather than a regression
- `npm run typecheck` — clean
- `npm run lint` — clean

## Follow-up (out of scope, noted per the issue)

The analytics pass/fail verdict at `src/handlers/tools.ts:1326-1331` still reads bare `result.passed` and will silently diverge from the Status line this PR fixes — the issue explicitly calls this out as a *different* surface, and this PR's scope ruling was display-only in `tool-formatters.ts`. Aligning the analytics verdict (or accepting the divergence) is a separate decision because it changes a telemetry series, not display text.

Fixes #809

🤖 Generated with [Claude Code](https://claude.com/claude-code)