### PR TITLE
fix(map-compliance): report passing-but-flagged controls as partial, not fail

### DIFF
--- a/src/lib/control-presence.ts
+++ b/src/lib/control-presence.ts
@@ -134,6 +134,57 @@ export function isSatisfiedControl(result: CheckResult): boolean {
 }
 
 /**
+ * The severities that mark a control's requirement as FOUND UNMET — the subset of
+ * {@link DISQUALIFYING_SEVERITIES} that keeps a hard `fail` verdict under #815.
+ * `medium` is deliberately absent: a check that `passed` and is flagged only at
+ * medium is deficient (implemented but flagged), not failed.
+ */
+const FAILING_SEVERITIES: ReadonlySet<Severity> = new Set<Severity>(['critical', 'high']);
+
+/**
+ * The three-way split of a completed check's control verdict (#815).
+ *
+ * - `'satisfied'` — the control certifies. EXACTLY the set `isSatisfiedControl`
+ *   accepts; the two can never drift because this classifier delegates to the same
+ *   clauses (pinned by `test/control-presence.spec.ts`).
+ * - `'deficient'` — the check `passed` and is disqualified ONLY by medium measured
+ *   findings: the control is implemented but flagged. Non-certifying, but not a
+ *   failed requirement.
+ * - `'unsatisfied'` — the requirement was found unmet: the check did not pass, a
+ *   measured high/critical finding exists, or the record is an unrebutted absence.
+ */
+export type ControlSatisfaction = 'satisfied' | 'deficient' | 'unsatisfied';
+
+/**
+ * Classify a completed check's control verdict on the three-way #815 scale.
+ *
+ * **Why a NEW export instead of changing `isSatisfiedControl`:** the binary
+ * predicate is consumed by `compare_baseline` (#706 — the policy gate customers
+ * wire into CI) and the deploy verifier (#725), both of which need exactly the
+ * boolean "does this certify". Their semantics must not move. `map_compliance`
+ * (#815) additionally needs the NON-satisfied side split, because the #726
+ * severity floor is category-scoped: a medium transport-hygiene finding sharing a
+ * category with an implemented control (google.com's "TXT RRset exceeds UDP
+ * limit" beside a passing SPF, validated live 2026-08-28) was flipping that
+ * control to a hard `fail` — the inverse error shape of #726's false PASS. The
+ * floor itself is untouched: `'deficient'` is still never `'satisfied'`, so the
+ * wiz.io CSP shape (#726 — http_security `passed` with two medium CSP findings)
+ * still cannot certify; it is reported `partial`, not `pass`.
+ *
+ * Ordering is load-bearing in one place only: unrebutted ABSENCE outranks the
+ * deficient band. An absent record with a medium "not configured" finding is not
+ * "implemented but flagged" — nothing is implemented — so it stays `'unsatisfied'`
+ * (the #705 shape must never soften to `partial`).
+ */
+export function classifyControlSatisfaction(result: CheckResult): ControlSatisfaction {
+	if (!result.passed) return 'unsatisfied';
+	if (isUnrebuttedAbsence(result)) return 'unsatisfied';
+	if (result.findings.some((finding) => FAILING_SEVERITIES.has(finding.severity) && isMeasuredFinding(finding))) return 'unsatisfied';
+	if (hasDisqualifyingFinding(result)) return 'deficient';
+	return 'satisfied';
+}
+
+/**
  * The scan-shaped input `notApplicableCategoriesFor` reads. Deliberately
  * structural and permissive rather than `ScanDomainResult`: hand-built results
  * (tests, external library consumers) reach these tools too, and a missing

--- a/src/tools/map-compliance.ts
+++ b/src/tools/map-compliance.ts
@@ -12,16 +12,28 @@ import type { ScanRuntimeOptions } from './scan/post-processing';
 import type { OutputFormat } from '../handlers/tool-args';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import { displayGradeFor, formatScoreGrade, hasCompletedEvidence, isCompletedCheck, UNGRADED_DISPLAY } from '../lib/ungraded-display';
-// `isSatisfiedControl` and the applicability derivation are SHARED with
+// The satisfaction classifier and the applicability derivation are SHARED with
 // `compare_baseline` (#706), which had the identical defect on the enforcement
 // surface. Both live in `lib/control-presence.ts` so the reporting tool and the
 // policy gate cannot drift on what "satisfied" and "applicable" mean.
-import { isSatisfiedControl, notApplicableCategoriesFor } from '../lib/control-presence';
+// `classifyControlSatisfaction` (#815) is the three-way refinement of
+// `isSatisfiedControl` — same satisfied set, but the non-satisfied side is split
+// into `deficient` (passed, medium-only flags → `partial`) and `unsatisfied`
+// (!passed / high / critical / absence → `fail`).
+import { classifyControlSatisfaction, notApplicableCategoriesFor } from '../lib/control-presence';
 
 export type ComplianceFramework = 'nist_800_177' | 'pci_dss_4' | 'soc2' | 'cis_controls';
 
 /**
  * A control's verdict.
+ *
+ * `partial` (#815) is non-certifying but NOT a failed requirement. It covers a control
+ * whose backing check `passed` but carries medium measured findings (implemented but
+ * flagged — the google.com "TXT RRset exceeds UDP limit" beside a passing SPF shape),
+ * and a multi-category control with mixed evidence. `fail` is reserved for a
+ * requirement FOUND UNMET: `!passed`, a measured high/critical finding, or an
+ * unrebutted record absence. A `partial` never counts as passing and never inflates a
+ * compliance percentage.
  *
  * `not_assessed` is NOT a soft failure — it is the absence of a verdict. A control is
  * `not_assessed` when its mapped categories produced NO check data at all, OR when they
@@ -301,13 +313,25 @@ export function evaluateCompliance(
 				// resolver must not turn into "DMARC Policy — FAIL" on a healthy domain.
 				status = 'not_assessed';
 			} else {
-				const passingCount = completed.filter(isSatisfiedControl).length;
-				const failingResults = completed.filter((r) => !isSatisfiedControl(r));
+				// #815: three-way per-category verdict. `satisfied` is EXACTLY the set
+				// `isSatisfiedControl` accepts (asserted in test/control-presence.spec.ts),
+				// so `compare_baseline`/the deploy verifier and this tool still agree on
+				// what certifies. The refinement is on the non-satisfied side: a check that
+				// `passed` and is disqualified only by MEDIUM measured findings is
+				// `deficient` — the control is implemented but flagged — and must not be
+				// published as a failed requirement ("google.com fails SPF Authentication"
+				// on a TXT-size hygiene finding was the live symptom).
+				const verdicts = completed.map((r) => ({ result: r, satisfaction: classifyControlSatisfaction(r) }));
+				const satisfiedCount = verdicts.filter((v) => v.satisfaction === 'satisfied').length;
+				const deficientCount = verdicts.filter((v) => v.satisfaction === 'deficient').length;
+				const completedUnsatisfiedCount = verdicts.filter((v) => v.satisfaction === 'unsatisfied').length;
 
-				// Collect finding titles from failing categories — completed ones only, so a
-				// transient check's "check error"/"timed out" title never reads as a graded
-				// compliance finding.
-				for (const r of failingResults) {
+				// Collect finding titles from every non-certifying category — completed ones
+				// only, so a transient check's "check error"/"timed out" title never reads as
+				// a graded compliance finding. Deficient categories carry their flags too:
+				// `partial` still surfaces WHY it is not a pass.
+				for (const { result: r, satisfaction } of verdicts) {
+					if (satisfaction === 'satisfied') continue;
 					for (const f of r.findings) {
 						if (f.severity !== 'info') {
 							relatedFindings.push(f.title);
@@ -327,15 +351,30 @@ export function evaluateCompliance(
 				// before this line, so no separate zero-check is needed here.
 				const transientCount = applicableResults.length - completed.length;
 				const totalCategories = control.categories.length - transientCount - notApplicableCount;
+				// A mapped category with NO CheckResult at all (sparse evidence) still counts
+				// as not-passing — pre-existing, intentional. It is UNSATISFIED, not
+				// deficient: nothing measured it as implemented.
+				const missingCount = totalCategories - completed.length;
+				const unsatisfiedCount = completedUnsatisfiedCount + missingCount;
 
 				if (control.requirePass) {
-					// All mapped categories must pass (and be present)
-					status = passingCount === totalCategories ? 'pass' : 'fail';
-				} else {
-					// Partial pass allowed — missing categories count as not passing
-					if (passingCount === totalCategories) {
+					// All mapped categories must certify (and be present). #815 coherence
+					// rule: any category failing → fail; none failing but some deficient →
+					// partial (implemented but flagged, non-certifying); all satisfied → pass.
+					if (unsatisfiedCount > 0) {
+						status = 'fail';
+					} else if (deficientCount > 0) {
+						status = 'partial';
+					} else {
 						status = 'pass';
-					} else if (passingCount > 0) {
+					}
+				} else {
+					// Partial pass allowed — missing categories count as not passing. A
+					// deficient category is implementation EVIDENCE (the check passed), so it
+					// keeps the control out of `fail`, but it can never complete a `pass`.
+					if (satisfiedCount === totalCategories) {
+						status = 'pass';
+					} else if (satisfiedCount > 0 || deficientCount > 0) {
 						status = 'partial';
 					} else {
 						status = 'fail';
@@ -435,7 +474,13 @@ const STATUS_ICON_FULL: Record<ComplianceStatus, string> = {
 
 const STATUS_LABEL: Record<ComplianceStatus, string> = {
 	pass: 'PASS',
-	partial: 'PARTIAL',
+	// #815: `partial` must read as non-certifying and clearly distinct from BOTH
+	// pass and fail. It covers two shapes — a control whose backing check passed
+	// but was flagged (medium measured findings, the google.com SPF shape), and a
+	// multi-category control with mixed evidence — and in neither may the label
+	// read as a certification. The wiz.io CSP shape (#726) lands here now, and
+	// "not certified" is what keeps that fix closed.
+	partial: 'PARTIAL — implemented but flagged (not certified)',
 	fail: 'FAIL',
 	not_assessed: 'NOT ASSESSED',
 };

--- a/test/control-presence.spec.ts
+++ b/test/control-presence.spec.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { CheckResult } from '../src/lib/scoring';
-import { isSatisfiedControl, isUnrebuttedAbsence, notApplicableCategoriesFor } from '../src/lib/control-presence';
+import { classifyControlSatisfaction, isSatisfiedControl, isUnrebuttedAbsence, notApplicableCategoriesFor } from '../src/lib/control-presence';
 
 /**
  * The truth table of the SHARED control-presence predicate.
@@ -138,6 +138,95 @@ describe('isSatisfiedControl — severity floor (#726)', () => {
 		expect(
 			isSatisfiedControl(check({ passed: true, score: 85, recordPresent: false, controlPresent: true, findings: [finding('low')] } as Partial<CheckResult>)),
 		).toBe(true);
+	});
+});
+
+/**
+ * #815 — the finer-grained companion to `isSatisfiedControl`. The binary predicate is
+ * consumed by `compare_baseline` (#706) and the deploy verifier (#725) and its
+ * semantics are UNTOUCHED; `classifyControlSatisfaction` splits the non-satisfied
+ * side so `map_compliance` can report "passed but disqualified by medium-only
+ * findings" (deficient → partial) separately from "!passed / high / critical /
+ * absent" (unsatisfied → fail).
+ */
+describe('classifyControlSatisfaction (#815)', () => {
+	it('agrees with isSatisfiedControl on the satisfied side — the two can never drift', () => {
+		const shapes: CheckResult[] = [
+			check({}),
+			check({ passed: false }),
+			check({ passed: true, score: 60, recordPresent: false, controlPresent: false }),
+			check({ passed: true, score: 85, recordPresent: false, controlPresent: true }),
+			check({ category: 'http_security', passed: true, findings: [finding('medium')] } as Partial<CheckResult>),
+			check({ category: 'http_security', passed: true, findings: [finding('high')] } as Partial<CheckResult>),
+			check({ category: 'http_security', passed: true, findings: [finding('low')] } as Partial<CheckResult>),
+			check({ category: 'http_security', passed: true, findings: [finding('medium', { inconclusive: true })] } as Partial<CheckResult>),
+		];
+		for (const shape of shapes) {
+			expect(classifyControlSatisfaction(shape) === 'satisfied').toBe(isSatisfiedControl(shape));
+		}
+	});
+
+	it('classifies passed-with-medium-only measured findings as deficient — implemented but flagged', () => {
+		// The google.com headline shape (#815): SPF passed at 85 with a medium
+		// transport-hygiene finding.
+		const flagged = check({
+			category: 'spf',
+			passed: true,
+			score: 85,
+			findings: [{ category: 'spf', title: 'TXT RRset exceeds UDP limit', severity: 'medium', detail: '' }],
+		} as Partial<CheckResult>);
+		expect(classifyControlSatisfaction(flagged)).toBe('deficient');
+
+		// The wiz.io #726 regression shape stays disqualified — deficient, never satisfied.
+		const csp = check({
+			category: 'http_security',
+			passed: true,
+			score: 65,
+			findings: [
+				{ category: 'http_security', title: 'CSP allows unsafe-inline scripts', severity: 'medium', detail: '' },
+				{ category: 'http_security', title: 'CSP allows unsafe-eval', severity: 'medium', detail: '' },
+			],
+		} as Partial<CheckResult>);
+		expect(classifyControlSatisfaction(csp)).toBe('deficient');
+	});
+
+	it('keeps unsatisfied for !passed, measured high/critical, and unrebutted absence', () => {
+		expect(classifyControlSatisfaction(check({ passed: false }))).toBe('unsatisfied');
+		expect(
+			classifyControlSatisfaction(check({ category: 'http_security', passed: true, findings: [finding('high')] } as Partial<CheckResult>)),
+		).toBe('unsatisfied');
+		expect(
+			classifyControlSatisfaction(check({ category: 'http_security', passed: true, findings: [finding('critical')] } as Partial<CheckResult>)),
+		).toBe('unsatisfied');
+		// The #705 shape: unpenalized but nothing published. Absence is not
+		// "implemented but flagged" — a medium finding beside it changes nothing.
+		expect(
+			classifyControlSatisfaction(
+				check({ passed: true, score: 60, recordPresent: false, controlPresent: false, findings: [finding('medium')] } as Partial<CheckResult>),
+			),
+		).toBe('unsatisfied');
+		// A measured high beside a medium: the high dominates.
+		expect(
+			classifyControlSatisfaction(
+				check({ category: 'ns', passed: true, findings: [finding('medium'), finding('high')] } as Partial<CheckResult>),
+			),
+		).toBe('unsatisfied');
+	});
+
+	it('ignores UNMEASURED high/critical findings when splitting deficient from unsatisfied', () => {
+		// An unmeasured high (probe never reached the origin) beside a measured medium:
+		// only the medium is evidence, so this is deficient, not unsatisfied.
+		expect(
+			classifyControlSatisfaction(
+				check({ category: 'ns', passed: true, findings: [finding('high', { errorKind: 'dns_error' }), finding('medium')] } as Partial<CheckResult>),
+			),
+		).toBe('deficient');
+	});
+
+	it('classifies clean and advisory-only results as satisfied', () => {
+		expect(classifyControlSatisfaction(check({}))).toBe('satisfied');
+		expect(classifyControlSatisfaction(check({ category: 'ssl', passed: true, findings: [finding('low')] } as Partial<CheckResult>))).toBe('satisfied');
+		expect(classifyControlSatisfaction(check({ category: 'ssl', passed: true, findings: [finding('info')] } as Partial<CheckResult>))).toBe('satisfied');
 	});
 });
 

