### PR TITLE
fix(authoritative-dns-infra): stop asserting a pass on zero conclusive evidence

### DIFF
--- a/src/lib/authoritative-dns-infra/analyze.ts
+++ b/src/lib/authoritative-dns-infra/analyze.ts
@@ -394,15 +394,38 @@ export function analyzeAuthoritativeDnsInfraEvidence(
 	);
 
 	if (findings.length === 0) {
-		findings.push(
-			createFinding(
-				CATEGORY,
-				'Authoritative DNS infrastructure checks passed',
-				'info',
-				`Infra probe evidence for ${evidence.hostname} satisfied all conclusive capability checks.`,
-				{ evidenceMode: 'infra_probe' },
-			),
-		);
+		// `findings.length === 0` only means no FAILURE finding was emitted — every
+		// `pushCapabilityResult(..., false, ...)` call above pushes one, so a failure
+		// would already show up here. It says nothing about whether anything was
+		// actually CONCLUSIVE: with every capability inconclusive (`passed` and
+		// `failed` both empty), this branch is reached with zero evidence either way.
+		// Asserting a pass there is a vacuous truth ("satisfied all zero checks") that
+		// directly contradicted the sibling structured fields the caller derives from
+		// this same `capabilitySummary` (`checkStatus: 'error'`, `passed: false`,
+		// `score: 0` — see `checkAuthoritativeDnsInfra`'s `measuredNothing`) (#812,
+		// split from #786). Gate the affirmative finding on at least one CONCLUSIVE
+		// (passed) capability, and tell the truth otherwise.
+		if (capabilitySummary.passed.length > 0) {
+			findings.push(
+				createFinding(
+					CATEGORY,
+					'Authoritative DNS infrastructure checks passed',
+					'info',
+					`Infra probe evidence for ${evidence.hostname} satisfied all conclusive capability checks.`,
+					{ evidenceMode: 'infra_probe' },
+				),
+			);
+		} else {
+			findings.push(
+				createFinding(
+					CATEGORY,
+					'Authoritative DNS infrastructure checks inconclusive',
+					'info',
+					`Infra probe evidence for ${evidence.hostname} did not yield any conclusive capability checks; nothing was verified.`,
+					{ evidenceMode: 'infra_probe', inconclusive: true },
+				),
+			);
+		}
 	}
 
 	return { findings, capabilitySummary };

--- a/test/check-authoritative-dns-infra.spec.ts
+++ b/test/check-authoritative-dns-infra.spec.ts
@@ -250,6 +250,41 @@ describe('checkAuthoritativeDnsInfra', () => {
 		]));
 	});
 
