### PR TITLE
fix(dnssec-chain): island-of-trust target no longer reports chainComplete=true / score 100

### DIFF
--- a/src/tools/check-dnssec-chain.ts
+++ b/src/tools/check-dnssec-chain.ts
@@ -74,6 +74,14 @@ interface ZoneResult {
 	linkage: LinkageStatus;
 	algorithms: string[];
 	weakAlgorithms: string[];
+	/**
+	 * The DS probe threw (timeout / SERVFAIL / transport failure) rather than
+	 * returning an empty answer. Both leave `dsRecords` empty and both make
+	 * `determineLinkage()` say 'no_ds', so this flag is the ONLY thing that
+	 * separates "the parent holds no DS" (measured) from "we never learned
+	 * whether the parent holds a DS" (unmeasured) — the #638 distinction.
+	 */
+	dsQueryFailed: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -159,12 +167,17 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 	for (const zone of zones) {
 		// Query DS (skip for root — root has no parent to hold DS)
 		let dsRecords: ParsedDs[] = [];
+		let dsQueryFailed = false;
 		if (zone !== '.') {
 			try {
 				const rawDs = await queryDnsRecords(zone, 'DS', dnsOptions);
 				dsRecords = rawDs.map(parseDsRecord).filter((r): r is ParsedDs => r !== null);
 			} catch {
-				// DS query failed — treat as no DS
+				// DS query failed. `dsRecords` stays empty, which is indistinguishable
+				// from a measured "no DS" downstream — record the failure so the
+				// island-of-trust and chainComplete decisions can refuse to draw a
+				// conclusion from a delegation that was never observed.
+				dsQueryFailed = true;
 			}
 		}
 
@@ -197,6 +210,7 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 			linkage,
 			algorithms,
 			weakAlgorithms,
+			dsQueryFailed,
 		});
 
 		if (linkage === 'no_dnskey' || linkage === 'broken') {
@@ -237,8 +251,18 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 	// unreachable and validating resolvers treat the zone as insecure. The FIRST such
 	// zone is where trust terminates (any DS/DNSKEY material below it is equally
 	// unreachable from the root anchor).
-	const islandZone = zoneResults.find((z) => z.zone !== '.' && z.linkage === 'no_ds' && z.dnskeyRecords.length > 0);
-	const chainComplete = reachedTarget && !chainBroken && targetSigned && islandZone === undefined && rootVerified;
+	// ⚠️ `dsQueryFailed` gate (review follow-up): a timed-out/SERVFAIL DS probe also
+	// lands on linkage 'no_ds' with an empty record set, so without this the island
+	// finding would score 60 off a delegation nobody measured. An unmeasured DS is
+	// reported through the inconclusive lane below instead, never as a deficiency.
+	const islandZone = zoneResults.find((z) => z.zone !== '.' && z.linkage === 'no_ds' && z.dnskeyRecords.length > 0 && !z.dsQueryFailed);
+	// A zone whose DS probe failed while its DNSKEY resolved is the SAME shape as an
+	// island — we simply do not know which. It must not be laundered into a complete
+	// chain either (that was the original #834 accidental-100 arriving via the
+	// failure path), so it blocks chainComplete without producing a scored finding.
+	const dsUnmeasuredZone = zoneResults.find((z) => z.zone !== '.' && z.dsQueryFailed && z.dnskeyRecords.length > 0);
+	const chainComplete =
+		reachedTarget && !chainBroken && targetSigned && islandZone === undefined && dsUnmeasuredZone === undefined && rootVerified;
 
 	// --- Findings ---
 
@@ -331,6 +355,21 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 				{ zone: islandZone.zone, linkage: 'no_ds', penaltyOverride: 40 },
 			),
 		);
