### PR TITLE
feat(scoring): DMARC p=none is a missing enforcement control (model 1.19.0)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.30.0",
+	"version": "1.31.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
@@ -92,11 +92,11 @@ describe('checkDMARC', () => {
 		// the parent, and the parent's own p= must reach the classifier for it to say so.
 		const enforcingParent = { '_dmarc.example.com': ['v=DMARC1; p=reject; sp=none; rua=mailto:dmarc@example.com'] };
 
-		it('reports the asymmetry in the detail while keeping title and severity', async () => {
+		it('reports the asymmetry in the detail while keeping the title (severity high since 1.19.0)', async () => {
 			const queryDNS = createMockDNS(enforcingParent);
 			const result = await checkDMARC('billing.example.com', queryDNS);
 			const none = result.findings.find((f) => f.title === 'DMARC policy set to none');
-			expect(none?.severity).toBe('medium');
+			expect(none?.severity).toBe('high');
 			expect(none?.detail).toContain('sp=none');
 			expect(none?.detail).toContain('p=reject');
 			expect(none?.detail).toContain('example.com');
@@ -119,7 +119,7 @@ describe('checkDMARC', () => {
 		it('keeps the generic wording when the parent is itself p=none', async () => {
 			const queryDNS = createMockDNS({ '_dmarc.example.com': ['v=DMARC1; p=none; sp=none; rua=mailto:dmarc@example.com'] });
 			const result = await checkDMARC('billing.example.com', queryDNS);
-			expect(result.findings.find((f) => f.title === 'DMARC policy set to none')?.detail).toContain('only monitors');
+			expect(result.findings.find((f) => f.title === 'DMARC policy set to none')?.detail).toContain('take no action');
 		});
 	});
 });

--- a/packages/dns-checks/src/__tests__/checks/record-present-signal.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/record-present-signal.test.ts
@@ -243,7 +243,13 @@ describe('recordPresent is score-neutral', () => {
 			resolver({ [`TXT:_dmarc.${D}`]: ['v=DMARC1; p=none; rua=mailto:a@x.test; adkim=s; aspf=s'] }),
 			opts,
 		);
-		expect(pnone.score).toBe(80);
-		expect(pnone.passed).toBe(true);
+		// Was 80/passed under the 1.14.0 capture; scoring model 1.19.0 declares p=none a
+		// missing enforcement control (score 0, failed). The score moved with the MODEL, not
+		// with the recordPresent field — which is still what this test proves: the pair below
+		// shows the observational field reporting "published" on a zeroed category.
+		expect(pnone.score).toBe(0);
+		expect(pnone.passed).toBe(false);
+		expect(pnone.recordPresent).toBe(true);
+		expect(pnone.controlPresent).toBe(false);
 	});
 });

--- a/packages/dns-checks/src/__tests__/scoring/dmarc-pnone-missing-control.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/dmarc-pnone-missing-control.spec.ts
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Scoring model 1.19.0 — DMARC `p=none` is a missing enforcement control.
+ *
+ * THE DECISION THIS FILE PINS.
+ * A published `p=none` policy instructs receivers to take NO action on messages that
+ * fail authentication (RFC 9989 §5.1.4 names it Monitoring Mode). For enforcement it
+ * is therefore equivalent to publishing nothing: spoofed mail is delivered either
+ * way. The reference class agrees — BitSight grades `p=none` identically to no
+ * record, dimension-scoped. The classifier now declares `{ missingControl: true }`
+ * on the `DMARC policy set to none` finding, which:
+ *
+ *   - zeroes the dmarc category (`buildCheckResult` → score 0, passed false), and
+ *   - arms the `criticalGapCeiling` (64 → NIST display D) in the profiles where
+ *     dmarc is a critical category — `mail_enabled` / `enterprise_mail` ONLY.
+ *
+ * WHAT IS DELIBERATELY NOT CHANGED.
+ * The finding TITLE is load-bearing downstream (the impersonation escalation and
+ * `dmarcIsWeak` in scan post-processing match it exactly; `assess_spoofability`
+ * derives posture from it; rollout planning matches it by substring) and stays
+ * `DMARC policy set to none`. Non-mail profiles gain NO ceiling: dmarc is not in
+ * their critical set, so a parked/web-only domain at p=none is NOT capped — that
+ * boundary is a separate, unratified product decision (Option B of the 2026-09-01
+ * research spec) and this file guards against it leaking in accidentally.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildCheckResult, computeScanScore, createFinding, getProfileWeights } from '../../scoring';
+import { classifyDmarc } from '../../scoring/classifiers/dmarc';
+import type { DomainContext } from '../../scoring';
+import type { CheckCategory, CheckResult } from '../../types';
+
+function ok(category: CheckCategory): CheckResult {
+	return buildCheckResult(category, [createFinding(category, `${category} OK`, 'info', 'Check passed')], true);
+}
+
+const NON_DMARC_CATEGORIES: CheckCategory[] = [
+	'spf',
+	'dkim',
+	'dnssec',
+	'ssl',
+	'mta_sts',
+	'caa',
+	'bimi',
+	'tlsrpt',
+	'subdomain_takeover',
+	'mx',
+	'ns',
+	'txt_hygiene',
+	'http_security',
+	'dane',
+	'mx_reputation',
+	'srv',
+	'zone_hygiene',
+	'dane_https',
+	'svcb_https',
+];
+
+/** An otherwise-clean roster with the REAL classifier's dmarc result for the given facts. */
+function rosterWithDmarc(dmarcResult: CheckResult): CheckResult[] {
+	return [...NON_DMARC_CATEGORIES.map(ok), dmarcResult];
+}
+
+function contextFor(profile: DomainContext['profile']): DomainContext {
+	return {
+		profile,
+		signals: ['test fixture'],
+		weights: getProfileWeights(profile),
+		detectedProvider: null,
+	};
+}
+
+/** The real classifier output for a plain organizational-domain p=none record. */
+function pNoneResult(): CheckResult {
+	return buildCheckResult('dmarc', classifyDmarc({ recordCount: 1, policy: 'none', domain: 'victim.example' }), false, true);
+}
+
+/** The real classifier output for a domain with no DMARC record at all. */
+function absentResult(): CheckResult {
+	return buildCheckResult('dmarc', classifyDmarc({ recordCount: 0, policy: null, domain: 'victim.example' }), false, false);
+}
+
+describe('classifier: p=none declares the missing enforcement control', () => {
+	it('emits the p=none finding at high severity with missingControl: true', () => {
+		const findings = classifyDmarc({ recordCount: 1, policy: 'none', domain: 'victim.example' });
+		const none = findings.find((f) => f.title === 'DMARC policy set to none');
+		expect(none).toBeDefined();
+		expect(none?.severity).toBe('high');
+		expect(none?.metadata?.missingControl).toBe(true);
+	});
+
+	it('keeps the declaration and severity on the parent-enforcing asymmetry variant, without renaming the title', () => {
+		const findings = classifyDmarc({
+			recordCount: 1,
+			policy: 'none',
+			domain: 'billing.example.com',
+			inheritedFromParent: true,
+			orgPolicy: 'reject',
+			orgDomain: 'example.com',
+		});
+		const none = findings.find((f) => f.title === 'DMARC policy set to none');
+		expect(none).toBeDefined();
+		expect(none?.severity).toBe('high');
+		expect(none?.metadata?.missingControl).toBe(true);
+		expect(none?.detail).toMatch(/asymmetric/i);
+	});
+
+	it('does NOT extend the declaration to quarantine (discrimination control)', () => {
+		const findings = classifyDmarc({ recordCount: 1, policy: 'quarantine', domain: 'victim.example', rua: 'mailto:d@victim.example' });
+		const quarantine = findings.find((f) => f.title === 'DMARC policy set to quarantine');
+		expect(quarantine?.severity).toBe('low');
+		expect(quarantine?.metadata?.missingControl).toBeUndefined();
+	});
+});
+
+describe('check result: p=none zeroes the dmarc category', () => {
+	it('scores 0 and fails, exactly like the absent-record case', () => {
+		const pNone = pNoneResult();
+		const absent = absentResult();
+		expect(pNone.score).toBe(0);
+		expect(pNone.passed).toBe(false);
+		expect(absent.score).toBe(0);
+		expect(absent.passed).toBe(false);
+	});
+
+	it('keeps the observational pair intact: record published, control not active', () => {
+		const pNone = pNoneResult();
+		expect(pNone.recordPresent).toBe(true);
+		expect(pNone.controlPresent).toBe(false);
+	});
+});
+
+describe('mail profiles: p=none arms the critical-gap ceiling', () => {
+	it('caps an otherwise-clean mail_enabled domain at 64', () => {
+		const score = computeScanScore(rosterWithDmarc(pNoneResult()), contextFor('mail_enabled'));
+		expect(score.overall).toBeLessThanOrEqual(64);
+	});
+
+	it('creates no ordering inversion: p=none and absent score identically on the same roster', () => {
+		const pNone = computeScanScore(rosterWithDmarc(pNoneResult()), contextFor('mail_enabled'));
+		const absent = computeScanScore(rosterWithDmarc(absentResult()), contextFor('mail_enabled'));
+		expect(pNone.overall).toBe(absent.overall);
+	});
+});
+
+describe('non-mail profiles: the ceiling does NOT leak (Option B is a separate decision)', () => {
+	it('web_only (dmarc weight 0, not critical) stays uncapped on an otherwise-clean roster', () => {
+		const score = computeScanScore(rosterWithDmarc(pNoneResult()), contextFor('web_only'));
+		expect(score.overall).toBeGreaterThan(64);
+	});
+
+	it('non_mail (dmarc weighted but not critical) stays uncapped on an otherwise-clean roster', () => {
+		const score = computeScanScore(rosterWithDmarc(pNoneResult()), contextFor('non_mail'));
+		expect(score.overall).toBeGreaterThan(64);
+	});
+});

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.30.0';
+export const PARITY_CORPUS_VERSION = '1.31.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):
@@ -286,13 +286,14 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 	},
 	{
 		check: 'dmarc',
-		// Scores here reflect model 1.15.0 (#842): relaxed aspf is advisory info (0),
-		// no longer a scored low (−5) — fixtures without aspf=s moved UP by 5.
+		// Model 1.19.0: p=none is a missing ENFORCEMENT control (BitSight equivalence with
+		// the no-record fixture above) — was 75/false under 1.15.0. The zeroing is declared
+		// via `metadata.missingControl`, not prose, so it survives a copy reword.
 		name: 'p=none + rua',
 		query: '_dmarc.example.com',
 		records: { '_dmarc.example.com': ['v=DMARC1; p=none; rua=mailto:d@example.com'] },
-		expectedScore: 75,
-		expectedMissingControl: false,
+		expectedScore: 0,
+		expectedMissingControl: true,
 	},
 	{
 		check: 'dmarc',

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -15,9 +15,13 @@ describe('classifyDmarc', () => {
 		expect(f[0].metadata?.missingControl).toBe(true);
 	});
 
-	it('scores p=none as a medium finding (NIST v3.5.0)', () => {
+	it('scores p=none as a high, category-zeroing finding (scoring model 1.19.0)', () => {
 		const f = classifyDmarc({ ...base, policy: 'none' });
-		expect(f.find((x) => x.title === 'DMARC policy set to none')?.severity).toBe('medium');
+		const none = f.find((x) => x.title === 'DMARC policy set to none');
+		expect(none?.severity).toBe('high');
+		// Declared, not just prose-matched — enforcement-equivalence with the absent-record
+		// case (BitSight-style) must survive a reword of the sentence.
+		expect(none?.metadata?.missingControl).toBe(true);
 	});
 
 	it('flags p=quarantine as low', () => {
@@ -217,10 +221,10 @@ describe('classifyDmarc', () => {
 			expect(none?.detail).toMatch(/asymmetric/i);
 		});
 
-		it('keeps the title and severity unchanged (downstream matchers + no score change)', () => {
+		it('keeps the title unchanged for downstream matchers; severity is high since 1.19.0', () => {
 			const f = classifyDmarc({ ...asymmetric });
 			const none = f.find((x) => x.title === 'DMARC policy set to none');
-			expect(none?.severity).toBe('medium');
+			expect(none?.severity).toBe('high');
 			expect(none?.title).toBe('DMARC policy set to none');
 		});
 
@@ -233,14 +237,14 @@ describe('classifyDmarc', () => {
 		it('keeps the generic wording when the org domain is NOT enforcing (p=none, sp=none)', () => {
 			const f = classifyDmarc({ ...asymmetric, orgPolicy: 'none' });
 			const none = f.find((x) => x.title === 'DMARC policy set to none');
-			expect(none?.detail).toContain('only monitors');
+			expect(none?.detail).toContain('take no action');
 			expect(none?.detail).not.toMatch(/asymmetric/i);
 		});
 
 		it('keeps the generic wording on an organizational-domain scan with p=none', () => {
 			const f = classifyDmarc({ recordCount: 1, policy: 'none', domain: 'example.com' });
 			const none = f.find((x) => x.title === 'DMARC policy set to none');
-			expect(none?.detail).toContain('only monitors');
+			expect(none?.detail).toContain('take no action');
 			expect(none?.detail).not.toMatch(/asymmetric/i);
 		});
 

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -133,13 +133,26 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 			),
 		);
 	} else if (policy === 'none') {
+		// Scoring model 1.19.0: p=none is a missing ENFORCEMENT control. A receiver applying
+		// p=none takes no action on failing mail (RFC 9989 §5.1.4, "Monitoring Mode"), so for
+		// enforcement the posture is equivalent to publishing nothing — BitSight grades the two
+		// identically, dimension-scoped. Declared structurally (`missingControl: true`) like the
+		// no-record / multiple-record / missing-p= siblings above: zeroes the category and arms
+		// the critical-gap ceiling in the profiles where dmarc is critical (mail_enabled /
+		// enterprise_mail ONLY — non-mail profiles gain no ceiling from this; that boundary is
+		// a separate unratified decision, see bv-web-prod
+		// docs/superpowers/specs/2026-09-01-dmarc-pnone-and-nonmail-grading-research.md).
+		//
+		// The TITLE stays unchanged — it is load-bearing downstream (the impersonation
+		// escalation and `dmarcIsWeak` in scan post-processing match it exactly; maturity
+		// staging / rollout planning match it by substring; `assess_spoofability` derives
+		// posture from it).
+		//
 		// Asymmetry case: a subdomain was scanned DIRECTLY, and the organizational domain it
 		// inherits from is itself enforcing while handing this child `sp=none`. The effective
-		// policy really is "none", so the severity and title are unchanged (both are load-bearing
-		// downstream — the non-mail downgrade and the impersonation escalation match the title
-		// exactly, and maturity staging / rollout planning match it by substring). Only the
-		// DETAIL changes, and only to name the shape of the risk: the parent is locked down
-		// while this specific child is wide open, which is precisely why it gets picked.
+		// policy really is "none"; only the DETAIL differs, to name the shape of the risk —
+		// the parent is locked down while this specific child is wide open, which is precisely
+		// why it gets picked.
 		const parentEnforcing = facts.inheritedFromParent === true && (facts.orgPolicy === 'quarantine' || facts.orgPolicy === 'reject');
 		const self = facts.domain ?? '<domain>';
 		const org = facts.orgDomain ?? 'the organizational domain';
@@ -147,10 +160,11 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 			createFinding(
 				'dmarc',
 				'DMARC policy set to none',
-				'medium',
+				'high',
 				parentEnforcing
 					? `This subdomain has no DMARC enforcement: it publishes no DMARC record of its own and inherits sp=none from ${org}, whose own policy is "p=${facts.orgPolicy}". The enforcement is asymmetric — mail claiming to be from ${org} is rejected or quarantined, while mail claiming to be from ${self} is not, which is exactly why an attacker would pick the subdomain. Set sp=quarantine or sp=reject on ${org}, or publish a dedicated DMARC record at _dmarc.${self}. (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`
-					: `DMARC policy is "none" which only monitors but does not reject or quarantine spoofed emails. Consider upgrading to "quarantine" or "reject". (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
+					: `DMARC policy is "none": receivers monitor but take no action on messages that fail authentication, so spoofed email is delivered exactly as if no DMARC record existed. Monitoring is a rollout stage, not a protection — upgrade to "quarantine" or "reject" once aggregate reports confirm legitimate mail aligns. (Escalated to critical by scan_domain when active lookalike/impersonation domains are detected.)`,
+				{ missingControl: true },
 			),
 		);
 	} else if (policy === 'quarantine') {

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -295,8 +295,28 @@
  *   records whose certificate association has not been compared against the served
  *   certificate now receive a low deduction instead of an unsupported perfect score.
  *   UPWARD for DNSSEC islands; DOWNWARD for domains publishing unverified TLSA records.
+ * - 1.19.0 — DMARC `p=none` is a missing ENFORCEMENT control. The `DMARC policy set to
+ *   none` finding moves `medium` → `high` and declares `missingControl: true`, zeroing
+ *   the dmarc category (was ~75–85) and arming the critical-gap ceiling (64, NIST
+ *   display D) in the profiles where dmarc is critical — `mail_enabled` /
+ *   `enterprise_mail` only; non-mail profiles gain no ceiling. Rationale: a receiver
+ *   applying p=none takes no action on failing mail (RFC 9989 §5.1.4 "Monitoring
+ *   Mode"), so for enforcement it is equivalent to publishing nothing — BitSight
+ *   grades the two identically, and no surveyed grader treats p=none as protective.
+ *   NZ SGE mandates p=reject on all email-enabled domains by October 2026. Operator
+ *   ratified 2026-09-01 (bv-web-prod research spec
+ *   docs/superpowers/specs/2026-09-01-dmarc-pnone-and-nonmail-grading-research.md).
+ *   MEASURED population (2,000-domain random sample of the bv-web GSI corpus,
+ *   direct DoH probe, n=1,953 measured): 12.7% of domains publish p=none (vs 75.7%
+ *   no record, 11.7% enforcing); of the p=none cohort, 50.0% scored >64 before this
+ *   change (mean 65.1) and would now cap, 32.7% drop a NIST display letter
+ *   (C/B/A → D). DOWNWARD only, and only for p=none domains; absent/enforcing
+ *   postures and every other category are bit-for-bit unchanged. The finding TITLE
+ *   is unchanged (impersonation escalation, dmarcIsWeak, spoofability posture and
+ *   rollout planning all match on it). No weight, tier, grade band,
+ *   `SEVERITY_PENALTIES` entry or profile-detection rule changed.
  */
-export const SCORING_MODEL_VERSION = '1.18.0';
+export const SCORING_MODEL_VERSION = '1.19.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/test/check-dmarc.spec.ts
+++ b/test/check-dmarc.spec.ts
@@ -57,12 +57,13 @@ describe('checkDmarc', () => {
 		expect(finding!.severity).toBe('critical');
 	});
 
-	it('should return medium finding for p=none (monitoring-only, not a hard fail)', async () => {
+	it('should return a high, category-zeroing finding for p=none (scoring model 1.19.0)', async () => {
 		mockTxtRecords(['v=DMARC1; p=none; rua=mailto:dmarc@example.com']);
 		const result = await run();
 		const finding = result.findings.find((f) => /policy set to none/i.test(f.title));
 		expect(finding).toBeDefined();
-		expect(finding!.severity).toBe('medium');
+		expect(finding!.severity).toBe('high');
+		expect(finding!.metadata?.missingControl).toBe(true);
 	});
 
 	it('should return low finding for p=quarantine', async () => {


### PR DESCRIPTION
## What

The `DMARC policy set to none` finding moves `medium` → `high` and declares `missingControl: true`. The dmarc category zeroes (was ~75–85 for p=none), and the critical-gap ceiling (64 → NIST display **D**) arms in the profiles where dmarc is critical — `mail_enabled` / `enterprise_mail` **only**. Non-mail profiles gain no ceiling, and a new spec (`dmarc-pnone-missing-control.spec.ts`) guards that boundary explicitly.

Package `1.30.0 → 1.31.0`; `PARITY_CORPUS_VERSION` and `SCORING_MODEL_VERSION` (`1.18.0 → 1.19.0`, with a full history entry) move in lockstep.

## Why

A receiver applying p=none takes **no action** on failing mail (RFC 9989 §5.1.4, "Monitoring Mode") — for enforcement it is equivalent to publishing nothing. BitSight grades p=none identically to no-record, dimension-scoped; no grader in a 12-grader survey treats p=none as protective; NZ SGE mandates p=reject on all email-enabled domains by October 2026. Research SSOT: bv-web-prod `docs/superpowers/specs/2026-09-01-dmarc-pnone-and-nonmail-grading-research.md` (operator ratified 2026-09-01).

## Measured blast radius

2,000-domain random GSI-corpus sample, direct DoH probe, n=1,953 measured: **12.7% publish p=none** (75.7% no record, 11.7% enforcing). Of the p=none cohort: 50.0% scored >64 before this change and now cap; 32.7% drop a NIST display letter (C/B/A → D). **DOWNWARD only, p=none domains only** — absent and enforcing postures are bit-for-bit unchanged (pinned by the no-ordering-inversion test).

## What is deliberately unchanged

- The finding **TITLE** — `escalateDmarcForImpersonation`/`dmarcIsWeak` match it exactly, `assess_spoofability` derives posture from it, rollout planning matches by substring.
- `controlPresent`/`recordPresent` semantics (already the enforcing/published pair).
- All weights, tiers, grade bands, `SEVERITY_PENALTIES`, profile detection.

## Verification

- New spec: 9 tests (classifier severity+flag both variants, quarantine discrimination control, check-level zeroing, mail-profile ceiling ≤64, p=none==absent equality, web_only/non_mail uncapped guards) — written RED first.
- Full suite: **8,373 passed / 0 failed** (`npm test`), incl. `missing-control-intent.audit.test.ts` and `parity-corpus.contract.test.ts`.
- `scripts/ci/check-scoring-version.mjs origin/main HEAD` → RC=0; typecheck + eslint clean.

Downstream: bv-web-prod re-vendors 1.31.0 after this lands (parity + golden re-baseline there, one public-claims event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
