### PR TITLE
fix(dnssec-chain): flag chain broken at unsigned ancestor zone, not just unsigned target

### DIFF
--- a/src/tools/check-dnssec-chain.ts
+++ b/src/tools/check-dnssec-chain.ts
@@ -221,6 +221,10 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 	// Determine chain completeness
 	const lastZone = zoneResults[zoneResults.length - 1];
 	const reachedTarget = lastZone?.zone === domain;
+	// The walk loop only ever exits early via the unsigned-zone `break` (no DS AND
+	// no DNSKEY at a non-root zone), so `stoppedEarly` means exactly "the chain of
+	// trust terminated unsigned at an ANCESTOR of the target".
+	const stoppedEarly = !reachedTarget;
 	// Chain is complete only if we reached the target AND it's not broken AND the target zone is actually signed
 	const targetSigned = reachedTarget && (lastZone.dsRecords.length > 0 || lastZone.dnskeyRecords.length > 0);
 	// The root trust anchor must have been retrieved for the chain to be "complete".
@@ -261,7 +265,14 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 		);
 	}
 
-	// Unsigned target zone (high severity, decoupled penalty). Mirrors check_dnssec's
+	// Unsigned chain termination (high severity, decoupled penalty). Fires when the
+	// walk reached the target and found it unsigned, OR when the walk stopped early
+	// at an unsigned ANCESTOR zone (`stoppedEarly`) — the chain of trust is broken at
+	// that ancestor, and any DNSSEC material published below it (an island of trust)
+	// is unreachable from the root anchor, so validating resolvers treat the target
+	// as insecure either way. Before this guard covered `stoppedEarly`, a subdomain
+	// under an unsigned parent scored an accidental 100/passed while check_dnssec
+	// scored the same domain 60 (#820 review follow-up). Mirrors check_dnssec's
 	// "DNSSEC not enabled" finding (packages/dns-checks/src/checks/check-dnssec.ts:130-151):
 	// the target has neither a DS in its parent nor a DNSKEY of its own, so the chain of
 	// trust terminates at the target and DNSSEC provides no origin authentication for it.
@@ -274,15 +285,19 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 	// `score: hasMissingControl ? 0 : score`) and the detail text avoids "no … record",
 	// "missing", "required", and "not found" so `scoreIndicatesMissingControl`
 	// (packages/dns-checks/src/scoring/model.ts:267-285) cannot auto-zero the finding.
-	if (reachedTarget && !targetSigned) {
+	if (!targetSigned || stoppedEarly) {
+		// The zone where the chain of trust terminated unsigned: the target itself
+		// when the walk got there, otherwise the unsigned ancestor it stopped at.
+		const terminalZone = stoppedEarly ? (lastZone?.zone ?? domain) : domain;
+		const detail = stoppedEarly
+			? `DNSSEC is not configured for ${terminalZone}: the chain-of-trust walk found neither a DS at its parent zone nor a DNSKEY published by ${terminalZone} itself, so the chain of trust terminates at ${terminalZone} before reaching ${domain}. Any DNSSEC material published below ${terminalZone} is an unreachable island of trust. Without an intact chain, DNS responses for ${domain} are not cryptographically verified, leaving SPF, DMARC, and DKIM vulnerable to DNS-level manipulation.`
+			: `DNSSEC is not configured for ${domain}: the chain-of-trust walk found neither a DS at the parent zone nor a DNSKEY published by ${domain} itself, so the chain terminates here. Without DNSSEC, DNS responses for ${domain} are not cryptographically verified, leaving SPF, DMARC, and DKIM vulnerable to DNS-level manipulation.`;
 		findings.push(
-			createFinding(
-				CATEGORY,
-				'DNSSEC chain terminates unsigned',
-				'high',
-				`DNSSEC is not configured for ${domain}: the chain-of-trust walk found neither a DS at the parent zone nor a DNSKEY published by ${domain} itself, so the chain terminates here. Without DNSSEC, DNS responses for ${domain} are not cryptographically verified, leaving SPF, DMARC, and DKIM vulnerable to DNS-level manipulation.`,
-				{ zone: domain, linkage: 'no_ds', penaltyOverride: 40 },
-			),
+			createFinding(CATEGORY, 'DNSSEC chain terminates unsigned', 'high', detail, {
+				zone: terminalZone,
+				linkage: 'no_ds',
+				penaltyOverride: 40,
+			}),
 		);
 	}
 
@@ -312,7 +327,6 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 		dsDigestTypes: [...new Set(z.dsRecords.map((ds) => DIGEST_TYPES[ds.digestType] ?? `Unknown(${ds.digestType})`))],
 	}));
 
