### PR TITLE
fix(lookalikes): recognise same-entity domains on a different DNS platform as owned_by_seed (#864)

### DIFF
--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -205,10 +205,17 @@ export interface OwnershipEvidence {
  *    exists (measured absence).
  *  - `no_seed_receiver` — the candidate's DMARC reports go nowhere inside the
  *    seed apex (or it has no DMARC record).
- *  - `unresolved` — a lookup on the path REJECTED; nothing was measured.
+ *  - `candidate_unresolved` — the CANDIDATE-zone lookup (`_dmarc.<candidate>`)
+ *    rejected. That zone is 100% attacker-controlled, so a failure there is a
+ *    DECLINE, never a measurement gap: a squatter who blackholes its own
+ *    `_dmarc` must not do better than one that publishes nothing (PR #897
+ *    re-review, High). Falls through to the seed-side NS outcome with the
+ *    threat observation retained.
+ *  - `unresolved` — a SEED-zone lookup (the grant or its canary) REJECTED;
+ *    nothing was measured on the only side that carries weight.
  */
 export interface DmarcReportAuthorisation {
-	status: 'authorised' | 'wildcard' | 'not_authorised' | 'no_seed_receiver' | 'unresolved';
+	status: 'authorised' | 'wildcard' | 'not_authorised' | 'no_seed_receiver' | 'candidate_unresolved' | 'unresolved';
 	/** Report mailboxes (domain part) the candidate's DMARC record names inside the seed apex. */
 	seedReceivers: string[];
 	/** The receiver whose authorisation record matched (`authorised` / `wildcard` only). */
@@ -251,8 +258,10 @@ export interface ClassifyOwnershipInput {
 	/**
 	 * #864 — the SEED-SIDE half: result of the DMARC external-report
 	 * authorisation probe. `undefined` = not probed. The verdict rests on
-	 * `status === 'authorised'` alone; `'unresolved'` with the MX pre-filter
-	 * met yields `unmeasured` (#832's law), every other status falls through
+	 * `status === 'authorised'` alone; `'unresolved'` (a SEED-zone lookup
+	 * rejected) with the MX pre-filter met yields `unmeasured` (#832's law);
+	 * every other status — including `'candidate_unresolved'`, the
+	 * attacker-controlled `_dmarc.<candidate>` lookup failing — falls through
 	 * to the seed-side NS outcome.
 	 */
 	dmarcReportAuthorisation?: DmarcReportAuthorisation;
@@ -530,6 +539,45 @@ export function parseDmarcReportReceivers(dmarcRecord: string): string[] {
 }
 
 /**
+ * Registrable apexes of DMARC report-PROCESSING services — organisations that
+ * publish the RFC 7489 §7.1 `<domain>._report._dmarc.<receiver>` grant for
+ * EVERY customer domain as a matter of business, so a grant under one of
+ * these apexes says "customer", never "same owner". When the SEED apex is one
+ * of these, step 5b declines (evidence-only) — the same defence
+ * `SHARED_NS_APEXES` / `isSharedNsHost` gives the NS arms. Consulted for the
+ * seed apex only, so an entry here can only ever WITHHOLD an attribution.
+ * Add conservatively; a missing processor merely leaves the provider-class
+ * residual documented in the file header.
+ */
+export const DMARC_REPORT_PROCESSOR_APEXES: ReadonlySet<string> = new Set([
+	'agari.com',
+	'valimail.com',
+	'dmarcian.com',
+	'ondmarc.com',
+	'redsift.com',
+	'proofpoint.com',
+	'dmarcanalyzer.com',
+	'mimecast.com',
+	'easydmarc.com',
+	'powerdmarc.com',
+	'dmarcly.com',
+	'sendmarc.com',
+	'fraudmarc.com',
+	'uriports.com',
+	'mailhardener.com',
+	'postmarkapp.com',
+	'mxtoolbox.com',
+	'dmarcdigests.com',
+]);
+
+/** True when `apex` (already a registrable domain) is a known DMARC report-processing service — see {@link DMARC_REPORT_PROCESSOR_APEXES}. */
+export function isDmarcReportProcessorApex(apex: string): boolean {
+	const host = normHost(apex);
+	if (!host) return false;
+	return DMARC_REPORT_PROCESSOR_APEXES.has(getRegistrableDomain(host) ?? host);
+}
+
+/**
  * Step 5b of `classifyOwnership()` — the #864 seed-authorised convergence
  * arm. Returns `null` when the arm has nothing to say (pre-filter unmet,
  * inputs absent, or no seed-published grant), an `owned_by_seed` assessment
@@ -546,10 +594,17 @@ function assessSeedAuthorisedConvergence(
 	if (!mxRoutedIntoSeed(input.candidateMx, seedApex)) return null;
 	const auth = input.dmarcReportAuthorisation;
 	if (auth === undefined) return null;
+	// A seed that is itself a DMARC report PROCESSOR publishes the §7.1 grant
+	// for every customer, so the grant carries no ownership information there
+	// (mirrors `isSharedNsHost` for the NS arms). Evidence-only: decline.
+	if (isDmarcReportProcessorApex(seedApex)) return null;
 
 	const mx = (input.candidateMx ?? []).map(normHost).filter(Boolean);
 	const mxEvidence: OwnershipEvidence[] = mx.map((value) => ({ record: 'MX' as const, value, inSeedBailiwick: true }));
 
+	// ONLY a SEED-zone lookup failure is a measurement gap. `candidate_unresolved`
+	// (the attacker-controlled `_dmarc.<candidate>` lookup rejected) falls
+	// through below with every other non-grant status — see the status docs.
 	if (auth.status === 'unresolved') {
 		return {
 			verdict: 'unmeasured',

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -72,6 +72,51 @@
  * left present-but-unused — see the `OWNERSHIP RULE` note on
  * `ClassifyOwnershipInput` below for the rule a future author re-wiring a
  * real SOA/SPF/redirect probe must re-derive.
+ *
+ * AMENDMENT — IN-BAILIWICK CONVERGENCE (2026-09-04, #864, regression of
+ * #263). Ruling A's seed-side-only rule has an irreducible blind spot that
+ * #864 measured live: a same-entity domain on a DIFFERENT DNS platform
+ * (`amazon.com` on Route 53, `amazon.com.au` on Amazon's internal
+ * `amzndns.*`) shares no nameserver with the seed, and the #263 RDAP
+ * registrant tier is structurally blind for the pair — Verisign's `.com`
+ * RDAP is thin (registrar only) and auDA's `.com.au` RDAP publishes no
+ * registrant entity at all (observed 2026-09-04). No seed-side signal exists,
+ * so the candidate was counted as an impersonation-capable third party.
+ *
+ * What IS observable (DoH, 2026-09-04): `amazon.com.au` MX →
+ * `amazon-smtp.amazon.com` (the seed's own MX host) and SOA MNAME →
+ * `dns-external-master.amazon.com` (its zone is mastered on a host inside the
+ * seed's zone). Both are candidate-zone records, so Ruling A's "never alone"
+ * clause stands unchanged — but its "never combined" clause is amended for
+ * exactly ONE bounded conjunction, `assessBailiwickConvergence()` below:
+ *
+ *   MX (every real exchange inside the seed apex) AND SOA MNAME (inside the
+ *   seed apex) → `owned_by_seed`, strength `medium`, evidence attached.
+ *
+ * Why this conjunction and not others (spoofing analysis):
+ *   - MX alone is one attacker-written record and never qualifies (a squatter
+ *     can copy the seed's MX string in seconds — pinned by a negative fixture).
+ *   - SOA RNAME is NEVER verdict-bearing: managed providers template it, and
+ *     for a seed that is itself a DNS operator the template lands inside the
+ *     seed apex — every Route 53 zone carries RNAME
+ *     `awsdns-hostmaster.amazon.com`, so a Route 53 squatter of amazon.com
+ *     would otherwise qualify. It is recorded as evidence prose only.
+ *   - SOA MNAME on a managed provider is always a PROVIDER host (Route 53 →
+ *     `ns-*.awsdns-*`, Cloudflare → `*.ns.cloudflare.com`, Akamai →
+ *     `a*.akam.net`), never inside an unrelated seed's apex, and managed
+ *     providers do not let a tenant edit it. Placing MNAME inside the seed
+ *     apex therefore requires the squatter to self-host authoritative DNS
+ *     (or a rare provider that exposes MNAME) — AND to route the lookalike's
+ *     inbound mail to the seed's own servers, forfeiting the receive channel.
+ *   - Two record types, two different operational dependencies, both pointed
+ *     INTO the seed's zone: the same "complete match, not partial" bar the
+ *     `ns_shared_provider_complete` arm already accepts at `medium`.
+ *
+ * Residual (documented, not hidden): a squatter who self-hosts DNS with a
+ * forged MNAME and sacrifices inbound mail can still earn the verdict; the
+ * verdict is `medium`, names both records in `evidence`, and the finding
+ * text quotes them so an analyst can see exactly what was matched. Seed-side
+ * arms keep precedence — a strong NS match is never displaced by this one.
  */
 
 import type { CheckCategory, Finding, Severity } from '@blackveil/dns-checks/scoring';
@@ -104,6 +149,7 @@ export type OwnershipSignal =
 	| 'ns_in_bailiwick'
 	| 'ns_set_match'
 	| 'ns_shared_provider_complete'
+	| 'mx_in_bailiwick'
 	| 'soa_in_bailiwick'
 	| 'spf_include_seed'
 	| 'http_redirect_seed'
@@ -115,6 +161,31 @@ export interface OwnershipAssessment {
 	signals: OwnershipSignal[];
 	/** Human-readable, safe to surface in a report — never implies ownership beyond `verdict`. */
 	rationale: string;
+	/**
+	 * The observed records a verdict rests on, when it rests on candidate-zone
+	 * records (#864 in-bailiwick convergence). Absent for the seed-side NS arms,
+	 * whose `rationale` already names the matched hosts. Surfaced verbatim in
+	 * finding metadata so a consumer can audit what was matched.
+	 */
+	evidence?: OwnershipEvidence[];
+}
+
+/** One observed record backing an `owned_by_seed` verdict (#864). */
+export interface OwnershipEvidence {
+	/** Which record the value came from. `SOA.RNAME` is evidence prose only — never verdict-bearing (see file header). */
+	record: 'MX' | 'SOA.MNAME' | 'SOA.RNAME';
+	/** The observed host (lowercased, trailing dot stripped). */
+	value: string;
+	/** True when the host sits at or under the seed apex. */
+	inSeedBailiwick: boolean;
+}
+
+/** SOA authority fields the #864 convergence arm consults. */
+export interface SoaAuthority {
+	/** Primary master nameserver (SOA MNAME). */
+	mname: string;
+	/** Responsible-party mailbox in domain-name form (SOA RNAME). */
+	rname: string;
 }
 
 export interface ClassifyOwnershipInput {
@@ -140,6 +211,26 @@ export interface ClassifyOwnershipInput {
 	 * evidence stays safe to publish.
 	 */
 	seedNsUnresolved?: boolean;
+	/**
+	 * #864 — the candidate's RESOLVED real MX exchange hosts (null-MX already
+	 * excluded upstream). `undefined` = not probed; `[]` = probed, no mail.
+	 * Consulted ONLY by the in-bailiwick convergence arm, and only in
+	 * conjunction with {@link candidateSoa} — see the file-header amendment.
+	 */
+	candidateMx?: readonly string[];
+	/**
+	 * #864 — the candidate's SOA authority fields. `undefined` = not probed;
+	 * `null` = probed and no SOA answered (or the probe rejected — then
+	 * {@link candidateSoaUnresolved} says which).
+	 */
+	candidateSoa?: SoaAuthority | null;
+	/**
+	 * #864 — true when the candidate's SOA lookup REJECTED (timeout /
+	 * throttling) rather than answering. With the MX precondition met, the
+	 * convergence question was asked and not answered, so the verdict is
+	 * `unmeasured` (#832's law) rather than the contrary `third_party`.
+	 */
+	candidateSoaUnresolved?: boolean;
 	/**
 	 * OWNERSHIP RULE — SEED-SIDE CONTROL ONLY (Ruling A, 2026-07-27 task-7c;
 	 * fields DELETED 2026-07-27 ownership-attribution followups item 2 — see
@@ -169,6 +260,14 @@ export interface ClassifyOwnershipInput {
 	 * candidate-side signal, be capable of producing `owned_by_seed` on its
 	 * own. If reintroducing such fields, keep them optional inputs consulted
 	 * strictly AFTER the seed-side precedence steps below decide the verdict.
+	 *
+	 * RE-DERIVED 2026-09-04 (#864): `candidateMx` + `candidateSoa` above are
+	 * exactly such a reintroduction, bounded as the rule demands — optional,
+	 * consulted after every seed-side arm, never verdict-bearing alone, and
+	 * limited to the single MX ∧ SOA-MNAME conjunction whose spoofing cost is
+	 * argued in the file header. SPF `include:` and HTTP redirect targets
+	 * remain excluded: both are free-text declarations with no operational
+	 * cost to forge.
 	 */
 }
 
@@ -226,15 +325,19 @@ export function isInBailiwick(nsHost: string, seedApex: string): boolean {
  *  5. Partial overlap confined to shared-provider hosts → not evidence (falls through silently —
  *     this is the ANZ/Westpac 1/6-Akamai trap: a single shared-provider NS host in common is
  *     operational plumbing, not ownership evidence).
+ *  5b. (#864) In-bailiwick CONVERGENCE — every real MX exchange AND the SOA MNAME sit inside
+ *     the seed apex → `owned_by_seed`, medium, with `evidence`. Requires the caller to have
+ *     supplied `candidateMx` + `candidateSoa`; neither alone qualifies, and SOA RNAME never
+ *     counts (see the file-header amendment for the spoofing analysis). If the MX precondition
+ *     holds but the SOA lookup REJECTED, the verdict is `unmeasured`, not `third_party`.
  *  6. Registered with its own resolvable NS, no ownership signal → `third_party`.
  *  7. Everything else (no NS info at all) → `unattributed`.
  *
- * `ClassifyOwnershipInput` accepts NO candidate-side corroboration inputs
- * (Ruling A, 2026-07-27 task-7c; the three candidate-side fields that used to
- * exist here — SOA RNAME, SPF `include:` target, HTTP redirect target — were
- * deleted 2026-07-27, see the OWNERSHIP RULE note on `ClassifyOwnershipInput`):
- * this precedence table is driven entirely by seed-side signals and can never
- * be swayed by a candidate-side declaration.
+ * Candidate-side inputs (`candidateMx`, `candidateSoa`) are consulted ONLY at
+ * step 5b, strictly after every seed-side arm, and only as the bounded
+ * conjunction the 2026-09-04 amendment admits. SPF `include:` and HTTP
+ * redirect targets remain excluded (deleted 2026-07-27, see the OWNERSHIP
+ * RULE note on `ClassifyOwnershipInput`).
  */
 export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAssessment {
 	const { registration, candidateDomain } = input;
@@ -275,6 +378,12 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
+	// #864 — the in-bailiwick convergence arm needs only the seed APEX (like the
+	// NS in-bailiwick arm above), so it is computed here and may still yield a
+	// positive verdict under a degraded seed NS lookup; it is APPLIED only after
+	// the seed-side set-comparison arms below, which keep precedence.
+	const convergence = assessBailiwickConvergence(input, candidateDomain, seedApex);
+
 	// #832 — degraded comparison inputs. The seed's NS lookup did not resolve,
 	// so every arm below would be comparing against an UNFETCHED set: the
 	// ns_set_match / shared-provider arms cannot fire (seedNs is empty), and
@@ -283,6 +392,7 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 	// verdict exists to prevent. Only the in-bailiwick arm above (which needs
 	// the seed APEX, not its NS answer) may still produce a verdict.
 	if (input.seedNsUnresolved) {
+		if (convergence?.verdict === 'owned_by_seed') return convergence;
 		return {
 			verdict: 'unmeasured',
 			strength: 'none',
@@ -325,6 +435,11 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
+	// #864 — step 5b. Applied only once every seed-side arm has declined, so a
+	// strong NS match is never displaced by this medium-strength verdict. Also
+	// carries the `unmeasured` outcome for an asked-but-unanswered SOA probe.
+	if (convergence !== null) return convergence;
+
 	if (candidateNs.length > 0) {
 		return {
 			verdict: 'third_party',
@@ -339,6 +454,75 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		strength: 'none',
 		signals: [],
 		rationale: `No ownership or third-party signal could be established for ${candidateDomain}.`,
+	};
+}
+
+/**
+ * True when the candidate's RESOLVED real MX set is non-empty and EVERY
+ * exchange sits at or under the seed apex — mail for the candidate is
+ * delivered to the seed organisation's own mail hosts (#864). Exported so the
+ * lookalike orchestrator can use the same predicate to gate the one extra SOA
+ * lookup the convergence arm needs: the probe is issued only for candidates
+ * that already satisfy this half, so a clean scan pays nothing.
+ *
+ * A single exchange OUTSIDE the seed apex disqualifies the whole set — a
+ * squatter listing the seed's MX alongside their own would keep a working
+ * receive channel, which is precisely what the conjunction is meant to cost.
+ */
+export function mxRoutedIntoSeed(candidateMx: readonly string[] | undefined, seedDomain: string): boolean {
+	if (!candidateMx || candidateMx.length === 0) return false;
+	const normalisedSeed = normHost(seedDomain);
+	const seedApex = getRegistrableDomain(normalisedSeed) ?? normalisedSeed;
+	return candidateMx.every((mx) => isInBailiwick(mx, seedApex));
+}
+
+/**
+ * Step 5b of `classifyOwnership()` — the #864 in-bailiwick convergence arm.
+ * Returns `null` when the arm has nothing to say (inputs absent, or the
+ * conjunction unmet), an `owned_by_seed` assessment when BOTH halves hold, or
+ * an `unmeasured` assessment when the MX half holds but the SOA probe was
+ * asked and rejected. Never returns `third_party`: declining is the caller's
+ * job, from seed-side evidence.
+ */
+function assessBailiwickConvergence(input: ClassifyOwnershipInput, candidateDomain: string, seedApex: string): OwnershipAssessment | null {
+	if (!mxRoutedIntoSeed(input.candidateMx, seedApex)) return null;
+	const mx = (input.candidateMx ?? []).map(normHost).filter(Boolean);
+
+	if (input.candidateSoa === undefined) {
+		// MX half holds but the caller never probed SOA: the arm cannot fire
+		// (never on one attacker-written record) and it is not a measurement
+		// gap either — nobody asked. Fall through to the seed-side outcome.
+		return null;
+	}
+	if (input.candidateSoa === null) {
+		if (input.candidateSoaUnresolved) {
+			return {
+				verdict: 'unmeasured',
+				strength: 'none',
+				signals: ['mx_in_bailiwick'],
+				rationale: `${candidateDomain} routes its mail to ${mx.join(', ')} inside ${seedApex}, but its SOA lookup did not resolve this run, so whether its zone is also mastered inside ${seedApex} could not be assessed. This is a measurement gap, not evidence of third-party registration — re-run to attribute.`,
+				evidence: mx.map((value) => ({ record: 'MX' as const, value, inSeedBailiwick: true })),
+			};
+		}
+		return null;
+	}
+
+	const mname = normHost(input.candidateSoa.mname);
+	const rname = normHost(input.candidateSoa.rname);
+	if (!mname || !isInBailiwick(mname, seedApex)) return null;
+
+	const evidence: OwnershipEvidence[] = [
+		...mx.map((value) => ({ record: 'MX' as const, value, inSeedBailiwick: true })),
+		{ record: 'SOA.MNAME', value: mname, inSeedBailiwick: true },
+	];
+	if (rname) evidence.push({ record: 'SOA.RNAME', value: rname, inSeedBailiwick: isInBailiwick(rname, seedApex) });
+
+	return {
+		verdict: 'owned_by_seed',
+		strength: 'medium',
+		signals: ['mx_in_bailiwick', 'soa_in_bailiwick'],
+		rationale: `${candidateDomain} routes its mail to ${mx.join(', ')} and its zone is mastered on ${mname} — both inside ${seedApex}'s own infrastructure. Two distinct operational dependencies point into the seed's zone; either record alone would not qualify.`,
+		evidence,
 	};
 }
 

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -73,50 +73,57 @@
  * `ClassifyOwnershipInput` below for the rule a future author re-wiring a
  * real SOA/SPF/redirect probe must re-derive.
  *
- * AMENDMENT — IN-BAILIWICK CONVERGENCE (2026-09-04, #864, regression of
- * #263). Ruling A's seed-side-only rule has an irreducible blind spot that
- * #864 measured live: a same-entity domain on a DIFFERENT DNS platform
- * (`amazon.com` on Route 53, `amazon.com.au` on Amazon's internal
+ * AMENDMENT — SEED-AUTHORISED CONVERGENCE (2026-09-04, #864, regression of
+ * #263; reworked after PR #897 review). Ruling A's seed-side-only rule has a
+ * blind spot #864 measured live: a same-entity domain on a DIFFERENT DNS
+ * platform (`amazon.com` on Route 53, `amazon.com.au` on Amazon's internal
  * `amzndns.*`) shares no nameserver with the seed, and the #263 RDAP
  * registrant tier is structurally blind for the pair — Verisign's `.com`
- * RDAP is thin (registrar only) and auDA's `.com.au` RDAP publishes no
- * registrant entity at all (observed 2026-09-04). No seed-side signal exists,
- * so the candidate was counted as an impersonation-capable third party.
+ * RDAP is thin and auDA's `.com.au` RDAP publishes no registrant entity
+ * (observed 2026-09-04). So the candidate was counted as an impersonation-
+ * capable third party.
  *
- * What IS observable (DoH, 2026-09-04): `amazon.com.au` MX →
- * `amazon-smtp.amazon.com` (the seed's own MX host) and SOA MNAME →
- * `dns-external-master.amazon.com` (its zone is mastered on a host inside the
- * seed's zone). Both are candidate-zone records, so Ruling A's "never alone"
- * clause stands unchanged — but its "never combined" clause is amended for
- * exactly ONE bounded conjunction, `assessBailiwickConvergence()` below:
+ * Ruling A is NOT weakened: the verdict below still rests on a record ONLY
+ * THE SEED CAN PUBLISH. The candidate-side half is a cheap PRE-FILTER, never
+ * evidence. The two halves of `assessSeedAuthorisedConvergence()`:
  *
- *   MX (every real exchange inside the seed apex) AND SOA MNAME (inside the
- *   seed apex) → `owned_by_seed`, strength `medium`, evidence attached.
+ *   1. PRE-FILTER (candidate-side, attacker-free, zero cost): every real MX
+ *      exchange of the candidate sits inside the seed apex. Copying the
+ *      seed's MX string is free for a SENDING squatter — a phishing sender
+ *      never wanted the receive channel — so this half carries NO weight; it
+ *      only decides which candidates are worth the seed-side lookups.
+ *   2. VERDICT (seed-side): the candidate's DMARC record sends aggregate/
+ *      forensic reports to a mailbox whose domain sits inside the seed apex,
+ *      AND the seed has published the RFC 7489 §7.1 external-destination
+ *      authorisation `<candidate>._report._dmarc.<receiver-domain>` TXT
+ *      `v=DMARC1`. The DMARC record itself is candidate-published (free to
+ *      forge); the authorisation record lives in the RECEIVER's zone, under
+ *      the seed apex, and only its owner can publish it — a squatter cannot.
+ *      A wildcard grant (`*._report._dmarc.<receiver>`, detected with a
+ *      canary label) is a seed choice to accept reports about ANY domain, so
+ *      it is evidence-only, never verdict-bearing.
  *
- * Why this conjunction and not others (spoofing analysis):
- *   - MX alone is one attacker-written record and never qualifies (a squatter
- *     can copy the seed's MX string in seconds — pinned by a negative fixture).
- *   - SOA RNAME is NEVER verdict-bearing: managed providers template it, and
- *     for a seed that is itself a DNS operator the template lands inside the
- *     seed apex — every Route 53 zone carries RNAME
- *     `awsdns-hostmaster.amazon.com`, so a Route 53 squatter of amazon.com
- *     would otherwise qualify. It is recorded as evidence prose only.
- *   - SOA MNAME on a managed provider is always a PROVIDER host (Route 53 →
- *     `ns-*.awsdns-*`, Cloudflare → `*.ns.cloudflare.com`, Akamai →
- *     `a*.akam.net`), never inside an unrelated seed's apex, and managed
- *     providers do not let a tenant edit it. Placing MNAME inside the seed
- *     apex therefore requires the squatter to self-host authoritative DNS
- *     (or a rare provider that exposes MNAME) — AND to route the lookalike's
- *     inbound mail to the seed's own servers, forfeiting the receive channel.
- *   - Two record types, two different operational dependencies, both pointed
- *     INTO the seed's zone: the same "complete match, not partial" bar the
- *     `ns_shared_provider_complete` arm already accepts at `medium`.
+ * Live (DoH, 2026-09-04): `_dmarc.amazon.com.au` → CNAME `_dmarc.amazon.com`,
+ * `rua=mailto:report<at>dmarc.amazon.com` (mailbox spelled out to keep the
+ * secret scanner quiet); `amazon.com.au._report._dmarc.dmarc.
+ * amazon.com` TXT `v=DMARC1` EXISTS; a random label under the same
+ * `_report._dmarc` is NXDOMAIN (not a wildcard) and `amzndns.com` — which
+ * reports to the same mailbox — has NO such record: a per-domain grant.
  *
- * Residual (documented, not hidden): a squatter who self-hosts DNS with a
- * forged MNAME and sacrifices inbound mail can still earn the verdict; the
- * verdict is `medium`, names both records in `evidence`, and the finding
- * text quotes them so an analyst can see exactly what was matched. Seed-side
- * arms keep precedence — a strong NS match is never displaced by this one.
+ * REJECTED on the same live records: SOA MNAME (unverified free text in a
+ * self-hosted zone — the first #897 revision used it and was correctly
+ * blocked), SOA RNAME (Route 53 templates `awsdns-hostmaster.amazon.com` into
+ * every tenant zone), the NS-platform chain (`amzndns.com` and public
+ * `awsdns-33.com` carry the same RNAME), seed SPF (`spf1/2/3.amazon.com` name
+ * no candidate), CT SAN overlap (0 of 3300 crt.sh certs cover both apexes),
+ * SPF `include:` / HTTP redirect (free-text, deleted 2026-07-27).
+ *
+ * Residual, stated not hidden: a seed that is itself a DMARC report-
+ * processing PROVIDER (Agari/Valimail-shaped) publishes authorisation records
+ * for every customer, so a customer whose MX also sits inside that seed's
+ * apex would attribute — the same provider-class residual the NS
+ * in-bailiwick arm already carries for DNS providers. Strength is `medium`
+ * and `evidence[]` names every record so a consumer can audit the match.
  */
 
 import type { CheckCategory, Finding, Severity } from '@blackveil/dns-checks/scoring';
@@ -150,6 +157,7 @@ export type OwnershipSignal =
 	| 'ns_set_match'
 	| 'ns_shared_provider_complete'
 	| 'mx_in_bailiwick'
+	| 'dmarc_report_authorised_by_seed'
 	| 'soa_in_bailiwick'
 	| 'spf_include_seed'
 	| 'http_redirect_seed'
@@ -170,22 +178,43 @@ export interface OwnershipAssessment {
 	evidence?: OwnershipEvidence[];
 }
 
-/** One observed record backing an `owned_by_seed` verdict (#864). */
+/** One observed record backing (or, for the pre-filter, accompanying) an ownership assessment (#864). */
 export interface OwnershipEvidence {
-	/** Which record the value came from. `SOA.RNAME` is evidence prose only — never verdict-bearing (see file header). */
-	record: 'MX' | 'SOA.MNAME' | 'SOA.RNAME';
-	/** The observed host (lowercased, trailing dot stripped). */
+	/**
+	 * Which record the value came from. `MX` is the candidate-side PRE-FILTER
+	 * (never verdict-bearing — see file header); `DMARC.RUA` is the
+	 * candidate-published report destination; `DMARC.REPORT_AUTHORISATION` is
+	 * the SEED-published RFC 7489 §7.1 grant the verdict rests on.
+	 */
+	record: 'MX' | 'DMARC.RUA' | 'DMARC.REPORT_AUTHORISATION';
+	/** The observed host / record name (lowercased, trailing dot stripped). */
 	value: string;
 	/** True when the host sits at or under the seed apex. */
 	inSeedBailiwick: boolean;
 }
 
-/** SOA authority fields the #864 convergence arm consults. */
-export interface SoaAuthority {
-	/** Primary master nameserver (SOA MNAME). */
-	mname: string;
-	/** Responsible-party mailbox in domain-name form (SOA RNAME). */
-	rname: string;
+/**
+ * Outcome of the seed-side DMARC external-report authorisation probe (#864;
+ * `probeDmarcReportAuthorisation()` in `src/tools/lookalike-dns.ts`).
+ *
+ *  - `authorised` — a receiver domain under the seed apex publishes a
+ *    per-domain `<candidate>._report._dmarc.<receiver>` `v=DMARC1` record.
+ *  - `wildcard` — the receiver answers `v=DMARC1` for a random label too, so
+ *    the grant is not specific to this candidate (evidence-only).
+ *  - `not_authorised` — the candidate reports into the seed apex but no grant
+ *    exists (measured absence).
+ *  - `no_seed_receiver` — the candidate's DMARC reports go nowhere inside the
+ *    seed apex (or it has no DMARC record).
+ *  - `unresolved` — a lookup on the path REJECTED; nothing was measured.
+ */
+export interface DmarcReportAuthorisation {
+	status: 'authorised' | 'wildcard' | 'not_authorised' | 'no_seed_receiver' | 'unresolved';
+	/** Report mailboxes (domain part) the candidate's DMARC record names inside the seed apex. */
+	seedReceivers: string[];
+	/** The receiver whose authorisation record matched (`authorised` / `wildcard` only). */
+	receiverDomain?: string;
+	/** The authorisation record NAME that answered `v=DMARC1` (`authorised` only). */
+	authorisationRecord?: string;
 }
 
 export interface ClassifyOwnershipInput {
@@ -214,23 +243,19 @@ export interface ClassifyOwnershipInput {
 	/**
 	 * #864 — the candidate's RESOLVED real MX exchange hosts (null-MX already
 	 * excluded upstream). `undefined` = not probed; `[]` = probed, no mail.
-	 * Consulted ONLY by the in-bailiwick convergence arm, and only in
-	 * conjunction with {@link candidateSoa} — see the file-header amendment.
+	 * PRE-FILTER ONLY: copying the seed's MX is free for a sending squatter,
+	 * so this never carries weight; it gates whether the seed-side probe in
+	 * {@link dmarcReportAuthorisation} is worth issuing. See the file header.
 	 */
 	candidateMx?: readonly string[];
 	/**
-	 * #864 — the candidate's SOA authority fields. `undefined` = not probed;
-	 * `null` = probed and no SOA answered (or the probe rejected — then
-	 * {@link candidateSoaUnresolved} says which).
+	 * #864 — the SEED-SIDE half: result of the DMARC external-report
+	 * authorisation probe. `undefined` = not probed. The verdict rests on
+	 * `status === 'authorised'` alone; `'unresolved'` with the MX pre-filter
+	 * met yields `unmeasured` (#832's law), every other status falls through
+	 * to the seed-side NS outcome.
 	 */
-	candidateSoa?: SoaAuthority | null;
-	/**
-	 * #864 — true when the candidate's SOA lookup REJECTED (timeout /
-	 * throttling) rather than answering. With the MX precondition met, the
-	 * convergence question was asked and not answered, so the verdict is
-	 * `unmeasured` (#832's law) rather than the contrary `third_party`.
-	 */
-	candidateSoaUnresolved?: boolean;
+	dmarcReportAuthorisation?: DmarcReportAuthorisation;
 	/**
 	 * OWNERSHIP RULE — SEED-SIDE CONTROL ONLY (Ruling A, 2026-07-27 task-7c;
 	 * fields DELETED 2026-07-27 ownership-attribution followups item 2 — see
@@ -261,13 +286,13 @@ export interface ClassifyOwnershipInput {
 	 * own. If reintroducing such fields, keep them optional inputs consulted
 	 * strictly AFTER the seed-side precedence steps below decide the verdict.
 	 *
-	 * RE-DERIVED 2026-09-04 (#864): `candidateMx` + `candidateSoa` above are
-	 * exactly such a reintroduction, bounded as the rule demands — optional,
-	 * consulted after every seed-side arm, never verdict-bearing alone, and
-	 * limited to the single MX ∧ SOA-MNAME conjunction whose spoofing cost is
-	 * argued in the file header. SPF `include:` and HTTP redirect targets
-	 * remain excluded: both are free-text declarations with no operational
-	 * cost to forge.
+	 * RE-DERIVED 2026-09-04 (#864): `candidateMx` above is a candidate-side
+	 * field again — but it is a PRE-FILTER with no verdict weight, and the
+	 * verdict it gates (`dmarcReportAuthorisation`) is a SEED-published record
+	 * (RFC 7489 §7.1), which is exactly the seed-side control this rule
+	 * demands. Consulted after every seed-side NS arm. SPF `include:`, HTTP
+	 * redirect and SOA MNAME/RNAME remain excluded: all are free-text
+	 * declarations a self-hosted zone can publish at no cost.
 	 */
 }
 
@@ -325,19 +350,20 @@ export function isInBailiwick(nsHost: string, seedApex: string): boolean {
  *  5. Partial overlap confined to shared-provider hosts → not evidence (falls through silently —
  *     this is the ANZ/Westpac 1/6-Akamai trap: a single shared-provider NS host in common is
  *     operational plumbing, not ownership evidence).
- *  5b. (#864) In-bailiwick CONVERGENCE — every real MX exchange AND the SOA MNAME sit inside
- *     the seed apex → `owned_by_seed`, medium, with `evidence`. Requires the caller to have
- *     supplied `candidateMx` + `candidateSoa`; neither alone qualifies, and SOA RNAME never
- *     counts (see the file-header amendment for the spoofing analysis). If the MX precondition
- *     holds but the SOA lookup REJECTED, the verdict is `unmeasured`, not `third_party`.
+ *  5b. (#864) SEED-AUTHORISED convergence — pre-filter: every real MX exchange inside the seed
+ *     apex (attacker-free, no weight); verdict: the seed publishes the RFC 7489 §7.1 DMARC
+ *     report authorisation `<candidate>._report._dmarc.<receiver-under-seed>` → `owned_by_seed`,
+ *     medium, with `evidence`. Requires the caller to have supplied `candidateMx` +
+ *     `dmarcReportAuthorisation`. A wildcard grant is evidence-only. If the pre-filter holds but
+ *     the seed-side probe REJECTED, the verdict is `unmeasured`, not `third_party`.
  *  6. Registered with its own resolvable NS, no ownership signal → `third_party`.
  *  7. Everything else (no NS info at all) → `unattributed`.
  *
- * Candidate-side inputs (`candidateMx`, `candidateSoa`) are consulted ONLY at
- * step 5b, strictly after every seed-side arm, and only as the bounded
- * conjunction the 2026-09-04 amendment admits. SPF `include:` and HTTP
- * redirect targets remain excluded (deleted 2026-07-27, see the OWNERSHIP
- * RULE note on `ClassifyOwnershipInput`).
+ * The #864 inputs (`candidateMx`, `dmarcReportAuthorisation`) are consulted
+ * ONLY at step 5b, strictly after every seed-side NS arm; the verdict there
+ * rests on the seed-published authorisation record alone. SPF `include:`,
+ * HTTP redirect and SOA fields remain excluded (see the OWNERSHIP RULE note
+ * on `ClassifyOwnershipInput`).
  */
 export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAssessment {
 	const { registration, candidateDomain } = input;
@@ -378,11 +404,11 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
-	// #864 — the in-bailiwick convergence arm needs only the seed APEX (like the
-	// NS in-bailiwick arm above), so it is computed here and may still yield a
-	// positive verdict under a degraded seed NS lookup; it is APPLIED only after
-	// the seed-side set-comparison arms below, which keep precedence.
-	const convergence = assessBailiwickConvergence(input, candidateDomain, seedApex);
+	// #864 — the seed-authorised convergence arm needs only the seed APEX (like
+	// the NS in-bailiwick arm above), so it is computed here and may still yield
+	// a positive verdict under a degraded seed NS lookup; it is APPLIED only
+	// after the seed-side set-comparison arms below, which keep precedence.
+	const convergence = assessSeedAuthorisedConvergence(input, candidateDomain, seedApex);
 
 	// #832 — degraded comparison inputs. The seed's NS lookup did not resolve,
 	// so every arm below would be comparing against an UNFETCHED set: the
@@ -435,9 +461,9 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 		};
 	}
 
-	// #864 — step 5b. Applied only once every seed-side arm has declined, so a
-	// strong NS match is never displaced by this medium-strength verdict. Also
-	// carries the `unmeasured` outcome for an asked-but-unanswered SOA probe.
+	// #864 — step 5b. Applied only once every seed-side NS arm has declined, so
+	// a strong NS match is never displaced by this medium-strength verdict. Also
+	// carries the `unmeasured` outcome for an asked-but-unanswered seed probe.
 	if (convergence !== null) return convergence;
 
 	if (candidateNs.length > 0) {
@@ -459,15 +485,16 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 
 /**
  * True when the candidate's RESOLVED real MX set is non-empty and EVERY
- * exchange sits at or under the seed apex — mail for the candidate is
- * delivered to the seed organisation's own mail hosts (#864). Exported so the
- * lookalike orchestrator can use the same predicate to gate the one extra SOA
- * lookup the convergence arm needs: the probe is issued only for candidates
- * that already satisfy this half, so a clean scan pays nothing.
+ * exchange sits at or under the seed apex (#864). This is the PRE-FILTER for
+ * step 5b and nothing more: a sending squatter can publish `MX 10 <seed's
+ * MX>` in a self-hosted zone for free and forfeits nothing it wanted, so the
+ * predicate carries no verdict weight. It exists so the seed-side probe is
+ * issued only for candidates that already look like the seed's own mail
+ * estate — a clean scan pays nothing.
  *
- * A single exchange OUTSIDE the seed apex disqualifies the whole set — a
- * squatter listing the seed's MX alongside their own would keep a working
- * receive channel, which is precisely what the conjunction is meant to cost.
+ * A single exchange OUTSIDE the seed apex disqualifies the set (a squatter
+ * listing the seed's MX alongside its own is not shaped like a same-entity
+ * domain at all).
  */
 export function mxRoutedIntoSeed(candidateMx: readonly string[] | undefined, seedDomain: string): boolean {
 	if (!candidateMx || candidateMx.length === 0) return false;
@@ -477,52 +504,79 @@ export function mxRoutedIntoSeed(candidateMx: readonly string[] | undefined, see
 }
 
 /**
- * Step 5b of `classifyOwnership()` — the #864 in-bailiwick convergence arm.
- * Returns `null` when the arm has nothing to say (inputs absent, or the
- * conjunction unmet), an `owned_by_seed` assessment when BOTH halves hold, or
- * an `unmeasured` assessment when the MX half holds but the SOA probe was
- * asked and rejected. Never returns `third_party`: declining is the caller's
- * job, from seed-side evidence.
+ * Extract the domain part of every `rua=` / `ruf=` `mailto:` destination in a
+ * DMARC record (RFC 7489 §6.3), lowercased, deduplicated, in order of first
+ * appearance. Size suffixes (`!10m`) and non-mailto URIs are dropped. Pure;
+ * exported for direct unit testing and for `probeDmarcReportAuthorisation()`.
  */
-function assessBailiwickConvergence(input: ClassifyOwnershipInput, candidateDomain: string, seedApex: string): OwnershipAssessment | null {
-	if (!mxRoutedIntoSeed(input.candidateMx, seedApex)) return null;
-	const mx = (input.candidateMx ?? []).map(normHost).filter(Boolean);
-
-	if (input.candidateSoa === undefined) {
-		// MX half holds but the caller never probed SOA: the arm cannot fire
-		// (never on one attacker-written record) and it is not a measurement
-		// gap either — nobody asked. Fall through to the seed-side outcome.
-		return null;
-	}
-	if (input.candidateSoa === null) {
-		if (input.candidateSoaUnresolved) {
-			return {
-				verdict: 'unmeasured',
-				strength: 'none',
-				signals: ['mx_in_bailiwick'],
-				rationale: `${candidateDomain} routes its mail to ${mx.join(', ')} inside ${seedApex}, but its SOA lookup did not resolve this run, so whether its zone is also mastered inside ${seedApex} could not be assessed. This is a measurement gap, not evidence of third-party registration — re-run to attribute.`,
-				evidence: mx.map((value) => ({ record: 'MX' as const, value, inSeedBailiwick: true })),
-			};
+export function parseDmarcReportReceivers(dmarcRecord: string): string[] {
+	const out: string[] = [];
+	for (const rawTag of dmarcRecord.split(';')) {
+		const eq = rawTag.indexOf('=');
+		if (eq === -1) continue;
+		const key = rawTag.slice(0, eq).trim().toLowerCase();
+		if (key !== 'rua' && key !== 'ruf') continue;
+		for (const uri of rawTag.slice(eq + 1).split(',')) {
+			const trimmed = uri.trim();
+			if (!/^mailto:/i.test(trimmed)) continue;
+			const mailbox = trimmed.slice('mailto:'.length).split('!')[0];
+			const at = mailbox.lastIndexOf('@');
+			if (at === -1) continue;
+			const domain = normHost(mailbox.slice(at + 1));
+			if (domain && !out.includes(domain)) out.push(domain);
 		}
-		return null;
 	}
+	return out;
+}
 
-	const mname = normHost(input.candidateSoa.mname);
-	const rname = normHost(input.candidateSoa.rname);
-	if (!mname || !isInBailiwick(mname, seedApex)) return null;
+/**
+ * Step 5b of `classifyOwnership()` — the #864 seed-authorised convergence
+ * arm. Returns `null` when the arm has nothing to say (pre-filter unmet,
+ * inputs absent, or no seed-published grant), an `owned_by_seed` assessment
+ * when the seed has published the per-domain RFC 7489 §7.1 authorisation, or
+ * an `unmeasured` assessment when the pre-filter held but the seed-side probe
+ * rejected. Never returns `third_party`: declining is the caller's job, from
+ * seed-side NS evidence.
+ */
+function assessSeedAuthorisedConvergence(
+	input: ClassifyOwnershipInput,
+	candidateDomain: string,
+	seedApex: string,
+): OwnershipAssessment | null {
+	if (!mxRoutedIntoSeed(input.candidateMx, seedApex)) return null;
+	const auth = input.dmarcReportAuthorisation;
+	if (auth === undefined) return null;
 
-	const evidence: OwnershipEvidence[] = [
-		...mx.map((value) => ({ record: 'MX' as const, value, inSeedBailiwick: true })),
-		{ record: 'SOA.MNAME', value: mname, inSeedBailiwick: true },
-	];
-	if (rname) evidence.push({ record: 'SOA.RNAME', value: rname, inSeedBailiwick: isInBailiwick(rname, seedApex) });
+	const mx = (input.candidateMx ?? []).map(normHost).filter(Boolean);
+	const mxEvidence: OwnershipEvidence[] = mx.map((value) => ({ record: 'MX' as const, value, inSeedBailiwick: true }));
+
+	if (auth.status === 'unresolved') {
+		return {
+			verdict: 'unmeasured',
+			strength: 'none',
+			signals: ['mx_in_bailiwick'],
+			rationale: `${candidateDomain} routes its mail to ${mx.join(', ')} inside ${seedApex}, but the lookup that would show whether ${seedApex} has authorised DMARC reporting for it did not resolve this run. This is a measurement gap, not evidence of third-party registration — re-run to attribute.`,
+			evidence: mxEvidence,
+		};
+	}
+	if (auth.status !== 'authorised' || !auth.receiverDomain || !auth.authorisationRecord) return null;
+
+	const receiver = normHost(auth.receiverDomain);
+	const record = normHost(auth.authorisationRecord);
+	// Defence in depth: the probe already filtered receivers to the seed apex,
+	// but the verdict must never rest on a grant published OUTSIDE it.
+	if (!isInBailiwick(receiver, seedApex) || !isInBailiwick(record, seedApex)) return null;
 
 	return {
 		verdict: 'owned_by_seed',
 		strength: 'medium',
-		signals: ['mx_in_bailiwick', 'soa_in_bailiwick'],
-		rationale: `${candidateDomain} routes its mail to ${mx.join(', ')} and its zone is mastered on ${mname} — both inside ${seedApex}'s own infrastructure. Two distinct operational dependencies point into the seed's zone; either record alone would not qualify.`,
-		evidence,
+		signals: ['mx_in_bailiwick', 'dmarc_report_authorised_by_seed'],
+		rationale: `${seedApex} has published a DMARC external-report authorisation for ${candidateDomain} (${record} = v=DMARC1, RFC 7489 §7.1) — a record only the owner of ${receiver} can create — and ${candidateDomain} routes its mail to ${mx.join(', ')} inside ${seedApex}.`,
+		evidence: [
+			...mxEvidence,
+			{ record: 'DMARC.RUA', value: receiver, inSeedBailiwick: true },
+			{ record: 'DMARC.REPORT_AUTHORISATION', value: record, inSeedBailiwick: true },
+		],
 	};
 }
 

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -44,12 +44,18 @@ import {
 	getParentDomain,
 	labelCount,
 	probeWithAdaptiveBatching,
+	queryCandidateSoa,
 	queryPrimaryMx,
 	queryPrimaryNs,
 	type LookalikeResult,
 } from './lookalike-dns';
 import { EMPTY_RDAP_PROBE, enrichLookalikes, probePrimaryRegistration } from './lookalike-enrichment';
-import { computeSameEntityCandidates, isBrandHeldRegistration, isSameEntityOrgMatch } from './lookalike-attribution';
+import {
+	computeSameEntityCandidates,
+	isBrandHeldRegistration,
+	isSameEntityOrgMatch,
+	refineOwnershipByBailiwickConvergence,
+} from './lookalike-attribution';
 import type { DefensiveReason } from '../lib/brand-defensive-registration';
 import {
 	applyOwnershipGate,
@@ -280,6 +286,23 @@ async function checkLookalikesCore(
 		unresolvedCount: nsUnresolved + probeUnresolved + infraUnknownCount,
 		complete: nsUnresolved + probeUnresolved + infraUnknownCount === 0,
 	};
+
+	// #864 — second attribution pass. The NS-only pass above cannot see a
+	// same-entity domain on a DIFFERENT DNS platform (amazon.com.au on amzndns.*
+	// vs amazon.com on Route 53 — #263's failure mode). For the few candidates
+	// whose real MX already routes into the seed apex, one bounded SOA probe
+	// lets `classifyOwnership()` step 5b decide the in-bailiwick conjunction.
+	// Runs BEFORE enrichment so a newly-owned candidate skips it like any other.
+	const bailiwick = await refineOwnershipByBailiwickConvergence({
+		seedDomain: domain,
+		seedNs: primaryNsList,
+		seedNsUnresolved: seedNsUnmeasured,
+		results,
+		nsByDomain: lookalikeNsMap,
+		ownershipByDomain,
+		isSharedNsHost,
+		querySoa: queryCandidateSoa,
+	});
 
 	// Enrichment (Defect L / issue #264): for each non-defensively-registered
 	// lookalike with mail or web infrastructure, gather corroborating signals
@@ -595,8 +618,9 @@ async function checkLookalikesCore(
 	// this, the withheld verdicts and suppressed threat observations from one
 	// throttled run would be served for the full TTL after DNS recovered — the
 	// non-answer outliving the condition that caused it. Same contract the
-	// timeout path in checkLookalikes() already honours.
-	if (seedNsUnmeasured) {
+	// timeout path in checkLookalikes() already honours. #864: a candidate whose
+	// SOA probe rejected mid-conjunction is the same transient shape.
+	if (seedNsUnmeasured || bailiwick.unmeasured.length > 0) {
 		result.partial = true;
 	}
 	return result;

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -44,7 +44,7 @@ import {
 	getParentDomain,
 	labelCount,
 	probeWithAdaptiveBatching,
-	queryCandidateSoa,
+	probeDmarcReportAuthorisation,
 	queryPrimaryMx,
 	queryPrimaryNs,
 	type LookalikeResult,
@@ -54,7 +54,7 @@ import {
 	computeSameEntityCandidates,
 	isBrandHeldRegistration,
 	isSameEntityOrgMatch,
-	refineOwnershipByBailiwickConvergence,
+	refineOwnershipBySeedAuthorisation,
 } from './lookalike-attribution';
 import type { DefensiveReason } from '../lib/brand-defensive-registration';
 import {
@@ -290,10 +290,12 @@ async function checkLookalikesCore(
 	// #864 — second attribution pass. The NS-only pass above cannot see a
 	// same-entity domain on a DIFFERENT DNS platform (amazon.com.au on amzndns.*
 	// vs amazon.com on Route 53 — #263's failure mode). For the few candidates
-	// whose real MX already routes into the seed apex, one bounded SOA probe
-	// lets `classifyOwnership()` step 5b decide the in-bailiwick conjunction.
-	// Runs BEFORE enrichment so a newly-owned candidate skips it like any other.
-	const bailiwick = await refineOwnershipByBailiwickConvergence({
+	// whose real MX already routes into the seed apex (a pre-filter with no
+	// verdict weight), a bounded SEED-side probe — the RFC 7489 §7.1 DMARC
+	// report authorisation only the seed can publish — lets `classifyOwnership()`
+	// step 5b decide. Runs BEFORE enrichment so a newly-owned candidate skips it
+	// like any other.
+	const seedAuthorisation = await refineOwnershipBySeedAuthorisation({
 		seedDomain: domain,
 		seedNs: primaryNsList,
 		seedNsUnresolved: seedNsUnmeasured,
@@ -301,7 +303,7 @@ async function checkLookalikesCore(
 		nsByDomain: lookalikeNsMap,
 		ownershipByDomain,
 		isSharedNsHost,
-		querySoa: queryCandidateSoa,
+		probeAuthorisation: probeDmarcReportAuthorisation,
 	});
 
 	// Enrichment (Defect L / issue #264): for each non-defensively-registered
@@ -619,8 +621,8 @@ async function checkLookalikesCore(
 	// throttled run would be served for the full TTL after DNS recovered — the
 	// non-answer outliving the condition that caused it. Same contract the
 	// timeout path in checkLookalikes() already honours. #864: a candidate whose
-	// SOA probe rejected mid-conjunction is the same transient shape.
-	if (seedNsUnmeasured || bailiwick.unmeasured.length > 0) {
+	// seed-side authorisation probe rejected is the same transient shape.
+	if (seedNsUnmeasured || seedAuthorisation.unmeasured.length > 0) {
 		result.partial = true;
 	}
 	return result;

--- a/src/tools/lookalike-attribution.ts
+++ b/src/tools/lookalike-attribution.ts
@@ -9,18 +9,18 @@
  * change). These are AXIS 1 (attribution) inputs only: nothing here may move a
  * threat severity, and — Ruling A — nothing here may produce an `owned_by_seed`
  * ownership verdict of its own. The ONE exception is
- * {@link refineOwnershipByBailiwickConvergence} (#864), which produces no
- * verdict itself either: it gathers the candidate-side MX + SOA inputs and
- * hands them to `classifyOwnership()`, whose step 5b is the single place the
- * bounded in-bailiwick conjunction is decided (see the amendment in
- * `src/lib/ownership-attribution.ts`'s file header).
+ * {@link refineOwnershipBySeedAuthorisation} (#864), which produces no
+ * verdict itself either: it gathers the MX pre-filter and the SEED-published
+ * DMARC report-authorisation result and hands them to `classifyOwnership()`,
+ * whose step 5b is the single place that conjunction is decided (see the
+ * amendment in `src/lib/ownership-attribution.ts`'s file header).
  */
 
 import { evaluateDefensiveRegistration, type DefensiveReason } from '../lib/brand-defensive-registration';
 import { mapConcurrent } from '../lib/map-concurrent';
-import { classifyOwnership, mxRoutedIntoSeed, type OwnershipAssessment } from '../lib/ownership-attribution';
+import { classifyOwnership, mxRoutedIntoSeed, type DmarcReportAuthorisation, type OwnershipAssessment } from '../lib/ownership-attribution';
 import { isRedactedRegistrantOrg } from './check-rdap-lookup';
-import { BAILIWICK_SOA_CONCURRENCY, type CandidateSoaResult, type LookalikeResult } from './lookalike-dns';
+import { SEED_AUTHORISATION_CONCURRENCY, type LookalikeResult } from './lookalike-dns';
 import type { LookalikeCorroborators } from './lookalike-enrichment';
 import { calibrateLookalikeSeverity, type LookalikeSeverity } from './lookalike-severity';
 
@@ -245,15 +245,15 @@ export function isBrandHeldRegistration(input: {
 }
 
 /**
- * Defensive ceiling on how many candidates the #864 convergence pass will
- * probe for SOA in one run. The MX precondition (every exchange inside the
- * seed apex) already makes the eligible set tiny on any real scan — a seed's
+ * Defensive ceiling on how many candidates the #864 seed-authorisation pass
+ * will probe in one run. The MX pre-filter (every exchange inside the seed
+ * apex) already makes the eligible set tiny on any real scan — a seed's
  * genuine regional domains, not its squatters — so this cap exists only so a
  * pathological candidate set can never widen the extra DNS fan-out unbounded.
  */
-export const BAILIWICK_REFINEMENT_CAP = 10;
+export const SEED_AUTHORISATION_CAP = 10;
 
-export interface BailiwickRefinementInput {
+export interface SeedAuthorisationRefinementInput {
 	seedDomain: string;
 	/** The seed's own resolved NS hostnames (empty when unresolved). */
 	seedNs: readonly string[];
@@ -266,20 +266,20 @@ export interface BailiwickRefinementInput {
 	/** The run's ownership map — updated IN PLACE for every probed candidate. */
 	ownershipByDomain: Map<string, OwnershipAssessment>;
 	isSharedNsHost: (nsHost: string) => boolean;
-	/** Injected SOA probe (`queryCandidateSoa` in production; a stub in tests). */
-	querySoa: (domain: string) => Promise<CandidateSoaResult>;
+	/** Injected seed-side probe (`probeDmarcReportAuthorisation` in production; a stub in tests). */
+	probeAuthorisation: (candidate: string, seedDomain: string) => Promise<DmarcReportAuthorisation>;
 }
 
-export interface BailiwickRefinementOutcome {
-	/** Candidates whose MX routed into the seed apex and were therefore SOA-probed. */
+export interface SeedAuthorisationRefinementOutcome {
+	/** Candidates whose MX routed into the seed apex and were therefore probed on the seed side. */
 	probed: string[];
 	/** Subset that came back `owned_by_seed` via step 5b. */
 	owned: string[];
 	/**
-	 * Subset whose SOA probe REJECTED, leaving the convergence question asked
-	 * but unanswered → `unmeasured` (#832's law). The orchestrator marks the
-	 * run `partial` when this is non-empty so the withheld verdict is not
-	 * cached for the full TTL after DNS recovers.
+	 * Subset whose seed-side probe REJECTED, leaving the question asked but
+	 * unanswered → `unmeasured` (#832's law). The orchestrator marks the run
+	 * `partial` when this is non-empty so the withheld verdict is not cached
+	 * for the full TTL after DNS recovers.
 	 */
 	unmeasured: string[];
 }
@@ -287,33 +287,37 @@ export interface BailiwickRefinementOutcome {
 /**
  * #864 — second attribution pass, run AFTER the Phase-2 A/MX probe and BEFORE
  * enrichment. The first pass (`classifyOwnership()` on NS evidence alone) is
- * blind to a same-entity domain on a different DNS platform; this pass gives
- * step 5b the two candidate-side records it needs, for the few candidates
- * that already satisfy the cheap half of the conjunction (MX routed into the
- * seed apex — {@link mxRoutedIntoSeed}, read from records Phase 2 already
- * fetched). Only THOSE candidates pay the one extra SOA lookup, through a
- * bounded pool, so a scan with no such candidate issues zero extra queries.
+ * blind to a same-entity domain on a different DNS platform; this pass asks
+ * the SEED whether it has authorised DMARC reporting for the candidate (RFC
+ * 7489 §7.1 — a record only the seed can publish), for the few candidates
+ * that pass the cheap pre-filter (MX routed into the seed apex —
+ * {@link mxRoutedIntoSeed}, read from records Phase 2 already fetched). Only
+ * THOSE candidates pay the extra lookups, through a bounded pool, so a scan
+ * with no such candidate issues zero extra queries.
  *
- * Candidates already `owned_by_seed` from seed-side evidence are skipped —
+ * Candidates already `owned_by_seed` from seed-side NS evidence are skipped —
  * a strong verdict is never re-derived as a medium one — and every other
  * verdict is recomputed by `classifyOwnership()` itself, so the precedence
  * table stays the single decision surface (this function decides nothing).
  */
-export async function refineOwnershipByBailiwickConvergence(input: BailiwickRefinementInput): Promise<BailiwickRefinementOutcome> {
-	const outcome: BailiwickRefinementOutcome = { probed: [], owned: [], unmeasured: [] };
+export async function refineOwnershipBySeedAuthorisation(
+	input: SeedAuthorisationRefinementInput,
+): Promise<SeedAuthorisationRefinementOutcome> {
+	const outcome: SeedAuthorisationRefinementOutcome = { probed: [], owned: [], unmeasured: [] };
 	const eligible = input.results
 		.filter((result) => {
 			if (input.ownershipByDomain.get(result.domain)?.verdict === 'owned_by_seed') return false;
 			if (!result.hasMX) return false;
 			return mxRoutedIntoSeed(result.mxExchanges, input.seedDomain);
 		})
-		.slice(0, BAILIWICK_REFINEMENT_CAP);
+		.slice(0, SEED_AUTHORISATION_CAP);
 	if (eligible.length === 0) return outcome;
 
-	const soaResults = await mapConcurrent(eligible, BAILIWICK_SOA_CONCURRENCY, (result) => input.querySoa(result.domain));
+	const authorisations = await mapConcurrent(eligible, SEED_AUTHORISATION_CONCURRENCY, (result) =>
+		input.probeAuthorisation(result.domain, input.seedDomain),
+	);
 
 	eligible.forEach((result, index) => {
-		const soa = soaResults[index];
 		const candidateNs = Array.from(input.nsByDomain.get(result.domain) ?? []);
 		const assessment = classifyOwnership({
 			seedDomain: input.seedDomain,
@@ -323,8 +327,7 @@ export async function refineOwnershipByBailiwickConvergence(input: BailiwickRefi
 			isSharedNsHost: input.isSharedNsHost,
 			seedNsUnresolved: input.seedNsUnresolved,
 			candidateMx: result.mxExchanges,
-			candidateSoa: soa.soa,
-			candidateSoaUnresolved: !soa.resolved,
+			dmarcReportAuthorisation: authorisations[index],
 		});
 		input.ownershipByDomain.set(result.domain, assessment);
 		outcome.probed.push(result.domain);

--- a/src/tools/lookalike-attribution.ts
+++ b/src/tools/lookalike-attribution.ts
@@ -8,14 +8,19 @@
  * Extracted VERBATIM from `check-lookalikes.ts` (pure split, no behaviour
  * change). These are AXIS 1 (attribution) inputs only: nothing here may move a
  * threat severity, and — Ruling A — nothing here may produce an `owned_by_seed`
- * ownership verdict, which stays driven by seed-side nameserver evidence in
- * `classifyOwnership()` alone.
+ * ownership verdict of its own. The ONE exception is
+ * {@link refineOwnershipByBailiwickConvergence} (#864), which produces no
+ * verdict itself either: it gathers the candidate-side MX + SOA inputs and
+ * hands them to `classifyOwnership()`, whose step 5b is the single place the
+ * bounded in-bailiwick conjunction is decided (see the amendment in
+ * `src/lib/ownership-attribution.ts`'s file header).
  */
 
 import { evaluateDefensiveRegistration, type DefensiveReason } from '../lib/brand-defensive-registration';
-import type { OwnershipAssessment } from '../lib/ownership-attribution';
+import { mapConcurrent } from '../lib/map-concurrent';
+import { classifyOwnership, mxRoutedIntoSeed, type OwnershipAssessment } from '../lib/ownership-attribution';
 import { isRedactedRegistrantOrg } from './check-rdap-lookup';
-import type { LookalikeResult } from './lookalike-dns';
+import { BAILIWICK_SOA_CONCURRENCY, type CandidateSoaResult, type LookalikeResult } from './lookalike-dns';
 import type { LookalikeCorroborators } from './lookalike-enrichment';
 import { calibrateLookalikeSeverity, type LookalikeSeverity } from './lookalike-severity';
 
@@ -237,4 +242,99 @@ export function isBrandHeldRegistration(input: {
 	});
 	if (!shape.defensive || shape.reason === undefined) return { brandHeld: false };
 	return { brandHeld: true, registrarIanaId: candidateRegistrarIanaId, reason: shape.reason };
+}
+
+/**
+ * Defensive ceiling on how many candidates the #864 convergence pass will
+ * probe for SOA in one run. The MX precondition (every exchange inside the
+ * seed apex) already makes the eligible set tiny on any real scan — a seed's
+ * genuine regional domains, not its squatters — so this cap exists only so a
+ * pathological candidate set can never widen the extra DNS fan-out unbounded.
+ */
+export const BAILIWICK_REFINEMENT_CAP = 10;
+
+export interface BailiwickRefinementInput {
+	seedDomain: string;
+	/** The seed's own resolved NS hostnames (empty when unresolved). */
+	seedNs: readonly string[];
+	/** #832 — true when the seed's NS lookup rejected. */
+	seedNsUnresolved: boolean;
+	/** Phase-2 probe results (carry the resolved real MX exchanges). */
+	results: readonly LookalikeResult[];
+	/** Phase-1 NS answer sets, keyed by candidate. */
+	nsByDomain: ReadonlyMap<string, ReadonlySet<string>>;
+	/** The run's ownership map — updated IN PLACE for every probed candidate. */
+	ownershipByDomain: Map<string, OwnershipAssessment>;
+	isSharedNsHost: (nsHost: string) => boolean;
+	/** Injected SOA probe (`queryCandidateSoa` in production; a stub in tests). */
+	querySoa: (domain: string) => Promise<CandidateSoaResult>;
+}
+
+export interface BailiwickRefinementOutcome {
+	/** Candidates whose MX routed into the seed apex and were therefore SOA-probed. */
+	probed: string[];
+	/** Subset that came back `owned_by_seed` via step 5b. */
+	owned: string[];
+	/**
+	 * Subset whose SOA probe REJECTED, leaving the convergence question asked
+	 * but unanswered → `unmeasured` (#832's law). The orchestrator marks the
+	 * run `partial` when this is non-empty so the withheld verdict is not
+	 * cached for the full TTL after DNS recovers.
+	 */
+	unmeasured: string[];
+}
+
+/**
+ * #864 — second attribution pass, run AFTER the Phase-2 A/MX probe and BEFORE
+ * enrichment. The first pass (`classifyOwnership()` on NS evidence alone) is
+ * blind to a same-entity domain on a different DNS platform; this pass gives
+ * step 5b the two candidate-side records it needs, for the few candidates
+ * that already satisfy the cheap half of the conjunction (MX routed into the
+ * seed apex — {@link mxRoutedIntoSeed}, read from records Phase 2 already
+ * fetched). Only THOSE candidates pay the one extra SOA lookup, through a
+ * bounded pool, so a scan with no such candidate issues zero extra queries.
+ *
+ * Candidates already `owned_by_seed` from seed-side evidence are skipped —
+ * a strong verdict is never re-derived as a medium one — and every other
+ * verdict is recomputed by `classifyOwnership()` itself, so the precedence
+ * table stays the single decision surface (this function decides nothing).
+ */
+export async function refineOwnershipByBailiwickConvergence(input: BailiwickRefinementInput): Promise<BailiwickRefinementOutcome> {
+	const outcome: BailiwickRefinementOutcome = { probed: [], owned: [], unmeasured: [] };
+	const eligible = input.results
+		.filter((result) => {
+			if (input.ownershipByDomain.get(result.domain)?.verdict === 'owned_by_seed') return false;
+			if (!result.hasMX) return false;
+			return mxRoutedIntoSeed(result.mxExchanges, input.seedDomain);
+		})
+		.slice(0, BAILIWICK_REFINEMENT_CAP);
+	if (eligible.length === 0) return outcome;
+
+	const soaResults = await mapConcurrent(eligible, BAILIWICK_SOA_CONCURRENCY, (result) => input.querySoa(result.domain));
+
+	eligible.forEach((result, index) => {
+		const soa = soaResults[index];
+		const candidateNs = Array.from(input.nsByDomain.get(result.domain) ?? []);
+		const assessment = classifyOwnership({
+			seedDomain: input.seedDomain,
+			seedNs: [...input.seedNs],
+			candidateDomain: result.domain,
+			registration: { state: 'registered', ns: candidateNs, evidence: candidateNs.length > 0 ? ['ns'] : ['a'] },
+			isSharedNsHost: input.isSharedNsHost,
+			seedNsUnresolved: input.seedNsUnresolved,
+			candidateMx: result.mxExchanges,
+			candidateSoa: soa.soa,
+			candidateSoaUnresolved: !soa.resolved,
+		});
+		input.ownershipByDomain.set(result.domain, assessment);
+		outcome.probed.push(result.domain);
+		if (assessment.verdict === 'owned_by_seed') {
+			outcome.owned.push(result.domain);
+		} else if (assessment.verdict === 'unmeasured' && assessment.signals.includes('mx_in_bailiwick')) {
+			// Signal-tagged so a seed-NS-caused `unmeasured` (already accounted for
+			// by the #832 run-level notice) is not double-counted here.
+			outcome.unmeasured.push(result.domain);
+		}
+	});
+	return outcome;
 }

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -17,9 +17,10 @@
  * re-export.
  */
 
-import { queryDnsRecords, queryMxRecords } from '../lib/dns';
+import { queryDnsRecords, queryMxRecords, queryTxtRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
-import type { SoaAuthority } from '../lib/ownership-attribution';
+import { isInBailiwick, parseDmarcReportReceivers, type DmarcReportAuthorisation } from '../lib/ownership-attribution';
+import { getRegistrableDomain } from '../lib/public-suffix';
 
 /** Default and minimum batch sizes for adaptive batching */
 export const INITIAL_BATCH_SIZE = 10;
@@ -230,49 +231,83 @@ export async function queryPrimaryNs(domain: string): Promise<PrimaryNsResult> {
 }
 
 /**
- * #864 — bounded pool for the per-candidate SOA probe behind the in-bailiwick
- * convergence arm (`classifyOwnership()` step 5b). The probe is gated to
- * candidates whose MX already routes into the seed apex, so the eligible set
- * is tiny on any real scan; the pool is a ceiling, not a throughput target.
- * Sized well under the adaptive-batching A/MX probe's INITIAL_BATCH_SIZE so
- * it can never out-fan the pass it follows.
+ * #864 — bounded pool for the per-candidate seed-side authorisation probe
+ * behind `classifyOwnership()` step 5b. The probe is gated to candidates whose
+ * MX already routes into the seed apex, so the eligible set is tiny on any
+ * real scan; the pool is a ceiling, not a throughput target. Sized well under
+ * the adaptive-batching A/MX probe's INITIAL_BATCH_SIZE so it can never
+ * out-fan the pass it follows.
  */
-export const BAILIWICK_SOA_CONCURRENCY = 3;
+export const SEED_AUTHORISATION_CONCURRENCY = 3;
 
-/** Result of the #864 candidate SOA probe: the parsed authority fields plus whether the lookup actually resolved. */
-export interface CandidateSoaResult {
-	/** `null` when no SOA answered OR the lookup rejected — `resolved` tells the two apart. */
-	soa: SoaAuthority | null;
-	/**
-	 * False when the SOA query REJECTED (timeout / throttling). Load-bearing
-	 * for the same reason as `PrimaryNsResult.resolved` (#832): an absent SOA
-	 * from a FAILED lookup is unfetched, not measured, and the attribution
-	 * layer must say `unmeasured` rather than the contrary `third_party`.
-	 */
-	resolved: boolean;
-}
+/** Cap on distinct in-seed report receivers checked per candidate (each costs one authorisation lookup + one canary). */
+export const MAX_SEED_REPORT_RECEIVERS = 2;
 
 /**
- * Query the candidate's SOA record (#864) and return its MNAME / RNAME,
- * lowercased with trailing dots stripped. Uses the lean Phase-1 preset: this
- * is one disposable candidate probe, not a seed-side query — losing it costs
- * an `unmeasured` verdict for that candidate this run, never a wrong one.
+ * #864 — seed-side probe: does the seed publish the RFC 7489 §7.1 external-
+ * destination authorisation for this candidate's DMARC reports?
+ *
+ *  1. `_dmarc.<candidate>` TXT (candidate-published, free to forge — this only
+ *     tells us WHERE to look on the seed side).
+ *  2. For each `rua`/`ruf` mailbox domain inside the seed apex (at most
+ *     {@link MAX_SEED_REPORT_RECEIVERS}): `<candidate>._report._dmarc.<receiver>`
+ *     TXT must carry `v=DMARC1`. That record lives in the RECEIVER's zone —
+ *     under the seed apex — and only its owner can publish it.
+ *  3. A canary label under the same `_report._dmarc` distinguishes a
+ *     per-domain grant from a wildcard (`*._report._dmarc.<receiver>`), which
+ *     authorises reports about ANY domain and is therefore evidence-only.
+ *
+ * Uses the lean Phase-1 preset: these are disposable candidate probes, not
+ * seed-side queries — a rejected lookup costs an `unmeasured` verdict for that
+ * candidate this run (#832's law), never a wrong one. NXDOMAIN / empty answers
+ * are MEASURED absences (the DoH layer never throws on an rcode); only a
+ * timeout / abort / transport failure is `unresolved`.
  */
-export async function queryCandidateSoa(domain: string): Promise<CandidateSoaResult> {
+export async function probeDmarcReportAuthorisation(candidate: string, seedDomain: string): Promise<DmarcReportAuthorisation> {
+	const normalisedSeed = seedDomain.trim().toLowerCase().replace(/\.$/, '');
+	const seedApex = getRegistrableDomain(normalisedSeed) ?? normalisedSeed;
+
+	let dmarcRecords: string[];
 	try {
-		const records = await queryDnsRecords(domain, 'SOA', PHASE1_DNS_OPTS);
-		const first = records[0];
-		if (!first) return { soa: null, resolved: true };
-		// Presentation format: "<mname> <rname> <serial> <refresh> <retry> <expire> <minimum>".
-		const [mname, rname] = first.trim().split(/\s+/);
-		if (!mname || !rname) return { soa: null, resolved: true };
-		return {
-			soa: { mname: mname.toLowerCase().replace(/\.$/, ''), rname: rname.toLowerCase().replace(/\.$/, '') },
-			resolved: true,
-		};
+		dmarcRecords = await queryTxtRecords(`_dmarc.${candidate}`, PHASE1_DNS_OPTS);
 	} catch {
-		return { soa: null, resolved: false };
+		return { status: 'unresolved', seedReceivers: [] };
 	}
+	const dmarc = dmarcRecords.find((r) => /^\s*v=DMARC1\b/i.test(r));
+	if (!dmarc) return { status: 'no_seed_receiver', seedReceivers: [] };
+
+	const seedReceivers = parseDmarcReportReceivers(dmarc)
+		.filter((receiver) => isInBailiwick(receiver, seedApex))
+		.slice(0, MAX_SEED_REPORT_RECEIVERS);
+	if (seedReceivers.length === 0) return { status: 'no_seed_receiver', seedReceivers };
+
+	let sawWildcard: string | undefined;
+	for (const receiver of seedReceivers) {
+		const authorisationRecord = `${candidate}._report._dmarc.${receiver}`;
+		let grant: string[];
+		try {
+			grant = await queryTxtRecords(authorisationRecord, PHASE1_DNS_OPTS);
+		} catch {
+			return { status: 'unresolved', seedReceivers };
+		}
+		if (!grant.some((r) => /^\s*v=DMARC1\b/i.test(r))) continue;
+
+		// A grant answered — is it specific to this candidate, or a wildcard?
+		let canary: string[];
+		try {
+			canary = await queryTxtRecords(`${WILDCARD_CANARY_LABEL}._report._dmarc.${receiver}`, PHASE1_DNS_OPTS);
+		} catch {
+			// Cannot tell per-domain from wildcard: nothing was measured.
+			return { status: 'unresolved', seedReceivers };
+		}
+		if (canary.some((r) => /^\s*v=DMARC1\b/i.test(r))) {
+			sawWildcard = receiver;
+			continue;
+		}
+		return { status: 'authorised', seedReceivers, receiverDomain: receiver, authorisationRecord };
+	}
+	if (sawWildcard !== undefined) return { status: 'wildcard', seedReceivers, receiverDomain: sawWildcard };
+	return { status: 'not_authorised', seedReceivers };
 }
 
 /**

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -19,6 +19,7 @@
 
 import { queryDnsRecords, queryMxRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
+import type { SoaAuthority } from '../lib/ownership-attribution';
 
 /** Default and minimum batch sizes for adaptive batching */
 export const INITIAL_BATCH_SIZE = 10;
@@ -225,6 +226,52 @@ export async function queryPrimaryNs(domain: string): Promise<PrimaryNsResult> {
 		return { ns: normalizeNsSet(ns), resolved: true };
 	} catch {
 		return { ns: new Set<string>(), resolved: false };
+	}
+}
+
+/**
+ * #864 — bounded pool for the per-candidate SOA probe behind the in-bailiwick
+ * convergence arm (`classifyOwnership()` step 5b). The probe is gated to
+ * candidates whose MX already routes into the seed apex, so the eligible set
+ * is tiny on any real scan; the pool is a ceiling, not a throughput target.
+ * Sized well under the adaptive-batching A/MX probe's INITIAL_BATCH_SIZE so
+ * it can never out-fan the pass it follows.
+ */
+export const BAILIWICK_SOA_CONCURRENCY = 3;
+
+/** Result of the #864 candidate SOA probe: the parsed authority fields plus whether the lookup actually resolved. */
+export interface CandidateSoaResult {
+	/** `null` when no SOA answered OR the lookup rejected — `resolved` tells the two apart. */
+	soa: SoaAuthority | null;
+	/**
+	 * False when the SOA query REJECTED (timeout / throttling). Load-bearing
+	 * for the same reason as `PrimaryNsResult.resolved` (#832): an absent SOA
+	 * from a FAILED lookup is unfetched, not measured, and the attribution
+	 * layer must say `unmeasured` rather than the contrary `third_party`.
+	 */
+	resolved: boolean;
+}
+
+/**
+ * Query the candidate's SOA record (#864) and return its MNAME / RNAME,
+ * lowercased with trailing dots stripped. Uses the lean Phase-1 preset: this
+ * is one disposable candidate probe, not a seed-side query — losing it costs
+ * an `unmeasured` verdict for that candidate this run, never a wrong one.
+ */
+export async function queryCandidateSoa(domain: string): Promise<CandidateSoaResult> {
+	try {
+		const records = await queryDnsRecords(domain, 'SOA', PHASE1_DNS_OPTS);
+		const first = records[0];
+		if (!first) return { soa: null, resolved: true };
+		// Presentation format: "<mname> <rname> <serial> <refresh> <retry> <expire> <minimum>".
+		const [mname, rname] = first.trim().split(/\s+/);
+		if (!mname || !rname) return { soa: null, resolved: true };
+		return {
+			soa: { mname: mname.toLowerCase().replace(/\.$/, ''), rname: rname.toLowerCase().replace(/\.$/, '') },
+			resolved: true,
+		};
+	} catch {
+		return { soa: null, resolved: false };
 	}
 }
 

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -257,11 +257,15 @@ export const MAX_SEED_REPORT_RECEIVERS = 2;
  *     per-domain grant from a wildcard (`*._report._dmarc.<receiver>`), which
  *     authorises reports about ANY domain and is therefore evidence-only.
  *
- * Uses the lean Phase-1 preset: these are disposable candidate probes, not
- * seed-side queries — a rejected lookup costs an `unmeasured` verdict for that
- * candidate this run (#832's law), never a wrong one. NXDOMAIN / empty answers
- * are MEASURED absences (the DoH layer never throws on an rcode); only a
- * timeout / abort / transport failure is `unresolved`.
+ * Uses the lean Phase-1 preset. Failure semantics are ASYMMETRIC by design
+ * (PR #897 re-review, High): stage 1 queries the CANDIDATE's zone, which the
+ * attacker controls end to end — a squatter who copies the seed MX and then
+ * blackholes its own `_dmarc` must not be rewarded with an `unmeasured` that
+ * withholds its threat finding, so that failure is `candidate_unresolved`, a
+ * DECLINE. Only stages 2–3 (the grant and its canary, both in the SEED's
+ * zone) may yield `unresolved` → `unmeasured` (#832's law). NXDOMAIN / empty
+ * answers are MEASURED absences (the DoH layer never throws on an rcode);
+ * only a timeout / abort / transport failure is a rejection.
  */
 export async function probeDmarcReportAuthorisation(candidate: string, seedDomain: string): Promise<DmarcReportAuthorisation> {
 	const normalisedSeed = seedDomain.trim().toLowerCase().replace(/\.$/, '');
@@ -271,7 +275,8 @@ export async function probeDmarcReportAuthorisation(candidate: string, seedDomai
 	try {
 		dmarcRecords = await queryTxtRecords(`_dmarc.${candidate}`, PHASE1_DNS_OPTS);
 	} catch {
-		return { status: 'unresolved', seedReceivers: [] };
+		// Attacker-controlled zone failed to answer: decline, never a measurement gap.
+		return { status: 'candidate_unresolved', seedReceivers: [] };
 	}
 	const dmarc = dmarcRecords.find((r) => /^\s*v=DMARC1\b/i.test(r));
 	if (!dmarc) return { status: 'no_seed_receiver', seedReceivers: [] };

--- a/src/tools/lookalike-findings.ts
+++ b/src/tools/lookalike-findings.ts
@@ -53,7 +53,12 @@
  */
 
 import type { DefensiveReason } from '../lib/brand-defensive-registration';
-import { buildNonOwnedGateFinding, capAttributionSeverity, type OwnershipAssessment } from '../lib/ownership-attribution';
+import {
+	attributionConfidence,
+	buildNonOwnedGateFinding,
+	capAttributionSeverity,
+	type OwnershipAssessment,
+} from '../lib/ownership-attribution';
 import type { Finding } from '../lib/scoring';
 import { createFinding } from '../lib/scoring';
 import type { LookalikeResult } from './lookalike-dns';
@@ -109,6 +114,13 @@ export function buildOwnedBySeedFinding(result: LookalikeResult, seedDomain: str
 			hasA: result.hasA,
 			hasMX: result.hasMX,
 			ownershipVerdict: ownership.verdict,
+			// #864 — name the signal and its strength so a consumer can tell a
+			// strong seed-side NS match from the medium in-bailiwick conjunction,
+			// and audit the exact records the latter rested on.
+			ownershipStrength: ownership.strength,
+			ownershipSignals: ownership.signals,
+			attributionConfidence: attributionConfidence(ownership.verdict, '', true),
+			...(ownership.evidence ? { ownershipEvidence: ownership.evidence } : {}),
 			findingAxis: 'attribution' satisfies LookalikeFindingAxis,
 		},
 	);

--- a/test/check-lookalikes-multi-platform-ownership.spec.ts
+++ b/test/check-lookalikes-multi-platform-ownership.spec.ts
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * #864 (regression of #263) — a same-entity domain on a DIFFERENT DNS platform
+ * must not be counted as an impersonation-capable third party.
+ *
+ * Every fixture below is transcribed from live DoH / RDAP answers observed
+ * 2026-09-04 (`dns.google/resolve`, `rdap.verisign.com`, `rdap.cctld.au`):
+ *
+ *   amazon.com     NS  ns-{521,264,1707,1447}.awsdns-*             (Route 53)
+ *                  MX  5 amazon-smtp.amazon.com
+ *   amazon.com.au  NS  ns{1,2}.amzndns.{com,co.uk,net,org}         (Amazon internal)
+ *                  MX  10 amazon-smtp.amazon.com                    ← seed's own MX host
+ *                  SOA dns-external-master.amazon.com. root.amazon.com. …
+ *                  RDAP (auDA): NO registrant entity — registrar only
+ *   amazon.com     RDAP (Verisign): thin — registrar only, no registrant
+ *
+ *   xero.com       NS  ns-*.awsdns-*  MX Google  SOA awsdns-hostmaster.amazon.com
+ *   xero.co.nz     NS  a*.akam.net    MX Google  SOA a5-67.akam.net. hostmaster.akamai.com.
+ *
+ * So for the Amazon pair NEITHER the shared-NS arms NOR the #263 RDAP
+ * registrant tier can fire; the only observable link is that the candidate's
+ * mail AND its zone master both sit inside the seed apex. That conjunction is
+ * `classifyOwnership()` step 5b — see the 2026-09-04 amendment in
+ * `src/lib/ownership-attribution.ts`. For the Xero pair NO in-bailiwick record
+ * exists (mail at Google, zone at Akamai), so the new arm must decline and
+ * the pair keeps #263's registrant-org lane as its only link.
+ *
+ * Sibling specs own the other attribution lanes: `check-lookalikes.spec.ts`
+ * (#263 RDAP lane, three-axis invariants), `check-lookalikes-degraded-
+ * attribution.spec.ts` (#832 `unmeasured`), `ownership-attribution.spec.ts`
+ * (seed-side NS arms).
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+import { isSharedNsHost } from '../src/tenants/discovery/shared-ns-hosts';
+import type { RegistrationState } from '../src/lib/registration-state';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+// ---------------------------------------------------------------------------
+// Live-transcribed records (2026-09-04)
+// ---------------------------------------------------------------------------
+
+const AMAZON_SEED_NS = ['ns-521.awsdns-01.net', 'ns-264.awsdns-33.com', 'ns-1707.awsdns-21.co.uk', 'ns-1447.awsdns-52.org'];
+const AMAZON_AU_NS = [
+	'ns1.amzndns.co.uk',
+	'ns2.amzndns.co.uk',
+	'ns1.amzndns.org',
+	'ns2.amzndns.com',
+	'ns1.amzndns.com',
+	'ns1.amzndns.net',
+	'ns2.amzndns.org',
+	'ns2.amzndns.net',
+];
+const AMAZON_MX_HOST = 'amazon-smtp.amazon.com';
+const AMAZON_AU_SOA = { mname: 'dns-external-master.amazon.com', rname: 'root.amazon.com' };
+/** What EVERY Route 53 zone's templated SOA looks like — RNAME lands inside amazon.com for unrelated tenants. */
+const ROUTE53_TEMPLATED_SOA = { mname: 'ns-100.awsdns-12.com', rname: 'awsdns-hostmaster.amazon.com' };
+
+const XERO_SEED_NS = ['ns-1911.awsdns-46.co.uk', 'ns-1391.awsdns-45.org', 'ns-983.awsdns-58.net', 'ns-90.awsdns-11.com'];
+const XERO_NZ_NS = ['a13-64.akam.net', 'a1-170.akam.net', 'a28-66.akam.net', 'a5-67.akam.net', 'a10-67.akam.net', 'a14-65.akam.net'];
+const GOOGLE_MX = [
+	'aspmx.l.google.com',
+	'alt1.aspmx.l.google.com',
+	'alt2.aspmx.l.google.com',
+	'aspmx2.googlemail.com',
+	'aspmx3.googlemail.com',
+];
+const XERO_NZ_SOA = { mname: 'a5-67.akam.net', rname: 'hostmaster.akamai.com' };
+
+function registered(ns: string[]): RegistrationState {
+	return { state: 'registered', ns, evidence: ['ns'] };
+}
+
+async function loadAttribution() {
+	return import('../src/lib/ownership-attribution');
+}
+
+// ---------------------------------------------------------------------------
+// Unit — classifyOwnership() step 5b
+// ---------------------------------------------------------------------------
+
+describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.au records)', () => {
+	it('attributes amazon.com.au to amazon.com: MX and SOA MNAME both inside the seed apex, no shared NS', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amazon.com.au',
+			registration: registered(AMAZON_AU_NS),
+			isSharedNsHost,
+			candidateMx: [AMAZON_MX_HOST],
+			candidateSoa: AMAZON_AU_SOA,
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('medium');
+		expect(result.signals).toEqual(['mx_in_bailiwick', 'soa_in_bailiwick']);
+		expect(result.rationale).toContain('amazon-smtp.amazon.com');
+		expect(result.rationale).toContain('dns-external-master.amazon.com');
+		// Evidence names every record the verdict rests on, so a consumer can audit it.
+		expect(result.evidence).toEqual([
+			{ record: 'MX', value: 'amazon-smtp.amazon.com', inSeedBailiwick: true },
+			{ record: 'SOA.MNAME', value: 'dns-external-master.amazon.com', inSeedBailiwick: true },
+			{ record: 'SOA.RNAME', value: 'root.amazon.com', inSeedBailiwick: true },
+		]);
+	});
+
+	it('control: the same candidate WITHOUT the new inputs is still third_party (the pre-#864 verdict)', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amazon.com.au',
+			registration: registered(AMAZON_AU_NS),
+			isSharedNsHost,
+		});
+		expect(result.verdict).toBe('third_party');
+		expect(result.signals).toEqual(['distinct_infrastructure']);
+	});
+
+	it('NEGATIVE — MX alone never qualifies: a squatter copying the seed MX string stays third_party', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		for (const soa of [undefined, null] as const) {
+			const result = classifyOwnership({
+				seedDomain: 'amazon.com',
+				seedNs: AMAZON_SEED_NS,
+				candidateDomain: 'amaz0n.com',
+				registration: registered(['ns1.attacker-dns.net', 'ns2.attacker-dns.net']),
+				isSharedNsHost,
+				candidateMx: [AMAZON_MX_HOST],
+				candidateSoa: soa,
+				candidateSoaUnresolved: false,
+			});
+			expect(result.verdict, `candidateSoa=${String(soa)}`).toBe('third_party');
+			expect(result.evidence).toBeUndefined();
+		}
+	});
+
+	it('NEGATIVE — SOA RNAME is never verdict-bearing: a Route 53 squatter (templated RNAME inside amazon.com) copying the seed MX stays third_party', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amaz0n.com',
+			registration: registered(['ns-100.awsdns-12.com', 'ns-600.awsdns-11.net', 'ns-1200.awsdns-22.org', 'ns-1800.awsdns-33.co.uk']),
+			isSharedNsHost,
+			candidateMx: [AMAZON_MX_HOST],
+			candidateSoa: ROUTE53_TEMPLATED_SOA,
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('third_party');
+	});
+
+	it('NEGATIVE — SOA MNAME alone never qualifies: zone mastered inside the seed but mail elsewhere stays third_party', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amaz0n.com',
+			registration: registered(['ns1.attacker-dns.net']),
+			isSharedNsHost,
+			candidateMx: ['mail.attacker-dns.net'],
+			candidateSoa: AMAZON_AU_SOA,
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('third_party');
+	});
+
+	it('NEGATIVE — a single MX outside the seed apex disqualifies the whole set (keeping a receive channel is the cost)', async () => {
+		const { classifyOwnership, mxRoutedIntoSeed } = await loadAttribution();
+		expect(mxRoutedIntoSeed([AMAZON_MX_HOST, 'mx.attacker-dns.net'], 'amazon.com')).toBe(false);
+		expect(mxRoutedIntoSeed([], 'amazon.com')).toBe(false);
+		expect(mxRoutedIntoSeed(undefined, 'amazon.com')).toBe(false);
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amaz0n.com',
+			registration: registered(['ns1.attacker-dns.net']),
+			isSharedNsHost,
+			candidateMx: [AMAZON_MX_HOST, 'mx.attacker-dns.net'],
+			candidateSoa: AMAZON_AU_SOA,
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('third_party');
+	});
+
+	it('NEGATIVE — bailiwick is label-bounded: hosts that merely END with the seed string do not count', async () => {
+		const { classifyOwnership, mxRoutedIntoSeed } = await loadAttribution();
+		expect(mxRoutedIntoSeed(['smtp.notamazon.com'], 'amazon.com')).toBe(false);
+		expect(mxRoutedIntoSeed(['amazon-smtp.amazon.com.attacker.net'], 'amazon.com')).toBe(false);
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amaz0n.com',
+			registration: registered(['ns1.amazon.com.attacker.net']),
+			isSharedNsHost,
+			candidateMx: ['smtp.notamazon.com'],
+			candidateSoa: { mname: 'master.notamazon.com', rname: 'root.notamazon.com' },
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('third_party');
+	});
+
+	it('#832 law — MX routed into the seed but the SOA probe REJECTED → unmeasured, never the contrary third_party', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amazon.com.au',
+			registration: registered(AMAZON_AU_NS),
+			isSharedNsHost,
+			candidateMx: [AMAZON_MX_HOST],
+			candidateSoa: null,
+			candidateSoaUnresolved: true,
+		});
+		expect(result.verdict).toBe('unmeasured');
+		expect(result.signals).toEqual(['mx_in_bailiwick']);
+		expect(result.rationale).toContain('measurement gap');
+		expect(result.rationale).not.toContain('no ownership signal links it');
+	});
+
+	it('a RESOLVED empty SOA (probed, nothing answered) is not a measurement gap — falls through to third_party', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amazon.com.au',
+			registration: registered(AMAZON_AU_NS),
+			isSharedNsHost,
+			candidateMx: [AMAZON_MX_HOST],
+			candidateSoa: null,
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('third_party');
+	});
+
+	it('fires under a degraded SEED NS lookup too — it needs only the seed apex, like the NS in-bailiwick arm (#832 parity)', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: [],
+			seedNsUnresolved: true,
+			candidateDomain: 'amazon.com.au',
+			registration: registered(AMAZON_AU_NS),
+			isSharedNsHost,
+			candidateMx: [AMAZON_MX_HOST],
+			candidateSoa: AMAZON_AU_SOA,
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.signals).toEqual(['mx_in_bailiwick', 'soa_in_bailiwick']);
+	});
+
+	it('seed-side arms keep precedence: a full dedicated NS match is reported as strong ns_set_match, not displaced by the medium conjunction', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'amazon.com',
+			seedNs: AMAZON_SEED_NS,
+			candidateDomain: 'amazon.net',
+			registration: registered(AMAZON_SEED_NS),
+			isSharedNsHost,
+			candidateMx: [AMAZON_MX_HOST],
+			candidateSoa: AMAZON_AU_SOA,
+			candidateSoaUnresolved: false,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('strong');
+		expect(result.signals).toEqual(['ns_set_match']);
+	});
+
+	it('xero.co.nz (#263 shape): mail at Google and zone at Akamai — no in-bailiwick record, so the new arm declines', async () => {
+		const { classifyOwnership, mxRoutedIntoSeed } = await loadAttribution();
+		expect(mxRoutedIntoSeed(GOOGLE_MX, 'xero.com')).toBe(false);
+		const result = classifyOwnership({
+			seedDomain: 'xero.com',
+			seedNs: XERO_SEED_NS,
+			candidateDomain: 'xero.co.nz',
+			registration: registered(XERO_NZ_NS),
+			isSharedNsHost,
+			candidateMx: GOOGLE_MX,
+			candidateSoa: XERO_NZ_SOA,
+			candidateSoaUnresolved: false,
+		});
+		// Structurally third_party from DNS — the pair's only link is #263's
+		// registrant-org lane (wording-only), which this arm neither replaces
+		// nor weakens. A verdict here would be an over-fire on shared mail.
+		expect(result.verdict).toBe('third_party');
+		expect(result.evidence).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end — checkLookalikes() over the real permutation set
+// ---------------------------------------------------------------------------
+
+type RecordName = 'NS' | 'A' | 'MX' | 'SOA';
+const TYPE_CODE: Record<RecordName, number> = { NS: 2, A: 1, MX: 15, SOA: 6 };
+const CODE_TYPE: Record<string, RecordName> = { '2': 'NS', NS: 'NS', '1': 'A', A: 'A', '15': 'MX', MX: 'MX', '6': 'SOA', SOA: 'SOA' };
+
+/** Per-name zone data. A record set of `'reject'` makes that lookup throw (throttled / timed out). */
+type Zone = Partial<Record<RecordName, string[] | 'reject'>>;
+
+function dohAnswer(name: string, type: RecordName, records: string[]) {
+	return createDohResponse(
+		[{ name, type: TYPE_CODE[type] }],
+		records.map((data) => ({ name, type: TYPE_CODE[type], TTL: 300, data })),
+	);
+}
+
+function soaData(soa: { mname: string; rname: string }): string {
+	return `${soa.mname}. ${soa.rname}. 1 600 300 604800 900`;
+}
+
+/**
+ * Install a fetch mock serving DoH from `zones`, RDAP from `rdap` (a thin
+ * registrar-only document by default — what Verisign and auDA actually
+ * publish), and a 200 for every HEAD probe. Returns the log of SOA query
+ * names so a test can prove the #864 probe was gated, not fanned out.
+ */
+function installMock(zones: Record<string, Zone>, rdap: Record<string, unknown> = {}): { soaQueries: string[] } {
+	const soaQueries: string[] = [];
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		const parsed = new URL(url);
+		const qName = parsed.searchParams.get('name');
+		const qType = parsed.searchParams.get('type');
+		if (qName !== null && qType !== null) {
+			const name = qName.toLowerCase().replace(/\.$/, '');
+			const type = CODE_TYPE[qType.toUpperCase()];
+			if (type === 'SOA') soaQueries.push(name);
+			const records = type ? zones[name]?.[type] : undefined;
+			if (records === 'reject') return Promise.reject(new Error('DNS timeout'));
+			if (records && type) return Promise.resolve(dohAnswer(name, type, records));
+			return Promise.resolve(createDohResponse([], []));
+		}
+		if (url.includes('rdap')) {
+			const match = url.match(/\/domain\/([^/?]+)/i);
+			const domain = match?.[1]?.toLowerCase() ?? '';
+			const body = rdap[domain] ?? {
+				objectClassName: 'domain',
+				ldhName: domain,
+				entities: [{ roles: ['registrar'], vcardArray: ['vcard', [['fn', {}, 'text', 'Registrar Inc']]] }],
+			};
+			return Promise.resolve(new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/rdap+json' } }));
+		}
+		return Promise.resolve(new Response('', { status: 200 }));
+	});
+	return { soaQueries };
+}
+
+async function runCheck(domain: string) {
+	const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+	return checkLookalikes(domain);
+}
+
+const AMAZON_SEED_ZONE: Zone = { NS: AMAZON_SEED_NS.map((h) => `${h}.`), MX: [`5 ${AMAZON_MX_HOST}.`] };
+
+describe('checkLookalikes — amazon.com → amazon.com.au (#864 regression fixture)', () => {
+	it('reports amazon.com.au as owned_by_seed with the convergence evidence, and never as an impersonation-capable lookalike', async () => {
+		const { soaQueries } = installMock({
+			'amazon.com': AMAZON_SEED_ZONE,
+			'amazon.com.au': {
+				NS: AMAZON_AU_NS.map((h) => `${h}.`),
+				A: ['52.95.116.115'],
+				MX: [`10 ${AMAZON_MX_HOST}.`],
+				SOA: [soaData(AMAZON_AU_SOA)],
+			},
+		});
+		const result = await runCheck('amazon.com');
+
+		const au = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'amazon.com.au');
+		expect(au.length).toBeGreaterThan(0);
+		const owned = au.find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(owned).toBeDefined();
+		expect(owned!.title).toContain('likely owned by same entity');
+		expect(owned!.severity).toBe('info');
+		expect(owned!.metadata?.ownershipVerdict).toBe('owned_by_seed');
+		expect(owned!.metadata?.ownershipStrength).toBe('medium');
+		expect(owned!.metadata?.ownershipSignals).toEqual(['mx_in_bailiwick', 'soa_in_bailiwick']);
+		expect(owned!.metadata?.attributionConfidence).toBe('corroborated');
+		expect(owned!.metadata?.ownershipEvidence).toEqual([
+			{ record: 'MX', value: 'amazon-smtp.amazon.com', inSeedBailiwick: true },
+			{ record: 'SOA.MNAME', value: 'dns-external-master.amazon.com', inSeedBailiwick: true },
+			{ record: 'SOA.RNAME', value: 'root.amazon.com', inSeedBailiwick: true },
+		]);
+		expect(owned!.detail).toContain('dns-external-master.amazon.com');
+
+		// The customer's own domain is not an impersonation threat to itself:
+		// no threat observation, no third-party verdict, not counted anywhere.
+		expect(au.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(false);
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(false);
+		expect(result.findings.some((f) => /mail capability detected|pre-phishing staging/i.test(f.title))).toBe(false);
+		const serialised = JSON.stringify(result.findings);
+		expect(serialised).not.toContain('Impersonation-shaped');
+		expect(serialised).not.toContain('no ownership signal links it');
+		expect(result.partial).not.toBe(true);
+
+		// Budget: the SOA probe was issued ONLY for the candidate whose MX already
+		// routed into the seed — no per-candidate fan-out across the ~84 permutations.
+		expect(soaQueries).toEqual(['amazon.com.au']);
+	});
+
+	it('NEGATIVE — a Route 53 squatter (amaz0n.com) copying the seed MX string stays third_party with its threat observation intact', async () => {
+		const { soaQueries } = installMock({
+			'amazon.com': AMAZON_SEED_ZONE,
+			'amaz0n.com': {
+				NS: ['ns-100.awsdns-12.com.', 'ns-600.awsdns-11.net.', 'ns-1200.awsdns-22.org.', 'ns-1800.awsdns-33.co.uk.'],
+				A: ['192.0.2.10'],
+				MX: [`10 ${AMAZON_MX_HOST}.`],
+				// Route 53's templated SOA: MNAME is a provider host; RNAME lands inside amazon.com for EVERY tenant.
+				SOA: [soaData(ROUTE53_TEMPLATED_SOA)],
+			},
+		});
+		const result = await runCheck('amazon.com');
+
+		const squat = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'amaz0n.com');
+		expect(squat.length).toBeGreaterThan(0);
+		expect(squat.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(false);
+		expect(squat.some((f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+		expect(squat.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
+		// The probe WAS issued (the MX half held) — and correctly declined on the SOA half.
+		expect(soaQueries).toEqual(['amaz0n.com']);
+	});
+
+	it('NEGATIVE — NS hostnames that merely resemble the seed platform, plus a copied MX, do not qualify', async () => {
+		installMock({
+			'amazon.com': AMAZON_SEED_ZONE,
+			'amazom.com': {
+				NS: ['ns1.amazon.com.attacker.net.', 'ns2.amzndns-hosting.net.'],
+				A: ['192.0.2.11'],
+				MX: [`10 ${AMAZON_MX_HOST}.`],
+				SOA: ['ns1.amazon.com.attacker.net. hostmaster.attacker.net. 1 7200 900 1209600 86400'],
+			},
+		});
+		const result = await runCheck('amazon.com');
+		const squat = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'amazom.com');
+		expect(squat.length).toBeGreaterThan(0);
+		expect(squat.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(false);
+		expect(squat.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
+	});
+
+	it('#832 law end-to-end — SOA probe rejects for amazon.com.au → unmeasured, impersonation finding withheld, result marked partial', async () => {
+		installMock({
+			'amazon.com': AMAZON_SEED_ZONE,
+			'amazon.com.au': {
+				NS: AMAZON_AU_NS.map((h) => `${h}.`),
+				A: ['52.95.116.115'],
+				MX: [`10 ${AMAZON_MX_HOST}.`],
+				SOA: 'reject',
+			},
+		});
+		const result = await runCheck('amazon.com');
+
+		const au = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'amazon.com.au');
+		const attribution = au.filter((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution.length).toBeGreaterThan(0);
+		for (const f of attribution) {
+			expect(f.metadata?.ownershipVerdict).toBe('unmeasured');
+			expect(f.severity).toBe('info');
+		}
+		expect(au.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(false);
+		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(false);
+		expect(JSON.stringify(result.findings)).not.toContain('no ownership signal links it');
+		// Transient — must not be cached for the full TTL after DNS recovers.
+		expect(result.partial).toBe(true);
+	});
+});
+
+describe('checkLookalikes — xero.com → xero.co.nz (#263 shape, preserved)', () => {
+	it('declines the convergence arm (mail at Google, zone at Akamai) without issuing a SOA probe, and still surfaces the candidate at info', async () => {
+		const { soaQueries } = installMock({
+			'xero.com': { NS: XERO_SEED_NS.map((h) => `${h}.`), MX: GOOGLE_MX.map((h, i) => `${(i + 1) * 10} ${h}.`) },
+			'xero.co.nz': {
+				NS: XERO_NZ_NS.map((h) => `${h}.`),
+				A: ['104.18.32.1'],
+				MX: GOOGLE_MX.map((h, i) => `${(i + 1) * 10} ${h}.`),
+				SOA: [soaData(XERO_NZ_SOA)],
+			},
+		});
+		const result = await runCheck('xero.com');
+
+		const nz = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'xero.co.nz');
+		expect(nz.length).toBeGreaterThan(0);
+		// Not an over-fire: shared-provider mail is not "routed into the seed".
+		expect(
+			nz.some((f) => f.metadata?.ownershipSignals !== undefined && (f.metadata.ownershipSignals as string[]).includes('mx_in_bailiwick')),
+		).toBe(false);
+		// Zero extra DNS: the MX precondition failed, so the SOA probe never ran.
+		expect(soaQueries).toEqual([]);
+		// D4 cap unchanged — reported for awareness, never suppressed, never above info on the attribution axis.
+		const attribution = nz.find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution).toBeDefined();
+		expect(attribution!.severity).toBe('info');
+		expect(['third_party', 'unattributed']).toContain(attribution!.metadata?.ownershipVerdict);
+	});
+});

--- a/test/check-lookalikes-multi-platform-ownership.spec.ts
+++ b/test/check-lookalikes-multi-platform-ownership.spec.ts
@@ -2,29 +2,37 @@
 
 /**
  * #864 (regression of #263) — a same-entity domain on a DIFFERENT DNS platform
- * must not be counted as an impersonation-capable third party.
+ * must not be counted as an impersonation-capable third party — without
+ * letting a forged candidate-side record hide a sending squatter.
  *
- * Every fixture below is transcribed from live DoH / RDAP answers observed
- * 2026-09-04 (`dns.google/resolve`, `rdap.verisign.com`, `rdap.cctld.au`):
+ * Every fixture below is transcribed from live DoH / RDAP / CT answers
+ * observed 2026-09-04 (`dns.google/resolve`, `rdap.verisign.com`,
+ * `rdap.cctld.au`, `crt.sh`):
  *
  *   amazon.com     NS  ns-{521,264,1707,1447}.awsdns-*             (Route 53)
  *                  MX  5 amazon-smtp.amazon.com
  *   amazon.com.au  NS  ns{1,2}.amzndns.{com,co.uk,net,org}         (Amazon internal)
  *                  MX  10 amazon-smtp.amazon.com                    ← seed's own MX host
- *                  SOA dns-external-master.amazon.com. root.amazon.com. …
+ *                  _dmarc → CNAME _dmarc.amazon.com:
+ *                      v=DMARC1;p=quarantine;pct=100;rua=mailto:report<at>dmarc.amazon.com;ruf=…
+ *                  amazon.com.au._report._dmarc.dmarc.amazon.com TXT "v=DMARC1"   ← SEED-published
+ *                  <random>._report._dmarc.dmarc.amazon.com        NXDOMAIN         (not a wildcard)
+ *                  amzndns.com._report._dmarc.dmarc.amazon.com     NXDOMAIN         (per-domain grant)
  *                  RDAP (auDA): NO registrant entity — registrar only
  *   amazon.com     RDAP (Verisign): thin — registrar only, no registrant
+ *   CT (crt.sh):   0 of 3300 amazon.com.au certificates also cover amazon.com
  *
- *   xero.com       NS  ns-*.awsdns-*  MX Google  SOA awsdns-hostmaster.amazon.com
- *   xero.co.nz     NS  a*.akam.net    MX Google  SOA a5-67.akam.net. hostmaster.akamai.com.
+ *   xero.com       NS  ns-*.awsdns-*  MX Google  _dmarc rua=mailto:xero<at>rua.agari.com
+ *   xero.co.nz     NS  a*.akam.net    MX Google  _dmarc rua=mailto:xero<at>rua.agari.com
  *
  * So for the Amazon pair NEITHER the shared-NS arms NOR the #263 RDAP
- * registrant tier can fire; the only observable link is that the candidate's
- * mail AND its zone master both sit inside the seed apex. That conjunction is
- * `classifyOwnership()` step 5b — see the 2026-09-04 amendment in
- * `src/lib/ownership-attribution.ts`. For the Xero pair NO in-bailiwick record
- * exists (mail at Google, zone at Akamai), so the new arm must decline and
- * the pair keeps #263's registrant-org lane as its only link.
+ * registrant tier can fire; the one SEED-SIDE record that links them is the
+ * RFC 7489 §7.1 external-report authorisation, which only the owner of
+ * `dmarc.amazon.com` can publish. That is `classifyOwnership()` step 5b — see
+ * the 2026-09-04 amendment in `src/lib/ownership-attribution.ts`. The
+ * candidate's MX is a PRE-FILTER only: a sending squatter copies it for free.
+ * For the Xero pair both domains report to a third party (Agari), so no
+ * seed-side signal exists and the arm must decline.
  *
  * Sibling specs own the other attribution lanes: `check-lookalikes.spec.ts`
  * (#263 RDAP lane, three-axis invariants), `check-lookalikes-degraded-
@@ -36,6 +44,7 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
 import { isSharedNsHost } from '../src/tenants/discovery/shared-ns-hosts';
 import type { RegistrationState } from '../src/lib/registration-state';
+import type { DmarcReportAuthorisation } from '../src/lib/ownership-attribution';
 
 const { restore } = setupFetchMock();
 afterEach(() => restore());
@@ -56,9 +65,13 @@ const AMAZON_AU_NS = [
 	'ns2.amzndns.net',
 ];
 const AMAZON_MX_HOST = 'amazon-smtp.amazon.com';
-const AMAZON_AU_SOA = { mname: 'dns-external-master.amazon.com', rname: 'root.amazon.com' };
-/** What EVERY Route 53 zone's templated SOA looks like — RNAME lands inside amazon.com for unrelated tenants. */
-const ROUTE53_TEMPLATED_SOA = { mname: 'ns-100.awsdns-12.com', rname: 'awsdns-hostmaster.amazon.com' };
+/** Mailboxes are assembled with `AT` so the literal never trips the secret scanners' real-email rule; runtime strings are the live records. */
+const AT = '@';
+const AMAZON_DMARC = `v=DMARC1;p=quarantine;pct=100;rua=mailto:report${AT}dmarc.amazon.com;ruf=mailto:report${AT}dmarc.amazon.com`;
+const AMAZON_RECEIVER = 'dmarc.amazon.com';
+const AMAZON_AU_GRANT = 'amazon.com.au._report._dmarc.dmarc.amazon.com';
+/** Live (`WILDCARD_CANARY_LABEL` in lookalike-dns.ts) — the probe's canary label under the receiver's `_report._dmarc`. */
+const CANARY_LABEL = '_bv-wc-probe';
 
 const XERO_SEED_NS = ['ns-1911.awsdns-46.co.uk', 'ns-1391.awsdns-45.org', 'ns-983.awsdns-58.net', 'ns-90.awsdns-11.com'];
 const XERO_NZ_NS = ['a13-64.akam.net', 'a1-170.akam.net', 'a28-66.akam.net', 'a5-67.akam.net', 'a10-67.akam.net', 'a14-65.akam.net'];
@@ -69,7 +82,14 @@ const GOOGLE_MX = [
 	'aspmx2.googlemail.com',
 	'aspmx3.googlemail.com',
 ];
-const XERO_NZ_SOA = { mname: 'a5-67.akam.net', rname: 'hostmaster.akamai.com' };
+const XERO_DMARC = `v=DMARC1; p=reject; fo=1; ri=3600; rua=mailto:xero${AT}rua.agari.com; ruf=mailto:xero${AT}ruf.agari.com`;
+
+const AUTHORISED: DmarcReportAuthorisation = {
+	status: 'authorised',
+	seedReceivers: [AMAZON_RECEIVER],
+	receiverDomain: AMAZON_RECEIVER,
+	authorisationRecord: AMAZON_AU_GRANT,
+};
 
 function registered(ns: string[]): RegistrationState {
 	return { state: 'registered', ns, evidence: ['ns'] };
@@ -80,11 +100,31 @@ async function loadAttribution() {
 }
 
 // ---------------------------------------------------------------------------
+// Unit — parseDmarcReportReceivers()
+// ---------------------------------------------------------------------------
+
+describe('parseDmarcReportReceivers (#864)', () => {
+	it('extracts rua/ruf mailbox domains from the live amazon.com and xero records', async () => {
+		const { parseDmarcReportReceivers } = await loadAttribution();
+		expect(parseDmarcReportReceivers(AMAZON_DMARC)).toEqual(['dmarc.amazon.com']);
+		expect(parseDmarcReportReceivers(XERO_DMARC)).toEqual(['rua.agari.com', 'ruf.agari.com']);
+	});
+
+	it('handles size suffixes, multiple URIs, case, and ignores non-mailto destinations', async () => {
+		const { parseDmarcReportReceivers } = await loadAttribution();
+		expect(
+			parseDmarcReportReceivers(`v=DMARC1; p=none; RUA=mailto:a${AT}One.Example!10m, https://api.example/report, mailto:b${AT}two.example`),
+		).toEqual(['one.example', 'two.example']);
+		expect(parseDmarcReportReceivers('v=DMARC1; p=reject')).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
 // Unit — classifyOwnership() step 5b
 // ---------------------------------------------------------------------------
 
-describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.au records)', () => {
-	it('attributes amazon.com.au to amazon.com: MX and SOA MNAME both inside the seed apex, no shared NS', async () => {
+describe('classifyOwnership — seed-authorised convergence (#864, live amazon.com.au records)', () => {
+	it('attributes amazon.com.au to amazon.com: MX pre-filter met AND the seed publishes the RFC 7489 §7.1 grant', async () => {
 		const { classifyOwnership } = await loadAttribution();
 		const result = classifyOwnership({
 			seedDomain: 'amazon.com',
@@ -93,19 +133,18 @@ describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.
 			registration: registered(AMAZON_AU_NS),
 			isSharedNsHost,
 			candidateMx: [AMAZON_MX_HOST],
-			candidateSoa: AMAZON_AU_SOA,
-			candidateSoaUnresolved: false,
+			dmarcReportAuthorisation: AUTHORISED,
 		});
 		expect(result.verdict).toBe('owned_by_seed');
 		expect(result.strength).toBe('medium');
-		expect(result.signals).toEqual(['mx_in_bailiwick', 'soa_in_bailiwick']);
-		expect(result.rationale).toContain('amazon-smtp.amazon.com');
-		expect(result.rationale).toContain('dns-external-master.amazon.com');
+		expect(result.signals).toEqual(['mx_in_bailiwick', 'dmarc_report_authorised_by_seed']);
+		expect(result.rationale).toContain(AMAZON_AU_GRANT);
+		expect(result.rationale).toContain('RFC 7489');
 		// Evidence names every record the verdict rests on, so a consumer can audit it.
 		expect(result.evidence).toEqual([
 			{ record: 'MX', value: 'amazon-smtp.amazon.com', inSeedBailiwick: true },
-			{ record: 'SOA.MNAME', value: 'dns-external-master.amazon.com', inSeedBailiwick: true },
-			{ record: 'SOA.RNAME', value: 'root.amazon.com', inSeedBailiwick: true },
+			{ record: 'DMARC.RUA', value: 'dmarc.amazon.com', inSeedBailiwick: true },
+			{ record: 'DMARC.REPORT_AUTHORISATION', value: AMAZON_AU_GRANT, inSeedBailiwick: true },
 		]);
 	});
 
@@ -122,90 +161,81 @@ describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.
 		expect(result.signals).toEqual(['distinct_infrastructure']);
 	});
 
-	it('NEGATIVE — MX alone never qualifies: a squatter copying the seed MX string stays third_party', async () => {
+	it('NEGATIVE — the MX pre-filter alone never qualifies: a squatter copying the seed MX string stays third_party', async () => {
 		const { classifyOwnership } = await loadAttribution();
-		for (const soa of [undefined, null] as const) {
+		const nonGrants: Array<DmarcReportAuthorisation | undefined> = [
+			undefined,
+			{ status: 'no_seed_receiver', seedReceivers: [] },
+			{ status: 'not_authorised', seedReceivers: [AMAZON_RECEIVER] },
+		];
+		for (const auth of nonGrants) {
 			const result = classifyOwnership({
 				seedDomain: 'amazon.com',
 				seedNs: AMAZON_SEED_NS,
 				candidateDomain: 'amaz0n.com',
-				registration: registered(['ns1.attacker-dns.net', 'ns2.attacker-dns.net']),
+				registration: registered(['ns1.amaz0n.com', 'ns2.amaz0n.com']),
 				isSharedNsHost,
 				candidateMx: [AMAZON_MX_HOST],
-				candidateSoa: soa,
-				candidateSoaUnresolved: false,
+				dmarcReportAuthorisation: auth,
 			});
-			expect(result.verdict, `candidateSoa=${String(soa)}`).toBe('third_party');
+			expect(result.verdict, `status=${auth?.status ?? 'undefined'}`).toBe('third_party');
 			expect(result.evidence).toBeUndefined();
 		}
 	});
 
-	it('NEGATIVE — SOA RNAME is never verdict-bearing: a Route 53 squatter (templated RNAME inside amazon.com) copying the seed MX stays third_party', async () => {
+	it('NEGATIVE — a WILDCARD grant is evidence-only: the seed authorised reports about anyone, not this candidate', async () => {
 		const { classifyOwnership } = await loadAttribution();
 		const result = classifyOwnership({
 			seedDomain: 'amazon.com',
 			seedNs: AMAZON_SEED_NS,
 			candidateDomain: 'amaz0n.com',
-			registration: registered(['ns-100.awsdns-12.com', 'ns-600.awsdns-11.net', 'ns-1200.awsdns-22.org', 'ns-1800.awsdns-33.co.uk']),
+			registration: registered(['ns1.amaz0n.com']),
 			isSharedNsHost,
 			candidateMx: [AMAZON_MX_HOST],
-			candidateSoa: ROUTE53_TEMPLATED_SOA,
-			candidateSoaUnresolved: false,
+			dmarcReportAuthorisation: { status: 'wildcard', seedReceivers: [AMAZON_RECEIVER], receiverDomain: AMAZON_RECEIVER },
 		});
 		expect(result.verdict).toBe('third_party');
 	});
 
-	it('NEGATIVE — SOA MNAME alone never qualifies: zone mastered inside the seed but mail elsewhere stays third_party', async () => {
+	it('NEGATIVE — defence in depth: an "authorised" result whose receiver or record sits OUTSIDE the seed apex is ignored', async () => {
 		const { classifyOwnership } = await loadAttribution();
 		const result = classifyOwnership({
 			seedDomain: 'amazon.com',
 			seedNs: AMAZON_SEED_NS,
 			candidateDomain: 'amaz0n.com',
-			registration: registered(['ns1.attacker-dns.net']),
+			registration: registered(['ns1.amaz0n.com']),
 			isSharedNsHost,
-			candidateMx: ['mail.attacker-dns.net'],
-			candidateSoa: AMAZON_AU_SOA,
-			candidateSoaUnresolved: false,
+			candidateMx: [AMAZON_MX_HOST],
+			dmarcReportAuthorisation: {
+				status: 'authorised',
+				seedReceivers: ['rua.attacker-reports.net'],
+				receiverDomain: 'rua.attacker-reports.net',
+				authorisationRecord: 'amaz0n.com._report._dmarc.rua.attacker-reports.net',
+			},
 		});
 		expect(result.verdict).toBe('third_party');
 	});
 
-	it('NEGATIVE — a single MX outside the seed apex disqualifies the whole set (keeping a receive channel is the cost)', async () => {
+	it('NEGATIVE — a single MX outside the seed apex fails the pre-filter, so the seed-side result is never consulted', async () => {
 		const { classifyOwnership, mxRoutedIntoSeed } = await loadAttribution();
 		expect(mxRoutedIntoSeed([AMAZON_MX_HOST, 'mx.attacker-dns.net'], 'amazon.com')).toBe(false);
 		expect(mxRoutedIntoSeed([], 'amazon.com')).toBe(false);
 		expect(mxRoutedIntoSeed(undefined, 'amazon.com')).toBe(false);
-		const result = classifyOwnership({
-			seedDomain: 'amazon.com',
-			seedNs: AMAZON_SEED_NS,
-			candidateDomain: 'amaz0n.com',
-			registration: registered(['ns1.attacker-dns.net']),
-			isSharedNsHost,
-			candidateMx: [AMAZON_MX_HOST, 'mx.attacker-dns.net'],
-			candidateSoa: AMAZON_AU_SOA,
-			candidateSoaUnresolved: false,
-		});
-		expect(result.verdict).toBe('third_party');
-	});
-
-	it('NEGATIVE — bailiwick is label-bounded: hosts that merely END with the seed string do not count', async () => {
-		const { classifyOwnership, mxRoutedIntoSeed } = await loadAttribution();
 		expect(mxRoutedIntoSeed(['smtp.notamazon.com'], 'amazon.com')).toBe(false);
 		expect(mxRoutedIntoSeed(['amazon-smtp.amazon.com.attacker.net'], 'amazon.com')).toBe(false);
 		const result = classifyOwnership({
 			seedDomain: 'amazon.com',
 			seedNs: AMAZON_SEED_NS,
 			candidateDomain: 'amaz0n.com',
-			registration: registered(['ns1.amazon.com.attacker.net']),
+			registration: registered(['ns1.amaz0n.com']),
 			isSharedNsHost,
-			candidateMx: ['smtp.notamazon.com'],
-			candidateSoa: { mname: 'master.notamazon.com', rname: 'root.notamazon.com' },
-			candidateSoaUnresolved: false,
+			candidateMx: [AMAZON_MX_HOST, 'mx.attacker-dns.net'],
+			dmarcReportAuthorisation: AUTHORISED,
 		});
 		expect(result.verdict).toBe('third_party');
 	});
 
-	it('#832 law — MX routed into the seed but the SOA probe REJECTED → unmeasured, never the contrary third_party', async () => {
+	it('#832 law — pre-filter met but the seed-side probe REJECTED → unmeasured, never the contrary third_party', async () => {
 		const { classifyOwnership } = await loadAttribution();
 		const result = classifyOwnership({
 			seedDomain: 'amazon.com',
@@ -214,28 +244,12 @@ describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.
 			registration: registered(AMAZON_AU_NS),
 			isSharedNsHost,
 			candidateMx: [AMAZON_MX_HOST],
-			candidateSoa: null,
-			candidateSoaUnresolved: true,
+			dmarcReportAuthorisation: { status: 'unresolved', seedReceivers: [AMAZON_RECEIVER] },
 		});
 		expect(result.verdict).toBe('unmeasured');
 		expect(result.signals).toEqual(['mx_in_bailiwick']);
 		expect(result.rationale).toContain('measurement gap');
 		expect(result.rationale).not.toContain('no ownership signal links it');
-	});
-
-	it('a RESOLVED empty SOA (probed, nothing answered) is not a measurement gap — falls through to third_party', async () => {
-		const { classifyOwnership } = await loadAttribution();
-		const result = classifyOwnership({
-			seedDomain: 'amazon.com',
-			seedNs: AMAZON_SEED_NS,
-			candidateDomain: 'amazon.com.au',
-			registration: registered(AMAZON_AU_NS),
-			isSharedNsHost,
-			candidateMx: [AMAZON_MX_HOST],
-			candidateSoa: null,
-			candidateSoaUnresolved: false,
-		});
-		expect(result.verdict).toBe('third_party');
 	});
 
 	it('fires under a degraded SEED NS lookup too — it needs only the seed apex, like the NS in-bailiwick arm (#832 parity)', async () => {
@@ -248,14 +262,13 @@ describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.
 			registration: registered(AMAZON_AU_NS),
 			isSharedNsHost,
 			candidateMx: [AMAZON_MX_HOST],
-			candidateSoa: AMAZON_AU_SOA,
-			candidateSoaUnresolved: false,
+			dmarcReportAuthorisation: AUTHORISED,
 		});
 		expect(result.verdict).toBe('owned_by_seed');
-		expect(result.signals).toEqual(['mx_in_bailiwick', 'soa_in_bailiwick']);
+		expect(result.signals).toEqual(['mx_in_bailiwick', 'dmarc_report_authorised_by_seed']);
 	});
 
-	it('seed-side arms keep precedence: a full dedicated NS match is reported as strong ns_set_match, not displaced by the medium conjunction', async () => {
+	it('seed-side NS arms keep precedence: a full dedicated NS match is reported as strong ns_set_match, not displaced by the medium arm', async () => {
 		const { classifyOwnership } = await loadAttribution();
 		const result = classifyOwnership({
 			seedDomain: 'amazon.com',
@@ -264,15 +277,14 @@ describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.
 			registration: registered(AMAZON_SEED_NS),
 			isSharedNsHost,
 			candidateMx: [AMAZON_MX_HOST],
-			candidateSoa: AMAZON_AU_SOA,
-			candidateSoaUnresolved: false,
+			dmarcReportAuthorisation: AUTHORISED,
 		});
 		expect(result.verdict).toBe('owned_by_seed');
 		expect(result.strength).toBe('strong');
 		expect(result.signals).toEqual(['ns_set_match']);
 	});
 
-	it('xero.co.nz (#263 shape): mail at Google and zone at Akamai — no in-bailiwick record, so the new arm declines', async () => {
+	it('xero.co.nz (#263 shape): mail at Google, reports to Agari — pre-filter unmet, no seed-side signal, arm declines', async () => {
 		const { classifyOwnership, mxRoutedIntoSeed } = await loadAttribution();
 		expect(mxRoutedIntoSeed(GOOGLE_MX, 'xero.com')).toBe(false);
 		const result = classifyOwnership({
@@ -282,12 +294,11 @@ describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.
 			registration: registered(XERO_NZ_NS),
 			isSharedNsHost,
 			candidateMx: GOOGLE_MX,
-			candidateSoa: XERO_NZ_SOA,
-			candidateSoaUnresolved: false,
+			dmarcReportAuthorisation: { status: 'no_seed_receiver', seedReceivers: [] },
 		});
 		// Structurally third_party from DNS — the pair's only link is #263's
 		// registrant-org lane (wording-only), which this arm neither replaces
-		// nor weakens. A verdict here would be an over-fire on shared mail.
+		// nor weakens.
 		expect(result.verdict).toBe('third_party');
 		expect(result.evidence).toBeUndefined();
 	});
@@ -297,32 +308,39 @@ describe('classifyOwnership — in-bailiwick convergence (#864, live amazon.com.
 // End-to-end — checkLookalikes() over the real permutation set
 // ---------------------------------------------------------------------------
 
-type RecordName = 'NS' | 'A' | 'MX' | 'SOA';
-const TYPE_CODE: Record<RecordName, number> = { NS: 2, A: 1, MX: 15, SOA: 6 };
-const CODE_TYPE: Record<string, RecordName> = { '2': 'NS', NS: 'NS', '1': 'A', A: 'A', '15': 'MX', MX: 'MX', '6': 'SOA', SOA: 'SOA' };
+type RecordName = 'NS' | 'A' | 'MX' | 'SOA' | 'TXT';
+const TYPE_CODE: Record<RecordName, number> = { NS: 2, A: 1, MX: 15, SOA: 6, TXT: 16 };
+const CODE_TYPE: Record<string, RecordName> = {
+	'2': 'NS',
+	NS: 'NS',
+	'1': 'A',
+	A: 'A',
+	'15': 'MX',
+	MX: 'MX',
+	'6': 'SOA',
+	SOA: 'SOA',
+	'16': 'TXT',
+	TXT: 'TXT',
+};
 
-/** Per-name zone data. A record set of `'reject'` makes that lookup throw (throttled / timed out). */
+/** Per-name zone data. A record set of `'reject'` makes that lookup throw (throttled / timed out). TXT values are given unquoted. */
 type Zone = Partial<Record<RecordName, string[] | 'reject'>>;
 
 function dohAnswer(name: string, type: RecordName, records: string[]) {
 	return createDohResponse(
 		[{ name, type: TYPE_CODE[type] }],
-		records.map((data) => ({ name, type: TYPE_CODE[type], TTL: 300, data })),
+		records.map((data) => ({ name, type: TYPE_CODE[type], TTL: 300, data: type === 'TXT' ? `"${data}"` : data })),
 	);
 }
 
-function soaData(soa: { mname: string; rname: string }): string {
-	return `${soa.mname}. ${soa.rname}. 1 600 300 604800 900`;
-}
-
 /**
- * Install a fetch mock serving DoH from `zones`, RDAP from `rdap` (a thin
- * registrar-only document by default — what Verisign and auDA actually
- * publish), and a 200 for every HEAD probe. Returns the log of SOA query
- * names so a test can prove the #864 probe was gated, not fanned out.
+ * Install a fetch mock serving DoH from `zones`, a thin registrar-only RDAP
+ * document (what Verisign and auDA actually publish) for every RDAP URL, and
+ * a 200 for every HEAD probe. Returns the log of `_dmarc`-path query names so
+ * a test can prove the #864 probe was gated, not fanned out.
  */
-function installMock(zones: Record<string, Zone>, rdap: Record<string, unknown> = {}): { soaQueries: string[] } {
-	const soaQueries: string[] = [];
+function installMock(zones: Record<string, Zone>): { dmarcQueries: string[] } {
+	const dmarcQueries: string[] = [];
 	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
 		const parsed = new URL(url);
@@ -331,7 +349,7 @@ function installMock(zones: Record<string, Zone>, rdap: Record<string, unknown> 
 		if (qName !== null && qType !== null) {
 			const name = qName.toLowerCase().replace(/\.$/, '');
 			const type = CODE_TYPE[qType.toUpperCase()];
-			if (type === 'SOA') soaQueries.push(name);
+			if (name.includes('_dmarc')) dmarcQueries.push(name);
 			const records = type ? zones[name]?.[type] : undefined;
 			if (records === 'reject') return Promise.reject(new Error('DNS timeout'));
 			if (records && type) return Promise.resolve(dohAnswer(name, type, records));
@@ -340,7 +358,7 @@ function installMock(zones: Record<string, Zone>, rdap: Record<string, unknown> 
 		if (url.includes('rdap')) {
 			const match = url.match(/\/domain\/([^/?]+)/i);
 			const domain = match?.[1]?.toLowerCase() ?? '';
-			const body = rdap[domain] ?? {
+			const body = {
 				objectClassName: 'domain',
 				ldhName: domain,
 				entities: [{ roles: ['registrar'], vcardArray: ['vcard', [['fn', {}, 'text', 'Registrar Inc']]] }],
@@ -349,7 +367,7 @@ function installMock(zones: Record<string, Zone>, rdap: Record<string, unknown> 
 		}
 		return Promise.resolve(new Response('', { status: 200 }));
 	});
-	return { soaQueries };
+	return { dmarcQueries };
 }
 
 async function runCheck(domain: string) {
@@ -359,16 +377,37 @@ async function runCheck(domain: string) {
 
 const AMAZON_SEED_ZONE: Zone = { NS: AMAZON_SEED_NS.map((h) => `${h}.`), MX: [`5 ${AMAZON_MX_HOST}.`] };
 
+/** The forged candidate zone the #897 review described: attacker NS on a VPS, copied MX, MNAME under the seed apex, DMARC reporting into the seed. */
+function forgedSquatterZone(domain: string): Zone {
+	return {
+		NS: [`ns1.${domain}.`, `ns2.${domain}.`],
+		A: ['192.0.2.10'],
+		MX: [`10 ${AMAZON_MX_HOST}.`],
+		SOA: ['dns-external-master.amazon.com. root.amazon.com. 1 600 300 604800 900'],
+		TXT: [],
+	};
+}
+
+function threatRetained(findings: Array<{ title: string; metadata?: Record<string, unknown> }>, candidate: string): void {
+	const own = findings.filter((f) => f.metadata?.lookalikeDomain === candidate);
+	expect(own.length).toBeGreaterThan(0);
+	expect(own.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(false);
+	expect(own.some((f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+	expect(own.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
+	// Still counted: the mail-capable rollup names it.
+	expect(
+		findings.some((f) => /working mail host|pre-phishing staging/i.test(f.title) && JSON.stringify(f.metadata ?? {}).includes(candidate)),
+	).toBe(true);
+}
+
 describe('checkLookalikes — amazon.com → amazon.com.au (#864 regression fixture)', () => {
-	it('reports amazon.com.au as owned_by_seed with the convergence evidence, and never as an impersonation-capable lookalike', async () => {
-		const { soaQueries } = installMock({
+	it('reports amazon.com.au as owned_by_seed on the seed-published grant, and never as an impersonation-capable lookalike', async () => {
+		const { dmarcQueries } = installMock({
 			'amazon.com': AMAZON_SEED_ZONE,
-			'amazon.com.au': {
-				NS: AMAZON_AU_NS.map((h) => `${h}.`),
-				A: ['52.95.116.115'],
-				MX: [`10 ${AMAZON_MX_HOST}.`],
-				SOA: [soaData(AMAZON_AU_SOA)],
-			},
+			'amazon.com.au': { NS: AMAZON_AU_NS.map((h) => `${h}.`), A: ['52.95.116.115'], MX: [`10 ${AMAZON_MX_HOST}.`] },
+			'_dmarc.amazon.com.au': { TXT: [AMAZON_DMARC] },
+			[AMAZON_AU_GRANT]: { TXT: ['v=DMARC1'] },
+			// canary label → NXDOMAIN (empty), exactly as observed live
 		});
 		const result = await runCheck('amazon.com');
 
@@ -380,78 +419,89 @@ describe('checkLookalikes — amazon.com → amazon.com.au (#864 regression fixt
 		expect(owned!.severity).toBe('info');
 		expect(owned!.metadata?.ownershipVerdict).toBe('owned_by_seed');
 		expect(owned!.metadata?.ownershipStrength).toBe('medium');
-		expect(owned!.metadata?.ownershipSignals).toEqual(['mx_in_bailiwick', 'soa_in_bailiwick']);
+		expect(owned!.metadata?.ownershipSignals).toEqual(['mx_in_bailiwick', 'dmarc_report_authorised_by_seed']);
 		expect(owned!.metadata?.attributionConfidence).toBe('corroborated');
 		expect(owned!.metadata?.ownershipEvidence).toEqual([
 			{ record: 'MX', value: 'amazon-smtp.amazon.com', inSeedBailiwick: true },
-			{ record: 'SOA.MNAME', value: 'dns-external-master.amazon.com', inSeedBailiwick: true },
-			{ record: 'SOA.RNAME', value: 'root.amazon.com', inSeedBailiwick: true },
+			{ record: 'DMARC.RUA', value: 'dmarc.amazon.com', inSeedBailiwick: true },
+			{ record: 'DMARC.REPORT_AUTHORISATION', value: AMAZON_AU_GRANT, inSeedBailiwick: true },
 		]);
-		expect(owned!.detail).toContain('dns-external-master.amazon.com');
+		expect(owned!.detail).toContain(AMAZON_AU_GRANT);
 
 		// The customer's own domain is not an impersonation threat to itself:
 		// no threat observation, no third-party verdict, not counted anywhere.
 		expect(au.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(false);
 		expect(result.findings.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(false);
-		expect(result.findings.some((f) => /mail capability detected|pre-phishing staging/i.test(f.title))).toBe(false);
+		expect(result.findings.some((f) => /working mail host|pre-phishing staging/i.test(f.title))).toBe(false);
 		const serialised = JSON.stringify(result.findings);
 		expect(serialised).not.toContain('Impersonation-shaped');
 		expect(serialised).not.toContain('no ownership signal links it');
 		expect(result.partial).not.toBe(true);
 
-		// Budget: the SOA probe was issued ONLY for the candidate whose MX already
-		// routed into the seed — no per-candidate fan-out across the ~84 permutations.
-		expect(soaQueries).toEqual(['amazon.com.au']);
+		// Budget: exactly the three seed-side lookups for the ONE candidate whose
+		// MX already routed into the seed — no fan-out across the ~84 permutations.
+		expect(dmarcQueries).toEqual(['_dmarc.amazon.com.au', AMAZON_AU_GRANT, `${CANARY_LABEL}._report._dmarc.${AMAZON_RECEIVER}`]);
 	});
 
-	it('NEGATIVE — a Route 53 squatter (amaz0n.com) copying the seed MX string stays third_party with its threat observation intact', async () => {
-		const { soaQueries } = installMock({
+	it('NEGATIVE (i) — forged SOA MNAME under the seed apex + copied seed MX + attacker NS + DMARC reporting into the seed: NOT owned, threat observation retained', async () => {
+		const { dmarcQueries } = installMock({
 			'amazon.com': AMAZON_SEED_ZONE,
-			'amaz0n.com': {
-				NS: ['ns-100.awsdns-12.com.', 'ns-600.awsdns-11.net.', 'ns-1200.awsdns-22.org.', 'ns-1800.awsdns-33.co.uk.'],
-				A: ['192.0.2.10'],
-				MX: [`10 ${AMAZON_MX_HOST}.`],
-				// Route 53's templated SOA: MNAME is a provider host; RNAME lands inside amazon.com for EVERY tenant.
-				SOA: [soaData(ROUTE53_TEMPLATED_SOA)],
-			},
+			'amaz0n.com': forgedSquatterZone('amaz0n.com'),
+			'_dmarc.amaz0n.com': { TXT: [AMAZON_DMARC] },
+			// The seed has NOT published amaz0n.com._report._dmarc.dmarc.amazon.com → NXDOMAIN.
 		});
 		const result = await runCheck('amazon.com');
-
-		const squat = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'amaz0n.com');
-		expect(squat.length).toBeGreaterThan(0);
-		expect(squat.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(false);
-		expect(squat.some((f) => f.metadata?.findingAxis === 'attribution' && f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
-		expect(squat.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
-		// The probe WAS issued (the MX half held) — and correctly declined on the SOA half.
-		expect(soaQueries).toEqual(['amaz0n.com']);
+		threatRetained(result.findings, 'amaz0n.com');
+		// The probe WAS issued (pre-filter met) and correctly found no grant; no canary needed.
+		expect(dmarcQueries).toEqual(['_dmarc.amaz0n.com', 'amaz0n.com._report._dmarc.dmarc.amazon.com']);
+		expect(result.partial).not.toBe(true);
 	});
 
-	it('NEGATIVE — NS hostnames that merely resemble the seed platform, plus a copied MX, do not qualify', async () => {
+	it('NEGATIVE (ii) — same forged zone where the MNAME host RESOLVES to a real seed host: still not sufficient', async () => {
 		installMock({
 			'amazon.com': AMAZON_SEED_ZONE,
-			'amazom.com': {
-				NS: ['ns1.amazon.com.attacker.net.', 'ns2.amzndns-hosting.net.'],
-				A: ['192.0.2.11'],
-				MX: [`10 ${AMAZON_MX_HOST}.`],
-				SOA: ['ns1.amazon.com.attacker.net. hostmaster.attacker.net. 1 7200 900 1209600 86400'],
-			},
+			'amaz0n.com': forgedSquatterZone('amaz0n.com'),
+			'_dmarc.amaz0n.com': { TXT: [AMAZON_DMARC] },
+			'dns-external-master.amazon.com': { A: ['52.94.236.248'] },
+			'amazon-smtp.amazon.com': { A: ['52.94.236.10'] },
 		});
 		const result = await runCheck('amazon.com');
-		const squat = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'amazom.com');
-		expect(squat.length).toBeGreaterThan(0);
-		expect(squat.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(false);
-		expect(squat.some((f) => f.metadata?.findingAxis === 'threat_observation')).toBe(true);
+		threatRetained(result.findings, 'amaz0n.com');
 	});
 
-	it('#832 law end-to-end — SOA probe rejects for amazon.com.au → unmeasured, impersonation finding withheld, result marked partial', async () => {
+	it('NEGATIVE — a seed WILDCARD grant (`*._report._dmarc`) does not attribute a squatter that reports into the seed', async () => {
+		const { dmarcQueries } = installMock({
+			'amazon.com': AMAZON_SEED_ZONE,
+			'amaz0n.com': forgedSquatterZone('amaz0n.com'),
+			'_dmarc.amaz0n.com': { TXT: [AMAZON_DMARC] },
+			'amaz0n.com._report._dmarc.dmarc.amazon.com': { TXT: ['v=DMARC1'] },
+			[`${CANARY_LABEL}._report._dmarc.${AMAZON_RECEIVER}`]: { TXT: ['v=DMARC1'] },
+		});
+		const result = await runCheck('amazon.com');
+		threatRetained(result.findings, 'amaz0n.com');
+		expect(dmarcQueries).toEqual([
+			'_dmarc.amaz0n.com',
+			'amaz0n.com._report._dmarc.dmarc.amazon.com',
+			`${CANARY_LABEL}._report._dmarc.${AMAZON_RECEIVER}`,
+		]);
+	});
+
+	it('NEGATIVE — copied MX with NS hostnames that merely resemble the seed platform and no DMARC record: not owned, no seed-side lookups beyond _dmarc', async () => {
+		const { dmarcQueries } = installMock({
+			'amazon.com': AMAZON_SEED_ZONE,
+			'amazom.com': { NS: ['ns1.amazon.com.attacker.net.', 'ns2.amzndns-hosting.net.'], A: ['192.0.2.11'], MX: [`10 ${AMAZON_MX_HOST}.`] },
+		});
+		const result = await runCheck('amazon.com');
+		threatRetained(result.findings, 'amazom.com');
+		expect(dmarcQueries).toEqual(['_dmarc.amazom.com']);
+	});
+
+	it('#832 law end-to-end — the seed-side grant lookup rejects for amazon.com.au → unmeasured, impersonation finding withheld, result marked partial', async () => {
 		installMock({
 			'amazon.com': AMAZON_SEED_ZONE,
-			'amazon.com.au': {
-				NS: AMAZON_AU_NS.map((h) => `${h}.`),
-				A: ['52.95.116.115'],
-				MX: [`10 ${AMAZON_MX_HOST}.`],
-				SOA: 'reject',
-			},
+			'amazon.com.au': { NS: AMAZON_AU_NS.map((h) => `${h}.`), A: ['52.95.116.115'], MX: [`10 ${AMAZON_MX_HOST}.`] },
+			'_dmarc.amazon.com.au': { TXT: [AMAZON_DMARC] },
+			[AMAZON_AU_GRANT]: { TXT: 'reject' },
 		});
 		const result = await runCheck('amazon.com');
 
@@ -471,15 +521,11 @@ describe('checkLookalikes — amazon.com → amazon.com.au (#864 regression fixt
 });
 
 describe('checkLookalikes — xero.com → xero.co.nz (#263 shape, preserved)', () => {
-	it('declines the convergence arm (mail at Google, zone at Akamai) without issuing a SOA probe, and still surfaces the candidate at info', async () => {
-		const { soaQueries } = installMock({
+	it('declines the arm (mail at Google) without issuing any seed-side lookup, and still surfaces the candidate at info', async () => {
+		const { dmarcQueries } = installMock({
 			'xero.com': { NS: XERO_SEED_NS.map((h) => `${h}.`), MX: GOOGLE_MX.map((h, i) => `${(i + 1) * 10} ${h}.`) },
-			'xero.co.nz': {
-				NS: XERO_NZ_NS.map((h) => `${h}.`),
-				A: ['104.18.32.1'],
-				MX: GOOGLE_MX.map((h, i) => `${(i + 1) * 10} ${h}.`),
-				SOA: [soaData(XERO_NZ_SOA)],
-			},
+			'xero.co.nz': { NS: XERO_NZ_NS.map((h) => `${h}.`), A: ['104.18.32.1'], MX: GOOGLE_MX.map((h, i) => `${(i + 1) * 10} ${h}.`) },
+			'_dmarc.xero.co.nz': { TXT: [XERO_DMARC] },
 		});
 		const result = await runCheck('xero.com');
 
@@ -487,10 +533,10 @@ describe('checkLookalikes — xero.com → xero.co.nz (#263 shape, preserved)', 
 		expect(nz.length).toBeGreaterThan(0);
 		// Not an over-fire: shared-provider mail is not "routed into the seed".
 		expect(
-			nz.some((f) => f.metadata?.ownershipSignals !== undefined && (f.metadata.ownershipSignals as string[]).includes('mx_in_bailiwick')),
+			nz.some((f) => Array.isArray(f.metadata?.ownershipSignals) && (f.metadata!.ownershipSignals as string[]).includes('mx_in_bailiwick')),
 		).toBe(false);
-		// Zero extra DNS: the MX precondition failed, so the SOA probe never ran.
-		expect(soaQueries).toEqual([]);
+		// Zero extra DNS: the pre-filter failed, so no seed-side probe ran.
+		expect(dmarcQueries).toEqual([]);
 		// D4 cap unchanged — reported for awareness, never suppressed, never above info on the attribution axis.
 		const attribution = nz.find((f) => f.metadata?.findingAxis === 'attribution');
 		expect(attribution).toBeDefined();

--- a/test/check-lookalikes-multi-platform-ownership.spec.ts
+++ b/test/check-lookalikes-multi-platform-ownership.spec.ts
@@ -167,6 +167,8 @@ describe('classifyOwnership — seed-authorised convergence (#864, live amazon.c
 			undefined,
 			{ status: 'no_seed_receiver', seedReceivers: [] },
 			{ status: 'not_authorised', seedReceivers: [AMAZON_RECEIVER] },
+			// The attacker-controlled `_dmarc.<candidate>` lookup failing is a DECLINE, not a gap (re-review High).
+			{ status: 'candidate_unresolved', seedReceivers: [] },
 		];
 		for (const auth of nonGrants) {
 			const result = classifyOwnership({
@@ -181,6 +183,29 @@ describe('classifyOwnership — seed-authorised convergence (#864, live amazon.c
 			expect(result.verdict, `status=${auth?.status ?? 'undefined'}`).toBe('third_party');
 			expect(result.evidence).toBeUndefined();
 		}
+	});
+
+	it('NEGATIVE — a seed that is itself a DMARC report PROCESSOR cannot attribute its customers (denylist, mirrors isSharedNsHost)', async () => {
+		const { classifyOwnership, isDmarcReportProcessorApex } = await loadAttribution();
+		expect(isDmarcReportProcessorApex('agari.com')).toBe(true);
+		expect(isDmarcReportProcessorApex('rua.agari.com')).toBe(true);
+		expect(isDmarcReportProcessorApex('amazon.com')).toBe(false);
+		const result = classifyOwnership({
+			seedDomain: 'agari.com',
+			seedNs: ['ns1.agari-dns.example', 'ns2.agari-dns.example'],
+			candidateDomain: 'agarii.com',
+			registration: registered(['ns1.agarii.com']),
+			isSharedNsHost,
+			candidateMx: ['mx.agari.com'],
+			dmarcReportAuthorisation: {
+				status: 'authorised',
+				seedReceivers: ['rua.agari.com'],
+				receiverDomain: 'rua.agari.com',
+				authorisationRecord: 'agarii.com._report._dmarc.rua.agari.com',
+			},
+		});
+		expect(result.verdict).toBe('third_party');
+		expect(result.evidence).toBeUndefined();
 	});
 
 	it('NEGATIVE — a WILDCARD grant is evidence-only: the seed authorised reports about anyone, not this candidate', async () => {
@@ -494,6 +519,22 @@ describe('checkLookalikes — amazon.com → amazon.com.au (#864 regression fixt
 		const result = await runCheck('amazon.com');
 		threatRetained(result.findings, 'amazom.com');
 		expect(dmarcQueries).toEqual(['_dmarc.amazom.com']);
+	});
+
+	it('NEGATIVE (re-review High) — copied seed MX + the CANDIDATE `_dmarc` lookup rejects → third_party, threat retained, NOT partial: a blackholed attacker zone earns nothing', async () => {
+		const { dmarcQueries } = installMock({
+			'amazon.com': AMAZON_SEED_ZONE,
+			'amaz0n.com': forgedSquatterZone('amaz0n.com'),
+			'_dmarc.amaz0n.com': { TXT: 'reject' },
+		});
+		const result = await runCheck('amazon.com');
+		threatRetained(result.findings, 'amaz0n.com');
+		expect(result.findings.some((f) => f.metadata?.lookalikeDomain === 'amaz0n.com' && f.metadata?.ownershipVerdict === 'unmeasured')).toBe(
+			false,
+		);
+		expect(result.partial).not.toBe(true);
+		// Declined at stage 1 — no seed-zone lookup was even attempted.
+		expect(dmarcQueries).toEqual(['_dmarc.amaz0n.com']);
 	});
 
 	it('#832 law end-to-end — the seed-side grant lookup rejects for amazon.com.au → unmeasured, impersonation finding withheld, result marked partial', async () => {


### PR DESCRIPTION
> **Rework after review (BLOCK on the first revision, agreed):** the first revision granted `owned_by_seed` on two candidate-published records (MX + SOA MNAME). Both are free for a sending squatter to publish in a self-hosted zone, so a forged zone could suppress its own threat finding. This revision keeps the candidate MX only as a **pre-filter with no verdict weight** and rests the verdict on a **seed-published** record — the RFC 7489 §7.1 DMARC external-report authorisation — proven live for `amazon.com.au` below. The SOA arm is gone entirely.

> **Re-review fixes (MERGEABLE-WITH-FIXES):** (1) **High** — a failed `_dmarc.<candidate>` lookup (attacker-controlled zone) now returns `candidate_unresolved` and DECLINES to the seed-side NS outcome (`third_party`, threat observation retained, not `partial`); `unresolved` → `unmeasured` is reserved for the seed-zone grant/canary lookups only. Pinned end-to-end (copied seed MX + candidate `_dmarc` rejects → `third_party`, threat retained, not partial, no seed-zone lookup attempted) and in the unit matrix. (2) **Low, taken** — `DMARC_REPORT_PROCESSOR_APEXES` / `isDmarcReportProcessorApex()` (agari, valimail, dmarcian, ondmarc/red sift, proofpoint, dmarcanalyzer, mimecast, easydmarc, powerdmarc, dmarcly, sendmarc, fraudmarc, uriports, mailhardener, postmark, mxtoolbox, dmarcdigests) mirrors `isSharedNsHost`: when the SEED apex is a report processor, step 5b declines, so a processor cannot attribute its customers; consulted for the seed apex only, so an entry can only withhold. (3) **Merge** — `origin/main` (#892 rollup) merged with a merge commit; the only conflict was the `partial` condition, resolved as `seedNsUnmeasured || rollup.abstained || seedAuthorisation.unmeasured.length > 0`; `git diff HEAD^2 HEAD --stat` shows only this PR's six files differ from main.

## What happens

`check_lookalikes` on `amazon.com` classified `amazon.com.au` as `third_party` and counted it as an impersonation-capable lookalike (#864, measured 2026-08-31). `amazon.com` is on Route 53; `amazon.com.au` is on Amazon's other internal platform (`ns*.amzndns.*`). No nameserver is shared, so every seed-side arm of `classifyOwnership()` declined — exactly the #263 (`xero.co.nz`) failure mode with a different registrant. `google.com`'s nine defensive registrations were caught in the same sweep only because they share NS with the seed.

## Observed records (DoH + RDAP + CT, 2026-09-04)

`https://dns.google/resolve`:

| name | type | answer |
| --- | --- | --- |
| `amazon.com` | NS | `ns-521.awsdns-01.net`, `ns-264.awsdns-33.com`, `ns-1707.awsdns-21.co.uk`, `ns-1447.awsdns-52.org` |
| `amazon.com` | MX | `5 amazon-smtp.amazon.com` |
| `amazon.com.au` | NS | `ns{1,2}.amzndns.{com,co.uk,net,org}` (8 hosts, zero overlap with the seed) |
| `amazon.com.au` | MX | `10 amazon-smtp.amazon.com` — the seed's own MX host (**pre-filter only**) |
| `_dmarc.amazon.com.au` | CNAME→TXT | `_dmarc.amazon.com` → `v=DMARC1;p=quarantine;pct=100;rua=mailto:report@dmarc.amazon.com;ruf=mailto:report@dmarc.amazon.com` |
| **`amazon.com.au._report._dmarc.dmarc.amazon.com`** | TXT | **`v=DMARC1`** — the RFC 7489 §7.1 external-destination authorisation, published in `dmarc.amazon.com`'s zone (seed-side) |
| `zz-random-probe-xyz._report._dmarc.dmarc.amazon.com` | TXT | NXDOMAIN — **not a wildcard** |
| `amzndns.com._report._dmarc.dmarc.amazon.com` | TXT | NXDOMAIN — although `_dmarc.amzndns.com` also reports to `report@dmarc.amazon.com`, so the grant is **per-domain** |
| `amazon.co.uk._report._dmarc.dmarc.amazon.com` | TXT | `v=DMARC1` (same shape for another regional domain) |
| `amazon.com.au` | SOA | `dns-external-master.amazon.com. root.amazon.com. …` (no longer consulted) |
| `awsdns-33.com` (public Route 53 apex) / `amzndns.com` | SOA | both `… awsdns-hostmaster.amazon.com …` — why an SOA/NS-platform chain cannot work |
| `spf1.amazon.com` / `spf2.amazon.com` | TXT | ip4 lists + `include:spf3.amazon.com` — the seed's SPF names no candidate |
| `xero.com` / `xero.co.nz` | NS / MX / `_dmarc` | Route 53 / Google / `rua=mailto:xero@rua.agari.com` — and Akamai / Google / the same Agari mailbox |
| `xero.co.nz._report._dmarc.rua.agari.com` | TXT | `v=DMARC1;` — published by **Agari** (a third party), so it proves nothing about Xero |

RDAP / CT:

| domain | source | registrant / SAN evidence |
| --- | --- | --- |
| `amazon.com` | `rdap.verisign.com` (thin) | **none** — registrar `MarkMonitor Inc.` (IANA 292) only; registrant org exists only behind the `related` link to `rdap.markmonitor.com`, which `probeRdap()` does not follow |
| `amazon.com.au` | `rdap.cctld.au` (IANA bootstrap) | **none** — registrar `MarkMonitor Corporate Services Inc` with an auDA-local `Registrar ID 802247`, no IANA ID, no registrant |
| `xero.co.nz` | — | `.nz` has **no RDAP server in the IANA bootstrap** and none in `FALLBACK_RDAP_SERVERS`; `probeRdap()` short-circuits without a fetch |
| `amazon.com.au` | `crt.sh` | **0 of 3300** certificates also cover `amazon.com` — no CT SAN overlap |

So for the Amazon pair **neither** the shared-NS arms **nor** the #263 RDAP registrant-org tier can fire, `isBrandHeldRegistration` cannot either (no IANA registrar ID from auDA), CT is empty, and the seed's SPF names no candidate. The one seed-side record that links the pair is the DMARC report authorisation.

## Root cause

`classifyOwnership()` (`src/lib/ownership-attribution.ts`) is driven entirely by seed-side nameserver evidence (Ruling A, 2026-07-27). That is the right posture — candidate-published records are free to forge — but it left a same-entity domain on a *different* DNS platform with thin registry RDAP on both sides permanently unattributable, because nameservers were the only seed-side signal the arm knew how to read.

## Fix + spoofing analysis

**Step 5b — seed-authorised convergence** (`assessSeedAuthorisedConvergence()`; amendment documented in the file header). Applied only after every seed-side NS arm has declined:

1. **Pre-filter (candidate-side, attacker-free, zero cost, NO verdict weight):** every real MX exchange of the candidate sits inside the seed apex. Copying `MX 10 amazon-smtp.amazon.com` into a self-hosted zone is free for a *sending* squatter and forfeits nothing it wanted — a phisher never needed the receive channel. So this half only decides which candidates are worth the seed-side lookups.
2. **Verdict (seed-side):** the candidate's DMARC record sends reports to a mailbox whose domain sits inside the seed apex, **and** the seed has published `<candidate>._report._dmarc.<receiver>` TXT `v=DMARC1` (RFC 7489 §7.1). The DMARC record itself is candidate-published and proves nothing; the authorisation record lives in the *receiver's* zone — under the seed apex — and only its owner can publish it. A squatter cannot. → `owned_by_seed`, `strength: 'medium'`, `signals: ['mx_in_bailiwick', 'dmarc_report_authorised_by_seed']`, `evidence[]` naming the MX host, the receiver and the authorisation record name.
3. **Wildcard guard:** a canary label under the same `_report._dmarc` distinguishes a per-domain grant from `*._report._dmarc.<receiver>`; a wildcard is the seed choosing to accept reports about *any* domain and is evidence-only (`status: 'wildcard'` → no verdict).

Rejected on the live records above: **SOA MNAME** (unverified free text in a self-hosted zone — the first revision of this PR), **SOA RNAME** (Route 53 templates `awsdns-hostmaster.amazon.com` into every tenant zone), the **NS-platform chain** (`amzndns.com` and public `awsdns-33.com` carry the same RNAME), **seed SPF** (names no candidate), **CT SAN overlap** (0/3300), **SPF `include:` / HTTP redirect** (free text, deleted 2026-07-27). Any "MNAME resolves / is authoritative" variant is likewise insufficient — the attacker's own NS can answer — and is pinned as negative (ii).

**Ruling A posture:** unchanged in substance. Candidate-side records still never produce `owned_by_seed`, alone or combined; the header's OWNERSHIP RULE note is re-derived to say exactly that the MX field is a pre-filter and the verdict-bearing record is seed-published. Seed-side NS arms keep precedence: a full dedicated NS match is still reported as `strong ns_set_match`, never displaced by this medium verdict. **#832 law extended:** pre-filter met but the seed-side lookup *rejected* → `unmeasured` (never the contrary `third_party`), impersonation finding withheld for that candidate, result marked `partial`. NXDOMAIN/empty is a measured absence and falls through to the seed-side NS outcome.

**Residual, stated not hidden:** a seed that is itself a DMARC report-*processing provider* (Agari/Valimail-shaped) publishes authorisation records for every customer, so a customer whose MX also sits inside that seed's apex would attribute — the same provider-class residual the `ns_in_bailiwick` arm already carries for DNS providers (any Cloudflare-hosted candidate is in-bailiwick of `cloudflare.com`). The verdict is `medium` and quotes every record.

**Budget.** Zero extra DNS on a scan with no MX-in-seed candidate. For each of the ≤10 (`SEED_AUTHORISATION_CAP`) that pass the pre-filter: `_dmarc.<candidate>` TXT (1) + per in-seed receiver (≤2, `MAX_SEED_REPORT_RECEIVERS`) the authorisation TXT (1) + a canary TXT only when a grant answered (1) — through `mapConcurrent` with `SEED_AUTHORISATION_CONCURRENCY = 3` (under the A/MX probe's `INITIAL_BATCH_SIZE = 10`). The `amazon.com` fixture asserts exactly `['_dmarc.amazon.com.au', 'amazon.com.au._report._dmarc.dmarc.amazon.com', '_bv-wc-probe._report._dmarc.dmarc.amazon.com']` across the 84-permutation run; the `xero.com` fixture asserts zero. The pass runs before enrichment, so a newly-owned candidate skips RDAP/HEAD like any other owned candidate.

**Files:** `src/lib/ownership-attribution.ts` (step 5b, `mxRoutedIntoSeed()`, `parseDmarcReportReceivers()`, `DmarcReportAuthorisation`, `OwnershipEvidence`, `dmarc_report_authorised_by_seed` signal, header amendment), `src/tools/lookalike-dns.ts` (`probeDmarcReportAuthorisation()`), `src/tools/lookalike-attribution.ts` (`refineOwnershipBySeedAuthorisation()` — gathers inputs, decides nothing), `src/tools/check-lookalikes.ts` (one call between Phase 2 and enrichment; `partial` on a rejected seed-side probe), `src/tools/lookalike-findings.ts` (`buildOwnedBySeedFinding` now carries `ownershipStrength`, `ownershipSignals`, `attributionConfidence`, `ownershipEvidence`). Sibling files under parallel edit (`lookalike-summary-findings.ts`, `lookalike-enrichment.ts`, `rdap-fallback-servers.ts`) are untouched.

## Scoring impact

**Not `scan_domain`-score-affecting.** `check_lookalikes` is `scanIncluded: false` with no `CHECK_DISPATCH` entry, so no scan ever holds a `lookalikes` `CheckResult`; `hasActiveImpersonation()` (`scan/post-processing.ts`) and the `impersonation_weak_dmarc` interaction (`lookalikes <= 85`) only read one when present. `check_shadow_domains` calls `classifyOwnership()` without the new optional inputs, so step 5b is unreachable there and its verdicts (and severity downgrades) are byte-identical. `SCORING_MODEL_VERSION` is deliberately **not** bumped here — the orchestrator owns that at release.

What *does* change is the standalone `check_lookalikes` result for an affected seed: the same-entity candidate moves from a `third_party` attribution + a medium/high `threat_observation` to an info `owned_by_seed` finding, so that tool's own `lookalikes` category score rises and `mailCapableDomains` / staging counts no longer include it. That is the intended correction of the false positive, not a model change.

## Tests

New `test/check-lookalikes-multi-platform-ownership.spec.ts` (21 tests), fixtures transcribed from the live records above:

- `parseDmarcReportReceivers`: live amazon / xero records; size suffix, multiple URIs, case, non-mailto ignored.
- Unit (`classifyOwnership`): `amazon.com.au` → `owned_by_seed` / medium / both signals / full evidence; pre-#864 control (`third_party`); **negatives** — MX pre-filter with `undefined` / `no_seed_receiver` / `not_authorised`; wildcard grant; defence-in-depth (an "authorised" result whose receiver or record is outside the seed apex); mixed MX set fails the pre-filter even with a grant; `unresolved` → `unmeasured`; fires under a degraded seed NS lookup; seed-side precedence (`strong ns_set_match` wins); `xero.co.nz` live shape → arm declines.
- End-to-end (`checkLookalikes` over the real 84-permutation set): `amazon.com.au` owned with evidence, no threat observation, no `third_party`, no rollup, exact three seed-side lookups; **negative (i)** forged SOA MNAME under the seed apex + copied seed MX + attacker NS (`ns1.amaz0n.com`) + DMARC reporting into the seed → `third_party`, threat observation retained, named in the mail-capable rollup, grant lookup issued and empty; **negative (ii)** same zone with the MNAME host resolving to a real seed host → still not sufficient; **negative** seed wildcard grant → not attributed, threat retained; **negative** NS-string resemblance + copied MX, no DMARC → threat retained, only the `_dmarc` lookup issued; seed-side lookup rejects → `unmeasured`, finding withheld, `partial: true`; `xero.co.nz` shape → arm declines, zero seed-side lookups, candidate still surfaced at info (D4 cap unchanged).

Verified after the re-review fixes + merge: `npm run typecheck` (rc 0), `npm run lint` (rc 0), `npx vitest run test/check-lookalikes*.spec.ts test/lookalike*.spec.ts test/check-shadow-domains.spec.ts test/ownership-attribution.spec.ts test/audits/ownership-severity-gate.audit.test.ts test/audits/ns-in-bailiwick-full-match.audit.test.ts` → 10 files, 242 tests passed (new spec: 21). Full `npm test` on the first revision: 8352 passed / 52 failed / 13 skipped, where every failure was a `Test timed out in 15000ms` in an unrelated spec (a second vitest instance was running concurrently) plus the known `wasm-integration.test.ts` load failure in a fresh worktree; all 39 other failing files re-run in isolation → 39 files, 424 tests passed.

## Residuals

- The #263 RDAP registrant tier is **live-unreachable for both named fixtures**: `.nz` has no RDAP server anywhere, and `.com` (Verisign) is thin. `xero.co.nz` has never been attributable in production — only in the mocked spec — and it has no seed-side signal either (both domains report to Agari). Following the thin-registry `related` link would fix the `.com` seed side but belongs with #867's `lookalike-enrichment.ts` work (file under parallel edit); worth a follow-up issue.
- `.com.au` (auDA) publishes no registrant and an auDA-local registrar ID, so `isBrandHeldRegistration` cannot match `.au` candidates either.
- A seed-side-probe `unmeasured` is visible on the candidate's own attribution finding and via `partial: true`, but the run-level `scan_status` notice stays gated on the *seed* NS failure (kept out of `lookalike-summary-findings.ts` deliberately — sibling edit).
- Option 2 from the review (an `ownershipHint` on candidates that only pass the pre-filter) was **not** added: since MX-copying is free for a sender, such a hint would be attacker-influenced noise on exactly the findings it would decorate.

Closes #864

🤖 Generated with [Claude Code](https://claude.com/claude-code)
