### PR TITLE
fix(dane): stop claiming 'Valid' for TLSA pins the check never verified

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
@@ -1,0 +1,77 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Issue #841 — the DANE info finding claimed "Valid TLSA record configured" for any
+ * syntactically well-formed TLSA record, without ever comparing the pinned data to
+ * the certificate the host actually serves. A stale DANE-EE pin (which actively
+ * breaks every DANE-validating client, and is DNSSEC-enforced) read as a pass.
+ *
+ * Full pin verification needs the live leaf/SPKI, which neither this runtime-agnostic
+ * package nor the Workers host can obtain today (fetch() exposes no peer certificate;
+ * bv-tls-probe returns TLS-version data only; CT tells you what a CA published, not
+ * what a server serves). Until a probe extension lands, the finding must be HONEST:
+ * state presence + syntactic validity, state that the certificate match was NOT
+ * verified, and carry machine-readable metadata saying so.
+ *
+ * Pinned here:
+ *  1. The info finding never uses the word "Valid" for an unverified pin.
+ *  2. The detail states the certificate match was not verified.
+ *  3. metadata.certificateMatchVerified === false (machine-readable marker).
+ *  4. No scoring change: severity stays info; a well-formed TLSA + DNSSEC still
+ *     scores 100 with recordPresent true (weight changes are operator-gated).
+ *  5. The load-bearing title "DANE TLSA configured for <name>" is unchanged —
+ *     maturity staging regex-matches it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { analyzeTlsaRecords } from '../../checks/dane-analysis';
+import { checkDANEHTTPS } from '../../checks/check-dane-https';
+import type { DNSQueryFunction, RawDNSQueryFunction } from '../../types';
+
+const SHA256_HASH = '0000000000000000000000000000000000000000000000000000000000000001';
+
+describe('analyzeTlsaRecords — honest labeling of unverified pins (#841)', () => {
+	it('does not claim "Valid" for a single well-formed record it never verified', () => {
+		const findings = analyzeTlsaRecords([`3 1 1 ${SHA256_HASH}`], '_443._tcp.example.com', true);
+		const info = findings.find((f) => f.severity === 'info');
+		expect(info).toBeDefined();
+		expect(info!.title).toBe('DANE TLSA configured for _443._tcp.example.com');
+		expect(info!.detail).not.toMatch(/valid tlsa/i);
+		expect(info!.detail).toMatch(/does not verify/i);
+		expect(info!.detail).toMatch(/well-formed/i);
+		expect(info!.metadata?.certificateMatchVerified).toBe(false);
+	});
+
+	it('does not claim verification for multiple well-formed records either', () => {
+		const findings = analyzeTlsaRecords([`3 1 1 ${SHA256_HASH}`, `2 0 1 ${SHA256_HASH}`], '_443._tcp.example.com', true);
+		const info = findings.find((f) => f.severity === 'info');
+		expect(info).toBeDefined();
+		expect(info!.detail).not.toMatch(/valid tlsa/i);
+		expect(info!.detail).toMatch(/does not verify/i);
+		expect(info!.metadata?.certificateMatchVerified).toBe(false);
+		expect(info!.metadata?.validRecordCount).toBe(2);
+	});
+});
+
+describe('checkDANEHTTPS — no scoring change from the relabel (#841)', () => {
+	it('a well-formed DANE-EE pin + DNSSEC still scores 100, but the finding is honest', async () => {
+		const queryDNS: DNSQueryFunction = async (name, type) => {
+			if (type === 'TLSA' && name === '_443._tcp.example.com') return [`3 1 1 ${SHA256_HASH}`];
+			return [];
+		};
+		const rawQueryDNS: RawDNSQueryFunction = async () => ({ AD: true, Answer: [] });
+
+		const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS });
+
+		expect(result.score).toBe(100);
+		expect(result.passed).toBe(true);
+		expect(result.recordPresent).toBe(true);
+
+		const info = result.findings.find((f) => f.severity === 'info');
+		expect(info).toBeDefined();
+		expect(info!.category).toBe('dane_https');
+		expect(info!.detail).not.toMatch(/valid tlsa/i);
+		expect(info!.detail).toMatch(/does not verify/i);
+		expect(info!.metadata?.certificateMatchVerified).toBe(false);
+	});
+});

