### PR TITLE
fix(scoring): unify missing-control semantics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5126,7 +5126,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.27.0",
+			"version": "1.28.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.27.0",
+	"version": "1.28.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-engine.suite.ts
@@ -592,6 +592,47 @@ export function defineScoringEngineSuite(s: ScoringModule): void {
 				const withMeasured = computeScanScore([...coreWithoutDmarc, measuredMissingDmarc]);
 				expect(withMeasured.overall).toBeLessThanOrEqual(DEFAULT_SCORING_CONFIG.thresholds.criticalGapCeiling);
 			});
+
+			it('structured missingControl metadata is equivalent to legacy prose for the critical-gap ceiling', () => {
+				const coreWithoutDmarc = passingCore().filter((r) => r.category !== 'dmarc');
+				const structured = buildCheckResult('dmarc', [
+					createFinding('dmarc', 'DMARC policy unavailable', 'high', 'The policy cannot protect this domain.', {
+						confidence: 'deterministic',
+						missingControl: true,
+					}),
+				]);
+				const legacyProse = buildCheckResult('dmarc', [
+					createFinding('dmarc', 'Missing DMARC policy', 'high', 'The required DMARC record is missing.', {
+						confidence: 'deterministic',
+					}),
+				]);
+
+				expect(structured.score).toBe(0);
+				expect(legacyProse.score).toBe(0);
+				const structuredScore = computeScanScore([...coreWithoutDmarc, structured]);
+				const proseScore = computeScanScore([...coreWithoutDmarc, legacyProse]);
+				expect(structuredScore.overall).toBe(DEFAULT_SCORING_CONFIG.thresholds.criticalGapCeiling);
+				expect(structuredScore.overall).toBe(proseScore.overall);
+			});
+
+			it('structured missingControl metadata on an UNMEASURED check cannot arm the ceiling', () => {
+				const coreWithoutDmarc = passingCore().filter((r) => r.category !== 'dmarc');
+				const baseline = computeScanScore(coreWithoutDmarc);
+				const erroredDmarc: CheckResult = {
+					...buildCheckResult('dmarc', [
+						createFinding('dmarc', 'DMARC unavailable', 'high', 'The probe did not complete.', {
+							confidence: 'deterministic',
+							missingControl: true,
+						}),
+					]),
+					checkStatus: 'error',
+				};
+
+				const withErrored = computeScanScore([...coreWithoutDmarc, erroredDmarc]);
+				expect(withErrored.overall).toBe(baseline.overall);
+				expect(withErrored.overall).toBeGreaterThan(DEFAULT_SCORING_CONFIG.thresholds.criticalGapCeiling);
+				expect(withErrored.categoryScores.dmarc).toBeUndefined();
+			});
 		});
 
 		describe('an OUT-OF-UNION checkStatus (version-skewed cache re-read) is excluded exactly like timeout/error, never silently scored via the ?? 100 full-credit fallback', () => {

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.27.0';
+export const PARITY_CORPUS_VERSION = '1.28.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -110,12 +110,9 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 				// evaluated by any receiver, so zeroing is correct — the same treatment the
 				// no-record case (`:67`) and the multiple-record case (`:82`) already get.
 				//
-				// Today this flag is BEHAVIOURALLY INERT: `engine.ts` builds `missingControls`
-				// from `scoreIndicatesMissingControl` alone and never reads `metadata`, and this
-				// detail happens to contain both "missing" and "required", so the prose already
-				// zeroes it. That accident is exactly the problem — reword the sentence and the
-				// zeroing silently disappears. Declaring the intent here makes it survive a copy
-				// edit and makes it legible if the engine ever starts reading the flag.
+				// Structured intent is consumed by the same canonical predicate as the legacy
+				// prose inference, so a copy edit cannot change either category zeroing or the
+				// critical-gap ceiling.
 				{ missingControl: true },
 			),
 		);

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -6,7 +6,7 @@ import {
 	type CheckResult,
 	type Finding,
 	inferFindingConfidence,
-	scoreIndicatesMissingControl,
+	findingsIndicateMissingControl,
 	type ScanScore,
 } from './model';
 import type { DomainContext } from './profiles';
