### PR TITLE
fix(dmarc): stop recommending aspf=s unconditionally (#842, scoring model 1.15.0)

### DIFF
--- a/packages/dns-checks/src/__tests__/scoring/subject-data-interpolation.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/subject-data-interpolation.spec.ts
@@ -194,9 +194,11 @@ describe('subject data interpolated into finding prose', () => {
 			const missing = buildCheckResult('dmarc', classifyDmarc({ recordCount: 1, policy: 'missing', domain: 'example.com' }));
 			const required = buildCheckResult('dmarc', classifyDmarc({ recordCount: 1, policy: 'required', domain: 'example.com' }));
 
-			expect(bogus.score).toBe(50);
-			expect(missing.score).toBe(50);
-			expect(required.score).toBe(50);
+			// 55 as of model 1.15.0 (#842: relaxed aspf is advisory info, no longer −5);
+			// what this test pins is the EQUALITY across trigger-named policy tokens.
+			expect(bogus.score).toBe(55);
+			expect(missing.score).toBe(55);
+			expect(required.score).toBe(55);
 			expect(scoreIndicatesMissingControl(missing.findings)).toBe(false);
 			expect(scoreIndicatesMissingControl(required.findings)).toBe(false);
 		});

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
+// bv-oversize-ok: single-file cross-repo parity corpus by design — bv-web consumes it
+// as one module; splitting it would fragment the shared contract surface.
 /**
  * Shared cross-repo scoring parity corpus.
  *
@@ -284,10 +286,12 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 	},
 	{
 		check: 'dmarc',
+		// Scores here reflect model 1.15.0 (#842): relaxed aspf is advisory info (0),
+		// no longer a scored low (−5) — fixtures without aspf=s moved UP by 5.
 		name: 'p=none + rua',
 		query: '_dmarc.example.com',
 		records: { '_dmarc.example.com': ['v=DMARC1; p=none; rua=mailto:d@example.com'] },
-		expectedScore: 70,
+		expectedScore: 75,
 		expectedMissingControl: false,
 	},
 	{
@@ -295,7 +299,7 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 		name: 'p=quarantine + rua',
 		query: '_dmarc.example.com',
 		records: { '_dmarc.example.com': ['v=DMARC1; p=quarantine; rua=mailto:d@example.com'] },
-		expectedScore: 80,
+		expectedScore: 85,
 		expectedMissingControl: false,
 	},
 	{
@@ -315,7 +319,7 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 		name: 't=y test mode (1.3.0 superset)',
 		query: '_dmarc.example.com',
 		records: { '_dmarc.example.com': ['v=DMARC1; p=reject; t=y; rua=mailto:d@example.com'] },
-		expectedScore: 65,
+		expectedScore: 70,
 		expectedMissingControl: false,
 	},
 	{
@@ -323,7 +327,7 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 		name: 'np=none spoofable (1.3.0 superset)',
 		query: '_dmarc.example.com',
 		records: { '_dmarc.example.com': ['v=DMARC1; p=reject; np=none; rua=mailto:d@example.com'] },
-		expectedScore: 65,
+		expectedScore: 70,
 		expectedMissingControl: false,
 	},
 	{
@@ -348,7 +352,7 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 			'_dmarc.blog.example.com': [],
 			'_dmarc.example.com': ['v=DMARC1; p=reject; sp=quarantine'],
 		},
-		expectedScore: 70,
+		expectedScore: 75,
 		expectedMissingControl: false,
 		treeWalkOnly: true,
 	},

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -177,6 +177,18 @@ describe('classifyDmarc', () => {
 			expect(finding.detail).toMatch(/ESP|subdomain/i);
 		});
 
+		it('conditions the failure claim on the From domain differing — never categorical over subdomain return-paths', () => {
+			// PR #846 review: a subdomain return-path does not itself break strict
+			// alignment — it PASSES when the RFC 5322 From domain is that same subdomain.
+			// The classifier has no From/sender evidence, so the detail must state the
+			// differing-From condition rather than assert unconditional failure.
+			const f = classifyDmarc({ ...rejectBase, aspf: 'r' });
+			const finding = f.find((x) => x.title === 'Relaxed SPF alignment')!;
+			expect(finding.detail).not.toMatch(/all such traffic/i);
+			expect(finding.detail).toMatch(/From address (stays|is) on this domain|From domain differs/i);
+			expect(finding.detail).toMatch(/still aligns/i);
+		});
+
 		it('strict aspf=s still emits no relaxed-alignment finding', () => {
 			const f = classifyDmarc({ ...rejectBase, aspf: 's' });
 			expect(f.some((x) => x.title === 'Relaxed SPF alignment')).toBe(false);

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -139,6 +139,50 @@ describe('classifyDmarc', () => {
 		expect(f.some((x) => x.title === 'Non-existent subdomains spoofable (np=none)')).toBe(false);
 	});
 
+	describe('aspf recommendation (#842 — strict SPF alignment must not be advised unconditionally)', () => {
+		// The classifier receives only record-derived facts (no SPF chain / sending-source
+		// inputs), so achievability of strict alignment CANNOT be determined here. The
+		// finding must therefore be advisory (info, penalty 0) and must state the
+		// precondition instead of a bare "consider strict": measured in production (#842),
+		// aspf=s on an ESP-relayed domain failed SPF alignment on 100% of that traffic and
+		// 21 legitimate messages were rejected outright when DKIM also hiccuped.
+		const rejectBase = { recordCount: 1, policy: 'reject', sp: 'reject', rua: 'mailto:dmarc@example.com', adkim: 's' } as const;
+
+		it('relaxed aspf (aspf=r) is advisory info, not a scored deficiency', () => {
+			const f = classifyDmarc({ ...rejectBase, aspf: 'r' });
+			const finding = f.find((x) => x.title === 'Relaxed SPF alignment');
+			expect(finding).toBeDefined();
+			expect(finding!.severity).toBe('info');
+		});
+
+		it('unset aspf gets the same advisory info finding', () => {
+			const f = classifyDmarc({ ...rejectBase });
+			expect(f.find((x) => x.title === 'Relaxed SPF alignment')?.severity).toBe('info');
+		});
+
+		it('states the strict-alignment precondition instead of a bare "consider strict"', () => {
+			const f = classifyDmarc({ ...rejectBase, aspf: 'r' });
+			const finding = f.find((x) => x.title === 'Relaxed SPF alignment')!;
+			// The precondition: strict SPF alignment needs the return-path (envelope-from)
+			// domain to exactly match the From domain — untrue for most ESP-relayed mail.
+			expect(finding.detail).toMatch(/return-path/i);
+			expect(finding.detail).toMatch(/exactly match/i);
+			expect(finding.detail).toMatch(/aspf=s/);
+			expect(finding.detail).not.toContain('Consider aspf=s (strict) for stronger authentication');
+		});
+
+		it('names the ESP-relayed breakage aspf=s would cause', () => {
+			const f = classifyDmarc({ ...rejectBase, aspf: 'r' });
+			const finding = f.find((x) => x.title === 'Relaxed SPF alignment')!;
+			expect(finding.detail).toMatch(/ESP|subdomain/i);
+		});
+
+		it('strict aspf=s still emits no relaxed-alignment finding', () => {
+			const f = classifyDmarc({ ...rejectBase, aspf: 's' });
+			expect(f.some((x) => x.title === 'Relaxed SPF alignment')).toBe(false);
+		});
+	});
+
 	describe('subdomain / org-domain enforcement asymmetry', () => {
 		const asymmetric = {
 			recordCount: 1,

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -479,7 +479,7 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 				'dmarc',
 				'Relaxed SPF alignment',
 				'info',
-				`SPF alignment mode is relaxed (aspf=r or unset). Strict alignment (aspf=s) only strengthens DMARC when every authorized sender's return-path (envelope-from) domain exactly matches the From domain — untrue for most ESP-relayed mail (e.g. Resend, SendGrid, Mailchimp, SES with a custom MAIL FROM), where the return-path sits on a subdomain and aspf=s would fail SPF alignment on all such traffic, leaving DKIM as the only authentication leg. Set aspf=s only after DMARC aggregate reports confirm every sender's return-path domain exactly matches the From domain; otherwise aspf=r is the correct setting.`,
+				`SPF alignment mode is relaxed (aspf=r or unset). Strict alignment (aspf=s) only strengthens DMARC when every authorized sender's return-path (envelope-from) domain exactly matches the From domain — untrue for most ESP-relayed mail (e.g. Resend, SendGrid, Mailchimp, SES with a custom MAIL FROM), where the return-path sits on a subdomain: wherever the From domain differs from it (typically the apex), aspf=s fails SPF alignment for that traffic and leaves DKIM as the only authentication leg. Mail whose From address stays on that same subdomain still aligns under aspf=s. Set aspf=s only after DMARC aggregate reports confirm every sender's return-path domain exactly matches the From domain; otherwise aspf=r is the correct setting.`,
 			),
 		);
 	}

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -463,12 +463,23 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 			),
 		);
 	} else if (!aspf || aspf === 'r') {
+		// #842: this must stay ADVISORY (info, penalty 0) and must never revert to a bare
+		// "consider aspf=s". The classifier receives only record-derived facts — no SPF
+		// chain or sending-source inputs — so whether strict alignment is ACHIEVABLE
+		// cannot be determined here. For any ESP-relayed domain (Resend, SendGrid,
+		// Mailchimp, Postmark, SES with a custom MAIL FROM) the return-path sits on a
+		// subdomain, so aspf=s fails SPF alignment on 100% of that traffic and deletes
+		// one of DMARC's two authentication legs. Measured on our own production domain
+		// (2026-08-30, 1,045 aggregate-report records): every ESP-sent message failed
+		// SPF alignment under aspf=s, and 21 legitimate messages were rejected outright
+		// on the occasions DKIM also failed. Title is load-bearing — assess-spoofability
+		// matches 'Relaxed SPF alignment' by prefix.
 		findings.push(
 			createFinding(
 				'dmarc',
 				'Relaxed SPF alignment',
-				'low',
-				`SPF alignment mode is relaxed (aspf=r or unset). Consider aspf=s (strict) for stronger authentication.`,
+				'info',
+				`SPF alignment mode is relaxed (aspf=r or unset). Strict alignment (aspf=s) only strengthens DMARC when every authorized sender's return-path (envelope-from) domain exactly matches the From domain — untrue for most ESP-relayed mail (e.g. Resend, SendGrid, Mailchimp, SES with a custom MAIL FROM), where the return-path sits on a subdomain and aspf=s would fail SPF alignment on all such traffic, leaving DKIM as the only authentication leg. Set aspf=s only after DMARC aggregate reports confirm every sender's return-path domain exactly matches the From domain; otherwise aspf=r is the correct setting.`,
 			),
 		);
 	}

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -244,8 +244,25 @@
  *   changed. The DMARC `p=none; sp=none` correction shipped in the same package is explicitly
  *   score-neutral (its new finding is `info`) but restores the evidence consumed by attack-path
  *   analysis. Affected population for all three shapes is unmeasured against the corpus.
+ * - 1.15.0 — relaxed SPF alignment (`aspf=r`/unset) is a severity reclassification `low` →
+ *   `info` (#842): the "Relaxed SPF alignment" DMARC finding no longer carries the −5 low
+ *   penalty, and its detail now states the precondition for strict alignment instead of a
+ *   bare "consider aspf=s". Rationale, measured not theoretical: the classifier receives
+ *   only record-derived facts, so whether strict alignment is ACHIEVABLE cannot be
+ *   determined — and for any ESP-relayed domain (Resend, SendGrid, Mailchimp, Postmark,
+ *   SES with a custom MAIL FROM) the return-path sits on a subdomain, so `aspf=s`
+ *   guarantees SPF-alignment failure on 100% of that traffic and converts a two-legged
+ *   DMARC posture into a one-legged one. Following the old advice on our own production
+ *   domain rejected 21 legitimate messages outright (1,045 aggregate-report records,
+ *   2026-08-30) whenever DKIM also failed. UPWARD only, +5 on the `dmarc` category for
+ *   every domain with `aspf=r`/unset (the common case); `aspf=s` domains and the strict
+ *   fixture are unchanged, and `adkim` (whose strict mode does not depend on the
+ *   return-path) keeps its existing low. Five DMARC parity fixtures moved up by exactly 5.
+ *   The finding title is unchanged (assess_spoofability matches it by prefix). No weight,
+ *   tier, grade band, `SEVERITY_PENALTIES` entry, missing-control rule or
+ *   profile-detection rule changed.
  */
-export const SCORING_MODEL_VERSION = '1.14.0';
+export const SCORING_MODEL_VERSION = '1.15.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/test/check-dmarc-scoring.spec.ts
+++ b/test/check-dmarc-scoring.spec.ts
@@ -78,7 +78,11 @@ describe('Defect J — DMARC scoring credits modern best practices', () => {
 				'v=DMARC1; p=reject; pct=100; fo=1; rua=mailto:dmarc@stripe.com; ruf=mailto:ruf@stripe.com',
 			),
 		);
-		expect(govuk.score).toBeGreaterThan(stripe.score);
+		// ≥, not >: since #842 (model 1.15.0) relaxed aspf is advisory info, so stripe's
+		// only aspf penalty is gone and the two records legitimately tie at 90 (gov.uk's
+		// sp=none/no-ruf lows offset stripe's adkim/no-sp lows). The regression this
+		// guards is gov.uk falling BELOW stripe (was 70 < 85), which ≥ still catches.
+		expect(govuk.score).toBeGreaterThanOrEqual(stripe.score);
 	});
 
 	it('np=reject downgrades "Subdomain policy weaker than parent" from HIGH to LOW (DMARCbis covers non-existent subdomains)', async () => {

--- a/test/check-dmarc.spec.ts
+++ b/test/check-dmarc.spec.ts
@@ -99,11 +99,13 @@ describe('checkDmarc', () => {
 	it('should return info finding for p=reject with rua and sp', async () => {
 		mockTxtRecords(['v=DMARC1; p=reject; sp=reject; rua=mailto:dmarc@example.com; ruf=mailto:forensic@example.com']);
 		const result = await run();
-		// Now includes alignment warnings (low severity) since adkim/aspf default to relaxed
+		// Now includes alignment notes since adkim/aspf default to relaxed (aspf is
+		// advisory info as of #842), so match the clean-config finding by title rather
+		// than taking whichever info finding happens to come first.
 		expect(result.findings.length).toBeGreaterThanOrEqual(1);
-		const infoFinding = result.findings.find((f) => f.severity === 'info');
+		const infoFinding = result.findings.find((f) => /DMARC properly configured/i.test(f.title));
 		expect(infoFinding).toBeDefined();
-		expect(infoFinding!.title).toMatch(/DMARC properly configured/i);
+		expect(infoFinding!.severity).toBe('info');
 	});
 
 	it('returns low finding for missing sp= when p=reject', async () => {
@@ -295,20 +297,24 @@ describe('checkDmarc', () => {
 		expect(f!.severity).toBe('medium');
 	});
 
-	it('warns about relaxed SPF alignment (aspf=r)', async () => {
+	it('notes relaxed SPF alignment (aspf=r) as advisory info stating the strict-alignment precondition (#842)', async () => {
 		mockTxtRecords(['v=DMARC1; p=reject; sp=reject; rua=mailto:d@example.com; aspf=r']);
 		const r = await run();
 		const f = r.findings.find((f) => /Relaxed SPF alignment/i.test(f.title));
 		expect(f).toBeDefined();
-		expect(f!.severity).toBe('low');
+		// #842: advisory only — aspf=s guarantees SPF-alignment failure on ESP-relayed
+		// mail (subdomain return-paths), so a bare "consider strict" is wrong advice.
+		expect(f!.severity).toBe('info');
+		expect(f!.detail).toMatch(/return-path/i);
+		expect(f!.detail).not.toContain('Consider aspf=s (strict) for stronger authentication');
 	});
 
-	it('warns about relaxed SPF alignment (aspf unset)', async () => {
+	it('notes relaxed SPF alignment (aspf unset) as advisory info (#842)', async () => {
 		mockTxtRecords(['v=DMARC1; p=reject; sp=reject; rua=mailto:d@example.com']);
 		const r = await run();
 		const f = r.findings.find((f) => /Relaxed SPF alignment/i.test(f.title));
 		expect(f).toBeDefined();
-		expect(f!.severity).toBe('low');
+		expect(f!.severity).toBe('info');
 	});
 
 	it('does not warn when SPF alignment is strict (aspf=s)', async () => {

--- a/test/cluster-3-canary-regression.spec.ts
+++ b/test/cluster-3-canary-regression.spec.ts
@@ -111,10 +111,13 @@ describe('Cluster 3 canary regression — DMARC scoring', () => {
 		expect(result.score).toBeGreaterThanOrEqual(85);
 	});
 
-	it('cross-domain ordering: gov.uk DMARC > stripe.com DMARC (regression — was 70 < 85)', async () => {
+	it('cross-domain ordering: gov.uk DMARC ≥ stripe.com DMARC (regression — was 70 < 85)', async () => {
 		const govuk = await checkDMARC('gov.uk', dmarcMock('gov.uk', GOV_UK_DMARC));
 		const stripe = await checkDMARC('stripe.com', dmarcMock('stripe.com', STRIPE_DMARC));
-		expect(govuk.score).toBeGreaterThan(stripe.score);
+		// ≥, not >: since #842 (model 1.15.0) relaxed aspf is advisory info, so the two
+		// records legitimately tie at 90. The regression this canary guards is gov.uk
+		// falling BELOW stripe (the 2026-05-28 70 < 85 defect), which ≥ still catches.
+		expect(govuk.score).toBeGreaterThanOrEqual(stripe.score);
 	});
 
 	it('np=reject downgrades subdomain-weaker finding from HIGH to LOW (mechanism that drives gov.uk floor)', async () => {


### PR DESCRIPTION
Closes #842

## The defect

`check_dmarc` emitted **"Relaxed SPF alignment — Consider aspf=s (strict) for stronger authentication"** (low, −5) whenever `aspf` was relaxed or unset, unconditionally. For any ESP-relayed domain (Resend, SendGrid, Mailchimp, Postmark, SES with a custom MAIL FROM) the return-path sits on a subdomain, so following the advice guarantees SPF-alignment failure on 100% of that traffic and converts a two-legged DMARC posture into a one-legged one.

The issue's evidence is measured, not theoretical: on our own production domain with `aspf=s; p=reject`, 1,045 DMARC aggregate-report records showed **every** ESP-sent message failing SPF alignment (`send.blackveilsecurity.com` return-path vs apex From), and **21 legitimate messages were rejected outright** on the occasions DKIM also failed — strict alignment had removed the leg that would otherwise have saved them.

## Where the recommendation is emitted

`packages/dns-checks/src/scoring/classifiers/dmarc.ts` — DMARC is the sole check that delegates finding emission to a classifier (confirmed by a package-wide `createFinding(` grep; neither `check-dmarc.ts` nor any sibling `*-analysis.ts` emits it).

## Which tier is implemented, and why

**Fallback tier only.** The issue suggests conditioning on SPF-chain / sending-source inputs, but those inputs genuinely do not exist in this check's scope:

- `classifyDmarc` is pure (no DNS) and `DmarcFacts` carries only record-derived tags — it is the shared bv-mcp/bv-web classifier, so widening its inputs is a cross-repo contract change.
- `scan_domain` runs its 19 categories in parallel via `Promise.allSettled` with no cross-check data flow, and `check_dmarc` is directly callable with no SPF context at all.
- Inferring achievability from the **apex** SPF record would be wrong in both directions — on the issue's own motivating domain the ESP include lives on the `send.` subdomain's SPF, not the apex, so an apex-SPF heuristic would conclude "aligned" and keep the bad advice exactly where it bit.

So the finding is now **advisory `info` (penalty 0)** and its detail states the precondition explicitly: strict SPF alignment requires every authorized sender's return-path (envelope-from) domain to exactly match the From domain — untrue for most ESP-relayed mail — and names what `aspf=s` would break. No bare "consider strict" remains. The title is unchanged (`assess_spoofability` matches `'Relaxed SPF alignment'` by prefix).

## Scoring impact (model 1.14.0 → 1.15.0)

- UPWARD only: +5 on the `dmarc` category for every `aspf=r`/unset domain (the common case). `aspf=s` domains unchanged; `adkim` (whose strict mode does not depend on the return-path) keeps its existing low.
- Five DMARC parity fixtures moved up by exactly 5 (`parity-fixtures.ts`); the strict-alignment fixture is untouched. bv-web re-grades identically on its next re-vendor.
- Two gov.uk-vs-stripe ordering canaries relaxed `>` → `>=` with in-test rationale: with stripe's only aspf penalty gone the two records legitimately tie at 90, and the regression those canaries guard (gov.uk falling **below** stripe, the 2026-05-28 70 < 85 defect) is still caught.
- No weight, tier, grade band, `SEVERITY_PENALTIES` entry, missing-control rule or profile-detection rule changed. The #643 inherited-enforcement gate in scan post-processing is untouched (post-processing specs green).

## Not in scope (noted for follow-up)

`generate` (`src/tools/generate-records.ts`) still includes `aspf=s` in its suggested DMARC record — same advice surface, different tool; left for a follow-up rather than scope-creeping a scoring change.

## Verification

- New classifier tests (written failing first) + updated root specs: `packages/dns-checks` full suite 904/904; scoped root set (check-dmarc, scoring, spoofability, impersonation-escalation, explain-finding, canaries, maturity, scan-domain, post-processing, badge parity, handlers, SPF, attack-paths, generate-records) 527/527.
- `npm run lint` + `npm run typecheck` clean.
- Full-suite wasm-integration load failure in a fresh worktree is the known non-failure; scoped specs run instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)