### PR TITLE
fix(delegation): validate probe evidence shape at the fetch boundary

### DIFF
--- a/src/lib/authoritative-dns-infra/probe-client.ts
+++ b/src/lib/authoritative-dns-infra/probe-client.ts
@@ -45,7 +45,40 @@ export async function fetchDelegationConsistencyEvidence(
 		body: JSON.stringify({ hostname: normalizeInfraHostname(domain) }),
 		signal: AbortSignal.timeout(INFRA_PROBE_TIMEOUT_MS),
 	});
-	return readJsonResponse<DelegationConsistencyEvidence>(response, 'delegation consistency probe');
+	const evidence = await readJsonResponse<DelegationConsistencyEvidence>(response, 'delegation consistency probe');
+	// `analyzeDelegationConsistency` dereferences these arrays (and each glue entry's
+	// parentIpv4/parentIpv6) unconditionally over this unchecked cast. Its sole caller,
+	// checkNs, currently survives a malformed body only because its try happens to wrap
+	// the analysis too — validate at the boundary so that fail-soft degrade is structural,
+	// not an accident of try-scope (#828/#837 sibling). Empty arrays are legitimate
+	// measurements here (e.g. `glue: []` = no in-bailiwick nameservers) and must pass.
+	if (!isUsableDelegationEvidence(evidence)) {
+		throw new Error('Invalid infra probe response: delegation consistency probe returned malformed evidence');
+	}
+	return evidence;
+}
+
+function isNamedObservationArray(value: unknown): boolean {
+	return Array.isArray(value)
+		&& value.every((entry) =>
+			typeof entry === 'object'
+			&& entry !== null
+			&& typeof (entry as Record<string, unknown>).nameserver === 'string');
+}
+
+function isStringArray(value: unknown): boolean {
+	return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
+}
+
+function isUsableDelegationEvidence(evidence: DelegationConsistencyEvidence): boolean {
+	return isStringArray(evidence.parentNameservers)
+		&& isStringArray(evidence.parentDelegationNs)
+		&& isNamedObservationArray(evidence.parentObservations)
+		&& isNamedObservationArray(evidence.childObservations)
+		&& isNamedObservationArray(evidence.glue)
+		&& evidence.glue.every((entry) =>
+			isStringArray((entry as unknown as Record<string, unknown>).parentIpv4)
+			&& isStringArray((entry as unknown as Record<string, unknown>).parentIpv6));
 }
 
 export async function fetchRootServerSetEvidence(infraProbe: InfraProbeBinding): Promise<RootServerSetEvidence> {

--- a/src/lib/authoritative-dns-infra/probe-client.ts
+++ b/src/lib/authoritative-dns-infra/probe-client.ts
@@ -58,27 +58,35 @@ export async function fetchDelegationConsistencyEvidence(
 	return evidence;
 }
 
-function isNamedObservationArray(value: unknown): boolean {
-	return Array.isArray(value)
-		&& value.every((entry) =>
-			typeof entry === 'object'
-			&& entry !== null
-			&& typeof (entry as Record<string, unknown>).nameserver === 'string');
+function isNamedEntry(entry: unknown): entry is Record<string, unknown> {
+	return typeof entry === 'object' && entry !== null && typeof (entry as Record<string, unknown>).nameserver === 'string';
 }
 
 function isStringArray(value: unknown): boolean {
 	return Array.isArray(value) && value.every((entry) => typeof entry === 'string');
 }
 
+// Optional in the typed contract means ABSENT, not "any type": the analyzer's `?? []`
+// defaults only handle undefined, so a present-but-wrong-typed value (null, a bare
+// string) would still reach canonical()'s .map / addressesDiffer()'s .length.
+function isOptionalStringArray(value: unknown): boolean {
+	return value === undefined || isStringArray(value);
+}
+
 function isUsableDelegationEvidence(evidence: DelegationConsistencyEvidence): boolean {
 	return isStringArray(evidence.parentNameservers)
 		&& isStringArray(evidence.parentDelegationNs)
-		&& isNamedObservationArray(evidence.parentObservations)
-		&& isNamedObservationArray(evidence.childObservations)
-		&& isNamedObservationArray(evidence.glue)
+		&& Array.isArray(evidence.parentObservations)
+		&& evidence.parentObservations.every((entry) => isNamedEntry(entry) && isOptionalStringArray(entry.delegationNs))
+		&& Array.isArray(evidence.childObservations)
+		&& evidence.childObservations.every((entry) => isNamedEntry(entry) && isOptionalStringArray(entry.publishedNs))
+		&& Array.isArray(evidence.glue)
 		&& evidence.glue.every((entry) =>
-			isStringArray((entry as unknown as Record<string, unknown>).parentIpv4)
-			&& isStringArray((entry as unknown as Record<string, unknown>).parentIpv6));
+			isNamedEntry(entry)
+			&& isStringArray(entry.parentIpv4)
+			&& isStringArray(entry.parentIpv6)
+			&& isOptionalStringArray(entry.currentIpv4)
+			&& isOptionalStringArray(entry.currentIpv6));
 }
 
 export async function fetchRootServerSetEvidence(infraProbe: InfraProbeBinding): Promise<RootServerSetEvidence> {

--- a/test/check-ns-delegation-consistency.spec.ts
+++ b/test/check-ns-delegation-consistency.spec.ts
@@ -105,4 +105,84 @@ describe('checkNs delegation consistency enrichment', () => {
 		expect(result.score).toBe(100);
 		expect(result.metadata?.delegationEvidenceMode).toBe('probe_unavailable');
 	});
+
+	// #828/#837 sibling — a malformed 200 body must degrade exactly like a probe outage,
+	// leaving the core NS score untouched. Today this holds only because checkNs's try
+	// happens to wrap the analysis too; the boundary guard below makes it structural.
+	it('keeps the core score unchanged when the probe returns a malformed 200 body', async () => {
+		mockCoreNsDns();
+		const probeFetch = vi.fn(async () => new Response(JSON.stringify({ hostname: 'example.com', parentZone: 'com' })));
+		const { checkNs } = await import('../src/tools/check-ns');
+		const result = await checkNs(
+			'example.com',
+			undefined,
+			{
+				scannedLabel: 'example.com', registrableDomain: 'example.com', isApex: true,
+				zoneApex: 'example.com', apexNsRecords: [], delegationStatus: 'apex',
+			},
+			{ infraProbe: { fetch: probeFetch as unknown as typeof globalThis.fetch } },
+		);
+		expect(result.score).toBe(100);
+		expect(result.metadata?.delegationEvidenceMode).toBe('probe_unavailable');
+	});
+});
+
+// #828/#837 sibling — `readJsonResponse<T>` is an unchecked generic cast, and
+// `analyzeDelegationConsistency` dereferences the required evidence arrays (and each glue
+// entry's parentIpv4/parentIpv6) unconditionally. Its only caller, checkNs, happens to
+// wrap the fetch AND the analysis in one try — incidental safety that a narrowed
+// try-scope would silently lose (exactly what had already happened to
+// check-root-server-set.ts, #828). The shape is therefore validated at the
+// fetchDelegationConsistencyEvidence boundary, mirroring PR #837's isUsableRootHintArray.
+describe('fetchDelegationConsistencyEvidence shape guard (#828/#837 sibling)', () => {
+	function probeReturning(body: unknown) {
+		return { fetch: vi.fn(async () => new Response(JSON.stringify(body))) as unknown as typeof globalThis.fetch };
+	}
+
+	it('rejects a 200 body missing the required arrays', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence('example.com', probeReturning({ hostname: 'example.com', parentZone: 'com' })),
+		).rejects.toThrow(/^Invalid infra probe response/);
+	});
+
+	it('rejects observation entries that are not objects carrying a nameserver string', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence(
+				'example.com',
+				probeReturning({ ...delegationEvidence(), childObservations: ['ns1.provider-a.com'] }),
+			),
+		).rejects.toThrow(/^Invalid infra probe response/);
+	});
+
+	it('rejects glue entries missing their required parentIpv4/parentIpv6 arrays', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence(
+				'example.com',
+				probeReturning({ ...delegationEvidence(), glue: [{ nameserver: 'ns1.example.com' }] }),
+			),
+		).rejects.toThrow(/^Invalid infra probe response/);
+	});
+
+	// Unlike the root-server-set probe (whose domain fixes a non-empty 13-entry answer),
+	// empty observation arrays here are legitimate measurements — e.g. `glue: []` simply
+	// means no in-bailiwick nameservers were observed. The guard must not reject them.
+	it('accepts a contract-valid body with empty observation arrays', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence(
+				'example.com',
+				probeReturning({ ...delegationEvidence(), parentObservations: [], childObservations: [], glue: [] }),
+			),
+		).resolves.toMatchObject({ hostname: 'example.com', parentZone: 'com' });
+	});
+
+	it('accepts the full valid fixture', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence('example.com', probeReturning(delegationEvidence())),
+		).resolves.toMatchObject({ hostname: 'example.com', parentDelegationNs: ['ns1.provider-a.com', 'ns2.provider-b.net'] });
+	});
 });

