### PR TITLE
fix(lookalikes): unmeasured ownership under degraded lookups (#832) + registered-but-dark visibility (#831)

### DIFF
--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -79,8 +79,18 @@ import { createFinding } from '@blackveil/dns-checks/scoring';
 import { getRegistrableDomain } from './public-suffix';
 import { UNKNOWN_REASON_PHRASES, type RegistrationState } from './registration-state';
 
-/** Final attribution verdict. */
-export type OwnershipVerdict = 'owned_by_seed' | 'third_party' | 'unattributed';
+/**
+ * Final attribution verdict.
+ *
+ * `unmeasured` (#832) means the lookups feeding the ownership comparison were
+ * DEGRADED — the seed's own NS set could not be fetched — so no comparison was
+ * possible. It is NOT a claim about the candidate: a throttled run must never
+ * publish the OPPOSITE attribution (`third_party`, "no ownership signal links
+ * it…") for signals that were unfetched rather than absent. A definitive
+ * `third_party` requires the same completeness bar `owned_by_seed` already
+ * implies (the full-set comparison).
+ */
+export type OwnershipVerdict = 'owned_by_seed' | 'third_party' | 'unattributed' | 'unmeasured';
 
 /**
  * `classifyOwnership()` only ever returns `'strong'`, `'medium'`, or
@@ -119,6 +129,17 @@ export interface ClassifyOwnershipInput {
 	 * never imports from `src/tenants/discovery/` (see file header).
 	 */
 	isSharedNsHost: (nsHost: string) => boolean;
+	/**
+	 * True when the SEED's own NS lookup REJECTED (timeout / throttling), so
+	 * `seedNs` is empty because it was UNFETCHED, not because the seed has no
+	 * nameservers (#832). With this set, no set-comparison verdict is
+	 * reachable: candidates that would otherwise fall through to the
+	 * `third_party` arm come back `unmeasured` instead. The in-bailiwick arm
+	 * still fires — it needs only the seed APEX, not the seed's NS answer, and
+	 * a positive `owned_by_seed` from resolved candidate-side delegation
+	 * evidence stays safe to publish.
+	 */
+	seedNsUnresolved?: boolean;
 	/**
 	 * OWNERSHIP RULE — SEED-SIDE CONTROL ONLY (Ruling A, 2026-07-27 task-7c;
 	 * fields DELETED 2026-07-27 ownership-attribution followups item 2 — see
@@ -254,6 +275,22 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
+	// #832 — degraded comparison inputs. The seed's NS lookup did not resolve,
+	// so every arm below would be comparing against an UNFETCHED set: the
+	// ns_set_match / shared-provider arms cannot fire (seedNs is empty), and
+	// the third_party arm would publish "no ownership signal links it" about
+	// signals nobody fetched — the exact non-answer-becomes-record defect this
+	// verdict exists to prevent. Only the in-bailiwick arm above (which needs
+	// the seed APEX, not its NS answer) may still produce a verdict.
+	if (input.seedNsUnresolved) {
+		return {
+			verdict: 'unmeasured',
+			strength: 'none',
+			signals: [],
+			rationale: `Ownership of ${candidateDomain} was not assessed in this run: the nameserver lookup for ${seedApex} did not resolve, so ${candidateDomain}'s nameservers could not be compared against it. This is a measurement gap, not evidence of third-party registration — re-run to attribute.`,
+		};
+	}
+
 	// Ruling A (2026-07-27, task-7c): candidate-side declarations (SOA RNAME,
 	// SPF include, HTTP redirect target — see the OWNERSHIP RULE note on
 	// `ClassifyOwnershipInput`) are never consulted here, and no such inputs
@@ -348,9 +385,9 @@ export function attributionConfidence(verdict: OwnershipVerdict, brandLabel: str
  * severity alone (`'unbounded'`) or clamp it (`'info'`). The finding itself
  * is ALWAYS emitted by the caller; only its severity and wording change.
  *
- * Per the load-bearing safety property (controller amendment 2), `third_party`
- * and `unattributed` are capped identically — only `owned_by_seed` is ever
- * exempt.
+ * Per the load-bearing safety property (controller amendment 2), `third_party`,
+ * `unattributed` and `unmeasured` are capped identically — only `owned_by_seed`
+ * is ever exempt.
  */
 export function capAttributionSeverity(verdict: OwnershipVerdict): Severity | 'unbounded' {
 	return verdict === 'owned_by_seed' ? 'unbounded' : 'info';
@@ -436,14 +473,22 @@ export function buildNonOwnedGateFinding(
 	const relation =
 		ownership.verdict === 'third_party'
 			? 'is registered to a different organisation'
-			: 'could not be attributed to the scanned organisation';
+			: ownership.verdict === 'unmeasured'
+				? 'could not be compared against the scanned organisation in this run — the lookups feeding the ownership comparison did not complete'
+				: 'could not be attributed to the scanned organisation';
 	const hedge =
 		confidence === 'uncorroborated'
 			? ` The shared label is under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters and nothing else corroborates a link, so the name similarity alone means little.`
 			: '';
+	// #832: an `unmeasured` verdict must not be TITLED "Unrelated domain" — that
+	// is the very third-party claim the degraded comparison failed to earn.
+	const title =
+		ownership.verdict === 'unmeasured'
+			? `Confusable label, ownership unmeasured this run: ${domain}`
+			: `Unrelated domain, confusable label: ${domain}`;
 	return createFinding(
 		options.category,
-		`Unrelated domain, confusable label: ${domain}`,
+		title,
 		ceiling,
 		`${domain} shares the "${brand}" label with the scanned domain but ${relation}. ${ownership.rationale} Its ${options.postureNoun} is reported for awareness only: no action by the scanned organisation is implied, and this finding asserts no control over ${domain}.${hedge}`,
 		metadata,

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -56,6 +56,7 @@ import {
 	buildBrandHeldFinding,
 	buildOwnedBySeedFinding,
 	buildRawAttributionFinding,
+	buildRegisteredDarkFinding,
 	buildSharedRegistrantOrgFinding,
 	buildThreatObservationFinding,
 	describeCorroborators,
@@ -248,6 +249,12 @@ async function checkLookalikesCore(
 	// Second silent-drop site (#781): a candidate already KNOWN registered, whose
 	// infrastructure probe failed, disappears here.
 	const probeUnresolved = probeResults.filter((r) => r.status === 'rejected').length;
+	// Third silent-drop site (#831): a registered candidate whose A/MX lookups
+	// REJECTED carries no positive signal and no measured absence — it cannot be
+	// classified as active, and it must not be reported as registered-but-dark
+	// either (the absence was unfetched). It is counted as unresolved so the
+	// run reports itself incomplete instead of erasing the candidate.
+	const infraUnknownCount = results.filter((r) => r.probeDegraded && !r.hasA && !r.hasMX).length;
 	/**
 	 * Enumeration coverage for this run.
 	 *
@@ -259,8 +266,8 @@ async function checkLookalikesCore(
 		permutationsGenerated: permutations.length,
 		permutationsProbed: permsToProbe.length,
 		candidatesResolved: results.length,
-		unresolvedCount: nsUnresolved + probeUnresolved,
-		complete: nsUnresolved + probeUnresolved === 0,
+		unresolvedCount: nsUnresolved + probeUnresolved + infraUnknownCount,
+		complete: nsUnresolved + probeUnresolved + infraUnknownCount === 0,
 	};
 
 	// Enrichment (Defect L / issue #264): for each non-defensively-registered
@@ -387,7 +394,19 @@ async function checkLookalikesCore(
 			continue;
 		}
 
-		if (!result.hasMX && !result.hasA) continue;
+		if (!result.hasMX && !result.hasA) {
+			// #831 — registered but dark: NS resolved, and the A/MX probe MEASURED
+			// no infrastructure. "Held and dark" and "unregistered" are opposite
+			// custody facts, so the candidate is surfaced (info, attribution axis,
+			// never impersonation-scored) instead of dropped silently. A DEGRADED
+			// probe is the one exception: the absence was unfetched, not measured
+			// (#832's law), so the candidate is left to the enumeration
+			// incompleteness accounting above rather than recorded as dark.
+			if (!result.probeDegraded) {
+				findings.push(buildRegisteredDarkFinding(result, domain, ownership));
+			}
+			continue;
+		}
 
 		const corroborators = enrichment.get(result.domain) ?? {
 			registrationDays: null,

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -254,7 +254,14 @@ async function checkLookalikesCore(
 	// classified as active, and it must not be reported as registered-but-dark
 	// either (the absence was unfetched). It is counted as unresolved so the
 	// run reports itself incomplete instead of erasing the candidate.
-	const infraUnknownCount = results.filter((r) => r.probeDegraded && !r.hasA && !r.hasMX).length;
+	//
+	// ⚠️ ANY degraded probe counts, not only the both-legs-empty case (review
+	// follow-up): a candidate whose A resolved while its MX rejected is half
+	// measured — its mail capability was never observed — so a run containing one
+	// is a SAMPLE, not a census. Gating on `!hasA && !hasMX` let those runs report
+	// `complete: true`, which is precisely the "partial run looks conclusive"
+	// shape this enumeration contract exists to prevent.
+	const infraUnknownCount = results.filter((r) => r.probeDegraded).length;
 	/**
 	 * Enumeration coverage for this run.
 	 *
@@ -505,7 +512,13 @@ async function checkLookalikesCore(
 	// consumer reading findings must be able to tell that from a concluded
 	// third-party verdict.
 	if (seedNsUnmeasured) {
-		findings.push(buildOwnershipUnmeasuredFinding(domain, registeredPerms.length));
+		// Count the verdicts that actually came out `unmeasured`, NOT the batch size
+		// (review follow-up): classifyOwnership() deliberately preserves
+		// `owned_by_seed` for an in-bailiwick candidate NS even when the seed lookup
+		// failed, so in a mixed batch `registeredPerms.length` overstates — the
+		// notice would claim candidates were unattributed that this run did attribute.
+		const unmeasuredCandidateCount = [...ownershipByDomain.values()].filter((a) => a.verdict === 'unmeasured').length;
+		findings.push(buildOwnershipUnmeasuredFinding(domain, unmeasuredCandidateCount));
 	}
 
 	if (!enumeration.complete) {
@@ -571,5 +584,16 @@ async function checkLookalikesCore(
 		}
 	}
 
-	return buildCheckResult('lookalikes', findings);
+	const result = buildCheckResult('lookalikes', findings);
+	// A degraded ownership comparison is TRANSIENT (throttled/timed-out seed NS
+	// lookup), but `check_lookalikes` is cached for an hour and the dispatcher
+	// skips cache writes only for `partial` results (review follow-up). Without
+	// this, the withheld verdicts and suppressed threat observations from one
+	// throttled run would be served for the full TTL after DNS recovered — the
+	// non-answer outliving the condition that caused it. Same contract the
+	// timeout path in checkLookalikes() already honours.
+	if (seedNsUnmeasured) {
+		result.partial = true;
+	}
+	return result;
 }

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -66,6 +66,7 @@ import {
 	buildNoActiveInfrastructureFinding,
 	buildNoPermutationsFinding,
 	buildNoRegisteredCandidatesFinding,
+	buildOwnershipUnmeasuredFinding,
 	buildReconCandidateFinding,
 	buildReconScanStatusFinding,
 	buildStagingSummaryFinding,
@@ -190,12 +191,18 @@ async function checkLookalikesCore(
 	// Also query the primary domain's NS + MX for ownership comparison: NS for
 	// the ownership verdict itself, MX for the D4 MX-overlap corroboration
 	// signal consulted by `attributionConfidence()` (wording only).
-	const [nsResult, primaryNs, primaryMx] = await Promise.all([
+	const [nsResult, primaryNsProbe, primaryMx] = await Promise.all([
 		filterByNsExistence(permsToProbe),
 		queryPrimaryNs(domain),
 		queryPrimaryMx(domain),
 	]);
 	const { registered: registeredPerms, nsMap: lookalikeNsMap, unresolved: nsUnresolved } = nsResult;
+	const primaryNs = primaryNsProbe.ns;
+	// #832 — the seed's own NS lookup failed, so the ownership comparison has
+	// nothing to compare against this run. Every set-comparison verdict below
+	// becomes `unmeasured` (never the CONTRARY `third_party`), and
+	// impersonation-shaped findings are withheld for unmeasured candidates.
+	const seedNsUnmeasured = !primaryNsProbe.resolved;
 
 	if (registeredPerms.length === 0) {
 		findings.push(buildNoRegisteredCandidatesFinding(domain, permutations.length));
@@ -225,6 +232,7 @@ async function checkLookalikesCore(
 				candidateDomain: perm,
 				registration: { state: 'registered', ns: candidateNs, evidence: candidateNs.length > 0 ? ['ns'] : ['a'] },
 				isSharedNsHost,
+				seedNsUnresolved: seedNsUnmeasured,
 			}),
 		);
 	}
@@ -423,12 +431,23 @@ async function checkLookalikesCore(
 			findings.push(applyOwnershipGate(rawFinding, ownership, brand, mxOverlapsPrimary));
 		}
 
+		// #832 — an UNMEASURED ownership verdict withholds the impersonation-
+		// shaped finding (and its counters) for this candidate in this run: the
+		// comparison that would justify "does not appear to belong to the
+		// scanned organisation" never completed, and near-complete runs have
+		// proven the same candidate `owned_by_seed` (jcpenny.com, full 8/8 NS
+		// match). The attribution finding above still names the candidate with
+		// its unmeasured verdict, and the run-level scan_status notice below
+		// explains the withholding, so the non-answer is visible — not a record.
+		if (ownership.verdict === 'unmeasured') continue;
+
 		// AXIS 2 — the observed threat, at the severity the #264 matrix computed
 		// and Task 7 used to discard. Emitted for EVERY non-owned candidate,
 		// including one whose RDAP registrant org matched the seed's (fix round 1,
 		// F1: that string is unverified and collision-prone, so it may annotate the
 		// observation but must never switch the axis off). Only `owned_by_seed`
-		// candidates are exempt — they `continue` above.
+		// candidates (which `continue` above) and `unmeasured` candidates (#832)
+		// are exempt.
 		findings.push(
 			buildThreatObservationFinding(
 				result.domain,
@@ -461,6 +480,13 @@ async function checkLookalikesCore(
 	// If no active lookalikes found
 	if (findings.length === 0) {
 		findings.push(buildNoActiveInfrastructureFinding(domain, permutations.length, enumeration));
+	}
+
+	// #832 — run-level honesty notice: attribution was declined this run, and a
+	// consumer reading findings must be able to tell that from a concluded
+	// third-party verdict.
+	if (seedNsUnmeasured) {
+		findings.push(buildOwnershipUnmeasuredFinding(domain, registeredPerms.length));
 	}
 
 	if (!enumeration.complete) {
@@ -499,15 +525,25 @@ async function checkLookalikesCore(
 				// (never `owned_by_seed` — an externally-sourced, unverified match
 				// is never sufficient to claim the candidate is the customer's own).
 				const reconOwnership: OwnershipAssessment = ownershipByDomain.get(matchedDomain) ?? {
-					verdict: 'unattributed',
+					// #832: when the seed's NS lookup failed, an externally-named
+					// candidate is exactly as uncomparable as the locally-generated
+					// ones — the run's attribution lane is down, so it inherits the
+					// unmeasured verdict rather than a definitive-sounding default.
+					verdict: seedNsUnmeasured ? 'unmeasured' : 'unattributed',
 					strength: 'none',
 					signals: [],
-					rationale: `No ownership signal is available for ${matchedDomain}.`,
+					rationale: seedNsUnmeasured
+						? `Ownership of ${matchedDomain} was not assessed in this run: the nameserver lookup for ${domain} did not resolve, so no comparison was possible.`
+						: `No ownership signal is available for ${matchedDomain}.`,
 				};
 				// Task 7b requirement 5: a candidate already known to be the
 				// customer's own domain gets no threat_observation finding — this
 				// enrichment is additive-only and adds nothing new for one.
-				if (reconOwnership.verdict !== 'owned_by_seed') {
+				// #832: an `unmeasured` candidate gets none either — the recon
+				// corroboration is a per-candidate impersonation-shaped claim, and
+				// the run's degraded comparison cannot rule out that the candidate
+				// is the customer's own (the scan_status notice covers the run).
+				if (reconOwnership.verdict !== 'owned_by_seed' && reconOwnership.verdict !== 'unmeasured') {
 					findings.push(buildReconCandidateFinding(matchedDomain, detail, reconOwnership));
 				}
 			} else {

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -42,6 +42,14 @@ export interface LookalikeResult {
 	hasMX: boolean;
 	/** MX exchange hosts (lowercased, trailing-dot-stripped) — empty when no real MX. */
 	mxExchanges: string[];
+	/**
+	 * True when the A or MX lookup for this candidate REJECTED (timeout /
+	 * throttling), so the corresponding `false` above is UNFETCHED, not
+	 * measured (#831/#832). A candidate with no positive signal and a degraded
+	 * probe must never be reported as "registered but dark" — that would
+	 * compile a non-answer into a custody record.
+	 */
+	probeDegraded: boolean;
 }
 
 /**
@@ -94,6 +102,7 @@ async function probeLookalike(domain: string): Promise<LookalikeResult> {
 		hasA: aRecords.status === 'fulfilled' && aRecords.value.length > 0,
 		hasMX: realMxRecords.length > 0,
 		mxExchanges,
+		probeDegraded: aRecords.status === 'rejected' || mxRecords.status === 'rejected',
 	};
 }
 

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -174,16 +174,31 @@ function normalizeNsSet(nsRecords: string[]): Set<string> {
 	return new Set(nsRecords.map((ns) => ns.replace(/\.$/, '').toLowerCase()));
 }
 
+/** Result of the seed-side NS probe: the answer set plus whether the lookup actually resolved. */
+export interface PrimaryNsResult {
+	ns: Set<string>;
+	/**
+	 * False when the NS query REJECTED (timeout / throttling). The distinction
+	 * is load-bearing (#832): an empty set from a FAILED lookup means the
+	 * ownership comparison has nothing to compare against — every downstream
+	 * verdict must be `unmeasured`, never `third_party`. An empty set from a
+	 * resolved lookup is a real measurement.
+	 */
+	resolved: boolean;
+}
+
 /**
  * Query NS records for the primary domain to use for ownership comparison.
- * Returns an empty set if the query fails.
+ * Fail-soft on the SET (empty), but the failure itself is surfaced via
+ * `resolved: false` so the attribution layer can decline to attribute (#832)
+ * rather than reading "unfetched" as "distinct infrastructure".
  */
-export async function queryPrimaryNs(domain: string): Promise<Set<string>> {
+export async function queryPrimaryNs(domain: string): Promise<PrimaryNsResult> {
 	try {
 		const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
-		return normalizeNsSet(ns);
+		return { ns: normalizeNsSet(ns), resolved: true };
 	} catch {
-		return new Set<string>();
+		return { ns: new Set<string>(), resolved: false };
 	}
 }
 

--- a/src/tools/lookalike-findings.ts
+++ b/src/tools/lookalike-findings.ts
@@ -115,6 +115,43 @@ export function buildOwnedBySeedFinding(result: LookalikeResult, seedDomain: str
 }
 
 /**
+ * AXIS 1 — a REGISTERED-BUT-DARK candidate (#831): NS resolved, but the A/MX
+ * probe measured no web and no mail infrastructure. Before this finding
+ * existed, the capability gate dropped such candidates silently, so "held and
+ * dark" (e.g. a defensive Azure-DNS registration like febreeze.com) rendered
+ * identically to "unregistered" — opposite custody facts, same silence.
+ *
+ * Always `info` and never a threat observation: a domain with no
+ * infrastructure is not impersonation-capable, so it must not move a score.
+ * The ownership-attribution lane applies exactly as for active candidates —
+ * the verdict (including `unmeasured` under a degraded comparison, #832)
+ * travels in metadata and the rationale is quoted. Callers must NOT route a
+ * candidate here when `probeDegraded` is set: an absence that was never
+ * fetched is unknown, not dark.
+ *
+ * WORDING CONSTRAINT (same as `DEFENSIVE_REASON_PHRASES` above): no
+ * `missing` / `required` / `not found` / `no <...> record` shapes —
+ * `scoreIndicatesMissingControl()` matches finding TEXT.
+ */
+export function buildRegisteredDarkFinding(result: LookalikeResult, seedDomain: string, ownership: OwnershipAssessment): Finding {
+	return createFinding(
+		'lookalikes',
+		`Registered, no active infrastructure: ${result.domain}`,
+		'info',
+		`The domain ${result.domain} is a confusable variant of ${seedDomain} and is registered (its nameservers resolve), but it carries neither web nor mail infrastructure — it is held and dark. Ownership evidence: ${ownership.rationale} A held-and-dark confusable can be a defensive registration by the brand or a third party's parked asset; it is reported for awareness and is not treated as impersonation-capable while it stays dark.`,
+		{
+			lookalikeDomain: result.domain,
+			hasA: false,
+			hasMX: false,
+			registeredDark: true,
+			ownershipVerdict: ownership.verdict,
+			ownershipRationale: ownership.rationale,
+			findingAxis: 'attribution' satisfies LookalikeFindingAxis,
+		},
+	);
+}
+
+/**
  * AXIS 1 — the registration record corroborates that this is the scanned
  * organisation's OWN defensive registration. Emitted INSTEAD of the neutral D4
  * gate template, which would otherwise state positively that the domain "is

--- a/src/tools/lookalike-summary-findings.ts
+++ b/src/tools/lookalike-summary-findings.ts
@@ -95,6 +95,32 @@ export function buildNoActiveInfrastructureFinding(
 }
 
 /**
+ * `scan_status` — the OWNERSHIP COMPARISON was degraded this run (#832): the
+ * seed's own NS lookup did not resolve, so every registered candidate carries
+ * an `unmeasured` ownership verdict and no impersonation-shaped finding was
+ * emitted. Surfaced as its own finding (not only per-candidate metadata) for
+ * the same reason as {@link buildIncompleteEnumerationFinding}: a consumer
+ * reading findings must be able to tell "attribution declined because the
+ * instrument was throttled" from "attribution concluded third-party" —
+ * otherwise a diff of consecutive runs sees the world flip
+ * (owned → third-party → owned) when only the run's completeness changed.
+ */
+export function buildOwnershipUnmeasuredFinding(seedDomain: string, candidateCount: number): Finding {
+	return createFinding(
+		'lookalikes',
+		'Ownership attribution unmeasured this run — treat verdicts as pending',
+		'info',
+		`The nameserver lookup for ${seedDomain} itself did not resolve in this run (DNS timeout or rate limiting), so registered candidates could not be compared against the organisation's own nameservers. ${candidateCount} candidate${candidateCount === 1 ? '' : 's'} ${candidateCount === 1 ? 'is' : 'are'} reported with an 'unmeasured' ownership verdict instead of a definitive attribution — a definitive third-party claim requires the same complete comparison an owned verdict does. Impersonation-shaped observations are withheld for unmeasured candidates; re-run to attribute.`,
+		{
+			findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
+			seedNsUnresolved: true,
+			unmeasuredCandidateCount: candidateCount,
+			confidence: 'heuristic',
+		},
+	);
+}
+
+/**
  * AXIS 2 — summary finding for high-severity lookalikes. Only fires when at
  * least one NON-OWNED candidate reached HIGH under the issue #264 matrix
  * (mail-infra + corroborator). Owned candidates never reach here.

--- a/src/tools/lookalike-summary-findings.ts
+++ b/src/tools/lookalike-summary-findings.ts
@@ -110,7 +110,9 @@ export function buildOwnershipUnmeasuredFinding(seedDomain: string, candidateCou
 		'lookalikes',
 		'Ownership attribution unmeasured this run — treat verdicts as pending',
 		'info',
-		`The nameserver lookup for ${seedDomain} itself did not resolve in this run (DNS timeout or rate limiting), so registered candidates could not be compared against the organisation's own nameservers. ${candidateCount} candidate${candidateCount === 1 ? '' : 's'} ${candidateCount === 1 ? 'is' : 'are'} reported with an 'unmeasured' ownership verdict instead of a definitive attribution — a definitive third-party claim requires the same complete comparison an owned verdict does. Impersonation-shaped observations are withheld for unmeasured candidates; re-run to attribute.`,
+		candidateCount === 0
+			? `The nameserver lookup for ${seedDomain} itself did not resolve in this run (DNS timeout or rate limiting), so registered candidates could not be compared against the organisation's own nameservers. No candidate needed that comparison here — each was attributed from its own evidence (nameservers within ${seedDomain} itself) — but a candidate relying on the comparison would have been reported 'unmeasured' rather than attributed. Re-run for a complete picture.`
+			: `The nameserver lookup for ${seedDomain} itself did not resolve in this run (DNS timeout or rate limiting), so registered candidates could not be compared against the organisation's own nameservers. ${candidateCount} candidate${candidateCount === 1 ? '' : 's'} ${candidateCount === 1 ? 'is' : 'are'} reported with an 'unmeasured' ownership verdict instead of a definitive attribution — a definitive third-party claim requires the same complete comparison an owned verdict does. Impersonation-shaped observations are withheld for unmeasured candidates; re-run to attribute.`,
 		{
 			findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
 			seedNsUnresolved: true,

--- a/test/audits/ownership-severity-gate.audit.test.ts
+++ b/test/audits/ownership-severity-gate.audit.test.ts
@@ -495,7 +495,14 @@ async function runLookalikesPostLoopScanStatusFixture() {
 		if (!q) return Promise.resolve(empty());
 		const { name, type } = q;
 		if (name === LOOKALIKES_SEED && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(LOOKALIKES_SEED, SEED_AKAMAI_NS));
-		if (name === 'tstco.com' && (type === 'NS' || type === '2')) return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+		if (name === 'tstco.com') {
+			if (type === 'NS' || type === '2') return Promise.resolve(nsRecords(name, ['ns1.registrar.com.']));
+			// #831: a MEASURED no-A/no-MX candidate now emits its own
+			// registered-but-dark finding, so the post-loop notice is only
+			// reachable when the detail probe was CUT (absence unfetched, not
+			// measured) — the one case that still yields no per-candidate finding.
+			if (type === 'A' || type === '1' || type === 'MX' || type === '15') return Promise.reject(new Error('DNS timeout'));
+		}
 		return Promise.resolve(empty());
 	});
 	const { checkLookalikes } = await import('../../src/tools/check-lookalikes');

--- a/test/check-lookalikes-degraded-attribution.spec.ts
+++ b/test/check-lookalikes-degraded-attribution.spec.ts
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Attribution honesty under degraded lookups (#832) and registered-but-dark
+ * visibility (#831) for `check_lookalikes`.
+ *
+ * #832 (measured 2026-08-29, jcpenney.com): a throttled run — the SEED's own
+ * NS lookup failed — published `third_party` ("no ownership signal links it…")
+ * plus an impersonation-shaped finding for a candidate that near-complete runs
+ * prove is `owned_by_seed` on a full 8/8 NS match. The signals were not
+ * absent; they were UNFETCHED. A definitive `third_party` requires the same
+ * completeness bar `owned_by_seed` already implies, so a degraded comparison
+ * must yield `unmeasured` and suppress the impersonation-shaped finding.
+ *
+ * #831 (measured 2026-08-29, febreeze.com): a candidate that resolves NS but
+ * has no A and no MX was silently dropped by the capability gate, so "held
+ * and dark" (a defensive Azure-DNS registration) rendered identically to
+ * "unregistered".
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/** Parse the DoH query name and type from a fetch URL (same helper as check-lookalikes.spec.ts). */
+function parseDohQuery(input: string | URL | Request): { name: string; type: string } {
+	const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+	const parsed = new URL(url);
+	return {
+		name: parsed.searchParams.get('name') ?? '',
+		type: parsed.searchParams.get('type') ?? '',
+	};
+}
+
+function nsResponse(name: string, hosts: string[]) {
+	return createDohResponse(
+		[{ name, type: 2 }],
+		hosts.map((data) => ({ name, type: 2, TTL: 300, data })),
+	);
+}
+
+function aResponse(name: string) {
+	return createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]);
+}
+
+function mxResponse(name: string) {
+	return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: `10 mail.${name}.` }]);
+}
+
+function empty() {
+	return createDohResponse([], []);
+}
+
+async function run(domain = 'test.com') {
+	const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+	return checkLookalikes(domain);
+}
+
+const isNs = (type: string) => type === 'NS' || type === '2';
+const isA = (type: string) => type === 'A' || type === '1';
+const isMx = (type: string) => type === 'MX' || type === '15';
+
+describe('checkLookalikes - degraded ownership comparison (#832)', () => {
+	/**
+	 * Fixture: the seed's own NS lookup FAILS (throttled), while the candidate
+	 * `tst.com` resolves cleanly with NS + A + MX. In a healthy run the same
+	 * candidate would be compared against the seed's NS set; in this run there
+	 * is nothing to compare against, so no definitive attribution is possible.
+	 */
+	function mockSeedNsFailure(): void {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) {
+				return Promise.reject(new Error('DNS timeout'));
+			}
+			if (name === 'tst.com') {
+				if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1-05.azure-dns.com.', 'ns2-05.azure-dns.net.']));
+				if (isA(type)) return Promise.resolve(aResponse(name));
+				if (isMx(type)) return Promise.resolve(mxResponse(name));
+			}
+			return Promise.resolve(empty());
+		});
+	}
+
+	it('emits an unmeasured ownership verdict, never third_party, when the seed NS lookup failed', async () => {
+		mockSeedNsFailure();
+		const result = await run('test.com');
+
+		const attribution = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com' && f.metadata?.findingAxis === 'attribution');
+		expect(attribution.length).toBeGreaterThan(0);
+		for (const f of attribution) {
+			expect(f.metadata?.ownershipVerdict).toBe('unmeasured');
+			expect(f.severity).toBe('info');
+		}
+		// The definitive negative must not appear anywhere in the run: the
+		// signals were unfetched, not absent.
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(false);
+		expect(JSON.stringify(result.findings)).not.toContain('no ownership signal links it');
+	});
+
+	it('suppresses the impersonation-shaped finding for candidates whose ownership comparison was degraded', async () => {
+		mockSeedNsFailure();
+		const result = await run('test.com');
+
+		expect(result.findings.some((f) => /Impersonation-shaped/i.test(f.title))).toBe(false);
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(false);
+		// The run-level scan_status notice tells the consumer WHY attribution is
+		// absent, so the non-answer is visible rather than silent.
+		const notice = result.findings.find((f) => f.metadata?.findingAxis === 'scan_status' && /ownership/i.test(f.title));
+		expect(notice).toBeDefined();
+		expect(notice!.severity).toBe('info');
+	});
+
+	it('control: a healthy seed NS lookup still yields third_party and the threat observation (no over-suppression)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) {
+				return Promise.resolve(nsResponse(name, ['ns1.cloudflare.com.', 'ns2.cloudflare.com.']));
+			}
+			if (name === 'tst.com') {
+				if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.attacker-dns.com.']));
+				if (isA(type)) return Promise.resolve(aResponse(name));
+				if (isMx(type)) return Promise.resolve(mxResponse(name));
+			}
+			return Promise.resolve(empty());
+		});
+		const result = await run('test.com');
+
+		const tst = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com');
+		expect(tst.some((f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+		expect(tst.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
+	});
+});

