### PR TITLE
fix(ssl): follow HTTPS redirect chains for HSTS analysis; abstain when unresolvable

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -240,8 +240,30 @@ describe('checkSSL', () => {
 		expect(result.findings.some((f) => f.title === 'HTTPS connection failed')).toBe(true);
 	});
 
-	it('reports missing HSTS when HTTPS redirects to another HTTPS URL', async () => {
+	it('reports missing HSTS when an HTTPS redirect chain ends without HSTS anywhere (#839)', async () => {
 		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
+			if (url.startsWith('http://')) {
+				return new Response('', { status: 301, headers: { location: 'https://example.com/' } });
+			}
+			if (url === 'https://example.com') {
+				return new Response('', { status: 307, headers: { location: 'https://www.example.com/' } });
+			}
+			// Final destination: reachable but no HSTS on the terminal 200 either.
+			return new Response('', { status: 200 });
+		});
+
+		const result = await checkSSL('example.com', fetchFn);
+
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(true);
+		expect(result.findings.some((f) => f.title === 'HTTPS and HSTS properly configured')).toBe(false);
+		expect(result.score).toBeLessThan(100);
+	});
+
+	it('passes when the HTTPS redirect target sets HSTS on the final response', async () => {
+		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
+			if (url.startsWith('http://')) {
+				return new Response('', { status: 301, headers: { location: 'https://example.com/' } });
+			}
 			if (url === 'https://example.com') {
 				return new Response('', { status: 307, headers: { location: 'https://www.example.com/' } });
 			}
@@ -250,9 +272,61 @@ describe('checkSSL', () => {
 
 		const result = await checkSSL('example.com', fetchFn);
 
-		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(true);
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(false);
+		expect(result.findings.some((f) => f.title === 'HTTPS and HSTS properly configured')).toBe(true);
+		expect(result.checkStatus).toBeUndefined();
+	});
+
+	it('uses HSTS from the redirect response itself without following the chain', async () => {
+		const httpsCalls: string[] = [];
+		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
+			if (url.startsWith('http://')) {
+				return new Response('', { status: 301, headers: { location: 'https://example.com/' } });
+			}
+			httpsCalls.push(url);
+			return new Response('', {
+				status: 307,
+				headers: { location: 'https://www.example.com/', 'strict-transport-security': 'max-age=31536000; includeSubDomains' },
+			});
+		});
+
+		const result = await checkSSL('example.com', fetchFn);
+
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(false);
+		// The redirect hop carried HSTS (the hstspreload.org-preferred deployment) — no follow-up fetch.
+		expect(httpsCalls).toEqual(['https://example.com']);
+	});
+
+	it('excludes the category when the HTTPS redirect chain cannot be resolved', async () => {
+		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
+			if (url.startsWith('http://')) {
+				return new Response('', { status: 301, headers: { location: 'https://example.com/' } });
+			}
+			// Every HTTPS response redirects to itself: the chain never terminates.
+			return new Response('', { status: 307, headers: { location: 'https://www.example.com/' } });
+		});
+
+		const result = await checkSSL('example.com', fetchFn);
+
+		expect(result.checkStatus).toBe('error');
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(false);
 		expect(result.findings.some((f) => f.title === 'HTTPS and HSTS properly configured')).toBe(false);