+	// #812 (split from #786): every capability inconclusive must NOT emit the
+	// "checks passed" finding — that prose directly contradicted the sibling
+	// structured fields (`passed: false`, `score: 0`, `checkStatus: 'error'`,
+	// capabilitySummary all-inconclusive) on this exact fixture shape.
+	it('does not claim a pass when every capability is inconclusive (#812)', async () => {
+		const fetch = vi.fn(async () => new Response(JSON.stringify({
+			hostname: 'trademe.co.nz',
+			checkedAt: '2026-05-29T00:00:00.000Z',
+			reachability: { udp53Reachable: false, tcp53Reachable: false },
+			// No authoritative/soa/dnssec/routing/vantage evidence at all — nothing
+			// the probe returned resolves to a conclusive pass or fail.
+		})));
+
+		const result = await checkAuthoritativeDnsInfra('trademe.co.nz', {
+			infraProbe: { fetch: fetch as unknown as typeof globalThis.fetch },
+		});
+
+		// Sibling structured fields already report "nothing measured" honestly.
+		expect(result).toMatchObject({ passed: false, score: 0, checkStatus: 'error', partial: true });
+		const summary = result.metadata?.capabilitySummary as { passed: string[]; failed: string[] };
+		expect(summary.passed).toEqual([]);
+		expect(summary.failed).toEqual([]);
+
+		const titles = result.findings.map((f) => f.title);
+		expect(titles).not.toContain('Authoritative DNS infrastructure checks passed');
+
+		const inconclusiveFinding = result.findings.find(
+			(f) => f.title === 'Authoritative DNS infrastructure checks inconclusive',
+		);
+		expect(inconclusiveFinding).toBeDefined();
+		expect(inconclusiveFinding!.severity).toBe('info');
+		expect(inconclusiveFinding!.detail).not.toMatch(/passed|satisfied/i);
+		expect(inconclusiveFinding!.metadata?.inconclusive).toBe(true);
+	});
+
 	it('degrades gracefully (does not throw) when the infra probe returns HTTP 503', async () => {
 		const fetch = vi.fn(async () => new Response('upstream unavailable', { status: 503 }));
 


### PR DESCRIPTION
## Symptom

`check_authoritative_dns_infra` returned a finding titled **"Authoritative DNS infrastructure checks passed"** with detail *"Infra probe evidence for `<hostname>` satisfied all conclusive capability checks."* — while the same result carried `passed: false`, `score: 0`, `checkStatus: 'error'`, `partial: true`, and a `capabilitySummary` with `passed: []`, `failed: []`, and every one of the 22 capabilities inconclusive. Observed live on 3.67.0 for google.com and cloudflare.com.

## Root cause

`src/lib/authoritative-dns-infra/analyze.ts:396` gated the pass finding on `findings.length === 0`. That guard only proves no *failure* finding was emitted (every `pushCapabilityResult(..., false, ...)` call pushes one) — it says nothing about whether anything was **conclusive**. When every capability came back inconclusive, `findings.length === 0` is still true, so the code asserted a pass on zero evidence: a vacuous truth ("satisfied all zero checks") that directly contradicted the sibling structured fields the caller (`checkAuthoritativeDnsInfra`'s `measuredNothing` branch) derives from the same `capabilitySummary`.

Split out of #786 per its closing comment, tracked as #812.

## Fix

Gate the affirmative "checks passed" finding on `capabilitySummary.passed.length > 0` (at least one capability was actually conclusive-and-passing). When nothing was conclusive, emit an honest **"Authoritative DNS infrastructure checks inconclusive"** info finding instead, worded to avoid `MISSING_CONTROL_REGEX` trigger shapes (`missing`/`required`/`not found`/`no ... record`) and marked `inconclusive: true` per the `control-presence.ts` contract, so downstream consumers correctly treat it as unmeasured rather than a measured absence.

The genuinely-all-passed path (conclusive capabilities present, none failed) is unchanged.

## Tests

Added to `test/check-authoritative-dns-infra.spec.ts`:
- New case reproducing the exact issue fixture (trademe.co.nz-style: `udp53Reachable: false, tcp53Reachable: false`, no other evidence) — asserts the old "checks passed" title is absent, the new "checks inconclusive" finding is present with `inconclusive: true` metadata, and its detail never claims a pass, consistent with `passed: false / score: 0 / checkStatus: 'error'`.
- Existing "passes healthy infra probe evidence" test (conclusive passes, no failures) continues to assert the pass finding is retained — unchanged, still green.
- Existing "fails risky infra probe evidence" test (failures present) continues to assert the per-capability failure findings — unchanged, still green.

Verified: `npx vitest run test/check-authoritative-dns-infra.spec.ts` (10/10 pass) plus the broader authoritative-dns-infra/root-server-set/scan-domain/map-compliance/maturity-staging suites (122/122 pass), `npm run typecheck` (clean), `npm run lint` (clean). Full `npm test` run showed 9 unrelated timeout failures (analytics/dispatch/streaming/wasm) that all pass in isolation — pre-existing resource-contention flakes, not caused by this change.

## Note

The same vacuous-pass pattern also exists in the sibling `src/lib/authoritative-dns-infra/analyze-root-server-set.ts` (`check_root_server_set`'s "Root server set checks passed" finding), which is out of scope for #812 but has been flagged separately as a follow-up.

Fixes #812

🤖 Generated with [Claude Code](https://claude.com/claude-code)