### PR TITLE
feat(scoring): web_only weights the non-sender lockdown (model 1.20.0)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.31.0",
+	"version": "1.32.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/scoring-contract.test.ts
+++ b/packages/dns-checks/src/__tests__/scoring-contract.test.ts
@@ -11,7 +11,8 @@ describe('machine-readable scoring contract', () => {
 
 	it('defines comparison and selection semantics for every profile', () => {
 		expect(Object.keys(SCORING_CONTRACT.profiles).sort()).toEqual(Object.keys(PROFILE_SEMANTICS).sort());
-		expect(PROFILE_SEMANTICS.web_only.emailPostureIncluded).toBe(false);
+		// true since model 1.20.0 — web_only weights the non-sender lockdown.
+		expect(PROFILE_SEMANTICS.web_only.emailPostureIncluded).toBe(true);
 		expect(PROFILE_SEMANTICS.minimal.comparisonClass).toBe('limited-footprint');
 		expect(PROFILE_SEMANTICS.authoritative_dns_infra.autoSelectable).toBe(false);
 	});

--- a/packages/dns-checks/src/__tests__/scoring/dmarc-pnone-missing-control.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/dmarc-pnone-missing-control.spec.ts
@@ -145,7 +145,7 @@ describe('mail profiles: p=none arms the critical-gap ceiling', () => {
 });
 
 describe('non-mail profiles: the ceiling does NOT leak (Option B is a separate decision)', () => {
-	it('web_only (dmarc weight 0, not critical) stays uncapped on an otherwise-clean roster', () => {
+	it('web_only (dmarc weighted 3 since model 1.20.0, still not critical) stays uncapped on an otherwise-clean roster', () => {
 		const score = computeScanScore(rosterWithDmarc(pNoneResult()), contextFor('web_only'));
 		expect(score.overall).toBeGreaterThan(64);
 	});

--- a/packages/dns-checks/src/__tests__/scoring/scoring-profiles.suite.ts
+++ b/packages/dns-checks/src/__tests__/scoring/scoring-profiles.suite.ts
@@ -535,11 +535,12 @@ export function defineScoringProfilesSuite(s: ScoringModule): void {
 				expect(coreSum).toBe(63);
 			});
 
-			it('web_only zeroes email auth core weights', () => {
+			it('web_only carries the non-sender lockdown identity weights (model 1.20.0: spf 2 / dmarc 3 / dkim 0)', () => {
 				const p = PROFILE_WEIGHTS.web_only;
-				expect(p.spf.importance).toBe(0);
-				expect(p.dmarc.importance).toBe(0);
+				expect(p.spf.importance).toBe(2);
+				expect(p.dmarc.importance).toBe(3);
 				expect(p.dkim.importance).toBe(0);
+				expect(p.mx.importance).toBe(1);
 				expect(p.ssl.importance).toBeGreaterThan(0);
 			});
 

--- a/packages/dns-checks/src/__tests__/scoring/web-only-lockdown-weights.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/web-only-lockdown-weights.spec.ts
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Scoring model 1.20.0 — `web_only` weights the non-sender lockdown (Option B,
+ * ratified 2026-09-02).
+ *
+ * THE DECISION THIS FILE PINS.
+ * A non-sending domain is a prime impersonation target, and the correct posture is
+ * the published lockdown: `v=spf1 -all` (NIST SP 800-177r1 §4.4.2), an enforcing
+ * DMARC policy, and a null MX (RFC 7505). The per-check rubric for that posture has
+ * existed for a long time — check-mx scores no-MX+no-SPF as spoofable with
+ * `{ missingControl: true }` (→ 0) and no-MX+`-all` as "Correctly-configured
+ * non-mail domain"; the dmarc classifier scores reject/quarantine/none correctly —
+ * but `web_only` multiplied all of it by an importance of ZERO, so a fully
+ * spoofable unconfigured domain and a locked-down one scored identically
+ * (measured 2026-09-02: fundhaus.app, no SPF record + plain no-MX, rendered 82/B).
+ *
+ * The change: `web_only` adopts the same small identity weights `non_mail` has
+ * always carried — spf 2, dmarc 3, mx 1 — so the existing rubric flows into the
+ * score, bounded to single-digit points by the tier normalizer.
+ *
+ * WHAT IS DELIBERATELY NOT CHANGED.
+ *   - NO critical-gap ceiling: spf/dmarc stay OUT of `web_only`'s critical set
+ *     (twin-settled 2026-09-01; measured 2026-09-02: 93.1% of the no-MX corpus
+ *     cohort — 55% of the whole corpus — lacks every lockdown record, so a
+ *     p=none-style hard cap here would re-grade half the index in one release).
+ *     Movement flows through weights only.
+ *   - dkim stays 0 in `web_only`: a non-sender cannot earn sender DKIM marks, and
+ *     the NZ SGE blank-key wildcard variant was examined and not adopted
+ *     (2026-09-01 research spec §Option B).
+ *   - Mail profiles and `non_mail` weights are untouched.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { buildCheckResult, computeScanScore, createFinding, getProfileWeights } from '../../scoring';
+import type { DomainContext } from '../../scoring';
+import type { CheckCategory, CheckResult, Finding } from '../../types';
+
+function ok(category: CheckCategory): CheckResult {
+	return buildCheckResult(category, [createFinding(category, `${category} OK`, 'info', 'Check passed')], true);
+}
+
+function zeroed(category: CheckCategory, title: string, detail: string): CheckResult {
+	const finding: Finding = createFinding(category, title, 'medium', detail, { missingControl: true });
+	return buildCheckResult(category, [finding], false);
+}
+
+const OTHER_CATEGORIES: CheckCategory[] = [
+	'dkim',
+	'dnssec',
+	'ssl',
+	'mta_sts',
+	'caa',
+	'bimi',
+	'tlsrpt',
+	'subdomain_takeover',
+	'ns',
+	'txt_hygiene',
+	'http_security',
+	'dane',
+	'mx_reputation',
+	'srv',
+	'zone_hygiene',
+	'dane_https',
+	'svcb_https',
+];
+
+/** A non-sender that published the full lockdown: -all SPF, enforcing DMARC, null MX. */
+function lockedDownRoster(): CheckResult[] {
+	return [
+		...OTHER_CATEGORIES.map(ok),
+		buildCheckResult('spf', [createFinding('spf', 'SPF hard-fail lockdown', 'info', 'v=spf1 -all')], true),
+		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC policy enforcing', 'info', 'p=reject')], true),
+		buildCheckResult('mx', [createFinding('mx', 'Null MX published', 'info', 'RFC 7505 null MX declares the domain non-receiving')], false),
+	];
+}
+
+/** The fundhaus class: no SPF record, no DMARC enforcement, plain no-MX — fully spoofable. */
+function unlockedRoster(): CheckResult[] {
+	return [
+		...OTHER_CATEGORIES.map(ok),
+		zeroed('spf', 'No SPF record', 'The domain publishes no SPF policy; any server may claim to send as it.'),
+		zeroed('dmarc', 'DMARC record not found', 'No DMARC policy is published.'),
+		zeroed('mx', 'No MX and no SPF — domain spoofable', 'No mail exchange records and no SPF policy.'),
+	];
+}
+
+function contextFor(profile: DomainContext['profile']): DomainContext {
+	return {
+		profile,
+		signals: ['test fixture'],
+		weights: getProfileWeights(profile),
+		detectedProvider: null,
+	};
+}
+
+describe('web_only identity weights (scoring model 1.20.0)', () => {
+	it('adopts the non_mail identity weights: spf 2, dmarc 3, mx 1', () => {
+		const w = getProfileWeights('web_only');
+		expect(w.spf.importance).toBe(2);
+		expect(w.dmarc.importance).toBe(3);
+		expect(w.mx.importance).toBe(1);
+	});
+
+	it('deliberately keeps dkim at 0 (a non-sender cannot earn sender DKIM marks)', () => {
+		expect(getProfileWeights('web_only').dkim.importance).toBe(0);
+	});
+
+	it('leaves every other profile identity weight untouched', () => {
+		expect(getProfileWeights('mail_enabled').spf.importance).toBe(10);
+		expect(getProfileWeights('mail_enabled').dmarc.importance).toBe(16);
+		expect(getProfileWeights('non_mail').spf.importance).toBe(2);
+		expect(getProfileWeights('non_mail').dmarc.importance).toBe(3);
+		expect(getProfileWeights('non_mail').mx.importance).toBe(1);
+	});
+});
+
+describe('web_only discriminates locked-down from spoofable non-senders', () => {
+	it('scores the lockdown strictly above the unconfigured domain', () => {
+		const locked = computeScanScore(lockedDownRoster(), contextFor('web_only'));
+		const unlocked = computeScanScore(unlockedRoster(), contextFor('web_only'));
+		expect(locked.overall).not.toBeNull();
+		expect(unlocked.overall).not.toBeNull();
+		expect(locked.overall!).toBeGreaterThanOrEqual(unlocked.overall! + 8);
+	});
+
+	it('pins the exact contract values: lockdown 100, spoofable 89 on the synthetic rosters', () => {
+		// The unlocked roster is otherwise PERFECT — real spoofable non-senders carry
+		// other flaws and land lower (fundhaus.app, 82/B pre-model, ≈ mid-70s / NIST C
+		// post-model). The 11-point spread is the ratified weights-only movement:
+		// spf+dmarc = 5/33 of the 70-point core tier, mx = 1/28 of protective.
+		const locked = computeScanScore(lockedDownRoster(), contextFor('web_only'));
+		const unlocked = computeScanScore(unlockedRoster(), contextFor('web_only'));
+		expect(locked.overall).toBe(100);
+		expect(unlocked.overall).toBe(89);
+	});
+
+	it('keeps a fully locked-down non-sender in the top band (the lockdown is rewarded, not just the gap punished)', () => {
+		const locked = computeScanScore(lockedDownRoster(), contextFor('web_only'));
+		expect(locked.overall!).toBeGreaterThanOrEqual(90);
+	});
+});
+
+describe('the movement is weights-only — no ceiling leaks into web_only', () => {
+	it('a fully spoofable non-sender is NOT capped at 64 (55% of the corpus; a hard cap is a separate, unratified decision)', () => {
+		const unlocked = computeScanScore(unlockedRoster(), contextFor('web_only'));
+		expect(unlocked.overall!).toBeGreaterThan(64);
+	});
+
+	it('mail_enabled scoring of the same rosters is unchanged by this model revision (identity weights already non-zero there)', () => {
+		const locked = computeScanScore(lockedDownRoster(), contextFor('mail_enabled'));
+		const unlocked = computeScanScore(unlockedRoster(), contextFor('mail_enabled'));
+		expect(locked.overall!).toBeGreaterThan(unlocked.overall!);
+	});
+});

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.31.0';
+export const PARITY_CORPUS_VERSION = '1.32.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/packages/dns-checks/src/scoring/contract.ts
+++ b/packages/dns-checks/src/scoring/contract.ts
@@ -47,7 +47,10 @@ const PROFILE_SEMANTIC_ENTRIES: ReadonlyArray<readonly [DomainProfile, ScoringPr
 		'web_only',
 		{
 			comparisonClass: 'ordinary-domain',
-			emailPostureIncluded: false,
+			// true since scoring model 1.20.0: web_only weights the non-sender
+			// lockdown (spf 2 / dmarc 3 / mx 1), so email posture IS part of the
+			// score — matching non_mail, which carries the same identity weights.
+			emailPostureIncluded: true,
 			autoSelectable: true,
 			selectionReason: 'web-presence-without-receiving-mail-detected',
 		},

--- a/packages/dns-checks/src/scoring/profiles.ts
+++ b/packages/dns-checks/src/scoring/profiles.ts
@@ -146,8 +146,18 @@ export const PROFILE_WEIGHTS: Record<DomainProfile, Record<CheckCategory, Import
 	},
 	web_only: {
 		// Core
-		spf: { importance: 0 },
-		dmarc: { importance: 0 },
+		// spf/dmarc were 0 until scoring model 1.20.0 (Option B, ratified 2026-09-02):
+		// zero weight meant a fully spoofable unconfigured non-sender and a locked-down
+		// one (v=spf1 -all + p=reject + RFC 7505 null MX) scored IDENTICALLY — the
+		// per-check rubric already distinguished them, multiplied by nothing. These are
+		// the same small identity weights `non_mail` has always carried. dkim stays 0
+		// on purpose: a non-sender cannot earn sender DKIM marks (the SGE blank-key
+		// wildcard variant was examined and not adopted). spf/dmarc must stay OUT of
+		// PROFILE_CRITICAL_CATEGORIES.web_only — movement is weights-only, no ceiling
+		// (93.1% of the no-MX corpus cohort lacks every lockdown record; a hard cap
+		// would re-grade half the index in one release).
+		spf: { importance: 2 },
+		dmarc: { importance: 3 },
 		dkim: { importance: 0 },
 		dnssec: { importance: 14 },
 		ssl: { importance: 14 },
@@ -156,7 +166,7 @@ export const PROFILE_WEIGHTS: Record<DomainProfile, Record<CheckCategory, Import
 		http_security: { importance: 8 },
 		mta_sts: { importance: 0 },
 		subdomailing: { importance: 0 },
-		mx: { importance: 0 },
+		mx: { importance: 1 },
 		caa: { importance: 3 },
 		ns: { importance: 3 },
 		lookalikes: { importance: 2 },

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -315,8 +315,28 @@
  *   is unchanged (impersonation escalation, dmarcIsWeak, spoofability posture and
  *   rollout planning all match on it). No weight, tier, grade band,
  *   `SEVERITY_PENALTIES` entry or profile-detection rule changed.
+ * - 1.20.0 — `web_only` weights the NON-SENDER LOCKDOWN (Option B of the 2026-09-01
+ *   research spec, operator ratified 2026-09-02). `web_only` identity weights move
+ *   from 0 to the values `non_mail` has always carried — spf 0→2, dmarc 0→3,
+ *   mx 0→1 (dkim stays 0: a non-sender cannot earn sender DKIM marks; the NZ SGE
+ *   blank-key wildcard variant was examined and not adopted). The per-check rubric
+ *   already scored the lockdown correctly (check-mx: no-MX+no-SPF → spoofable,
+ *   missingControl, 0; no-MX+`v=spf1 -all` → "Correctly-configured non-mail
+ *   domain" per NIST SP 800-177r1 §4.4.2; RFC 7505 null MX recognized; dmarc:
+ *   reject/quarantine/none graded) — zero weight simply multiplied it away, so a
+ *   fully spoofable unconfigured domain and a locked-down one scored identically.
+ *   Weights-only, NO ceiling: spf/dmarc stay OUT of
+ *   `PROFILE_CRITICAL_CATEGORIES.web_only`. MEASURED population (same 2,000-domain
+ *   GSI corpus sample, 3-record DoH probe 2026-09-02, n=1,926 measured): 59.6% of
+ *   the corpus has no MX; of that cohort 93.1% publishes NONE of the lockdown
+ *   records (0.4% has the full triple), so a p=none-style hard cap would re-grade
+ *   ~55% of the index in one release — the weights bound the movement to ≤11.3
+ *   points instead (spf+dmarc = 5/33 of the 70-pt core tier + mx = 1/28 of
+ *   protective; measured live anchor fundhaus.app 82/B → ≈76/NIST C). DOWNWARD for
+ *   un-locked-down no-MX domains, UPWARD-neutral (unchanged 100) for locked-down
+ *   ones; `non_mail` and every mail profile are bit-for-bit unchanged.
  */
-export const SCORING_MODEL_VERSION = '1.19.0';
+export const SCORING_MODEL_VERSION = '1.20.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/test/scan-domain-spf-timeout-scoring.spec.ts
+++ b/test/scan-domain-spf-timeout-scoring.spec.ts
@@ -83,19 +83,25 @@ async function scanWithSpfFailure(mode: 'missingControl' | 'throws') {
 describe('Finding 1 — a transient check failure scores the same however it surfaces', () => {
 	// SCORING-EQUIVALENCE GUARD (one axis only — see caveat below).
 	//
-	// A transient DNS failure surfaced as a heuristic `missingControl` finding must not
-	// score worse than the same failure surfaced as a `checkStatus`/throw transient.
-	// Verified empirically: both land on the identical overall score because the
-	// `confidence: 'heuristic'` finding never enters the engine's `missingControls` set
-	// (no critical-gap ceiling), so its zeroed category contribution nets out to the
-	// same headline number as transient exclusion.
+	// A transient DNS failure surfaced as a heuristic `missingControl` finding must never
+	// arm the critical-gap ceiling, and its two surfacing shapes must keep their traced
+	// per-check asymmetry (zeroed-and-counted vs excluded-and-renormalised).
 	//
-	// CAVEAT: score-equivalent is NOT behaviour-equivalent. The two shapes differ in
-	// scan_domain's transient-zero RETRY: shouldRetry() keys off `checkStatus === 'error'`,
-	// so only the throw/checkStatus shape is retried — a `missingControl` shape is not.
-	// This is why buildDnsErrorResult (the Finding-1 fix) uses `checkStatus`, NOT
-	// `missingControl`. The two corpora are not interchangeable; do not collapse them.
-	it('overall score is identical whether spf fails via internal-catch or via throw', async () => {
+	// HISTORY: until scoring model 1.20.0 this test asserted the two shapes produce an
+	// IDENTICAL overall score. That equality was an ARTIFACT, not an invariant: the
+	// fixture domain mocks no MX, so it detects as `web_only`, and `web_only` weighted
+	// spf at 0 — a zero-weight category contributes nothing whether counted or excluded.
+	// In every profile with a non-zero spf weight the two shapes have ALWAYS diverged
+	// (zeroed drags the weighted mean; excluded renormalises it away), so the equality
+	// claim never described mail profiles at all. Model 1.20.0 gave `web_only` spf
+	// weight 2 (non-sender lockdown), ending the accidental equality here too. The
+	// production check is unaffected: real check-spf uses buildDnsErrorResult (the
+	// `checkStatus` shape) precisely so transients are excluded AND retried.
+	//
+	// CAVEAT (unchanged): score posture is NOT behaviour posture. shouldRetry() keys
+	// off `checkStatus === 'error'`, so only the throw/checkStatus shape is retried —
+	// a `missingControl` shape is not. Do not collapse the two shapes.
+	it('keeps the traced shape asymmetry, bounds the divergence to the spf weight share, and arms no ceiling', async () => {
 		const viaMissingControl = await scanWithSpfFailure('missingControl');
 		const viaThrow = await scanWithSpfFailure('throws');
 
@@ -108,7 +114,21 @@ describe('Finding 1 — a transient check failure scores the same however it sur
 		expect(viaMissingControl.score.categoryScores.spf).toBe(0); // present-and-zeroed
 		expect(viaThrow.score.categoryScores.spf).toBeUndefined(); // excluded/n-a
 
-		// ...yet the headline score is the SAME. No regression from the wrapper catch.
-		expect(viaMissingControl.score.overall).toBe(viaThrow.score.overall);
+		// Narrow `overall: number | null` FIRST — an un-narrowed comparison is vacuous
+		// against the UNGRADED case (`null >= null` and `null - null <= 6` are both true).
+		const mcOverall = viaMissingControl.score.overall;
+		const throwOverall = viaThrow.score.overall;
+		if (mcOverall === null || throwOverall === null) {
+			throw new Error('fixture scans must be graded — got a null overall');
+		}
+
+		// The heuristic finding must not arm the critical-gap ceiling on either path.
+		expect(mcOverall).toBeGreaterThan(64);
+		expect(throwOverall).toBeGreaterThan(64);
+
+		// The zeroed shape may only trail the excluded shape by spf's small weight
+		// share in this profile (web_only spf=2 → a few points), never by a cliff.
+		expect(throwOverall).toBeGreaterThanOrEqual(mcOverall);
+		expect(throwOverall - mcOverall).toBeLessThanOrEqual(6);
 	});
 });


### PR DESCRIPTION
Option B of the 2026-09-01 research spec, operator-ratified 2026-09-02. Scoring model **1.20.0**, package **1.32.0**.

## What changes

`web_only` identity weights move from 0 to the values `non_mail` has always carried: **spf 0→2, dmarc 0→3, mx 0→1** (dkim stays 0 — a non-sender cannot earn sender DKIM marks). The per-check rubric already scored the non-sender lockdown correctly (check-mx: no-MX+no-SPF → spoofable/`missingControl`/0; no-MX+`v=spf1 -all` → correctly-configured non-mail domain per NIST SP 800-177r1 §4.4.2; RFC 7505 null MX; dmarc reject/quarantine/none) — zero weight multiplied it away, so a fully spoofable unconfigured domain and a locked-down one scored identically (live anchor: fundhaus.app 82/B).

**Weights-only, NO ceiling:** spf/dmarc stay OUT of `PROFILE_CRITICAL_CATEGORIES.web_only`. Measured on a 2,000-domain GSI corpus sample (n=1,926): 59.6% of the corpus has no MX; 93.1% of that cohort publishes none of the lockdown records, so a hard cap would re-grade ~55% of the index — the weights bound movement to ≤11.3 pts. Mail profiles and `non_mail` are bit-for-bit unchanged.

Also bumps `PARITY_CORPUS_VERSION` to 1.32.0 (version-lock step) and records the 1.20.0 model-history entry in `src/lib/scoring-version.ts`.

## Verification

- Full suite green: **8,381 passed / 0 failed**, RC=0.
- New spec `packages/dns-checks/src/__tests__/scoring/web-only-lockdown-weights.spec.ts`: **8/8** (re-run at the committed SHA).
- TDD RED→GREEN: the new spec failed against the 0-weights, passes with the 1.20.0 weights.
- Restated guard `test/scan-domain-spf-timeout-scoring.spec.ts`: 1/1 (re-run at the committed SHA).
- `npm run typecheck` RC=0 · `npm run typecheck:tests` RC=0 · `npm run lint` RC=0.

## Guard restated

`test/scan-domain-spf-timeout-scoring.spec.ts` previously asserted that a transient SPF failure lands on an **identical** overall score whether it surfaces as an internal-catch `missingControl` finding or as a `checkStatus`/throw transient. That equality was an **accident of the zero weight**, not an invariant: the fixture mocks no MX, so the domain detects as `web_only`, and with spf weighted 0 a category contributes nothing whether counted-and-zeroed or excluded-and-renormalised. In every profile with a non-zero spf weight the two shapes have always diverged — the equality claim never described mail profiles at all.

The test now pins the true invariants instead:

- the traced per-check **shape asymmetry** (`missingControl` → present-and-zeroed `categoryScores.spf = 0`; throw → `checkStatus: 'error'`, excluded/undefined);
- **no ceiling**: the heuristic finding must not arm the critical-gap cap on either path (both overalls > 64);
- **bounded divergence**: the zeroed shape may trail the excluded shape only by spf's small weight share (≤6 pts), never a cliff — with both `overall` values explicitly null-narrowed first, so the bound cannot pass vacuously on an UNGRADED result.

The behaviour caveat is unchanged and preserved in the test: only the `checkStatus` shape is retried by `shouldRetry()`; the two shapes must not be collapsed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