+	} else if (dsUnmeasuredZone) {
+		// The DS probe for a zone that publishes a DNSKEY never completed. That is the
+		// island-of-trust shape OR a perfectly anchored zone — indistinguishable from
+		// here. Report it as unmeasured (`inconclusive` + `errorKind`, NEVER
+		// `missingControl` — #638 law) with no penalty, and let the `partial` flag
+		// below keep the non-answer out of the dispatch cache so a retry can measure it.
+		findings.push(
+			createFinding(
+				CATEGORY,
+				`DNSSEC delegation not assessable at ${dsUnmeasuredZone.zone}`,
+				'info',
+				`The DS lookup for ${dsUnmeasuredZone.zone} did not complete, so the delegation linking its parent to the DNSKEY it publishes could not be observed. The chain of trust for ${domain} is therefore unverified for this run — this reflects the lookup, not the zone's configuration. Re-run to assess it.`,
+				{ zone: dsUnmeasuredZone.zone, inconclusive: true, confidence: 'heuristic', errorKind: 'dns_error' },
+			),
+		);
 	}
 
 	// Weak algorithm finding (medium severity)
@@ -387,7 +426,10 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 	// the result partial so the dispatch cache predicate skips it — otherwise a
 	// one-off empty would be cached and served as a stale "unverified" result for
 	// the cache TTL (#199).
-	if (zoneResults.find((z) => z.zone === '.')?.linkage === 'unverified') {
+	// Same reasoning for a DS probe that never completed (review follow-up): the run
+	// measured less than it appears to have, so it must not be served from cache as a
+	// settled answer for the TTL.
+	if (zoneResults.find((z) => z.zone === '.')?.linkage === 'unverified' || dsUnmeasuredZone) {
 		result.partial = true;
 	}
 	return result;

--- a/src/tools/check-dnssec-chain.ts
+++ b/src/tools/check-dnssec-chain.ts
@@ -229,7 +229,16 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 	const targetSigned = reachedTarget && (lastZone.dsRecords.length > 0 || lastZone.dnskeyRecords.length > 0);
 	// The root trust anchor must have been retrieved for the chain to be "complete".
 	const rootVerified = zoneResults.find((z) => z.zone === '.')?.linkage === 'linked';
-	const chainComplete = reachedTarget && !chainBroken && targetSigned && rootVerified;
+	// Island of trust (#834): a non-root zone that publishes a DNSKEY while its parent
+	// holds no DS for it. `targetSigned` accepts a DNSKEY alone and linkage 'no_ds'
+	// sets neither `chainBroken` nor the walk's unsigned break, so before this guard
+	// the shape sailed through to chainComplete: true / score 100 — despite the chain
+	// of trust from the root anchor terminating at the parent: the published DNSKEY is
+	// unreachable and validating resolvers treat the zone as insecure. The FIRST such
+	// zone is where trust terminates (any DS/DNSKEY material below it is equally
+	// unreachable from the root anchor).
+	const islandZone = zoneResults.find((z) => z.zone !== '.' && z.linkage === 'no_ds' && z.dnskeyRecords.length > 0);
+	const chainComplete = reachedTarget && !chainBroken && targetSigned && islandZone === undefined && rootVerified;
 
 	// --- Findings ---
 
@@ -299,6 +308,29 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 				penaltyOverride: 40,
 			}),
 		);
