### PR TITLE
fix(http-security,ssl): close no-content guard gaps — https leg, mixed dual-fetch, transient caching

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/http-security-no-content.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/http-security-no-content.test.ts
@@ -39,6 +39,11 @@ function expectUnmeasuredNoContent(result: Awaited<ReturnType<typeof checkHTTPSe
 	expect(result.score).toBe(0);
 	expect(result.passed).toBe(false);
 	expect(result.checkStatus).toBe('error');
+	// A no-content answer is a TRANSIENT anomaly (an egress blip, not an origin-persistent
+	// state): `partial: true` keeps it out of the 5-min per-check cache — matching the
+	// buildDnsErrorResult convention — so it self-heals on the next probe instead of a
+	// one-off 204 pinning the category excluded for every caller for 5 minutes.
+	expect(result.partial).toBe(true);
 }
 
 describe('checkHTTPSecurity — a no-content 2xx is unmeasured, not a missing-header slate (issue #806)', () => {
@@ -70,6 +75,16 @@ describe('checkHTTPSecurity — a no-content 2xx is unmeasured, not a missing-he
 			return new Response(null, { status: 405 });
 		};
 		expectUnmeasuredNoContent(await checkHTTPSecurity('example.com', fetchFn));
+	});
+
+	it('a WAF/appliance block (403 on HEAD and GET) is UNCHANGED — cached deliberately, no `partial`', async () => {
+		// The pre-existing blocked-probe branches describe origin-PERSISTENT states (a WAF
+		// isn't going away in 5 minutes) and deliberately remain cacheable; `partial` is
+		// scoped to the transient no-content anomaly only.
+		const fetchFn: FetchFunction = async () => new Response(null, { status: 403 });
+		const result = await checkHTTPSecurity('example.com', fetchFn);
+		expect(result.checkStatus).toBe('error');
+		expect(result.partial).toBeUndefined();
 	});
 
 	it('a real headerless 200 is UNCHANGED — still analyzed as a measured page', async () => {

--- a/packages/dns-checks/src/__tests__/checks/ssl-no-content.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/ssl-no-content.test.ts
@@ -15,6 +15,8 @@
 
 import { describe, it, expect } from 'vitest';
 import { getHttpRedirectFindings } from '../../checks/ssl-analysis';
+import { checkSSL } from '../../checks/check-ssl';
+import type { FetchFunction } from '../../types';
 
 describe('getHttpRedirectFindings — no-content HTTP probe responses are unmeasured (issue #806)', () => {
 	it.each([[204], [205]])('status %d emits NO redirect finding', (status) => {
@@ -36,5 +38,45 @@ describe('getHttpRedirectFindings — no-content HTTP probe responses are unmeas
 
 	it('an https:// redirect stays clean', () => {
 		expect(getHttpRedirectFindings('example.com', 301, 'https://example.com/')).toEqual([]);
+	});
+});
+
+describe('checkSSL — a no-content 2xx on the https:// probe is unmeasured, not a missing-HSTS slate (issue #806 follow-up)', () => {
+	it.each([[204], [205]])('https HEAD %d: no HSTS finding, inconclusive/excluded shape, redirect leg skipped', async (status) => {
+		// A terminal 204/205 on the https:// leg is not a redirect, so before the guard it
+		// flowed into getHttpsFindings() with its empty header set and produced a confident
+		// scored "No HSTS header" medium finding from a response that delivered no page —
+		// the exact defect family #819 fixed on the http:// leg.
+		const httpCalls: string[] = [];
+		const fetchFn: FetchFunction = async (url) => {
+			if (url.startsWith('http://')) {
+				httpCalls.push(url);
+				return new Response(null, { status: 301, headers: { location: 'https://example.com/' } });
+			}
+			return new Response(null, { status });
+		};
+		const result = await checkSSL('example.com', fetchFn);
+		// No confident HSTS verdict may be derived from a bodyless response…
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(false);
+		// …and absolutely no claim of absence (issue #638 law).
+		expect(result.findings.some((f) => f.metadata?.missingControl === true)).toBe(false);
+		// One honest unmeasured finding with the transient-exclusion markers.
+		const marker = result.findings.find((f) => f.metadata?.inconclusive === true);
+		expect(marker).toBeDefined();
+		expect(marker!.metadata?.errorKind).toBe('no_content');
+		// The category is EXCLUDED from scoring (transient-failure renormalization).
+		expect(result.checkStatus).toBe('error');
+		// Nothing reliable to compare the redirect leg against — it must be skipped.
+		expect(httpCalls).toEqual([]);
+	});
+
+	it('a real headerless 200 is UNCHANGED — still a confident "No HSTS header" finding', async () => {
+		const fetchFn: FetchFunction = async (url) =>
+			url.startsWith('http://')
+				? new Response(null, { status: 301, headers: { location: 'https://example.com/' } })
+				: new Response('<html></html>', { status: 200 });
+		const result = await checkSSL('example.com', fetchFn);
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(true);
+		expect(result.checkStatus).toBeUndefined();
 	});
 });

--- a/packages/dns-checks/src/checks/check-http-security.ts
+++ b/packages/dns-checks/src/checks/check-http-security.ts
@@ -162,6 +162,14 @@ export async function checkHTTPSecurity(
 	// Generalising "inconclusive ⇒ zero" would silently rescore both. It is scoped to the
 	// branches that made the contradictory claim.
 	let unmeasuredZero = false;
+	// Set ONLY on the two no-content (204/205) branches (issue #806 follow-up). A no-content
+	// answer is a TRANSIENT anomaly — an egress blip or challenge, not an origin-persistent
+	// state — so the result carries `partial: true` to stay OUT of the 5-min per-check cache
+	// (scan-domain's runWithCache predicate is `(r) => !r.partial`), matching the
+	// buildDnsErrorResult convention for transient states. Deliberately NOT set on the
+	// WAF-block/401/other-4xx branches: those describe origin-persistent states and cache
+	// deliberately.
+	let transientNoContent = false;
 
 	try {
 		let response = await fetchFn(`https://${domain}`, {
@@ -182,6 +190,7 @@ export async function checkHTTPSecurity(
 			// rather than score the 0 — so the transient-zero retry can fire.
 			inconclusive = 'error';
 			unmeasuredZero = true;
+			transientNoContent = true;
 			findings.push(noContentFinding(domain, response.status));
 		} else if (response.ok) {
 			// 200-299: analyze headers normally
@@ -209,6 +218,7 @@ export async function checkHTTPSecurity(
 					// same no-content guard applies before analysis.
 					inconclusive = 'error';
 					unmeasuredZero = true;
+					transientNoContent = true;
 					findings.push(noContentFinding(domain, followed.status));
 				} else {
 					findings.push(...analyzeSecurityHeaders(followed.headers));
@@ -301,6 +311,9 @@ export async function checkHTTPSecurity(
 	// Preserves the exact score-0/passed-false shape the removed `missingControl` flags used to
 	// produce on the four never-completed-probe paths, without asserting the control is absent
 	// (issue #638).
-	const result = unmeasuredZero ? { ...base, score: 0, passed: false } : base;
+	const zeroed = unmeasuredZero ? { ...base, score: 0, passed: false } : base;
+	// `partial: true` (transient no-content only) keeps the anomaly out of the 5-min cache —
+	// see the `transientNoContent` note above.
+	const result = transientNoContent ? { ...zeroed, partial: true } : zeroed;
 	return inconclusive ? { ...result, checkStatus: inconclusive } : result;
 }

--- a/packages/dns-checks/src/checks/check-ssl.ts
+++ b/packages/dns-checks/src/checks/check-ssl.ts
@@ -107,6 +107,26 @@ async function checkHttps(
 					`https://${domain} returned status ${response.status}; the HTTPS endpoint could not be reached to assess HSTS/redirect posture, so this control was not assessed.`,
 				),
 			);
+		} else if (response.status === 204 || response.status === 205) {
+			// Issue #806 follow-up: a no-content 2xx satisfies neither the redirect nor the error
+			// branch, so before this guard its (by definition empty) header set flowed into
+			// getHttpsFindings() and produced a confident scored "No HSTS header" finding from a
+			// response that delivered no page — the exact defect family #819 fixed on the http://
+			// leg (getHttpRedirectFindings) and in the sibling check-http-security. Route it to
+			// the same inconclusive/'error' lane as the unassessable-origin branch above so the
+			// category is EXCLUDED from scoring and the transient-zero retry can fire. Never
+			// `missingControl`: a 204 measured nothing (issue #638 law) — `inconclusive` +
+			// `errorKind` are the honest unmeasured markers.
+			inconclusive = 'error';
+			findings.push(
+				createFinding(
+					'ssl',
+					'HTTPS response carried no content',
+					'info',
+					`https://${domain} answered the scanner with HTTP ${response.status} (no content). No page was delivered, so HSTS/redirect posture could not be verified — the response may be an egress anomaly or challenge rather than the site.`,
+					{ inconclusive: true, confidence: 'heuristic', errorKind: 'no_content' },
+				),
+			);
 		} else {
 			const isRedirect = response.status >= 300 && response.status < 400;
 			const location = isRedirect ? response.headers.get('location') : null;

--- a/src/tools/check-http-security.ts
+++ b/src/tools/check-http-security.ts
@@ -307,7 +307,17 @@ async function dualFetchHeaders(
 	}
 
 	const merged = mergeSecurityHeaders(usable[0].headers, usable[1].headers);
-	const primary = usable[0].ok ? usable[0] : usable[1].ok ? usable[1] : usable[0];
+	// Issue #806 follow-up: `ok` alone let an anomalous no-content 204/205 (which satisfies
+	// `response.ok`) win primary over a real 200 whenever it settled into usable[0] — the
+	// synthetic Response then carried status 204 with the MERGED real headers, and the
+	// package's no-content guard discarded a genuine measurement (order-dependent flap).
+	// Prefer a usable probe that actually delivered content; only when EVERY usable probe
+	// is no-content does the old preference apply (and the package guard then rightly
+	// routes it to the unmeasured lane).
+	const isNoContent = (r: Response) => r.status === 204 || r.status === 205;
+	const contentful = usable.filter((r) => !isNoContent(r));
+	const pool = contentful.length > 0 ? contentful : usable;
+	const primary = pool.find((r) => r.ok) ?? pool[0];
 	return { headers: merged, edgeSignals, ok: primary.ok, status: primary.status, usable: true };
 }
 

--- a/test/check-http-security.spec.ts
+++ b/test/check-http-security.spec.ts
@@ -916,5 +916,53 @@ describe('checkHttpSecurity — a no-content 2xx is unmeasured, not a missing-he
 		expect(result.score).toBe(0);
 		expect(result.passed).toBe(false);
 		expect(result.checkStatus).toBe('error');
+		// Transient anomaly — `partial: true` keeps it out of the 5-min per-check cache
+		// (scan-domain's runWithCache predicate is `(r) => !r.partial`), matching the
+		// buildDnsErrorResult convention. Issue #806 follow-up.
+		expect(result.partial).toBe(true);
+	});
+
+	it.each([
+		['204 first, 200 second', [204, 200]],
+		['200 first, 204 second', [200, 204]],
+	])('mixed dual-fetch (%s): the real 200 is analyzed normally, never discarded as no-content', async (_label, statuses) => {
+		// The dual-fetch fires two parallel probes. When one edge answers with an anomalous
+		// 204 and the other with the real 200, `primary = usable[0].ok ? ...` made the
+		// outcome ORDER-DEPENDENT: a 204 settling into usable[0] stamped the synthetic
+		// Response with status 204 (while carrying the MERGED real headers), and the #819
+		// no-content guard then discarded a genuine measurement. A real 200 with headers
+		// must beat a 204 regardless of settle order.
+		const fullHeaders = {
+			'content-security-policy': "default-src 'self'; script-src 'self'; frame-ancestors 'none'",
+			'x-frame-options': 'DENY',
+			'x-content-type-options': 'nosniff',
+			'permissions-policy': 'camera=(), microphone=()',
+			'referrer-policy': 'strict-origin-when-cross-origin',
+			'cross-origin-resource-policy': 'same-origin',
+			'cross-origin-opener-policy': 'same-origin',
+			'cross-origin-embedder-policy': 'require-corp',
+		};
+		let probeCalls = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('/robots.txt')) {
+				// Fail-open robots answer so the probes below are the only counted fetches.
+				return Promise.resolve({ ok: false, status: 404, type: 'basic', headers: new Headers() });
+			}
+			const status = statuses[Math.min(probeCalls, statuses.length - 1)];
+			probeCalls++;
+			return Promise.resolve({
+				ok: true,
+				status,
+				type: 'basic',
+				headers: new Headers(status === 200 ? fullHeaders : {}),
+			});
+		});
+		const result = await run();
+		// Analyzed from the real 200 — never routed to the no-content exclusion lane.
+		expect(result.checkStatus).toBeUndefined();
+		expect(result.findings.some((f) => f.metadata?.errorKind === 'no_content')).toBe(false);
+		expect(result.passed).toBe(true);
+		expect(result.findings.some((f) => f.title === 'HTTP security headers well configured')).toBe(true);
 	});
 });

--- a/test/check-ssl.spec.ts
+++ b/test/check-ssl.spec.ts
@@ -215,4 +215,40 @@ describe('checkSsl', () => {
 		const finding = result.findings.find((f) => f.title === 'No HTTP to HTTPS redirect');
 		expect(finding).toBeUndefined();
 	});
+
+	it.each([[204], [205]])(
+		'should NOT emit an HSTS finding when the https:// probe returns a no-content %d (issue #806 follow-up)',
+		async (status) => {
+			// A terminal 204/205 on the https:// leg satisfies neither the redirect nor the
+			// error branch, so before the guard its EMPTY header set flowed into
+			// getHttpsFindings() and produced a confident scored "No HSTS header" medium
+			// finding from a response that delivered no page. Same family as the http:// leg
+			// fixed in #819: withhold the verdict, exclude the category.
+			globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+				const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+				if (url.startsWith('https://')) {
+					// Anomalous no-content answer on the https:// probe (robots.txt included —
+					// an empty robots answer fails open, matching this file's other mocks).
+					return Promise.resolve({
+						url: 'https://example.com/',
+						ok: true,
+						status,
+						headers: new Headers(),
+					});
+				}
+				return Promise.resolve({
+					ok: false,
+					status: 301,
+					headers: new Headers({ location: 'https://example.com/' }),
+				});
+			});
+			const result = await run();
+			expect(result.findings.find((f) => f.title === 'No HSTS header')).toBeUndefined();
+			expect(result.findings.some((f) => f.metadata?.missingControl === true)).toBe(false);
+			const marker = result.findings.find((f) => f.metadata?.inconclusive === true);
+			expect(marker).toBeDefined();
+			expect(marker!.metadata?.errorKind).toBe('no_content');
+			expect(result.checkStatus).toBe('error');
+		},
+	);
 });


