### PR TITLE
fix(discover-subdomains): present a degraded single-source count as a floor, split wildcards, raise the caveat to low (#866)

### DIFF
--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -1774,9 +1774,13 @@ export async function handleToolsCall(
 						...(scanCacheKV && { cacheKv: scanCacheKV }),
 						...(runtimeOptions?.waitUntil && { waitUntil: runtimeOptions.waitUntil }),
 					});
-					logResult = `${result.totalSubdomains} subdomains`;
+					logResult = `${result.countBasis === 'floor' ? '>=' : ''}${result.totalSubdomains} subdomains`;
 					logDetails = {
 						totalSubdomains: result.totalSubdomains,
+						// #866: a floor must read as a floor in tail too — a rising floor
+						// rate is the alarm for a CT source that has started failing.
+						countBasis: result.countBasis ?? 'sample',
+						concreteSubdomains: result.concreteSubdomains ?? result.totalSubdomains - result.wildcardCerts,
 						issues: result.issues.length,
 						sourceUnavailable: result.sourceUnavailable ?? false,
 						stale: result.stale ?? false,

--- a/src/lib/brand-audit-csc-deepscan.ts
+++ b/src/lib/brand-audit-csc-deepscan.ts
@@ -65,6 +65,12 @@ interface DiscoverSubdomainsStructured {
 	partial?: boolean;
 	/** Certificate Transparency source could not be queried at all. */
 	sourceUnavailable?: boolean;
+	/**
+	 * `'floor'` = recall was cut on that call (a source failed, an index was not
+	 * read to the end, or the data is a stale re-serve) — `totalSubdomains` is a
+	 * floor, not a count (#866). Absent on older producers → treated as a sample.
+	 */
+	countBasis?: 'sample' | 'floor';
 }
 
 /** A `CheckResult` finding as it appears in `check_subdomain_takeover`'s `structuredContent`. */
@@ -287,7 +293,9 @@ export async function runDeepScan(input: RunDeepScanInput): Promise<RunDeepScanR
 					.slice(0, SAMPLE_SUBDOMAIN_CAP)
 					.map((s) => s.subdomain ?? '')
 					.filter(Boolean),
-				partial: Boolean(r.discover.partial || r.discover.sourceUnavailable),
+				// A floor is an incomplete inventory by definition (#866) — publish it as
+				// partial rather than as a confident `total`.
+				partial: Boolean(r.discover.partial || r.discover.sourceUnavailable || r.discover.countBasis === 'floor'),
 			};
 		}
 	}

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -507,7 +507,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	discover_subdomains: {
 		description:
-			'Find subdomains of a domain using Certificate Transparency logs. Reveals shadow IT, forgotten services, and unauthorized certificate issuance. Returns a CT SAMPLE, not an asset inventory: the count is a lower bound, a host with no publicly-logged certificate never appears, and the result carries a per-source `coverage` record stating what was actually consulted.',
+			'Find subdomains of a domain using Certificate Transparency logs. Reveals shadow IT, forgotten services, and unauthorized certificate issuance. Returns a CT SAMPLE, not an asset inventory: the count is a lower bound, a host with no publicly-logged certificate never appears, and the result carries a per-source `coverage` record stating what was actually consulted. `countBasis` says whether `totalSubdomains` is the tool’s normal reach (`sample`) or a `floor` from a run whose recall was cut (then `minSubdomainsObserved` is present); `concreteSubdomains` excludes wildcard patterns.',
 		schema: BaseDomainArgs,
 		group: 'intelligence',
 		scanIncluded: false,

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -408,6 +408,101 @@ export interface SubdomainDiscoveryResult {
 	 * no value a consumer can read as "complete inventory".
 	 */
 	coverage?: CtCoverage;
+	/**
+	 * Whether {@link totalSubdomains} is what this tool can normally see, or a
+	 * FLOOR from a run whose recall was cut (#866).
+	 *
+	 *  - `'sample'` — every source consulted on this call answered and was read
+	 *    to the end of its index. Still a CT sample (see {@link coverage}), never
+	 *    an inventory — but it is the tool's normal reach.
+	 *  - `'floor'`  — recall on THIS call fell below that: a source was asked and
+	 *    failed, a contributing index was not read to the end, the budget
+	 *    tripped, or the data is a stale re-serve. `totalSubdomains` is then a
+	 *    floor even of what this tool normally sees, and
+	 *    {@link minSubdomainsObserved} is present.
+	 *
+	 * Deliberately NOT derived from `coverage.degraded`, which is true on every
+	 * run (the direct ladder is crt.sh → Certspotter-as-fallback, so a healthy
+	 * crt.sh answer always leaves Certspotter `notConsulted`) and therefore
+	 * cannot discriminate. Measured 2026-08-31 (anthropic.com): crt.sh
+	 * `http_error`, Certspotter the only contributor with its recent-window index
+	 * exhausted — and `totalSubdomains: 107` shipped shaped exactly like a
+	 * complete count, the caveat living only in `coverage.caveat` and an `info`
+	 * issue.
+	 *
+	 * Optional only so hand-built fixtures typecheck; every production path sets
+	 * it, and the formatter derives it when absent.
+	 */
+	countBasis?: SubdomainCountBasis;
+	/**
+	 * Present ONLY when {@link countBasis} is `'floor'` — its PRESENCE is the
+	 * shape signal a consumer keys on. Numerically equal to
+	 * {@link totalSubdomains}, which is kept so no existing reader breaks.
+	 */
+	minSubdomainsObserved?: number;
+	/**
+	 * {@link totalSubdomains} minus {@link wildcardCerts}: names that can resolve
+	 * to a host. A wildcard (`*.example.com`) is a PATTERN — a certificate
+	 * observation, not a subdomain — and a prior sweep measured wildcards plus
+	 * dead-but-certificated hosts inflating CT counts ~1.6× over live estate.
+	 */
+	concreteSubdomains?: number;
+}
+
+/** See {@link SubdomainDiscoveryResult.countBasis}. */
+export type SubdomainCountBasis = 'sample' | 'floor';
+
+/** The members {@link countBasisFor} reads. */
+type CountBasisInputs = Pick<SubdomainDiscoveryResult, 'coverage' | 'sourceIndexExhausted' | 'partial' | 'stale' | 'sourceUnavailable'>;
+
+/** A per-source outcome meaning the source was asked and did NOT answer. */
+function sourceFailed(outcome: CtSourceOutcome): boolean {
+	return outcome !== 'ok' && outcome !== 'empty';
+}
+
+/**
+ * Decide whether a result's count is the tool's normal reach or a floor. Pure;
+ * exported so a renderer of an older payload (no `countBasis`) can derive it.
+ *
+ * `empty` is NOT a failure: a source that answered "nothing" was read, so its
+ * silence does not cut recall the way an `http_error`/`timeout`/`rate_limited`
+ * does.
+ */
+export function countBasisFor(r: CountBasisInputs): SubdomainCountBasis {
+	if (r.partial || r.stale || r.sourceUnavailable) return 'floor';
+	if (r.sourceIndexExhausted === false) return 'floor';
+	if (r.coverage?.perSource.some((s) => sourceFailed(s.outcome))) return 'floor';
+	return 'sample';
+}
+
+/** The count-contract members (#866) for a result being built. */
+function countContract(
+	total: number,
+	wildcardCerts: number,
+	basis: SubdomainCountBasis,
+): { countBasis: SubdomainCountBasis; concreteSubdomains: number; minSubdomainsObserved?: number } {
+	return {
+		countBasis: basis,
+		concreteSubdomains: Math.max(0, total - wildcardCerts),
+		...(basis === 'floor' ? { minSubdomainsObserved: total } : {}),
+	};
+}
+
+/**
+ * Re-derive the count contract on a finished result. Used by the cache
+ * re-serve paths, where the stored contract described the CACHING call: a
+ * healthy enumeration re-served `stale` is a floor NOW, and an entry written
+ * before this contract existed has no contract at all. Also lifts the stored
+ * sample caveat to `low` when the re-serve is a floor.
+ */
+function withCountContract(result: SubdomainDiscoveryResult): SubdomainDiscoveryResult {
+	const { minSubdomainsObserved: _min, ...rest } = result;
+	const basis = countBasisFor(result);
+	const issues =
+		basis === 'floor'
+			? rest.issues.map((i) => (i.type === 'ct_sample_not_inventory' && i.severity === 'info' ? { ...i, severity: 'low' as const } : i))
+			: rest.issues;
+	return { ...rest, issues, ...countContract(result.totalSubdomains, result.wildcardCerts, basis) };
 }
 
 /** Provenance/completeness metadata threaded from a source into the result builders. */
@@ -759,9 +854,10 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[],
 
 	const sourceIndexExhausted = (meta?.sourceIndexExhausted ?? true) && !entryCapHit;
 	const flags = enumerationFlags(allSubdomains.length, subdomains.length, meta?.sources, sourceIndexExhausted, meta?.attempts);
+	const count = countContract(allSubdomains.length, wildcardCerts, countBasisFor(flags));
 	// Prepended, not appended: a caller that truncates the issue list for display
 	// must not lose the one line saying the list itself is a floor.
-	if (flags.coverage) issues.unshift(sampleCaveatIssue(flags.coverage, allSubdomains.length));
+	if (flags.coverage) issues.unshift(sampleCaveatIssue(flags.coverage, allSubdomains.length, wildcardCerts, count.countBasis));
 
 	return {
 		domain,
@@ -773,6 +869,7 @@ export function buildResultFromEntries(domain: string, rawEntries: CrtShEntry[],
 		uniqueIssuers,
 		issues,
 		...flags,
+		...count,
 	};
 }
 
@@ -819,10 +916,12 @@ function attemptsFromSources(sources: string[] | undefined, sourceIndexExhausted
  *
  * `unconfirmed_zero` already covers the empty case, so this one rides on
  * non-empty results — the shape that looked healthy and therefore did the
- * damage. Severity `info`: it is a standing property of CT-derived evidence,
- * not a finding about the domain.
+ * damage. Severity `info` on a healthy run: it is a standing property of
+ * CT-derived evidence, not a finding about the domain. Severity `low` under a
+ * `'floor'` basis (#866): a count derived from one exhausted index after the
+ * other source failed is a scan-QUALITY finding, and it names why.
  */
-function sampleCaveatIssue(coverage: CtCoverage, total: number): SubdomainIssue {
+function sampleCaveatIssue(coverage: CtCoverage, total: number, wildcardCerts: number, basis: SubdomainCountBasis): SubdomainIssue {
 	// Kept SHORT deliberately, and BOUNDED: `formatCompact`/`formatFull` push issue
 	// details through `sanitizeOutputText(…, 200|300)`, so a detail that carried the
 	// full `coverage.caveat` prose was truncated mid-sentence — losing the clause
@@ -831,8 +930,18 @@ function sampleCaveatIssue(coverage: CtCoverage, total: number): SubdomainIssue 
 	// The lead sentence is the non-negotiable part and is built first; the source
 	// summary is appended only while it still fits under the tightest cap, so a
 	// long source list can never push the meaning off the end.
-	const lead = `${total} subdomains is a LOWER BOUND from a CT sample, not an inventory — hosts with no logged certificate never appear.`;
 	const answered = coverage.contributing.length > 0 ? coverage.contributing.join(', ') : 'no source';
+	if (basis === 'floor') {
+		const failed = coverage.perSource.filter((s) => sourceFailed(s.outcome)).map((s) => s.source);
+		const lead = `At least ${total} subdomains observed (${concreteWildcardSplit(total, wildcardCerts)}) — a FLOOR, not a count: recall was cut on this call.`;
+		const why = failed.length > 0 ? ` Failed: ${failed.join(', ')}; answered: ${answered}.` : ` Answered: ${answered}; index not read to the end.`;
+		return {
+			type: 'ct_sample_not_inventory',
+			severity: 'low',
+			detail: lead.length + why.length <= COMPACT_ISSUE_DETAIL_CAP ? `${lead}${why}` : lead,
+		};
+	}
+	const lead = `${total} subdomains is a LOWER BOUND from a CT sample, not an inventory — hosts with no logged certificate never appear.`;
 	const missing = [...coverage.unavailable, ...coverage.notConsulted];
 	const suffix = ` Answered: ${answered}${missing.length > 0 ? `; no data from ${missing.join(', ')}` : ''}.`;
 	return {
@@ -840,6 +949,12 @@ function sampleCaveatIssue(coverage: CtCoverage, total: number): SubdomainIssue 
 		severity: 'info',
 		detail: lead.length + suffix.length <= COMPACT_ISSUE_DETAIL_CAP ? `${lead}${suffix}` : lead,
 	};
+}
+
+/** `"97 concrete, 10 wildcard patterns"` — the split every headline carries (#866). */
+function concreteWildcardSplit(total: number, wildcardCerts: number): string {
+	const concrete = Math.max(0, total - wildcardCerts);
+	return `${concrete} concrete, ${wildcardCerts} wildcard pattern${wildcardCerts === 1 ? '' : 's'}`;
 }
 
 /**
@@ -1301,11 +1416,13 @@ async function cacheSuccess(domain: string, result: SubdomainDiscoveryResult, op
 async function readLastKnownGood(domain: string, options?: DiscoverSubdomainsOptions): Promise<SubdomainDiscoveryResult | null> {
 	const loaded = await loadCacheEntry(domain, options);
 	if (!loaded) return null;
-	return {
+	// Re-derived, not re-served: the stored contract described the caching call,
+	// and a stale re-serve is a floor NOW whatever that call was (#866).
+	return withCountContract({
 		...stripTransientFlags(loaded.result),
 		stale: true,
 		cacheAgeMinutes: Math.floor(loaded.ageMs / 60_000),
-	};
+	});
 }
 
 /**
@@ -1342,11 +1459,13 @@ async function readFreshCache(domain: string, options?: DiscoverSubdomainsOption
 	const loaded = await loadCacheEntry(domain, options);
 	if (!loaded) return null;
 	if (loaded.ageMs > SUBDOMAIN_FRESH_TTL_SECONDS * 1000) return null;
-	return {
+	// `withCountContract` also backfills entries written before the contract
+	// existed (the LKG TTL is 7 days), so a fresh hit is never shape-less.
+	return withCountContract({
 		...stripTransientFlags(loaded.result),
 		cached: true,
 		cacheAgeMinutes: Math.floor(loaded.ageMs / 60_000),
-	};
+	});
 }
 
 /**
@@ -1673,7 +1792,12 @@ function buildCertstreamResult(
 	const flags = enumerationFlags(dedupedAll.length, deduped.length, ['certstream'], sourceIndexExhausted, [
 		{ source: 'certstream', outcome: dedupedAll.length === 0 ? 'empty' : 'ok', contributed: true, indexExhausted: sourceIndexExhausted },
 	]);
-	if (flags.coverage && dedupedAll.length > 0) issues.unshift(sampleCaveatIssue(flags.coverage, dedupedAll.length));
+	// A timed-out / truncated upstream read is `sourceIndexExhausted: false`, so
+	// the floor is decided here even though `partial: true` is spread on later.
+	const count = countContract(dedupedAll.length, wildcardCerts, countBasisFor(flags));
+	if (flags.coverage && dedupedAll.length > 0) {
+		issues.unshift(sampleCaveatIssue(flags.coverage, dedupedAll.length, wildcardCerts, count.countBasis));
+	}
 
 	return {
 		domain,
@@ -1685,6 +1809,7 @@ function buildCertstreamResult(
 		uniqueIssuers: [],
 		issues,
 		...flags,
+		...count,
 	};
 }
 
@@ -1707,6 +1832,7 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false,
 	// A source outage or a budget trip is by definition not an exhaustive read —
 	// never let an empty error read as a confident "none found".
 	const sourceIndexExhausted = sourceUnavailable || partial ? false : (meta?.sourceIndexExhausted ?? true);
+	const flags = enumerationFlags(0, 0, meta?.sources, sourceIndexExhausted, meta?.attempts);
 	return {
 		domain,
 		totalSubdomains: 0,
@@ -1726,7 +1852,10 @@ function emptyResult(domain: string, sourceUnavailable = false, partial = false,
 		],
 		sourceUnavailable,
 		...(partial ? { partial: true } : {}),
-		...enumerationFlags(0, 0, meta?.sources, sourceIndexExhausted, meta?.attempts),
+		...flags,
+		// A zero from an outage or a budget trip is a floor of zero, not a sample
+		// of zero — the shape must say so as loudly as the `unconfirmed_zero` issue.
+		...countContract(0, 0, countBasisFor({ ...flags, partial, sourceUnavailable })),
 	};
 }
 
@@ -1919,10 +2048,32 @@ function partialBanner(): string {
 	return `⚠️ PARTIAL RESULT: the Certificate Transparency source timed out before finishing this enumeration — the subdomains below are real, but there may be more that were not found in time.`;
 }
 
+/**
+ * The headline count, honest about wildcards and about a floor (#866).
+ *
+ * Derives the basis for payloads that predate the contract (hand-built
+ * fixtures, cache entries written before it) so an old payload can never
+ * render as a bare count by omission.
+ */
+function headlineCount(result: SubdomainDiscoveryResult): string {
+	const split = concreteWildcardSplit(result.totalSubdomains, result.wildcardCerts);
+	const basis = result.countBasis ?? countBasisFor(result);
+	return basis === 'floor'
+		? `at least ${result.totalSubdomains} subdomains observed (${split})`
+		: `${result.totalSubdomains} subdomains (${split})`;
+}
+
+/** Appended to a floor headline so the qualifier sits ON the number, not three fields away. */
+function floorSuffix(result: SubdomainDiscoveryResult): string {
+	return (result.countBasis ?? countBasisFor(result)) === 'floor' ? ' — FLOOR from an incomplete read, not a count' : '';
+}
+
 /** Compact format: concise one-line-per-subdomain output. */
 function formatCompact(result: SubdomainDiscoveryResult): string {
 	const lines: string[] = [];
-	lines.push(`Subdomain Discovery: ${result.domain} — ${result.totalSubdomains} subdomains (${result.totalCertificates} certificates)`);
+	lines.push(
+		`Subdomain Discovery: ${result.domain} — ${headlineCount(result)} (${result.totalCertificates} certificates)${floorSuffix(result)}`,
+	);
 	if (result.uniqueIssuers.length > 0) {
 		lines.push(`Issuers: ${result.uniqueIssuers.map((i) => sanitizeOutputText(i, 60)).join(', ')}`);
 	}
@@ -1959,7 +2110,7 @@ function formatCompact(result: SubdomainDiscoveryResult): string {
 function formatFull(result: SubdomainDiscoveryResult): string {
 	const lines: string[] = [];
 	lines.push(`# Subdomain Discovery: ${result.domain}`);
-	lines.push(`Total: ${result.totalSubdomains} subdomains across ${result.totalCertificates} certificates`);
+	lines.push(`Total: ${headlineCount(result)} across ${result.totalCertificates} certificates${floorSuffix(result)}`);
 	lines.push(`Issuers: ${result.uniqueIssuers.map((i) => sanitizeOutputText(i, 60)).join(', ')}`);
 	lines.push(`Wildcards: ${result.wildcardCerts} | Expired: ${result.expiredCerts}`);
 	lines.push('');

--- a/src/tools/discover-subdomains.ts
+++ b/src/tools/discover-subdomains.ts
@@ -498,11 +498,27 @@ function countContract(
 function withCountContract(result: SubdomainDiscoveryResult): SubdomainDiscoveryResult {
 	const { minSubdomainsObserved: _min, ...rest } = result;
 	const basis = countBasisFor(result);
-	const issues =
-		basis === 'floor'
-			? rest.issues.map((i) => (i.type === 'ct_sample_not_inventory' && i.severity === 'info' ? { ...i, severity: 'low' as const } : i))
-			: rest.issues;
+	const issues = basis === 'floor' ? refloorCaveat(rest, basis) : rest.issues;
 	return { ...rest, issues, ...countContract(result.totalSubdomains, result.wildcardCerts, basis) };
+}
+
+/**
+ * Regenerate the standing caveat for a result that has BECOME a floor after it
+ * was built (the stale re-serve). Only flipping `severity` would re-serve the
+ * healthy sample wording under a `[LOW]` tag — the #866 shape (degraded count,
+ * healthy prose) reintroduced on a different path. The text is rebuilt from the
+ * stored coverage and names staleness as the reason when that is what forced
+ * the floor; without a coverage record (a pre-contract entry) the caveat is
+ * rebuilt with a synthetic one so the wording is still honest.
+ */
+function refloorCaveat(result: Omit<SubdomainDiscoveryResult, 'minSubdomainsObserved'>, basis: SubdomainCountBasis): SubdomainIssue[] {
+	if (result.totalSubdomains === 0) return result.issues;
+	const coverage = result.coverage ?? buildCtCoverage(attemptsFromSources(result.sources, result.sourceIndexExhausted ?? true));
+	// Short on purpose: it must fit beside the lead under the 200-char compact cap.
+	const why = result.stale ? ' Served STALE from cache: no live CT source answered this call.' : undefined;
+	const caveat = sampleCaveatIssue(coverage, result.totalSubdomains, result.wildcardCerts, basis, why);
+	const others = result.issues.filter((i) => i.type !== 'ct_sample_not_inventory');
+	return [caveat, ...others];
 }
 
 /** Provenance/completeness metadata threaded from a source into the result builders. */
@@ -921,7 +937,14 @@ function attemptsFromSources(sources: string[] | undefined, sourceIndexExhausted
  * `'floor'` basis (#866): a count derived from one exhausted index after the
  * other source failed is a scan-QUALITY finding, and it names why.
  */
-function sampleCaveatIssue(coverage: CtCoverage, total: number, wildcardCerts: number, basis: SubdomainCountBasis): SubdomainIssue {
+function sampleCaveatIssue(
+	coverage: CtCoverage,
+	total: number,
+	wildcardCerts: number,
+	basis: SubdomainCountBasis,
+	/** Overrides the derived "why" clause under a floor — e.g. a stale re-serve, where no source on THIS call failed. */
+	whyOverride?: string,
+): SubdomainIssue {
 	// Kept SHORT deliberately, and BOUNDED: `formatCompact`/`formatFull` push issue
 	// details through `sanitizeOutputText(…, 200|300)`, so a detail that carried the
 	// full `coverage.caveat` prose was truncated mid-sentence — losing the clause
@@ -934,7 +957,8 @@ function sampleCaveatIssue(coverage: CtCoverage, total: number, wildcardCerts: n
 	if (basis === 'floor') {
 		const failed = coverage.perSource.filter((s) => sourceFailed(s.outcome)).map((s) => s.source);
 		const lead = `At least ${total} subdomains observed (${concreteWildcardSplit(total, wildcardCerts)}) — a FLOOR, not a count: recall was cut on this call.`;
-		const why = failed.length > 0 ? ` Failed: ${failed.join(', ')}; answered: ${answered}.` : ` Answered: ${answered}; index not read to the end.`;
+		const why =
+			whyOverride ?? (failed.length > 0 ? ` Failed: ${failed.join(', ')}; answered: ${answered}.` : ` Answered: ${answered}; index not read to the end.`);
 		return {
 			type: 'ct_sample_not_inventory',
 			severity: 'low',

--- a/test/discover-subdomains-count-basis.spec.ts
+++ b/test/discover-subdomains-count-basis.spec.ts
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Regression suite for #866 — a degraded single-source count presented as a bare
+// integer.
+//
+// Measured 2026-08-31 on anthropic.com: crt.sh returned `http_error`, certstream
+// was not bound, and Certspotter — the ONLY contributor — reported
+// `indexExhausted: true` over a `recent-window` history. The payload still led
+// with `totalSubdomains: 107`, shaped exactly like a complete count, while the
+// caveat lived in `coverage.caveat` and an `info` finding. Ten of the 107 were
+// wildcard patterns (`*.anthropic.com` …), which resolve to no host.
+//
+// What is locked here:
+//   1. `countBasis` says whether `totalSubdomains` is the tool's normal reach
+//      (`'sample'`) or a `'floor'` from a run whose recall was cut — a source
+//      failed, an index was not read to the end, the budget tripped, or the data
+//      is a stale re-serve. NOTE: it is deliberately NOT keyed on
+//      `coverage.degraded`, which is `true` on every run (the direct ladder is
+//      crt.sh → Certspotter-as-fallback, so a healthy crt.sh answer always leaves
+//      Certspotter `notConsulted`) and therefore cannot discriminate.
+//   2. Under a floor the payload carries `minSubdomainsObserved` — its PRESENCE is
+//      the shape signal — and `totalSubdomains` stays numerically present so no
+//      existing reader breaks.
+//   3. `concreteSubdomains` (non-wildcard) is always split out of the headline.
+//   4. The standing `ct_sample_not_inventory` caveat is `low` under a floor, and
+//      stays `info` on a healthy run — a one-exhausted-index result is a
+//      scan-quality finding, not a note.
+//   5. Both prose formats say "at least N … observed" with the concrete/wildcard
+//      split under a floor, never a bare "N subdomains".
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { setupFetchMock } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+function entry(name: string, i: number) {
+	return {
+		name_value: name,
+		issuer_name: "CN=R3, O=Let's Encrypt",
+		not_before: `2026-01-01T00:00:00.${String(9_999 - i).padStart(4, '0')}Z`,
+		not_after: '2030-01-01T00:00:00Z',
+	};
+}
+
+function issuance(id: number, names: string[]) {
+	return {
+		id: String(id),
+		dns_names: names,
+		not_before: '2026-02-01T00:00:00Z',
+		not_after: '2030-05-01T00:00:00Z',
+		issuer: { name: "C=US, O=Let's Encrypt, CN=R11" },
+	};
+}
+
+function urlOf(url: string | URL | Request): string {
+	return typeof url === 'string' ? url : url instanceof URL ? url.toString() : (url as Request).url;
+}
+
+/** The production #866 shape: crt.sh fails, Certspotter alone answers (index exhausted). */
+function mockDegradedSingleSource() {
+	globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+		const s = urlOf(url);
+		if (s.includes('crt.sh')) return Response.json({}, { status: 502 });
+		if (s.includes('certspotter.com')) {
+			return Response.json(
+				[issuance(1, ['api.example.com']), issuance(2, ['vpn.example.com']), issuance(3, ['*.example.com'])],
+				{ status: 200 },
+			);
+		}
+		return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+	});
+}
+
+/** A healthy run: the first source answers and is read to the end. */
+function mockHealthy() {
+	globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+		const s = urlOf(url);
+		if (s.includes('crt.sh')) {
+			return Response.json([entry('api.example.com', 0), entry('vpn.example.com', 1), entry('*.example.com', 2)], { status: 200 });
+		}
+		return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+	});
+}
+
+function makeKv() {
+	const store = new Map<string, string>();
+	return {
+		store,
+		get: async (key: string, type?: string) => {
+			const raw = store.get(key);
+			if (raw === undefined) return null;
+			return type === 'json' ? JSON.parse(raw) : raw;
+		},
+		put: async (key: string, value: string) => {
+			store.set(key, value);
+		},
+		delete: async (key: string) => {
+			store.delete(key);
+		},
+	};
+}
+
+function asKv(kv: ReturnType<typeof makeKv>): KVNamespace {
+	return kv as unknown as KVNamespace;
+}
+
+describe('discover_subdomains — degraded single-source run is a FLOOR, not a count (#866)', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('marks the count as a floor and keeps totalSubdomains numerically present', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		mockDegradedSingleSource();
+
+		const result = await discoverSubdomains('example.com');
+
+		// Premise: this IS the production shape — one contributor, index exhausted, crt.sh failed.
+		expect(result.coverage?.contributing).toEqual(['certspotter']);
+		expect(result.coverage?.perSource.find((s) => s.source === 'crtsh')?.outcome).toBe('http_error');
+		expect(result.coverage?.perSource.find((s) => s.source === 'certspotter')?.indexExhausted).toBe(true);
+
+		expect(result.countBasis).toBe('floor');
+		expect(result.minSubdomainsObserved).toBe(3);
+		// Backward compatibility: every existing reader keys on this integer.
+		expect(result.totalSubdomains).toBe(3);
+	});
+
+	it('splits wildcard patterns out of the headline count', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		mockDegradedSingleSource();
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(result.wildcardCerts).toBe(1);
+		expect(result.concreteSubdomains).toBe(2);
+		expect(result.concreteSubdomains).toBe(result.totalSubdomains - result.wildcardCerts);
+	});
+
+	it('raises the sample caveat to LOW and words it as a floor', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		mockDegradedSingleSource();
+
+		const result = await discoverSubdomains('example.com');
+		const caveat = result.issues.find((i) => i.type === 'ct_sample_not_inventory');
+
+		expect(caveat).toBeDefined();
+		expect(caveat?.severity).toBe('low');
+		expect(caveat?.detail).toMatch(/at least 3/i);
+		expect(caveat?.detail).toMatch(/floor/i);
+		expect(caveat?.detail).toMatch(/2 concrete/);
+		expect(caveat?.detail).toMatch(/1 wildcard/);
+		// Must still name the failed source so the reader knows WHY it is a floor.
+		expect(caveat?.detail).toMatch(/crtsh/);
+		// Survives the 200-char compact sanitizer intact (see coverage spec).
+		expect(caveat!.detail.length).toBeLessThanOrEqual(200);
+		// Still the first issue — a display-truncated list must not drop it.
+		expect(result.issues[0].type).toBe('ct_sample_not_inventory');
+	});
+
+	it.each(['compact', 'full'] as const)('%s prose says "at least N observed" with the split, never a bare count', async (format) => {
+		const { discoverSubdomains, formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+		mockDegradedSingleSource();
+
+		const result = await discoverSubdomains('example.com');
+		const output = formatSubdomainDiscovery(result, format);
+
+		expect(output).toMatch(/at least 3 subdomains observed/i);
+		expect(output).toMatch(/2 concrete/);
+		expect(output).toMatch(/1 wildcard pattern/);
+		expect(output).toMatch(/floor/i);
+		// The pre-fix headline shapes.
+		expect(output).not.toMatch(/— 3 subdomains \(/);
+		expect(output).not.toMatch(/Total: 3 subdomains across/);
+		expect(output).toMatch(/\[LOW\]/);
+	});
+
+	it('carries the floor contract through the MCP handler structuredContent', async () => {
+		const { handleToolsCall } = await import('../src/handlers/tools');
+		mockDegradedSingleSource();
+
+		const res = await handleToolsCall({ name: 'discover_subdomains', arguments: { domain: 'example.com' } }, undefined, undefined);
+		const payload = res.structuredContent as Record<string, unknown>;
+
+		expect(payload.countBasis).toBe('floor');
+		expect(payload.minSubdomainsObserved).toBe(3);
+		expect(payload.concreteSubdomains).toBe(2);
+		expect(payload.totalSubdomains).toBe(3);
+	});
+});
+
+describe('discover_subdomains — a healthy run is unchanged', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('reports countBasis sample, no floor member, and keeps the caveat at info', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		mockHealthy();
+
+		const result = await discoverSubdomains('example.com');
+
+		// Control for the discriminator: `coverage.degraded` is true here too
+		// (Certspotter was never needed), yet nothing about THIS run cut recall.
+		expect(result.coverage?.degraded).toBe(true);
+		expect(result.countBasis).toBe('sample');
+		expect(result).not.toHaveProperty('minSubdomainsObserved');
+		expect(result.totalSubdomains).toBe(3);
+		expect(result.concreteSubdomains).toBe(2);
+
+		const caveat = result.issues.find((i) => i.type === 'ct_sample_not_inventory');
+		expect(caveat?.severity).toBe('info');
+		expect(result.issues.some((i) => i.severity === 'low')).toBe(false);
+	});
+
+	it.each(['compact', 'full'] as const)('%s prose keeps a plain count but still shows the concrete/wildcard split', async (format) => {
+		const { discoverSubdomains, formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+		mockHealthy();
+
+		const result = await discoverSubdomains('example.com');
+		const output = formatSubdomainDiscovery(result, format);
+
+		expect(output).toMatch(/3 subdomains \(2 concrete, 1 wildcard pattern\)/);
+		expect(output).not.toMatch(/at least 3/i);
+		expect(output).not.toMatch(/\[LOW\]/);
+	});
+});
+
+describe('discover_subdomains — other recall-cut paths are floors too', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('a certstream answer that timed out mid-query (partial, index not exhausted) is a floor', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const certstreamFetch = vi.fn(async () =>
+			Response.json({ domain: 'example.com', subdomains: ['api.example.com', '*.example.com'], certificateCount: 2, timedOut: true, cached: false }),
+		);
+		globalThis.fetch = vi.fn(async () => {
+			throw new Error('direct sources must not be used when certstream answers');
+		});
+
+		const result = await discoverSubdomains('example.com', { fetch: certstreamFetch as unknown as typeof fetch });
+
+		expect(result.partial).toBe(true);
+		expect(result.sourceIndexExhausted).toBe(false);
+		expect(result.countBasis).toBe('floor');
+		expect(result.minSubdomainsObserved).toBe(2);
+		expect(result.concreteSubdomains).toBe(1);
+		expect(result.issues.find((i) => i.type === 'ct_sample_not_inventory')?.severity).toBe('low');
+	});
+
+	it('a stale last-known-good re-serve is a floor even though the cached run was healthy', async () => {
+		const { discoverSubdomains } = await import('../src/tools/discover-subdomains');
+		const kv = makeKv();
+
+		mockHealthy();
+		const fresh = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
+		expect(fresh.countBasis).toBe('sample');
+
+		// Age past the fresh window so the next call reaches the (failing) sources.
+		for (const [key, raw] of kv.store) {
+			const e = JSON.parse(raw) as { cachedAt?: number };
+			if (typeof e.cachedAt === 'number') kv.store.set(key, JSON.stringify({ ...e, cachedAt: e.cachedAt - 2 * 60 * 60 * 1000 }));
+		}
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = urlOf(url);
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const stale = await discoverSubdomains('example.com', undefined, undefined, { cacheKv: asKv(kv) });
+
+		expect(stale.stale).toBe(true);
+		expect(stale.countBasis).toBe('floor');
+		expect(stale.minSubdomainsObserved).toBe(3);
+		expect(stale.concreteSubdomains).toBe(2);
+	});
+});
+
+describe('discover_subdomains — total failure keeps the existing not-assessed shape', () => {
+	beforeEach(() => {
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+	afterEach(() => vi.restoreAllMocks());
+
+	it('still reports sourceUnavailable + a high unconfirmed_zero, and never claims a sample basis', async () => {
+		const { discoverSubdomains, formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+		globalThis.fetch = vi.fn(async (url: string | URL | Request) => {
+			const s = urlOf(url);
+			if (s.includes('crt.sh') || s.includes('certspotter.com')) return Response.json({}, { status: 503 });
+			return Response.json({ Status: 0, Answer: [] }, { status: 200 });
+		});
+
+		const result = await discoverSubdomains('example.com');
+
+		expect(result.sourceUnavailable).toBe(true);
+		expect(result.totalSubdomains).toBe(0);
+		expect(result.issues.find((i) => i.type === 'unconfirmed_zero')?.severity).toBe('high');
+		expect(result.countBasis).toBe('floor');
+		expect(result.minSubdomainsObserved).toBe(0);
+		expect(result.concreteSubdomains).toBe(0);
+		// The prose branch for an outage is untouched.
+		expect(formatSubdomainDiscovery(result, 'full')).toMatch(/source unavailable/i);
+	});
+});
+
+describe('discover_subdomains — standalone: this change cannot move a scan score', () => {
+	it('is not a scan-included category and carries no scoring tier', async () => {
+		const { TOOLS } = await import('../src/schemas/tool-definitions');
+		const def = TOOLS.find((t) => t.name === 'discover_subdomains') as { scanIncluded?: boolean; tier?: unknown; group?: string } | undefined;
+		expect(def).toBeDefined();
+		expect(def!.scanIncluded).toBe(false);
+		expect(def!.tier).toBeUndefined();
+		expect(def!.group).toBe('intelligence');
+	});
+});

--- a/test/discover-subdomains-count-basis.spec.ts
+++ b/test/discover-subdomains-count-basis.spec.ts
@@ -280,6 +280,21 @@ describe('discover_subdomains — other recall-cut paths are floors too', () => 
 		expect(stale.countBasis).toBe('floor');
 		expect(stale.minSubdomainsObserved).toBe(3);
 		expect(stale.concreteSubdomains).toBe(2);
+
+		// The caveat must be REWRITTEN, not merely re-tagged: a `[LOW]` issue that
+		// still carries the healthy sample wording is the #866 shape on a new path.
+		const caveat = stale.issues.find((i) => i.type === 'ct_sample_not_inventory');
+		expect(caveat?.severity).toBe('low');
+		expect(caveat?.detail).toMatch(/floor/i);
+		expect(caveat?.detail).toMatch(/recall was cut/i);
+		expect(caveat?.detail).toMatch(/stale/i);
+		expect(caveat?.detail).not.toMatch(/is a LOWER BOUND from a CT sample/);
+		expect(caveat!.detail.length).toBeLessThanOrEqual(200);
+		expect(stale.issues[0].type).toBe('ct_sample_not_inventory');
+		// The stale caveat also renders, in both formats.
+		const { formatSubdomainDiscovery } = await import('../src/tools/discover-subdomains');
+		expect(formatSubdomainDiscovery(stale, 'compact')).toContain(caveat!.detail);
+		expect(formatSubdomainDiscovery(stale, 'full')).toMatch(/\[LOW\]/);
 	});
 });
 


### PR DESCRIPTION
Closes #866

## What happens

A `discover_subdomains` run in which crt.sh errored, certstream was not consulted, and Certspotter — the only contributor — reported `indexExhausted: true` over a `recent-window` history still returned `totalSubdomains: 107` as a bare top-level integer (anthropic.com, 2026-08-31). `coverage.degraded: true` and an `info` issue carried the caveat, but the number a consumer keys on was shaped exactly like a complete count. Ten of the 107 rows were wildcard patterns (`*.anthropic.com` …), which resolve to no host; `wildcardCerts: 10` was computed but never separated from the headline.

## Root cause

The result contract had no member that qualified the count itself. `coverage` describes provenance, `sourceIndexExhausted` describes one source, and the caveat was prose — nothing on the count said "floor". The prose headline (`— 107 subdomains (…)` / `Total: 107 subdomains across …`) and the tail log printed the same bare integer.

A second, subtler problem surfaced while fixing it: `coverage.degraded` cannot be the discriminator. The direct ladder is crt.sh → Certspotter-as-fallback, and the certstream fast path returns before either, so on every run at least one known source is `notConsulted` and `degraded` is `true` — including a perfectly healthy crt.sh answer. Keying the floor on it would make every result a floor and the signal meaningless.

## Fix

**Output-shape decision — additive, `totalSubdomains` kept.** Every in-repo reader (`src/handlers/tools.ts` tail log, the registrar-complement deep-scan inventory in `src/lib/`) and bv-web-prod (`app/lib/scan/scanning-depth.server.ts` reads `sourceUnavailable`/`totalSubdomains` in `isSourceUnavailable`; `summariseToolResult` reads only `result.domains[]`/`result.findings[]`) keys on `totalSubdomains` as an integer, and the registrar-complement pipeline integration + chaos tests and `test/brand-audit-queue-consumer.integration.test.ts` build fixtures with it. Nulling or removing it would break those for no gain, so the payload is made self-describing instead:

- `countBasis: 'sample' | 'floor'` — `'floor'` when recall on **this** call was cut: a source was asked and failed (`http_error`/`timeout`/`rate_limited`/`error` — an `empty` answer is a read, not a failure), a contributing index was not read to the end, the budget tripped (`partial`), or the data is a stale re-serve. Exported as `countBasisFor()` so renderers of older payloads can derive it.
- `minSubdomainsObserved` — present **only** under a floor; its presence is the shape signal. Numerically equal to `totalSubdomains`.
- `concreteSubdomains` — `totalSubdomains − wildcardCerts`, always present.
- The standing `ct_sample_not_inventory` issue becomes `low` under a floor and names the failed source ("At least 3 subdomains observed (2 concrete, 1 wildcard pattern) — a FLOOR, not a count … Failed: crtsh; answered: certspotter."); it stays `info` on a healthy run. Still prepended, still ≤ 200 chars for the compact sanitizer.
- Prose (both `full` and `compact`): headline becomes `at least N subdomains observed (M concrete, K wildcard patterns) … — FLOOR from an incomplete read, not a count` under a floor, and `N subdomains (M concrete, K wildcard patterns)` otherwise. The formatter derives the basis when the field is absent (fixtures, pre-contract cache entries), so an old payload cannot render as a bare count by omission.
- Cache re-serves (`readLastKnownGood`, `readFreshCache`) re-derive the contract: a healthy enumeration re-served `stale` is a floor now, and its stored `info` caveat is lifted to `low`; entries written before the contract are backfilled.
- Tail log: `logResult` prints `>=N subdomains` for a floor; `logDetails` gains `countBasis` + `concreteSubdomains`.
- the registrar-complement deep-scan module: the per-apex inventory publishes a floor as `partial: true` rather than a confident `total`.
- Tool description mentions the three members (`check:tool-surface` green — no counts change).

**Scoring:** `discover_subdomains` is a standalone intelligence tool (`group: 'intelligence'`, `scanIncluded: false`, no `tier`) and not a `scan_domain` category, so no scan score can move. The new spec pins that invariant from `TOOLS`.

## Tests

New `test/discover-subdomains-count-basis.spec.ts` (13 tests, TDD — all red before the fix):
- degraded single-source index-exhausted run → `countBasis: 'floor'`, `minSubdomainsObserved`, `totalSubdomains` kept, `concreteSubdomains` split, caveat `low` naming `crtsh`, both prose formats say "at least N observed" + split + `[LOW]`, contract survives the MCP handler `structuredContent`;
- healthy run → `'sample'`, no `minSubdomainsObserved` member, caveat `info`, no `low` issue, plain-count headline with the split (control: `coverage.degraded` is `true` here too);
- certstream timed-out partial → floor; stale LKG re-serve of a healthy run → floor;
- all-sources-failed → existing `sourceUnavailable` + `high unconfirmed_zero` + "source unavailable" prose intact, `countBasis: 'floor'`, floor of 0;
- scan-inclusion invariant.

```
npm run typecheck            # rc=0
npm run lint                 # rc=0
npm run check:tool-surface   # rc=0 — "79 public tools, 35 check_* tools", unchanged
npm run typecheck:tests      # rc=0 — no file exceeds baseline (delta −4 from unrelated env files; not banked)
npx vitest run test/discover-subdomains-count-basis.spec.ts test/discover-subdomains.spec.ts \
  test/discover-subdomains-coverage.spec.ts test/discover-subdomains-resilience.spec.ts \
  test/discover-subdomains-truncation.spec.ts test/discover-subdomains-failover-budget.spec.ts \
  test/discover-subdomains-deadline.spec.ts <registrar-complement deep-scan spec> \
  test/asset-discovery-integration.spec.ts   # 131 passed
npm test                     # see below
```

`npm test`: **8,396 passed, 13 skipped, 4 failed** — every failure is a 15,0xx ms timeout (`streaming-sse`, `dispatch-reinitialize`, `queue-batch-analytics`, `brand-audit-view-gate`), the documented Workers-pool runtime-crash signature; all four re-run in isolation → **25/25 passed**. The one failed *file* is `test/wasm-integration.test.ts` failing to load (`No such module …bv_wasm_core_bg.wasm`), the documented fresh-worktree artefact (`npm run build:wasm` not run) — 0 test failures in it.

## Residuals

- `coverage.degraded` remains `true` on essentially every run (by construction of the source ladder). It is still a truthful "recall below what the tool can reach" statement, but it is not a per-run quality signal — `countBasis` is. Consumers that branch on `degraded` alone should move to `countBasis`.
- bv-web-prod's `summariseToolResult` reads `result.domains[]` / `result.findings[]`, neither of which `discover_subdomains` emits (it emits `subdomains[]` of objects), so its subdomain view already counts 0 for this tool regardless of this change. Out of scope here; worth a bv-web-prod issue.
- A stale re-serve lifts the stored `info` caveat to `low` but keeps its original wording (written by the caching call); the stale banner and the floor headline carry the current-call reason.
- Wildcards are still counted inside `totalSubdomains` (kept for compatibility); `concreteSubdomains` is the number to publish as estate size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
