### PR TITLE
docs: recreate production capacity testing guidance

### DIFF
--- a/docs/load-testing/2026-09-01-cloudflare-ddos-activation.md
+++ b/docs/load-testing/2026-09-01-cloudflare-ddos-activation.md
@@ -1,0 +1,61 @@
+# Cloudflare DDoS activation — 2026-09-01
+
+## Summary
+
+A locally generated production edge-capacity test activated a Cloudflare DDoS rule. The event invalidated the suspected capacity boundary because Cloudflare mitigation, not demonstrated Worker saturation, constrained accepted traffic.
+
+## Impact
+
+- High-rate requests experienced failures, dial timeouts, and connection resets.
+- Independent health monitoring triggered its stop behavior during one repetition.
+- The test stopped after consecutive unstable stages.
+- Post-test production health returned HTTP 200 with normal latency.
+- Available evidence showed no corruption, cross-tenant leakage, queue corruption, or persistent ordinary-user degradation.
+
+## Timeline
+
+1. Edge stages from 10 through 800 RPS completed successfully once.
+2. The 1,600-RPS stage crossed the failure threshold and aborted.
+3. Refinement at 960 and 1,120 RPS also aborted.
+4. Repetition at 800 RPS first succeeded, then encountered VU exhaustion, dropped iterations, dial timeouts, resets, and probe failure.
+5. Cloudflare security telemetry confirmed DDoS-rule activation.
+6. All load stopped; three recovery probes returned HTTP 200.
+
+Security-event identifiers, source addresses, account identifiers, and raw Cloudflare exports belong only in the restricted evidence store.
+
+## Root cause
+
+The offered traffic was a uniform, single-source request stream against one edge endpoint. At the attempted rates, that pattern crossed Cloudflare's DDoS detection boundary. The test had not been coordinated with a Cloudflare-approved treatment for the test source.
+
+This was a test-design and coordination failure, not evidence that DDoS protection malfunctioned.
+
+## Contributing factors
+
+- A single source concentrated traffic and resembled an attack pattern.
+- The test attempted to infer global capacity from a workstation source path.
+- The harness could not directly correlate failures with Cloudflare Security Events.
+- The edge lane did not distinguish mitigation from generic transport or HTTP failure.
+- An unrelated D1 control-plane error blocked deployment of the identity-bound authenticated lanes.
+
+## Corrective actions
+
+Before another production run:
+
+- Obtain Cloudflare confirmation for planned rates and topology.
+- Define approved generator addresses and the test window.
+- Decide with Cloudflare whether identity-and-source-scoped treatment is supported. Never disable global DDoS protection.
+- Use distributed dedicated runners and independent monitoring.
+- Add Security Events correlation and transport/mitigation classification to the evidence workflow.
+- Prove the global kill switch at every generator.
+- Resolve the production D1 preflight failure before creating the temporary authenticated identity.
+
+Until then:
+
+- Do not run another production staircase from a workstation.
+- Do not resume at 800 RPS or above.
+- Keep production testing at smoke-test rates unless a new coordinated window is approved.
+- Treat the 2026-09-01 figures as harness observations, not capacity commitments.
+
+## Closure
+
+The production-impacting event is closed when health, ordinary-user probes, security mitigations, and downstream queues are at baseline. Readiness for a future capacity test is a separate gate.

