### PR TITLE
fix(lookalikes): restore registration-age lookups for .com candidates and mark unknown ages explicitly (#867)

### DIFF
--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -79,13 +79,31 @@ import {
 // consumer (or test) has to know where a symbol now lives. This list is the
 // tool's external contract; it is byte-identical to the pre-split one.
 // ---------------------------------------------------------------------------
-export { INITIAL_BATCH_SIZE, MIN_BATCH_SIZE, BACKOFF_DELAY_MS, FAILURE_THRESHOLD, WILDCARD_CANARY_LABEL, PHASE1_DNS_OPTS } from './lookalike-dns';
+export {
+	INITIAL_BATCH_SIZE,
+	MIN_BATCH_SIZE,
+	BACKOFF_DELAY_MS,
+	FAILURE_THRESHOLD,
+	WILDCARD_CANARY_LABEL,
+	PHASE1_DNS_OPTS,
+} from './lookalike-dns';
 export { probeHasWebContent } from './lookalike-enrichment';
 export { isBrandHeldRegistration, isSameEntityOrgMatch } from './lookalike-attribution';
 export { DEFENSIVE_REASON_PHRASES, type LookalikeFindingAxis } from './lookalike-findings';
 
 /** Maximum wall-clock time for the entire lookalike check (ms). */
 const LOOKALIKE_TIMEOUT_MS = 20_000;
+
+/**
+ * Wall-clock the enrichment phase must leave for what follows it (the seed's
+ * own RDAP fetch, the recon call, assembly) so a large candidate set — the
+ * #867 shape — cannot run the check into the outer timeout, which discards
+ * EVERY finding, not just the unenriched ones. Enrichment is bounded to the
+ * platform's six connection slots (`lookalike-enrichment.ts`), so its duration
+ * scales with candidate count; the deadline is what turns the tail of a large
+ * set into explicit `not_attempted` ages instead of a timed-out check.
+ */
+const ENRICHMENT_RESERVE_MS = 4_000;
 
 /**
  * Extract a specific candidate domain bv-recon's CT_LOOKALIKE hit names, if
@@ -131,6 +149,7 @@ async function checkLookalikesCore(
 	domain: string,
 	reconOptions: { reconBinding?: ReconBinding; reconAuthToken?: string; onBindingDegradation?: BindingDegradationSink } = {},
 ): Promise<CheckResult> {
+	const startedAt = Date.now();
 	const findings: Finding[] = [];
 	// THREE disjoint candidate lanes, deduped into one set that flows through the
 	// same NS-existence → probe → enrich → severity pipeline:
@@ -291,7 +310,8 @@ async function checkLookalikesCore(
 		const sameOwner = ownershipByDomain.get(r.domain)?.verdict === 'owned_by_seed';
 		return !sameOwner && (r.hasMX || r.hasA);
 	});
-	const enrichment = await enrichLookalikes(candidatesToEnrich);
+	const enrichmentDeadlineMs = startedAt + LOOKALIKE_TIMEOUT_MS - ENRICHMENT_RESERVE_MS;
+	const enrichment = await enrichLookalikes(candidatesToEnrich, { deadlineMs: enrichmentDeadlineMs });
 
 	// Same-entity correlation (issue #263): a flagged lookalike that shares the
 	// scan domain's RDAP registrant org is almost certainly the org's own
@@ -314,7 +334,10 @@ async function checkLookalikesCore(
 	// ONE RDAP fetch for the seed, reused for BOTH correlations: the registrant
 	// org (unverified, wording-only) and the registry-published registrar ID
 	// (the brand-held-registration signal). No extra network cost for the second.
-	const primaryRegistration = sameEntityCandidates.length > 0 ? await probePrimaryRegistration(domain) : EMPTY_RDAP_PROBE;
+	const primaryRegistration =
+		sameEntityCandidates.length > 0
+			? await probePrimaryRegistration(domain, { deadlineMs: enrichmentDeadlineMs + ENRICHMENT_RESERVE_MS / 2 })
+			: EMPTY_RDAP_PROBE;
 	const primaryRegistrantOrg = primaryRegistration.registrantOrg;
 	const sameEntityMatches = new Map<string, string>();
 	/** Candidates the registration record corroborates as the seed org's own defensive registrations. */
@@ -421,6 +444,7 @@ async function checkLookalikesCore(
 
 		const corroborators = enrichment.get(result.domain) ?? {
 			registrationDays: null,
+			registrationLookup: 'not_attempted' as const,
 			mxOnDisposable: false,
 			hasWebContent: true,
 			registrantOrg: null,
@@ -429,6 +453,7 @@ async function checkLookalikesCore(
 			hasA: result.hasA,
 			hasMX: result.hasMX,
 			registrationDays: corroborators.registrationDays,
+			registrationLookup: corroborators.registrationLookup,
 			mxOnDisposable: corroborators.mxOnDisposable,
 			hasWebContent: corroborators.hasWebContent,
 		};
@@ -502,7 +527,9 @@ async function checkLookalikesCore(
 	}
 
 	if (highCount > 0) {
-		findings.push(buildStagingSummaryFinding({ seedDomain: domain, highCount, highDomains, highVerdicts, mailCapableDomains, enumeration }));
+		findings.push(
+			buildStagingSummaryFinding({ seedDomain: domain, highCount, highDomains, highVerdicts, mailCapableDomains, enumeration }),
+		);
 	} else if (mailCapableDomains.length > 0) {
 		findings.push(buildMailCapableSummaryFinding({ seedDomain: domain, mailCapableDomains, enumeration }));
 	}

--- a/src/tools/lookalike-enrichment.ts
+++ b/src/tools/lookalike-enrichment.ts
@@ -3,10 +3,9 @@
 /**
  * Enrichment probes for the lookalike check (Defect L / issue #264 + #263).
  *
- * Extracted VERBATIM from `check-lookalikes.ts` (pure split, no behaviour
- * change). One RDAP fetch and at most one HEAD probe per candidate, both on
- * tight budgets, yielding the corroborating signals the severity calibrator and
- * the attribution predicates consume:
+ * One RDAP fetch and at most one HEAD probe per candidate, both on tight
+ * budgets, yielding the corroborating signals the severity calibrator and the
+ * attribution predicates consume:
  *
  *  - `registrationDays` — the "recently registered" corroborator (#264);
  *  - `registrantOrg` — the same-entity correlation input (#263);
@@ -15,25 +14,84 @@
  *
  * EVERY path here is FAIL-SOFT and the direction of each failure default is
  * load-bearing: a missing RDAP field becomes `null` ("unknown", never elevates
- * severity and never suppresses a threat), and a failed HEAD probe becomes
- * `true` ("has content", so a flaky probe cannot synthesise a HIGH). Nothing in
- * this module throws out of the tool.
+ * severity and never suppresses a threat), and an UNATTEMPTED HEAD probe
+ * becomes `true` ("has content", so a probe that never ran cannot synthesise a
+ * HIGH). Nothing in this module throws out of the tool.
+ *
+ * ⚠️ FAN-OUT IS BOUNDED, AND THE BOUND IS THE PLATFORM'S (#867). A Worker
+ * invocation may hold at most SIX connections simultaneously waiting for
+ * response headers (developers.cloudflare.com/workers/platform/limits/
+ * #simultaneous-open-connections); further `fetch()` calls QUEUE. This module
+ * used to dispatch every candidate's RDAP + HEAD at once — ~48 fetches for a
+ * 25-candidate seed — each armed with `AbortSignal.timeout(2500)` at call time,
+ * so the timers of the ~42 queued fetches ran while they waited for a slot and
+ * they aborted before the request was ever sent. The fail-soft then recorded
+ * `registrationDays: null` for every candidate past the first slot-fill (and
+ * `hasWebContent: false`, a manufactured HIGH corroborator). Measured live on
+ * anthropic.com 2026-09-04: exactly the first 8 candidates carried an age, the
+ * first 6 `hasWebContent: true`, every later one `null` + `false`. `.ai` seeds
+ * (#780) only looked fixed because a short brand yields few candidates.
+ *
+ * Two pools now share the six slots — {@link RDAP_PROBE_CONCURRENCY} +
+ * {@link WEB_PROBE_CONCURRENCY} — and each fetch arms its timeout when it is
+ * actually dispatched. Do not widen the pools past six in total, and do not
+ * re-introduce a `candidates.map(fetch)` fan-out anywhere in this module.
  */
 
 import { safeFetch } from '../lib/safe-fetch';
 import { readJsonResponseCapped } from '../lib/response-body';
+import { mapConcurrent } from '../lib/map-concurrent';
 import { extractRegistrantOrg, findEntityByRole } from './check-rdap-lookup';
 import { FALLBACK_RDAP_SERVERS } from './rdap-fallback-servers';
 import { isDisposableMxHost } from './lookalike-severity';
 import type { LookalikeResult } from './lookalike-dns';
 
-/** Budgets for the Defect L enrichment probes. Both are intentionally tight so 12 candidates × (RDAP + HEAD) stays under LOOKALIKE_TIMEOUT_MS. */
+/** Per-probe budgets for the Defect L enrichment probes. Each timer is armed when the fetch is DISPATCHED, never earlier (#867). */
 const RDAP_PROBE_TIMEOUT_MS = 2500;
 const WEB_PROBE_TIMEOUT_MS = 2500;
 const RDAP_PROBE_MAX_BODY_BYTES = 512 * 1024;
 
+/**
+ * Pool widths. Their SUM is the Workers simultaneous-open-connection cap (6):
+ * nothing else in `check_lookalikes` is fetching while enrichment runs (the
+ * DNS phases complete before it), so the two pools own the whole budget. RDAP
+ * gets the larger share because the age lookup is the signal #867 is about;
+ * the HEAD probe is a corroborator whose unattempted default is safe.
+ */
+export const RDAP_PROBE_CONCURRENCY = 4;
+export const WEB_PROBE_CONCURRENCY = 2;
+
+/**
+ * Why a candidate's registration age is what it is. `ok` is the only value
+ * under which `registrationDays` is a number; every other value means the age
+ * is UNKNOWN for that stated reason — never "absent", never "old". Exposed on
+ * every enriched finding so a consumer can tell "we could not measure" from
+ * "we measured nothing notable" (#867, #780).
+ */
+export type RegistrationLookupOutcome =
+	/** RDAP answered with a parseable `registration` event. */
+	| 'ok'
+	/** RDAP answered 200 but published no parseable `registration` event. */
+	| 'no_registration_event'
+	/** No RDAP server is known for the candidate's TLD (`FALLBACK_RDAP_SERVERS`). */
+	| 'unsupported_tld'
+	/** The registry answered 404 for the name. */
+	| 'not_found'
+	/** The registry answered 429 — rate-limited. */
+	| 'throttled'
+	/** No answer within the per-probe budget (or the remaining enrichment deadline). */
+	| 'timeout'
+	/** Transport error, non-2xx other than the above, or an unreadable body. */
+	| 'failed'
+	/** The enrichment deadline was already spent before this candidate's turn; no request was issued. */
+	| 'not_attempted';
+
 export interface LookalikeCorroborators {
 	registrationDays: number | null;
+	/** `true` iff `registrationDays` is `null`; see {@link registrationLookup} for why. */
+	ageUnknown: boolean;
+	/** Why the age is known or not — `ok` iff `registrationDays` is a number. */
+	registrationLookup: RegistrationLookupOutcome;
 	mxOnDisposable: boolean;
 	hasWebContent: boolean;
 	/**
@@ -54,34 +112,70 @@ export interface LookalikeCorroborators {
 	registrarName: string | null;
 }
 
+export interface EnrichmentOptions {
+	/**
+	 * Wall-clock deadline (epoch ms) for the whole enrichment phase. A probe
+	 * whose turn comes after it is NOT issued (`not_attempted`); a probe that
+	 * starts before it has its per-probe timeout clamped to the remainder.
+	 * Absent → each probe gets its full per-probe budget (direct callers).
+	 */
+	deadlineMs?: number;
+}
+
+/**
+ * Order candidates so the ones the age signal protects are looked up FIRST:
+ * mail-capable candidates (the age corroborator can lift them to HIGH, and a
+ * pre-dating age lets a consumer exclude them) ahead of web-only ones. Stable
+ * within each group, so a tight deadline drops the tail of the web-only set,
+ * never a mail host.
+ */
+export function prioritiseForEnrichment(candidates: readonly LookalikeResult[]): LookalikeResult[] {
+	const mail: LookalikeResult[] = [];
+	const rest: LookalikeResult[] = [];
+	for (const c of candidates) (c.hasMX ? mail : rest).push(c);
+	return [...mail, ...rest];
+}
+
 /**
  * Run the Defect L enrichment probes (RDAP registration age + web HEAD probe)
- * for every candidate in parallel. Failure to enrich is fail-soft: missing
- * RDAP data becomes `registrationDays: null` (treated as "unknown — not recent")
- * and a probe error becomes `hasWebContent: true` to avoid synthesising HIGH
- * out of nothing. `mxOnDisposable` is derived synchronously from the already-
- * parsed MX exchanges, no extra DNS needed.
+ * for every candidate through two bounded pools (see the module JSDoc for why
+ * the bound is six). Failure to enrich is fail-soft: missing RDAP data becomes
+ * `registrationDays: null` WITH a stated {@link RegistrationLookupOutcome}
+ * (treated as "unknown — not recent"), and an unattempted HEAD probe becomes
+ * `hasWebContent: true` to avoid synthesising HIGH out of nothing.
+ * `mxOnDisposable` is derived synchronously from the already-parsed MX
+ * exchanges, no extra DNS needed.
  */
-export async function enrichLookalikes(candidates: LookalikeResult[]): Promise<Map<string, LookalikeCorroborators>> {
+export async function enrichLookalikes(
+	candidates: LookalikeResult[],
+	options: EnrichmentOptions = {},
+): Promise<Map<string, LookalikeCorroborators>> {
 	const map = new Map<string, LookalikeCorroborators>();
 	if (candidates.length === 0) return map;
-	await Promise.allSettled(
-		candidates.map(async (candidate) => {
-			const [rdap, hasWebContent] = await Promise.all([
-				probeRdap(candidate.domain),
-				candidate.hasA ? probeHasWebContent(candidate.domain) : Promise.resolve(true),
-			]);
-			const mxOnDisposable = candidate.mxExchanges.some(isDisposableMxHost);
-			map.set(candidate.domain, {
-				registrationDays: rdap.registrationDays,
-				mxOnDisposable,
-				hasWebContent,
-				registrantOrg: rdap.registrantOrg,
-				registrarIanaId: rdap.registrarIanaId,
-				registrarName: rdap.registrarName,
-			});
-		}),
-	);
+	const ordered = prioritiseForEnrichment(candidates);
+	const deadlineMs = options.deadlineMs;
+	// Two independent pools: a slow HEAD probe (dark domains hang for the full
+	// budget) must not hold an RDAP slot hostage. Neither probe ever throws, so
+	// mapConcurrent cannot reject.
+	const [rdapResults, webResults] = await Promise.all([
+		mapConcurrent(ordered, RDAP_PROBE_CONCURRENCY, (candidate) => probeRdap(candidate.domain, deadlineMs)),
+		mapConcurrent(ordered, WEB_PROBE_CONCURRENCY, (candidate) =>
+			candidate.hasA ? probeHasWebContent(candidate.domain, deadlineMs) : Promise.resolve(true),
+		),
+	]);
+	ordered.forEach((candidate, i) => {
+		const rdap = rdapResults[i];
+		map.set(candidate.domain, {
+			registrationDays: rdap.registrationDays,
+			ageUnknown: rdap.registrationDays === null,
+			registrationLookup: rdap.lookup,
+			mxOnDisposable: candidate.mxExchanges.some(isDisposableMxHost),
+			hasWebContent: webResults[i],
+			registrantOrg: rdap.registrantOrg,
+			registrarIanaId: rdap.registrarIanaId,
+			registrarName: rdap.registrarName,
+		});
+	});
 	return map;
 }
 
@@ -89,6 +183,8 @@ export async function enrichLookalikes(candidates: LookalikeResult[]): Promise<M
 export interface RdapProbeResult {
 	/** Age in days since the RDAP `registration` event, or `null` on any failure / missing data. */
 	registrationDays: number | null;
+	/** Why {@link registrationDays} is or is not populated. */
+	lookup: RegistrationLookupOutcome;
 	/** Normalised RDAP registrant org, or `null` on any failure / missing data. */
 	registrantOrg: string | null;
 	/**
@@ -102,8 +198,28 @@ export interface RdapProbeResult {
 	registrarName: string | null;
 }
 
-/** Empty probe result — used for early-outs and the catch path (fail-soft). */
-export const EMPTY_RDAP_PROBE: RdapProbeResult = { registrationDays: null, registrantOrg: null, registrarIanaId: null, registrarName: null };
+/** Empty probe result — the "never looked" shape, used when a lookup is skipped outright (fail-soft). */
+export const EMPTY_RDAP_PROBE: RdapProbeResult = {
+	registrationDays: null,
+	lookup: 'not_attempted',
+	registrantOrg: null,
+	registrarIanaId: null,
+	registrarName: null,
+};
+
+/** An attempted-but-unanswered probe: same nulls as {@link EMPTY_RDAP_PROBE}, with the reason recorded. */
+function failedProbe(lookup: Exclude<RegistrationLookupOutcome, 'ok'>): RdapProbeResult {
+	return { ...EMPTY_RDAP_PROBE, lookup };
+}
+
+/**
+ * Remaining per-probe budget: the probe's own ceiling, clamped to whatever is
+ * left before `deadlineMs`. `<= 0` means "do not issue the request".
+ */
+function remainingBudgetMs(probeTimeoutMs: number, deadlineMs: number | undefined): number {
+	if (typeof deadlineMs !== 'number') return probeTimeoutMs;
+	return Math.min(probeTimeoutMs, deadlineMs - Date.now());
+}
 
 /**
  * Pull the registrar's IANA ID and display name out of a parsed RDAP domain
@@ -151,24 +267,30 @@ function extractRegistrar(rdapData: unknown): { ianaId: string | null; name: str
 /**
  * Lightweight RDAP lookup constrained for use inside the lookalike check.
  * Hits the hardcoded {@link FALLBACK_RDAP_SERVERS} map only (no IANA bootstrap),
- * single fetch, hard 2.5s timeout, no retries. From that single response it
- * derives BOTH the registration age (issue #264 corroborator) AND the registrant
- * org (issue #263 same-entity correlation) — no extra fetch for the org signal.
- * Any failure / missing data yields `null` for the affected field, which the
- * calibrator treats as "unknown" (never elevates severity) and the same-entity
- * check treats as "no match" (never suppresses a real threat).
+ * single fetch, hard 2.5s timeout armed at dispatch, no retries. From that
+ * single response it derives BOTH the registration age (issue #264
+ * corroborator) AND the registrant org (issue #263 same-entity correlation) —
+ * no extra fetch for the org signal. Any failure / missing data yields `null`
+ * for the affected field PLUS a `lookup` reason; the calibrator treats a null
+ * age as "unknown" (never elevates severity) and the same-entity check treats
+ * a null org as "no match" (never suppresses a real threat).
  *
- * ⚠️ A DEAD ENTRY IN THAT MAP DEGRADES SILENTLY (#780) — a host that does not
- * resolve is indistinguishable here from "old domain, nothing notable". The
- * class-level guard is `scripts/audits/rdap-fallback-reconcile.ts`, which
- * reconciles the table against IANA's authoritative bootstrap out-of-band.
+ * ⚠️ A DEAD ENTRY IN THAT MAP STILL DEGRADES QUIETLY (#780) — it surfaces as
+ * `lookup: 'failed'` / `'timeout'` on every domain under the TLD rather than
+ * as an error. The class-level guard is `scripts/audits/rdap-fallback-reconcile.ts`,
+ * which reconciles the table against IANA's authoritative bootstrap out-of-band.
  */
-async function probeRdap(domain: string): Promise<RdapProbeResult> {
+async function probeRdap(domain: string, deadlineMs?: number): Promise<RdapProbeResult> {
 	const labels = domain.split('.');
 	const tld = labels[labels.length - 1]?.toLowerCase();
-	if (!tld) return EMPTY_RDAP_PROBE;
+	if (!tld) return failedProbe('unsupported_tld');
 	const serverUrl = FALLBACK_RDAP_SERVERS[tld];
-	if (!serverUrl) return EMPTY_RDAP_PROBE;
+	if (!serverUrl) return failedProbe('unsupported_tld');
+	const budgetMs = remainingBudgetMs(RDAP_PROBE_TIMEOUT_MS, deadlineMs);
+	if (budgetMs <= 0) return failedProbe('not_attempted');
+	// Armed HERE, at dispatch — the pool guarantees a connection slot is free,
+	// so the timer measures the server, not a queue (#867).
+	const signal = AbortSignal.timeout(budgetMs);
 	try {
 		const baseUrl = serverUrl.endsWith('/') ? serverUrl : `${serverUrl}/`;
 		const rdapUrl = `${baseUrl}domain/${domain}`;
@@ -178,22 +300,24 @@ async function probeRdap(domain: string): Promise<RdapProbeResult> {
 		// for parity: validateOutboundUrl() re-validates the destination host (SSRF
 		// gate) and manual redirect stops the worker chasing a server-supplied
 		// Location. safeFetch throws on a blocked host (matching native fetch error
-		// semantics); the surrounding try/catch degrades it to EMPTY_RDAP_PROBE
+		// semantics); the surrounding try/catch degrades it to a failed probe
 		// exactly like any other probe failure (fail-soft, never throws out of the tool).
 		const resp = await safeFetch(rdapUrl, {
 			redirect: 'manual',
-			signal: AbortSignal.timeout(RDAP_PROBE_TIMEOUT_MS),
+			signal,
 			headers: { Accept: 'application/rdap+json, application/json' },
 		});
 		if (!resp.ok) {
 			void resp.body?.cancel().catch(() => undefined);
-			return EMPTY_RDAP_PROBE;
+			if (resp.status === 429) return failedProbe('throttled');
+			if (resp.status === 404) return failedProbe('not_found');
+			return failedProbe('failed');
 		}
 		const data = await readJsonResponseCapped<{ events?: Array<{ eventAction?: string; eventDate?: string }> }>(
 			resp,
 			RDAP_PROBE_MAX_BODY_BYTES,
 		);
-		if (data === null) return EMPTY_RDAP_PROBE;
+		if (data === null) return failedProbe('failed');
 		const registration = Array.isArray(data.events) ? data.events.find((e) => e.eventAction === 'registration') : undefined;
 		let registrationDays: number | null = null;
 		if (registration?.eventDate) {
@@ -205,12 +329,13 @@ async function probeRdap(domain: string): Promise<RdapProbeResult> {
 		const registrar = extractRegistrar(data);
 		return {
 			registrationDays,
+			lookup: registrationDays === null ? 'no_registration_event' : 'ok',
 			registrantOrg: extractRegistrantOrg(data),
 			registrarIanaId: registrar.ianaId,
 			registrarName: registrar.name,
 		};
 	} catch {
-		return EMPTY_RDAP_PROBE;
+		return failedProbe(signal.aborted ? 'timeout' : 'failed');
 	}
 }
 
@@ -218,10 +343,10 @@ async function probeRdap(domain: string): Promise<RdapProbeResult> {
  * Fetch the scan domain's own registration record — registrant org for the
  * same-entity correlation (issue #263) AND the registry-published registrar ID
  * for `isBrandHeldRegistration`. ONE fetch serves both; reuses
- * {@link probeRdap} and fails soft to {@link EMPTY_RDAP_PROBE}.
+ * {@link probeRdap} and fails soft to {@link EMPTY_RDAP_PROBE}'s nulls.
  */
-export async function probePrimaryRegistration(domain: string): Promise<RdapProbeResult> {
-	return probeRdap(domain);
+export async function probePrimaryRegistration(domain: string, options: EnrichmentOptions = {}): Promise<RdapProbeResult> {
+	return probeRdap(domain, options.deadlineMs);
 }
 
 /**
@@ -234,8 +359,13 @@ export async function probePrimaryRegistration(domain: string): Promise<RdapProb
  * the server just errored. Phishing infra rarely 5xx's; parked-page infra
  * usually 200's with adverts. The only consistent "no content" signal is a
  * hard transport failure.
+ *
+ * A probe whose turn comes after `deadlineMs` is NOT issued and reports `true`
+ * — "unknown" must fail toward the safe side, never toward the HIGH corroborator.
  */
-export async function probeHasWebContent(domain: string): Promise<boolean> {
+export async function probeHasWebContent(domain: string, deadlineMs?: number): Promise<boolean> {
+	const budgetMs = remainingBudgetMs(WEB_PROBE_TIMEOUT_MS, deadlineMs);
+	if (budgetMs <= 0) return true;
 	try {
 		// safeFetch + manual redirect: the candidate is attacker-influenced, so we
 		// MUST NOT auto-follow a 302 → internal/Cloudflare host (blind SSRF oracle,
@@ -245,7 +375,7 @@ export async function probeHasWebContent(domain: string): Promise<boolean> {
 		const resp = await safeFetch(`https://${domain}/`, {
 			method: 'HEAD',
 			redirect: 'manual',
-			signal: AbortSignal.timeout(WEB_PROBE_TIMEOUT_MS),
+			signal: AbortSignal.timeout(budgetMs),
 		});
 		// Any HTTP response (incl. 3xx) means the host is reachable — content exists.
 		return Boolean(resp);

--- a/src/tools/lookalike-findings.ts
+++ b/src/tools/lookalike-findings.ts
@@ -58,6 +58,7 @@ import type { Finding } from '../lib/scoring';
 import { createFinding } from '../lib/scoring';
 import type { LookalikeResult } from './lookalike-dns';
 import type { LookalikeSeverity, LookalikeSignals } from './lookalike-severity';
+import type { RegistrationLookupOutcome } from './lookalike-enrichment';
 
 export type LookalikeFindingAxis = 'attribution' | 'threat_observation' | 'scan_status';
 
@@ -77,6 +78,22 @@ export const DEFENSIVE_REASON_PHRASES: Record<DefensiveReason, string> = {
 	'parked-ns': 'its nameservers are at a domain-parking provider',
 	'no-mx': 'it carries no active mail service',
 };
+
+/**
+ * The explicit unknown-age marker that travels beside `registrationDays` on
+ * every per-candidate finding (#867). A bare `registrationDays: null` was read
+ * downstream as "nothing notable" / "not excluded by the age filter"; these two
+ * fields let a consumer tell "we could not measure" from "we measured nothing
+ * notable". `ageUnknown` is `true` iff the age is `null`; `registrationLookup`
+ * says why (`ok` iff the age is a number). A signals bag built without the
+ * outcome (see `computeSameEntityCandidates`) is one where no lookup ran.
+ */
+export function registrationAgeMetadata(signals: LookalikeSignals): { ageUnknown: boolean; registrationLookup: RegistrationLookupOutcome } {
+	return {
+		ageUnknown: signals.registrationDays === null,
+		registrationLookup: signals.registrationLookup ?? 'not_attempted',
+	};
+}
 
 /**
  * Build a short human-readable list of corroborating signals for the finding
@@ -262,6 +279,7 @@ export function buildRawAttributionFinding(
 					hasA: result.hasA,
 					hasMX: result.hasMX,
 					registrationDays: signals.registrationDays,
+					...registrationAgeMetadata(signals),
 					mxOnDisposable: signals.mxOnDisposable,
 					hasWebContent: signals.hasWebContent,
 					findingAxis: 'attribution' satisfies LookalikeFindingAxis,
@@ -277,6 +295,7 @@ export function buildRawAttributionFinding(
 					hasA: result.hasA,
 					hasMX: result.hasMX,
 					registrationDays: signals.registrationDays,
+					...registrationAgeMetadata(signals),
 					mxOnDisposable: signals.mxOnDisposable,
 					hasWebContent: signals.hasWebContent,
 					findingAxis: 'attribution' satisfies LookalikeFindingAxis,
@@ -406,6 +425,7 @@ export function buildThreatObservationFinding(
 			hasA: signals.hasA,
 			hasMX: signals.hasMX,
 			registrationDays: signals.registrationDays,
+			...registrationAgeMetadata(signals),
 			mxOnDisposable: signals.mxOnDisposable,
 			hasWebContent: signals.hasWebContent,
 			findingAxis: 'threat_observation' satisfies LookalikeFindingAxis,

--- a/src/tools/lookalike-severity.ts
+++ b/src/tools/lookalike-severity.ts
@@ -21,6 +21,7 @@
  */
 
 import type { Severity } from '../lib/scoring';
+import type { RegistrationLookupOutcome } from './lookalike-enrichment';
 
 /** Severity assigned to lookalikes that should not surface as a finding at all. */
 export type LookalikeSeverity = Extract<Severity, 'low' | 'medium' | 'high'>;
@@ -58,6 +59,13 @@ export interface LookalikeSignals {
 	 * fallback map. Per design: null is "unknown" and never elevates severity.
 	 */
 	registrationDays: number | null;
+	/**
+	 * Why {@link registrationDays} is or is not populated (#867). Optional so
+	 * callers that only need the calibration matrix can omit it; the finding
+	 * builders default an absent value to `not_attempted`. Never read by the
+	 * calibrator — an unknown age is "not recent" whatever the reason.
+	 */
+	registrationLookup?: RegistrationLookupOutcome;
 	/** MX exchange host suffix matches one of {@link DISPOSABLE_MX_PROVIDERS}. */
 	mxOnDisposable: boolean;
 	/**

--- a/test/check-lookalikes-registration-age.spec.ts
+++ b/test/check-lookalikes-registration-age.spec.ts
@@ -11,7 +11,8 @@
 // `AbortSignal.timeout(2500)` AT CALL TIME. A Worker invocation may hold at most
 // SIX connections simultaneously waiting for response headers
 // (developers.cloudflare.com/workers/platform/limits/#simultaneous-open-connections);
-// the rest queue. A 25-candidate seed dispatches ~48 fetches; the 2.5s timers of
+// the rest queue. The 'REPRODUCTION' case below runs the pre-fix fan-out shape
+// against an emulated six-slot runtime and shows the tail nulling. A 25-candidate seed dispatches ~48 fetches; the 2.5s timers of
 // the ~42 queued ones run while they WAIT for a slot, so they abort before the
 // request is ever sent and fail-soft to `registrationDays: null` (and, for the
 // HEAD probe, to `hasWebContent: false` — a manufactured HIGH corroborator).
@@ -134,66 +135,158 @@ describe('enrichLookalikes — bounded fan-out (#867)', () => {
 		}
 	});
 
-	it('REPRODUCTION: an emulated six-slot connection queue starves the unbounded fan-out but not the bounded one', async () => {
-		// Emulate the Workers runtime: at most six fetches are "connected" at a
-		// time; the rest wait in a FIFO queue with their AbortSignal already
-		// ticking, exactly as the real queue behaves.
+	/**
+	 * Emulate the Workers runtime: at most `SLOTS` fetches are "connected" at a
+	 * time; the rest wait in a FIFO queue with their AbortSignal already ticking,
+	 * exactly as the real queue behaves. `HOLD_MS` is how long a connected fetch
+	 * occupies its slot. With 50 fetches through 6 slots, a fetch dispatched at
+	 * position p waits ≈ floor(p / 6) × HOLD_MS; at 600ms the fifth round onward
+	 * (p ≥ 30) waits > 2500ms — past the REAL `RDAP_PROBE_TIMEOUT_MS` — so a
+	 * pre-armed timer fires while its fetch is still queued. `peakWaiting` is
+	 * the deterministic tell: it is > 0 iff something ever queued.
+	 */
+	function buildSixSlotRuntime(holdMs: number) {
 		const SLOTS = 6;
-		const HOLD_MS = 400;
 		let active = 0;
 		const waiting: Array<() => void> = [];
+		/**
+		 * `queuedThenAborted` counts fetches that had to WAIT for a slot and were
+		 * then torn down by their own timer before completing a hold — i.e. the
+		 * request's budget was spent in the queue, not at the server. (Every
+		 * signal here is created within the same millisecond, so at T+2500 the
+		 * in-hold fetches abort, each release hands its slot to a waiter whose own
+		 * timer fires a microtask later, and the whole tail collapses in one
+		 * grant-then-abort cascade — which is why the count is taken on the
+		 * rejection, not on the `abort` event.)
+		 */
+		const stats = { peakWaiting: 0, queuedThenAborted: 0 };
 		const releaseSlot = () => {
 			active--;
-			const next = waiting.shift();
-			if (next) next();
+			// Drain until one waiter actually takes the slot (an already-aborted
+			// waiter is rejected by `grant` without occupying it).
+			while (active < SLOTS && waiting.length > 0) {
+				const before = active;
+				waiting.shift()!();
+				if (active > before) break;
+			}
 		};
-		globalThis.fetch = vi.fn().mockImplementation(async (input: FetchInput, init?: RequestInit) => {
+		const fetchImpl = async (input: FetchInput, init?: RequestInit): Promise<Response> => {
 			const url = new URL(urlOf(input));
 			const signal = init?.signal;
+			let wasQueued = false;
 			// Waiting for a slot is abortable — a queued fetch whose timer fires
 			// rejects without ever being sent (and leaves the queue).
 			await new Promise<void>((resolve, reject) => {
+				const abortReason = () => signal?.reason ?? new DOMException('aborted', 'AbortError');
 				const grant = () => {
-					active++;
 					signal?.removeEventListener('abort', onAbort);
+					// The runtime hands the slot to a fetch whose timer already fired:
+					// it is torn down without being sent. Counted here as well as in
+					// the listener because workerd does not reliably dispatch the
+					// `abort` event to a listener registered on a signal that is
+					// merely parked in a queue (observed 2026-09-04); the flag is
+					// authoritative either way.
+					if (signal?.aborted) {
+						stats.queuedThenAborted++;
+						reject(abortReason());
+						return;
+					}
+					active++;
 					resolve();
 				};
 				const onAbort = () => {
 					const idx = waiting.indexOf(grant);
-					if (idx >= 0) waiting.splice(idx, 1);
-					reject(signal?.reason ?? new DOMException('aborted', 'AbortError'));
+					if (idx >= 0) {
+						waiting.splice(idx, 1);
+						stats.queuedThenAborted++;
+					}
+					reject(abortReason());
 				};
 				if (signal?.aborted) return onAbort();
 				signal?.addEventListener('abort', onAbort, { once: true });
-				if (active < SLOTS) grant();
-				else waiting.push(grant);
+				if (active < SLOTS) {
+					grant();
+				} else {
+					wasQueued = true;
+					waiting.push(grant);
+					stats.peakWaiting = Math.max(stats.peakWaiting, waiting.length);
+				}
 			});
 			try {
 				return await delayHonouringSignal(
-					HOLD_MS,
+					holdMs,
 					() => (url.pathname.includes('/domain/') ? jsonResponse(rdapBody(400)) : new Response(null, { status: 200 })),
 					signal,
 				);
+			} catch (err) {
+				// Granted in the cascade described above, then killed by a timer
+				// that was armed while it sat in the queue.
+				if (wasQueued) stats.queuedThenAborted++;
+				throw err;
 			} finally {
 				releaseSlot();
 			}
-		});
+		};
+		return { fetchImpl, stats };
+	}
 
-		// 30 RDAP + 20 HEAD = 50 fetches through 6 slots × 400ms ≈ 3.6s of queue,
-		// longer than the 2.5s per-probe timer. Unbounded (the #867 code): every
-		// fetch is dispatched at t=0 with its timer already running, so the last
-		// ~2 slot-rounds abort while still queued — measured 15 of 30 candidates
-		// null under the pre-fix code with this exact emulation. Bounded: a fetch
-		// is dispatched only when a pool worker is free, so its timer starts when
-		// it can actually be sent, and no candidate is starved.
-		const candidates = Array.from({ length: 30 }, (_, i) => candidate(`starve${i}.com`, { hasA: i < 20, hasMX: true }));
+	const QUEUE_HOLD_MS = 600;
+	const queueCandidates = () => Array.from({ length: 30 }, (_, i) => candidate(`starve${i}.com`, { hasA: i < 20, hasMX: true }));
+
+	it('REPRODUCTION (pre-fix shape): the old per-candidate fan-out queues behind six slots and its pre-armed timers null the tail', async () => {
+		const { fetchImpl, stats } = buildSixSlotRuntime(QUEUE_HOLD_MS);
+		globalThis.fetch = vi.fn().mockImplementation(fetchImpl);
+		const { probePrimaryRegistration, probeHasWebContent } = await loadEnrichment();
+
+		// EXACTLY the #867 code path: `Promise.allSettled(candidates.map(...))`
+		// dispatching RDAP + HEAD for every candidate at once, each probe arming
+		// its own 2500ms timer at call time. `probePrimaryRegistration` IS the
+		// per-candidate `probeRdap` (same function, no deadline), and
+		// `probeHasWebContent` is the same HEAD probe the old loop called.
+		const candidates = queueCandidates();
+		const results = new Map<string, { registrationDays: number | null; lookup: string; hasWebContent: boolean }>();
+		await Promise.allSettled(
+			candidates.map(async (c) => {
+				const [rdap, hasWebContent] = await Promise.all([
+					probePrimaryRegistration(c.domain),
+					c.hasA ? probeHasWebContent(c.domain) : Promise.resolve(true),
+				]);
+				results.set(c.domain, { registrationDays: rdap.registrationDays, lookup: rdap.lookup, hasWebContent });
+			}),
+		);
+
+		// Something queued — the branch the bounded path must never reach.
+		expect(stats.peakWaiting).toBeGreaterThan(0);
+		expect(stats.queuedThenAborted).toBeGreaterThanOrEqual(10);
+		// The tail aborted IN THE QUEUE: null age, recorded as a timeout, with no
+		// server ever answering slowly. Positions ≥ 30 of 50 → ≥ 10 RDAP probes.
+		const starved = candidates.filter((c) => results.get(c.domain)?.registrationDays === null);
+		expect(starved.length).toBeGreaterThanOrEqual(10);
+		for (const c of starved) expect(results.get(c.domain)?.lookup, c.domain).toBe('timeout');
+		// And the same starvation manufactured the "no reachable web content"
+		// HIGH corroborator for HEAD probes that were never sent.
+		expect(candidates.some((c) => results.get(c.domain)?.hasWebContent === false)).toBe(true);
+	});
+
+	it('bounded fan-out never queues behind the six slots, so no timer runs while waiting and every candidate is populated', async () => {
+		const { fetchImpl, stats } = buildSixSlotRuntime(QUEUE_HOLD_MS);
+		globalThis.fetch = vi.fn().mockImplementation(fetchImpl);
+
+		const candidates = queueCandidates();
 		const { enrichLookalikes } = await loadEnrichment();
-		const enrichment = await enrichLookalikes(candidates, { deadlineMs: Date.now() + 8_000 });
+		const enrichment = await enrichLookalikes(candidates, { deadlineMs: Date.now() + 10_000 });
+
+		// The load-bearing guard against a pool-width regression: with
+		// RDAP_PROBE_CONCURRENCY + WEB_PROBE_CONCURRENCY ≤ 6 nothing can ever
+		// wait for a slot. Any widening past six turns this red deterministically
+		// — the timer-based assertions below would only catch a LARGE overshoot,
+		// because a queued fetch must wait ≥ 5 rounds to outlive 2500ms.
+		expect(stats.peakWaiting).toBe(0);
+		expect(stats.queuedThenAborted).toBe(0);
 
 		const populated = candidates.filter((c) => enrichment.get(c.domain)?.registrationDays === 400).length;
 		expect(populated).toBe(30);
-		// The HEAD probes that were NOT starved must not have been recorded as
-		// "no reachable web content" — that was the manufactured HIGH corroborator.
+		for (const c of candidates) expect(enrichment.get(c.domain)?.registrationLookup, c.domain).toBe('ok');
 		const noContent = candidates.filter((c) => enrichment.get(c.domain)?.hasWebContent === false).length;
 		expect(noContent).toBe(0);
 	});

--- a/test/check-lookalikes-registration-age.spec.ts
+++ b/test/check-lookalikes-registration-age.spec.ts
@@ -1,0 +1,468 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Regression for #867 (the inversion of #780): `registrationDays` was null for
+// MOST `.com` candidates of a large seed (anthropic.com: 8 populated / 24 null;
+// cohere.com: 14 of 15 mail-capable null) while small `.ai` seeds populated
+// fully.
+//
+// ROOT CAUSE — connection-slot starvation, not a TLD map or a parser.
+// `enrichLookalikes()` fanned out EVERY candidate's RDAP fetch + HEAD probe at
+// once (`Promise.allSettled(candidates.map(...))`), each armed with
+// `AbortSignal.timeout(2500)` AT CALL TIME. A Worker invocation may hold at most
+// SIX connections simultaneously waiting for response headers
+// (developers.cloudflare.com/workers/platform/limits/#simultaneous-open-connections);
+// the rest queue. A 25-candidate seed dispatches ~48 fetches; the 2.5s timers of
+// the ~42 queued ones run while they WAIT for a slot, so they abort before the
+// request is ever sent and fail-soft to `registrationDays: null` (and, for the
+// HEAD probe, to `hasWebContent: false` — a manufactured HIGH corroborator).
+// Measured live 2026-09-04 on anthropic.com: candidates in processing order,
+// exactly the first 8 carry an age and the first 6 `hasWebContent: true`; every
+// later candidate is `null` + `false`. RDAP and HEAD target different hosts, so
+// a registry rate limit cannot explain both. `.ai` seeds only LOOKED fixed
+// because a short brand yields few candidates (x.ai: 7 → 14 fetches, all served
+// within 2.5s).
+//
+// The fix bounds the fan-out to the platform's connection cap (RDAP pool 4 +
+// HEAD pool 2), arms each timeout when the fetch is actually dispatched,
+// prioritises mail-capable candidates, and reports WHY an age is unknown.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+import type { LookalikeResult } from '../src/tools/lookalike-dns';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => {
+	restore();
+	vi.restoreAllMocks();
+});
+
+type FetchInput = string | URL | Request;
+
+function urlOf(input: FetchInput): string {
+	return typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+}
+
+function candidate(domain: string, opts: { hasA?: boolean; hasMX?: boolean } = {}): LookalikeResult {
+	const hasMX = opts.hasMX ?? false;
+	return {
+		domain,
+		hasA: opts.hasA ?? true,
+		hasMX,
+		mxExchanges: hasMX ? ['mail.example.net'] : [],
+		probeDegraded: false,
+	};
+}
+
+function rdapBody(daysAgo: number | null): Record<string, unknown> {
+	return {
+		objectClassName: 'domain',
+		events: daysAgo === null ? [] : [{ eventAction: 'registration', eventDate: new Date(Date.now() - daysAgo * 86_400_000).toISOString() }],
+		entities: [
+			{
+				objectClassName: 'entity',
+				roles: ['registrar'],
+				publicIds: [{ type: 'IANA Registrar ID', identifier: '1234' }],
+				vcardArray: ['vcard', [['fn', {}, 'text', 'Example Registrar']]],
+			},
+		],
+	};
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+	return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/rdap+json' } });
+}
+
+/** Resolve after `ms`, or reject with an AbortError as soon as `signal` fires — the shape a real fetch has. */
+function delayHonouringSignal<T>(ms: number, value: () => T, signal: AbortSignal | null | undefined): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const abort = () => {
+			clearTimeout(timer);
+			reject(signal?.reason instanceof Error ? signal.reason : new DOMException('The operation was aborted', 'AbortError'));
+		};
+		if (signal?.aborted) {
+			abort();
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener('abort', abort);
+			resolve(value());
+		}, ms);
+		signal?.addEventListener('abort', abort, { once: true });
+	});
+}
+
+async function loadEnrichment() {
+	return import('../src/tools/lookalike-enrichment');
+}
+
+// ---------------------------------------------------------------------------
+// The fan-out contract — the mechanism behind #867.
+// ---------------------------------------------------------------------------
+
+describe('enrichLookalikes — bounded fan-out (#867)', () => {
+	it('never has more than six enrichment fetches in flight, and every .com candidate of a 30+ set gets an age', async () => {
+		let inFlight = 0;
+		let peakInFlight = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			inFlight++;
+			peakInFlight = Math.max(peakInFlight, inFlight);
+			const release = () => {
+				inFlight--;
+			};
+			if (url.pathname.includes('/domain/')) {
+				return delayHonouringSignal(15, () => jsonResponse(rdapBody(400)), init?.signal).finally(release);
+			}
+			// HEAD probe of the candidate itself.
+			return delayHonouringSignal(15, () => new Response(null, { status: 200 }), init?.signal).finally(release);
+		});
+
+		const candidates = Array.from({ length: 32 }, (_, i) => candidate(`brand${i}.com`, { hasA: true, hasMX: i % 2 === 0 }));
+		const { enrichLookalikes } = await loadEnrichment();
+		const enrichment = await enrichLookalikes(candidates);
+
+		// The platform cap: six connections per invocation. Before the fix this was 64.
+		expect(peakInFlight).toBeLessThanOrEqual(6);
+		expect(enrichment.size).toBe(32);
+		for (const c of candidates) {
+			const corroborators = enrichment.get(c.domain);
+			expect(corroborators?.registrationDays, c.domain).toBe(400);
+			expect(corroborators?.ageUnknown, c.domain).toBe(false);
+			expect(corroborators?.registrationLookup, c.domain).toBe('ok');
+			expect(corroborators?.hasWebContent, c.domain).toBe(true);
+		}
+	});
+
+	it('REPRODUCTION: an emulated six-slot connection queue starves the unbounded fan-out but not the bounded one', async () => {
+		// Emulate the Workers runtime: at most six fetches are "connected" at a
+		// time; the rest wait in a FIFO queue with their AbortSignal already
+		// ticking, exactly as the real queue behaves.
+		const SLOTS = 6;
+		const HOLD_MS = 400;
+		let active = 0;
+		const waiting: Array<() => void> = [];
+		const releaseSlot = () => {
+			active--;
+			const next = waiting.shift();
+			if (next) next();
+		};
+		globalThis.fetch = vi.fn().mockImplementation(async (input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			const signal = init?.signal;
+			// Waiting for a slot is abortable — a queued fetch whose timer fires
+			// rejects without ever being sent (and leaves the queue).
+			await new Promise<void>((resolve, reject) => {
+				const grant = () => {
+					active++;
+					signal?.removeEventListener('abort', onAbort);
+					resolve();
+				};
+				const onAbort = () => {
+					const idx = waiting.indexOf(grant);
+					if (idx >= 0) waiting.splice(idx, 1);
+					reject(signal?.reason ?? new DOMException('aborted', 'AbortError'));
+				};
+				if (signal?.aborted) return onAbort();
+				signal?.addEventListener('abort', onAbort, { once: true });
+				if (active < SLOTS) grant();
+				else waiting.push(grant);
+			});
+			try {
+				return await delayHonouringSignal(
+					HOLD_MS,
+					() => (url.pathname.includes('/domain/') ? jsonResponse(rdapBody(400)) : new Response(null, { status: 200 })),
+					signal,
+				);
+			} finally {
+				releaseSlot();
+			}
+		});
+
+		// 30 RDAP + 20 HEAD = 50 fetches through 6 slots × 400ms ≈ 3.6s of queue,
+		// longer than the 2.5s per-probe timer. Unbounded (the #867 code): every
+		// fetch is dispatched at t=0 with its timer already running, so the last
+		// ~2 slot-rounds abort while still queued — measured 15 of 30 candidates
+		// null under the pre-fix code with this exact emulation. Bounded: a fetch
+		// is dispatched only when a pool worker is free, so its timer starts when
+		// it can actually be sent, and no candidate is starved.
+		const candidates = Array.from({ length: 30 }, (_, i) => candidate(`starve${i}.com`, { hasA: i < 20, hasMX: true }));
+		const { enrichLookalikes } = await loadEnrichment();
+		const enrichment = await enrichLookalikes(candidates, { deadlineMs: Date.now() + 8_000 });
+
+		const populated = candidates.filter((c) => enrichment.get(c.domain)?.registrationDays === 400).length;
+		expect(populated).toBe(30);
+		// The HEAD probes that were NOT starved must not have been recorded as
+		// "no reachable web content" — that was the manufactured HIGH corroborator.
+		const noContent = candidates.filter((c) => enrichment.get(c.domain)?.hasWebContent === false).length;
+		expect(noContent).toBe(0);
+	});
+
+	it('dispatches mail-capable candidates before web-only ones, so a tight budget protects the ones the age signal matters for', async () => {
+		const rdapOrder: string[] = [];
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			if (url.pathname.includes('/domain/')) {
+				rdapOrder.push(url.pathname.split('/domain/')[1]);
+				return delayHonouringSignal(5, () => jsonResponse(rdapBody(400)), init?.signal);
+			}
+			return delayHonouringSignal(5, () => new Response(null, { status: 200 }), init?.signal);
+		});
+
+		// Web-only candidates listed FIRST; mail-capable ones last.
+		const webOnly = Array.from({ length: 6 }, (_, i) => candidate(`web${i}.com`, { hasA: true, hasMX: false }));
+		const mail = Array.from({ length: 6 }, (_, i) => candidate(`mail${i}.com`, { hasA: true, hasMX: true }));
+		const { enrichLookalikes } = await loadEnrichment();
+		await enrichLookalikes([...webOnly, ...mail]);
+
+		expect(rdapOrder.slice(0, 6).sort()).toEqual(mail.map((c) => c.domain).sort());
+		expect(rdapOrder.slice(6).sort()).toEqual(webOnly.map((c) => c.domain).sort());
+	});
+
+	it('with the deadline already spent, issues NO fetch and marks every candidate not_attempted (never a bare null)', async () => {
+		const fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(jsonResponse(rdapBody(400))));
+		globalThis.fetch = fetchSpy;
+
+		const candidates = [candidate('late1.com', { hasMX: true }), candidate('late2.com', { hasA: true })];
+		const { enrichLookalikes } = await loadEnrichment();
+		const enrichment = await enrichLookalikes(candidates, { deadlineMs: Date.now() - 1 });
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		for (const c of candidates) {
+			const corroborators = enrichment.get(c.domain);
+			expect(corroborators?.registrationDays).toBeNull();
+			expect(corroborators?.ageUnknown).toBe(true);
+			expect(corroborators?.registrationLookup).toBe('not_attempted');
+			// An unattempted HEAD probe is "unknown", which fails soft to "has
+			// content" — it must never synthesise the no-content HIGH corroborator.
+			expect(corroborators?.hasWebContent).toBe(true);
+		}
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Explicit unknown-age reasons — "unknown" must be distinguishable from "absent".
+// ---------------------------------------------------------------------------
+
+describe('enrichLookalikes — registrationLookup outcomes (#867)', () => {
+	async function outcomeFor(domain: string, respond: (init?: RequestInit) => Promise<Response>, deadlineMs?: number) {
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			if (url.pathname.includes('/domain/')) return respond(init);
+			return Promise.resolve(new Response(null, { status: 200 }));
+		});
+		const { enrichLookalikes } = await loadEnrichment();
+		const enrichment = await enrichLookalikes([candidate(domain, { hasA: true, hasMX: true })], deadlineMs ? { deadlineMs } : undefined);
+		return enrichment.get(domain)!;
+	}
+
+	it('populated age → ok, ageUnknown false', async () => {
+		const c = await outcomeFor('ok.com', () => Promise.resolve(jsonResponse(rdapBody(10_000))));
+		expect(c.registrationDays).toBe(10_000);
+		expect(c.ageUnknown).toBe(false);
+		expect(c.registrationLookup).toBe('ok');
+	});
+
+	it('HTTP 429 → throttled', async () => {
+		const c = await outcomeFor('busy.com', () => Promise.resolve(new Response('slow down', { status: 429 })));
+		expect(c.registrationDays).toBeNull();
+		expect(c.ageUnknown).toBe(true);
+		expect(c.registrationLookup).toBe('throttled');
+	});
+
+	it('HTTP 404 → not_found', async () => {
+		const c = await outcomeFor('gone.com', () => Promise.resolve(new Response('nope', { status: 404 })));
+		expect(c.registrationLookup).toBe('not_found');
+		expect(c.ageUnknown).toBe(true);
+	});
+
+	it('other HTTP failure → failed', async () => {
+		const c = await outcomeFor('broken.com', () => Promise.resolve(new Response('boom', { status: 503 })));
+		expect(c.registrationLookup).toBe('failed');
+		expect(c.ageUnknown).toBe(true);
+	});
+
+	it('transport error → failed', async () => {
+		const c = await outcomeFor('dead.com', () => Promise.reject(new TypeError('connection reset')));
+		expect(c.registrationLookup).toBe('failed');
+		expect(c.ageUnknown).toBe(true);
+	});
+
+	it('server hangs past the (deadline-clamped) timeout → timeout', async () => {
+		const c = await outcomeFor(
+			'slow.com',
+			(init) => delayHonouringSignal(10_000, () => jsonResponse(rdapBody(400)), init?.signal),
+			Date.now() + 150,
+		);
+		expect(c.registrationDays).toBeNull();
+		expect(c.ageUnknown).toBe(true);
+		expect(c.registrationLookup).toBe('timeout');
+	});
+
+	it('200 with no registration event → no_registration_event, registrar still harvested', async () => {
+		const c = await outcomeFor('noevent.com', () => Promise.resolve(jsonResponse(rdapBody(null))));
+		expect(c.registrationDays).toBeNull();
+		expect(c.ageUnknown).toBe(true);
+		expect(c.registrationLookup).toBe('no_registration_event');
+		expect(c.registrarIanaId).toBe('1234');
+	});
+
+	it('TLD with no RDAP server in the map (.co) → unsupported_tld, no fetch issued', async () => {
+		const fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(new Response(null, { status: 200 })));
+		globalThis.fetch = fetchSpy;
+		const { enrichLookalikes } = await loadEnrichment();
+		const enrichment = await enrichLookalikes([candidate('brand.co', { hasA: false, hasMX: true })]);
+		const c = enrichment.get('brand.co')!;
+		expect(c.registrationLookup).toBe('unsupported_tld');
+		expect(c.ageUnknown).toBe(true);
+		expect(fetchSpy.mock.calls.map((call) => urlOf(call[0] as FetchInput)).filter((u) => u.includes('/domain/'))).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End to end through checkLookalikes: .com AND .ai populate, and the finding
+// metadata carries the explicit unknown marker.
+// ---------------------------------------------------------------------------
+
+describe('checkLookalikes — registration age end to end (#867)', () => {
+	/**
+	 * DoH: every candidate under `tld` that is not the seed resolves with NS + A
+	 * + MX (so it reaches enrichment as mail-capable). RDAP: `rdapDaysAgo` for
+	 * every domain, or a per-domain override. HEAD: 200.
+	 */
+	function mockPipeline(opts: {
+		seed: string;
+		tld: string;
+		rdapDaysAgo: number;
+		rdapOverride?: (domain: string) => Response | null;
+		onRdapHost?: (host: string) => void;
+	}) {
+		const enrichmentInFlight = { now: 0, peak: 0 };
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			if (url.pathname === '/dns-query') {
+				const name = url.searchParams.get('name') ?? '';
+				const type = url.searchParams.get('type') ?? '';
+				const isCandidate = name !== opts.seed && name.endsWith(`.${opts.tld}`) && name.split('.').length === 2;
+				if (isCandidate) {
+					if (type === 'NS' || type === '2') {
+						return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.other-registrar.net.' }]));
+					}
+					if (type === 'MX' || type === '15') {
+						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mx.other-mail.net.' }]));
+					}
+					if (type === 'A' || type === '1') {
+						return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.10' }]));
+					}
+				}
+				if (name === opts.seed && (type === 'NS' || type === '2')) {
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.seed-dns.example.' }]));
+				}
+				return Promise.resolve(createDohResponse([], []));
+			}
+			enrichmentInFlight.now++;
+			enrichmentInFlight.peak = Math.max(enrichmentInFlight.peak, enrichmentInFlight.now);
+			const release = () => {
+				enrichmentInFlight.now--;
+			};
+			if (url.pathname.includes('/domain/')) {
+				opts.onRdapHost?.(url.hostname);
+				const domain = url.pathname.split('/domain/')[1];
+				const override = opts.rdapOverride?.(domain);
+				return delayHonouringSignal(5, () => override ?? jsonResponse(rdapBody(opts.rdapDaysAgo)), init?.signal).finally(release);
+			}
+			return delayHonouringSignal(5, () => new Response(null, { status: 200 }), init?.signal).finally(release);
+		});
+		return enrichmentInFlight;
+	}
+
+	it('.com seed with 30+ mail-capable candidates: every .com candidate carries a populated age and registrationLookup: ok', async () => {
+		const inFlight = mockPipeline({ seed: 'example.com', tld: 'com', rdapDaysAgo: 365 });
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('example.com');
+
+		const observations = result.findings.filter(
+			(f) =>
+				f.metadata?.findingAxis === 'threat_observation' && typeof f.metadata?.lookalikeDomain === 'string' && f.metadata.hasMX === true,
+		);
+		const comObservations = observations.filter((f) => String(f.metadata?.lookalikeDomain).endsWith('.com'));
+		// The premise of #867 is a LARGE candidate set — anthropic.com resolved 25.
+		expect(comObservations.length).toBeGreaterThanOrEqual(30);
+		for (const f of comObservations) {
+			expect(f.metadata?.registrationDays, String(f.metadata?.lookalikeDomain)).toBe(365);
+			expect(f.metadata?.ageUnknown, String(f.metadata?.lookalikeDomain)).toBe(false);
+			expect(f.metadata?.registrationLookup, String(f.metadata?.lookalikeDomain)).toBe('ok');
+		}
+		expect(inFlight.peak).toBeLessThanOrEqual(6);
+	});
+
+	it('.ai seed still populates (Identity Digital RDAP host, #780 stays fixed)', async () => {
+		const hosts = new Set<string>();
+		mockPipeline({ seed: 'openclaw.ai', tld: 'ai', rdapDaysAgo: 20, onRdapHost: (h) => hosts.add(h) });
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('openclaw.ai');
+
+		const aiObservations = result.findings.filter(
+			(f) =>
+				f.metadata?.findingAxis === 'threat_observation' &&
+				String(f.metadata?.lookalikeDomain).endsWith('.ai') &&
+				f.metadata?.hasMX === true,
+		);
+		expect(aiObservations.length).toBeGreaterThan(0);
+		for (const f of aiObservations) {
+			expect(f.metadata?.registrationDays, String(f.metadata?.lookalikeDomain)).toBe(20);
+			expect(f.metadata?.registrationLookup).toBe('ok');
+		}
+		expect(hosts.has('rdap.identitydigital.services')).toBe(true);
+		expect(hosts.has('rdap.nic.ai')).toBe(false);
+	});
+
+	it('a failed lookup is marked ageUnknown with a reason on the finding, and a pre-dating candidate keeps its real age so the age filter can exclude it', async () => {
+		mockPipeline({
+			seed: 'example.com',
+			tld: 'com',
+			rdapDaysAgo: 30,
+			rdapOverride: (domain) => {
+				if (domain === 'exmple.com') return new Response('rate limited', { status: 429 });
+				// Registered ~1998 — predates any brand founded after it, so a
+				// consumer's "a typosquat cannot predate the brand" filter must be
+				// able to see the age rather than a null it would read as "not excluded".
+				if (domain === 'exampl.com') return jsonResponse(rdapBody(10_000));
+				return null;
+			},
+		});
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('example.com');
+
+		const threatFor = (d: string) =>
+			result.findings.find((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === d);
+
+		const throttled = threatFor('exmple.com');
+		expect(throttled).toBeDefined();
+		expect(throttled!.metadata?.registrationDays).toBeNull();
+		expect(throttled!.metadata?.ageUnknown).toBe(true);
+		expect(throttled!.metadata?.registrationLookup).toBe('throttled');
+		// Unknown age never elevates: mail-infra with no corroborator is MEDIUM.
+		expect(throttled!.severity).toBe('medium');
+
+		const ancient = threatFor('exampl.com');
+		expect(ancient).toBeDefined();
+		expect(ancient!.metadata?.registrationDays).toBe(10_000);
+		expect(ancient!.metadata?.ageUnknown).toBe(false);
+		expect(ancient!.metadata?.registrationLookup).toBe('ok');
+		// Not "recent" → no elevation from age.
+		expect(ancient!.severity).toBe('medium');
+
+		// A recent one (30 days) elevates to HIGH — the signal the lookup exists for.
+		const recent = result.findings.find(
+			(f) =>
+				f.metadata?.findingAxis === 'threat_observation' &&
+				f.metadata?.registrationDays === 30 &&
+				f.metadata?.lookalikeDomain !== 'exmple.com' &&
+				f.metadata?.lookalikeDomain !== 'exampl.com',
+		);
+		expect(recent).toBeDefined();
+		expect(recent!.severity).toBe('high');
+		expect(recent!.metadata?.registrationLookup).toBe('ok');
+	});
+});


### PR DESCRIPTION
Closes #867

## What happens

`check_lookalikes` reports `registrationDays: null` for most candidates of any seed that resolves a large candidate set. Measured live 2026-09-04 (`force_refresh: true`, anthropic.com): 25 candidates resolved, **8 with an age, 17 null** — and the nulls are not scattered, they are a contiguous tail. In processing order, exactly the first 8 candidates carry an age, the first 6 carry `hasWebContent: true`, and every candidate from the 9th on is `registrationDays: null` **and** `hasWebContent: false`:

| # | candidate | registrationDays | hasWebContent |
|---|---|---|---|
| 1–6 | aanthropic, amthropic, annthropic, anrhropic, anthhropic, anthripic (.com) | 204, 188, 151, 76, 151, 852 | true |
| 7–8 | anthrolic.com, anthroopic.com | 74, 518 | false |
| 9–25 | anthrop1c … anthrapic (.com/.co/.io/.net/.org) | **null** | **false** |

That second column matters: the same starvation that nulls the age also records "no reachable web content" for 17 domains it never probed, which is a HIGH corroborator in the #264 matrix — 7 of the 7 HIGH threat observations in that run cite it.

The `.ai` seeds in the issue were never "fixed" by something that then broke `.com`; a short brand (x.ai, mistral.ai) simply yields few candidates, and few candidates do not trigger the mechanism below.

## Root cause (with evidence)

**Connection-slot starvation, not a TLD map, a bootstrap order, a registry rate limit, or a parser.**

`enrichLookalikes()` (`src/tools/lookalike-enrichment.ts`, previously lines 68–84) fanned out every candidate at once:

```ts
await Promise.allSettled(
	candidates.map(async (candidate) => {
		const [rdap, hasWebContent] = await Promise.all([
			probeRdap(candidate.domain),                                   // AbortSignal.timeout(2500) armed HERE
			candidate.hasA ? probeHasWebContent(candidate.domain) : ...,   // AbortSignal.timeout(2500) armed HERE
		]);
```

A Worker invocation may hold **at most six connections simultaneously waiting for response headers**; further `fetch()` calls queue ([Workers limits — Simultaneous open connections](https://developers.cloudflare.com/workers/platform/limits/#simultaneous-open-connections), re-read 2026-09-04). A 25-candidate seed dispatches ~48 fetches (25 RDAP + 23 HEAD). Each `AbortSignal.timeout(2500)` starts ticking at the `safeFetch()` call — i.e. while the fetch is still in the runtime's queue. HEAD probes to dark/parked candidates hold their slot for the full 2.5s, so slots free slowly; by the time the queue would reach the ~42 fetches behind the first fill, their timers have fired and they abort **without ever being sent**. `probeRdap`'s `catch` fail-softs to `EMPTY_RDAP_PROBE` → `registrationDays: null`; `probeHasWebContent`'s `catch` returns `false`.

Why the evidence fits only this hypothesis, checked in the order briefed:

- **(a) RDAP path / bootstrap / map** — ruled out. `probeRdap` reads `FALLBACK_RDAP_SERVERS` directly (no bootstrap); `com` → `rdap.verisign.com/com/v1/` is present and unchanged by #785. The first 6–8 `.com` lookups of the same run succeed against that exact host.
- **(c) Verisign rate limit** — ruled out. RDAP and HEAD go to different hosts (the registry vs. the candidate itself), and both fail on exactly the same contiguous tail; a registry 429 cannot null `hasWebContent`. The failing tail also spans `.org` (PIR), `.io` (Identity Digital) and `.net`, which are different registries.
- **(d) parse change** — ruled out. The parse is identical for candidate 8 (populated) and candidate 9 (null).
- **(b) budget/ordering** — confirmed. It is not a *deadline* (there was none in enrichment) but the platform connection cap plus pre-armed timers. The reproduction spec emulates a six-slot FIFO with abortable waiting and a 400ms hold: under the pre-fix code **15 of 30** candidates come back null with no server ever answering slowly; under the fix, 0.

How many candidates got looked up per run and why: ~6 immediately (one slot-fill) plus whatever the fast RDAP responses could free before 2.5s elapsed — 8 on anthropic.com, 4 of 8 on openai.com, 1 of 15 mail-capable on cohere.com (per #867). The count is a function of how many HEAD probes land on dark hosts in the first fill, which is why it varies run to run.

History: the fan-out was written in #265 (May 2026) with the comment "12 candidates × (RDAP + HEAD) stays under LOOKALIKE_TIMEOUT_MS" — sized for the 50-permutation motor lane. #629 (2026-08-06) added the cognitive (+30) and combosquat lanes, taking anthropic.com to 97 permutations / 25 resolved candidates. Nothing ever bounded the fan-out to the connection cap. #785 did not move the problem; #780's reporter used small seeds.

## Fix

`src/tools/lookalike-enrichment.ts`

- Enrichment runs through two `mapConcurrent` pools whose widths **sum to the platform cap**: `RDAP_PROBE_CONCURRENCY = 4` + `WEB_PROBE_CONCURRENCY = 2`. Separate pools so a HEAD probe hanging on a dark host cannot hold an RDAP slot. Total in-flight is ≤ 6 (asserted by the spec), down from 2 × candidates — this **reduces** fan-out, it adds none.
- Each `AbortSignal.timeout` is armed when the fetch is dispatched by a pool worker, so it measures the server, never the queue.
- `prioritiseForEnrichment()` — mail-capable candidates are looked up first (the ones the age corroborator can lift to HIGH and a pre-dating age lets a consumer exclude), then web-only, stable within each group.
- `EnrichmentOptions.deadlineMs` — a candidate whose turn comes after the deadline is **not** issued (`not_attempted`); one that starts before it has its per-probe budget clamped to the remainder.
- Every unknown age now carries a reason: `registrationLookup: 'ok' | 'no_registration_event' | 'unsupported_tld' | 'not_found' | 'throttled' | 'timeout' | 'failed' | 'not_attempted'` plus `ageUnknown: boolean` (`true` iff `registrationDays === null`). `RdapProbeResult`/`EMPTY_RDAP_PROBE` carry `lookup`. An unattempted HEAD probe reports `hasWebContent: true` (the documented safe direction), never the HIGH corroborator.

`src/tools/check-lookalikes.ts` (minimal — 5 lines of logic)

- Records `startedAt`; passes `deadlineMs = startedAt + LOOKALIKE_TIMEOUT_MS − ENRICHMENT_RESERVE_MS (4s)` to `enrichLookalikes` and the seed's own `probePrimaryRegistration`, so a large set degrades to explicit `not_attempted` tails instead of tripping the 20s outer race (which discards every finding).
- Threads `registrationLookup` into `LookalikeSignals`.

`src/tools/lookalike-severity.ts` — optional `registrationLookup` on `LookalikeSignals` (never read by the calibrator; an unknown age is "not recent" whatever the reason).

`src/tools/lookalike-findings.ts` — `registrationAgeMetadata()` adds `ageUnknown` + `registrationLookup` beside `registrationDays` on the three per-candidate emission sites (attribution ×2, threat observation).

Not touched, per the sibling ownership in the brief: `lookalike-summary-findings.ts` (#865/#863 — the rollup can read `registrationDays == null` or the new `ageUnknown`), `lib/ownership-attribution.ts`, `lookalike-attribution.ts` (#864). `computeSameEntityCandidates` in the latter still builds its signals bag without the outcome; the finding builders default that to `not_attempted`, which is accurate for a bag no lookup produced.

Pool widths are a per-check constant, not `SCAN_DNS_CONCURRENCY`: `check_lookalikes` is `scanIncluded: false` and enrichment runs after both DNS phases finish, so it owns all six slots.

## Tests

New file `test/check-lookalikes-registration-age.spec.ts` (16 tests, written red first — 14 failed on the old code with `expected 64 to be less than or equal to 6`):

- bounded fan-out: peak in-flight ≤ 6 with 32 `.com` candidates, all populated
- REPRODUCTION (pre-fix shape): runs the exact old `Promise.allSettled(candidates.map(...))` fan-out through the exported probes (`probePrimaryRegistration` IS `probeRdap`; `probeHasWebContent` is the same HEAD probe) against an emulated six-slot runtime whose queued wait exceeds the real 2500ms per-probe timer — asserts something queued, ≥ 10 fetches queued-then-aborted, ≥ 10 candidates `null` + `timeout`, and a manufactured `hasWebContent: false`
- bounded path against the same runtime: `peakWaiting === 0` / `queuedThenAborted === 0`, all 30 populated — deterministic red on ANY pool widening past six (mutation-checked: `RDAP_PROBE_CONCURRENCY` 4 → 5 fails `expected 1 to be +0`)
- mail-capable candidates dispatched before web-only
- deadline already spent → zero fetches, every candidate `not_attempted`, `hasWebContent: true`
- outcome vocabulary: `ok`, `throttled` (429), `not_found` (404), `failed` (503 / transport), `timeout` (hang past a clamped deadline), `no_registration_event` (registrar still harvested), `unsupported_tld` (`.co`, no fetch issued)
- end to end through `checkLookalikes`: a `.com` seed with 30+ mail-capable candidates → every one `registrationDays` populated, `registrationLookup: 'ok'`, peak in-flight ≤ 6; an `.ai` seed still populates via `rdap.identitydigital.services` (never `rdap.nic.ai` — #780 stays fixed); a throttled candidate carries `ageUnknown: true` + `throttled` at MEDIUM (unknown never elevates), a ~1998-registered candidate keeps `registrationDays: 10000` so a downstream "cannot predate the brand" filter can exclude it, and a 30-day candidate still lifts to HIGH.

Note on "the age filter": there is no brand-predates exclusion in this repo — the only in-tree consumer of the age is the #264 `< 90 days` corroborator. The predating exclusions in #867 are the reporter's downstream filter over `registrationDays`; this PR makes that field honest and marks the cases where it cannot be.

Commands and results:

```
npm run typecheck                                                                   → 0 errors
npm run lint                                                                        → clean
npx vitest run test/check-lookalikes test/lookalike test/check-rdap test/registration test/brand-defensive-registration.test.ts
                                                                                    → 13 files, 230 passed
node scripts/ci/typecheck-tests.mjs                                                 → OK, new spec 0 errors (delta −4, unrelated wasm/report files)
npm test                                                                            → see below
```

`npm test` (full suite, Workers pool): **8401 passed / 13 skipped / 1 failed**, 690 files passed, 2 files failed:

- `test/wasm-integration.test.ts` — suite-load error `No such module …/crates/bv-wasm-core/pkg/bv_wasm_core_bg.wasm`; the documented fresh-worktree shape (`crates/*/pkg` is built only by `npm run build:wasm`), 0 test failures inside it.
- `test/subdomain-takeover-cachekey.spec.ts › produces DIFFERENT keys for different same-length custom lists` — `Test timed out in 15000ms` on a pure cache-key test whose only await is the dynamic import of `handlers/tools`; re-run in isolation: 3/3 passed. Runtime-load flake, unrelated to this change (the test touches nothing in the lookalike path).

`scan_domain`: `check_lookalikes` is `scanIncluded: false` and unreferenced by `scan-domain.ts`; no scan score can move.

## Residuals

- **The same mechanism almost certainly explains the run's `unresolvedCount: 48 of 95`** on the DNS phases (`filterByNsExistence` / `probeWithAdaptiveBatching` also fan out DoH queries past six with pre-armed timers; the adaptive batching masks it as "DNS timeout or rate limiting"). Out of scope here (#781/#831 territory) — worth its own issue: bounding those pools would likely turn the "treat this list as a sample" notice off for most seeds.
- `probeHasWebContent` still maps a genuine 2.5s timeout to `false` (the HIGH corroborator), contradicting the module doc's "a failed HEAD probe becomes `true`". With the pool fix a timeout now means the host really did not answer within 2.5s, so it is defensible, but a slow parked host still reads as "no content". Not changed here.
- With ~23 web-only candidates and a 2-wide HEAD pool, the tail of the web-only set will hit the enrichment deadline on large seeds and report `hasWebContent: true` (unknown → safe). The RDAP pool (4-wide, ~0.5s per lookup) finishes a 25-candidate set in ~3–4s, well inside the deadline.
- `check_lookalikes` is declared `tier: 'protective'` with `scanIncluded: false` in `TOOL_DEFS` — pre-existing, unrelated, noted because CLAUDE.md says never to ship that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
