### PR TITLE
fix(srv): add directory/M365-federation prefixes and scope the negative claim

### DIFF
--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -393,7 +393,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	check_srv: {
 		description:
-			"Map a domain's DNS-visible service footprint by probing ~16 common SRV record prefixes (email, calendar, messaging, web, directory) in parallel. Returns discovered services and flags insecure service advertisements — e.g. plaintext IMAP/POP3 without an encrypted variant. Use when asked to map DNS-visible services or flag insecure service advertisements.",
+			"Map a domain's DNS-visible service footprint by probing 19 common SRV record prefixes (email, calendar, messaging, directory, web) in parallel. Returns discovered services and flags insecure service advertisements — e.g. plaintext IMAP/POP3/LDAP without an encrypted variant. A domain with no matches among the probed prefixes is not proof the domain has no services at all. Use when asked to map DNS-visible services or flag insecure service advertisements.",
 		schema: BaseDomainArgs,
 		group: 'infrastructure',
 		tier: 'hardening',

--- a/src/tools/check-srv.ts
+++ b/src/tools/check-srv.ts
@@ -3,7 +3,7 @@
 /**
  * SRV Service Discovery Audit tool.
  * Probes common SRV prefixes to map a domain's DNS-visible service footprint.
- * Flags insecure protocol advertisements (plain-text IMAP/POP3 without encrypted variants).
+ * Flags insecure protocol advertisements (plain-text IMAP/POP3/LDAP without encrypted variants).
  *
  * Workers-compatible: uses fetch API only (DNS-over-HTTPS).
  */
@@ -17,8 +17,8 @@ import type { SrvProbeResult } from './srv-analysis';
 /**
  * Audit SRV service discovery records for a domain.
  *
- * Probes ~16 common SRV prefixes (email, calendar, messaging, web) in parallel
- * and analyzes discovered services for security concerns.
+ * Probes 19 common SRV prefixes (email, calendar, messaging, directory, web) in parallel
+ * and analyzes discovered services for security concerns. See {@link SRV_PREFIXES} for the exact list.
  *
  * @param domain - The domain to check (must already be validated and sanitized)
  * @param dnsOptions - Optional DNS query options (e.g., scan-context optimizations)

--- a/src/tools/srv-analysis.ts
+++ b/src/tools/srv-analysis.ts
@@ -5,7 +5,7 @@ import { createFinding } from '../lib/scoring';
 
 /**
  * Common SRV service prefixes to probe during a domain service discovery audit.
- * Covers email, autodiscovery, calendar, messaging, and web/infra services.
+ * Covers email, autodiscovery, calendar, messaging, directory, and web/infra services.
  */
 export const SRV_PREFIXES = [
 	// Email
@@ -23,8 +23,12 @@ export const SRV_PREFIXES = [
 	// Communication
 	'_sip._tcp', // SIP
 	'_sip._udp', // SIP UDP
+	'_sipfederationtls._tcp', // SIP federation TLS (Microsoft Teams/Skype for Business federation, port 5061)
 	'_xmpp-client._tcp', // XMPP client
 	'_xmpp-server._tcp', // XMPP server
+	// Directory
+	'_ldap._tcp', // LDAP plain (389)
+	'_ldaps._tcp', // LDAP TLS (636)
 	// Web/Infra
 	'_http._tcp', // HTTP
 	'_https._tcp', // HTTPS
@@ -40,6 +44,7 @@ export interface SrvProbeResult {
 const INSECURE_PAIRS: Array<{ plain: string; encrypted: string; protocol: string }> = [
 	{ plain: '_imap._tcp', encrypted: '_imaps._tcp', protocol: 'IMAP' },
 	{ plain: '_pop3._tcp', encrypted: '_pop3s._tcp', protocol: 'POP3' },
+	{ plain: '_ldap._tcp', encrypted: '_ldaps._tcp', protocol: 'LDAP' },
 ];
 
 /**
@@ -56,7 +61,14 @@ export function analyzeSrvResults(results: SrvProbeResult[]): Finding[] {
 	const discovered = results.filter((r) => r.records.length > 0);
 
 	if (discovered.length === 0) {
-		findings.push(createFinding('srv', 'No SRV service records found', 'info', 'No SRV service discovery records were found for this domain.'));
+		findings.push(
+			createFinding(
+				'srv',
+				'No SRV service records found',
+				'info',
+				`No SRV records were found across the ${results.length} common service prefixes probed. This does not rule out a service record under a prefix outside the probed set.`,
+			),
+		);
 		return findings;
 	}
 
@@ -97,7 +109,7 @@ export function analyzeSrvResults(results: SrvProbeResult[]): Finding[] {
 	}
 
 	// SIP/XMPP services
-	const commPrefixes = ['_sip._tcp', '_sip._udp', '_xmpp-client._tcp', '_xmpp-server._tcp'];
+	const commPrefixes = ['_sip._tcp', '_sip._udp', '_sipfederationtls._tcp', '_xmpp-client._tcp', '_xmpp-server._tcp'];
 	const activeComm = commPrefixes.filter((p) => discoveredPrefixes.has(p));
 	if (activeComm.length > 0) {
 		findings.push(

--- a/test/check-srv.spec.ts
+++ b/test/check-srv.spec.ts
@@ -2,6 +2,7 @@
 
 import { describe, it, expect, afterEach, vi } from 'vitest';
 import { setupFetchMock, createDohResponse, srvResponse } from './helpers/dns-mock';
+import { SRV_PREFIXES } from '../src/tools/srv-analysis';
 
 const { restore } = setupFetchMock();
 
@@ -32,7 +33,11 @@ describe('checkSrv', () => {
 		const result = await run();
 		expect(result.category).toBe('srv');
 		expect(result.passed).toBe(true);
-		expect(result.findings.some((f) => f.title === 'No SRV service records found')).toBe(true);
+		const negative = result.findings.find((f) => f.title === 'No SRV service records found');
+		expect(negative).toBeDefined();
+		// The negative claim must be scoped to the evidence basis (the N probed prefixes), not
+		// asserted as a domain-wide absence — a record could still exist under an unprobed prefix.
+		expect(negative!.detail).toContain(`across the ${SRV_PREFIXES.length} common service prefixes probed`);
 	});
 
 	it('should return info findings when SRV records are discovered', async () => {
@@ -76,6 +81,52 @@ describe('checkSrv', () => {
 		const medium = result.findings.filter((f) => f.severity === 'medium');
 		expect(medium.length).toBeGreaterThanOrEqual(1);
 		expect(medium.some((f) => f.title.includes('Plain-text IMAP'))).toBe(true);
+	});
+
+	it('should discover _ldap._tcp and flag plain-text LDAP without LDAPS', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			// Return LDAP plain-text but no LDAPS (google.com shape from issue #813)
+			if (url.includes('_ldap._tcp') && !url.includes('_ldaps') && (url.includes('type=SRV') || url.includes('type=33'))) {
+				return Promise.resolve(srvResponse('_ldap._tcp.example.com', [{ priority: 5, weight: 0, port: 389, target: 'ldap.example.com' }]));
+			}
+			if (url.includes('type=SRV') || url.includes('type=33')) {
+				const nameMatch = url.match(/name=([^&]+)/);
+				const name = nameMatch ? decodeURIComponent(nameMatch[1]) : 'unknown';
+				return Promise.resolve(emptyResponse(name, 33));
+			}
+			return Promise.resolve(emptyResponse('example.com', 1));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('srv');
+		const discovered = result.findings.filter((f) => f.title.startsWith('SRV service discovered'));
+		expect(discovered.some((f) => f.title.includes('_ldap._tcp'))).toBe(true);
+		const medium = result.findings.filter((f) => f.severity === 'medium');
+		expect(medium.some((f) => f.title.includes('Plain-text LDAP'))).toBe(true);
+	});
+
+	it('should discover _sipfederationtls._tcp (M365/Teams federation artifact)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			// blackveilsecurity.com shape from issue #813: sipfed.online.lync.com
+			if (url.includes('_sipfederationtls._tcp') && (url.includes('type=SRV') || url.includes('type=33'))) {
+				return Promise.resolve(
+					srvResponse('_sipfederationtls._tcp.example.com', [{ priority: 100, weight: 1, port: 5061, target: 'sipfed.online.lync.com' }]),
+				);
+			}
+			if (url.includes('type=SRV') || url.includes('type=33')) {
+				const nameMatch = url.match(/name=([^&]+)/);
+				const name = nameMatch ? decodeURIComponent(nameMatch[1]) : 'unknown';
+				return Promise.resolve(emptyResponse(name, 33));
+			}
+			return Promise.resolve(emptyResponse('example.com', 1));
+		});
+
+		const result = await run();
+		expect(result.category).toBe('srv');
+		const discovered = result.findings.filter((f) => f.title.startsWith('SRV service discovered'));
+		expect(discovered.some((f) => f.title.includes('_sipfederationtls._tcp'))).toBe(true);
 	});
 
 	it('should flag autodiscover exposure', async () => {

--- a/test/srv-analysis.spec.ts
+++ b/test/srv-analysis.spec.ts
@@ -5,13 +5,26 @@ import { analyzeSrvResults, SRV_PREFIXES } from '../src/tools/srv-analysis';
 import type { SrvProbeResult } from '../src/tools/srv-analysis';
 
 describe('analyzeSrvResults', () => {
-	it('should return info finding when no services found', () => {
+	it('should return info finding when no services found, scoped to the probed prefix count', () => {
 		const results: SrvProbeResult[] = SRV_PREFIXES.map((prefix) => ({ prefix, records: [] }));
 		const findings = analyzeSrvResults(results);
 
 		expect(findings).toHaveLength(1);
 		expect(findings[0].severity).toBe('info');
 		expect(findings[0].title).toBe('No SRV service records found');
+		expect(findings[0].detail).toBe(
+			`No SRV records were found across the ${SRV_PREFIXES.length} common service prefixes probed. This does not rule out a service record under a prefix outside the probed set.`,
+		);
+	});
+
+	it('should scope the negative finding to the actual evidence set when fewer results were analyzed than the full probe list', () => {
+		// Simulates checkSrv passing only the SUCCESSFUL probes (some failed and were excluded upstream) —
+		// the "no records found" claim must be honest about what was actually measured, not the full list size.
+		const partial: SrvProbeResult[] = SRV_PREFIXES.slice(0, 5).map((prefix) => ({ prefix, records: [] }));
+		const findings = analyzeSrvResults(partial);
+
+		expect(findings).toHaveLength(1);
+		expect(findings[0].detail).toContain('across the 5 common service prefixes probed');
 	});
 
 	it('should return info finding for a single discovered service', () => {
@@ -58,6 +71,46 @@ describe('analyzeSrvResults', () => {
 
 		const medium = findings.filter((f) => f.severity === 'medium');
 		expect(medium).toHaveLength(0);
+	});
+
+	it('should flag plain-text LDAP without LDAPS as medium', () => {
+		const results: SrvProbeResult[] = [
+			{ prefix: '_ldap._tcp', records: [{ priority: 5, weight: 0, port: 389, target: 'ldap.example.com' }] },
+		];
+		const findings = analyzeSrvResults(results);
+
+		const medium = findings.filter((f) => f.severity === 'medium');
+		expect(medium).toHaveLength(1);
+		expect(medium[0].title).toContain('Plain-text LDAP');
+		expect(medium[0].detail).toContain('_ldap._tcp');
+		expect(medium[0].detail).toContain('_ldaps._tcp');
+	});
+
+	it('should NOT flag LDAP when LDAPS is also present', () => {
+		const results: SrvProbeResult[] = [
+			{ prefix: '_ldap._tcp', records: [{ priority: 5, weight: 0, port: 389, target: 'ldap.example.com' }] },
+			{ prefix: '_ldaps._tcp', records: [{ priority: 5, weight: 0, port: 636, target: 'ldap.example.com' }] },
+		];
+		const findings = analyzeSrvResults(results);
+
+		const medium = findings.filter((f) => f.severity === 'medium');
+		expect(medium).toHaveLength(0);
+	});
+
+	it('should report _sipfederationtls._tcp as a discovered service and include it in the SIP/XMPP finding', () => {
+		const results: SrvProbeResult[] = [
+			{ prefix: '_sipfederationtls._tcp', records: [{ priority: 100, weight: 1, port: 5061, target: 'sipfed.online.lync.com' }] },
+		];
+		const findings = analyzeSrvResults(results);
+
+		const discovered = findings.find((f) => f.title === 'SRV service discovered: _sipfederationtls._tcp');
+		expect(discovered).toBeDefined();
+		expect(discovered!.metadata?.port).toBe(5061);
+		expect(discovered!.metadata?.target).toBe('sipfed.online.lync.com');
+
+		const comm = findings.find((f) => f.title === 'SIP/XMPP services publicly advertised');
+		expect(comm).toBeDefined();
+		expect(comm!.detail).toContain('_sipfederationtls._tcp');
 	});
 
 	it('should NOT flag POP3 when POP3S is also present', () => {


### PR DESCRIPTION
## Symptom

Issue #813 (live-verified 2026-08-28/29 against google.com and blackveilsecurity.com):

1. `check_srv`'s tool description advertises probing "email, calendar, messaging, web, **directory**" services, but `SRV_PREFIXES` contained no directory prefix at all — no `_ldap._tcp`, no `_ldaps._tcp`. A live plaintext LDAP service on google.com (`_ldap._tcp.google.com` → port 389) went entirely unreported.
2. The domain-wide negative finding — "No SRV service records found" / "No SRV service discovery records were found for this domain." — asserted an absolute negative beyond what the ~16 probed prefixes could attest to. blackveilsecurity.com has a live `_sipfederationtls._tcp` record (Teams/Lync SIP federation, `sipfed.online.lync.com`) outside the probed set, yet the tool reported a clean "none found" with no scoping.
3. (Minor, same root cause) The insecure-pair flagging logic only covered plaintext IMAP/POP3, not the plaintext-LDAP-without-LDAPS pattern that would newly become reportable.

## Root cause

`SRV_PREFIXES` (`src/tools/srv-analysis.ts`) never included a directory-service or M365-federation prefix, and `analyzeSrvResults()`'s "no records" finding was phrased as a domain-wide fact rather than scoped to the evidence it actually had (the same evidence-basis-honesty issue the lame-delegation and DBL findings already guard against).

## Fix

- `SRV_PREFIXES`: added `_ldap._tcp`, `_ldaps._tcp` (new "Directory" group) and `_sipfederationtls._tcp` (grouped with the existing SIP/Communication prefixes) — 16 → 19 prefixes total.
- `analyzeSrvResults()`: the "no records found" finding detail now reads `No SRV records were found across the ${N} common service prefixes probed. This does not rule out a service record under a prefix outside the probed set.` — `N` is derived from the analyzed result set (`results.length`), never hardcoded, so it stays honest even under partial probe failure.
- `INSECURE_PAIRS`: added `{ plain: '_ldap._tcp', encrypted: '_ldaps._tcp', protocol: 'LDAP' }`, so plaintext LDAP (389) advertised without LDAPS (636) now gets the same `medium` "Plain-text LDAP advertised without encrypted variant" treatment as IMAP/POP3.
- `_sipfederationtls._tcp` also feeds the existing "SIP/XMPP services publicly advertised" info finding when discovered.
- Updated the `check_srv` `TOOL_DEFS` description and the doc comments in `check-srv.ts`/`srv-analysis.ts` off the stale "~16" count to "19".

### Deliberately out of scope

Issue #813 also noted `_caldav._tcp.google.com` → port 80 (plaintext CalDAV) is discovered but not flagged as insecure, unlike IMAP/POP3/LDAP. CalDAV has no parallel plain/encrypted *prefix* pair in `SRV_PREFIXES` the way IMAP/POP3/LDAP do (`_caldav._tcp` vs `_caldavs._tcp` are both already probed, but the "insecure" signal there is port 80 vs port-in-record, not prefix presence/absence) — flagging it correctly needs a different mechanism than `INSECURE_PAIRS`. Left as a follow-up scope decision per the issue, not addressed in this PR.

## Tests

TDD: wrote failing tests first, then made them pass.

- `test/srv-analysis.spec.ts` (unit, `analyzeSrvResults`):
  - negative finding now asserts the scoped detail string including `SRV_PREFIXES.length`
  - a second case with a partial result set (5 of 19 prefixes) asserts the count is derived from what was actually analyzed, not hardcoded
  - plaintext LDAP without LDAPS → `medium` finding; LDAP+LDAPS present → no flag
  - `_sipfederationtls._tcp` discovered → reported as a discovered service and folded into the SIP/XMPP finding
- `test/check-srv.spec.ts` (integration, DNS-mocked via `test/helpers/dns-mock.ts`):
  - no-SRV-records case asserts the new scoped wording end-to-end
  - `_ldap._tcp` answered without `_ldaps._tcp` (google.com shape from the issue) → service reported + plaintext-LDAP finding
  - `_sipfederationtls._tcp` answered (blackveilsecurity.com shape from the issue, target `sipfed.online.lync.com`) → service reported

25/25 targeted tests pass (`npx vitest run test/srv-analysis.spec.ts test/check-srv.spec.ts`). Also ran clean: `npm run typecheck`, `npm run lint`, `npm run check:tool-surface` (76 public / 35 `check_*` tools — unchanged, this PR adds no tool).

`check_srv` is standalone (`scanIncluded: false`), so this carries no scan-score risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)