### PR TITLE
feat(scoring): publish immutable behavior contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
           cache: npm
 
       - run: npm ci
+      - run: npm run check:scoring-contract-change
       - run: npm run build --workspace=packages/dns-checks
 
       - name: Cache Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
 
       - run: npm ci
       - run: npm run check:scoring-contract-change
+        env:
+          SCORING_CONTRACT_BASE_REF: ${{ github.event.pull_request.base.sha || github.event.before }}
       - run: npm run build --workspace=packages/dns-checks
 
       - name: Cache Rust

--- a/.github/workflows/dns-checks-release.yml
+++ b/.github/workflows/dns-checks-release.yml
@@ -1,0 +1,69 @@
+name: Release dns-checks contract
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Exact dns-checks package version to release
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: dns-checks-v${{ inputs.version }}
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+      - run: npm run build --workspace=packages/dns-checks
+
+      - name: Verify exact tagged version
+        env:
+          EXPECTED_VERSION: ${{ inputs.version }}
+        run: |
+          ACTUAL_VERSION="$(node -p "require('./packages/dns-checks/package.json').version")"
+          test "$ACTUAL_VERSION" = "$EXPECTED_VERSION"
+          test "$(git describe --tags --exact-match HEAD)" = "dns-checks-v$EXPECTED_VERSION"
+
+      - name: Pack immutable artifact and checksum
+        id: pack
+        run: |
+          TARBALL="$(npm pack --workspace=packages/dns-checks --json | jq -r '.[0].filename')"
+          SHA256="$(sha256sum "$TARBALL" | cut -d ' ' -f 1)"
+          printf '%s  %s\n' "$SHA256" "$TARBALL" > "$TARBALL.sha256"
+          printf 'tarball=%s\nsha256=%s\n' "$TARBALL" "$SHA256" >> "$GITHUB_OUTPUT"
+
+      - name: Create immutable release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ inputs.version }}
+          TARBALL: ${{ steps.pack.outputs.tarball }}
+        run: >-
+          gh release create "dns-checks-v$VERSION" "$TARBALL" "$TARBALL.sha256"
+          --verify-tag --title "@blackveil/dns-checks $VERSION"
+          --notes "Immutable scoring artifact. Consumers must verify the attached SHA-256 before installation."
+
+      - name: Request bv-web-prod promotion PR
+        env:
+          GH_TOKEN: ${{ secrets.BV_WEB_PROD_REPO_TOKEN }}
+          VERSION: ${{ inputs.version }}
+          SHA256: ${{ steps.pack.outputs.sha256 }}
+          SOURCE_COMMIT: ${{ github.sha }}
+        run: |
+          test -n "$GH_TOKEN"
+          gh api repos/MadaBurns/bv-web-prod/dispatches --method POST \
+            -f event_type=dns-checks-released \
+            -f "client_payload[version]=$VERSION" \
+            -f "client_payload[sha256]=$SHA256" \
+            -f "client_payload[source_commit]=$SOURCE_COMMIT" \
+            -f "client_payload[release_tag]=dns-checks-v$VERSION"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5126,7 +5126,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.29.0",
+			"version": "1.30.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.4.3"

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 		"check:deploy-freshness": "tsx scripts/ci/deploy-freshness-check.ts",
 		"check:release-integrity": "tsx scripts/ci/release-integrity-check.ts --mode deploy",
 		"check:release-integrity:publish": "tsx scripts/ci/release-integrity-check.ts --mode publish",