--- a/test/check-lookalikes-degraded-attribution.spec.ts
+++ b/test/check-lookalikes-degraded-attribution.spec.ts
@@ -134,3 +134,91 @@ describe('checkLookalikes - degraded ownership comparison (#832)', () => {
 		expect(tst.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
 	});
 });
+
+describe('checkLookalikes - registered-but-dark candidates (#831)', () => {
+	it('emits an info finding for an NS-resolved candidate with no A and no MX instead of dropping it silently', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) {
+				return Promise.resolve(nsResponse(name, ['ns1.cloudflare.com.', 'ns2.cloudflare.com.']));
+			}
+			if (name === 'tst.com' && isNs(type)) {
+				// Registered on Azure DNS, deliberately dark: A and MX both resolve
+				// EMPTY (NOERROR, no answers) — the febreeze.com shape.
+				return Promise.resolve(nsResponse(name, ['ns1-05.azure-dns.com.', 'ns2-05.azure-dns.net.', 'ns3-05.azure-dns.org.']));
+			}
+			return Promise.resolve(empty());
+		});
+		const result = await run('test.com');
+
+		const dark = result.findings.find((f) => f.title === 'Registered, no active infrastructure: tst.com');
+		expect(dark).toBeDefined();
+		expect(dark!.severity).toBe('info');
+		expect(dark!.metadata?.findingAxis).toBe('attribution');
+		expect(dark!.metadata?.lookalikeDomain).toBe('tst.com');
+		// Ownership-attribution lane applies the same as for active candidates.
+		expect(dark!.metadata?.ownershipVerdict).toBe('third_party');
+		// Not scored as impersonation-capable: no threat observation, nothing above info.
+		expect(result.findings.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(false);
+		expect(result.findings.every((f) => f.severity === 'info')).toBe(true);
+	});
+
+	it('applies owned_by_seed attribution to an NS-only candidate sharing the seed nameserver set (defensive registration)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if ((name === 'test.com' || name === 'tst.com') && isNs(type)) {
+				// Identical dedicated 2/2 NS set → owned_by_seed under classifyOwnership.
+				return Promise.resolve(nsResponse(name, ['ns1.cloudflare.com.', 'ns2.cloudflare.com.']));
+			}
+			return Promise.resolve(empty());
+		});
+		const result = await run('test.com');
+
+		const owned = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'tst.com');
+		expect(owned.length).toBeGreaterThan(0);
+		expect(owned.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
+		expect(owned.every((f) => f.severity === 'info')).toBe(true);
+	});
+
+	it('does NOT report registered-but-dark when the A/MX probe itself was degraded (absence unfetched, not measured)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) {
+				return Promise.resolve(nsResponse(name, ['ns1.cloudflare.com.', 'ns2.cloudflare.com.']));
+			}
+			if (name === 'tst.com') {
+				if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1-05.azure-dns.com.']));
+				// The detail probe is throttled: A and MX lookups both REJECT.
+				if (isA(type) || isMx(type)) return Promise.reject(new Error('DNS timeout'));
+			}
+			return Promise.resolve(empty());
+		});
+		const result = await run('test.com');
+
+		// No dark claim from an absence never measured…
+		expect(result.findings.some((f) => /Registered, no active infrastructure/.test(f.title))).toBe(false);
+		// …but the candidate does not vanish silently either: the run reports
+		// itself incomplete.
+		const incomplete = result.findings.find((f) => /enumeration was incomplete/i.test(f.title));
+		expect(incomplete).toBeDefined();
+	});
+
+	it('a dark candidate under a degraded seed NS lookup carries the unmeasured verdict (interplay with #832)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) {
+				return Promise.reject(new Error('DNS timeout'));
+			}
+			if (name === 'tst.com' && isNs(type)) {
+				return Promise.resolve(nsResponse(name, ['ns1-05.azure-dns.com.']));
+			}
+			return Promise.resolve(empty());
+		});
+		const result = await run('test.com');
+
+		const dark = result.findings.find((f) => f.title === 'Registered, no active infrastructure: tst.com');
+		expect(dark).toBeDefined();
+		expect(dark!.metadata?.ownershipVerdict).toBe('unmeasured');
+		expect(dark!.severity).toBe('info');
+	});
+});