### PR DESCRIPTION
## What

Three follow-up gaps from #819 (the fix for #806), all in the same defect family — a no-content 2xx (204/205) satisfies `response.ok` but by definition delivered no page, so nothing derived from it may be scored as a measurement:

1. **`packages/dns-checks/src/checks/check-ssl.ts` — https:// leg.** `checkHttps` treated a terminal 204/205 as a normal 2xx and fed its empty header set to `getHttpsFindings()`, producing a confident scored "No HSTS header" medium finding. Now routed to the check's existing inconclusive/`'error'` lane (same mechanism as its unassessable-origin 0/5xx branch): `checkStatus: 'error'` so scoring EXCLUDES the category and the transient-zero retry can fire, one honest info finding carrying `inconclusive: true` + `errorKind: 'no_content'`, never `missingControl` (issue #638 law). The HTTP-redirect leg is skipped — nothing reliable to compare against.

2. **`src/tools/check-http-security.ts` — mixed dual-fetch order dependence.** `primary = usable[0].ok ? usable[0] : …` let an anomalous 204 that settled into `usable[0]` win primary over a real 200: the synthetic Response then carried status 204 with the MERGED real headers, and the #819 no-content guard discarded a genuine measurement. Primary now prefers a usable probe that actually delivered content (a real 200 with headers beats a 204, in both settle orders); only when every usable probe is no-content does the guard rightly fire.