--- a/docs/load-testing/2026-09-01-global-ceiling-report.md
+++ b/docs/load-testing/2026-09-01-global-ceiling-report.md
@@ -1,0 +1,71 @@
+# Production capacity test report — 2026-09-01
+
+## Executive conclusion
+
+The production service ceiling was **not established**.
+
+The local Auckland-origin edge test completed five-minute 800-RPS stages, but later stages activated Cloudflare DDoS mitigation and subsequent repetitions showed generator exhaustion, dial timeouts, connection resets, and dropped iterations. These are exclusion conditions for a service-capacity result.
+
+Authenticated protocol, useful-work, and heavy-work lanes were not executed. The temporary-credential release could not pass its mandatory production D1 schema preflight because the Cloudflare D1 control plane repeatedly returned internal error code 7500. The safety gate was not bypassed.
+
+## Configuration
+
+- Origin: production MCP service behind Cloudflare.
+- Generator: one local Auckland-origin machine.
+- Lane: edge `GET /health`.
+- Stages: five minutes with two-minute recovery.
+- Production remained on the release preceding v3.73.2; v3.73.2 was merged and tagged but not deployed during the exercise.
+- No permanent internal development credential was used.
+- No temporary production credential or WAF exception was created.
+
+## Valid observations
+
+| Offered rate | Requests | Failures | p95 | p99 | Maximum | Outcome |
+| ---: | ---: | ---: | ---: | ---: | ---: | --- |
+| 10 RPS | 3,001 | 0% | 30.31 ms | 42.60 ms | 260.60 ms | Stable single stage |
+| 25 RPS | 7,501 | 0% | 31.72 ms | 51.70 ms | 585.36 ms | Stable single stage |
+| 50 RPS | 15,001 | 0% | 28.77 ms | 45.94 ms | 842.61 ms | Stable single stage |
+| 100 RPS | 30,001 | 0% | 27.69 ms | 52.54 ms | 664.43 ms | Stable single stage |
+| 200 RPS | 60,001 | 0% | 28.09 ms | 49.21 ms | 726.75 ms | Stable single stage |
+| 400 RPS | 120,001 | 0% | 27.31 ms | 48.32 ms | 540.90 ms | Stable single stage |
+| 800 RPS | 240,001 | 0% | 26.52 ms | 45.13 ms | 526.93 ms | Stable single stage |
+| 800 RPS repeat | 240,000 | 0% | 25.43 ms | 41.50 ms | 529.81 ms | Stable single repetition |
+
+These stages prove only that this source path delivered 800 successful edge requests per second for five minutes on those attempts.
+
+## Invalidated boundary observations
+
+- The 1,600-RPS stage aborted with approximately 87% failed requests.
+- Refinement at 960 and 1,120 RPS aborted with approximately 99% failures.
+- A repeated 800-RPS stage exhausted 1,600 VUs, dropped 12,593 iterations, produced dial timeouts and resets, and triggered the independent-probe abort.
+- A following 800-RPS attempt exceeded the failure threshold and aborted.
+- Cloudflare security telemetry identified DDoS-rule activation caused by the test.
+
+Low latency among completed responses does not convert these stages into application-capacity evidence.
+
+## Required figures
+
+| Figure | Result |
+| --- | --- |
+| Peak accepted RPS | At least 800 RPS for a completed five-minute edge stage |
+| Maximum stable RPS | Not established; no boundary rate passed three repetitions without exclusions |
+| Sustained RPS | Not established; no qualifying 30-minute hold completed |
+| Recommended operating limit | Not established |
+
+Do not use 800 RPS as a production rate limit or capacity promise.
+
+## Recovery
+
+- All generators stopped and no load process remained active.
+- Three post-test `/health` probes returned HTTP 200 in approximately 46–49 ms.
+- No DDoS or WAF protection was weakened.
+- No temporary credential or security exception required cleanup.
+
+## Next gates
+
+1. Resolve the D1 preflight failure and deploy the guarded credential.
+2. Coordinate planned traffic with Cloudflare.
+3. Use distributed dedicated generators with independent generator-health telemetry.
+4. Rehearse in production-equivalent staging.
+5. Restart at a conservative baseline, not the prior failure rate.
+6. Complete three boundary repetitions, a 30-minute hold, and the 80% endurance stage before calculating an operating limit.

--- a/docs/load-testing/README.md
+++ b/docs/load-testing/README.md
@@ -1,0 +1,21 @@
+# Production capacity testing
+
+This directory is the source of truth for controlled capacity testing of the production MCP service.
+
+Capacity testing is an operator-controlled production change. It must not start from an ordinary development credential, an unapproved source address, or an uncoordinated workstation. Cloudflare DDoS protection and emergency controls remain enabled throughout every test.
+
+## Documents
+
+- [Measurement plan](./global-ceiling-plan.md) — ceilings, SLOs, stages, workload mix, and evidence requirements.
+- [Operator runbook](./global-ceiling-runbook.md) — preparation, execution, stop conditions, recovery, and cleanup.
+- [2026-09-01 report](./2026-09-01-global-ceiling-report.md) — observed results and their limits.
+- [2026-09-01 incident note](./2026-09-01-cloudflare-ddos-activation.md) — DDoS activation, response, and corrective actions.
+
+## Implemented harness
+
+- `scripts/load/global-ceiling.k6.js` implements the edge, protocol, useful, heavy, and mixed lanes.
+- `scripts/load/run-global-ceiling.mjs` executes a local staircase, records independent health probes, stops after two consecutive unstable stages, and writes sanitized JSON evidence to a temporary directory.
+- `npm run load:global-ceiling` runs one configured k6 test.
+- `npm run load:global-ceiling:run` runs the staircase orchestrator.
+
+The harness does not grant approval to run a production test. Follow the runbook gates first.