+		"check:scoring-contract-change": "tsx scripts/ci/scoring-contract-change-check.ts",
 		"prepack": "npm run check:release-integrity:publish",
 		"publish:registry": "npm run check:release-integrity:publish && mcp-publisher publish",
 		"check:bindings": "npm run typecheck",

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.29.0",
+	"version": "1.30.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/scoring-contract.test.ts
+++ b/packages/dns-checks/src/__tests__/scoring-contract.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { PARITY_CORPUS_VERSION } from '../parity-fixtures';
+import { PROFILE_SEMANTICS, SCORING_CONTRACT, canonicalScoringContractJson } from '../scoring/contract';
+
+describe('machine-readable scoring contract', () => {
+	it('identifies the exact package behavior version', () => {
+		expect(SCORING_CONTRACT.packageVersion).toBe(PARITY_CORPUS_VERSION);
+	});
+
+	it('defines comparison and selection semantics for every profile', () => {
+		expect(Object.keys(SCORING_CONTRACT.profiles).sort()).toEqual(Object.keys(PROFILE_SEMANTICS).sort());
+		expect(PROFILE_SEMANTICS.web_only.emailPostureIncluded).toBe(false);
+		expect(PROFILE_SEMANTICS.minimal.comparisonClass).toBe('limited-footprint');
+		expect(PROFILE_SEMANTICS.authoritative_dns_infra.autoSelectable).toBe(false);
+	});
+
+	it('serializes deterministically with sorted object keys', () => {
+		const first = canonicalScoringContractJson();
+		expect(canonicalScoringContractJson()).toBe(first);
+		expect(first.endsWith('\n')).toBe(true);
+		expect(first.indexOf('enterprise_mail')).toBeLessThan(first.indexOf('mail_enabled'));
+	});
+});

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.29.0';
+export const PARITY_CORPUS_VERSION = '1.30.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/packages/dns-checks/src/scoring/contract.ts
+++ b/packages/dns-checks/src/scoring/contract.ts
@@ -2,12 +2,7 @@
 
 import { PARITY_CORPUS_VERSION } from '../parity-fixtures';
 import { NIST_GRADE_THRESHOLDS } from './engine';
-import {
-	PROFILE_CRITICAL_CATEGORIES,
-	PROFILE_EMAIL_BONUS_ELIGIBLE,
-	PROFILE_WEIGHTS,
-	type DomainProfile,
-} from './profiles';
+import { PROFILE_CRITICAL_CATEGORIES, PROFILE_EMAIL_BONUS_ELIGIBLE, PROFILE_WEIGHTS, type DomainProfile } from './profiles';
 
 export const SCORING_CONTRACT_SCHEMA_VERSION = 1;
 
@@ -20,44 +15,66 @@ export interface ScoringProfileSemantics {
 	selectionReason: string;
 }
 