--- a/test/check-lookalikes-degraded-attribution.spec.ts
+++ b/test/check-lookalikes-degraded-attribution.spec.ts
@@ -222,3 +222,95 @@ describe('checkLookalikes - registered-but-dark candidates (#831)', () => {
 		expect(dark!.severity).toBe('info');
 	});
 });
+
+describe('checkLookalikes - review follow-ups on the degraded-run contract (#847)', () => {
+	/**
+	 * A candidate whose A lookup RESOLVES while its MX lookup REJECTS is
+	 * `probeDegraded`, but only half-measured: its mail capability was never
+	 * observed. The enumeration contract ("complete: false means this set is a
+	 * SAMPLE") must reflect that, or a partial run reads as a census.
+	 */
+	it('counts a half-degraded detail probe as unresolved, so the run is not reported complete', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.test.com.']));
+			if (name === 'tst.com') {
+				if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.other.com.']));
+				if (isA(type)) return Promise.resolve(aResponse(name));
+				// Mail capability never measured.
+				if (isMx(type)) return Promise.reject(new Error('DNS timeout'));
+			}
+			return Promise.resolve(empty());
+		});
+
+		const result = await run('test.com');
+
+		const withEnum = result.findings.find((f) => f.metadata?.enumeration !== undefined);
+		expect(withEnum).toBeDefined();
+		const enumeration = withEnum!.metadata!.enumeration as { complete: boolean; unresolvedCount: number };
+		expect(enumeration.complete).toBe(false);
+		expect(enumeration.unresolvedCount).toBeGreaterThan(0);
+	});
+
+	/**
+	 * `classifyOwnership()` deliberately preserves `owned_by_seed` for an
+	 * in-bailiwick candidate NS even when the seed NS lookup failed, so in a
+	 * mixed batch NOT every registered candidate is unmeasured. The status
+	 * finding must count the actual unmeasured verdicts, not the batch size.
+	 */
+	it('reports the true unmeasured count in a mixed batch, not every registered candidate', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) return Promise.reject(new Error('DNS timeout'));
+			// In-bailiwick candidate: its NS sits under the seed domain, so ownership
+			// is concluded from the candidate's own evidence despite the seed failure.
+			if (name === 'tes.com') {
+				if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.test.com.']));
+				if (isA(type)) return Promise.resolve(aResponse(name));
+				if (isMx(type)) return Promise.resolve(mxResponse(name));
+			}
+			// Unrelated third-party NS: genuinely unmeasurable without the seed set.
+			if (name === 'tst.com') {
+				if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.elsewhere.net.']));
+				if (isA(type)) return Promise.resolve(aResponse(name));
+				if (isMx(type)) return Promise.resolve(mxResponse(name));
+			}
+			return Promise.resolve(empty());
+		});
+
+		const result = await run('test.com');
+
+		const notice = result.findings.find((f) => f.metadata?.unmeasuredCandidateCount !== undefined);
+		expect(notice).toBeDefined();
+		const claimed = notice!.metadata!.unmeasuredCandidateCount as number;
+		const actualUnmeasured = result.findings.filter(
+			(f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.ownershipVerdict === 'unmeasured',
+		).length;
+		// The owned_by_seed candidate must not be counted as unmeasured.
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(true);
+		expect(claimed).toBe(actualUnmeasured);
+	});
+
+	/**
+	 * The degraded outcome is TRANSIENT. `check_lookalikes` is cached for an hour
+	 * and the dispatcher skips cache writes only for `partial` results, so an
+	 * unmeasured run must be marked partial — otherwise withheld verdicts are
+	 * served for the full TTL after DNS recovers. Same contract the timeout path
+	 * already honours.
+	 */
+	it('marks a degraded run partial so the non-answer is not cached for the TTL', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const { name, type } = parseDohQuery(input);
+			if (name === 'test.com' && isNs(type)) return Promise.reject(new Error('DNS timeout'));
+			if (name === 'tst.com') {
+				if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.elsewhere.net.']));
+				if (isA(type)) return Promise.resolve(aResponse(name));
+				if (isMx(type)) return Promise.resolve(mxResponse(name));
+			}
+			return Promise.resolve(empty());
+		});
+
+		const result = await run('test.com');
+		expect(result.partial).toBe(true);
+	});
+});


