### PR TITLE
fix(lookalikes): throttled runs abstain from the threat rollup and report counts as floors (#865)

### DIFF
--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -35,7 +35,7 @@ import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult } from '../lib/scoring';
 import { generateCognitiveLookalikes, generateCombosquats, generateLookalikes } from './lookalike-analysis';
 import { calibrateLookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
-import { classifyOwnership, type OwnershipAssessment, type OwnershipVerdict } from '../lib/ownership-attribution';
+import { classifyOwnership, type OwnershipAssessment } from '../lib/ownership-attribution';
 import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 import { extractBrandName } from '../lib/public-suffix';
 import {
@@ -63,15 +63,15 @@ import {
 } from './lookalike-findings';
 import {
 	buildIncompleteEnumerationFinding,
-	buildMailCapableSummaryFinding,
 	buildNoActiveInfrastructureFinding,
 	buildNoPermutationsFinding,
 	buildNoRegisteredCandidatesFinding,
 	buildOwnershipUnmeasuredFinding,
 	buildReconCandidateFinding,
 	buildReconScanStatusFinding,
-	buildStagingSummaryFinding,
+	buildThreatRollupFinding,
 	buildTimeoutFinding,
+	type ThreatRollupMember,
 } from './lookalike-summary-findings';
 
 // ---------------------------------------------------------------------------
@@ -359,31 +359,27 @@ async function checkLookalikesCore(
 	// #264-calibrated OBSERVED-threat severity rides a separate finding that
 	// asserts nothing about ownership.
 	//
-	// `highCount` is reachable again as of Task 7b: it counts threat-OBSERVATION
-	// highs, which the ownership cap no longer touches. Under Task 7 it could
-	// never increment and the summary finding below was dead code.
-	let highCount = 0;
-	/** The counted candidates, so the aggregate summary can name what it counted (invariant 4). */
-	const highDomains: string[] = [];
-	/** Their ownership verdicts — always non-owned, since owned candidates never reach the counter. */
-	const highVerdicts = new Set<OwnershipVerdict>();
-	/**
-	 * EVERY non-owned candidate with a working mail host — a strictly WIDER set
-	 * than `highDomains`, which additionally requires a #264 corroborator.
-	 *
-	 * Tracked separately because the summary finding used to be TITLED for this
-	 * set ("N lookalike domains with mail capability detected") while being
-	 * COUNTED from the narrower one (#779). Measured on openclaw.ai the title
-	 * said 2 while six candidates in the SAME response carried `hasMX: true`;
-	 * on openclaw.org it said 1 against 3. A three-fold undercount, in the one
-	 * finding a consumer is most likely to read without expanding the per-domain
-	 * detail — and it propagated into a client-facing report.
-	 *
-	 * A domain with working mail AND a live website is not the safer case: the
-	 * site lends the mail credibility. Excluding it from a count labelled "mail
-	 * capability" was the wrong direction to be wrong in.
-	 */
-	const mailCapableDomains: string[] = [];
+	// The staging count is reachable again as of Task 7b: it counts
+	// threat-OBSERVATION highs, which the ownership cap no longer touches. Under
+	// Task 7 it could never increment and the summary finding below was dead code.
+	//
+	// EVERY non-owned, measured candidate that received a threat observation is
+	// a rollup member; `buildThreatRollupFinding` derives BOTH counted sets from
+	// the one list — the mail-capable set, and its HIGH subset. They used to be
+	// collected separately, and the summary finding was TITLED for the wider set
+	// ("N lookalike domains with mail capability detected") while COUNTED from
+	// the narrower one (#779). Measured on openclaw.ai the title said 2 while six
+	// candidates in the SAME response carried `hasMX: true`; on openclaw.org it
+	// said 1 against 3. A three-fold undercount, in the one finding a consumer
+	// is most likely to read without expanding the per-domain detail — and it
+	// propagated into a client-facing report. A domain with working mail AND a
+	// live website is not the safer case: the site lends the mail credibility.
+	//
+	// Each member carries its own `registrationDays` so the rollup can say how
+	// many of the domains it counts were never age-checked (#865) — counted
+	// still, because the mail host is a real observation; hedged, because the
+	// "recent registration" corroborator was unmeasured for them.
+	const rollupMembers: ThreatRollupMember[] = [];
 	for (const result of results) {
 		const ownership: OwnershipAssessment = ownershipByDomain.get(result.domain) ?? {
 			verdict: 'unattributed',
@@ -491,21 +487,21 @@ async function checkLookalikesCore(
 			),
 		);
 		// `hasMX` is already false for an RFC 7505 null MX (`0 .`), which is the
-		// explicit way a domain declines mail — so this counts real mail hosts,
-		// not merely "an MX record exists".
-		if (result.hasMX) mailCapableDomains.push(result.domain);
-		if (result.hasMX && severity === 'high') {
-			highCount++;
-			highDomains.push(result.domain);
-			highVerdicts.add(ownership.verdict);
-		}
+		// explicit way a domain declines mail — so the rollup counts real mail
+		// hosts, not merely "an MX record exists".
+		rollupMembers.push({
+			domain: result.domain,
+			hasMX: result.hasMX,
+			severity,
+			ownershipVerdict: ownership.verdict,
+			registrationDays: signals.registrationDays,
+		});
 	}
 
-	if (highCount > 0) {
-		findings.push(buildStagingSummaryFinding({ seedDomain: domain, highCount, highDomains, highVerdicts, mailCapableDomains, enumeration }));
-	} else if (mailCapableDomains.length > 0) {
-		findings.push(buildMailCapableSummaryFinding({ seedDomain: domain, mailCapableDomains, enumeration }));
-	}
+	// #865 — the rollup decides for itself whether coverage permits a count;
+	// a throttled run gets a not-assessed notice instead of an integer.
+	const rollup = buildThreatRollupFinding({ seedDomain: domain, members: rollupMembers, enumeration });
+	if (rollup.finding) findings.push(rollup.finding);
 
 	// If no active lookalikes found
 	if (findings.length === 0) {
@@ -596,7 +592,10 @@ async function checkLookalikesCore(
 	// throttled run would be served for the full TTL after DNS recovered — the
 	// non-answer outliving the condition that caused it. Same contract the
 	// timeout path in checkLookalikes() already honours.
-	if (seedNsUnmeasured) {
+	//
+	// #865 — the same law for a rollup ABSTENTION: enumeration throttling is
+	// transient too, and a cached "not assessed" would outlive the throttling.
+	if (seedNsUnmeasured || rollup.abstained) {
 		result.partial = true;
 	}
 	return result;

--- a/src/tools/lookalike-summary-findings.ts
+++ b/src/tools/lookalike-summary-findings.ts
@@ -19,6 +19,7 @@ import type { Finding } from '../lib/scoring';
 import { createFinding } from '../lib/scoring';
 import type { OwnershipAssessment, OwnershipVerdict } from '../lib/ownership-attribution';
 import type { LookalikeFindingAxis } from './lookalike-findings';
+import type { LookalikeSeverity } from './lookalike-severity';
 
 /**
  * Enumeration coverage for one run.
@@ -33,6 +34,80 @@ export interface LookalikeEnumeration {
 	candidatesResolved: number;
 	unresolvedCount: number;
 	complete: boolean;
+}
+
+/**
+ * Share of the PROBED permutation space that went unresolved at or above which
+ * the threat rollup ABSTAINS instead of publishing a count (#865).
+ *
+ * Why one half: the rollup is a claim about a SET. Once more of the probed
+ * namespace is unobserved than observed, the emitted count is bounded below by
+ * what resolved and above by nothing — its plausible range exceeds its value,
+ * so it is dominated by coverage, not by the world. Below the line the count
+ * is still reported, but as a FLOOR with the coverage stats beside it.
+ *
+ * Calibrated against the issue's measured table (2026-08-31, eight providers,
+ * same tool, same day): amazon.com 1.2% and cohere.com 43% emit; microsoft.com
+ * 51%, meta.com 62%, google.com 67% and openai.com 86% abstain. The openai run
+ * — 12 of 90 resolved, published as "8 can send mail in total" at `high` —
+ * is the shape this constant exists to stop. #847's degraded-comparison law
+ * (`seedNsUnresolved` → every verdict `unmeasured`) is BINARY and about the
+ * ownership instrument; this ratio is about enumeration coverage, a separate
+ * instrument, and is the first threshold on it.
+ */
+export const ROLLUP_ABSTAIN_UNRESOLVED_RATIO = 0.5;
+
+/** True when the run's enumeration coverage is too degraded to publish a rollup count (see {@link ROLLUP_ABSTAIN_UNRESOLVED_RATIO}). */
+export function isRollupCoverageDegraded(enumeration: LookalikeEnumeration): boolean {
+	if (enumeration.permutationsProbed <= 0) return false;
+	return enumeration.unresolvedCount / enumeration.permutationsProbed >= ROLLUP_ABSTAIN_UNRESOLVED_RATIO;
+}
+
+/**
+ * One NON-OWNED, MEASURED candidate the aggregate rollup may count. Assembled
+ * by the orchestrator's classification loop for every candidate that received
+ * a per-domain `threat_observation` — `owned_by_seed` and `unmeasured`
+ * candidates never reach it (#832).
+ */
+export interface ThreatRollupMember {
+	domain: string;
+	/** A working mail host (an RFC 7505 null MX is already `false` here). */
+	hasMX: boolean;
+	/** The #264-calibrated per-domain severity. */
+	severity: LookalikeSeverity;
+	ownershipVerdict: OwnershipVerdict;
+	/** `null` when the RDAP age probe failed or returned nothing — "unknown", never "not recent" for reporting purposes. */
+	registrationDays: number | null;
+}
+
+/**
+ * The enumeration stats FLATTENED onto a rollup finding's own metadata (#865).
+ * `enumeration` is still carried as the structured block; these duplicates
+ * exist because a consumer reading only the rollup — which is what a rollup
+ * is for — must not have to descend into a nested object to learn that the
+ * count it is about to quote came from a sample.
+ */
+function flatEnumerationStats(enumeration: LookalikeEnumeration): Record<string, number | boolean> {
+	return {
+		permutationsProbed: enumeration.permutationsProbed,
+		candidatesResolved: enumeration.candidatesResolved,
+		unresolvedCount: enumeration.unresolvedCount,
+		complete: enumeration.complete,
+	};
+}
+
+/** Prose fragment stating that an incomplete run's count is a floor, with the coverage numbers that make it one. */
+function floorClause(enumeration: LookalikeEnumeration): string {
+	return ` This is a floor, not a total: ${enumeration.unresolvedCount} of ${enumeration.permutationsProbed} probed lookup${enumeration.permutationsProbed === 1 ? '' : 's'} did not resolve, so those permutations could be neither confirmed nor ruled out and the true number can only be higher.`;
+}
+
+/**
+ * Prose fragment naming how many counted members carry no registration age, so
+ * "no recent-registration signal" is not read as "not recent". Unpunctuated —
+ * the caller supplies the leading connective and trailing stop.
+ */
+function ageUnknownSentence(ageUnknownCount: number, total: number): string {
+	return `${ageUnknownCount} of ${total} could not be age-checked (the registration-date lookup returned nothing), so "recently registered" is neither confirmed nor ruled out for ${ageUnknownCount === 1 ? 'that one' : 'those'}`;
 }
 
 /**
@@ -123,19 +198,93 @@ export function buildOwnershipUnmeasuredFinding(seedDomain: string, candidateCou
 }
 
 /**
+ * THE threat-rollup decision point (#865). Exactly one of three outcomes:
+ *
+ *  - no mail-capable member → `finding: null` (nothing to roll up — the
+ *    per-domain findings stand alone, as before);
+ *  - enumeration coverage degraded past {@link ROLLUP_ABSTAIN_UNRESOLVED_RATIO}
+ *    → the not-assessed `scan_status` notice from
+ *    {@link buildRollupNotAssessedFinding}, `abstained: true`, so the caller
+ *    marks the run `partial` and the abstention is not cached for the TTL;
+ *  - otherwise → the staging rollup when any member reached HIGH with mail,
+ *    else the mail-capable rollup — each worded as a FLOOR when the run is
+ *    incomplete, and each carrying the enumeration stats flat in its metadata.
+ *
+ * The order matters: abstention is decided BEFORE either rollup is built, so
+ * a throttled run can never reach the count-carrying builders at all.
+ */
+export function buildThreatRollupFinding(input: { seedDomain: string; members: ThreatRollupMember[]; enumeration: LookalikeEnumeration }): {
+	finding: Finding | null;
+	abstained: boolean;
+} {
+	const { seedDomain, members, enumeration } = input;
+	const mailCapable = members.filter((m) => m.hasMX);
+	if (mailCapable.length === 0) return { finding: null, abstained: false };
+	if (isRollupCoverageDegraded(enumeration)) {
+		return { finding: buildRollupNotAssessedFinding(seedDomain, enumeration), abstained: true };
+	}
+	const staging = mailCapable.filter((m) => m.severity === 'high');
+	if (staging.length > 0) {
+		return { finding: buildStagingSummaryFinding({ seedDomain, staging, mailCapable, enumeration }), abstained: false };
+	}
+	return { finding: buildMailCapableSummaryFinding({ seedDomain, mailCapable, enumeration }), abstained: false };
+}
+
+/**
+ * `scan_status` — the threat rollup was NOT ASSESSED this run because
+ * enumeration coverage was too degraded to count (#865). Carries NO count and
+ * NO domain list on purpose: the whole defect was an integer stated as fact
+ * beside a coverage block that contradicted it. Uses the repo's codified
+ * "probe never reached the origin" markers (`inconclusive` + `errorKind`,
+ * see `lib/control-presence.ts`) so a consumer keyed on those reads this as
+ * unmeasured, never as "no lookalike exposure".
+ */
+export function buildRollupNotAssessedFinding(seedDomain: string, enumeration: LookalikeEnumeration): Finding {
+	const pct = Math.round((enumeration.unresolvedCount / Math.max(1, enumeration.permutationsProbed)) * 100);
+	return createFinding(
+		'lookalikes',
+		'Lookalike threat rollup not assessed this run — enumeration too incomplete to count',
+		'info',
+		`${enumeration.unresolvedCount} of ${enumeration.permutationsProbed} candidate lookups for ${seedDomain} did not resolve (${pct}% — DNS timeout or rate limiting), so most of the permutation space was never observed. No count of mail-capable or staging-flagged lookalikes is published for this run: any such number would measure the throttling, not the estate, and would not be comparable with a run — or another organisation — that resolved more. The ${enumeration.candidatesResolved} candidate${enumeration.candidatesResolved === 1 ? '' : 's'} that did resolve are reported individually below as observed examples. Re-run to obtain a rollup.`,
+		{
+			findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
+			notAssessedReason: 'enumeration_throttled',
+			inconclusive: true,
+			errorKind: 'dns_error',
+			enumeration,
+			...flatEnumerationStats(enumeration),
+			unresolvedRatio: enumeration.permutationsProbed > 0 ? enumeration.unresolvedCount / enumeration.permutationsProbed : 0,
+			abstainThreshold: ROLLUP_ABSTAIN_UNRESOLVED_RATIO,
+			confidence: 'heuristic',
+		},
+	);
+}
+
+/**
  * AXIS 2 — summary finding for high-severity lookalikes. Only fires when at
  * least one NON-OWNED candidate reached HIGH under the issue #264 matrix
- * (mail-infra + corroborator). Owned candidates never reach here.
+ * (mail-infra + corroborator). Owned candidates never reach here. Reached only
+ * through {@link buildThreatRollupFinding}, which has already ruled out a
+ * degraded-coverage run (#865).
  */
 export function buildStagingSummaryFinding(input: {
 	seedDomain: string;
-	highCount: number;
-	highDomains: string[];
-	highVerdicts: Set<OwnershipVerdict>;
-	mailCapableDomains: string[];
+	/** Members that reached HIGH with a working mail host — the counted set. */
+	staging: ThreatRollupMember[];
+	/** Every member with a working mail host — the wider set, a superset of `staging`. */
+	mailCapable: ThreatRollupMember[];
 	enumeration: LookalikeEnumeration;
 }): Finding {
-	const { seedDomain: domain, highCount, highDomains, highVerdicts, mailCapableDomains, enumeration } = input;
+	const { seedDomain: domain, staging, mailCapable, enumeration } = input;
+	const highCount = staging.length;
+	const highDomains = staging.map((m) => m.domain);
+	const highVerdicts = new Set(staging.map((m) => m.ownershipVerdict));
+	const mailCapableDomains = mailCapable.map((m) => m.domain);
+	const ageUnknownCount = mailCapable.filter((m) => m.registrationDays === null).length;
+	// #865 — an incomplete run's count is a FLOOR. The title says so, because
+	// the title is what gets quoted.
+	const floor = !enumeration.complete;
+	const lead = floor ? `At least ${highCount}` : `${highCount}`;
 	return createFinding(
 		'lookalikes',
 		// TITLE NAMES THE PREDICATE IT COUNTS (#779). It used to say "with
@@ -145,13 +294,13 @@ export function buildStagingSummaryFinding(input: {
 		// evidence. The staging subset is the right thing to lead with; it
 		// just has to be named as the subset it is, with the wider
 		// mail-capable figure alongside rather than implied.
-		`${highCount} lookalike domain${highCount > 1 ? 's' : ''} showing pre-phishing staging signals`,
+		`${lead} lookalike domain${highCount > 1 ? 's' : ''} showing pre-phishing staging signals`,
 		'high',
-		`${highCount} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging.${
+		`${lead} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging.${
 			mailCapableDomains.length > highCount
-				? ` A further ${mailCapableDomains.length - highCount} confusable domain${mailCapableDomains.length - highCount > 1 ? 's' : ''} also ${mailCapableDomains.length - highCount > 1 ? 'have' : 'has'} a working mail host without those additional signals — ${mailCapableDomains.length} can send mail in total.`
+				? ` A further ${mailCapableDomains.length - highCount} confusable domain${mailCapableDomains.length - highCount > 1 ? 's' : ''} also ${mailCapableDomains.length - highCount > 1 ? 'have' : 'has'} a working mail host without those additional signals — ${floor ? 'at least ' : ''}${mailCapableDomains.length} can send mail in total.`
 				: ''
-		} ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
+		}${floor ? floorClause(enumeration) : ''}${ageUnknownCount > 0 ? ` ${ageUnknownSentence(ageUnknownCount, mailCapableDomains.length)}.` : ''} ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
 		{
 			lookalikeDomainCount: highCount,
 			lookalikeDomains: highDomains,
@@ -160,7 +309,14 @@ export function buildStagingSummaryFinding(input: {
 			// and what nobody did.
 			mailCapableCount: mailCapableDomains.length,
 			mailCapableDomains,
+			// #865 — the counts above are lower bounds when the run is a sample.
+			countIsFloor: floor,
+			// How many of the mail-capable set carry no registration age. They
+			// are COUNTED (the mail host is a real observation); this says that
+			// "no recent-registration corroborator" was unmeasured for them.
+			ageUnknownCount,
 			enumeration,
+			...flatEnumerationStats(enumeration),
 			// Set-level claim, so its confidence tracks ENUMERATION coverage,
 			// not per-domain measurement quality (#781). Each row remains
 			// deterministic about its own domain; what is uncertain when a
@@ -186,24 +342,32 @@ export function buildStagingSummaryFinding(input: {
  *
  * MEDIUM, not high: mail capability alone is a real observation but not
  * evidence of staging, and the severity has to stay honest about which
- * of the two it is.
+ * of the two it is. Reached only through {@link buildThreatRollupFinding}
+ * (#865: never for a degraded-coverage run).
  */
 export function buildMailCapableSummaryFinding(input: {
 	seedDomain: string;
-	mailCapableDomains: string[];
+	mailCapable: ThreatRollupMember[];
 	enumeration: LookalikeEnumeration;
 }): Finding {
-	const { seedDomain: domain, mailCapableDomains, enumeration } = input;
+	const { seedDomain: domain, mailCapable, enumeration } = input;
+	const mailCapableDomains = mailCapable.map((m) => m.domain);
+	const ageUnknownCount = mailCapable.filter((m) => m.registrationDays === null).length;
 	const n = mailCapableDomains.length;
+	const floor = !enumeration.complete;
+	const lead = floor ? `At least ${n}` : `${n}`;
 	return createFinding(
 		'lookalikes',
-		`${n} lookalike domain${n > 1 ? 's' : ''} with a working mail host`,
+		`${lead} lookalike domain${n > 1 ? 's' : ''} with a working mail host`,
 		'medium',
-		`${n} confusable domain${n > 1 ? 's' : ''} of ${domain} ${n > 1 ? 'have' : 'has'} a working mail host, so ${n > 1 ? 'they are' : 'it is'} capable of sending mail that resembles ${domain}. No additional corroborating signal of pre-phishing staging was observed, and ${n > 1 ? 'none appears' : 'it does not appear'} to belong to the scanned organisation — this is an infrastructure observation, not an allegation. Enforcing DMARC p=reject on ${domain} is what makes receivers reject mail forging that name.`,
+		`${lead} confusable domain${n > 1 ? 's' : ''} of ${domain} ${n > 1 ? 'have' : 'has'} a working mail host, so ${n > 1 ? 'they are' : 'it is'} capable of sending mail that resembles ${domain}.${floor ? floorClause(enumeration) : ''} No additional corroborating signal of pre-phishing staging was observed${ageUnknownCount > 0 ? ` — though ${ageUnknownSentence(ageUnknownCount, n)}` : ''}, and ${n > 1 ? 'none appears' : 'it does not appear'} to belong to the scanned organisation — this is an infrastructure observation, not an allegation. Enforcing DMARC p=reject on ${domain} is what makes receivers reject mail forging that name.`,
 		{
 			mailCapableCount: n,
 			mailCapableDomains,
+			countIsFloor: floor,
+			ageUnknownCount,
 			enumeration,
+			...flatEnumerationStats(enumeration),
 			confidence: enumeration.complete ? 'deterministic' : 'heuristic',
 			// Names what it observed — invariant 4, asserted by
 			// `assertAxisInvariants`: every threat_observation must identify

--- a/test/check-lookalikes-throttled-rollup.spec.ts
+++ b/test/check-lookalikes-throttled-rollup.spec.ts
@@ -1,0 +1,258 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * #865 — a THROTTLED `check_lookalikes` run must not publish a hard threat
+ * rollup count at `high` severity.
+ *
+ * Measured 2026-08-31 (openai.com, engine 1.29.0): `enumeration` said
+ * 90 probed / 12 resolved / 77 unresolved / `complete: false`, yet the same
+ * payload carried "6 lookalike domains showing pre-phishing staging signals"
+ * at `high` with `mailCapableCount: 8` and "8 can send mail in total". The
+ * scan_status finding said the list was a sample; the rollup — the finding a
+ * consumer keys on, at higher severity — stated the integer as fact. Across
+ * eight providers the same day the unresolved rate ranged 1.2% → 86%, so
+ * side-by-side counts reported a rate-limiting artifact as a security
+ * difference between named companies.
+ *
+ * Contract pinned here:
+ *  1. at or above `ROLLUP_ABSTAIN_UNRESOLVED_RATIO` the rollup ABSTAINS — a
+ *     not-assessed `scan_status` finding, no integer count, never `high`;
+ *  2. whenever it DOES emit, the enumeration stats travel INSIDE the rollup
+ *     finding's own metadata (flat, not only under `enumeration`);
+ *  3. an incomplete run reports its count as a FLOOR, never a bare N;
+ *  4. members whose registration age could not be fetched are counted in
+ *     `ageUnknownCount` and named as such in the prose — never dropped.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/** Parse the DoH query name and type from a fetch URL (same helper as check-lookalikes.spec.ts). */
+function parseDohQuery(input: string | URL | Request): { name: string; type: string } {
+	const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+	const parsed = new URL(url);
+	return {
+		name: parsed.searchParams.get('name') ?? '',
+		type: parsed.searchParams.get('type') ?? '',
+	};
+}
+
+const isNs = (type: string) => type === 'NS' || type === '2';
+const isMx = (type: string) => type === 'MX' || type === '15';
+
+function nsResponse(name: string, hosts: string[]) {
+	return createDohResponse(
+		[{ name, type: 2 }],
+		hosts.map((data) => ({ name, type: 2, TTL: 300, data })),
+	);
+}
+
+function mxResponse(name: string, exchange: string) {
+	return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: `10 ${exchange}` }]);
+}
+
+function empty() {
+	return createDohResponse([], []);
+}
+
+async function run(domain = 'testco.com') {
+	const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+	return checkLookalikes(domain);
+}
+
+/**
+ * Seed `testco.com` on its own NS; candidate `twstco.com` on unrelated NS with
+ * a working mail host. `mx.mailgun.org` sits in DISPOSABLE_MX_PROVIDERS, so the
+ * #264 matrix reaches HIGH without an RDAP mock — which also leaves
+ * `registrationDays: null` (age unknown), the shape #867 is about.
+ *
+ * `rejectOthers` controls how much of the permutation space is throttled:
+ *  - `'all'`   → every other permutation's NS lookup REJECTS (openai shape, ~99%)
+ *  - a number  → only the first N distinct other names reject; the rest
+ *                answer empty (a partial run well below the abstain threshold)
+ *  - `0`       → nothing rejects (a complete run)
+ */
+function mockRun(opts: { rejectOthers: 'all' | number; candidateMx?: string }): void {
+	const { rejectOthers, candidateMx = 'mx.mailgun.org.' } = opts;
+	const rejected = new Set<string>();
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const { name, type } = parseDohQuery(input);
+		if (name === 'testco.com' && isNs(type)) {
+			return Promise.resolve(nsResponse(name, ['ns1.primary-dns.com.']));
+		}
+		if (name === 'twstco.com') {
+			if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.unrelated-dns.com.']));
+			if (isMx(type)) return Promise.resolve(mxResponse(name, candidateMx));
+			return Promise.resolve(empty());
+		}
+		if (isNs(type) && name !== '' && name !== 'testco.com') {
+			if (rejectOthers === 'all' || rejected.has(name) || rejected.size < rejectOthers) {
+				rejected.add(name);
+				return Promise.reject(new Error('DNS timeout'));
+			}
+		}
+		return Promise.resolve(empty());
+	});
+}
+
+const STAGING_TITLE = /lookalike domains? showing pre-phishing staging signals/i;
+const MAIL_HOST_TITLE = /lookalike domains? with a working mail host/i;
+
+/** The aggregate rollup: a threat_observation that names a LIST, not a single candidate. */
+function findRollup(findings: Awaited<ReturnType<typeof run>>['findings']) {
+	return findings.find((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === undefined);
+}
+
+describe('checkLookalikes - throttled runs abstain from the threat rollup (#865)', () => {
+	it('abstains at or above the unresolved-ratio threshold: not-assessed, no integer, never high', async () => {
+		mockRun({ rejectOthers: 'all' });
+		const result = await run('testco.com');
+
+		// The two aggregate rollups are both withheld.
+		expect(result.findings.some((f) => STAGING_TITLE.test(f.title))).toBe(false);
+		expect(result.findings.some((f) => MAIL_HOST_TITLE.test(f.title))).toBe(false);
+		expect(findRollup(result.findings)).toBeUndefined();
+
+		// In their place: a not-assessed scan_status notice that reuses the
+		// repo's "probe never reached the origin" vocabulary.
+		const abstained = result.findings.find((f) => f.metadata?.notAssessedReason === 'enumeration_throttled');
+		expect(abstained, 'an abstention must be VISIBLE, not silent').toBeDefined();
+		expect(abstained!.severity).toBe('info');
+		expect(abstained!.metadata?.findingAxis).toBe('scan_status');
+		expect(abstained!.metadata?.inconclusive).toBe(true);
+		expect(abstained!.metadata?.errorKind).toBe('dns_error');
+		// No count of any kind on the abstention.
+		expect(abstained!.metadata?.lookalikeDomainCount).toBeUndefined();
+		expect(abstained!.metadata?.mailCapableCount).toBeUndefined();
+		expect(abstained!.metadata?.lookalikeDomains).toBeUndefined();
+		expect(abstained!.metadata?.mailCapableDomains).toBeUndefined();
+		expect(abstained!.title).not.toMatch(/\d+ lookalike domain/);
+		// The enumeration stats a consumer needs to judge the abstention are on
+		// the finding itself.
+		expect(abstained!.metadata?.complete).toBe(false);
+		expect(abstained!.metadata?.permutationsProbed as number).toBeGreaterThan(0);
+		expect(abstained!.metadata?.unresolvedCount as number).toBeGreaterThan(0);
+		expect(abstained!.metadata?.candidatesResolved).toBe(1);
+
+		// No aggregate finding anywhere carries a bare count in its title.
+		for (const f of result.findings) {
+			if (f.metadata?.lookalikeDomain !== undefined) continue;
+			expect(f.title).not.toMatch(/^\d+ lookalike domain/);
+			expect(f.title).not.toMatch(/^At least \d+/);
+		}
+	});
+
+	it('an abstained run is marked partial so the non-answer is not cached for the TTL (#847 law)', async () => {
+		mockRun({ rejectOthers: 'all' });
+		const result = await run('testco.com');
+		expect(result.partial).toBe(true);
+	});
+
+	it('the mail-capable-only (medium) rollup abstains under the same threshold', async () => {
+		mockRun({ rejectOthers: 'all', candidateMx: 'mail.twstco.com.' });
+		const result = await run('testco.com');
+		expect(result.findings.some((f) => MAIL_HOST_TITLE.test(f.title))).toBe(false);
+		expect(result.findings.some((f) => STAGING_TITLE.test(f.title))).toBe(false);
+		expect(result.findings.find((f) => f.metadata?.notAssessedReason === 'enumeration_throttled')).toBeDefined();
+	});
+
+	it('below the threshold an incomplete run still emits, but as a FLOOR with the enumeration stats inside the rollup', async () => {
+		mockRun({ rejectOthers: 3 });
+		const result = await run('testco.com');
+
+		const rollup = result.findings.find((f) => STAGING_TITLE.test(f.title));
+		expect(rollup, 'a mildly incomplete run must not be silenced').toBeDefined();
+		expect(rollup!.metadata?.findingAxis).toBe('threat_observation');
+		// Floor wording, not a bare integer.
+		expect(rollup!.title).toMatch(/^At least 1 lookalike domain showing pre-phishing staging signals/);
+		expect(rollup!.detail).toMatch(/floor/i);
+		expect(rollup!.detail).toMatch(/of \d+ probed/);
+		expect(rollup!.metadata?.countIsFloor).toBe(true);
+		expect(rollup!.metadata?.lookalikeDomainCount).toBe(1);
+		expect(rollup!.metadata?.lookalikeDomains).toEqual(['twstco.com']);
+		// The four enumeration stats are FLAT on the rollup — a consumer reading
+		// only this finding cannot miss them.
+		expect(rollup!.metadata?.complete).toBe(false);
+		expect(rollup!.metadata?.unresolvedCount).toBe(3);
+		expect(rollup!.metadata?.permutationsProbed as number).toBeGreaterThan(3);
+		expect(rollup!.metadata?.candidatesResolved).toBe(1);
+		expect(rollup!.metadata?.confidence).toBe('heuristic');
+		// No abstention notice when the rollup did emit.
+		expect(result.findings.some((f) => f.metadata?.notAssessedReason === 'enumeration_throttled')).toBe(false);
+	});
+
+	it('names how many counted members could not be age-checked, without dropping them', async () => {
+		mockRun({ rejectOthers: 3 });
+		const result = await run('testco.com');
+		const rollup = result.findings.find((f) => STAGING_TITLE.test(f.title));
+		expect(rollup).toBeDefined();
+		// No RDAP mock → registrationDays null for the one mail-capable member.
+		expect(rollup!.metadata?.ageUnknownCount).toBe(1);
+		expect(rollup!.metadata?.mailCapableCount).toBe(1);
+		expect(rollup!.metadata?.mailCapableDomains).toEqual(['twstco.com']);
+		expect(rollup!.detail).toMatch(/1 of 1 .*could not be age-checked/i);
+	});
+
+	it('a complete run is unchanged: bare count, no floor marker, stats say complete', async () => {
+		mockRun({ rejectOthers: 0 });
+		const result = await run('testco.com');
+
+		const rollup = result.findings.find((f) => STAGING_TITLE.test(f.title));
+		expect(rollup).toBeDefined();
+		expect(rollup!.title).toBe('1 lookalike domain showing pre-phishing staging signals');
+		expect(rollup!.severity).toBe('high');
+		expect(rollup!.detail).not.toMatch(/floor/i);
+		expect(rollup!.metadata?.countIsFloor).toBeFalsy();
+		expect(rollup!.metadata?.complete).toBe(true);
+		expect(rollup!.metadata?.unresolvedCount).toBe(0);
+		expect(rollup!.metadata?.confidence).toBe('deterministic');
+		expect(rollup!.metadata?.lookalikeDomainCount).toBe(1);
+		expect(result.findings.some((f) => f.metadata?.notAssessedReason === 'enumeration_throttled')).toBe(false);
+		expect(result.partial).toBeFalsy();
+	});
+
+	it('the mail-capable-only (medium) rollup carries the same floor + stats contract when incomplete', async () => {
+		mockRun({ rejectOthers: 3, candidateMx: 'mail.twstco.com.' });
+		const result = await run('testco.com');
+		const rollup = result.findings.find((f) => MAIL_HOST_TITLE.test(f.title));
+		expect(rollup).toBeDefined();
+		expect(rollup!.severity).toBe('medium');
+		expect(rollup!.title).toMatch(/^At least 1 lookalike domain with a working mail host/);
+		expect(rollup!.metadata?.countIsFloor).toBe(true);
+		expect(rollup!.metadata?.complete).toBe(false);
+		expect(rollup!.metadata?.unresolvedCount).toBe(3);
+		expect(rollup!.metadata?.ageUnknownCount).toBe(1);
+		expect(rollup!.detail).toMatch(/floor/i);
+	});
+});
+
+describe('lookalike-summary-findings - abstain threshold (#865)', () => {
+	it('is a named constant at 50%: the unobserved share may never exceed the observed one', async () => {
+		const { ROLLUP_ABSTAIN_UNRESOLVED_RATIO, isRollupCoverageDegraded } = await import('../src/tools/lookalike-summary-findings');
+		expect(ROLLUP_ABSTAIN_UNRESOLVED_RATIO).toBe(0.5);
+		const at = (unresolvedCount: number, permutationsProbed = 100) => ({
+			permutationsGenerated: permutationsProbed,
+			permutationsProbed,
+			candidatesResolved: permutationsProbed - unresolvedCount,
+			unresolvedCount,
+			complete: unresolvedCount === 0,
+		});
+		// The issue's measured table: amazon 1/82 and cohere 40/94 emit; microsoft
+		// 48/95, meta 41/66, google 60/89 and openai 77/90 abstain.
+		expect(isRollupCoverageDegraded(at(1, 82))).toBe(false);
+		expect(isRollupCoverageDegraded(at(40, 94))).toBe(false);
+		expect(isRollupCoverageDegraded(at(48, 95))).toBe(true);
+		expect(isRollupCoverageDegraded(at(41, 66))).toBe(true);
+		expect(isRollupCoverageDegraded(at(60, 89))).toBe(true);
+		expect(isRollupCoverageDegraded(at(77, 90))).toBe(true);
+		// Boundary: exactly half abstains; one under emits.
+		expect(isRollupCoverageDegraded(at(50))).toBe(true);
+		expect(isRollupCoverageDegraded(at(49))).toBe(false);
+		// Nothing probed → nothing to be degraded about.
+		expect(isRollupCoverageDegraded(at(0, 0))).toBe(false);
+	});
+});


### PR DESCRIPTION
## What happens

A throttled `check_lookalikes` run still publishes the aggregate threat rollup as a hard integer at `high` severity. Measured 2026-08-31 on openai.com (issue #865): `enumeration` said 90 probed / 12 resolved / 77 unresolved / `complete: false`, and the same payload carried **"6 lookalike domains showing pre-phishing staging signals"** at `high` with `mailCapableCount: 8` and the prose "8 can send mail in total". The `scan_status` finding said the list was a sample; the rollup — the finding a consumer keys on, at higher severity — stated the number as fact. Across eight providers the same day the unresolved rate ranged 1.2% → 86%, so side-by-side counts reported a rate-limiting artifact as a security difference between named companies.

This is the enumeration-coverage sibling of #832 (closed by #847): there the throttled instrument was the seed NS lookup and the contrary output was an ownership *verdict*; here the throttled instrument is the permutation fan-out and the contrary output is a *count with a confidence*. Neither #847's `unmeasured` law nor #781's `scan_status` sample notice reached the rollup finding itself.

## Root cause

`buildStagingSummaryFinding` / `buildMailCapableSummaryFinding` (`src/tools/lookalike-summary-findings.ts`) were fed the counted domains and the `enumeration` block, and did two things with the block: nested it under `metadata.enumeration` and flipped `confidence` from `deterministic` to `heuristic`. Nothing in the builders — or in the orchestrator that called them unconditionally whenever `mailCapableDomains.length > 0` — could abstain, and the title/prose always rendered a bare `N`.

Members whose RDAP age probe returned nothing (`registrationDays: null`, the #867 shape) were also counted with no indication that the "recent registration" corroborator had been unmeasured for them.

## Fix

`src/tools/lookalike-summary-findings.ts`

- New named constant `ROLLUP_ABSTAIN_UNRESOLVED_RATIO = 0.5` and predicate `isRollupCoverageDegraded(enumeration)`.
- New single decision point `buildThreatRollupFinding({ seedDomain, members, enumeration })` → `{ finding, abstained }`. Abstention is decided **before** either count-carrying builder is reached, so a throttled run can never produce an integer.
- New `buildRollupNotAssessedFinding` — `scan_status`, `info`, `notAssessedReason: 'enumeration_throttled'`, `inconclusive: true`, `errorKind: 'dns_error'` (the repo's codified "probe never reached the origin" markers from `lib/control-presence.ts`). Carries **no** count, no domain list; carries the enumeration stats flat plus `unresolvedRatio` and `abstainThreshold`.
- Both rollup builders now take `ThreatRollupMember[]` and, whenever they emit:
  - carry `permutationsProbed`, `candidatesResolved`, `unresolvedCount`, `complete` **flat** in their own metadata (the nested `enumeration` block stays);
  - when `complete: false`, lead the title and prose with **"At least N"**, add `countIsFloor: true`, and state the floor with its coverage numbers ("N of M probed lookups did not resolve … the true number can only be higher"); the wider "can send mail in total" figure gets the same "at least" treatment;
  - carry `ageUnknownCount` (members with `registrationDays === null`) and say "K of N could not be age-checked". Those members are still counted — the mail host is a real observation — the prose just stops implying the recency corroborator was checked.
- A complete run with all ages known renders byte-identically to before.

`src/tools/check-lookalikes.ts` (call-site only)

- The three separate collectors (`highCount`/`highDomains`/`highVerdicts`/`mailCapableDomains`) collapse into one `rollupMembers: ThreatRollupMember[]` push per threat-observed candidate; the two `if/else` rollup calls become one `buildThreatRollupFinding` call.
- An abstained run is marked `partial: true` — the same law #847 applied to the degraded ownership comparison: the throttling is transient, and `check_lookalikes` is cached for an hour, so a cached "not assessed" would outlive the condition that caused it.

## Threshold rationale

`ROLLUP_ABSTAIN_UNRESOLVED_RATIO = 0.5`, applied to `unresolvedCount / permutationsProbed`, abstain at `>=`.

- A rollup is a claim about a **set**. Once more of the probed namespace is unobserved than observed, the count is bounded below by what resolved and above by nothing: its plausible range exceeds its value, so it measures coverage, not the estate. Below the line the number is still informative and is published — as a floor, with the coverage beside it.
- Against the issue's measured table: amazon.com (1.2%), anthropic.com, perplexity.ai (39%) and cohere.com (43%) emit; microsoft.com (51%), meta.com (62%), google.com (67%) and openai.com (86%) abstain. The openai run — 12 of 90 resolved, published as "8 can send mail in total" at `high` — is the shape the constant exists to stop.
- #847 defined "degraded" as a **binary** on a different instrument (the seed's own NS lookup failed → every ownership verdict `unmeasured`). It has no ratio to align with, so this is the first threshold on the enumeration instrument rather than a second notion of the same one; the two compose (a seed-NS failure already withholds every threat observation, so no rollup member exists at all).
- Any incompleteness (`complete: false`, i.e. one unresolved lookup) triggers floor wording — that needs no threshold, it is simply what "sample" means.

## Tests

New `test/check-lookalikes-throttled-rollup.spec.ts` (8 tests, DNS mocked via `dns-mock`, tool dynamically imported per test):

- openai-shaped run (every other permutation's NS lookup rejects, ~99% unresolved) → both rollups withheld, `notAssessedReason: 'enumeration_throttled'` at `info`/`scan_status` with `inconclusive`/`errorKind`, no `lookalikeDomainCount`/`mailCapableCount`/domain lists, stats flat on the notice, no aggregate title with a leading integer;
- abstained run → `partial: true`;
- mail-capable-only (medium) rollup abstains under the same threshold;
- partially incomplete run (3 rejected lookups, well below the threshold) → "At least 1 lookalike domain showing pre-phishing staging signals", `countIsFloor: true`, `unresolvedCount: 3`, `permutationsProbed`/`candidatesResolved`/`complete: false` flat, `confidence: 'heuristic'`, no abstention notice;
- `ageUnknownCount: 1` with "1 of 1 … could not be age-checked" prose, member still counted;
- complete run → title exactly `1 lookalike domain showing pre-phishing staging signals`, no floor marker, `complete: true`, `deterministic`, not partial;
- medium rollup carries the same floor + stats contract;
- threshold unit test: the constant is 0.5, each row of the issue's table lands on the intended side, boundary at exactly 50%, and `permutationsProbed: 0` is never "degraded".

Commands run, all green:

```
npx vitest run test/check-lookalikes-throttled-rollup.spec.ts test/check-lookalikes.spec.ts \
  test/check-lookalikes-degraded-attribution.spec.ts test/check-lookalikes-recon-enrichment.integration.test.ts \
  test/lookalike-analysis.spec.ts test/lookalike-severity.spec.ts      # 6 files, 121 tests (113 baseline + 8 new)
npm run typecheck   # rc 0
npm run lint        # rc 0
```

Existing title matchers checked and unchanged: `test/check-lookalikes.spec.ts` matches `/pre-phishing staging signals/i` and `/lookalike domains? showing pre-phishing staging signals/i` — both still match the "At least N …" form, and the complete-run fixtures they use render the original title verbatim. No other source file matches the rollup title; `discover-brand-domains.ts` reads only per-domain `lookalikeDomain` metadata, `scan/post-processing.ts`'s `hasActiveImpersonation` keys on severity within a `scan_domain` run, which never includes `check_lookalikes`.

## Residuals

- `check_lookalikes` is a standalone intelligence tool outside the scored `CheckCategory` union and not in `scan_domain`'s dispatch, so **no `scan_domain` score moves**. Within the tool's own `CheckResult`, an abstained run drops the rollup's `high` penalty from its self-score — the per-domain `high` threat observations still apply.
- Per-domain findings are unchanged; an abstained run still lists each resolved candidate individually, with the existing #781 sample notice.
- Why `.com` registration ages come back `null` (#867) is being fixed separately in `lookalike-enrichment.ts`; this PR only makes the rollup honest about it via `ageUnknownCount`.
- The threshold is a first calibration from eight data points; if a future corpus shows counts stable well above 50% unresolved (or unstable below it), move the constant — everything keys on it.

Closes #865

🤖 Generated with [Claude Code](https://claude.com/claude-code)