-export const PROFILE_SEMANTICS: Readonly<Record<DomainProfile, ScoringProfileSemantics>> = Object.freeze({
-	mail_enabled: {
-		comparisonClass: 'ordinary-domain',
-		emailPostureIncluded: true,
-		autoSelectable: true,
-		selectionReason: 'mail-routing-detected',
-	},
-	enterprise_mail: {
-		comparisonClass: 'ordinary-domain',
-		emailPostureIncluded: true,
-		autoSelectable: true,
-		selectionReason: 'enterprise-mail-and-enforcing-dmarc-detected',
-	},
-	non_mail: {
-		comparisonClass: 'ordinary-domain',
-		emailPostureIncluded: true,
-		autoSelectable: true,
-		selectionReason: 'no-receiving-mail-or-web-presence-detected',
-	},
-	web_only: {
-		comparisonClass: 'ordinary-domain',
-		emailPostureIncluded: false,
-		autoSelectable: true,
-		selectionReason: 'web-presence-without-receiving-mail-detected',
-	},
-	minimal: {
-		comparisonClass: 'limited-footprint',
-		emailPostureIncluded: true,
-		autoSelectable: true,
-		selectionReason: 'more-than-half-of-measured-checks-failed',
-	},
-	authoritative_dns_infra: {
-		comparisonClass: 'specialist-dns',
-		emailPostureIncluded: false,
-		autoSelectable: false,
-		selectionReason: 'explicit-specialist-profile-only',
-	},
-});
+const PROFILE_SEMANTIC_ENTRIES: ReadonlyArray<readonly [DomainProfile, ScoringProfileSemantics]> = [
+	[
+		'mail_enabled',
+		{
+			comparisonClass: 'ordinary-domain',
+			emailPostureIncluded: true,
+			autoSelectable: true,
+			selectionReason: 'mail-routing-detected',
+		},
+	],
+	[
+		'enterprise_mail',
+		{
+			comparisonClass: 'ordinary-domain',
+			emailPostureIncluded: true,
+			autoSelectable: true,
+			selectionReason: 'enterprise-mail-and-enforcing-dmarc-detected',
+		},
+	],
+	[
+		'non_mail',
+		{
+			comparisonClass: 'ordinary-domain',
+			emailPostureIncluded: true,
+			autoSelectable: true,
+			selectionReason: 'no-receiving-mail-or-web-presence-detected',
+		},
+	],
+	[
+		'web_only',
+		{
+			comparisonClass: 'ordinary-domain',
+			emailPostureIncluded: false,
+			autoSelectable: true,
+			selectionReason: 'web-presence-without-receiving-mail-detected',
+		},
+	],
+	[
+		'minimal',
+		{
+			comparisonClass: 'limited-footprint',
+			emailPostureIncluded: true,
+			autoSelectable: true,
+			selectionReason: 'more-than-half-of-measured-checks-failed',
+		},
+	],
+	[
+		'authoritative_dns_infra',
+		{
+			comparisonClass: 'specialist-dns',
+			emailPostureIncluded: false,
+			autoSelectable: false,
+			selectionReason: 'explicit-specialist-profile-only',
+		},
+	],
+];
+
+export const PROFILE_SEMANTICS = Object.freeze(Object.fromEntries(PROFILE_SEMANTIC_ENTRIES)) as Readonly<
+	Record<DomainProfile, ScoringProfileSemantics>
+>;
 
 /**
  * Machine-readable scoring behavior contract. Object keys are normalized by
@@ -75,9 +92,9 @@ export const SCORING_CONTRACT = Object.freeze({
 				criticalCategories: PROFILE_CRITICAL_CATEGORIES[profile],
 				emailBonusEligible: PROFILE_EMAIL_BONUS_ELIGIBLE[profile],
 				semantics: PROFILE_SEMANTICS[profile],
-				},
-			]),
-		),
+			},
+		]),
+	),
 });
 
 function normalize(value: unknown): unknown {

--- a/packages/dns-checks/src/scoring/contract.ts
+++ b/packages/dns-checks/src/scoring/contract.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { PARITY_CORPUS_VERSION } from '../parity-fixtures';
+import { NIST_GRADE_THRESHOLDS } from './engine';
+import {
+	PROFILE_CRITICAL_CATEGORIES,
+	PROFILE_EMAIL_BONUS_ELIGIBLE,
+	PROFILE_WEIGHTS,
+	type DomainProfile,
+} from './profiles';
+
+export const SCORING_CONTRACT_SCHEMA_VERSION = 1;
+
+export type ProfileComparisonClass = 'ordinary-domain' | 'limited-footprint' | 'specialist-dns';
+
+export interface ScoringProfileSemantics {
+	comparisonClass: ProfileComparisonClass;
+	emailPostureIncluded: boolean;
+	autoSelectable: boolean;
+	selectionReason: string;
+}
+
+export const PROFILE_SEMANTICS: Readonly<Record<DomainProfile, ScoringProfileSemantics>> = Object.freeze({
+	mail_enabled: {
+		comparisonClass: 'ordinary-domain',
+		emailPostureIncluded: true,
+		autoSelectable: true,
+		selectionReason: 'mail-routing-detected',
+	},
+	enterprise_mail: {
+		comparisonClass: 'ordinary-domain',
+		emailPostureIncluded: true,
+		autoSelectable: true,
+		selectionReason: 'enterprise-mail-and-enforcing-dmarc-detected',
+	},
+	non_mail: {
+		comparisonClass: 'ordinary-domain',
+		emailPostureIncluded: true,
+		autoSelectable: true,
+		selectionReason: 'no-receiving-mail-or-web-presence-detected',
+	},
+	web_only: {
+		comparisonClass: 'ordinary-domain',
+		emailPostureIncluded: false,
+		autoSelectable: true,
+		selectionReason: 'web-presence-without-receiving-mail-detected',
+	},
+	minimal: {
+		comparisonClass: 'limited-footprint',
+		emailPostureIncluded: true,
+		autoSelectable: true,
+		selectionReason: 'more-than-half-of-measured-checks-failed',
+	},
+	authoritative_dns_infra: {
+		comparisonClass: 'specialist-dns',
+		emailPostureIncluded: false,
+		autoSelectable: false,
+		selectionReason: 'explicit-specialist-profile-only',
+	},
+});
+
+/**
+ * Machine-readable scoring behavior contract. Object keys are normalized by
+ * `canonicalScoringContractJson`; release tooling hashes those canonical bytes.
+ */
+export const SCORING_CONTRACT = Object.freeze({
+	schemaVersion: SCORING_CONTRACT_SCHEMA_VERSION,
+	packageVersion: PARITY_CORPUS_VERSION,
+	gradeThresholds: NIST_GRADE_THRESHOLDS,
+	profiles: Object.fromEntries(
+		(Object.keys(PROFILE_WEIGHTS) as DomainProfile[]).map((profile) => [
+			profile,
+			{
+				weights: PROFILE_WEIGHTS[profile],
+				criticalCategories: PROFILE_CRITICAL_CATEGORIES[profile],
+				emailBonusEligible: PROFILE_EMAIL_BONUS_ELIGIBLE[profile],
+				semantics: PROFILE_SEMANTICS[profile],
+				},
+			]),
+		),
+});
+
+function normalize(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(normalize);
+	if (value !== null && typeof value === 'object') {
+		return Object.fromEntries(
+			Object.entries(value as Record<string, unknown>)
+				.sort(([left], [right]) => left.localeCompare(right))
+				.map(([key, child]) => [key, normalize(child)]),
+		);
+	}
+	return value;
+}
+
+/** Stable bytes used for hashing, attestation and cross-repository comparison. */
+export function canonicalScoringContractJson(): string {
+	return `${JSON.stringify(normalize(SCORING_CONTRACT), null, 2)}\n`;
+}