3. **`packages/dns-checks/src/checks/check-http-security.ts` — transient caching.** The no-content result (`checkStatus: 'error'`, score 0) did not set `partial: true`, so it passed scan-domain's `(r) => !r.partial` cache predicate and a one-off 204 anomaly was cached for 5 minutes. It now carries `partial: true`, matching the `buildDnsErrorResult` convention for transient states. The pre-existing WAF-block/401/other-4xx branches are deliberately untouched (origin-persistent states that cache on purpose) — pinned by a new test.

## Why

#819 closed the http:// redirect leg and the package http-security terminal path, but the same anomalous egress 204 observed live on google.com (#806) can still (a) fabricate a scored HSTS deficiency via the https:// ssl leg, (b) flap the http_security category order-dependently when only one of the two parallel probes is anomalous, and (c) pin the excluded category for 5 minutes for every caller via the per-check cache.

## Verification

TDD — each test written first and watched fail, then pass:

- Package: `npm -w packages/dns-checks test` — 50 files / 904 tests green (was 6 failing pre-fix: ssl 204/205 emitting "No HSTS header"; no-content results lacking `partial`).
- Worker: `npx vitest run test/check-http-security.spec.ts test/check-ssl.spec.ts` — 67 tests green (was 5 failing pre-fix: mixed dual-fetch 204-first order excluded a genuine 200 measurement; worker-path ssl 204/205; worker-path `partial`).
- `npx vitest run test/scan-domain.spec.ts` — 51 green (cache-predicate consumer).
- `npm run typecheck` clean, `npm run lint` clean.

## Release note

Core check source under `packages/dns-checks` changed — the next release must bump `@blackveil/dns-checks` and `PARITY_CORPUS_VERSION` in lockstep (per the 3.69.0 changelog precedent). No version bump in this PR by design.

Refs #806, #819.

🤖 Generated with [Claude Code](https://claude.com/claude-code)