### PR TITLE
fix(access-log): attribute no-cf-connecting-ip public requests instead of collapsing them into 'unknown' (#876)

### DIFF
--- a/src/lib/access-log-event.ts
+++ b/src/lib/access-log-event.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { piiAllows, type AnalyticsPiiLevel } from './analytics-pii';
+import { hashNetworkLocalityForAnalytics, type NetworkLocalityInput } from './analytics';
 
 /**
  * One captured access-log record. Used both as the queue message payload and
@@ -54,5 +55,45 @@ export function buildAccessLogEvent(raw: AccessLogEventInput, level: AnalyticsPi
 		userAgent: piiAllows(level, 'user_agent') ? raw.userAgent : null,
 		ptrHostname: null,
 		piiLevel: level,
+	};
+}
+
+/**
+ * `ip_masked` marker for a public-path row whose request carried no
+ * `cf-connecting-ip` but did carry `request.cf` (#876). Distinguishes "the edge
+ * never gave us a client IP" from a hashing failure or the internal door's
+ * deliberate `'unknown'` sentinel.
+ */
+export const NO_CF_HEADER_MARKER = 'no-cf-header';
+
+/** Inputs for {@link resolveAccessLogAttribution}. */
+export interface AccessLogAttributionInput extends NetworkLocalityInput {
+	/** Already-computed `i_` hash of cf-connecting-ip, or the internal door's explicit `'unknown'`; undefined = header absent. */
+	ipHash?: string;
+	/** `maskIp(ip)` output — passed through unchanged when the header was present. */
+	ipMasked: string;
+}
+
+/**
+ * Attribution for one access-log row (#876). Precedence:
+ *   1. an explicit `ipHash` (real `i_` hash, or the internal door's `'unknown'`) wins untouched;
+ *   2. header absent but any `request.cf` locality field usable → `n_` network-locality
+ *      key + `ip_masked = 'no-cf-header'`, so the rows stop collapsing into one "user";
+ *   3. nothing usable (off-CF, tests) → the historical bare `'unknown'` sentinel.
+ * The IP-source rule (cf-connecting-ip only; never x-forwarded-for) is NOT touched — this
+ * never feeds rate limiting, dedup, or tier gating, only the analytics attribution key.
+ */
+export function resolveAccessLogAttribution(input: AccessLogAttributionInput): { ipHash: string; ipMasked: string } {
+	if (input.ipHash !== undefined) return { ipHash: input.ipHash, ipMasked: input.ipMasked };
+	const usable = (v: string | null | undefined) => typeof v === 'string' && v.length > 0 && v !== 'unknown';
+	const cfPresent = (typeof input.asn === 'number' && Number.isFinite(input.asn)) || usable(input.colo) || usable(input.country);
+	if (!cfPresent) return { ipHash: 'unknown', ipMasked: input.ipMasked };
+	return {
+		ipHash: hashNetworkLocalityForAnalytics({
+			asn: input.asn,
+			colo: usable(input.colo) ? input.colo : null,
+			country: usable(input.country) ? input.country : null,
+		}),
+		ipMasked: NO_CF_HEADER_MARKER,
 	};
 }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -456,6 +456,26 @@ export function hashForAnalytics(value: string): string {
 export function hashIpForAnalytics(ip: string): string {
 	return fnv1aHash(ip, 'i_');
 }
+/** Inputs for {@link hashNetworkLocalityForAnalytics} — the `request.cf` fields a no-header row already stores in plaintext. */
+export interface NetworkLocalityInput {
+	asn?: number | null;
+	colo?: string | null;
+	country?: string | null;
+}
+
+/**
+ * FNV-1a hash of `asn|colo|country` — `n_` prefix so it can never be mistaken
+ * for an `i_` IP hash. Fallback attribution key for public-path access-log rows
+ * whose request carried NO `cf-connecting-ip` but did carry `request.cf` (#876).
+ * Deliberately built ONLY from fields the row already stores in plaintext at the
+ * `coarse` PII level, so it adds no dimension the row lacks. Coarse by design:
+ * every caller in one ASN behind one colo shares a key. Not a trust source —
+ * the IP-source rule (cf-connecting-ip only) is unchanged; this is attribution.
+ */
+export function hashNetworkLocalityForAnalytics(input: NetworkLocalityInput): string {
+	const asn = typeof input.asn === 'number' && Number.isFinite(input.asn) ? String(input.asn) : '-';
+	return fnv1aHash(`${asn}|${input.colo || '-'}|${input.country || '-'}`, 'n_');
+}
 
 /** Shared FNV-1a hash with configurable prefix. */
 function fnv1aHash(value: string, prefix: string): string {

--- a/src/mcp/execute.ts
+++ b/src/mcp/execute.ts
@@ -41,7 +41,7 @@ import { hashDomain } from '../lib/analytics';
 import { classifyError as classifyFuzzError } from '../lib/fuzzing-detector';
 import { recordEvent as recordFuzzCounter } from '../lib/fuzzing-counter';
 import { piiAllows } from '../lib/analytics-pii';
-import { buildAccessLogEvent, type AccessLogEvent } from '../lib/access-log-event';
+import { buildAccessLogEvent, resolveAccessLogAttribution, type AccessLogEvent } from '../lib/access-log-event';
 import { extractProtocolHeaders, readJsonRpcErrorPayload } from './response';
 
 export type ProcessedRequestResult =
@@ -371,11 +371,21 @@ function recordMcpAccessLog(
 	if (!options.intelligenceDb && !options.analyticsQueue) return;
 	const logger = getLogger();
 	const level = options.analyticsPiiLevel ?? 'coarse';
+	// #876 — header present → real `i_` hash; header absent but request.cf present →
+	// `n_` network-locality key + ip_masked='no-cf-header'; neither → bare 'unknown'.
+	// The internal door passes ipHash='unknown' explicitly and is untouched.
+	const attribution = resolveAccessLogAttribution({
+		ipHash: options.ipHash,
+		ipMasked: maskIp(options.ip),
+		asn: options.asn,
+		colo: options.colo,
+		country: options.country,
+	});
 	const event = buildAccessLogEvent(
 		{
 			ip: options.ip,
-			ipHash: options.ipHash ?? 'unknown',
-			ipMasked: maskIp(options.ip),
+			ipHash: attribution.ipHash,
+			ipMasked: attribution.ipMasked,
 			toolName: input.toolName,
 			domain: input.domain,
 			source: options.source ?? 'public',

--- a/test/analytics.spec.ts
+++ b/test/analytics.spec.ts
@@ -154,9 +154,9 @@ describe('createAnalyticsClient', () => {
 		expect(point.blobs[0]).toBe('scan_domain');
 		expect(point.blobs[4]).toBe('NZ');
 		expect(point.blobs[9]).toBe('i_cafef00d'); // blob10 ipHash unmoved
-		expect(point.blobs[10]).toBe('SYD');        // blob11 colo unmoved
+		expect(point.blobs[10]).toBe('SYD'); // blob11 colo unmoved
 		// New trailing dimension (C2).
-		expect(point.blobs[11]).toBe('check_spf');  // blob12 priorTool
+		expect(point.blobs[11]).toBe('check_spf'); // blob12 priorTool
 	});
 
 	it('emitToolEvent appends a privacy-safe outcome and completion counters', () => {
@@ -369,5 +369,27 @@ describe('createAnalyticsClient', () => {
 		expect(() =>
 			client.emitQueueBatchEvent({ handler: 'brand-audit-queue', outcome: 'ok', durationMs: 1, messageCount: 1, failureCount: 0 }),
 		).not.toThrow();
+	});
+});
+
+describe('hashNetworkLocalityForAnalytics (#876)', () => {
+	it('produces an n_-prefixed FNV-1a key that can never be mistaken for an IP hash', async () => {
+		const { hashNetworkLocalityForAnalytics, hashIpForAnalytics } = await import('../src/lib/analytics');
+		const key = hashNetworkLocalityForAnalytics({ asn: 13335, colo: 'AKL', country: 'NZ' });
+		expect(key).toMatch(/^n_[0-9a-f]{1,8}$/);
+		expect(key).toBe(hashNetworkLocalityForAnalytics({ asn: 13335, colo: 'akl', country: 'nz' })); // case-normalized
+		expect(key).not.toBe(hashNetworkLocalityForAnalytics({ asn: 13335, colo: 'SYD', country: 'AU' }));
+		// Same digest input under the i_ prefix is a different namespace.
+		expect(hashIpForAnalytics('13335|akl|nz')).not.toBe(key);
+	});
+
+	it('tolerates missing fields deterministically', async () => {
+		const { hashNetworkLocalityForAnalytics } = await import('../src/lib/analytics');
+		expect(hashNetworkLocalityForAnalytics({ asn: undefined, colo: undefined, country: 'US' })).toBe(
+			hashNetworkLocalityForAnalytics({ asn: null, colo: null, country: 'US' }),
+		);
+		expect(hashNetworkLocalityForAnalytics({ asn: undefined, colo: 'IAD', country: 'US' })).not.toBe(
+			hashNetworkLocalityForAnalytics({ asn: undefined, colo: undefined, country: 'US' }),
+		);
 	});
 });

--- a/test/mcp-access-log.spec.ts
+++ b/test/mcp-access-log.spec.ts
@@ -505,7 +505,13 @@ describe('recordMcpAccessLog routing', () => {
 			},
 		};
 		// @ts-expect-error — exercising the internal helper via the exported recorder
-		mod.__recordMcpAccessLogForTest(options, { toolName: 'check_spf', domain: 'example.com', rateLimited: false, method: 'tools/call', status: 'pass' });
+		mod.__recordMcpAccessLogForTest(options, {
+			toolName: 'check_spf',
+			domain: 'example.com',
+			rateLimited: false,
+			method: 'tools/call',
+			status: 'pass',
+		});
 		await new Promise((r) => setTimeout(r, 0));
 		expect(prepare).not.toHaveBeenCalled();
 		expect(sent).toHaveLength(1);
@@ -534,7 +540,13 @@ describe('recordMcpAccessLog routing', () => {
 			},
 		};
 		// @ts-expect-error — internal helper
-		mod.__recordMcpAccessLogForTest(options, { toolName: 'check_spf', domain: 'example.com', rateLimited: true, method: 'tools/call', status: 'unknown' });
+		mod.__recordMcpAccessLogForTest(options, {
+			toolName: 'check_spf',
+			domain: 'example.com',
+			rateLimited: true,
+			method: 'tools/call',
+			status: 'unknown',
+		});
 		await new Promise((r) => setTimeout(r, 0));
 		expect(prepare).toHaveBeenCalledTimes(1);
 		expect(String(prepare.mock.calls[0][0])).toContain('INSERT INTO mcp_access_log');
@@ -587,5 +599,159 @@ describe('recordInternalAccessLog', () => {
 			'pass',
 			'internal', // source
 		);
+	});
+});
+
+// #876 — public-path rows whose request carried no `cf-connecting-ip` used to
+// collapse into the bare `'unknown'` sentinel even when `request.cf` geo was
+// present, making every such caller one "user" in count(DISTINCT ip_hash) and
+// indistinguishable from a hashing failure. The recorder now derives a
+// network-locality fallback key (`n_<hex>` over asn|colo|country — all three
+// already stored in plaintext at the coarse PII level, so no new leakage) and
+// marks `ip_masked = 'no-cf-header'`. The IP-source rule (cf-connecting-ip
+// ONLY) is untouched: this is attribution of the no-header case, not a new
+// trust source.
+describe('recordMcpAccessLog attribution without cf-connecting-ip (#876)', () => {
+	function baseOptions(overrides: Record<string, unknown>) {
+		const run = vi.fn(async () => ({ success: true }));
+		const bind = vi.fn(() => ({ run }));
+		const prepare = vi.fn(() => ({ bind }));
+		const promises: Promise<unknown>[] = [];
+		const options = {
+			intelligenceDb: { prepare } as unknown as D1Database,
+			analyticsPiiLevel: 'coarse' as const,
+			responseTransport: 'sse',
+			startTime: Date.now(),
+			waitUntil: (p: Promise<unknown>) => promises.push(p),
+			...overrides,
+		};
+		return { options, bind, drain: () => Promise.all(promises) };
+	}
+
+	it('keeps the real IP hash and masked octets when cf-connecting-ip is present', async () => {
+		const mod = await import('../src/mcp/execute');
+		const { options, bind, drain } = baseOptions({ ip: '192.0.2.9', ipHash: 'i_real', country: 'NZ', colo: 'AKL', asn: 13335 });
+		// @ts-expect-error — internal helper
+		mod.__recordMcpAccessLogForTest(options, {
+			toolName: 'check_spf',
+			domain: 'example.com',
+			rateLimited: false,
+			method: 'tools/call',
+			status: 'pass',
+		});
+		await drain();
+		const row = bind.mock.calls[0] as unknown[];
+		expect(row[0]).toBe('i_real');
+		expect(row[1]).toBe('192.0.2.xxx');
+	});
+
+	it('records a network-locality fallback key + no-cf-header marker when the header is absent but request.cf is present', async () => {
+		const mod = await import('../src/mcp/execute');
+		const { hashNetworkLocalityForAnalytics } = await import('../src/lib/analytics');
+		const { NO_CF_HEADER_MARKER } = await import('../src/lib/access-log-event');
+		const { options, bind, drain } = baseOptions({ ip: 'unknown', ipHash: undefined, country: 'US', colo: 'IAD', asn: 396982 });
+		// @ts-expect-error — internal helper
+		mod.__recordMcpAccessLogForTest(options, {
+			toolName: 'scan_domain',
+			domain: 'example.com',
+			rateLimited: false,
+			method: 'tools/call',
+			status: 'pass',
+		});
+		await drain();
+		const row = bind.mock.calls[0] as unknown[];
+		expect(row[0]).toBe(hashNetworkLocalityForAnalytics({ asn: 396982, colo: 'IAD', country: 'US' }));
+		expect(row[0]).toMatch(/^n_[0-9a-f]{1,8}$/);
+		expect(row[0]).not.toBe('unknown');
+		expect(row[1]).toBe(NO_CF_HEADER_MARKER);
+		expect(row[1]).toBe('no-cf-header');
+		// Plaintext geo columns are unchanged — the key adds no dimension the row lacks.
+		expect(row[4]).toBe('US'); // country
+		expect(row[14]).toBe(396982); // asn
+		expect(row[19]).toBe('IAD'); // colo
+	});
+
+	it('gives two no-header callers in different network localities different keys', async () => {
+		const mod = await import('../src/mcp/execute');
+		const a = baseOptions({ ip: 'unknown', ipHash: undefined, country: 'NZ', colo: 'AKL', asn: 136557 });
+		const b = baseOptions({ ip: 'unknown', ipHash: undefined, country: 'IE', colo: 'DUB', asn: 6830 });
+		// @ts-expect-error — internal helper
+		mod.__recordMcpAccessLogForTest(a.options, {
+			toolName: 'check_spf',
+			domain: 'example.com',
+			rateLimited: false,
+			method: 'tools/call',
+			status: 'pass',
+		});
+		// @ts-expect-error — internal helper
+		mod.__recordMcpAccessLogForTest(b.options, {
+			toolName: 'check_spf',
+			domain: 'example.com',
+			rateLimited: false,
+			method: 'tools/call',
+			status: 'pass',
+		});
+		await Promise.all([a.drain(), b.drain()]);
+		const keyA = (a.bind.mock.calls[0] as unknown[])[0];
+		const keyB = (b.bind.mock.calls[0] as unknown[])[0];
+		expect(keyA).not.toBe(keyB);
+	});
+
+	it('falls back to the bare unknown sentinel when neither the header nor request.cf is present', async () => {
+		const mod = await import('../src/mcp/execute');
+		// Off-CF shape as index.ts produces it: country/colo default to 'unknown', asn undefined.
+		const { options, bind, drain } = baseOptions({ ip: 'unknown', ipHash: undefined, country: 'unknown', colo: 'unknown', asn: undefined });
+		// @ts-expect-error — internal helper
+		mod.__recordMcpAccessLogForTest(options, {
+			toolName: 'check_spf',
+			domain: 'example.com',
+			rateLimited: false,
+			method: 'tools/call',
+			status: 'pass',
+		});
+		await drain();
+		const row = bind.mock.calls[0] as unknown[];
+		expect(row[0]).toBe('unknown');
+		expect(row[1]).toBe('unknown');
+	});
+
+	it('leaves the internal door sentinel untouched (explicit ipHash wins over any cf fields)', async () => {
+		const { resolveAccessLogAttribution } = await import('../src/lib/access-log-event');
+		// recordInternalAccessLog passes ipHash: 'unknown' explicitly and no cf fields;
+		// even if cf fields were ever threaded through, an explicit ipHash must win.
+		expect(resolveAccessLogAttribution({ ipHash: 'unknown', ipMasked: 'unknown', asn: 13335, colo: 'AKL', country: 'NZ' })).toEqual({
+			ipHash: 'unknown',
+			ipMasked: 'unknown',
+		});
+	});
+
+	it('routes the same attribution through the queue path', async () => {
+		const mod = await import('../src/mcp/execute');
+		const sent: unknown[] = [];
+		const { options, drain } = baseOptions({
+			ip: 'unknown',
+			ipHash: undefined,
+			country: 'DE',
+			colo: 'FRA',
+			asn: 47583,
+			analyticsQueue: {
+				send: async (m: unknown) => {
+					sent.push(m);
+				},
+			},
+		});
+		// @ts-expect-error — internal helper
+		mod.__recordMcpAccessLogForTest(options, {
+			toolName: 'check_spf',
+			domain: 'example.com',
+			rateLimited: false,
+			method: 'tools/call',
+			status: 'pass',
+		});
+		await drain();
+		const ev = sent[0] as { ip: string; ipHash: string; ipMasked: string };
+		expect(ev.ipHash).toMatch(/^n_/);
+		expect(ev.ipMasked).toBe('no-cf-header');
+		expect(ev.ip).toBe('unknown'); // consumer PTR/encrypt short-circuit unchanged
 	});
 });


### PR DESCRIPTION
Closes #876

## What happens

Public-path `mcp_access_log` rows whose request carried no `cf-connecting-ip` were written with the bare sentinel `ip_hash = 'unknown'` / `ip_masked = 'unknown'` even though `request.cf` geo (country, colo, ASN) was present on the same row. Every such caller collapsed into one "user" for `count(DISTINCT ip_hash)`, and the sentinel was indistinguishable from a hashing failure or from the internal door's deliberate sentinel.

## Evidence (D1 `bv-intelligence`, read-only aggregates, last 30 days, `source` public)

The picture is materially different from the issue's monitor hypothesis. Sentinel rows are now the **majority of public traffic and almost all of the real-client traffic**:

| | rows | distinct `ip_hash` |
|---|---|---|
| hashed rows | 11,669 | 3 (all NZ: two operator IPs + the `bv_load_test` client) |
| sentinel rows | 3,560 (3,550 `sse`, 10 `json`) | 1 (the literal `'unknown'`) |

Sentinel rows by `client_type` / auth state: `claude_code` 2,842 (2,765 **authenticated with a `key_hash`**), `claude_connector` 232 (230 authenticated), `unknown` 486, `bv_load_test` 2. On ordinary days the sentinel share of public rows is ~100% (e.g. 186/186, 96/96, 185/186); the only days with a meaningful hashed share are load-test days.

By colo: AKL 2,850 · IAD 232 · DUB 200 · PDX 165 · LHR 45 · SJC 36 · CDG 10 · FRA 9 · (TXL, AMS, LAX, ATL, DFW ≤ 4 each). By country/ASN-org: NZ (Host Universal) 2,848 · US (Anthropic — the remote connector) 232 · IE (Virgin Media) 200 · US (Render) 165 · NL (LeaseWeb) 45 · US (Comcast) 36 · FR/DE/DK ≤ 11 each. Hour-of-day shows no regular cadence; 182 distinct session hashes; `user_agent` is NULL on every row (coarse PII level), so a directory-monitor UA heuristic is **not** derivable from the data and was not added.

Only the PDX/Render (165) and LeaseWeb (45) buckets look like hosted probes; the `transport='sse'` skew is simply the Streamable HTTP path with an `Accept: text/event-stream` (`responseTransport: acceptsSSE(accept) ? 'sse' : 'json'`), not the legacy `/mcp/messages` door.

**Implication (operator, out of scope for this PR):** `cf-connecting-ip` appears to be absent for essentially all traffic reaching the Worker via the public custom domain, while the operator's workers.dev-URL traffic carries it. This is consistent with the existing note that owner-tier auth via the custom domain downgrades to `partner` (the IP allowlist fails closed on `'unknown'`). Worth checking at the zone: a Managed Transform ("Remove visitor IP headers"), a request-header transform rule, or an upstream proxy in front of the route. This PR does not change the IP-source rule (cf-connecting-ip only, never `x-forwarded-for`).

## Root cause

`recordMcpAccessLog` (`src/mcp/execute.ts`) used `options.ipHash ?? 'unknown'`; `index.ts` sets `ipHash` only when `resolveClientIpFromHeaders` (cf-connecting-ip only, by design) returns a real IP. Nothing distinguished "header absent, cf present" from "nothing known".

## Fix (no D1 migration — both columns already exist and are free-form TEXT)

- `src/lib/analytics.ts` — `hashNetworkLocalityForAnalytics({asn, colo, country})`: FNV-1a over `asn|colo|country` with an **`n_` prefix** so it can never be mistaken for an `i_` IP hash. Built only from fields the row already stores in plaintext at the `coarse` PII level, so it leaks nothing the row did not already carry.
- `src/lib/access-log-event.ts` — `NO_CF_HEADER_MARKER = 'no-cf-header'` and `resolveAccessLogAttribution()`: explicit `ipHash` wins untouched (real `i_` hash, or the internal door's `'unknown'`); header absent + any usable cf field → `n_` key + `ip_masked = 'no-cf-header'`; nothing usable (off-CF, tests) → the historical bare `'unknown'`.
- `src/mcp/execute.ts` — the recorder calls the resolver; the queue and inline-insert paths both carry the result. `recordInternalAccessLog` is unchanged (it passes `ipHash: 'unknown'` explicitly and no cf fields).

Rate limiting, dedup, fuzz counters, tier gating, and the AE `ipHash` blob are deliberately **not** touched — this is analytics attribution only. Over the 30-day window the fallback would have split the one sentinel key into 15 distinct locality keys.

## Tests

- `test/mcp-access-log.spec.ts` — new describe `recordMcpAccessLog attribution without cf-connecting-ip (#876)`: header present → unchanged `i_` hash + masked octets; header absent + cf present → `n_` key + `no-cf-header` (asserting the plaintext geo columns are unchanged); two localities → two keys; header absent + no cf → bare `'unknown'`; explicit internal-door sentinel wins over cf fields; queue path carries the same attribution with `ip` still `'unknown'`.
- `test/analytics.spec.ts` — `hashNetworkLocalityForAnalytics`: `n_` prefix, case-normalised, distinct from the `i_` namespace, deterministic on missing fields.
- Existing `recordInternalAccessLog` / `internal-access-log.spec.ts` assertions (`'unknown'`, `'unknown'`) still pass unchanged.

Commands: `npx vitest run test/mcp-access-log.spec.ts test/analytics.spec.ts test/internal-access-log.spec.ts test/analytics-rollup-routing.spec.ts test/queue-consumer-analytics.spec.ts` → 55 passed. `npm run typecheck` → clean. `npm run lint` → clean. `npm test` → 8,395 passed, 0 failed, 13 skipped; the sole "failed" file is `test/wasm-integration.test.ts` failing to **load** (`No such module …bv_wasm_core_bg.wasm` — the documented fresh-worktree artefact, `npm run build:wasm` not run).

## Residuals

1. **Shared rate-limit bucket (confirmed, not changed here).** Every *unauthenticated* no-header caller is keyed on the literal `'unknown'` for `checkRateLimit` (50/min, 300/hr), `checkIpDailyLimit`, `checkToolDailyRateLimit`, `checkIpScopedQuotaBatch`, and `checkDistinctDomainDailyLimit` (12 domains/day) — one global bucket for all of them. At the three `principalId: keyHash ?? ipHash` sites (`src/index.ts` ~1044/1150/1358) the value is `undefined` for those callers, so fuzz counters silently skip (`if (!principalId) return`) and brand-audit quota receives no principal. Authenticated no-header callers are keyed on `keyHash` and unaffected. Consistent with the data: 261 of 3,562 sentinel rows (7.3%) are `rate_limited = 1` vs 0 of 11,669 hashed rows. Posture decision for the operator; the real fix is restoring the header at the edge (above), not widening the trust source.
2. **Header absence on the custom domain** — see Implication above; operator zone check.
3. **`client_type` monitor tag** — not added: `user_agent` is NULL at coarse PII, so no safe heuristic exists in the data; the two hosted-looking buckets (Render/LeaseWeb) are now separable by their `n_` keys anyway.
4. `/internal/analytics/forensics` returns `ip_masked` as the `ip` fallback when no ciphertext decrypts, so those rows will now read `no-cf-header` instead of `unknown` — intended, and more informative.

5. Off-Cloudflare only: `index.ts` falls back to the client-supplied `cf-ipcountry` header for `country`, so an off-CF caller could pick its own `n_` bucket. Analytics-only, pre-existing storage of that header, both prod doors are behind Cloudflare — noted, not changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