-		expect(result.score).toBeLessThan(100);
+	});
+
+	it('reports a downgrade when the HTTPS redirect chain lands on HTTP', async () => {
+		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
+			if (url.startsWith('http://')) {
+				return new Response('', { status: 301, headers: { location: 'https://example.com/' } });
+			}
+			if (url === 'https://example.com') {
+				return new Response('', { status: 307, headers: { location: 'https://www.example.com/' } });
+			}
+			return new Response('', { status: 302, headers: { location: 'http://www.example.com/' } });
+		});
+
+		const result = await checkSSL('example.com', fetchFn);
+
+		expect(result.findings.some((f) => f.title === 'HTTPS redirects to HTTP')).toBe(true);
 	});
 });
 

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -73,11 +73,7 @@ describe('checkCAA', () => {
 
 	it('returns info for properly configured CAA', async () => {
 		const queryDNS = createMockDNS({
-			'example.com': [
-				'0 issue "letsencrypt.org"',
-				'0 issuewild "letsencrypt.org"',
-				'0 iodef "mailto:security@example.com"',
-			],
+			'example.com': ['0 issue "letsencrypt.org"', '0 issuewild "letsencrypt.org"', '0 iodef "mailto:security@example.com"'],
 		});
 		const result = await checkCAA('example.com', queryDNS);
 		expect(result.findings.some((f) => f.title === 'CAA properly configured')).toBe(true);
@@ -162,7 +158,9 @@ describe('checkNS', () => {
 		// A thrown NS query is a transient resolver failure — we could not MEASURE the posture, so
 		// the category is excluded from scoring (checkStatus 'error') with an info-only finding,
 		// rather than penalizing a possibly-healthy domain with a critical "NS query failed".
-		const queryDNS: DNSQueryFunction = vi.fn(async () => { throw new Error('fail'); });
+		const queryDNS: DNSQueryFunction = vi.fn(async () => {
+			throw new Error('fail');
+		});
 		const result = await checkNS('example.com', queryDNS);
 		expect(result.checkStatus).toBe('error');
 		expect(result.findings[0].severity).toBe('info');
@@ -227,7 +225,7 @@ describe('checkSSL', () => {
 			// HTTP redirect to HTTPS
 			return new Response('', {
 				status: 301,
-				headers: { 'location': 'https://example.com/' },
+				headers: { location: 'https://example.com/' },
 			});
 		});
 		const result = await checkSSL('example.com', fetchFn);
@@ -235,9 +233,26 @@ describe('checkSSL', () => {
 	});
 
 	it('reports connection failure', async () => {
-		const fetchFn: FetchFunction = vi.fn(async () => { throw new Error('Connection failed'); });
+		const fetchFn: FetchFunction = vi.fn(async () => {
+			throw new Error('Connection failed');
+		});
 		const result = await checkSSL('example.com', fetchFn);
 		expect(result.findings.some((f) => f.title === 'HTTPS connection failed')).toBe(true);
+	});
+
+	it('reports missing HSTS when HTTPS redirects to another HTTPS URL', async () => {
+		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
+			if (url === 'https://example.com') {
+				return new Response('', { status: 307, headers: { location: 'https://www.example.com/' } });
+			}
+			return new Response('', { status: 200, headers: { 'strict-transport-security': 'max-age=31536000; includeSubDomains' } });
+		});
+
+		const result = await checkSSL('example.com', fetchFn);
+
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(true);
+		expect(result.findings.some((f) => f.title === 'HTTPS and HSTS properly configured')).toBe(false);
+		expect(result.score).toBeLessThan(100);
 	});
 });
 
@@ -249,19 +264,22 @@ describe('checkHTTPSecurity', () => {
 	});
 
 	it('reports all headers configured', async () => {
-		const fetchFn: FetchFunction = vi.fn(async () => new Response('', {
-			status: 200,
-			headers: {
-				'content-security-policy': "default-src 'self'",
-				'x-frame-options': 'DENY',
-				'x-content-type-options': 'nosniff',
-				'permissions-policy': 'geolocation=()',
-				'referrer-policy': 'strict-origin-when-cross-origin',
-				'cross-origin-resource-policy': 'same-origin',
-				'cross-origin-opener-policy': 'same-origin',
-				'cross-origin-embedder-policy': 'require-corp',
-			},
-		}));
+		const fetchFn: FetchFunction = vi.fn(
+			async () =>
+				new Response('', {
+					status: 200,
+					headers: {
+						'content-security-policy': "default-src 'self'",
+						'x-frame-options': 'DENY',
+						'x-content-type-options': 'nosniff',
+						'permissions-policy': 'geolocation=()',
+						'referrer-policy': 'strict-origin-when-cross-origin',
+						'cross-origin-resource-policy': 'same-origin',
+						'cross-origin-opener-policy': 'same-origin',
+						'cross-origin-embedder-policy': 'require-corp',
+					},
+				}),
+		);
 		const result = await checkHTTPSecurity('example.com', fetchFn);
 		expect(result.findings.some((f) => f.title === 'HTTP security headers well configured')).toBe(true);
 	});

--- a/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-remaining.test.ts
@@ -313,6 +313,26 @@ describe('checkSSL', () => {
 		expect(result.findings.some((f) => f.title === 'HTTPS and HSTS properly configured')).toBe(false);
 	});
 
+	it('excludes the category when the HTTPS redirect chain terminates in a no-content response', async () => {
+		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
+			if (url.startsWith('http://')) {
+				return new Response('', { status: 301, headers: { location: 'https://example.com/' } });
+			}
+			if (url === 'https://example.com') {
+				return new Response('', { status: 307, headers: { location: 'https://www.example.com/' } });
+			}
+			// Terminal 204: no page was delivered — same #806/#819 shape as the initial-response
+			// no-content branch, reached via a redirect instead.
+			return new Response(null, { status: 204 });
+		});
+
+		const result = await checkSSL('example.com', fetchFn);
+
+		expect(result.checkStatus).toBe('error');
+		expect(result.findings.some((f) => f.title === 'No HSTS header')).toBe(false);
+		expect(result.findings.some((f) => f.title === 'HTTPS and HSTS properly configured')).toBe(false);
+	});
+
 	it('reports a downgrade when the HTTPS redirect chain lands on HTTP', async () => {
 		const fetchFn: FetchFunction = vi.fn(async (url: string) => {
 			if (url.startsWith('http://')) {

--- a/packages/dns-checks/src/checks/check-ssl.ts
+++ b/packages/dns-checks/src/checks/check-ssl.ts
@@ -149,11 +149,20 @@ async function checkHttps(
 				findings.push(...getHttpsFindings(domain, redirectTarget, hstsHeader));
 			} else {
 				const followed = await followHttpsRedirectChain(response, fetchFn, timeoutMs);
+				// Terminal statuses that measure nothing: origin-unreachable / server error, and the
+				// #806/#819 no-content pair — the same classes the initial-response branches above
+				// route to the inconclusive lane, reached via a redirect instead of directly.
+				const terminalUnassessable =
+					followed.kind === 'final' &&
+					(followed.response.status === 0 ||
+						followed.response.status >= 500 ||
+						followed.response.status === 204 ||
+						followed.response.status === 205);
 				if (followed.kind === 'downgrade') {
 					// The chain left HTTPS mid-flight — same critical downgrade the first-hop
 					// `isDowngrade` branch scores, just discovered a hop later.
 					findings.push(...getHttpsFindings(domain, followed.target, null));
-				} else if (followed.kind === 'final' && followed.response.status !== 0 && followed.response.status < 500) {
+				} else if (followed.kind === 'final' && !terminalUnassessable) {
 					findings.push(...getHttpsFindings(domain, undefined, followed.response.headers.get('strict-transport-security')));
 				} else {
 					// Chain cut (fetch failure / hop cap / unassessable terminal status): HSTS was
@@ -215,6 +224,11 @@ type RedirectChainResult =
  * Embedders that pass raw `fetch` are responsible for their own SSRF protection.
  */
 async function followHttpsRedirectChain(response: Response, fetchFn: FetchFunction, timeoutMs: number): Promise<RedirectChainResult> {
+	// ONE deadline for the whole chain, not a fresh timeout per hop: per-hop timeouts stack
+	// (3 hops × timeoutMs on top of the initial and HTTP legs), which on unbudgeted direct
+	// calls can push the check past the tool-level race. A chain that cannot resolve within
+	// one leg's allowance reports `unresolved` — the inconclusive lane — rather than stalling.
+	const chainSignal = AbortSignal.timeout(timeoutMs);
 	let current = response;
 	for (let hop = 0; hop < MAX_REDIRECT_HOPS; hop++) {
 		const isRedirect = current.status >= 300 && current.status < 400;
@@ -238,7 +252,7 @@ async function followHttpsRedirectChain(response: Response, fetchFn: FetchFuncti
 			current = await fetchFn(nextUrl, {
 				method: 'HEAD',
 				redirect: 'manual',
-				signal: AbortSignal.timeout(timeoutMs),
+				signal: chainSignal,
 			});
 		} catch (err) {
 			// Includes SSRF/robots rejection from a gated fetchFn — the chain is unmeasurable,

--- a/packages/dns-checks/src/checks/check-ssl.ts
+++ b/packages/dns-checks/src/checks/check-ssl.ts
@@ -133,10 +133,8 @@ async function checkHttps(
 			const isDowngrade = location?.startsWith('http://') ?? false;
 			const isHttpsRedirect = isRedirect && !isDowngrade;
 
-			if (!isHttpsRedirect) {
-				const redirectTarget = isDowngrade ? (location ?? undefined) : undefined;
-				findings.push(...getHttpsFindings(domain, redirectTarget, response.headers.get('strict-transport-security')));
-			}
+			const redirectTarget = isDowngrade ? (location ?? undefined) : undefined;
+			findings.push(...getHttpsFindings(domain, redirectTarget, response.headers.get('strict-transport-security')));
 		}
 	} catch (err) {
 		if (err instanceof RobotsDisallowedError) {

--- a/packages/dns-checks/src/checks/check-ssl.ts
+++ b/packages/dns-checks/src/checks/check-ssl.ts
@@ -131,10 +131,47 @@ async function checkHttps(
 			const isRedirect = response.status >= 300 && response.status < 400;
 			const location = isRedirect ? response.headers.get('location') : null;
 			const isDowngrade = location?.startsWith('http://') ?? false;
-			const isHttpsRedirect = isRedirect && !isDowngrade;
+			const isHttpsRedirect = isRedirect && !isDowngrade && location !== null;
 
 			const redirectTarget = isDowngrade ? (location ?? undefined) : undefined;
-			findings.push(...getHttpsFindings(domain, redirectTarget, response.headers.get('strict-transport-security')));
+			const hstsHeader = response.headers.get('strict-transport-security');
+
+			// HTTPS→HTTPS redirects: HSTS on the redirect hop itself is complete evidence (it is
+			// where hstspreload.org requires the header), so analyze it directly. When the hop
+			// lacks HSTS, the header may still live on the terminal response only — a common CDN /
+			// bare-domain→www layout — so follow the chain and score the final page instead of the
+			// hop. History: an unconditional read here was reverted once already (642cbb3c,
+			// 2026-03) because the hop-only read penalized correctly-configured sites, and the
+			// replacement guard silently skipped measurement, which #839 showed reads as a false
+			// "properly configured" pass. Follow-or-abstain is the resolution of that pair: an
+			// unresolvable chain routes to the inconclusive lane below, never to a scored absence.
+			if (!isHttpsRedirect || hstsHeader !== null) {
+				findings.push(...getHttpsFindings(domain, redirectTarget, hstsHeader));
+			} else {
+				const followed = await followHttpsRedirectChain(response, fetchFn, timeoutMs);
+				if (followed.kind === 'downgrade') {
+					// The chain left HTTPS mid-flight — same critical downgrade the first-hop
+					// `isDowngrade` branch scores, just discovered a hop later.
+					findings.push(...getHttpsFindings(domain, followed.target, null));
+				} else if (followed.kind === 'final' && followed.response.status !== 0 && followed.response.status < 500) {
+					findings.push(...getHttpsFindings(domain, undefined, followed.response.headers.get('strict-transport-security')));
+				} else {
+					// Chain cut (fetch failure / hop cap / unassessable terminal status): HSTS was
+					// never measured, so exclude the category (#638 law — a cut probe must not be
+					// recorded as absence) instead of scoring "No HSTS header" from a hop nobody
+					// would ever land on, or letting the empty finding set read as a clean pass.
+					inconclusive = followed.kind === 'unresolved' && followed.reason === 'timeout' ? 'timeout' : 'error';
+					findings.push(
+						createFinding(
+							'ssl',
+							'HTTPS redirect chain not assessable',
+							'info',
+							`https://${domain} redirects to another HTTPS URL, and the redirect chain could not be followed to a final response, so HSTS posture could not be verified.`,
+							{ inconclusive: true, confidence: 'heuristic', errorKind: 'redirect_chain_unresolved' },
+						),
+					);
+				}
+			}
 		}
 	} catch (err) {
 		if (err instanceof RobotsDisallowedError) {
@@ -155,6 +192,63 @@ async function checkHttps(
 	}
 
 	return { findings, reachable, robotsDisallowed: false, inconclusive };
+}
+
+/** Maximum HTTPS→HTTPS hops to follow when hunting the terminal response's HSTS header. */
+const MAX_REDIRECT_HOPS = 3;
+
+type RedirectChainResult =
+	| { kind: 'final'; response: Response }
+	| { kind: 'downgrade'; target: string }
+	| { kind: 'unresolved'; reason: 'timeout' | 'error' };
+
+/**
+ * Follow an HTTPS→HTTPS redirect chain to its terminal response so HSTS can be read from the
+ * page users actually land on. Mirrors `followRedirects` in check-http-security, with one
+ * deliberate divergence: where that check analyzes whatever headers it holds when a chain
+ * breaks, this one reports `unresolved` so the caller can route to the inconclusive lane —
+ * check-ssl's HSTS verdict is scored, and a broken chain measured nothing.
+ *
+ * SSRF note (same contract as check-http-security's follower): each hop's target hostname is
+ * attacker-controlled (`Location:` header). Callers must pass a `fetchFn` that validates the
+ * destination before issuing the request — the bv-mcp Worker passes a safeFetch-based wrapper.
+ * Embedders that pass raw `fetch` are responsible for their own SSRF protection.
+ */
+async function followHttpsRedirectChain(response: Response, fetchFn: FetchFunction, timeoutMs: number): Promise<RedirectChainResult> {
+	let current = response;
+	for (let hop = 0; hop < MAX_REDIRECT_HOPS; hop++) {
+		const isRedirect = current.status >= 300 && current.status < 400;
+		const location = isRedirect ? current.headers.get('location') : null;
+		// A non-redirect (or a 3xx with no Location, which delivers its own headers) terminates
+		// the chain: analyzable.
+		if (!location) return { kind: 'final', response: current };
+
+		let nextUrl: string;
+		try {
+			nextUrl = new URL(location, current.url || undefined).href;
+		} catch {
+			return { kind: 'unresolved', reason: 'error' };
+		}
+		if (nextUrl.startsWith('http://')) return { kind: 'downgrade', target: nextUrl };
+		if (!nextUrl.startsWith('https://')) return { kind: 'unresolved', reason: 'error' };
+
+		try {
+			// Release the abandoned hop's body so workerd doesn't cancel a stalled stream.
+			void current.body?.cancel().catch(() => undefined);
+			current = await fetchFn(nextUrl, {
+				method: 'HEAD',
+				redirect: 'manual',
+				signal: AbortSignal.timeout(timeoutMs),
+			});
+		} catch (err) {
+			// Includes SSRF/robots rejection from a gated fetchFn — the chain is unmeasurable,
+			// which the caller must NOT score as a header absence.
+			const timedOut = err instanceof Error && (err.message.includes('timeout') || err.message.includes('abort'));
+			return { kind: 'unresolved', reason: timedOut ? 'timeout' : 'error' };
+		}
+	}
+	const stillRedirecting = current.status >= 300 && current.status < 400 && current.headers.get('location') !== null;
+	return stillRedirecting ? { kind: 'unresolved', reason: 'error' } : { kind: 'final', response: current };
 }
 
 /** Check if HTTP redirects to HTTPS */

--- a/src/tools/check-ssl.ts
+++ b/src/tools/check-ssl.ts
@@ -16,6 +16,7 @@ import { callTlsProbe, mergeTlsFinding } from '../lib/tls-probe-binding';
 import { enrichWithCertificateMetadata } from '../lib/cert-metadata-enrich';
 import type { TlsProbeBinding, BindingDegradationSink } from '../lib/tls-probe-binding';
 import { withAbortSignal } from '../lib/abort-signal';
+import { safeFetch } from '../lib/safe-fetch';
 import { withRobotsFetchMemo, type RobotsFetchMemo } from '../lib/robots-memo';
 import { createFetchBudget } from '../lib/fetch-budget';
 import { createRobotsProvenance } from '../lib/robots-provenance';
@@ -109,8 +110,25 @@ export async function checkSsl(
 	// including the fail-open one, so a scored `ssl` category carries positive
 	// evidence of WHY it was scored. Observation only: no finding, no score effect.
 	const provenance = createRobotsProvenance(domain);
+	// checkSSL follows HTTPS→HTTPS redirect chains to read HSTS off the terminal response
+	// (#839), and each hop's target comes from an attacker-controlled `Location:` header, so
+	// cross-host fetches route through safeFetch — the same H3 contract check-http-security's
+	// follower documents. First-party fetches (any URL on the already-validated scanned host:
+	// the https leg, the plain-HTTP redirect probe, their robots.txt) stay on raw fetch per the
+	// already-validated-hostname rule — safeFetch would also reject the http:// probe (it is
+	// https-only) and re-judge the input domain against the SSRF blocklist mid-check.
+	const sslProbeFetch: typeof fetch = (input, init) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		let firstParty = false;
+		try {
+			firstParty = new URL(url).hostname === domain;
+		} catch {
+			// Malformed URL: fall through to safeFetch, which rejects it with fetch semantics.
+		}
+		return firstParty ? fetch(input, init) : safeFetch(input, init);
+	};
 	const fetchFn = withRobotsGate(
-		withRobotsFetchMemo(budget.wrap(withAbortSignal(fetch, tlsProbeOptions.signal)), tlsProbeOptions.robotsMemo),
+		withRobotsFetchMemo(budget.wrap(withAbortSignal(sslProbeFetch, tlsProbeOptions.signal)), tlsProbeOptions.robotsMemo),
 		{ onRobotsResolution: provenance.onResolution },
 	);
 	// The TLS probe is launched HERE, alongside the HTTPS legs, not after them.


### PR DESCRIPTION
## Issue

Closes #839. Supersedes #840 — builds directly on @mikemikimike's commit (retained in this branch for attribution) and addresses the review finding on it.

## Background

Two defects were entangled on this code path:

- **#839 (what #840 fixed):** the `!isHttpsRedirect` guard silently skipped HSTS measurement on HTTPS→HTTPS redirects, and the empty finding set then read as a confident "HTTPS and HSTS properly configured" pass.
- **What #840 reintroduced:** the guard was added deliberately in 642cbb3c (2026-03) because with `redirect: 'manual'` the header is read off the intermediate 3xx, which commonly lacks the HSTS the terminal 200 carries — an unconditional read falsely penalizes correctly-configured sites (the hazard `followRedirects()` in check-http-security documents). The explanatory comment was lost in the monorepo port.

## Fix

Follow-or-abstain, resolving both halves:

- HSTS on the redirect hop itself → analyzed directly (the hstspreload.org-preferred deployment); no extra fetch.
- Hop lacks HSTS → follow up to 3 HTTPS→HTTPS hops and score the terminal response, mirroring `followRedirects()` in check-http-security.
- Chain unresolvable (fetch failure, hop cap, unassessable terminal status) → the established inconclusive lane (`checkStatus: 'error'`, category excluded, retryable) — never a scored absence (#638 law), never a silent skip.
- Mid-chain downgrade to `http://` → the same critical "HTTPS redirects to HTTP" finding as a first-hop downgrade.
- Worker wrapper (`src/tools/check-ssl.ts`): followed-hop targets are attacker-controlled `Location:` values, so cross-host fetches now route through `safeFetch` (H3 contract); first-party legs stay on raw fetch (safeFetch is https-only and would reject the deliberate plain-HTTP redirect probe).

The rationale now lives in-code at the branch point so the 642cbb3c ↔ #839 tension isn't re-litigated a third time.

## Tests

Five tests in `check-remaining.test.ts` (replacing #840's single test, whose mock let an accidental http-leg finding drive two assertions): chain-ends-without-HSTS penalized (#839 regression), final-response HSTS passes, hop HSTS short-circuits (fetch-count pinned), unresolvable chain excluded from scoring, mid-chain downgrade flagged.

- dns-checks package: 909/909 passing
- Root suite: 8289 passing, 1 pre-existing wasm worktree load-failure (documented shape), lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)