-	const stoppedEarly = !reachedTarget;
 	let summaryStatus: string;
 	if (stoppedEarly) {
 		summaryStatus = `stopped at ${lastZone?.zone ?? '.'} — zone has no DS and no DNSKEY (not signed)`;

--- a/test/check-dnssec-chain.spec.ts
+++ b/test/check-dnssec-chain.spec.ts
@@ -190,6 +190,47 @@ describe('checkDnssecChain', () => {
 		expect(result.passed).toBe(true);
 	});
 
+	it('unsigned ANCESTOR zone (walk stops before target) scores 60, not an accidental 100 pass', async () => {
+		// www.example.com where example.com is unsigned (com signed): the walk breaks
+		// at example.com before ever reaching the target, so the #820 guard
+		// (`reachedTarget && !targetSigned`) never fired and the tool returned
+		// score 100 / passed true while check_dnssec scored the same domain 60.
+		// The chain of trust is broken at the unsigned ancestor — even a DNSKEY
+		// published below it would be an unreachable island of trust.
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			// example.com (ANCESTOR of the target) has no DS and no DNSKEY → unsigned
+			'example.com:DS': emptyDsResponse('example.com'),
+			'example.com:DNSKEY': emptyDnskeyResponse('example.com'),
+			'www.example.com:A': adResponse('www.example.com', false),
+		});
+
+		const result = await run('www.example.com');
+
+		// Same finding shape as the reached-target case (#820): high severity with a
+		// decoupled -40 penalty, and NO missingControl (which would zero the score).
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.metadata?.penaltyOverride).toBe(40);
+		expect(highFinding!.metadata?.missingControl).toBeUndefined();
+
+		// The finding is keyed to the zone where the chain terminated unsigned.
+		expect(highFinding!.metadata?.zone).toBe('example.com');
+		expect(highFinding!.detail).toContain('example.com');
+
+		// Aligned with check_dnssec's 60 for the same shape; passed=true under the
+		// documented `passed = score>=50 && !hasMissingControl` formula.
+		expect(result.score).toBe(60);
+		expect(result.passed).toBe(true);
+
+		// Summary must not claim a complete chain.
+		const summary = result.findings.find((f) => f.severity === 'info' && f.metadata?.chainComplete !== undefined);
+		expect(summary).toBeDefined();
+		expect(summary!.metadata!.chainComplete).toBe(false);
+	});
+
 	it('broken linkage (DS exists but no DNSKEY) produces high severity', async () => {
 		mockDnsFetch({
 			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),


### PR DESCRIPTION
## What

Broadens `check_dnssec_chain`'s unsigned-chain guard in `src/tools/check-dnssec-chain.ts` from `reachedTarget && !targetSigned` to `!targetSigned || stoppedEarly`, and keys the finding's detail/`metadata.zone` to the zone where the chain of trust actually terminated unsigned.

## Why

Found in review of merged PR #820 (follow-up to #810). The #820 guard only fired when the walk *reached* the target and found it unsigned. When an **ancestor** zone is unsigned (e.g. `example.com` unsigned under a signed `com`), the walk `break`s before reaching the target, `reachedTarget` stays false, and no finding was emitted — `checkDnssecChain('www.example.com')` returned score 100 / passed true while `check_dnssec` scored the same domain 60. The chain of trust is broken at the unsigned ancestor; any DNSSEC material published below it is an unreachable island of trust, so validating resolvers treat the target as insecure either way.

Finding shape is identical to #820's: `high` severity, `penaltyOverride: 40` (category lands at 60), no `missingControl`, and title/detail wording clear of `MISSING_CONTROL_REGEX`. Tool is `scanIncluded: false` — no scan/parity surfaces affected.

## Verification

- TDD: new spec case (`www.example.com` under unsigned `example.com`, signed `com`) written first and confirmed failing (no high finding, score 100) before the fix.
- `npx vitest run test/check-dnssec-chain.spec.ts` — 10/10 passing (9 pre-existing cases untouched and green).
- `npm run typecheck` clean; `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)