--- a/test/check-ns-delegation-consistency.spec.ts
+++ b/test/check-ns-delegation-consistency.spec.ts
@@ -166,6 +166,68 @@ describe('fetchDelegationConsistencyEvidence shape guard (#828/#837 sibling)', (
 		).rejects.toThrow(/^Invalid infra probe response/);
 	});
 
+	// Optional fields that are PRESENT but wrong-typed still reach unguarded dereferences
+	// in the analyzer (canonical()'s .map on delegationNs/publishedNs, addressesDiffer()'s
+	// .length on currentIpv4/currentIpv6 — `?? []` only handles undefined, not null or a
+	// string). The guard must reject present-but-malformed optional fields too.
+	it('rejects a parent observation whose delegationNs is present but not an array', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence(
+				'example.com',
+				probeReturning({
+					...delegationEvidence(),
+					parentObservations: [{ nameserver: 'a.gtld-servers.net', delegationNs: 'ns1.provider-a.com', rcode: 0 }],
+				}),
+			),
+		).rejects.toThrow(/^Invalid infra probe response/);
+	});
+
+	it('rejects a child observation whose publishedNs is present but not an array', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence(
+				'example.com',
+				probeReturning({
+					...delegationEvidence(),
+					childObservations: [{ nameserver: 'ns1.provider-a.com', aaFlag: true, publishedNs: 'ns1.provider-a.com', rcode: 0 }],
+				}),
+			),
+		).rejects.toThrow(/^Invalid infra probe response/);
+	});
+
+	it('rejects a glue entry whose currentIpv4 is null', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence(
+				'example.com',
+				probeReturning({
+					...delegationEvidence(),
+					glue: [{ nameserver: 'ns1.example.com', parentIpv4: ['192.0.2.53'], parentIpv6: [], currentIpv4: null }],
+				}),
+			),
+		).rejects.toThrow(/^Invalid infra probe response/);
+	});
+
+	it('accepts a populated, well-formed glue entry with optional fields present', async () => {
+		const { fetchDelegationConsistencyEvidence } = await import('../src/lib/authoritative-dns-infra/probe-client');
+		await expect(
+			fetchDelegationConsistencyEvidence(
+				'example.com',
+				probeReturning({
+					...delegationEvidence(),
+					glue: [{
+						nameserver: 'ns1.example.com',
+						parentIpv4: ['192.0.2.53'],
+						parentIpv6: ['2001:db8::53'],
+						currentIpv4: ['192.0.2.53'],
+						currentIpv6: ['2001:db8::53'],
+					}],
+				}),
+			),
+		).resolves.toMatchObject({ hostname: 'example.com' });
+	});
+
 	// Unlike the root-server-set probe (whose domain fixes a non-empty 13-entry answer),
 	// empty observation arrays here are legitimate measurements — e.g. `glue: []` simply
 	// means no in-bailiwick nameservers were observed. The guard must not reject them.


