### PR TITLE
chore: release 3.73.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.73.2] - 2026-09-01
+
+Operational release adding a guarded production-capacity harness. No scoring changes — `SCORING_MODEL_VERSION` stays 1.18.0.
+
+### Added
+
+- Added a temporary, IP-restricted load-test credential that fails closed and receives owner-equivalent quota without exposing permanent operator keys. (PR #872)
+- Added local k6 edge, MCP protocol, DNS, scan, and realistic mixed-workload lanes with SSE and JSON-RPC semantic validation, independent health probes, automatic stop conditions, and sanitized evidence output. (PR #872)
+
+### Changed
+
+- Ceiling stages now reject dropped generator iterations and record latency tails, response sizes, schema failures, quota responses, and WAF responses so client saturation cannot be misreported as server capacity. (PR #872)
+
 ## [3.73.1] - 2026-09-01
 
 Performance and resilience hardening for synchronous and asynchronous scan orchestration. No scoring changes — `SCORING_MODEL_VERSION` stays 1.18.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.73.1",
+	"version": "3.73.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.73.1",
+			"version": "3.73.2",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.73.1",
+	"version": "3.73.2",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.73.1",
+	"version": "3.73.2",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Summary

- synchronize release surfaces at 3.73.2
- document the guarded production-capacity harness from #872
- preserve scoring model version 1.18.0

## Verification

- npm run audit:repo-safety
- release CI gates