--- a/docs/load-testing/README.md
+++ b/docs/load-testing/README.md
@@ -6,7 +6,7 @@ Capacity testing is an operator-controlled production change. It must not start 
 
 ## Documents
 
-- [Measurement plan](./global-ceiling-plan.md) — ceilings, SLOs, stages, workload mix, and evidence requirements.
+- [Measurement procedure](./global-ceiling-procedure.md) — ceilings, SLOs, stages, workload mix, and evidence requirements.
 - [Operator runbook](./global-ceiling-runbook.md) — preparation, execution, stop conditions, recovery, and cleanup.
 - [2026-09-01 report](./2026-09-01-global-ceiling-report.md) — observed results and their limits.
 - [2026-09-01 incident note](./2026-09-01-cloudflare-ddos-activation.md) — DDoS activation, response, and corrective actions.

--- a/docs/load-testing/global-ceiling-procedure.md
+++ b/docs/load-testing/global-ceiling-procedure.md
@@ -1,0 +1,84 @@
+# Global ceiling measurement procedure
+
+## Objective
+
+Determine the maximum globally distributed throughput the production service can sustain while preserving latency, correctness, availability, and ordinary-user experience.
+
+A single-host test can validate the harness and establish a source-path ceiling. It cannot establish a global service ceiling.
+
+## Capacity lanes
+
+| Lane | Workload | Purpose |
+| --- | --- | --- |
+| Edge | `GET /health` | Cloudflare routing, DDoS/WAF, TLS, and HTTP capacity |
+| Protocol | Authenticated MCP `tools/list` | Session and serialization capacity |
+| Useful | `check_spf`, cached and uncached | DNS and lightweight processing capacity |
+| Heavy | `scan_domain` and bounded investigation operations | Queue, upstream, and downstream capacity |
+| Mixed | Weighted combination of all lanes | Production-shaped capacity and contention |
+
+## Stable-stage criteria
+
+A stage is stable only when all of the following hold:
+
+- HTTP and MCP semantic success are at least 99.9%.
+- Lightweight p95 latency is at most 500 ms.
+- Full-scan p95 latency is at most 10 seconds.
+- Schema and correctness failures are zero.
+- Generator dropped iterations are zero.
+- Independent ordinary-user probes remain healthy.
+- Queue backlog drains to its pre-test range.
+- No persistent downstream, Durable Object, or ordinary-user degradation occurs.
+- Cloudflare has not activated DDoS, WAF, bot, or abuse mitigation because of the test.
+
+A stage rejected by the generator, source network, or Cloudflare mitigation is not evidence of the application ceiling.
+
+## Required preparation
+
+1. Approve the test window, maximum offered rate, and spend ceiling.
+2. Confirm Cloudflare's current load-testing policy and notify Cloudflare when required.
+3. Create a temporary `BV_LOAD_TEST_KEY` secret and configure `BV_LOAD_TEST_ALLOW_IPS` for only approved generator addresses.
+4. Never use `BV_INTERNAL_DEV_KEY_2` or expose a permanent owner credential.
+5. Identify Cloudflare rules that may classify the planned traffic. Do not disable account-wide DDoS protection.
+6. Establish and test a kill switch reachable by every generator.
+7. Record baseline Worker, Durable Object, KV, D1, queue, binding, error, latency, and cost signals.
+8. Confirm the deployed release and the `bv_load_test` analytics identity.
+
+## Generator topology
+
+For a global result, use synchronized generators in at least Auckland or Sydney, Singapore, Mumbai, Frankfurt, London, Virginia, Oregon, and Sao Paulo. Use unique MCP sessions per virtual client.
+
+Each generator records offered, sent, completed, and dropped work; HTTP and MCP outcome; p50/p95/p99/max latency; connection and TLS timing; response size; schema failures; WAF/quota/mitigation outcomes; region; and workload.
+
+## Workload mix
+
+| Workload | Share |
+| --- | ---: |
+| MCP initialization/session traffic | 5% |
+| `tools/list` and discovery | 10% |
+| Cached lightweight DNS checks | 35% |
+| Uncached lightweight checks | 20% |
+| `scan_domain` | 20% |
+| Investigation status/report operations | 10% |
+
+Use BlackVeil-controlled domains and reserved synthetic domains only. Do not generate invasive people-centric traffic or repeatedly scan unrelated third parties.
+
+## Stages
+
+1. Validate contracts locally and against production-equivalent staging.
+2. Run each lane at 10 RPS for five minutes and reconcile generator and Cloudflare counts within 2%.
+3. Run five-minute staircase stages at 25, 50, 100, 200, 400, 800, 1,600, and 3,200 global RPS, with two-minute recovery intervals.
+4. On the first instability, stop doubling and use 10–20% increments.
+5. At the suspected boundary, run three five-minute repetitions per rate. Stop after two consecutive unstable stages.
+6. Hold the highest repeated stable rate for 30 minutes, then 80% of that rate for two hours.
+7. Only after endurance, test bounded bursts of 2x for 10 seconds, 3x for five seconds, and 5x for one second.
+
+Do not advance while failure attribution is uncertain.
+
+## Result definitions
+
+- **Peak accepted RPS:** highest momentary successful throughput.
+- **Maximum stable RPS:** highest repeated five-minute stage satisfying every stable-stage criterion.
+- **Sustained RPS:** highest rate maintained for 30 minutes.
+- **Recommended operating limit:** normally 60–70% of sustained capacity, reduced further when downstream or regional headroom requires it.
+
+Report these figures by region and workload. If evidence is incomplete, report “not established” rather than substituting a transient peak.