### PR DESCRIPTION
Two defects sharing the `check_lookalikes` attribution lane, fixed together (one per commit).

## #832 — throttled run publishes a CONTRARY ownership attribution

**Measured evidence (issue, 2026-08-29, three sequential `force_refresh` runs on jcpenney.com):** run 1 (63/94 lookups unresolved) reported `jcpenny.com` as `third_party` — "no ownership signal links it to this organisation" — plus an "Impersonation-shaped web infrastructure observed" finding; runs 2–3 (1/94 unresolved) reported the same domain `owned_by_seed` on a full 8/8 nameserver match. The signals were unfetched, not absent.

**Mechanism:** `queryPrimaryNs()` fail-softed a rejected seed NS lookup into an empty set, which fell through `classifyOwnership()`'s set-comparison arms to the `third_party` arm — a definitive negative manufactured from a lookup that never completed.

**Fix:**
- `queryPrimaryNs()` now returns `{ ns, resolved }`, surfacing the failure instead of collapsing it.
- `classifyOwnership()` gains an `unmeasured` verdict: with `seedNsUnresolved` set, the `third_party` arm is replaced by an honest measurement-gap rationale. The in-bailiwick arm (seed apex only, resolved candidate-side evidence) still yields `owned_by_seed`.
- The impersonation-shaped `threat_observation` (and its staging/mail-capable counters, and the recon CT per-candidate corroboration) is withheld for `unmeasured` candidates in that run. The attribution finding still names each candidate at `info` with the `unmeasured` verdict, and a run-level `scan_status` notice explains the withholding — the non-answer is visible, never a record.
- A definitive `third_party` now requires the same completeness bar `owned_by_seed` already implies (the full-set comparison). `capAttributionSeverity()` untouched: `unmeasured` is non-owned and capped at `info`.

