### PR TITLE
chore: release 3.73.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.73.3] - 2026-09-01
+
+Documentation and production release completing the guarded capacity-test rollout. No scoring changes — `SCORING_MODEL_VERSION` stays 1.18.0.
+
+### Added
+
+- Added the production capacity measurement procedure, operator runbook, dated test report, and Cloudflare DDoS activation record. (PR #874)
+
+### Changed
+
+- Clarified that Cloudflare mitigation, generator exhaustion, dropped iterations, and source-path failures invalidate a service-ceiling result. (PR #874)
+
 ## [3.73.2] - 2026-09-01
 
 Operational release adding a guarded production-capacity harness. No scoring changes — `SCORING_MODEL_VERSION` stays 1.18.0.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.73.2",
+	"version": "3.73.3",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.73.2",
+			"version": "3.73.3",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.73.2",
+	"version": "3.73.3",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -6,7 +6,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.73.2",
+	"version": "3.73.3",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
## Summary

- synchronize release surfaces at 3.73.3
- include the merged capacity-testing documentation on the deployable release commit
- preserve scoring model version 1.18.0

## Verification

- npm run audit:repo-safety
- npm test -- test/bump-version.spec.ts test/release-integrity.spec.ts
- 42 focused tests passed
- npm audit: 0 vulnerabilities