@@ -206,9 +206,9 @@ function buildGenericContext(
 
 	// --- Build missingControls map ---
 	// Only mark a category as missing when an actual result exists and
-	// scoreIndicatesMissingControl returns true. Absent categories must NOT
+	// findingsIndicateMissingControl returns true. Absent categories must NOT
 	// be marked missing — the original engine's critical gap ceiling check
-	// requires an actual result (`result && scoreIndicatesMissingControl(...)`),
+	// requires an actual result (`result && findingsIndicateMissingControl(...)`),
 	// and absent categories default to 100 with no zeroing.
 	//
 	// Only a MEASURED check may assert absence. An errored/timed-out check's synthetic
@@ -222,7 +222,7 @@ function buildGenericContext(
 	const resultMap = new Map<CheckCategory, CheckResult>();
 	for (const result of results) {
 		resultMap.set(result.category, result);
-		if (isCheckMeasured(result.checkStatus) && scoreIndicatesMissingControl(result.findings)) {
+		if (isCheckMeasured(result.checkStatus) && findingsIndicateMissingControl(result.findings)) {
 			missingControls[result.category] = true;
 		}
 	}
@@ -331,9 +331,9 @@ function buildGenericContext(
  *
  * Three tiers:
  * - **Core** (default 70 points): Weighted accumulation of foundational categories (SPF, DMARC, DKIM, DNSSEC, SSL).
- *   `scoreIndicatesMissingControl()` can zero a category's contribution when confidence is deterministic/verified.
+ *   `findingsIndicateMissingControl()` can zero a category's contribution from structured intent or deterministic/verified prose.
  * - **Protective** (default 20 points): Weighted accumulation of active defense categories.
- *   No `scoreIndicatesMissingControl()` override.
+ *   No `findingsIndicateMissingControl()` override.
  * - **Hardening** (default 10 points): Binary pass/fail — each category with score >= 50 contributes
  *   `tierSplit.hardening / hardeningCount` points. Never subtracts.
  *

--- a/packages/dns-checks/src/scoring/index.ts
+++ b/packages/dns-checks/src/scoring/index.ts
@@ -13,6 +13,7 @@ export {
 	SEVERITY_PENALTIES,
 	inferFindingConfidence,
 	scoreIndicatesMissingControl,
+	findingsIndicateMissingControl,
 	redactSubjectData,
 	SUBJECT_TERMS_METADATA_KEY,
 	computeCategoryScore,

--- a/packages/dns-checks/src/scoring/model.ts
+++ b/packages/dns-checks/src/scoring/model.ts
@@ -285,6 +285,21 @@ export function scoreIndicatesMissingControl(findings: Finding[]): boolean {
 }
 
 /**
+ * Canonical missing-control decision for a set of findings.
+ *
+ * A check author may declare the state structurally with
+ * `metadata.missingControl: true`; legacy checks may still express it through
+ * deterministic/verified prose interpreted by {@link scoreIndicatesMissingControl}.
+ * Every scoring layer must use this predicate so category zeroing, the email
+ * bonus and the critical-gap ceiling cannot disagree about the same evidence.
+ * Measurement status is intentionally not accepted here: callers operating on
+ * whole check results must gate this predicate with `isCheckMeasured`.
+ */
+export function findingsIndicateMissingControl(findings: Finding[]): boolean {
+	return scoreIndicatesMissingControl(findings) || findings.some((f) => f.metadata?.missingControl === true);
+}
+
+/**
  * Build a CheckResult from a category and its findings.
  * A check fails (passed=false) if the score is below 50, if findings indicate
  * a fundamentally missing security control (e.g., no SPF/DMARC record), or if
@@ -303,8 +318,7 @@ export function buildCheckResult(
 ): CheckResult {
 	const normalizedFindings = findings.map(withConfidenceMetadata);
 	const score = computeCategoryScore(normalizedFindings, category);
-	const hasMissingControl =
-		scoreIndicatesMissingControl(normalizedFindings) || normalizedFindings.some((f) => f.metadata?.missingControl === true);
+	const hasMissingControl = findingsIndicateMissingControl(normalizedFindings);
 	const passed = score >= 50 && !hasMissingControl;
 	return {
 		category,

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -277,8 +277,20 @@
  *   (`check_dnssec_chain`'s parallel ordering fix in #852 is NOT reflected here: it is a
  *   standalone tool whose category is outside the `CheckCategory` union, so it contributes
  *   nothing to a scan score.)
+ * - 1.17.0 — structured `metadata.missingControl: true` and legacy deterministic prose now
+ *   feed one canonical missing-control predicate at every scoring layer. Before this change,
+ *   both paths zeroed the category in `buildCheckResult`, but `buildGenericContext` populated
+ *   the whole-scan `missingControls` map from prose inference alone. On an otherwise identical
+ *   measured DMARC roster, structured intent therefore produced 71/C+ while equivalent prose
+ *   armed the critical-gap ceiling and produced 64/C. The structured declaration now also
+ *   drives the critical-gap ceiling and email-bonus guards; timeout/error checks remain gated
+ *   by `isCheckMeasured` and cannot assert absence. DOWNWARD only for measured critical
+ *   categories whose finding declares `missingControl: true` without also matching the legacy
+ *   prose regex; findings that already matched prose and all inconclusive results are unchanged.
+ *   Affected population is UNMEASURED. No weight, tier, grade band, severity penalty,
+ *   profile-detection rule or check roster changed.
  */
-export const SCORING_MODEL_VERSION = '1.16.0';
+export const SCORING_MODEL_VERSION = '1.17.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';


### PR DESCRIPTION
## Summary

- introduces one canonical missing-control predicate for structured metadata and legacy prose
- makes category zeroing, email-bonus guards, and the critical-gap ceiling agree
- preserves the measurement-status gate so timeout/error results cannot assert absence
- advances dns-checks to 1.28.0 and scoring model to 1.17.0

## Verification

- source red test reproduced structured 71/C+ versus prose 64/C
- fixed source and built-package scoring suites: 135 passed
- dns-checks build and typecheck passed
- repo safety passed