--- a/packages/dns-checks/src/scoring/index.ts
+++ b/packages/dns-checks/src/scoring/index.ts
@@ -45,7 +45,15 @@ export {
 	detectDomainContext,
 	getProfileWeights,
 } from './profiles';
-export type { DomainProfile, DomainContext } from './profiles';
+export type { DomainProfile, DomainContext, ImportanceProfile } from './profiles';
+
+export {
+	SCORING_CONTRACT,
+	SCORING_CONTRACT_SCHEMA_VERSION,
+	PROFILE_SEMANTICS,
+	canonicalScoringContractJson,
+} from './contract';
+export type { ProfileComparisonClass, ScoringProfileSemantics } from './contract';
 
 export {
 	sanitizeFindingMetadata,

--- a/packages/dns-checks/src/scoring/profiles.ts
+++ b/packages/dns-checks/src/scoring/profiles.ts
@@ -29,7 +29,7 @@ export interface DomainContext {
 	detectedProvider: string | null;
 }
 
-interface ImportanceProfile {
+export interface ImportanceProfile {
 	importance: number;
 }
 

--- a/scripts/ci/dns-checks-prepack.ts
+++ b/scripts/ci/dns-checks-prepack.ts
@@ -30,9 +30,11 @@
 
 import { spawnSync } from 'node:child_process';
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { assessPackIntegrity, buildBuildInfo } from '../pack-integrity';
+import { canonicalScoringContractJson } from '../../packages/dns-checks/src/scoring/contract';
 
 /**
  * Resolve the repo root from this file's own location rather than from cwd.
@@ -96,11 +98,14 @@ function main(): void {
 
 	if (verdict.code === 'override') console.error(`\n${verdict.message}\n`);
 
+	const contractJson = canonicalScoringContractJson();
+	const scoringContractSha256 = createHash('sha256').update(contractJson).digest('hex');
 	const buildInfo = buildBuildInfo({
 		name: pkgName,
 		version: workingVersion ?? '0.0.0',
 		commit: verdict.commit,
 		provenance: verdict.provenance,
+		scoringContractSha256,
 	});
 
 	const distDir = join(PKG_DIR, 'dist');
@@ -109,8 +114,12 @@ function main(): void {
 	// same commit reproduces byte-identical output and the downstream sha256 pin
 	// stays meaningful.
 	writeFileSync(join(distDir, 'BUILD_INFO.json'), `${JSON.stringify(buildInfo, null, 2)}\n`, 'utf8');
+	writeFileSync(join(distDir, 'SCORING_CONTRACT.json'), contractJson, 'utf8');
 
-	console.log(`${verdict.message}\nStamped dist/BUILD_INFO.json (provenance=${buildInfo.provenance}).`);
+	console.log(
+		`${verdict.message}\nStamped dist/BUILD_INFO.json and dist/SCORING_CONTRACT.json ` +
+			`(contract sha256=${scoringContractSha256}).`,
+	);
 }
 
 main();

--- a/scripts/ci/scoring-contract-change-check.ts
+++ b/scripts/ci/scoring-contract-change-check.ts
@@ -17,9 +17,9 @@ function versionFromJson(text: string): string | null {
 	}
 }
 
-const baseRef = process.env.GITHUB_BASE_REF
-	? `origin/${process.env.GITHUB_BASE_REF}`
-	: process.env.SCORING_CONTRACT_BASE_REF;
+const baseRef =
+	process.env.SCORING_CONTRACT_BASE_REF ??
+	(process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : undefined);
 
 if (!baseRef) {
 	console.log('scoring-contract change gate: no base ref supplied; source contract self-tests remain active.');

--- a/scripts/ci/scoring-contract-change-check.ts
+++ b/scripts/ci/scoring-contract-change-check.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { assessScoringContractChange } from '../scoring-contract-change';
+
+function git(args: string[]): string {
+	return execFileSync('git', args, { encoding: 'utf8' }).trim();
+}
+
+function versionFromJson(text: string): string | null {
+	try {
+		const value = (JSON.parse(text) as { version?: unknown }).version;
+		return typeof value === 'string' ? value : null;
+	} catch {
+		return null;
+	}
+}
+
+const baseRef = process.env.GITHUB_BASE_REF
+	? `origin/${process.env.GITHUB_BASE_REF}`
+	: process.env.SCORING_CONTRACT_BASE_REF;
+
+if (!baseRef) {
+	console.log('scoring-contract change gate: no base ref supplied; source contract self-tests remain active.');
+	process.exit(0);
+}
+
+const packagePath = 'packages/dns-checks/package.json';
+const changedPaths = git(['diff', '--name-only', `${baseRef}...HEAD`]).split('\n').filter(Boolean);
+const violations = assessScoringContractChange({
+	changedPaths,
+	baseVersion: versionFromJson(git(['show', `${baseRef}:${packagePath}`])),
+	headVersion: versionFromJson(readFileSync(packagePath, 'utf8')),
+});
+
+if (violations.length > 0) {
+	console.error(`scoring-contract change gate: BLOCKED\n- ${violations.join('\n- ')}`);
+	process.exit(1);
+}
+
+console.log('scoring-contract change gate: OK');

--- a/scripts/pack-integrity.ts
+++ b/scripts/pack-integrity.ts
@@ -77,7 +77,7 @@ export interface PackIntegrityVerdict {
 const OVERRIDE_ENV = 'BV_ALLOW_UNCOMMITTED_PACK';
 
 /** Current shape of `dist/BUILD_INFO.json`. Bump when fields change meaning. */
-export const BUILD_INFO_SCHEMA = 1;
+export const BUILD_INFO_SCHEMA = 2;
 
 export interface BuildInfo {
 	schema: number;
@@ -86,6 +86,8 @@ export interface BuildInfo {
 	/** Full 40-hex commit these bytes were packed from, or null under an override. */
 	commit: string | null;
 	provenance: Provenance;
+	/** SHA-256 of dist/SCORING_CONTRACT.json. */
+	scoringContractSha256: string;
 }
 
 /**
@@ -102,13 +104,20 @@ export interface BuildInfo {
  * tarball produced under duress still says so, in the tarball, forever — which
  * is precisely what 1.18.0 could not do.
  */
-export function buildBuildInfo(input: { name: string; version: string; commit: string | null; provenance: Provenance }): BuildInfo {
+export function buildBuildInfo(input: {
+	name: string;
+	version: string;
+	commit: string | null;
+	provenance: Provenance;
+	scoringContractSha256: string;
+}): BuildInfo {
 	return {
 		schema: BUILD_INFO_SCHEMA,
 		name: input.name,
 		version: input.version,
 		commit: input.provenance === 'committed' ? input.commit : null,
 		provenance: input.provenance,
+		scoringContractSha256: input.scoringContractSha256,
 	};
 }
 

--- a/scripts/scoring-contract-change.ts
+++ b/scripts/scoring-contract-change.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+export interface ScoringChangeInput {
+	changedPaths: string[];
+	baseVersion: string | null;
+	headVersion: string | null;
+}
+
+const BEHAVIOR_PATHS = [
+	'packages/dns-checks/src/scoring/',
+	'packages/dns-checks/src/parity-fixtures.ts',
+	'packages/dns-checks/src/types.ts',
+];
+
+export function assessScoringContractChange(input: ScoringChangeInput): string[] {
+	const behaviorChanged = input.changedPaths.some((path) =>
+		BEHAVIOR_PATHS.some((prefix) => path === prefix || path.startsWith(prefix)),
+	);
+	if (!behaviorChanged) return [];
+	if (!input.baseVersion || !input.headVersion) {
+		return ['could not resolve both base and head dns-checks versions'];
+	}
+	if (input.baseVersion === input.headVersion) {
+		return [
+			`scoring behavior changed while @blackveil/dns-checks remained at ${input.headVersion}`,
+			'bump packages/dns-checks/package.json and PARITY_CORPUS_VERSION in the same PR',
+		];
+	}
+	return [];
+}

--- a/test/pack-integrity.spec.ts
+++ b/test/pack-integrity.spec.ts
@@ -140,31 +140,32 @@ describe('assessPackIntegrity — the override self-incriminates rather than hid
 
 describe('buildBuildInfo — the provenance stamp', () => {
 	it('records the source commit for a committed pack', () => {
-		const info = buildBuildInfo({ name: '@blackveil/dns-checks', version: VERSION, commit: COMMIT, provenance: 'committed' });
+		const info = buildBuildInfo({ name: '@blackveil/dns-checks', version: VERSION, commit: COMMIT, provenance: 'committed', scoringContractSha256: 'a'.repeat(64) });
 		expect(info).toEqual({
 			schema: BUILD_INFO_SCHEMA,
 			name: '@blackveil/dns-checks',
 			version: VERSION,
 			commit: COMMIT,
 			provenance: 'committed',
+			scoringContractSha256: 'a'.repeat(64),
 		});
 	});
 
 	it('refuses to record a commit for an overridden pack even if one is passed', () => {
 		// Defence in depth: a caller that forwards HEAD regardless must not be able
 		// to make an unverified tarball claim a reviewable source commit.
-		const info = buildBuildInfo({ name: '@blackveil/dns-checks', version: VERSION, commit: COMMIT, provenance: 'uncommitted-override' });
+		const info = buildBuildInfo({ name: '@blackveil/dns-checks', version: VERSION, commit: COMMIT, provenance: 'uncommitted-override', scoringContractSha256: 'a'.repeat(64) });
 		expect(info.commit).toBeNull();
 		expect(info.provenance).toBe('uncommitted-override');
 	});
 
 	it('is DETERMINISTIC — no timestamps, so re-packing a commit reproduces the sha256 pin', () => {
-		const args = { name: '@blackveil/dns-checks', version: VERSION, commit: COMMIT, provenance: 'committed' as const };
+		const args = { name: '@blackveil/dns-checks', version: VERSION, commit: COMMIT, provenance: 'committed' as const, scoringContractSha256: 'a'.repeat(64) };
 		expect(JSON.stringify(buildBuildInfo(args))).toBe(JSON.stringify(buildBuildInfo(args)));
 	});
 
 	it('carries a schema number so consumers can detect a shape change', () => {
-		const info = buildBuildInfo({ name: 'x', version: '1.0.0', commit: COMMIT, provenance: 'committed' });
+		const info = buildBuildInfo({ name: 'x', version: '1.0.0', commit: COMMIT, provenance: 'committed', scoringContractSha256: 'a'.repeat(64) });
 		expect(info.schema).toBe(BUILD_INFO_SCHEMA);
 		expect(typeof info.schema).toBe('number');
 	});

--- a/test/scoring-contract-change.spec.ts
+++ b/test/scoring-contract-change.spec.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { assessScoringContractChange } from '../scripts/scoring-contract-change';
+
+describe('scoring-contract change gate', () => {
+	it('blocks a scoring behavior change without a package version bump', () => {
+		expect(
+			assessScoringContractChange({
+				changedPaths: ['packages/dns-checks/src/scoring/profiles.ts'],
+				baseVersion: '1.28.0',
+				headVersion: '1.28.0',
+			}),
+		).not.toEqual([]);
+	});
+
+	it('allows a behavior change accompanied by a version bump', () => {
+		expect(
+			assessScoringContractChange({
+				changedPaths: ['packages/dns-checks/src/scoring/profiles.ts'],
+				baseVersion: '1.28.0',
+				headVersion: '1.29.0',
+			}),
+		).toEqual([]);
+	});
+
+	it('does not require a package bump for unrelated changes', () => {
+		expect(
+			assessScoringContractChange({
+				changedPaths: ['src/oauth/token.ts'],
+				baseVersion: '1.28.0',
+				headVersion: '1.28.0',
+			}),
+		).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Outcome

Makes scoring behavior an immutable, machine-verifiable release contract instead of relying on matching version strings.

## Changes

- publishes canonical profile weights, grade thresholds, critical categories, email bonus eligibility, and profile semantics
- stamps the contract SHA-256 into BUILD_INFO and the package artifact
- fails required CI when scoring behavior changes without a dns-checks version bump
- binds CI comparison to GitHub's immutable base SHA
- adds an operator-only exact-tag release workflow that dispatches a consumer promotion event
- advances dns-checks to 1.30.0 after main independently consumed 1.29.0; this PR's contract packaging itself does not change weights

## Validation

- repo-safety audit
- lint and typecheck
- dns-checks build and exact-commit pack integrity
- scoring-contract and profile-SSOT tests
- scoring-contract change gate
- full local suite passed 684 files / 8,333 tests; the isolated clone's only unrelated failure was its missing external WASM fixture, which hosted CI builds before testing

No package was published and no production deployment was performed.