### PR DESCRIPTION
Sibling of #828 / #837 (found by the #837 reviewer).

## Defect class

`analyzeDelegationConsistency` (`src/lib/authoritative-dns-infra/delegation-analysis.ts`) unconditionally dereferences the required `DelegationConsistencyEvidence` arrays — `childObservations.filter`, `parentObservations.filter`, `glue.filter` (twice, including each entry's required `parentIpv4`/`parentIpv6`), and `parentDelegationNs` — over `readJsonResponse<T>`'s unchecked generic cast. Its sole caller, `checkNs` (`src/tools/check-ns.ts`), survives a malformed 200 body **only** because its try happens to wrap the fetch *and* the analysis, with the catch discarding malformed evidence fail-soft. That safety is incidental try-scope width — exactly the thing that had already been narrowed away in `check-root-server-set.ts` and produced #828's uncaught TypeError.

## Fix

Boundary guard in `fetchDelegationConsistencyEvidence` (`probe-client.ts`), mirroring #837's `isUsableRootHintArray`: the five required arrays must be present with correctly-typed elements (observation entries: non-null objects with a string `nameserver`; glue entries additionally string-arrays `parentIpv4`/`parentIpv6`). A violation throws `Invalid infra probe response: delegation consistency probe returned malformed evidence` (allowlisted `Invalid` prefix) into `checkNs`'s existing fail-soft catch → `delegationEvidenceMode: 'probe_unavailable'`, core NS score untouched. Unlike the root-hint set (fixed 13-entry domain), **empty arrays are accepted** — they are legitimate measurements here (`glue: []` = no in-bailiwick nameservers), pinned by a dedicated test.

## Verified degrade path

`checkNs`'s catch returns the base result unchanged with `delegationEvidenceMode: 'probe_unavailable'` — a malformed body can never score, satisfying the missingControl-vs-inconclusive doctrine.

## Tests (failing-first)

- 3 new boundary rejection tests failed before the guard (fetch resolved malformed bodies) and pass after.
- 2 boundary acceptance tests (empty-arrays body; full fixture) pin against over-tightening.
- 1 new `checkNs`-level pin: malformed 200 → score 100 unchanged, `probe_unavailable`.
- `check-ns`, `check-ns-delegation-consistency`, `delegation-analysis`, `check-root-server-set` specs: 34/34; `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)