## #831 — registered-but-dark lookalike is invisible

**Measured evidence (issue, 2026-08-29):** `febreeze.com` — NS = Azure DNS (NOERROR), A empty, MX empty; registered and dark — appeared in zero findings across three byte-identical runs of `check_lookalikes('febreze.com')`, because the post-NS capability gate dropped candidates with neither A nor MX. "Held and dark" and "unregistered" are opposite custody facts rendered identically as silence.

**Fix:**
- NS-resolved candidates whose A/MX probe **measured** no infrastructure now emit an `info` attribution finding — `Registered, no active infrastructure: <domain>` — with the ownership-attribution lane applied the same as for active candidates: `owned_by_seed` keeps its native same-owner finding, `third_party`/`unattributed` get the custody observation with verdict + rationale in metadata, and a degraded seed comparison yields #832's `unmeasured` verdict. Never a `threat_observation`, never above `info` — a dark domain is not scored as impersonation-capable.
- A candidate whose A/MX lookups **rejected** is not recorded as dark (absence unfetched, not measured — the same law as #832); it is counted into the enumeration `unresolvedCount` so the run reports itself incomplete instead of erasing the candidate — closing a residual silent-drop site adjacent to #781.

## Tests

New `test/check-lookalikes-degraded-attribution.spec.ts` (7 tests, written failing-first): degraded → `unmeasured` verdict; degraded → impersonation finding suppressed + `scan_status` notice; healthy control (no over-suppression); NS-only dark → info finding; NS-only + shared seed NS → `owned_by_seed`; degraded probe → no dark claim + incomplete enumeration; dark + degraded seed → `unmeasured`. The ownership-severity-gate audit's post-loop fixture now cuts the detail probe, since a measured dark candidate emits its own finding.

Verified: `npm run typecheck`, `npm run lint`, and the adjacent suite green (check-lookalikes, ownership-attribution, check-shadow-domains, ownership-severity-gate + ns-in-bailiwick audits, recon-enrichment integration, discover-brand-domains, lookalike-analysis/severity, control-regression audit, varied-domain chaos matrix).

Closes #832
Closes #831

🤖 Generated with [Claude Code](https://claude.com/claude-code)