### PR TITLE
chore: release 3.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.73.0] - 2026-08-31
+
+Small release shipping the immutable scoring behavior contract and an honesty fix for budget-truncated batches. No scoring changes — `SCORING_MODEL_VERSION` stays 1.18.0.
+
+### Added
+
+- **The scoring behavior contract is now published as code.** `@blackveil/dns-checks` (1.30.0) exports `SCORING_CONTRACT` — an immutable, canonically-serializable snapshot of profile semantics and comparison classes — with CI gates (`scoring-contract-change-check`, pack-integrity) that fail any change to scoring behavior that does not advance the contract release. Runtime scan behavior is unchanged. (PR #862)
+- **`batch_scan` now surfaces its budget-dropped tail at batch level.** A batch that exhausts its wall-clock budget previously stamped dropped rows `error: 'batch_budget_exceeded'` per row only, so callers that skipped per-row `measured` inspection silently treated those domains as unscored. The compact payload now carries `incomplete: boolean` plus `unscanned: string[]` (input order, recoverable via a smaller follow-up batch), derived by the `budgetExceededDomains()` predicate — budget class only, never invalid-input or scan-threw placeholders. (PR #868)
+
 ## [3.72.0] - 2026-08-31
 
 Correctness release for DNSSEC and DANE scoring, plus deterministic OAuth rate-limit coverage and an advisory scoring-version governance gate.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.72.0",
+	"version": "3.73.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.72.0",
+			"version": "3.73.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.72.0",
+	"version": "3.73.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.72.0",
+	"version": "3.73.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Release 3.73.0 — ships #862 (immutable scoring behavior contract, behavior-neutral) and #868 (batch_scan batch-level `incomplete`/`unscanned` rollup for budget-dropped domains).

No scoring changes; `SCORING_MODEL_VERSION` stays 1.18.0 (checked at release time per the 3.71.0 lesson). Version surfaces bumped via `npm version` lifecycle hook (package.json + lock, server.json, CHANGELOG heading).

Post-merge: tag `v3.73.0` on the merge commit → `deploy:prod` from a tag-pinned worktree → verify live → registry publish last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)