### PR TITLE
fix(batch_scan): surface budget-dropped domains as a batch-level incomplete rollup

### DIFF
--- a/src/tools/batch-scan.ts
+++ b/src/tools/batch-scan.ts
@@ -38,6 +38,19 @@ export interface CompactBatchScanResultItem {
 /** Compact wire payload for bulk triage; use `format: "full"` for complete findings. */
 export interface CompactBatchScanResult {
 	results: CompactBatchScanResultItem[];
+	/**
+	 * TRUE when one or more domains hit the batch wall-clock budget and were never
+	 * scanned — their rows carry `measured: false, error: 'batch_budget_exceeded'`.
+	 * An unmissable BATCH-LEVEL flag so a caller that does not inspect every row's
+	 * `measured` flag cannot silently treat the budget-dropped tail as unscored/zero.
+	 */
+	incomplete: boolean;
+	/**
+	 * Domains that hit the batch budget and were NOT scanned, in input order. These
+	 * are recoverable: re-run them in a smaller follow-up batch. Empty (`[]`) when the
+	 * whole batch completed. Distinct from invalid-input errors, which are not listed here.
+	 */
+	unscanned: string[];
 	/** Scoring-POLICY semver. ⚠️ Not the npm package version — see `dnsChecksPackageVersion` (#707). */
 	scoringModelVersion: string;
 	/** `@blackveil/dns-checks` engine-package version bundled by this build (#707). */
@@ -211,11 +224,25 @@ export async function batchScan(domains: string[], options: BatchScanOptions = {
 }
 
 /**
+ * Domains that hit the batch wall-clock budget and were never scanned. Both the
+ * pre-scan deadline check and the per-scan timeout stamp `error: 'batch_budget_exceeded'`,
+ * so this single predicate captures the whole budget-dropped tail — and ONLY that tail,
+ * not invalid-input or scan-threw placeholders, which are a different failure class.
+ */
+export function budgetExceededDomains(results: BatchScanResultItem[]): string[] {
+	return results.filter((r) => r.error === 'batch_budget_exceeded').map((r) => r.domain);
+}
+
+/**
  * Reduce a batch to the fields needed to rank an estate and select domains for
  * a full scan. Findings and per-check diagnostics are intentionally excluded:
  * their repeated explanatory prose makes multi-domain MCP responses unusable.
  */
 export function compactBatchScanResults(results: BatchScanResultItem[]): CompactBatchScanResult {
+	// Batch-level incompleteness signal: surfaces the budget-dropped tail at the top
+	// of the payload so a caller cannot silently treat those domains as unscored/zero
+	// by skipping the per-row `measured` flag.
+	const unscanned = budgetExceededDomains(results);
 	return {
 		results: results.map(({ domain, score, grade, measured, findingCounts, categoryScores, scoringProfile, evidence, error }) => ({
 			domain,
@@ -228,6 +255,8 @@ export function compactBatchScanResults(results: BatchScanResultItem[]): Compact
 			evidence,
 			...(error === undefined ? {} : { error }),
 		})),
+		incomplete: unscanned.length > 0,
+		unscanned,
 		// These are computed once for the batch, so hoist them rather than repeating
 		// identical values in every domain result.
 		scoringModelVersion: results[0]?.scoringModelVersion ?? SCORING_MODEL_VERSION,
@@ -280,5 +309,15 @@ export function formatBatchScan(results: BatchScanResultItem[], format: OutputFo
 
 	lines.push('');
 	lines.push(`Scanned ${results.filter((r) => r.measured && r.score !== null).length}/${results.length} domain(s) successfully`);
+
+	// Batch-level incompleteness banner: the per-row `not measured: batch_budget_exceeded`
+	// lines above are easy to miss in a 10-row list, so name the dropped tail explicitly.
+	const unscanned = budgetExceededDomains(results);
+	if (unscanned.length > 0) {
+		lines.push('');
+		lines.push(`⚠ INCOMPLETE: ${unscanned.length} domain(s) hit the batch time budget and were NOT scanned:`);
+		lines.push(`   ${unscanned.join(', ')}`);
+		lines.push('   These are recoverable — re-run them in a smaller follow-up batch.');
+	}
 	return lines.join('\n');
 }

--- a/test/batch-scan.spec.ts
+++ b/test/batch-scan.spec.ts
@@ -259,6 +259,56 @@ describe('batchScan', () => {
 		}
 	});
 
+	// Tail-drop regression: a batch that silently dropped its budget-exceeded tail
+	// (e.g. a 10-domain estate scan that only measured 7) exposed NO top-level signal
+	// that it was incomplete, so a caller that did not inspect every row's `measured`
+	// flag treated the dropped domains as unscored/zero. The batch now carries an
+	// explicit `incomplete`/`unscanned` summary in addition to the per-row placeholders.
+	it('exposes a batch-level incomplete flag and unscanned list when the budget drops the tail', async () => {
+		const { batchScan, compactBatchScanResults, formatBatchScan } = await import('../src/tools/batch-scan');
+		// Each scan takes 300ms; a 10ms budget guarantees every domain is
+		// budget-exceeded before its worker slot opens, so the whole tail is dropped.
+		const slowScan = (async (domain: string) => {
+			await new Promise((resolve) => setTimeout(resolve, 300));
+			return fakeScanResult(domain);
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		}) as any;
+		const inputs = ['nec.co.nz', 'ird.govt.nz', 'nzta.govt.nz'];
+		const results = await batchScan(inputs, { kv: env.SCAN_CACHE, budgetMs: 10, concurrency: 1, scanFn: slowScan });
+
+		// Per-row contract is unchanged: budget-dropped rows still carry measured:false + error.
+		const dropped = results.filter((r) => r.error === 'batch_budget_exceeded');
+		expect(dropped.length).toBeGreaterThan(0);
+		for (const r of dropped) expect(r.measured).toBe(false);
+
+		// NEW batch-level signal on the compact wire payload.
+		const compact = compactBatchScanResults(results);
+		expect(compact.incomplete).toBe(true);
+		expect(compact.unscanned).toEqual(expect.arrayContaining(dropped.map((r) => r.domain)));
+		expect(compact.unscanned).toHaveLength(dropped.length);
+
+		// NEW unmissable banner in the text summary (both compact and full formats).
+		const text = formatBatchScan(results, 'compact');
+		expect(text).toContain('INCOMPLETE');
+		for (const r of dropped) expect(text).toContain(r.domain);
+	});
+
+	it('reports a complete batch as not incomplete with an empty unscanned list', async () => {
+		const { batchScan, compactBatchScanResults, formatBatchScan } = await import('../src/tools/batch-scan');
+		const fastScan = (async (domain: string) => ({
+			...fakeScanResult(domain),
+			// isMeasured() reads checks.length > 0 — populate one so measured: true.
+			checks: [{ category: 'dmarc', checkStatus: 'completed' }],
+			// eslint-disable-next-line @typescript-eslint/no-explicit-any
+		})) as any;
+		const results = await batchScan(['a.com', 'b.com'], { kv: env.SCAN_CACHE, scanFn: fastScan });
+
+		const compact = compactBatchScanResults(results);
+		expect(compact.incomplete).toBe(false);
+		expect(compact.unscanned).toEqual([]);
+		expect(formatBatchScan(results, 'compact')).not.toContain('INCOMPLETE');
+	});
+
 	it('formatBatchScan renders "not measured" for an invalid domain', async () => {
 		const { batchScan, formatBatchScan } = await import('../src/tools/batch-scan');
 		const results = await batchScan(['not--valid--domain!@#'], { kv: env.SCAN_CACHE });


### PR DESCRIPTION
## Summary

A batch that exhausts its wall-clock budget stamps each dropped row `error: 'batch_budget_exceeded'`, but a caller that skips per-row `measured` inspection silently treats the dropped tail as unscored/zero — the same silent-truncation defect class as the no-silent-caps doctrine. This adds an unmissable batch-level signal to `CompactBatchScanResult`:

- `incomplete: boolean` — true when any domain was budget-dropped
- `unscanned: string[]` — the dropped domains in input order (recoverable via a smaller follow-up batch)
- `budgetExceededDomains()` — the single predicate deriving both, capturing ONLY the budget class, never invalid-input or scan-threw placeholders

## Provenance

Rescued during checkout reconciliation from orphaned commit `364613cd` — committed 2026-08-30 to local `main` in a `/private/tmp` worktree and never pushed. That commit's DNSSEC half (retry + inconclusive guard) is deliberately dropped here: its substance landed via #850/#860.

## Testing

- `test/batch-scan.spec.ts` + `test/scan-version-stamps.spec.ts`: 23/23 pass
- `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)