--- a/docs/load-testing/global-ceiling-runbook.md
+++ b/docs/load-testing/global-ceiling-runbook.md
@@ -1,0 +1,99 @@
+# Global ceiling operator runbook
+
+## Authority and stop rule
+
+Production execution requires explicit approval for the test window and rate envelope. Any operator may stop the test. No operator may bypass a failed deployment, schema, security, or kill-switch gate merely to continue testing.
+
+Never weaken account-wide DDoS protection. A security-rule treatment, when Cloudflare supports and approves it, must be limited to the temporary identity and exact generator addresses and removed immediately afterward.
+
+## Preconditions
+
+- The harness release is live and verified.
+- Cloudflare policy and notification requirements are satisfied.
+- Security Events and DDoS analytics are open on an independent monitor.
+- Queue, Worker, service-binding, and cost telemetry are visible.
+- `k6` is installed on every generator.
+- The temporary key and allowlist are active; an unapproved address fails closed.
+- The kill switch returns exactly `run`, and changing it stops every generator.
+- `BV_LOAD_DOMAIN` is an approved BlackVeil-controlled domain for useful, heavy, or mixed lanes.
+
+## Environment
+
+Set secrets without printing them or placing them in shell history.
+
+| Variable | Meaning |
+| --- | --- |
+| `BV_LOAD_BASE_URL` | Production or staging origin |
+| `BV_LOAD_LANE` | `edge`, `protocol`, `useful`, `heavy`, or `mixed` |
+| `BV_LOAD_TEST_KEY` | Temporary credential; required outside `edge` |
+| `BV_LOAD_DOMAIN` | Approved controlled domain |
+| `BV_LOAD_UNCACHED_SUFFIX` | Controlled suffix for uncached checks |
+| `BV_LOAD_KILL_SWITCH_URL` | Endpoint whose body must be exactly `run` |
+| `BV_LOAD_RATES` | Comma-separated staircase rates |
+| `BV_LOAD_STAGE_DURATION` | Stage duration; production default `5m` |
+| `BV_LOAD_RECOVERY_MS` | Recovery interval; production default `120000` |
+
+## Validation
+
+```bash
+npm run audit:repo-safety
+npm test -- test/tier-auth.spec.ts
+k6 inspect scripts/load/global-ceiling.k6.js
+```
+
+Run a one-RPS staging smoke. Verify SSE parsing, JSON-RPC errors, `result.isError`, invalid schemas, analytics identity, independent probes, and kill-switch termination.
+
+## Production execution
+
+Start with one lane and one region:
+
+```bash
+BV_LOAD_LANE=edge \
+BV_LOAD_RATES=10 \
+BV_LOAD_STAGE_DURATION=5m \
+BV_LOAD_RECOVERY_MS=120000 \
+npm run load:global-ceiling:run
+```
+
+Authenticated lanes require the temporary key. Useful, heavy, and mixed lanes require `BV_LOAD_DOMAIN`. After baseline reconciliation, expand to the approved regional topology. The global controller stops every generator when any region or independent monitor crosses a stop condition.
+
+## Stop conditions
+
+Abort globally when any condition persists for 30 seconds:
+
+- HTTP 5xx exceeds 1%.
+- MCP semantic failures exceed 1%.
+- Lightweight p95 exceeds two seconds.
+- Full-scan p95 exceeds 30 seconds.
+- The ordinary-user probe fails twice.
+- Queue backlog exceeds its recovery threshold.
+- Durable Object errors or upstream throttling materially increase.
+- Cloudflare activates DDoS, WAF, bot, or abuse mitigation because of the test.
+- Generator VUs are exhausted, iterations drop, or the source network reports dial timeouts or resets.
+- Spend crosses the approved limit.
+
+Stop immediately for corruption, cross-tenant leakage, security-boundary failure, or an instruction from Cloudflare.
+
+## Failure attribution
+
+| Signal | Classification |
+| --- | --- |
+| Dropped iterations or insufficient VUs | Generator ceiling |
+| Dial timeout, socket exhaustion, router/NAT reset | Source-path ceiling |
+| DDoS/security event matching generator traffic | Mitigation boundary |
+| Independent probes healthy but generator failing | Generator or source-path issue |
+| Independent probes and ordinary users failing | Service-impacting event; stop immediately |
+| Worker latency/errors rise without generator or mitigation signals | Candidate application ceiling |
+| Queue grows after offered load stops | Downstream or drain-capacity ceiling |
+
+Only the final two rows can support an application or downstream ceiling, and only after repetition.
+
+## Recovery and cleanup
+
+1. Stop every generator and confirm no `k6` or orchestrator process remains.
+2. Verify `/health`, MCP initialization, a lightweight call, and a bounded scan independently.
+3. Confirm security mitigations clear and ordinary traffic returns to baseline.
+4. Confirm queues drain and downstream errors normalize.
+5. Revoke `BV_LOAD_TEST_KEY` and remove `BV_LOAD_TEST_ALLOW_IPS` plus any scoped test treatment.
+6. Preserve sanitized summaries, metric exports, security-event identifiers, exact release, regions, and timings outside the repository.
+7. Publish a dated report. Never claim a service ceiling when the limiter was the generator, network path, or Cloudflare mitigation.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -6,6 +6,8 @@ operations (tenant D1 restore drills, erasure, quota sharding) live in
 repo root. Nothing here contains real IDs or hostnames — actual values live in the
 operator secret manager.
 
+Production load and capacity testing has a separate [capacity-testing runbook](./load-testing/README.md). If a test activates Cloudflare mitigation, it measures a mitigation or source-path boundary rather than the application ceiling.
+
 ## 1. Deploying (any operator, not just the primary)
 
 Prerequisites:


### PR DESCRIPTION
## Summary

- recreate the global ceiling measurement procedure and operator runbook
- document the 2026-09-01 results without misclassifying Cloudflare mitigation as service capacity
- record the DDoS activation, recovery, corrective actions, and future production gates
- link the capacity documentation from the platform operator runbook

## Key conclusion

The production service ceiling was not established. The observed boundary was invalidated by Cloudflare DDoS mitigation and local generator/source-path exhaustion.

## Verification

- `git diff --check`
- `npm run audit:repo-safety`
- commit and push secret/PII hooks