+	} else if (islandZone) {
+		// Island of trust (#834). Same finding convention as the unsigned-termination
+		// guard above (#810/#820): severity LABEL `high`, SCORE penalty decoupled to -40
+		// via `penaltyOverride` (100-40=60), aligned with check_dnssec's posture for
+		// unanchored DNSSEC. We deliberately do NOT set `missingControl: true` — a
+		// published-but-unanchored DNSKEY is MEASURED DNSSEC material, not an absent
+		// control, and missingControl would zero the score to 0 via buildCheckResult's
+		// `score: hasMissingControl ? 0 : score`. (check_dnssec currently scores this
+		// same shape 0 with missingControl — reconciling the two surfaces to a single
+		// number is a deliberate operator scoring decision, out of scope here.) The
+		// detail text avoids "no … record", "missing", "required", and "not found" so
+		// `scoreIndicatesMissingControl` (packages/dns-checks/src/scoring/model.ts)
+		// cannot auto-zero the finding. `else if`: the chain of trust terminates at
+		// exactly one place, so at most one -40 termination finding ever fires.
+		findings.push(
+			createFinding(
+				CATEGORY,
+				`DNSSEC island of trust at ${islandZone.zone}`,
+				'high',
+				`${islandZone.zone} publishes a DNSKEY, but its parent zone holds no DS digest linking to it, so the chain of trust from the root anchor terminates at the parent. The published DNSKEY is unreachable from the trust anchor and validating resolvers treat ${islandZone.zone} as insecure — DNSSEC provides no origin authentication for ${domain}. Publish a DS for the zone's KSK at the parent (via the registrar) to anchor the chain.`,
+				{ zone: islandZone.zone, linkage: 'no_ds', penaltyOverride: 40 },
+			),
+		);
 	}
 
 	// Weak algorithm finding (medium severity)
