### PR TITLE
fix(lookalikes): short seed labels and uncorroborated members no longer drive the threat rollup (#863)

### DIFF
--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -35,7 +35,7 @@ import type { CheckResult, Finding } from '../lib/scoring';
 import { buildCheckResult } from '../lib/scoring';
 import { generateCognitiveLookalikes, generateCombosquats, generateLookalikes } from './lookalike-analysis';
 import { calibrateLookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
-import { classifyOwnership, type OwnershipAssessment } from '../lib/ownership-attribution';
+import { attributionConfidence, classifyOwnership, type OwnershipAssessment } from '../lib/ownership-attribution';
 import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 import { extractBrandName } from '../lib/public-suffix';
 import {
@@ -441,6 +441,10 @@ async function checkLookalikesCore(
 		// low-noise, not worth the fetch).
 		const matchedOrg = sameEntityMatches.get(result.domain);
 		const brandHeld = brandHeldMatches.get(result.domain);
+		// The D4 MX-overlap corroboration signal feeds `attributionConfidence()`
+		// for BOTH the per-domain attribution wording below and the rollup member
+		// (#863) — computed once so the two can never disagree.
+		const mxOverlapsPrimary = result.mxExchanges.some((ex) => primaryMx.has(ex));
 		if (brandHeld !== undefined) {
 			findings.push(buildBrandHeldFinding(result, domain, ownership, brandHeld));
 		} else if (matchedOrg !== undefined) {
@@ -448,8 +452,7 @@ async function checkLookalikesCore(
 		} else {
 			// AXIS 1 — the ownership verdict caps the ATTRIBUTION finding's
 			// severity. `attributionConfidence()` (fed the MX-overlap
-			// corroboration signal below) governs WORDING/CONFIDENCE only.
-			const mxOverlapsPrimary = result.mxExchanges.some((ex) => primaryMx.has(ex));
+			// corroboration signal above) governs WORDING/CONFIDENCE only.
 			const rawFinding = buildRawAttributionFinding(result, domain, severity, signals, corroboratorReasons);
 
 			// Attribution pushed FIRST so a consumer scanning for the ownership
@@ -495,12 +498,16 @@ async function checkLookalikesCore(
 			severity,
 			ownershipVerdict: ownership.verdict,
 			registrationDays: signals.registrationDays,
+			// #863 — the row's own hedge travels with it; the rollup excludes and
+			// caps on `uncorroborated` so it never out-claims the rows.
+			attributionConfidence: attributionConfidence(ownership.verdict, brand, mxOverlapsPrimary),
 		});
 	}
 
-	// #865 — the rollup decides for itself whether coverage permits a count;
-	// a throttled run gets a not-assessed notice instead of an integer.
-	const rollup = buildThreatRollupFinding({ seedDomain: domain, members: rollupMembers, enumeration });
+	// #865 / #863 — the rollup decides for itself whether coverage and the
+	// seed label permit a count; otherwise a not-assessed notice, never an
+	// integer.
+	const rollup = buildThreatRollupFinding({ seedDomain: domain, seedLabel: brand, members: rollupMembers, enumeration });
 	if (rollup.finding) findings.push(rollup.finding);
 
 	// If no active lookalikes found
@@ -593,9 +600,12 @@ async function checkLookalikesCore(
 	// non-answer outliving the condition that caused it. Same contract the
 	// timeout path in checkLookalikes() already honours.
 	//
-	// #865 — the same law for a rollup ABSTENTION: enumeration throttling is
-	// transient too, and a cached "not assessed" would outlive the throttling.
-	if (seedNsUnmeasured || rollup.abstained) {
+	// #865 — the same law for a THROTTLED rollup abstention: enumeration
+	// throttling is transient too, and a cached "not assessed" would outlive
+	// it. The #863 abstentions are structural (the seed's own label) and are
+	// deliberately NOT partial — every run of that seed abstains, so caching
+	// the abstention is correct.
+	if (seedNsUnmeasured || rollup.notAssessedReason === 'enumeration_throttled') {
 		result.partial = true;
 	}
 	return result;

--- a/src/tools/lookalike-summary-findings.ts
+++ b/src/tools/lookalike-summary-findings.ts
@@ -17,7 +17,12 @@
 
 import type { Finding } from '../lib/scoring';
 import { createFinding } from '../lib/scoring';
-import type { OwnershipAssessment, OwnershipVerdict } from '../lib/ownership-attribution';
+import {
+	MIN_ATTRIBUTION_LABEL_LENGTH,
+	type AttributionConfidence,
+	type OwnershipAssessment,
+	type OwnershipVerdict,
+} from '../lib/ownership-attribution';
 import type { LookalikeFindingAxis } from './lookalike-findings';
 import type { LookalikeSeverity } from './lookalike-severity';
 
@@ -57,6 +62,19 @@ export interface LookalikeEnumeration {
  */
 export const ROLLUP_ABSTAIN_UNRESOLVED_RATIO = 0.5;
 
+/**
+ * Minimum seed-label length below which the threat rollup ABSTAINS (#863).
+ *
+ * THE SAME CONSTANT the per-domain attribution hedge already cites ("The
+ * shared label is under 5 characters and nothing else corroborates a link") —
+ * re-exported, not redeclared, so the aggregate can never disagree with the
+ * rows it aggregates about where "too short" begins. At 1 character (x.ai)
+ * every single-letter domain is one edit away; at 4 (meta.com) the confusable
+ * set is still most of the short-name namespace. Edit distance is not
+ * low-precision there — it is undefined.
+ */
+export const MIN_ROLLUP_SEED_LABEL_LENGTH = MIN_ATTRIBUTION_LABEL_LENGTH;
+
 /** True when the run's enumeration coverage is too degraded to publish a rollup count (see {@link ROLLUP_ABSTAIN_UNRESOLVED_RATIO}). */
 export function isRollupCoverageDegraded(enumeration: LookalikeEnumeration): boolean {
 	if (enumeration.permutationsProbed <= 0) return false;
@@ -78,6 +96,14 @@ export interface ThreatRollupMember {
 	ownershipVerdict: OwnershipVerdict;
 	/** `null` when the RDAP age probe failed or returned nothing — "unknown", never "not recent" for reporting purposes. */
 	registrationDays: number | null;
+	/**
+	 * The per-domain WORDING confidence from `attributionConfidence()` — the
+	 * hedge the row carries. `uncorroborated` (short seed label, no MX overlap
+	 * with the seed) excludes the member from every rollup list and count and
+	 * caps the rollup's severity (#863): the aggregate may never be more
+	 * confident than its rows.
+	 */
+	attributionConfidence: AttributionConfidence;
 }
 
 /**
@@ -198,36 +224,133 @@ export function buildOwnershipUnmeasuredFinding(seedDomain: string, candidateCou
 }
 
 /**
- * THE threat-rollup decision point (#865). Exactly one of three outcomes:
+ * Why the threat rollup declined to publish a count. `null` on the finding
+ * builders' result means a rollup WAS published (or there was nothing to roll
+ * up). Only `enumeration_throttled` is transient — the orchestrator marks the
+ * run `partial` for that one alone; the other two are structural properties
+ * of the seed / the members and would recur on every run.
+ */
+export type RollupNotAssessedReason = 'enumeration_throttled' | 'seed_label_too_short' | 'members_uncorroborated';
+
+/**
+ * THE threat-rollup decision point (#865, #863). Exactly one outcome:
  *
  *  - no mail-capable member → `finding: null` (nothing to roll up — the
  *    per-domain findings stand alone, as before);
+ *  - seed label shorter than {@link MIN_ROLLUP_SEED_LABEL_LENGTH} →
+ *    {@link buildRollupShortLabelFinding}, reason `seed_label_too_short`
+ *    (#863: at that length every same-length label is one edit away, so the
+ *    aggregate cannot tell a typosquat from an independent registration;
+ *    checked FIRST because it is a property of the seed, not of this run);
  *  - enumeration coverage degraded past {@link ROLLUP_ABSTAIN_UNRESOLVED_RATIO}
- *    → the not-assessed `scan_status` notice from
- *    {@link buildRollupNotAssessedFinding}, `abstained: true`, so the caller
- *    marks the run `partial` and the abstention is not cached for the TTL;
- *  - otherwise → the staging rollup when any member reached HIGH with mail,
- *    else the mail-capable rollup — each worded as a FLOOR when the run is
- *    incomplete, and each carrying the enumeration stats flat in its metadata.
+ *    → {@link buildRollupNotAssessedFinding}, reason `enumeration_throttled`
+ *    (#865), so the caller marks the run `partial`;
+ *  - every mail-capable member `uncorroborated` →
+ *    {@link buildRollupUncorroboratedFinding}, reason `members_uncorroborated`
+ *    (unreachable today for a seed that passed the label gate — kept so the
+ *    rollup can never exceed the confidence of what it aggregates if the
+ *    per-domain classifier ever produces the value for another cause);
+ *  - otherwise → the staging rollup when any COUNTED member reached HIGH with
+ *    mail, else the mail-capable rollup — `uncorroborated` members excluded
+ *    from both lists and counts, and their presence capping the staging
+ *    rollup below `high`; each worded as a FLOOR when the run is incomplete,
+ *    and each carrying the enumeration stats flat in its metadata.
  *
- * The order matters: abstention is decided BEFORE either rollup is built, so
- * a throttled run can never reach the count-carrying builders at all.
+ * The gates run BEFORE either count-carrying builder is reached, so an
+ * abstaining run can never produce an integer.
  */
-export function buildThreatRollupFinding(input: { seedDomain: string; members: ThreatRollupMember[]; enumeration: LookalikeEnumeration }): {
-	finding: Finding | null;
-	abstained: boolean;
-} {
-	const { seedDomain, members, enumeration } = input;
+export function buildThreatRollupFinding(input: {
+	seedDomain: string;
+	/** The seed's second-level label (`extractBrandName`), the string the edit-distance permutations were built from. */
+	seedLabel: string;
+	members: ThreatRollupMember[];
+	enumeration: LookalikeEnumeration;
+}): { finding: Finding | null; notAssessedReason: RollupNotAssessedReason | null } {
+	const { seedDomain, seedLabel, members, enumeration } = input;
 	const mailCapable = members.filter((m) => m.hasMX);
-	if (mailCapable.length === 0) return { finding: null, abstained: false };
+	if (mailCapable.length === 0) return { finding: null, notAssessedReason: null };
+	if (seedLabel.length < MIN_ROLLUP_SEED_LABEL_LENGTH) {
+		return { finding: buildRollupShortLabelFinding(seedDomain, seedLabel), notAssessedReason: 'seed_label_too_short' };
+	}
 	if (isRollupCoverageDegraded(enumeration)) {
-		return { finding: buildRollupNotAssessedFinding(seedDomain, enumeration), abstained: true };
+		return { finding: buildRollupNotAssessedFinding(seedDomain, enumeration), notAssessedReason: 'enumeration_throttled' };
 	}
-	const staging = mailCapable.filter((m) => m.severity === 'high');
+	const counted = mailCapable.filter((m) => m.attributionConfidence !== 'uncorroborated');
+	const uncorroboratedExcludedCount = mailCapable.length - counted.length;
+	if (counted.length === 0) {
+		return { finding: buildRollupUncorroboratedFinding(seedDomain, seedLabel), notAssessedReason: 'members_uncorroborated' };
+	}
+	const staging = counted.filter((m) => m.severity === 'high');
 	if (staging.length > 0) {
-		return { finding: buildStagingSummaryFinding({ seedDomain, staging, mailCapable, enumeration }), abstained: false };
+		return {
+			finding: buildStagingSummaryFinding({
+				seedDomain,
+				seedLabel,
+				staging,
+				mailCapable: counted,
+				uncorroboratedExcludedCount,
+				enumeration,
+			}),
+			notAssessedReason: null,
+		};
 	}
-	return { finding: buildMailCapableSummaryFinding({ seedDomain, mailCapable, enumeration }), abstained: false };
+	return {
+		finding: buildMailCapableSummaryFinding({ seedDomain, seedLabel, mailCapable: counted, uncorroboratedExcludedCount, enumeration }),
+		notAssessedReason: null,
+	};
+}
+
+/**
+ * `scan_status` — the threat rollup was NOT ASSESSED because the seed's label
+ * is too short for edit distance to mean anything at the aggregate level
+ * (#863). Measured on `x.ai`: the per-domain findings hedged ("under 5
+ * characters and nothing else corroborates a link"), the rollup dropped the
+ * hedge and named Zhipu AI and Character.AI as pre-phishing staging. Carries
+ * NO count and NO domain list. Structural, not transient — no
+ * `inconclusive`/`errorKind`, and the caller must NOT mark the run partial:
+ * every run of this seed abstains, and caching that is correct.
+ */
+export function buildRollupShortLabelFinding(seedDomain: string, seedLabel: string): Finding {
+	return createFinding(
+		'lookalikes',
+		'Lookalike threat rollup not assessed — seed label too short to attribute confusables',
+		'info',
+		`The label "${seedLabel}" of ${seedDomain} is under ${MIN_ROLLUP_SEED_LABEL_LENGTH} characters, so every same-length label in the TLD is one edit away and permutation analysis cannot separate a typosquat from an independent registration — the confusable set is the whole short-name namespace. No aggregate count of mail-capable or staging-flagged lookalikes is published for this seed, because such a count would name unrelated organisations as attack preparation. Each resolved candidate is reported individually below with an attribution hedge; treat those as observations about real domains, not as a list of impersonators.`,
+		{
+			findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
+			notAssessedReason: 'seed_label_too_short' satisfies RollupNotAssessedReason,
+			seedLabel,
+			seedLabelLength: seedLabel.length,
+			minLabelLength: MIN_ROLLUP_SEED_LABEL_LENGTH,
+			confidence: 'heuristic',
+		},
+	);
+}
+
+/**
+ * `scan_status` — every mail-capable member was `uncorroborated`, so there is
+ * nothing the rollup may count at any confidence (#863, invariant: the
+ * aggregate never exceeds the confidence of what it aggregates). Structural,
+ * like {@link buildRollupShortLabelFinding}.
+ */
+export function buildRollupUncorroboratedFinding(seedDomain: string, seedLabel: string): Finding {
+	return createFinding(
+		'lookalikes',
+		'Lookalike threat rollup not assessed — no candidate attributable beyond a bare label match',
+		'info',
+		`Every mail-capable confusable candidate of ${seedDomain} matches it only on the "${seedLabel}" label, with nothing else corroborating a link. Name similarity alone does not support an aggregate claim of pre-phishing staging, so no count is published. Each candidate is reported individually below with an attribution hedge.`,
+		{
+			findingAxis: 'scan_status' satisfies LookalikeFindingAxis,
+			notAssessedReason: 'members_uncorroborated' satisfies RollupNotAssessedReason,
+			seedLabel,
+			confidence: 'heuristic',
+		},
+	);
+}
+
+/** Prose fragment for members left out of a rollup because their only link to the seed is a short-label match. Unpunctuated. */
+function uncorroboratedExcludedSentence(excluded: number, seedDomain: string): string {
+	return `${excluded} further mail-capable confusable domain${excluded === 1 ? ' was' : 's were'} excluded from this rollup: ${excluded === 1 ? 'its' : 'their'} only link to ${seedDomain} is a label match under ${MIN_ROLLUP_SEED_LABEL_LENGTH} characters with nothing else corroborating it, so ${excluded === 1 ? 'it is' : 'they are'} reported individually with a hedge and not counted here`;
 }
 
 /**
@@ -269,13 +392,20 @@ export function buildRollupNotAssessedFinding(seedDomain: string, enumeration: L
  */
 export function buildStagingSummaryFinding(input: {
 	seedDomain: string;
-	/** Members that reached HIGH with a working mail host — the counted set. */
+	seedLabel: string;
+	/** COUNTED members that reached HIGH with a working mail host (`uncorroborated` already excluded). */
 	staging: ThreatRollupMember[];
-	/** Every member with a working mail host — the wider set, a superset of `staging`. */
+	/** Every COUNTED member with a working mail host — the wider set, a superset of `staging`. */
 	mailCapable: ThreatRollupMember[];
+	/** Mail-capable members left out because their only link to the seed is a short-label match (#863). */
+	uncorroboratedExcludedCount: number;
 	enumeration: LookalikeEnumeration;
 }): Finding {
-	const { seedDomain: domain, staging, mailCapable, enumeration } = input;
+	const { seedDomain: domain, staging, mailCapable, uncorroboratedExcludedCount, enumeration } = input;
+	// #863 — an excluded member is still evidence that the counted set sits in
+	// a namespace where label matches mean little, so the aggregate is capped
+	// below `high` whenever one was excluded.
+	const capped = uncorroboratedExcludedCount > 0;
 	const highCount = staging.length;
 	const highDomains = staging.map((m) => m.domain);
 	const highVerdicts = new Set(staging.map((m) => m.ownershipVerdict));
@@ -295,12 +425,12 @@ export function buildStagingSummaryFinding(input: {
 		// just has to be named as the subset it is, with the wider
 		// mail-capable figure alongside rather than implied.
 		`${lead} lookalike domain${highCount > 1 ? 's' : ''} showing pre-phishing staging signals`,
-		'high',
+		capped ? 'medium' : 'high',
 		`${lead} lookalike domain${highCount > 1 ? 's' : ''} of ${domain} ${highCount > 1 ? 'have' : 'has'} active mail infrastructure with corroborating signals consistent with pre-phishing staging.${
 			mailCapableDomains.length > highCount
 				? ` A further ${mailCapableDomains.length - highCount} confusable domain${mailCapableDomains.length - highCount > 1 ? 's' : ''} also ${mailCapableDomains.length - highCount > 1 ? 'have' : 'has'} a working mail host without those additional signals — ${floor ? 'at least ' : ''}${mailCapableDomains.length} can send mail in total.`
 				: ''
-		}${floor ? floorClause(enumeration) : ''}${ageUnknownCount > 0 ? ` ${ageUnknownSentence(ageUnknownCount, mailCapableDomains.length)}.` : ''} ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
+		}${floor ? floorClause(enumeration) : ''}${ageUnknownCount > 0 ? ` ${ageUnknownSentence(ageUnknownCount, mailCapableDomains.length)}.` : ''}${capped ? ` ${uncorroboratedExcludedSentence(uncorroboratedExcludedCount, domain)}.` : ''} ${highCount > 1 ? 'None of them appear' : 'It does not appear'} to belong to the scanned organisation, and no action on ${highCount > 1 ? 'them' : 'it'} is requested here. Defensive options: monitor ${highCount > 1 ? 'them' : 'it'}, and enforce DMARC p=reject on ${domain} itself so receivers reject mail spoofing that name.`,
 		{
 			lookalikeDomainCount: highCount,
 			lookalikeDomains: highDomains,
@@ -311,6 +441,9 @@ export function buildStagingSummaryFinding(input: {
 			mailCapableDomains,
 			// #865 — the counts above are lower bounds when the run is a sample.
 			countIsFloor: floor,
+			// #863 — members the lists above deliberately omit, and the cap they impose.
+			uncorroboratedExcludedCount,
+			...(capped ? { severityCappedBy: 'attribution_confidence' } : {}),
 			// How many of the mail-capable set carry no registration age. They
 			// are COUNTED (the mail host is a real observation); this says that
 			// "no recent-registration corroborator" was unmeasured for them.
@@ -347,10 +480,14 @@ export function buildStagingSummaryFinding(input: {
  */
 export function buildMailCapableSummaryFinding(input: {
 	seedDomain: string;
+	seedLabel: string;
+	/** COUNTED members with a working mail host (`uncorroborated` already excluded). */
 	mailCapable: ThreatRollupMember[];
+	/** Mail-capable members left out because their only link to the seed is a short-label match (#863). */
+	uncorroboratedExcludedCount: number;
 	enumeration: LookalikeEnumeration;
 }): Finding {
-	const { seedDomain: domain, mailCapable, enumeration } = input;
+	const { seedDomain: domain, mailCapable, uncorroboratedExcludedCount, enumeration } = input;
 	const mailCapableDomains = mailCapable.map((m) => m.domain);
 	const ageUnknownCount = mailCapable.filter((m) => m.registrationDays === null).length;
 	const n = mailCapableDomains.length;
@@ -360,11 +497,12 @@ export function buildMailCapableSummaryFinding(input: {
 		'lookalikes',
 		`${lead} lookalike domain${n > 1 ? 's' : ''} with a working mail host`,
 		'medium',
-		`${lead} confusable domain${n > 1 ? 's' : ''} of ${domain} ${n > 1 ? 'have' : 'has'} a working mail host, so ${n > 1 ? 'they are' : 'it is'} capable of sending mail that resembles ${domain}.${floor ? floorClause(enumeration) : ''} No additional corroborating signal of pre-phishing staging was observed${ageUnknownCount > 0 ? ` — though ${ageUnknownSentence(ageUnknownCount, n)}` : ''}, and ${n > 1 ? 'none appears' : 'it does not appear'} to belong to the scanned organisation — this is an infrastructure observation, not an allegation. Enforcing DMARC p=reject on ${domain} is what makes receivers reject mail forging that name.`,
+		`${lead} confusable domain${n > 1 ? 's' : ''} of ${domain} ${n > 1 ? 'have' : 'has'} a working mail host, so ${n > 1 ? 'they are' : 'it is'} capable of sending mail that resembles ${domain}.${floor ? floorClause(enumeration) : ''} No additional corroborating signal of pre-phishing staging was observed${ageUnknownCount > 0 ? ` — though ${ageUnknownSentence(ageUnknownCount, n)}` : ''}, and ${n > 1 ? 'none appears' : 'it does not appear'} to belong to the scanned organisation — this is an infrastructure observation, not an allegation.${uncorroboratedExcludedCount > 0 ? ` ${uncorroboratedExcludedSentence(uncorroboratedExcludedCount, domain)}.` : ''} Enforcing DMARC p=reject on ${domain} is what makes receivers reject mail forging that name.`,
 		{
 			mailCapableCount: n,
 			mailCapableDomains,
 			countIsFloor: floor,
+			uncorroboratedExcludedCount,
 			ageUnknownCount,
 			enumeration,
 			...flatEnumerationStats(enumeration),

--- a/src/tools/lookalike-summary-findings.ts
+++ b/src/tools/lookalike-summary-findings.ts
@@ -102,6 +102,21 @@ export interface ThreatRollupMember {
 	 * with the seed) excludes the member from every rollup list and count and
 	 * caps the rollup's severity (#863): the aggregate may never be more
 	 * confident than its rows.
+	 *
+	 * ⚠️ REACHABILITY: with the current classifier this value is
+	 * `'uncorroborated'` ONLY when the seed label is shorter than
+	 * `MIN_ATTRIBUTION_LABEL_LENGTH` — the same string and the same constant
+	 * `buildThreatRollupFinding` gates on FIRST (as `MIN_ROLLUP_SEED_LABEL_LENGTH`,
+	 * a re-export). So for any member that reaches the exclusion/cap path the
+	 * value is always `'corroborated'`, and `uncorroboratedExcludedCount` is
+	 * always 0 on real scan data. The field and the path are defence-in-depth
+	 * for the invariant "the rollup never exceeds the confidence of its
+	 * members", exercised only by builder-level unit tests that hand-build
+	 * members. The coupling is pinned from BOTH sides:
+	 * `test/check-lookalikes-short-label-rollup.spec.ts` asserts
+	 * `MIN_ROLLUP_SEED_LABEL_LENGTH === MIN_ATTRIBUTION_LABEL_LENGTH` and that
+	 * `attributionConfidence()` is `'corroborated'` at exactly the threshold —
+	 * whoever separates the two thresholds trips a red test pointing here.
 	 */
 	attributionConfidence: AttributionConfidence;
 }
@@ -275,6 +290,18 @@ export function buildThreatRollupFinding(input: {
 	if (isRollupCoverageDegraded(enumeration)) {
 		return { finding: buildRollupNotAssessedFinding(seedDomain, enumeration), notAssessedReason: 'enumeration_throttled' };
 	}
+	// ⚠️ UNREACHABLE ON REAL SCAN DATA with the current classifier (#863
+	// review): every member here belongs to a seed that passed the label gate
+	// above, and `attributionConfidence()` returns `'corroborated'`
+	// unconditionally at `brandLabel.length >= MIN_ATTRIBUTION_LABEL_LENGTH` —
+	// the same string, the same constant. `counted` therefore always equals
+	// `mailCapable` and `uncorroboratedExcludedCount` is always 0 from
+	// `checkLookalikesCore`. Kept as defence-in-depth for the invariant "the
+	// rollup never exceeds the confidence of its members", so that a future
+	// classifier producing `'uncorroborated'` for another cause (or a split of
+	// the two thresholds) is caught here rather than re-opening #863. The
+	// coupling is pinned on both sides by the short-label spec: constant
+	// equality, and `'corroborated'` at exactly the threshold length.
 	const counted = mailCapable.filter((m) => m.attributionConfidence !== 'uncorroborated');
 	const uncorroboratedExcludedCount = mailCapable.length - counted.length;
 	if (counted.length === 0) {

--- a/test/check-lookalikes-short-label-rollup.spec.ts
+++ b/test/check-lookalikes-short-label-rollup.spec.ts
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * #863 — a SHORT seed label makes the whole TLD "confusable", and the threat
+ * rollup must not turn that into an attack-preparation claim about named
+ * companies.
+ *
+ * Measured 2026-08-31 on `x.ai` (enumeration complete, 25/25 probed): the
+ * per-domain findings hedged correctly — `attributionConfidence:
+ * "uncorroborated"`, "The shared label is under 5 characters and nothing else
+ * corroborates a link, so the name similarity alone means little." — but the
+ * rollup dropped the hedge and published "1 lookalike domain showing
+ * pre-phishing staging signals" at `high`, naming `z.ai` (Zhipu AI) with
+ * `mailCapableDomains: ["c.ai", "s.ai", "z.ai"]` (Character.AI, a personal
+ * site, Zhipu AI). None is a typosquat: at one character every single-letter
+ * domain is one edit away, so edit distance cannot separate a typosquat from
+ * an independent registration. `meta.com` (4 chars) returned 16 mail-capable /
+ * 9 staging-flagged in the same sweep for the same reason.
+ *
+ * Contract pinned here:
+ *  1. below `MIN_ATTRIBUTION_LABEL_LENGTH` — the SAME constant the per-domain
+ *     hedge already cites — the rollup ABSTAINS (not-assessed, no count, no
+ *     `high`), and the abstention is structural, so the run is NOT partial;
+ *  2. the rollup never exceeds the confidence of what it aggregates: an
+ *     `uncorroborated` member is excluded from `lookalikeDomains` /
+ *     `mailCapableDomains` / the counts, and its presence caps the rollup's
+ *     severity below `high`;
+ *  3. a seed at or above the threshold is unchanged.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => restore());
+
+/** Parse the DoH query name and type from a fetch URL (same helper as check-lookalikes.spec.ts). */
+function parseDohQuery(input: string | URL | Request): { name: string; type: string } {
+	const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+	const parsed = new URL(url);
+	return {
+		name: parsed.searchParams.get('name') ?? '',
+		type: parsed.searchParams.get('type') ?? '',
+	};
+}
+
+const isNs = (type: string) => type === 'NS' || type === '2';
+const isMx = (type: string) => type === 'MX' || type === '15';
+
+function nsResponse(name: string, hosts: string[]) {
+	return createDohResponse(
+		[{ name, type: 2 }],
+		hosts.map((data) => ({ name, type: 2, TTL: 300, data })),
+	);
+}
+
+function mxResponse(name: string, exchange: string) {
+	return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: `10 ${exchange}` }]);
+}
+
+function empty() {
+	return createDohResponse([], []);
+}
+
+async function run(domain: string) {
+	const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+	return checkLookalikes(domain);
+}
+
+/**
+ * Seed on its own NS; each named candidate on unrelated NS with a mail host
+ * on a DISPOSABLE provider, so the #264 matrix reaches HIGH per domain and the
+ * staging rollup WOULD fire if nothing stopped it. Everything else resolves
+ * empty (a complete run — coverage is not the variable here).
+ */
+function mockSeedWithCandidates(seed: string, candidates: string[]): void {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const { name, type } = parseDohQuery(input);
+		if (name === seed && isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.primary-dns.com.']));
+		if (candidates.includes(name)) {
+			if (isNs(type)) return Promise.resolve(nsResponse(name, ['ns1.unrelated-dns.com.']));
+			if (isMx(type)) return Promise.resolve(mxResponse(name, 'mx.mailgun.org.'));
+		}
+		return Promise.resolve(empty());
+	});
+}
+
+const STAGING_TITLE = /lookalike domains? showing pre-phishing staging signals/i;
+const MAIL_HOST_TITLE = /lookalike domains? with a working mail host/i;
+
+/** The aggregate rollup: a threat_observation that names a LIST, not a single candidate. */
+function findRollup(findings: Awaited<ReturnType<typeof run>>['findings']) {
+	return findings.find((f) => f.metadata?.findingAxis === 'threat_observation' && f.metadata?.lookalikeDomain === undefined);
+}
+
+describe('checkLookalikes - short seed labels abstain from the threat rollup (#863)', () => {
+	it('x.ai (1-char label): per-domain hedge is present, the rollup abstains, and no aggregate high is published', async () => {
+		mockSeedWithCandidates('x.ai', ['z.ai', 'c.ai']);
+		const result = await run('x.ai');
+
+		// The tool already knew: the per-domain attribution finding hedges.
+		const zAttribution = result.findings.find((f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.lookalikeDomain === 'z.ai');
+		expect(zAttribution).toBeDefined();
+		expect(zAttribution!.metadata?.attributionConfidence).toBe('uncorroborated');
+
+		// The rollup no longer drops that hedge.
+		expect(result.findings.some((f) => STAGING_TITLE.test(f.title))).toBe(false);
+		expect(result.findings.some((f) => MAIL_HOST_TITLE.test(f.title))).toBe(false);
+		expect(findRollup(result.findings)).toBeUndefined();
+		// Nothing aggregate names z.ai / c.ai in a list.
+		for (const f of result.findings) {
+			if (f.metadata?.lookalikeDomain !== undefined) continue;
+			expect(f.metadata?.lookalikeDomains).toBeUndefined();
+			expect(f.metadata?.mailCapableDomains).toBeUndefined();
+			expect(f.severity).not.toBe('high');
+		}
+
+		const abstained = result.findings.find((f) => f.metadata?.notAssessedReason === 'seed_label_too_short');
+		expect(abstained, 'the abstention must be VISIBLE, not silent').toBeDefined();
+		expect(abstained!.severity).toBe('info');
+		expect(abstained!.metadata?.findingAxis).toBe('scan_status');
+		expect(abstained!.metadata?.seedLabel).toBe('x');
+		expect(abstained!.metadata?.seedLabelLength).toBe(1);
+		expect(abstained!.metadata?.lookalikeDomainCount).toBeUndefined();
+		expect(abstained!.metadata?.mailCapableCount).toBeUndefined();
+		expect(abstained!.title).not.toMatch(/\d+ lookalike domain/);
+		expect(abstained!.detail).toMatch(/every .*one edit away|cannot separate/i);
+	});
+
+	it('cites the SAME threshold constant the per-domain hedge uses — one number, one home', async () => {
+		const { MIN_ATTRIBUTION_LABEL_LENGTH } = await import('../src/lib/ownership-attribution');
+		mockSeedWithCandidates('x.ai', ['z.ai']);
+		const result = await run('x.ai');
+		const abstained = result.findings.find((f) => f.metadata?.notAssessedReason === 'seed_label_too_short');
+		expect(abstained!.metadata?.minLabelLength).toBe(MIN_ATTRIBUTION_LABEL_LENGTH);
+		expect(abstained!.detail).toContain(`under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters`);
+		const hedge = result.findings.find((f) => f.metadata?.attributionConfidence === 'uncorroborated');
+		expect(hedge!.detail).toContain(`under ${MIN_ATTRIBUTION_LABEL_LENGTH} characters`);
+	});
+
+	it('a short-label abstention is structural, so the run is NOT marked partial (cacheable — every run would abstain)', async () => {
+		mockSeedWithCandidates('x.ai', ['z.ai']);
+		const result = await run('x.ai');
+		expect(result.partial).toBeFalsy();
+	});
+
+	it('meta.com (4-char label): abstains too — the blast-radius case from the issue', async () => {
+		mockSeedWithCandidates('meta.com', ['mata.com', 'meta.co']);
+		const result = await run('meta.com');
+		expect(result.findings.some((f) => STAGING_TITLE.test(f.title))).toBe(false);
+		expect(findRollup(result.findings)).toBeUndefined();
+		const abstained = result.findings.find((f) => f.metadata?.notAssessedReason === 'seed_label_too_short');
+		expect(abstained).toBeDefined();
+		expect(abstained!.metadata?.seedLabelLength).toBe(4);
+	});
+
+	it('control: a 6-char seed label is unchanged — the staging rollup fires at high with its bare count', async () => {
+		mockSeedWithCandidates('testco.com', ['twstco.com']);
+		const result = await run('testco.com');
+		const rollup = result.findings.find((f) => STAGING_TITLE.test(f.title));
+		expect(rollup).toBeDefined();
+		expect(rollup!.title).toBe('1 lookalike domain showing pre-phishing staging signals');
+		expect(rollup!.severity).toBe('high');
+		expect(rollup!.metadata?.lookalikeDomains).toEqual(['twstco.com']);
+		expect(rollup!.metadata?.uncorroboratedExcludedCount).toBe(0);
+		expect(result.findings.some((f) => f.metadata?.notAssessedReason !== undefined)).toBe(false);
+	});
+});
+
+describe('buildThreatRollupFinding - never exceeds the confidence of what it aggregates (#863)', () => {
+	const enumeration = { permutationsGenerated: 10, permutationsProbed: 10, candidatesResolved: 2, unresolvedCount: 0, complete: true };
+	const member = (domain: string, attributionConfidence: 'corroborated' | 'uncorroborated', severity: 'high' | 'medium' = 'high') => ({
+		domain,
+		hasMX: true,
+		severity,
+		ownershipVerdict: 'third_party' as const,
+		registrationDays: 400,
+		attributionConfidence,
+	});
+
+	it('excludes an uncorroborated member from every list and count, and caps the rollup below high', async () => {
+		const { buildThreatRollupFinding } = await import('../src/tools/lookalike-summary-findings');
+		const { finding, notAssessedReason } = buildThreatRollupFinding({
+			seedDomain: 'testco.com',
+			seedLabel: 'testco',
+			members: [member('twstco.com', 'corroborated'), member('tstco.com', 'uncorroborated')],
+			enumeration,
+		});
+		expect(notAssessedReason).toBeNull();
+		expect(finding).not.toBeNull();
+		expect(finding!.metadata?.lookalikeDomains).toEqual(['twstco.com']);
+		expect(finding!.metadata?.mailCapableDomains).toEqual(['twstco.com']);
+		expect(finding!.metadata?.lookalikeDomainCount).toBe(1);
+		expect(finding!.metadata?.mailCapableCount).toBe(1);
+		expect(finding!.metadata?.uncorroboratedExcludedCount).toBe(1);
+		// The aggregate cannot be more confident than its weakest member.
+		expect(finding!.severity).toBe('medium');
+		expect(finding!.metadata?.severityCappedBy).toBe('attribution_confidence');
+		expect(finding!.detail).toMatch(/1 further .*excluded/i);
+	});
+
+	it('with no corroborated member left, abstains rather than publishing an empty or hedged count', async () => {
+		const { buildThreatRollupFinding } = await import('../src/tools/lookalike-summary-findings');
+		const { finding, notAssessedReason } = buildThreatRollupFinding({
+			seedDomain: 'testco.com',
+			seedLabel: 'testco',
+			members: [member('tstco.com', 'uncorroborated'), member('tesco.com', 'uncorroborated', 'medium')],
+			enumeration,
+		});
+		expect(notAssessedReason).toBe('members_uncorroborated');
+		expect(finding).not.toBeNull();
+		expect(finding!.severity).toBe('info');
+		expect(finding!.metadata?.findingAxis).toBe('scan_status');
+		expect(finding!.metadata?.notAssessedReason).toBe('members_uncorroborated');
+		expect(finding!.metadata?.lookalikeDomains).toBeUndefined();
+		expect(finding!.metadata?.mailCapableDomains).toBeUndefined();
+	});
+
+	it('the short-label gate runs before member filtering and before the coverage gate', async () => {
+		const { buildThreatRollupFinding, MIN_ROLLUP_SEED_LABEL_LENGTH } = await import('../src/tools/lookalike-summary-findings');
+		const { MIN_ATTRIBUTION_LABEL_LENGTH } = await import('../src/lib/ownership-attribution');
+		// One constant, re-exported — not a second number.
+		expect(MIN_ROLLUP_SEED_LABEL_LENGTH).toBe(MIN_ATTRIBUTION_LABEL_LENGTH);
+		const { finding, notAssessedReason } = buildThreatRollupFinding({
+			seedDomain: 'x.ai',
+			seedLabel: 'x',
+			members: [member('z.ai', 'corroborated')],
+			enumeration: { ...enumeration, unresolvedCount: 9, candidatesResolved: 1, complete: false },
+		});
+		expect(notAssessedReason).toBe('seed_label_too_short');
+		expect(finding!.metadata?.notAssessedReason).toBe('seed_label_too_short');
+	});
+});

--- a/test/check-lookalikes-short-label-rollup.spec.ts
+++ b/test/check-lookalikes-short-label-rollup.spec.ts
@@ -217,6 +217,30 @@ describe('buildThreatRollupFinding - never exceeds the confidence of what it agg
 		expect(finding!.metadata?.mailCapableDomains).toBeUndefined();
 	});
 
+	/**
+	 * Review finding on #863: the exclusion/cap path above is UNREACHABLE from
+	 * `checkLookalikesCore` today, because the rollup's label gate and the
+	 * classifier's corroboration bar are the same constant on the same string.
+	 * Pin that coupling from the CLASSIFIER side too: at exactly the threshold
+	 * length, with no other corroboration, the verdict is `'corroborated'`. If
+	 * someone splits the two thresholds this goes red and points at the rollup
+	 * path that would silently become live.
+	 */
+	it('classifier-side pin: a label of exactly MIN_ATTRIBUTION_LABEL_LENGTH chars is corroborated with no other signal', async () => {
+		const { attributionConfidence, MIN_ATTRIBUTION_LABEL_LENGTH } = await import('../src/lib/ownership-attribution');
+		const { MIN_ROLLUP_SEED_LABEL_LENGTH } = await import('../src/tools/lookalike-summary-findings');
+		const atThreshold = 'a'.repeat(MIN_ATTRIBUTION_LABEL_LENGTH);
+		const belowThreshold = 'a'.repeat(MIN_ATTRIBUTION_LABEL_LENGTH - 1);
+		for (const verdict of ['third_party', 'unattributed', 'unmeasured'] as const) {
+			expect(attributionConfidence(verdict, atThreshold, false)).toBe('corroborated');
+			expect(attributionConfidence(verdict, belowThreshold, false)).toBe('uncorroborated');
+		}
+		// Therefore every member of a seed that passes the rollup's label gate is
+		// corroborated: the gate and the classifier bar are the same number.
+		expect(atThreshold.length >= MIN_ROLLUP_SEED_LABEL_LENGTH).toBe(true);
+		expect(belowThreshold.length < MIN_ROLLUP_SEED_LABEL_LENGTH).toBe(true);
+	});
+
 	it('the short-label gate runs before member filtering and before the coverage gate', async () => {
 		const { buildThreatRollupFinding, MIN_ROLLUP_SEED_LABEL_LENGTH } = await import('../src/tools/lookalike-summary-findings');
 		const { MIN_ATTRIBUTION_LABEL_LENGTH } = await import('../src/lib/ownership-attribution');


### PR DESCRIPTION
> **Stacked on #892** (`fix-lookalikes-rollup`, the #865 fix). This branch contains that commit plus one more; the diff view will show both until #892 merges, after which this PR rebases cleanly onto `main`.

## What happens

For a seed whose second-level label is very short, `check_lookalikes` publishes a HIGH attack-preparation claim naming real companies. Measured 2026-08-31 on `x.ai` (issue #863, enumeration **complete**, 25/25 probed): the per-domain findings hedged correctly — `attributionConfidence: "uncorroborated"`, *"The shared label is under 5 characters and nothing else corroborates a link, so the name similarity alone means little."* — but the rollup dropped the hedge and emitted **"1 lookalike domain showing pre-phishing staging signals"** at `high`, `lookalikeDomains: ["z.ai"]` (Zhipu AI), `mailCapableDomains: ["c.ai", "s.ai", "z.ai"]` (Character.AI, a personal site, Zhipu AI). None is a typosquat. `meta.com` (4 chars) returned 16 mail-capable / 9 staging-flagged in the same sweep for the same reason.

At one character every single-letter domain in the TLD is one edit away, so precision is not low — it is undefined. Same shape as #779 and #705: a hedge applied per finding, lost at the aggregation layer.

## Root cause

- `attributionConfidence()` (`src/lib/ownership-attribution.ts`) already classifies a non-owned candidate as `uncorroborated` when the brand label is shorter than `MIN_ATTRIBUTION_LABEL_LENGTH` (5) and nothing else (MX overlap with the seed) corroborates a link, and `buildNonOwnedGateFinding` words the per-domain attribution finding accordingly. That value never reached the rollup: the orchestrator collected mail-capable / HIGH candidates by `hasMX` and the #264 severity alone.
- The rollup builders had no notion of the seed label at all.

## Fix

`src/tools/lookalike-summary-findings.ts`

- `MIN_ROLLUP_SEED_LABEL_LENGTH` is a **re-export of `MIN_ATTRIBUTION_LABEL_LENGTH`** — the one number the per-domain hedge already cites, not a second declaration (pinned by a test that imports both and compares them, and that checks the hedge text and the abstention text quote the same value).
- `buildThreatRollupFinding` gains `seedLabel` and now returns `{ finding, notAssessedReason: 'enumeration_throttled' | 'seed_label_too_short' | 'members_uncorroborated' | null }`. Gate order: short label → coverage (#865) → member confidence → count. The label gate runs first because it is a property of the seed, not of this run.
- New `buildRollupShortLabelFinding` — `scan_status`, `info`, `notAssessedReason: 'seed_label_too_short'`, `seedLabel`, `seedLabelLength`, `minLabelLength`; **no count, no domain list**. It is structural, so it carries no `inconclusive`/`errorKind` (no probe failed) and the run is **not** marked `partial` — every run of that seed abstains, and caching that is correct (contrast the transient #865 abstention, which is partial).
- `ThreatRollupMember` gains `attributionConfidence`. Members at `uncorroborated` are excluded from `lookalikeDomains`, `mailCapableDomains` and both counts; the number left out is carried as `uncorroboratedExcludedCount`, named in the prose, and their presence caps the staging rollup at `medium` with `severityCappedBy: 'attribution_confidence'`. If no corroborated member remains, the rollup abstains with `members_uncorroborated` (`buildRollupUncorroboratedFinding`). Today that path is unreachable for a seed that passed the label gate (a label ≥ 5 chars is always `corroborated`), so it is a defensive invariant — "the aggregate never exceeds the confidence of its rows" — that survives a future change to the classifier.

`src/tools/check-lookalikes.ts` (call site only)

- `mxOverlapsPrimary` is hoisted above the attribution `if/else` so the same signal feeds both the per-domain `applyOwnershipGate` wording and the rollup member's `attributionConfidence` — computed once, so the two can never disagree.
- The member push adds `attributionConfidence`; the rollup call passes `seedLabel: brand` (`extractBrandName`); the `partial` condition keys on `notAssessedReason === 'enumeration_throttled'` only.

Per-domain findings are untouched: `x.ai`'s `z.ai` row still appears with its `uncorroborated` hedge, as the issue said it should.

## Threshold rationale

No new number. `MIN_ATTRIBUTION_LABEL_LENGTH = 5` was set for the D4 attribution guard ("a short brand label, e.g. `bnz`, collides with too much unrelated global DNS for a bare label match to mean anything on its own") and is the value the per-domain prose has been printing to customers. The issue asks for the rollup to use "the threshold the tool's own prose already cites"; re-exporting the constant is the only way to guarantee that stays true. Both measured cases fall below it (`x` = 1, `meta` = 4); `testco`/`openai`/`anthropic` etc. are unaffected.

## Tests

New `test/check-lookalikes-short-label-rollup.spec.ts` (8 tests; DNS mocked via `dns-mock`, tool dynamically imported; the fixtures use candidates the generator really produces for those seeds — `z.ai`, `c.ai`, `mata.com`, `meta.co` — each on unrelated NS with a disposable-provider MX so the staging rollup WOULD fire if nothing stopped it):

- `x.ai`: per-domain `uncorroborated` hedge present; no staging or mail-host rollup; no aggregate finding carries `lookalikeDomains`/`mailCapableDomains` or `high`; `seed_label_too_short` notice at `info`/`scan_status` with `seedLabel: 'x'`, `seedLabelLength: 1`, no counts;
- abstention cites `MIN_ATTRIBUTION_LABEL_LENGTH` (imported from its home) in `minLabelLength` and in the prose, and the per-domain hedge quotes the same value;
- short-label abstention → `partial` **not** set;
- `meta.com` (4 chars) abstains, `seedLabelLength: 4`;
- control `testco.com` (6 chars) → title exactly `1 lookalike domain showing pre-phishing staging signals`, `high`, `uncorroboratedExcludedCount: 0`, no `notAssessedReason` anywhere;
- builder-level: one `corroborated` + one `uncorroborated` member → lists and counts contain only the corroborated one, `uncorroboratedExcludedCount: 1`, severity `medium`, `severityCappedBy: 'attribution_confidence'`, prose names the exclusion;
- all members `uncorroborated` → `members_uncorroborated` abstention, no lists;
- `MIN_ROLLUP_SEED_LABEL_LENGTH === MIN_ATTRIBUTION_LABEL_LENGTH`, and the label gate wins over an incomplete enumeration.

Written failing-first (7 of 8 red before the change; the `partial`-not-set test is vacuously green on `main`).

Commands run, all green:

```
npx vitest run test/check-lookalikes-short-label-rollup.spec.ts test/check-lookalikes-throttled-rollup.spec.ts \
  test/check-lookalikes.spec.ts test/check-lookalikes-degraded-attribution.spec.ts \
  test/check-lookalikes-recon-enrichment.integration.test.ts test/lookalike-analysis.spec.ts test/lookalike-severity.spec.ts \
  test/audits/ns-in-bailiwick-full-match.audit.test.ts test/audits/ownership-severity-gate.audit.test.ts \
  test/brand-defensive-registration.test.ts test/brand-discovery-tier3-unchanged.integration.test.ts \
  test/chaos/discover-seed-literal.chaos.test.ts test/discover-brand-domains-corroboration.test.ts \
  test/discover-brand-domains.spec.ts test/ownership-attribution.spec.ts test/check-shadow-domains.spec.ts
  # 16 files, 328 tests (every test file that touches the lookalike surface)
npm run typecheck   # rc 0
npm run lint        # rc 0
npm test            # full suite — see the final comment on this PR for the run summary
```

Rollup title consumers checked (unchanged): `test/check-lookalikes.spec.ts` regexes on `pre-phishing staging signals`; no source file matches the title; `discover-brand-domains.ts` reads per-domain `lookalikeDomain` only; `scan/post-processing.ts` keys on severity inside `scan_domain`, which never runs `check_lookalikes`.

## Residuals

- `check_lookalikes` is standalone (outside the scored `CheckCategory` union, not in `scan_domain`), so **no `scan_domain` score moves**. Its own `CheckResult` self-score no longer carries the rollup's `high` penalty for a short-label seed; the per-domain `high` threat observation for e.g. `z.ai` still applies.
- The per-domain **threat_observation** for a short-label seed is still emitted at the #264-calibrated severity (`high` for `z.ai` on a disposable MX). The issue scoped the defect to the rollup and explicitly credited the per-domain hedge, so this PR leaves the rows alone; whether the row-level threat axis should also be capped for `uncorroborated` candidates is a separate wording/severity decision (it would touch `buildThreatObservationFinding`'s pinned wording contract).
- The `members_uncorroborated` path is unreachable with today's classifier; it exists so the invariant holds if `attributionConfidence()` ever grows another `uncorroborated` cause.

Closes #863

🤖 Generated with [Claude Code](https://claude.com/claude-code)
