### PR TITLE
chore(release): prepare 3.69.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.69.1] - 2026-08-29
+
+Patch release folding in two post-3.69.0 follow-up fixes so the deploy ships from a tagged commit (3.69.0 was tagged but never deployed; this supersedes it).
+
+### Fixed
+
+- **http_security + ssl: no-content guard gaps closed** — the 204/205 guard from #806/#819 now also covers the https leg, the mixed dual-fetch shape (one leg a real page, the other a 204), and no longer lets a transient no-content result enter the cache. (PR #835)
+- **check_dnssec_chain: a chain broken at an unsigned ANCESTOR zone is now flagged** — the #810/#820 fix covered only the target zone itself; an early-stopped walk over an unsigned intermediate could still present the accidental-pass shape. (PR #833)
+
 ## [3.69.0] - 2026-08-28
 
 Correctness release: twelve fixes from the 2026-08-28 full-tool scanner validation sweep (issues #806–#815, #828 filed from the same campaign). Every fix shipped as its own reviewed PR.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.69.0",
+	"version": "3.69.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.69.0",
+			"version": "3.69.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.69.0",
+	"version": "3.69.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.69.0",
+	"version": "3.69.1",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Patch release so the deploy ships from a tagged commit: folds the two post-3.69.0 follow-ups (#833 no-content guard gaps on the https/mixed/cache paths; #835... correction: #835 is the guard-gaps PR, #833 the dnssec-chain ancestor fix) on top of 3.69.0, which was tagged but never deployed. Version surfaces synced by the lifecycle hook; CHANGELOG entry included.

Post-merge: tag `v3.69.1` at the squashed commit → `npm run deploy:prod` from the tag-pinned worktree (D1 migration `0001_watch_webhook_outbox.sql` must be applied to `brand-audit-v1` first — the deploy preflight fails closed until it is) → verify live → registry publish last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)