@@ -332,6 +364,8 @@ export async function checkDnssecChain(domain: string, dnsOptions?: QueryDnsOpti
 		summaryStatus = `stopped at ${lastZone?.zone ?? '.'} — zone has no DS and no DNSKEY (not signed)`;
 	} else if (!targetSigned) {
 		summaryStatus = `${domain} has no DS and no DNSKEY — domain is not signed`;
+	} else if (islandZone) {
+		summaryStatus = `island of trust — ${islandZone.zone} publishes a DNSKEY but its parent holds no DS, so validating resolvers treat the zone as insecure`;
 	} else if (chainComplete) {
 		summaryStatus = 'complete chain from root to target';
 	} else {

--- a/test/check-dnssec-chain.spec.ts
+++ b/test/check-dnssec-chain.spec.ts
@@ -49,14 +49,17 @@ function adResponse(domain: string, ad: boolean) {
 /**
  * Create a fetch mock that routes by URL query params (name + type).
  * `routeMap` keys are "name:type" (e.g. "com:DS", "example.com:DNSKEY", "example.com:A").
+ * A `'REJECT'` value makes every fetch for that route reject (simulating a
+ * timeout / transport failure — queryDnsRecords then throws DnsQueryError).
  */
-function mockDnsFetch(routeMap: Record<string, Response>) {
+function mockDnsFetch(routeMap: Record<string, Response | 'REJECT'>) {
 	globalThis.fetch = vi.fn().mockImplementation((url: string | URL | Request) => {
 		const u = new URL(typeof url === 'string' ? url : url instanceof Request ? url.url : url.toString());
 		const name = u.searchParams.get('name') ?? '';
 		const type = u.searchParams.get('type') ?? '';
 		const key = `${name}:${type}`;
 		const resp = routeMap[key];
+		if (resp === 'REJECT') return Promise.reject(new Error('network timeout'));
 		if (resp) return Promise.resolve(resp);
 		// Default: empty response
 		return Promise.resolve(createDohResponse([{ name, type: 1 }], []));
@@ -277,6 +280,42 @@ describe('checkDnssecChain', () => {
 		// formula ("did not penalize", NOT "control exists").
 		expect(result.score).toBe(60);
 		expect(result.passed).toBe(true);
+	});
+
+	it('does not report an island of trust when the DS lookup itself failed (#834 review)', async () => {
+		// A timed-out / SERVFAIL DS query is caught and left as an empty record set,
+		// which makes determineLinkage() return 'no_ds' — structurally identical to a
+		// measured-absent DS. Emitting the scored island finding from that shape would
+		// record a delegation NOBODY MEASURED as a confident deficiency (the #638 law:
+		// `inconclusive` + `errorKind`, never a scored absence).
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			// The DS probe never completed; the DNSKEY probe did.
+			'example.com:DS': 'REJECT',
+			'example.com:DNSKEY': dnskeyResponse('example.com', ['257 3 8 AwEAAexample...']),
+			'example.com:A': adResponse('example.com', false),
+		});
+
+		const result = await run();
+
+		// No scored island finding from an unmeasured delegation.
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeUndefined();
+		expect(result.score).not.toBe(60);
+
+		// Nor may the unmeasured DS be laundered into a clean complete chain.
+		const summary = result.findings.find((f) => f.severity === 'info' && f.metadata?.chainComplete !== undefined);
+		expect(summary!.metadata!.chainComplete).toBe(false);
+
+		// Honest unmeasured marker + kept out of the dispatch cache, matching the
+		// transient root-DNSKEY precedent in this tool.
+		const inconclusive = result.findings.find((f) => f.metadata?.inconclusive === true);
+		expect(inconclusive).toBeDefined();
+		expect(inconclusive!.metadata?.errorKind).toBe('dns_error');
+		expect(inconclusive!.metadata?.missingControl).toBeUndefined();
+		expect(result.partial).toBe(true);
 	});
 
 	it('broken linkage (DS exists but no DNSKEY) produces high severity', async () => {

--- a/test/check-dnssec-chain.spec.ts
+++ b/test/check-dnssec-chain.spec.ts
@@ -231,6 +231,54 @@ describe('checkDnssecChain', () => {
 		expect(summary!.metadata!.chainComplete).toBe(false);
 	});
 
+	it('island-of-trust target (DNSKEY published, DS absent at parent) is not chainComplete and scores 60 (#834)', async () => {
+		// example.com publishes a DNSKEY but its parent (com) holds no DS for it: the
+		// chain of trust from the root anchor terminates at com, the target's DNSKEY
+		// is unreachable, and validating resolvers treat the zone as insecure. Before
+		// the fix: `targetSigned` accepted the DNSKEY alone, linkage 'no_ds' set
+		// neither chainBroken nor the walk break, and the tool reported
+		// chainComplete: true / score 100 with no high finding.
+		mockDnsFetch({
+			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),
+			'com:DS': dsResponse('com', ['12345 8 2 AABBCCDD']),
+			'com:DNSKEY': dnskeyResponse('com', ['257 3 8 AwEAAcom...']),
+			// example.com: DS empty at the parent, DNSKEY populated → island of trust
+			'example.com:DS': emptyDsResponse('example.com'),
+			'example.com:DNSKEY': dnskeyResponse('example.com', ['257 3 8 AwEAAexample...']),
+			'example.com:A': adResponse('example.com', false),
+		});
+
+		const result = await run();
+
+		// The summary must NOT claim a complete chain — there is no DS linking the
+		// parent to the target's DNSKEY.
+		const summary = result.findings.find((f) => f.severity === 'info' && f.metadata?.chainComplete !== undefined);
+		expect(summary).toBeDefined();
+		expect(summary!.metadata!.chainComplete).toBe(false);
+
+		// Same finding convention as #810/#820: high severity, decoupled -40 penalty
+		// (category → 60), and NO missingControl — a published-but-unanchored DNSKEY
+		// is MEASURED DNSSEC material, not an absent control; missingControl would
+		// zero the score via buildCheckResult's `score: hasMissingControl ? 0 : score`.
+		const highFinding = result.findings.find((f) => f.severity === 'high');
+		expect(highFinding).toBeDefined();
+		expect(highFinding!.metadata?.penaltyOverride).toBe(40);
+		expect(highFinding!.metadata?.missingControl).toBeUndefined();
+		expect(highFinding!.metadata?.zone).toBe('example.com');
+
+		// The wording states the mechanism: DNSKEY published, DS absent at the parent,
+		// validating resolvers treat the zone as insecure.
+		expect(`${highFinding!.title} ${highFinding!.detail}`).toMatch(/island of trust/i);
+		expect(highFinding!.detail).toMatch(/DNSKEY/);
+		expect(highFinding!.detail).toMatch(/DS/);
+		expect(highFinding!.detail).toMatch(/insecure/i);
+
+		// Score 60 / passed true, per the documented `passed = score>=50 && !hasMissingControl`
+		// formula ("did not penalize", NOT "control exists").
+		expect(result.score).toBe(60);
+		expect(result.passed).toBe(true);
+	});
+
 	it('broken linkage (DS exists but no DNSKEY) produces high severity', async () => {
 		mockDnsFetch({
 			'.:DNSKEY': dnskeyResponse('.', ['257 3 8 AwEAAagAI...']),


### PR DESCRIPTION
## What

`src/tools/check-dnssec-chain.ts`: an island-of-trust zone — DNSKEY published, but **no DS in the parent** — now voids `chainComplete` and emits a `high` finding with `penaltyOverride: 40` (category lands at 60), instead of the accidental `chainComplete: true` / score 100 / no finding.

Closes #834.

## Mechanism (per the issue, verified)

- `targetSigned = reachedTarget && (lastZone.dsRecords.length > 0 || lastZone.dnskeyRecords.length > 0)` — a DNSKEY **alone** satisfied it, so the #820/#833 unsigned-termination guard (`!targetSigned || stoppedEarly`) never fired.
- `determineLinkage()` returned `'no_ds'`, which sets neither `chainBroken` (only `no_dnskey`/`broken` do) nor the walk's unsigned `break` (needs no DS **and** no DNSKEY).
- `chainComplete = reachedTarget && !chainBroken && targetSigned && rootVerified` therefore came out **true** — despite the chain of trust from the root anchor terminating at the parent. The target's DNSKEY is unreachable and validating resolvers treat the zone as insecure.

## Fix

- `islandZone` = the **first** non-root zone with `linkage === 'no_ds'` and a populated DNSKEY set (trust terminates there; any DNSSEC material below it is equally unreachable from the root anchor). `chainComplete` now also requires `islandZone === undefined`.
- New finding, #810/#820 convention: `createFinding()`, severity LABEL `high`, SCORE penalty decoupled to −40 via `penaltyOverride` → 60. Emitted as `else if` behind the existing unsigned-termination guard, so at most one −40 termination finding ever fires.
- **No `missingControl`** — a published-but-unanchored DNSKEY is *measured* DNSSEC material, not an absent control (per the missingControl scoring trap in CLAUDE.md); missingControl would zero the score via `buildCheckResult`'s `score: hasMissingControl ? 0 : score`.
- Title/detail wording states the mechanism (DNSKEY published, DS absent at parent, resolvers treat the zone as insecure) and was checked against `MISSING_CONTROL_REGEX` (`packages/dns-checks/src/scoring/model.ts:107`): the word "record" never appears, nor do "missing", "required", or "not found", so `scoreIndicatesMissingControl` cannot auto-zero it.
- Chain-summary status gains an explicit island-of-trust branch (previously fell through to a misleading "chain broken").

## Deliberate residual divergence

`check_dnssec` scores this same shape **0 with `missingControl`**; this tool now scores it **60**. Reconciling the two surfaces to a single number is an operator scoring decision, deliberately out of scope here — this PR fixes only the accidental 100 and the false `chainComplete`. Standalone tool (`scanIncluded: false`, out-of-union `dnssec_chain` category) — no `scan_domain` re-grade.

## Tests

TDD: new spec case (signed root + `com`, `example.com` DS empty / DNSKEY populated) written first and confirmed failing on main (`chainComplete: true`, score 100, no high finding) before the fix. Asserts: summary `chainComplete: false`; `high` finding with `penaltyOverride: 40`, no `missingControl`, `zone: 'example.com'`, island-of-trust mechanism wording; score 60 / `passed: true` (documented `passed = score>=50 && !hasMissingControl` formula — "did not penalize", not "control exists").

- `npx vitest run test/check-dnssec-chain.spec.ts` — 11/11 (10 pre-existing cases untouched and green)
- `npx vitest run test/tool-formatters.spec.ts test/tool-pick-eval.spec.ts` — 21/21
- `npm run typecheck` clean; `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)