### PR TITLE
fix(scoring): resolve open correctness issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,19 @@ permissions:
   contents: read
 
 jobs:
+  scoring-version-advisory:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Review scoring-model version decision
+        env:
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: node scripts/ci/check-scoring-version.mjs ${{ github.event.pull_request.base.sha }} ${{ github.event.pull_request.head.sha }}
+
   build-and-test:
     runs-on: ubuntu-latest
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5126,7 +5126,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.28.0",
+			"version": "1.29.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.28.0",
+	"version": "1.29.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dnssec.test.ts
@@ -45,7 +45,7 @@ describe('checkDNSSEC', () => {
 		expect(result.controlPresent).toBe(false);
 	});
 
-	it('reports chain of trust incomplete when DNSKEY present but no DS', async () => {
+	it('reports an insecure island of trust when DNSKEY is present without a parent DS', async () => {
 		// Return DNSKEY from first call, empty from second (DS)
 		const mockDNS: DNSQueryFunction = vi.fn(async (_domain: string, type: string) => {
 			if (type === 'DNSKEY') return ['257 3 13 base64key...'];
@@ -53,7 +53,9 @@ describe('checkDNSSEC', () => {
 		});
 		const rawQueryDNS: RawDNSQueryFunction = vi.fn(async () => ({ AD: false }));
 		const result = await checkDNSSEC('example.com', mockDNS, { rawQueryDNS });
-		expect(result.findings.some((f) => f.title === 'DNSSEC chain of trust incomplete')).toBe(true);
+		expect(result.findings.some((f) => f.title === 'DNSSEC island of trust')).toBe(true);
+		expect(result.score).toBe(60);
+		expect(result.findings.some((f) => f.metadata?.missingControl === true)).toBe(false);
 	});
 
 	it('does not declare a broken chain when the DS lookup itself failed', async () => {
@@ -71,7 +73,7 @@ describe('checkDNSSEC', () => {
 		const rawQueryDNS: RawDNSQueryFunction = vi.fn(async () => ({ AD: false }));
 		const result = await checkDNSSEC('example.com', mockDNS, { rawQueryDNS });
 
-		expect(result.findings.some((f) => f.title === 'DNSSEC chain of trust incomplete')).toBe(false);
+		expect(result.findings.some((f) => f.title === 'DNSSEC island of trust')).toBe(false);
 		expect(result.findings.some((f) => f.metadata?.missingControl === true)).toBe(false);
 		// The repo's standard unmeasured contract: checkStatus 'error' EXCLUDES the
 		// category from scoring, and `score: 0` + `checkStatus: 'error'` is exactly what

--- a/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
@@ -6,19 +6,16 @@
  * the certificate the host actually serves. A stale DANE-EE pin (which actively
  * breaks every DANE-validating client, and is DNSSEC-enforced) read as a pass.
  *
- * Full pin verification needs the live leaf/SPKI, which neither this runtime-agnostic
- * package nor the Workers host can obtain today (fetch() exposes no peer certificate;
- * bv-tls-probe returns TLS-version data only; CT tells you what a CA published, not
- * what a server serves). Until a probe extension lands, the finding must be HONEST:
+ * Full pin verification needs the live leaf/SPKI. Until that probe output is wired
+ * into this runtime-agnostic package, the finding must be HONEST:
  * state presence + syntactic validity, state that the certificate match was NOT
  * verified, and carry machine-readable metadata saying so.
  *
  * Pinned here:
- *  1. The info finding never uses the word "Valid" for an unverified pin.
+ *  1. The low finding never uses the word "Valid" for an unverified pin.
  *  2. The detail states the certificate match was not verified.
  *  3. metadata.certificateMatchVerified === false (machine-readable marker).
- *  4. No scoring change: severity stays info; a well-formed TLSA + DNSSEC still
- *     scores 100 with recordPresent true (weight changes are operator-gated).
+ *  4. An unverified pin receives a small deduction instead of full marks.
  *  5. The load-bearing title "DANE TLSA configured for <name>" is unchanged —
  *     maturity staging regex-matches it.
  */
@@ -33,13 +30,14 @@ const SHA256_HASH = '00000000000000000000000000000000000000000000000000000000000
 describe('analyzeTlsaRecords — honest labeling of unverified pins (#841)', () => {
 	it('does not claim "Valid" for a single well-formed record it never verified', () => {
 		const findings = analyzeTlsaRecords([`3 1 1 ${SHA256_HASH}`], '_443._tcp.example.com', true);
-		const info = findings.find((f) => f.severity === 'info');
-		expect(info).toBeDefined();
-		expect(info!.title).toBe('DANE TLSA configured for _443._tcp.example.com');
-		expect(info!.detail).not.toMatch(/valid tlsa/i);
-		expect(info!.detail).toMatch(/does not verify/i);
-		expect(info!.detail).toMatch(/well-formed/i);
-		expect(info!.metadata?.certificateMatchVerified).toBe(false);
+		const unverified = findings.find((f) => f.title.startsWith('DANE TLSA configured'));
+		expect(unverified).toBeDefined();
+		expect(unverified!.severity).toBe('low');
+		expect(unverified!.title).toBe('DANE TLSA configured for _443._tcp.example.com');
+		expect(unverified!.detail).not.toMatch(/valid tlsa/i);
+		expect(unverified!.detail).toMatch(/does not verify/i);
+		expect(unverified!.detail).toMatch(/well-formed/i);
+		expect(unverified!.metadata?.certificateMatchVerified).toBe(false);
 	});
 
 	it('does not overstate stale-pin impact — rejection is conditional on DNSSEC + no matching association (PR #845 review)', () => {
@@ -49,26 +47,26 @@ describe('analyzeTlsaRecords — honest labeling of unverified pins (#841)', () 
 		// set breaks nothing). The prose must not claim unconditional breakage.
 		for (const hasDnssec of [true, false]) {
 			const findings = analyzeTlsaRecords([`3 1 1 ${SHA256_HASH}`], '_443._tcp.example.com', hasDnssec);
-			const info = findings.find((f) => f.severity === 'info');
-			expect(info).toBeDefined();
-			expect(info!.detail).not.toMatch(/which breaks DANE-validating clients/i);
-			expect(info!.detail).toMatch(/DNSSEC-authenticated/);
+			const unverified = findings.find((f) => f.title.startsWith('DANE TLSA configured'));
+			expect(unverified).toBeDefined();
+			expect(unverified!.detail).not.toMatch(/which breaks DANE-validating clients/i);
+			expect(unverified!.detail).toMatch(/DNSSEC-authenticated/);
 		}
 	});
 
 	it('does not claim verification for multiple well-formed records either', () => {
 		const findings = analyzeTlsaRecords([`3 1 1 ${SHA256_HASH}`, `2 0 1 ${SHA256_HASH}`], '_443._tcp.example.com', true);
-		const info = findings.find((f) => f.severity === 'info');
-		expect(info).toBeDefined();
-		expect(info!.detail).not.toMatch(/valid tlsa/i);
-		expect(info!.detail).toMatch(/does not verify/i);
-		expect(info!.metadata?.certificateMatchVerified).toBe(false);
-		expect(info!.metadata?.validRecordCount).toBe(2);
+		const unverified = findings.find((f) => f.title.startsWith('DANE TLSA configured'));
+		expect(unverified).toBeDefined();
+		expect(unverified!.detail).not.toMatch(/valid tlsa/i);
+		expect(unverified!.detail).toMatch(/does not verify/i);
+		expect(unverified!.metadata?.certificateMatchVerified).toBe(false);
+		expect(unverified!.metadata?.validRecordCount).toBe(2);
 	});
 });
 
-describe('checkDANEHTTPS — no scoring change from the relabel (#841)', () => {
-	it('a well-formed DANE-EE pin + DNSSEC still scores 100, but the finding is honest', async () => {
+describe('checkDANEHTTPS — unverified pins do not receive full marks (#841)', () => {
+	it('a well-formed DANE-EE pin + DNSSEC scores 95 until its certificate match is verified', async () => {
 		const queryDNS: DNSQueryFunction = async (name, type) => {
 			if (type === 'TLSA' && name === '_443._tcp.example.com') return [`3 1 1 ${SHA256_HASH}`];
 			return [];
@@ -77,15 +75,16 @@ describe('checkDANEHTTPS — no scoring change from the relabel (#841)', () => {
 
 		const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS });
 
-		expect(result.score).toBe(100);
+		expect(result.score).toBe(95);
 		expect(result.passed).toBe(true);
 		expect(result.recordPresent).toBe(true);
 
-		const info = result.findings.find((f) => f.severity === 'info');
-		expect(info).toBeDefined();
-		expect(info!.category).toBe('dane_https');
-		expect(info!.detail).not.toMatch(/valid tlsa/i);
-		expect(info!.detail).toMatch(/does not verify/i);
-		expect(info!.metadata?.certificateMatchVerified).toBe(false);
+		const unverified = result.findings.find((f) => f.title.startsWith('DANE TLSA configured'));
+		expect(unverified).toBeDefined();
+		expect(unverified!.category).toBe('dane_https');
+		expect(unverified!.severity).toBe('low');
+		expect(unverified!.detail).not.toMatch(/valid tlsa/i);
+		expect(unverified!.detail).toMatch(/does not verify/i);
+		expect(unverified!.metadata?.certificateMatchVerified).toBe(false);
 	});
 });

--- a/packages/dns-checks/src/__tests__/checks/record-present-signal.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/record-present-signal.test.ts
@@ -185,14 +185,14 @@ describe('DNSSEC adoption is readable without the magic 60', () => {
 		expect(r.passed).toBe(true);
 	});
 
-	it('BROKEN chain (DNSKEY, no DS) → recordPresent TRUE, controlPresent false — published but not working', async () => {
+	it('island of trust (DNSKEY, no parent DS) → recordPresent true, controlPresent false', async () => {
 		const r = await checkDNSSEC(D, dnssecResolver({ DNSKEY: ['257 3 13 base64key...'] }), {
 			rawQueryDNS: async () => ({ AD: false }),
 		});
 		expect(r.recordPresent).toBe(true);
 		expect(r.controlPresent).toBe(false);
-		// Broken IS the missing-control zero — distinct from unsigned's 60, and unchanged.
-		expect(r.score).toBe(0);
+		// The delegation is insecure rather than bogus, so it is graded like unsigned.
+		expect(r.score).toBe(60);
 	});
 
 	it('SIGNED and validating → recordPresent true, controlPresent true', async () => {

--- a/packages/dns-checks/src/__tests__/scoring/missing-control-intent.audit.test.ts
+++ b/packages/dns-checks/src/__tests__/scoring/missing-control-intent.audit.test.ts
@@ -117,9 +117,9 @@ const INTENDED_MISSING_CONTROLS: readonly IntendedZeroer[] = [
 		title: 'DNSSEC chain of trust incomplete',
 		category: 'dnssec',
 		reason:
-			'DNSKEY published but no DS in the parent zone — BOGUS to any validating resolver, i.e. worse ' +
-			'than unsigned. Carries an explicit `{ missingControl: true }` and the comment above it states ' +
-			'"explicit missingControl -> score 0". Declared intent, verified in source.',
+			'A parent DS is published while the child DNSKEY is unavailable, so validating resolvers cannot ' +
+			'authenticate the zone. This genuinely bogus branch retains explicit `{ missingControl: true }`; ' +
+			'the DNSKEY-without-parent-DS island now has a distinct graded title.',
 	},
 	{
 		file: 'scoring/classifiers/dmarc.ts',

--- a/packages/dns-checks/src/__tests__/scoring/subject-data-interpolation.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/subject-data-interpolation.spec.ts
@@ -112,20 +112,18 @@ describe('subject data interpolated into finding prose', () => {
 			expect(result.passed).toBe(false);
 		});
 
-		it('check-dnssec.ts:156 "DNSSEC chain of trust incomplete" still zeroes dnssec', async () => {
+		it('check-dnssec.ts island-of-trust detail stays clear of missing-control inference', async () => {
 			const queryDNS = vi.fn(async (_d: string, type: string) =>
 				type === 'DNSKEY' ? ['257 3 13 base64key...'] : [],
 			) as unknown as DNSQueryFunction;
 			const rawQueryDNS = vi.fn(async () => ({ AD: false })) as unknown as RawDNSQueryFunction;
 			const result = await checkDNSSEC('example.com', queryDNS, { rawQueryDNS });
-			const finding = result.findings.find((f) => f.title === 'DNSSEC chain of trust incomplete');
+			const finding = result.findings.find((f) => f.title === 'DNSSEC island of trust');
 			expect(finding).toBeDefined();
-			// The prose route must remain live here even though the site ALSO carries the
-			// explicit flag — it is the prose, not the flag, that reaches engine.ts's
-			// critical-gap ceiling (engine.ts:213-219 does not read metadata.missingControl).
-			expect(scoreIndicatesMissingControl([finding!])).toBe(true);
-			expect(result.score).toBe(0);
-			expect(result.passed).toBe(false);
+			expect(finding?.metadata?.missingControl).toBeUndefined();
+			expect(scoreIndicatesMissingControl([finding!])).toBe(false);
+			expect(result.score).toBe(60);
+			expect(result.passed).toBe(true);
 		});
 
 		it('classifiers/dmarc.ts "No DMARC record found" still zeroes dmarc', () => {
@@ -158,7 +156,7 @@ describe('subject data interpolated into finding prose', () => {
 
 			const chain = await checkDNSSEC(
 				'missingkids.org',
-				vi.fn(async (_d: string, type: string) => (type === 'DNSKEY' ? ['257 3 13 base64key...'] : [])) as unknown as DNSQueryFunction,
+				vi.fn(async (_d: string, type: string) => (type === 'DS' ? ['12345 13 2 abc123'] : [])) as unknown as DNSQueryFunction,
 				{ rawQueryDNS: vi.fn(async () => ({ AD: false })) as unknown as RawDNSQueryFunction },
 			);
 			expect(chain.score).toBe(0);

--- a/packages/dns-checks/src/checks/check-dnssec.ts
+++ b/packages/dns-checks/src/checks/check-dnssec.ts
@@ -150,8 +150,12 @@ export async function checkDNSSEC(
 			),
 		);
 	} else if (dnskeyRecords.length > 0 && dsRecords.length === 0 && !dsQueryFailed) {
-		// DNSKEY published but no DS in parent zone — broken chain. BOGUS to any
-		// validating resolver (worse than unsigned): explicit missingControl → score 0.
+		// DNSKEY published without a parent DS is an island of trust. Validating
+		// resolvers classify the delegation as INSECURE, not BOGUS: the zone gets no
+		// origin authentication, but answers do not fail validation solely because the
+		// parent has not anchored the child. Grade it like an unsigned zone (60) and do
+		// not assert missingControl, which would zero this critical category and cap the
+		// entire domain at grade D.
 		//
 		// ⚠️ The `!dsQueryFailed` gate is LOAD-BEARING. A DS probe that THREW leaves
 		// `dsRecords` empty, which is structurally indistinguishable here from a
@@ -166,10 +170,10 @@ export async function checkDNSSEC(
 		findings.push(
 			createFinding(
 				'dnssec',
-				'DNSSEC chain of trust incomplete',
+				'DNSSEC island of trust',
 				'high',
-				`DNSKEY records are published for ${target} but no DS records exist in the parent zone. The chain of trust is broken — DNSSEC validation will fail.`,
-				{ missingControl: true },
+				`DNSKEY records are published for ${target}, but the parent zone does not publish a DS linkage. Validating resolvers therefore treat the delegation as insecure: answers remain available, but DNSSEC provides no origin authentication until the registrar publishes the DS.`,
+				{ penaltyOverride: 40 },
 			),
 		);
 	} else if (dnskeyRecords.length === 0 && dsRecords.length > 0 && !dnskeyQueryFailed) {

--- a/packages/dns-checks/src/checks/dane-analysis.ts
+++ b/packages/dns-checks/src/checks/dane-analysis.ts
@@ -156,15 +156,16 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 	// data still matches — a stale DANE-EE pin (which breaks every DANE-validating
 	// client) parses identically to a correct one. The wording and the
 	// `certificateMatchVerified: false` marker must keep saying so until a live
-	// leaf/SPKI source exists (fetch() exposes no peer certificate on workerd, and
-	// CT tells you what a CA published, not what a server serves).
+	// leaf/SPKI source is wired into this check. The upstream browser probe can expose
+	// certificate material, but this package does not receive it yet. Presence therefore
+	// earns a small deduction rather than the former unsupported perfect score.
 	if (validRecordCount > 0) {
 		const detail =
 			validRecordCount === 1
 				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection. Confirm the pin matches the live certificate after every certificate rotation.`
 				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Authentication succeeds while any one association still matches, so a single superseded record during a rollover is not itself fatal; where the RRset is DNSSEC-authenticated and none match, DANE-validating clients reject the connection. Confirm each pin matches the live certificate after every certificate rotation.`;
 		findings.push(
-			createFinding('dane', `DANE TLSA configured for ${name}`, 'info', detail, {
+			createFinding('dane', `DANE TLSA configured for ${name}`, 'low', detail, {
 				name,
 				validRecordCount,
 				certificateMatchVerified: false,

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.28.0';
+export const PARITY_CORPUS_VERSION = '1.29.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):
@@ -372,20 +372,20 @@ export const DANE_HTTPS_PARITY_FIXTURES: DaneHttpsParityFixture[] = [
 	},
 	{
 		check: 'dane_https',
-		name: 'valid DANE-EE (3 1 1) + DNSSEC',
+		name: 'well-formed but unverified DANE-EE (3 1 1) + DNSSEC',
 		domain: 'example.com',
 		tlsa: [`3 1 1 ${SHA256_HASH}`],
 		ad: true,
-		expectedScore: 100,
+		expectedScore: 95,
 		expectedMissingControl: false,
 	},
 	{
 		check: 'dane_https',
-		name: 'valid DANE-EE (3 1 1) without DNSSEC',
+		name: 'well-formed but unverified DANE-EE (3 1 1) without DNSSEC',
 		domain: 'example.com',
 		tlsa: [`3 1 1 ${SHA256_HASH}`],
 		ad: false,
-		expectedScore: 75,
+		expectedScore: 70,
 		expectedMissingControl: false,
 	},
 	{
@@ -399,11 +399,11 @@ export const DANE_HTTPS_PARITY_FIXTURES: DaneHttpsParityFixture[] = [
 	},
 	{
 		check: 'dane_https',
-		name: 'PKIX-EE (1 1 1) without DNSSEC',
+		name: 'unverified PKIX-EE (1 1 1) without DNSSEC',
 		domain: 'example.com',
 		tlsa: [`1 1 1 ${SHA256_HASH}`],
 		ad: false,
-		expectedScore: 100,
+		expectedScore: 95,
 		expectedMissingControl: false,
 	},
 ];
@@ -444,23 +444,23 @@ export const DANE_EMAIL_PARITY_FIXTURES: DaneEmailParityFixture[] = [
 	},
 	{
 		check: 'dane',
-		name: 'valid DANE-EE (3 1 1) + DNSSEC on MX',
+		name: 'well-formed but unverified DANE-EE (3 1 1) + DNSSEC on MX',
 		domain: 'example.com',
 		mx: ['10 mail.example.com'],
 		tlsaByHost: { 'mail.example.com': [`3 1 1 ${SHA256_HASH}`] },
 		adByHost: { 'mail.example.com': true },
-		expectedScore: 100,
+		expectedScore: 95,
 		expectedMissingControl: false,
 	},
 	{
-		// DANE-EE without DNSSEC on the MX zone → spoofable → high (−25) → 75.
+		// DANE-EE without DNSSEC is spoofable (−25) and the certificate match is unverified (−5).
 		check: 'dane',
 		name: 'DANE-EE without DNSSEC on MX',
 		domain: 'example.com',
 		mx: ['10 mail.example.com'],
 		tlsaByHost: { 'mail.example.com': [`3 1 1 ${SHA256_HASH}`] },
 		adByHost: { 'mail.example.com': false },
-		expectedScore: 75,
+		expectedScore: 70,
 		expectedMissingControl: false,
 	},
 	{
@@ -631,14 +631,14 @@ export const DNSSEC_PARITY_FIXTURES: DnssecParityFixture[] = [
 	},
 	{
 		check: 'dnssec',
-		name: 'broken chain (DNSKEY, no DS — BOGUS)',
+		name: 'island of trust (DNSKEY, no parent DS — INSECURE)',
 		domain: 'example.com',
 		ad: false,
 		dnskey: ['257 3 13 AwEAAabc'],
 		ds: [],
 		nsec3param: [],
-		expectedScore: 0,
-		expectedMissingControl: true,
+		expectedScore: 60,
+		expectedMissingControl: false,
 	},
 	{
 		check: 'dnssec',

--- a/scripts/ci/check-scoring-version.mjs
+++ b/scripts/ci/check-scoring-version.mjs
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { execFileSync } from 'node:child_process';
+
+const SCORING_SENSITIVE_PREFIXES = [
+	'packages/dns-checks/src/checks/',
+	'packages/dns-checks/src/scoring/',
+];
+const SCORING_VERSION_FILE = 'src/lib/scoring-version.ts';
+const OPT_OUT_MARKER = '[no-scoring-change]';
+
+export function evaluateScoringVersionGate(files, labels = [], pullRequestBody = '') {
+	const touchesScoring = files.some(
+		(file) =>
+			SCORING_SENSITIVE_PREFIXES.some((prefix) => file.startsWith(prefix)) ||
+			(file.startsWith('src/lib/scoring-') && file.endsWith('.ts')),
+	);
+	const versionChanged = files.includes(SCORING_VERSION_FILE);
+	const optedOut = labels.includes('no-scoring-change') || pullRequestBody.toLowerCase().includes(OPT_OUT_MARKER);
+
+	return { touchesScoring, versionChanged, optedOut, needsAttention: touchesScoring && !versionChanged && !optedOut };
+}
+
+function changedFiles(baseSha, headSha) {
+	return execFileSync('git', ['diff', '--name-only', `${baseSha}...${headSha}`], { encoding: 'utf8' })
+		.split('\n')
+		.map((file) => file.trim())
+		.filter(Boolean);
+}
+
+function main() {
+	const [baseSha, headSha] = process.argv.slice(2);
+	if (!baseSha || !headSha) {
+		throw new Error('Usage: node scripts/ci/check-scoring-version.mjs <base-sha> <head-sha>');
+	}
+
+	const labels = JSON.parse(process.env.PR_LABELS_JSON || '[]');
+	const result = evaluateScoringVersionGate(changedFiles(baseSha, headSha), labels, process.env.PR_BODY || '');
+	if (!result.needsAttention) return;
+
+	const message =
+		'Scoring-sensitive files changed without a SCORING_MODEL_VERSION update. ' +
+		'Confirm the change is score-neutral with the no-scoring-change label or [no-scoring-change] in the PR body.';
+	if (process.env.SCORING_GATE_ENFORCE === 'true') {
+		throw new Error(message);
+	}
+	process.stdout.write(`::warning title=Scoring model version review::${message}\n`);
+}
+
+if (process.argv[1]?.endsWith('check-scoring-version.mjs')) main();

--- a/scripts/vitest-node-suites.mjs
+++ b/scripts/vitest-node-suites.mjs
@@ -27,6 +27,7 @@ export const NODE_POOL_AUDIT_TESTS = [
 	'test/audits/private-config-injection.node.test.ts',
 	'test/audits/repo-safety-push-range-scanner.audit.test.ts',
 	'test/audits/score-stability-chaos-script.node.test.ts',
+	'test/audits/scoring-version-gate.node.test.ts',
 	'test/audits/security-capability-inventory.node.test.ts',
 	'test/audits/vitest-workerd-stderr-filter.node.test.ts',
 ];

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -289,8 +289,14 @@
  *   prose regex; findings that already matched prose and all inconclusive results are unchanged.
  *   Affected population is UNMEASURED. No weight, tier, grade band, severity penalty,
  *   profile-detection rule or check roster changed.
+ * - 1.18.0 — corrected two affirmative-safety inversions. A DNSKEY without a parent DS
+ *   is an RFC 4033 insecure delegation, not a bogus chain: it now scores 60 like an
+ *   unsigned zone and no longer arms the critical-gap grade-D ceiling. Well-formed TLSA
+ *   records whose certificate association has not been compared against the served
+ *   certificate now receive a low deduction instead of an unsupported perfect score.
+ *   UPWARD for DNSSEC islands; DOWNWARD for domains publishing unverified TLSA records.
  */
-export const SCORING_MODEL_VERSION = '1.17.0';
+export const SCORING_MODEL_VERSION = '1.18.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/src/tools/check-dnssec.ts
+++ b/src/tools/check-dnssec.ts
@@ -116,12 +116,12 @@ export async function checkDnssec(domain: string, dnsOptions?: QueryDnsOptions, 
 		}
 
 		// Skip augmentation when DNSSEC is definitively absent, failed, or misconfigured at the domain level.
-		// 'DNSSEC chain of trust incomplete' means the domain has DNSKEY but no DS — it is domain-operator-configured
-		// (just broken), not TLD-inherited.
+		// 'DNSSEC island of trust' means the domain has DNSKEY but no parent DS — it is
+		// domain-operator-configured but not anchored, rather than TLD-inherited.
 		// (A transient transport failure already returned above via checkStatus:'error'.)
 		const dnssecAbsent =
 			baseResult.findings.some((f) => f.title === 'DNSSEC not enabled') ||
-			baseResult.findings.some((f) => f.title === 'DNSSEC chain of trust incomplete');
+			baseResult.findings.some((f) => f.title === 'DNSSEC island of trust');
 		if (dnssecAbsent) {
 			return baseResult;
 		}

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -188,7 +188,7 @@ async function checkLookalikesCore(
 
 	const permsToProbe = [...nonDotInsertionPerms, ...filteredDotInsertionPerms];
 
-	// Phase 0 (#850): resolve the SEED's own NS + MX BEFORE the permutation
+	// Phase 0 (#853): resolve the SEED's own NS + MX BEFORE the permutation
 	// fan-out, not alongside it. These two queries used to share a Promise.all
 	// with `filterByNsExistence`, which dispatches ~66 probes in adaptive
 	// batches — so the one lookup that gates every ownership verdict competed

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -37,7 +37,7 @@ export const PHASE1_DNS_OPTS: QueryDnsOptions = {
 };
 
 /**
- * Resilient DNS options for the SEED domain's own NS/MX lookups (#850).
+ * Resilient DNS options for the SEED domain's own NS/MX lookups (#853).
  *
  * The blast radius is what separates these from `PHASE1_DNS_OPTS`, not the
  * record type. A dropped CANDIDATE probe costs one disposable permutation out

--- a/src/tools/scan/format-report.ts
+++ b/src/tools/scan/format-report.ts
@@ -305,7 +305,7 @@ export function buildStructuredScanResult(result: ScanDomainResult, enrichment?:
 		// so only a genuinely validated/configured zone (no deficiency finding) defaults
 		// to `domain_configured`.
 		const dnssecDeficient = dnssecCheck.findings.some(
-			(f) => f.title === 'DNSSEC not enabled' || f.title === 'DNSSEC chain of trust incomplete' || f.title === 'DNSSEC validation failing',
+			(f) => f.title === 'DNSSEC not enabled' || f.title === 'DNSSEC island of trust' || f.title === 'DNSSEC chain of trust incomplete' || f.title === 'DNSSEC validation failing',
 		);
 		if (dnssecSource === null && dnssecCheck.passed && !dnssecDeficient && isCompletedCheck(dnssecCheck)) {
 			dnssecSource = 'domain_configured';

--- a/test/audits/scoring-version-gate.node.test.ts
+++ b/test/audits/scoring-version-gate.node.test.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { evaluateScoringVersionGate } from '../../scripts/ci/check-scoring-version.mjs';
+
+describe('scoring-version PR advisory', () => {
+	it('flags scoring-sensitive changes without a model-version decision', () => {
+		expect(evaluateScoringVersionGate(['packages/dns-checks/src/checks/check-dnssec.ts']).needsAttention).toBe(true);
+	});
+
+	it('accepts a scoring-model version change in the same diff', () => {
+		const result = evaluateScoringVersionGate([
+			'packages/dns-checks/src/scoring/engine.ts',
+			'src/lib/scoring-version.ts',
+		]);
+		expect(result.needsAttention).toBe(false);
+		expect(result.versionChanged).toBe(true);
+	});
+
+	it('accepts either explicit opt-out mechanism', () => {
+		expect(evaluateScoringVersionGate(['src/lib/scoring-policy.ts'], ['no-scoring-change']).needsAttention).toBe(false);
+		expect(evaluateScoringVersionGate(['packages/dns-checks/src/checks/check-caa.ts'], [], '[no-scoring-change]').needsAttention).toBe(
+			false,
+		);
+	});
+
+	it('ignores unrelated changes', () => {
+		expect(evaluateScoringVersionGate(['docs/scoring.md']).needsAttention).toBe(false);
+	});
+});

--- a/test/check-dane-https.spec.ts
+++ b/test/check-dane-https.spec.ts
@@ -18,7 +18,7 @@ describe('checkDaneHttps', () => {
 		return checkDaneHttps(domain);
 	}
 
-	it('should return info finding when HTTPS TLSA record is present with DNSSEC', async () => {
+	it('should return an unverified-pin finding when HTTPS TLSA is present with DNSSEC', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 
@@ -40,9 +40,10 @@ describe('checkDaneHttps', () => {
 		const result = await run();
 		expect(result.category).toBe('dane_https');
 		expect(result.passed).toBe(true);
-		const infoFindings = result.findings.filter((f) => f.severity === 'info');
-		expect(infoFindings.length).toBeGreaterThanOrEqual(1);
-		expect(infoFindings[0].title).toContain('DANE TLSA configured');
+		const unverified = result.findings.find((f) => f.title.includes('DANE TLSA configured'));
+		expect(unverified).toBeDefined();
+		expect(unverified?.severity).toBe('low');
+		expect(result.score).toBe(95);
 	});
 
 	it('should return high finding when TLSA present but no DNSSEC', async () => {

--- a/test/check-dane.spec.ts
+++ b/test/check-dane.spec.ts
@@ -50,9 +50,11 @@ describe('checkDane', () => {
 		const result = await run();
 		expect(result.category).toBe('dane');
 		expect(result.passed).toBe(true);
-		// Should have info findings for MX TLSA (HTTPS DANE is handled by check-dane-https)
-		const infoFindings = result.findings.filter((f) => f.severity === 'info');
-		expect(infoFindings.length).toBeGreaterThanOrEqual(1);
+		// The pin is present but has not been compared with the served certificate.
+		const unverified = result.findings.find((f) => f.title.includes('DANE TLSA configured'));
+		expect(unverified).toBeDefined();
+		expect(unverified?.severity).toBe('low');
+		expect(result.score).toBe(95);
 	});
 
 	it('should return high finding when DANE exists but no DNSSEC', async () => {

--- a/test/check-dnssec.spec.ts
+++ b/test/check-dnssec.spec.ts
@@ -102,11 +102,13 @@ describe('DNSSEC finding consolidation', () => {
 		expect(result.score).toBe(60);
 	});
 
-	it('emits HIGH when DNSKEY present but DS missing', async () => {
+	it('emits a graded HIGH island finding when DNSKEY is present without a parent DS', async () => {
 		// AD=false, DNSKEY present, no DS
 		mockDnssecResponses(false, true, false);
 		const result = await run();
-		expect(result.findings.some((f) => f.title === 'DNSSEC chain of trust incomplete' && f.severity === 'high')).toBe(true);
+		expect(result.findings.some((f) => f.title === 'DNSSEC island of trust' && f.severity === 'high')).toBe(true);
+		expect(result.score).toBe(60);
+		expect(result.findings.some((f) => f.metadata?.missingControl === true)).toBe(false);
 	});
 
 	it('does NOT add tld_inherited finding when chain-of-trust is incomplete', async () => {

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -2329,7 +2329,7 @@ describe('isSameEntityOrgMatch - fix round 2 residual (direct semantic pin)', ()
 		}
 	});
 
-	// #850 — the seed NS lookup gates EVERY ownership verdict: when it fails,
+	// #853 — the seed NS lookup gates EVERY ownership verdict: when it fails,
 	// all candidates degrade to `unmeasured` and impersonation-shaped findings
 	// are withheld wholesale. It was issued with PHASE1_DNS_OPTS (retries: 0,
 	// timeoutMs: 2000) inside the SAME Promise.all as the 66-permutation
@@ -2338,7 +2338,7 @@ describe('isSameEntityOrgMatch - fix round 2 residual (direct semantic pin)', ()
 	// 2026-08-31: meta.com reported `seedNsUnresolved: true` on 2/2 idle runs
 	// while a standalone DoH NS query for meta.com returned 4 answers.
 	// The seed must survive ONE transient failure; the fan-out may not need to.
-	it('retries the seed NS lookup so one transient failure does not void every ownership verdict (#850)', async () => {
+	it('retries the seed NS lookup so one transient failure does not void every ownership verdict (#853)', async () => {
 		let seedNsAttempts = 0;
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const { name, type } = parseDohQuery(input);
@@ -2355,7 +2355,7 @@ describe('isSameEntityOrgMatch - fix round 2 residual (direct semantic pin)', ()
 
 			// One registered candidate sharing the seed's nameservers — it can
 			// only be attributed if the seed NS resolved.
-			if (name === 'tset.com') {
+			if (name === 'tes.com') {
 				if (isNs) {
 					return Promise.resolve(
 						createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.seedowner.com.' }]),
@@ -2381,6 +2381,9 @@ describe('isSameEntityOrgMatch - fix round 2 residual (direct semantic pin)', ()
 		// And no candidate was degraded to `unmeasured` by a seed failure.
 		const unmeasured = result.findings.filter((f) => f.metadata?.ownershipVerdict === 'unmeasured');
 		expect(unmeasured).toHaveLength(0);
+		const attributedCandidate = result.findings.find((f) => f.metadata?.lookalikeDomain === 'tes.com');
+		expect(attributedCandidate).toBeDefined();
+		expect(attributedCandidate?.metadata?.ownershipVerdict).not.toBe('unmeasured');
 	});
 
 });

--- a/test/oauth/register-rate-limit.spec.ts
+++ b/test/oauth/register-rate-limit.spec.ts
@@ -13,6 +13,12 @@ import { clearKvPrefix } from '../helpers/kv';
 const VALID_BODY = JSON.stringify({ redirect_uris: ['https://claude.ai/cb'] });
 const HEADERS = { 'Content-Type': 'application/json' };
 
+function uniqueRateLimitIp(): string {
+	const words = new Uint16Array(4);
+	crypto.getRandomValues(words);
+	return `2001:db8:0:0:${Array.from(words, (word) => word.toString(16)).join(':')}`;
+}
+
 beforeEach(async () => {
 	await clearKvPrefix(env.SESSION_STORE, 'oauth:');
 	await resetQuotaCoordinatorState(env.QUOTA_COORDINATOR);
@@ -33,7 +39,7 @@ function register(ip: string): Promise<Response> {
 
 describe('POST /oauth/register — per-IP rate limit', () => {
 	it('allows 10 registrations from the same IP then blocks the 11th with 429', async () => {
-		const ip = '203.0.113.1';
+		const ip = uniqueRateLimitIp();
 
 		// Drive 10 successful requests.
 		for (let i = 0; i < 10; i++) {
@@ -57,8 +63,8 @@ describe('POST /oauth/register — per-IP rate limit', () => {
 	});
 
 	it('allows a different IP to register after the first IP is blocked', async () => {
-		const blockedIp = '203.0.113.2';
-		const allowedIp = '198.51.100.9';
+		const blockedIp = uniqueRateLimitIp();
+		const allowedIp = uniqueRateLimitIp();
 
 		// Exhaust the limit for blockedIp.
 		for (let i = 0; i < 10; i++) {
@@ -73,7 +79,8 @@ describe('POST /oauth/register — per-IP rate limit', () => {
 	});
 
 	it('admits exactly 10 registrations from a concurrent same-IP burst', async () => {
-		const responses = await Promise.all(Array.from({ length: 25 }, () => register('203.0.113.77')));
+		const ip = uniqueRateLimitIp();
+		const responses = await Promise.all(Array.from({ length: 25 }, () => register(ip)));
 		const statuses = responses.map((response) => response.status);
 		expect(statuses.filter((status) => status === 201)).toHaveLength(10);
 		expect(statuses.filter((status) => status === 429)).toHaveLength(15);

--- a/test/oauth/token.spec.ts
+++ b/test/oauth/token.spec.ts
@@ -12,6 +12,12 @@ const TEST_SIGNING_SECRET = 'a'.repeat(32);
 type TestEnv = typeof env & { BV_API_KEY?: string; OAUTH_SIGNING_SECRET?: string };
 const authEnv = { ...env, BV_API_KEY: TEST_API_KEY, OAUTH_SIGNING_SECRET: TEST_SIGNING_SECRET } as TestEnv;
 
+function uniqueRateLimitIp(): string {
+	const words = new Uint16Array(4);
+	crypto.getRandomValues(words);
+	return `2001:db8:0:0:${Array.from(words, (word) => word.toString(16)).join(':')}`;
+}
+
 function base64url(buf: ArrayBuffer): string {
 	const b = new Uint8Array(buf);
 	let s = '';
@@ -420,7 +426,7 @@ describe('POST /oauth/token', () => {
 		// with a bogus code so each one short-circuits at invalid_grant (cheap path) — the rate
 		// limiter check runs BEFORE content-type / grant-type / Zod parsing, so the status
 		// progression is deterministic regardless of downstream validation.
-		const ip = '203.0.113.42';
+		const ip = uniqueRateLimitIp();
 		const body = new URLSearchParams({
 			grant_type: 'authorization_code',
 			code: 'never-issued',
@@ -460,9 +466,8 @@ describe('POST /oauth/token', () => {
 			redirect_uri: 'https://claude.ai/cb',
 			code_verifier: 'v'.repeat(43),
 		});
-		const responses = await Promise.all(
-			Array.from({ length: 50 }, () => postToken(body, authEnv, { 'cf-connecting-ip': '203.0.113.78' })),
-		);
+		const ip = uniqueRateLimitIp();
+		const responses = await Promise.all(Array.from({ length: 50 }, () => postToken(body, authEnv, { 'cf-connecting-ip': ip })));
 		const statuses = responses.map((response) => response.status);
 		expect(statuses.filter((status) => status === 400)).toHaveLength(30);
 		expect(statuses.filter((status) => status === 429)).toHaveLength(20);


### PR DESCRIPTION
## Summary

- classify DNSKEY-without-parent-DS as an insecure island of trust rather than a bogus chain, removing the false grade-D ceiling
- deduct five points for syntactically valid TLSA pins until the served-certificate association is actually verified
- isolate OAuth rate-limit tests with per-test documentation-range IPv6 buckets
- add an advisory scoring-version diff check with explicit opt-out mechanisms
- repair the lookalike seed-NS regression test so it exercises a generated candidate
- advance the scoring model to 1.18.0 and dns-checks/parity corpus to 1.29.0

## Verification

- npm run audit:repo-safety
- npm run build
- npm run typecheck
- npm run lint
- npm run validate:internal-deps
- focused Worker/package suites: 264 tests passed
- full suite: 8,330 passed; two intentional stale assertions found, corrected, and re-run green; isolated-worktree WASM resolver remains environment-only because it resolves the crate at /private/tmp/crates rather than the worktree

Closes #851
Closes #856
Closes #857
Closes #858

Progresses #841 and #855; their cross-repository follow-ups remain open.