### PR TITLE
Release v3.73.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.73.1] - 2026-09-01
+
+Performance and resilience hardening for synchronous and asynchronous scan orchestration. No scoring changes — `SCORING_MODEL_VERSION` stays 1.18.0.
+
+### Added
+
+- Added owner-scoped `batch_scan_start`, `batch_scan_status`, and `batch_scan_findings` tools backed by a bounded Cloudflare Queue consumer, deterministic idempotency, execution leases, seven-day results, retries, and a dead-letter queue. (PR #870)
+- Added machine-queryable timeout, rate-limit, cancellation, batch-budget, and partial-work Analytics Engine outcomes with scheduled alerting. (PR #870)
+
+### Changed
+
+- Propagated cancellation through scan orchestration and capped shared outbound DNS concurrency at five connections per invocation. (PR #870)
+- Persisted shared CertSpotter cooldown state and honored upstream `Retry-After` guidance across requests to prevent repeated 429s. (PR #870)
+
 ## [3.73.0] - 2026-08-31
 
 Small release shipping the immutable scoring behavior contract and an honesty fix for budget-truncated batches. No scoring changes — `SCORING_MODEL_VERSION` stays 1.18.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.73.0",
+	"version": "3.73.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.73.0",
+			"version": "3.73.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.73.0",
+	"version": "3.73.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.73.0",
+	"version": "3.73.1",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Release

Patch release for the performance and resilience hardening merged in PR #870.

- asynchronous owner-scoped batch scan queue tools
- bounded cancellation-aware DNS concurrency
- shared CertSpotter Retry-After cooldown
- timeout, rate-limit, cancellation, and partial-work telemetry and alerts

No scoring changes; SCORING_MODEL_VERSION remains 1.18.0.

## Verification

- npm run audit:repo-safety
- release integrity: all version surfaces match 3.73.1
- packages/dns-checks build
- npm run typecheck

Production queue/DLQ provisioning and manual deployment will follow the protected merge.