--- a/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
@@ -42,6 +42,20 @@ describe('analyzeTlsaRecords — honest labeling of unverified pins (#841)', () 
 		expect(info!.metadata?.certificateMatchVerified).toBe(false);
 	});
 
+	it('does not overstate stale-pin impact — rejection is conditional on DNSSEC + no matching association (PR #845 review)', () => {
+		// This SAME detail string is emitted for unsigned zones (where RFC 7671
+		// clients treat the RRset as unusable and fall back — nothing breaks) and
+		// for multi-record rollover RRsets (one stale association among a matching
+		// set breaks nothing). The prose must not claim unconditional breakage.
+		for (const hasDnssec of [true, false]) {
+			const findings = analyzeTlsaRecords([`3 1 1 ${SHA256_HASH}`], '_443._tcp.example.com', hasDnssec);
+			const info = findings.find((f) => f.severity === 'info');
+			expect(info).toBeDefined();
+			expect(info!.detail).not.toMatch(/which breaks DANE-validating clients/i);
+			expect(info!.detail).toMatch(/DNSSEC-authenticated/);
+		}
+	});
+
 	it('does not claim verification for multiple well-formed records either', () => {
 		const findings = analyzeTlsaRecords([`3 1 1 ${SHA256_HASH}`, `2 0 1 ${SHA256_HASH}`], '_443._tcp.example.com', true);
 		const info = findings.find((f) => f.severity === 'info');

--- a/packages/dns-checks/src/checks/dane-analysis.ts
+++ b/packages/dns-checks/src/checks/dane-analysis.ts
@@ -161,8 +161,8 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 	if (validRecordCount > 0) {
 		const detail =
 			validRecordCount === 1
-				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm the pin matches the live certificate after every certificate rotation.`
-				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm each pin matches the live certificate after every certificate rotation.`;
+				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection. Confirm the pin matches the live certificate after every certificate rotation.`
+				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Authentication succeeds while any one association still matches, so a single superseded record during a rollover is not itself fatal; where the RRset is DNSSEC-authenticated and none match, DANE-validating clients reject the connection. Confirm each pin matches the live certificate after every certificate rotation.`;
 		findings.push(
 			createFinding('dane', `DANE TLSA configured for ${name}`, 'info', detail, {
 				name,

--- a/packages/dns-checks/src/checks/dane-analysis.ts
+++ b/packages/dns-checks/src/checks/dane-analysis.ts
@@ -72,14 +72,7 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 	for (const record of records) {
 		const parsed = parseTlsaRecord(record);
 		if (!parsed) {
-			findings.push(
-				createFinding(
-					'dane',
-					'Malformed TLSA record',
-					'medium',
-					`Could not parse TLSA record for ${name}: ${record}`,
-				),
-			);
+			findings.push(createFinding('dane', 'Malformed TLSA record', 'medium', `Could not parse TLSA record for ${name}: ${record}`));
 			continue;
 		}
 
@@ -157,14 +150,25 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 		validRecordCount++;
 	}
 
-	// Emit a single consolidated info finding for all valid TLSA records
+	// Emit a single consolidated info finding for all well-formed TLSA records.
+	// HONESTY (#841): "well-formed" is a SYNTAX verdict only. This analyzer never
+	// fetches the certificate the host serves, so it cannot know whether the pinned
+	// data still matches — a stale DANE-EE pin (which breaks every DANE-validating
+	// client) parses identically to a correct one. The wording and the
+	// `certificateMatchVerified: false` marker must keep saying so until a live
+	// leaf/SPKI source exists (fetch() exposes no peer certificate on workerd, and
+	// CT tells you what a CA published, not what a server serves).
 	if (validRecordCount > 0) {
 		const detail =
 			validRecordCount === 1
-				? `Valid TLSA record configured for ${name}.`
-				: `${validRecordCount} DANE TLSA records configured for ${name}.`;
+				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm the pin matches the live certificate after every certificate rotation.`
+				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm each pin matches the live certificate after every certificate rotation.`;
 		findings.push(
-			createFinding('dane', `DANE TLSA configured for ${name}`, 'info', detail, { name, validRecordCount }),
+			createFinding('dane', `DANE TLSA configured for ${name}`, 'info', detail, {
+				name,
+				validRecordCount,
+				certificateMatchVerified: false,
+			}),
 		);
 	}
 

--- a/src/tools/dane-analysis.ts
+++ b/src/tools/dane-analysis.ts
@@ -120,8 +120,8 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 	if (validRecordCount > 0) {
 		const detail =
 			validRecordCount === 1
-				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm the pin matches the live certificate after every certificate rotation.`
-				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm each pin matches the live certificate after every certificate rotation.`;
+				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection. Confirm the pin matches the live certificate after every certificate rotation.`
+				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Authentication succeeds while any one association still matches, so a single superseded record during a rollover is not itself fatal; where the RRset is DNSSEC-authenticated and none match, DANE-validating clients reject the connection. Confirm each pin matches the live certificate after every certificate rotation.`;
 		findings.push(
 			createFinding('dane', `DANE TLSA configured for ${name}`, 'info', detail, {
 				name,

--- a/src/tools/dane-analysis.ts
+++ b/src/tools/dane-analysis.ts
@@ -35,14 +35,7 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 	for (const record of records) {
 		const parsed = parseTlsaRecord(record);
 		if (!parsed) {
-			findings.push(
-				createFinding(
-					'dane',
-					'Malformed TLSA record',
-					'medium',
-					`Could not parse TLSA record for ${name}: ${record}`,
-				),
-			);
+			findings.push(createFinding('dane', 'Malformed TLSA record', 'medium', `Could not parse TLSA record for ${name}: ${record}`));
 			continue;
 		}
 
@@ -120,14 +113,21 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 		validRecordCount++;
 	}
 
-	// Emit a single consolidated info finding for all valid TLSA records
+	// Emit a single consolidated info finding for all well-formed TLSA records.
+	// HONESTY (#841): mirrors packages/dns-checks/src/checks/dane-analysis.ts —
+	// "well-formed" is a SYNTAX verdict only; the pinned data is never compared to
+	// the certificate the host serves, and the wording + metadata must say so.
 	if (validRecordCount > 0) {
 		const detail =
 			validRecordCount === 1
-				? `Valid TLSA record configured for ${name}.`
-				: `${validRecordCount} DANE TLSA records configured for ${name}.`;
+				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm the pin matches the live certificate after every certificate rotation.`
+				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin — which breaks DANE-validating clients — is not detected here. Confirm each pin matches the live certificate after every certificate rotation.`;
 		findings.push(
-			createFinding('dane', `DANE TLSA configured for ${name}`, 'info', detail, { name, validRecordCount }),
+			createFinding('dane', `DANE TLSA configured for ${name}`, 'info', detail, {
+				name,
+				validRecordCount,
+				certificateMatchVerified: false,
+			}),
 		);
 	}
 

--- a/test/dane-analysis.spec.ts
+++ b/test/dane-analysis.spec.ts
@@ -125,6 +125,16 @@ describe('analyzeTlsaRecords', () => {
 		expect(mediumFinding).toBeDefined();
 	});
 
+	it('should not claim "Valid" for a pin it never verified against the served certificate (#841)', () => {
+		const findings = analyzeTlsaRecords(['3 1 1 aabbccdd'], '_25._tcp.mx.example.com', true);
+		const infoFinding = findings.find((f) => f.severity === 'info');
+		expect(infoFinding).toBeDefined();
+		expect(infoFinding!.title).toContain('DANE TLSA configured');
+		expect(infoFinding!.detail).not.toMatch(/valid tlsa/i);
+		expect(infoFinding!.detail).toMatch(/does not verify/i);
+		expect(infoFinding!.metadata?.certificateMatchVerified).toBe(false);
+	});
+
 	it('should handle hex wire format TLSA records', () => {
 		// Hex wire format: usage=3 selector=1 matchingType=1 + cert data
 		const records = ['\\# 35 03 01 01 aa bb cc dd'];


### PR DESCRIPTION
## What

`analyzeTlsaRecords` emitted an info finding whose detail read **"Valid TLSA record configured for <name>."** for any syntactically well-formed TLSA record. The check never fetches the certificate the host serves, so it cannot know whether the pin still matches — the word "Valid" claimed a verification that was never performed. As #841 documents, a stale DANE-EE pin (DNSSEC-enforced, actively breaking every DANE-validating client) scored 100 with that wording, while deleting the broken record scored 95.

This PR makes the finding honest:

- **Detail reworded**: the record is *present and syntactically well-formed*, the pinned data was **not** verified against the certificate the server presents, a stale pin is not detected here, and pins should be re-confirmed after every certificate rotation (the CDN-managed-cert drift case from the issue).
- **Machine-readable marker**: the finding's metadata gains `certificateMatchVerified: false` alongside the existing `name`/`validRecordCount`.
- **No scoring change**: severity stays `info`, scores are byte-identical (parity fixtures pass unchanged) — scoring/weight changes are operator-gated in this repo.
- **Load-bearing title untouched**: `DANE TLSA configured for <name>` is regex-matched by `computeMaturityStage()` (`src/tools/scan/maturity-staging.ts`), so only the detail + metadata changed.

Applied at both emission sites: the runtime path `packages/dns-checks/src/checks/dane-analysis.ts` (shared by `check_dane_https` and `check_dane`) and its legacy mirror `src/tools/dane-analysis.ts`.

## Why not real verification

Investigated first, per the issue's suggested fix:

- **workerd cannot read the peer certificate** — `fetch()` exposes no handshake/leaf/SPKI, and the Worker runs without `nodejs_compat`.
- **bv-tls-probe** (`src/lib/tls-probe-binding.ts`) returns TLS-version data only (`minVersion`/`maxVersion`/`supportedVersions`/`cipher`) — no leaf cert or SPKI digest to compare a `3 1 1` pin against.
- **CT enrichment** (`packages/dns-checks/src/cert/`) is explicitly documented as "CT tells you what a CA published, not what a server is currently serving" — a pin matching *some* CT-logged cert proves nothing about the served one, and private-CA certs never appear at all.

So genuine usage-3/usage-2 digest comparison needs a **bv-tls-probe extension** that returns the served leaf's cert/SPKI digests (cross-repo, out of scope here).

## Tests

TDD — new tests written first and watched fail (3/3 failed on the old wording), then:

- `packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts` (new): no "Valid" claim, "does not verify" language, `certificateMatchVerified: false`, and an end-to-end `checkDANEHTTPS` blast-radius pin (score still 100, `passed`, `recordPresent: true`).
- `test/dane-analysis.spec.ts`: mirror assertion for the `src/tools` copy.

Ran: full `packages/dns-checks` suite (51 files / 907 tests passed, incl. parity corpus), root scoped specs `dane-analysis` / `check-dane-https` / `check-dane` / `maturity-staging-profile` / `cluster-3-canary-regression` / `maturity-evidence-gating.contract` (123 tests passed), `npm run typecheck`, `npm run lint`, Prettier.

## Residual (why not "Closes")

Partially addresses #841. Still open after this PR:

1. **Actual pin verification** (usage 3 digest compare, usage 2 chain-anchor check) — blocked on a bv-tls-probe extension exposing the served leaf/SPKI; mismatch ⇒ high severity, unreachable/handshake-failure ⇒ not-assessed.
2. **The scoring inversion** (well-formed-but-unverified pin 100 vs. absent 95) — deliberately untouched: any score/weight movement re-grades every customer and is an operator decision (`bv-mcp-scoring`).

Partially addresses #841

🤖 Generated with [Claude Code](https://claude.com/claude-code)