--- a/test/map-compliance.spec.ts
+++ b/test/map-compliance.spec.ts
@@ -65,14 +65,22 @@ describe('evaluateCompliance', () => {
 	 * A literal per-control expectation is what let this survive #705 and #706: those
 	 * fixes keyed on `recordPresent`, which only 9 checks emit, so the five that never
 	 * do (spf, dkim, ssl, ns, http_security) silently kept grading on bare `passed`.
+	 *
+	 * #815 refined the VERDICT (not the floor): a check that `passed` and is
+	 * disqualified only by MEDIUM measured findings is now `partial` — implemented
+	 * but flagged — rather than `fail`. The #726 regression shape stays
+	 * non-certifying either way: `partial` is never `pass`, never counted as
+	 * passing, and never inflates a compliance percentage.
 	 */
-	it('never reports a control as pass while its backing check carries a medium-or-worse finding (#726)', () => {
+	it('reports the wiz.io CSP shape as partial — NEVER pass (#726), no longer a bare fail (#815)', () => {
 		// Measured on wiz.io, 2026-08-20: PCI DSS 4.0 came back "5/5, 100%" with 6.4.2
 		// (Web Application Firewall / CSP — `categories: ['http_security']`,
 		// `requirePass: true`) as PASS, while the SAME scan scored http_security 65 on
 		// these two findings and rated the resulting xss_injection path HIGH. A CSP
 		// permitting both inline script and dynamic code execution is substantially no
-		// XSS protection, and the tool certified it.
+		// XSS protection, and the tool certified it. #726 closed that with the severity
+		// floor; #815 re-words the floor's verdict for a passing-but-flagged check as
+		// `partial` — still not a certification.
 		const results = makeAllPassing().map((r) =>
 			r.category === 'http_security'
 				? makeCheckResult('http_security', true, [
@@ -85,10 +93,13 @@ describe('evaluateCompliance', () => {
 		const report = evaluateCompliance(results, 'wiz.example', 78, 'C');
 
 		const waf = report.frameworks.pci_dss_4.mappings.find((m) => m.controlId === '6.4.2');
-		expect(waf!.status).toBe('fail');
+		// The #726 invariant, stated positively: NEVER 'pass'.
+		expect(waf!.status).not.toBe('pass');
+		expect(waf!.status).toBe('partial');
 		expect(waf!.relatedFindings).toEqual(['CSP allows unsafe-inline scripts', 'CSP allows unsafe-eval']);
+		// A partial must never inflate the compliance percentage as if it were a pass.
 		expect(report.frameworks.pci_dss_4.percentage).not.toBe(100);
-
+		expect(report.frameworks.pci_dss_4.passing).not.toBe(report.frameworks.pci_dss_4.totalControls);
 	});
 
 	/**
@@ -344,6 +355,148 @@ describe('evaluateCompliance', () => {
 		// instead would report 13% — a compliance number driven by how much was
 		// never looked at. This assertion is what separates the two denominators.
 		expect(nist.percentage).toBe(100);
+	});
+});
+
+/**
+ * #815 — the severity floor's verdict, calibrated. The floor (#726) is category-scoped:
+ * any measured medium-or-worse finding in a category disqualifies the control it backs,
+ * even when the finding says nothing about the control's own requirement. Validated
+ * live on google.com (3.67.0, 2026-08-28): NIST §4.3.1 "SPF Authentication" published
+ * `status: "fail"` on "TXT RRset exceeds UDP limit" — a transport-hygiene finding —
+ * while the same window's `check_spf` returned `passed: true, score 85` on a valid
+ * record under DMARC p=reject. "google.com fails SPF Authentication" is not a
+ * defensible compliance statement.
+ *
+ * Option 1 from the issue (operator-ruled): the floor itself is untouched — a flagged
+ * control still cannot certify — but its verdict for a check that `passed` and is
+ * disqualified ONLY by medium measured findings is `partial` (implemented but flagged),
+ * not `fail`. `fail` remains reserved for `!passed`, measured high/critical findings,
+ * and unrebutted record absence.
+ */
+describe('evaluateCompliance — medium-only flags on a passing check are partial, never fail (#815)', () => {
+	it('the google.com headline shape: check passed (85) with one medium hygiene finding → partial, never fail', () => {
+		const results = makeAllPassing().map((r) =>
+			r.category === 'spf' ? makeCheckResult('spf', true, [{ title: 'TXT RRset exceeds UDP limit', severity: 'medium' }]) : r,
+		);
+
+		const report = evaluateCompliance(results, 'google.com', 85, 'B');
+		const spf = report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§4.3.1');
+		expect(spf).toBeDefined();
+		expect(spf!.status).not.toBe('fail');
+		expect(spf!.status).toBe('partial');
+		// relatedFindings carried exactly as before — the flag is still surfaced.
+		expect(spf!.relatedFindings).toEqual(['TXT RRset exceeds UDP limit']);
+	});
+
+	it('a measured HIGH finding on a passing check is still fail — #815 narrows, it does not soften', () => {
+		const results = makeAllPassing().map((r) =>
+			r.category === 'spf' ? makeCheckResult('spf', true, [{ title: 'SPF record permits arbitrary senders (+all)', severity: 'high' }]) : r,
+		);
+		const report = evaluateCompliance(results, 'openspf-bad.com', 60, 'D');
+		expect(report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§4.3.1')!.status).toBe('fail');
+	});
+
+	it('a check that did NOT pass is still fail, whatever the finding severities', () => {
+		const results = makeAllPassing().map((r) =>
+			r.category === 'spf' ? makeCheckResult('spf', false, [{ title: 'SPF lookup limit exceeded', severity: 'medium' }]) : r,
+		);
+		const report = evaluateCompliance(results, 'failing-spf.com', 45, 'F');
+		expect(report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§4.3.1')!.status).toBe('fail');
+	});
+
+	it('the #705 shape — unsigned zone, high "DNSSEC not enabled" — is still fail, not partial', () => {
+		// passed: true (unpenalized under the profile) + recordPresent: false is the
+		// exact defect shape #705 closed: the control is ABSENT, not implemented-but-
+		// flagged, so `partial` would be a regression of that fix.
+		const results = makeAllPassing().map((r) =>
+			r.category === 'dnssec'
+				? ({
+						category: 'dnssec',
+						passed: true,
+						score: 60,
+						recordPresent: false,
+						controlPresent: false,
+						findings: [{ category: 'dnssec', title: 'DNSSEC not enabled', severity: 'high', detail: '' }],
+					} as CheckResult)
+				: r,
+		);
+		const report = evaluateCompliance(results, 'unsigned-zone.com', 82, 'B');
+		expect(report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§5.1')!.status).toBe('fail');
+	});
+
+	it('an unrebutted record ABSENCE with only medium findings is still fail — absence is not "implemented but flagged"', () => {
+		const results = makeAllPassing().map((r) =>
+			r.category === 'caa'
+				? ({
+						category: 'caa',
+						passed: true,
+						score: 60,
+						recordPresent: false,
+						controlPresent: false,
+						findings: [{ category: 'caa', title: 'No CAA records', severity: 'medium', detail: '' }],
+					} as CheckResult)
+				: r,
+		);
+		const report = evaluateCompliance(results, 'no-caa.com', 82, 'B');
+		expect(report.frameworks.nist_800_177.mappings.find((m) => m.controlId === '§5.2')!.status).toBe('fail');
+	});
+
+	it('a multi-category control whose every category is implemented-but-flagged is partial, not fail', () => {
+		// SOC 2 CC7.1 maps [tlsrpt, dmarc], requirePass: false. Both categories passed
+		// with a medium flag each: nothing here is a failed requirement, but nothing
+		// certifies either.
+		const results = makeAllPassing().map((r) => {
+			if (r.category === 'tlsrpt') return makeCheckResult('tlsrpt', true, [{ title: 'TLS-RPT rua endpoint unreachable', severity: 'medium' }]);
+			if (r.category === 'dmarc') return makeCheckResult('dmarc', true, [{ title: 'No aggregate reporting (rua) configured', severity: 'medium' }]);
+			return r;
+		});
+		const report = evaluateCompliance(results, 'flagged-both.com', 75, 'C');
+		const cc71 = report.frameworks.soc2.mappings.find((m) => m.controlId === 'CC7.1');
+		expect(cc71!.status).toBe('partial');
+	});
+
+	it('a multi-category control with one genuinely failing category is fail when requirePass, regardless of flags elsewhere', () => {
+		// NIST controls are all requirePass single-category; the coherent multi-category
+		// rule (any failing → fail; none failing but some flagged → partial; all
+		// satisfied → pass) is pinned here via the requirePass:false ladder instead:
+		// CC7.1 [tlsrpt, dmarc] with dmarc genuinely failing and tlsrpt flagged must not
+		// come out 'pass', and the failing evidence must be surfaced.
+		const results = makeAllPassing().map((r) => {
+			if (r.category === 'tlsrpt') return makeCheckResult('tlsrpt', true, [{ title: 'TLS-RPT rua endpoint unreachable', severity: 'medium' }]);
+			if (r.category === 'dmarc') return makeCheckResult('dmarc', false, [{ title: 'No DMARC record found', severity: 'high' }]);
+			return r;
+		});
+		const report = evaluateCompliance(results, 'mixed-flag-fail.com', 55, 'D');
+		const cc71 = report.frameworks.soc2.mappings.find((m) => m.controlId === 'CC7.1');
+		expect(cc71!.status).toBe('partial'); // requirePass: false — some implementation evidence exists
+		expect(cc71!.status).not.toBe('pass');
+		expect(cc71!.relatedFindings).toContain('No DMARC record found');
+		expect(cc71!.relatedFindings).toContain('TLS-RPT rua endpoint unreachable');
+	});
+
+	it('summary counts a partial honestly: not passing, not failing, never in the percentage numerator', () => {
+		// NIST 800-177: spf partial (medium-flagged, passing check), mta_sts genuine
+		// fail, remaining six controls pass.
+		const results = makeAllPassing().map((r) => {
+			if (r.category === 'spf') return makeCheckResult('spf', true, [{ title: 'TXT RRset exceeds UDP limit', severity: 'medium' }]);
+			if (r.category === 'mta_sts') return makeCheckResult('mta_sts', false, [{ title: 'Missing MTA-STS', severity: 'medium' }]);
+			return r;
+		});
+
+		const report = evaluateCompliance(results, 'summary-partial.com', 78, 'C');
+		const nist = report.frameworks.nist_800_177;
+
+		expect(nist.totalControls).toBe(8);
+		expect(nist.passing).toBe(6);
+		expect(nist.failing).toBe(1);
+		expect(nist.partial).toBe(1);
+		expect(nist.notAssessed).toBe(0);
+		expect(nist.assessedControls).toBe(8);
+		expect(nist.passing + nist.failing + nist.partial).toBe(nist.assessedControls);
+		// percentage = passing / assessed — the partial is in the denominator but never
+		// the numerator, so it can only lower the number, never inflate it.
+		expect(nist.percentage).toBe(75); // Math.round(6/8 * 100)
 	});
 });
 
@@ -849,6 +1002,33 @@ describe('formatCompliance', () => {
 		// The per-control column must not read as a failure verdict either.
 		expect(text).not.toMatch(/\bFAIL\b/);
 		expect(text.toLowerCase()).toContain('not assessed');
+	});
+
+	it('renders a partial verdict as implemented-but-flagged — non-certifying, distinct from both pass and fail (#815)', () => {
+		// The google.com headline shape: SPF passed with one medium hygiene finding.
+		const results = makeAllPassing().map((r) =>
+			r.category === 'spf' ? makeCheckResult('spf', true, [{ title: 'TXT RRset exceeds UDP limit', severity: 'medium' }]) : r,
+		);
+		const report = evaluateCompliance(results, 'google.com', 85, 'B');
+		const output = formatCompliance(report, 'full');
+
+		const spfLine = output.split('\n').find((l) => l.includes('§4.3.1'));
+		expect(spfLine).toBeDefined();
+		expect(spfLine).toContain('PARTIAL');
+		// Non-certifying wording: the control is implemented, the scan flagged it, and
+		// the line must read as neither a certification nor a failed requirement.
+		expect(spfLine).toContain('implemented but flagged');
+		expect(spfLine).toContain('not certified');
+		expect(spfLine).not.toMatch(/\bFAIL\b/);
+		expect(spfLine).not.toMatch(/\bPASS\b(?!IVE)/);
+		// The flag itself is still surfaced as a sub-item.
+		expect(output).toContain('TXT RRset exceeds UDP limit');
+
+		// Compact keeps the distinct '~' glyph and carries the finding.
+		const compact = formatCompliance(report, 'compact');
+		const compactSpfLine = compact.split('\n').find((l) => l.includes('§4.3.1'));
+		expect(compactSpfLine).toContain('~');
+		expect(compactSpfLine).toContain('TXT RRset exceeds UDP limit');
 	});
 
 	it('should not show related findings for passing controls in compact format', () => {


### PR DESCRIPTION
## Symptom

Validation sweep 2026-08-28/29 (live 3.67.0, google.com, nist_800_177): `map_compliance` published `{"controlId":"§4.3.1","controlName":"SPF Authentication","status":"fail","relatedFindings":["TXT RRset exceeds UDP limit"]}` — while the same window's `check_spf` returned `passed: true, score 85` on a valid record under DMARC `p=reject`. Same shape for §4.3.2 DKIM Signing on a correctly-revoked retired selector. "google.com fails SPF Authentication" is not a defensible compliance statement. (#815)

## Root cause

The #726 severity floor in `isSatisfiedControl` (`src/lib/control-presence.ts`) is deliberately **category-scoped**: any measured medium-or-worse finding in a category disqualifies the control it backs — including transport-hygiene findings that say nothing about the control's own requirement. `map_compliance` mapped every non-satisfied verdict to a hard `fail`, so a medium hygiene flag beside an implemented, passing control published as a failed requirement — the inverse error shape of #726's false PASS.

## Fix (Option 1 per the issue's operator ruling — the floor itself is untouched)

The floor stays exactly as #726 shipped it: a control flagged at medium or worse by the same scan **still cannot certify**. What changes is the *verdict wording* for the passing-but-flagged case:

- **`src/lib/control-presence.ts`** — NEW `classifyControlSatisfaction` (satisfied / deficient / unsatisfied) added **beside** `isSatisfiedControl`, whose semantics are unchanged: `compare_baseline` (#706) and the deploy verifier (#725) keep consuming the binary predicate, and a test pins that the classifier's `satisfied` set is exactly `isSatisfiedControl`'s so the two can never drift. `deficient` = passed, disqualified only by medium measured findings; `unsatisfied` = `!passed`, measured high/critical, or unrebutted record absence (absence outranks deficiency — the #705 shape never softens to partial).
- **`src/tools/map-compliance.ts`** — verdicts derive from the classifier. `requirePass`: any unsatisfied → `fail`; none but some deficient → `partial`; all satisfied → `pass`. Lenient ladder: deficient evidence keeps a control out of `fail` but can never complete a `pass`. Summary counting: a `partial` sits in the percentage **denominator, never the numerator** — it can only lower a compliance percentage, never inflate one (now pinned by test). `relatedFindings` carried exactly as before, including on partials.
- **Formatter** — `partial` renders `PARTIAL — implemented but flagged (not certified)`: non-certifying, clearly distinct from both PASS and FAIL.

**#726 stays closed**: the wiz.io regression shape (http_security `passed` with "CSP allows unsafe-inline scripts" + "CSP allows unsafe-eval" mediums) is re-tested — it now reports `partial`, asserted `not.toBe('pass')` first, with both findings carried and the framework percentage not 100.

## Tests

TDD (red first, 11 failures, then green):

- google.com headline shape: check passed (85) + one medium hygiene finding → `partial`, never `fail`
- wiz.io #726 regression: `partial`, **never** `pass`; percentage not inflated
- measured HIGH on a passing check → `fail` unchanged; `!passed` → `fail` unchanged
- #705 shape (unsigned zone, high "DNSSEC not enabled", `recordPresent: false`) → `fail`, not partial; unrebutted absence with medium-only findings → `fail`
- multi-category coherence: all-deficient → `partial`; failing + flagged → never `pass`, both findings surfaced
- summary honesty: partial counted in neither `passing` nor `failing`; percentage = passing/assessed (75 on the fixture)
- classifier truth table incl. `isSatisfiedControl` agreement sweep and unmeasured-finding (`errorKind`/`inconclusive`) handling
- formatter wording: full format reads "implemented but flagged (not certified)", compact keeps the `~` glyph + finding

Evidence: `test/map-compliance.spec.ts` + `test/control-presence.spec.ts` → 58 passed. Blast-radius isolation run (`compare-baseline`, `verify-deploy-control-predicate`, `reporting-surfaces-unmeasured`, chaos varied-domain, `internal` cross-door parity, + the two changed specs) → 7 files, 161 passed. Consumer/audit batch (predicate-agreement, evidence-SSOT, ungraded-representation audits, generate-fix-plan, map-registrar-products, tool-pick-eval, ungraded-formatter) → 10 files, 172 passed. `npm run typecheck` + `npm run lint` clean. One full-suite run showed 2 failed files / 1 failed test with 8219 passed; every implicated spec passes in isolation and the file-level failure with zero failing tests matches the documented workerd teardown noise signature.

Cross-refs: #726 (the false-PASS the floor closed — regression re-tested here), #705/#706 (passed-as-verdict lineage; both consumers of the untouched binary predicate), #808 (revoked-selector DKIM cliff feeding §4.3.2).

Fixes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)