### PR TITLE
fix(mta-sts): scanner-side fetch/resolver failures abstain instead of scoring the domain (#889)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.32.0",
+	"version": "1.33.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-mta-sts-not-assessed.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-mta-sts-not-assessed.test.ts
@@ -1,0 +1,248 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Issue #889 — the scanner's OWN I/O failure inside `checkMTASTS` must abstain, never score.
+ *
+ * Three catch paths used to convert a thrown fetch / resolver call into a SCORED finding
+ * with no `checkStatus`: the policy fetch (`medium` → category 85), the `_smtp._tls`
+ * lookup (`low` → 95, recorded as `tlsRptChecked = true` as if measured) and the
+ * `_mta-sts` lookup (`low`). None of those is an observation about the domain, and bv-web
+ * consumes this package export directly — so the grade published on a named third party
+ * went DOWN from zero evidence.
+ *
+ * The rule (CLAUDE.md "DNS-failure resilience", bv-mcp-scoring): `missingControl` =
+ * "we MEASURED and the control is absent"; a probe that never reached the origin is
+ * `checkStatus: 'error' | 'timeout'` + `score: 0` + `partial: true` + an `info`
+ * not-assessed finding, so scoring EXCLUDES the category and the transient-zero retry
+ * can fire. The `CheckStatus` union is NOT widened (#743) — the reason travels in
+ * finding metadata (`notAssessedReason`, `robotsAbstentionMetadata`).
+ *
+ * A DEFINITE negative answer is still evidence and keeps its scored finding: a non-ok
+ * HTTP response on the policy URL, and an empty (NXDOMAIN/NODATA) TXT answer.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { checkMTASTS } from '../../checks/check-mta-sts';
+import { RobotsDisallowedError } from '../../robots-gate';
+import type { DNSQueryFunction, FetchFunction, Finding } from '../../types';
+
+const STS_RECORD = 'v=STSv1; id=20240101';
+const TLSRPT_RECORD = 'v=TLSRPTv1; rua=mailto:tlsrpt@example.com';
+const HEALTHY_POLICY = 'version: STSv1\nmode: enforce\nmx: mail.example.com\nmax_age: 604800';
+const POLICY_URL = 'https://mta-sts.example.com/.well-known/mta-sts.txt';
+
+/** Resolver: `_mta-sts` published, TLS-RPT published, MX present; anything else empty. */
+function healthyDNS(overrides: Partial<Record<string, string[] | Error>> = {}): DNSQueryFunction {
+	const table: Record<string, string[] | Error> = {
+		'_mta-sts.example.com': [STS_RECORD],
+		'_smtp._tls.example.com': [TLSRPT_RECORD],
+		'example.com': ['10 mail.example.com.'],
+		...overrides,
+	};
+	return async (name: string) => {
+		const entry = table[name];
+		if (entry instanceof Error) throw entry;
+		return entry ?? [];
+	};
+}
+
+const okPolicy: FetchFunction = async () => new Response(HEALTHY_POLICY, { status: 200 });
+
+function throwing(err: Error): FetchFunction {
+	return async () => {
+		throw err;
+	};
+}
+
+function named(name: string, message = name): Error {
+	const err = new Error(message);
+	err.name = name;
+	return err;
+}
+
+/** True when a finding would actually move the score (medium and above). */
+function hasScoredDeficiency(findings: Finding[]): boolean {
+	return findings.some((f) => f.severity === 'medium' || f.severity === 'high' || f.severity === 'critical');
+}
+
+function notAssessed(findings: Finding[]): Finding | undefined {
+	return findings.find((f) => f.metadata?.inconclusive === true);
+}
+
+describe('checkMTASTS — scanner-side failure abstains instead of scoring the domain (#889)', () => {
+	it('control: a served policy is measured and scored normally (no checkStatus, no partial)', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: okPolicy });
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.partial).toBeUndefined();
+		expect(r.score).toBe(100);
+		expect(r.controlPresent).toBe(true);
+		expect(r.recordPresent).toBe(true);
+	});
+
+	it('policy fetch throws a generic transport error (the issue repro) → checkStatus error, score 0, partial, info only', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(new Error('ECONNRESET')) });
+
+		// The issue's observed shape: score 85, checkStatus undefined, a medium "fetch failed".
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.passed).toBe(false);
+		expect(r.partial).toBe(true);
+		expect(hasScoredDeficiency(r.findings)).toBe(false);
+		expect(r.findings.some((f) => f.title === 'MTA-STS policy fetch failed')).toBe(false);
+
+		const f = notAssessed(r.findings);
+		expect(f, 'an info not-assessed finding must document the abstention').toBeDefined();
+		expect(f!.severity).toBe('info');
+		expect(f!.metadata?.notAssessedReason).toBe('policy_fetch_failed');
+		expect(f!.metadata?.errorKind).toBe('transport_error');
+		// Never both: an unmeasured probe must not also claim the control is absent (#638).
+		expect(f!.metadata?.missingControl).toBeUndefined();
+		expect(f!.detail).toContain(POLICY_URL);
+	});
+
+	it("policy fetch throws AbortError (the package's own AbortSignal.timeout) → checkStatus timeout", async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(named('AbortError', 'The operation was aborted')) });
+		expect(r.checkStatus).toBe('timeout');
+		expect(r.score).toBe(0);
+		expect(r.partial).toBe(true);
+		expect(hasScoredDeficiency(r.findings)).toBe(false);
+		expect(notAssessed(r.findings)?.metadata?.errorKind).toBe('timeout');
+	});
+
+	it('policy fetch throws TimeoutError (DOMException name in workerd) → checkStatus timeout', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(named('TimeoutError', 'The operation timed out')) });
+		expect(r.checkStatus).toBe('timeout');
+		expect(notAssessed(r.findings)?.metadata?.notAssessedReason).toBe('policy_fetch_failed');
+	});
+
+	it('the observed _mta-sts record is still credited on the policy-fetch abstention (true, never false)', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(new Error('ECONNRESET')) });
+		// The TXT record WAS observed; only the policy file was not fetched. `false` here
+		// would assert an absence nobody measured; `undefined` would discard a measurement.
+		expect(r.controlPresent).toBe(true);
+		expect(r.recordPresent).toBe(true);
+	});
+
+	it('RobotsDisallowedError → labelled robots abstention (checkStatus error) using the shared vocabulary', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(new RobotsDisallowedError(POLICY_URL, 'blanket')) });
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.partial).toBe(true);
+		expect(hasScoredDeficiency(r.findings)).toBe(false);
+
+		const f = notAssessed(r.findings);
+		expect(f).toBeDefined();
+		expect(f!.severity).toBe('info');
+		// Same machine-readable abstention as ssl / http_security / bimi (#743).
+		expect(f!.metadata?.notAssessedReason).toBe('robots_disallowed');
+		expect(f!.metadata?.robotsScope).toBe('blanket');
+		expect(f!.metadata?.confidence).toBe('deterministic');
+		expect(f!.detail).toContain('robots.txt');
+		// A blanket block must not be reported as the site naming this scanner.
+		expect(f!.detail).not.toContain('BlackVeil-Security-Scanner');
+	});
+
+	it('RobotsDisallowedError with scope named says so plainly', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(new RobotsDisallowedError(POLICY_URL, 'named')) });
+		const f = notAssessed(r.findings)!;
+		expect(f.metadata?.robotsScope).toBe('named');
+		expect(f.detail).toContain('BlackVeil-Security-Scanner');
+	});
+
+	it('_smtp._tls lookup rejects → not assessed, NOT recorded as a measured TLS-RPT absence', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_smtp._tls.example.com': new Error('SERVFAIL') }), { fetchFn: okPolicy });
+
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.partial).toBe(true);
+		expect(hasScoredDeficiency(r.findings)).toBe(false);
+		// The old `low` "TLS-RPT DNS query failed" (→ 95) is gone…
+		expect(r.findings.some((f) => f.title === 'TLS-RPT DNS query failed')).toBe(false);
+		// …and so is any claim that TLS-RPT was looked for and found missing.
+		expect(r.findings.some((f) => /TLS-RPT record missing/i.test(f.title))).toBe(false);
+		expect(r.findings.some((f) => f.title === 'No MTA-STS or TLS-RPT records found')).toBe(false);
+
+		const f = notAssessed(r.findings);
+		expect(f?.severity).toBe('info');
+		expect(f?.metadata?.notAssessedReason).toBe('dns_query_failed');
+		expect(f?.metadata?.errorKind).toBe('dns_error');
+	});
+
+	it('_smtp._tls lookup rejects with a timeout-class error → checkStatus timeout', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_smtp._tls.example.com': named('TimeoutError') }), { fetchFn: okPolicy });
+		expect(r.checkStatus).toBe('timeout');
+	});
+
+	it('_mta-sts lookup rejects → not assessed; recordPresent / controlPresent are undefined (unknown), never false', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_mta-sts.example.com': new Error('DNS timeout') }), { fetchFn: okPolicy });
+
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.passed).toBe(false);
+		expect(r.partial).toBe(true);
+		expect(hasScoredDeficiency(r.findings)).toBe(false);
+		expect(r.findings.some((f) => f.title === 'MTA-STS DNS query failed')).toBe(false);
+		expect(r.controlPresent).toBeUndefined();
+		expect(r.recordPresent).toBeUndefined();
+
+		const f = notAssessed(r.findings);
+		expect(f?.severity).toBe('info');
+		expect(f?.metadata?.notAssessedReason).toBe('dns_query_failed');
+	});
+
+	it('a not-assessed result never carries a low/medium/high finding derived from the failure itself', async () => {
+		// Every abstention path: no finding whose title reads as a failure verdict on the domain.
+		const cases: Array<Promise<Awaited<ReturnType<typeof checkMTASTS>>>> = [
+			checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(new Error('boom')) }),
+			checkMTASTS('example.com', healthyDNS({ '_smtp._tls.example.com': new Error('boom') }), { fetchFn: okPolicy }),
+			checkMTASTS('example.com', healthyDNS({ '_mta-sts.example.com': new Error('boom') }), { fetchFn: okPolicy }),
+		];
+		for (const r of await Promise.all(cases)) {
+			expect(r.findings.filter((f) => /query failed|fetch failed/i.test(f.title))).toHaveLength(0);
+		}
+	});
+});
+
+describe('checkMTASTS — a DEFINITE negative answer is still evidence (#889 boundary)', () => {
+	it('HTTP 404 on the policy URL keeps the scored high "policy file not accessible" finding', async () => {
+		const fetchFn: FetchFunction = async () => new Response('Not Found', { status: 404 });
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn });
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.partial).toBeUndefined();
+		expect(r.findings.some((f) => f.title === 'MTA-STS policy file not accessible' && f.severity === 'high')).toBe(true);
+		expect(notAssessed(r.findings)).toBeUndefined();
+	});
+
+	it('HTTP 5xx on the policy URL is likewise a measured negative', async () => {
+		const fetchFn: FetchFunction = async () => new Response('', { status: 503 });
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn });
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.findings.some((f) => f.title === 'MTA-STS policy file not accessible')).toBe(true);
+	});
+
+	it('an EMPTY _smtp._tls answer (NXDOMAIN/NODATA) still yields the graded record-missing finding', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_smtp._tls.example.com': [] }), { fetchFn: okPolicy });
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.partial).toBeUndefined();
+		expect(r.findings.some((f) => /TLS-RPT record missing/i.test(f.title) && f.severity === 'low')).toBe(true);
+		expect(r.score).toBe(95);
+	});
+
+	it('an EMPTY _mta-sts answer with MX still yields the graded absence finding (85, not zeroed, not excluded)', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_mta-sts.example.com': [], '_smtp._tls.example.com': [] }), {
+			fetchFn: okPolicy,
+		});
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.findings.some((f) => f.title === 'No MTA-STS or TLS-RPT records found' && f.severity === 'medium')).toBe(true);
+		expect(r.score).toBe(85);
+		expect(r.recordPresent).toBe(false);
+	});
+
+	it('the MX-coverage sub-check keeps its silent abstention when only the MX lookup fails', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ 'example.com': new Error('SERVFAIL') }), { fetchFn: okPolicy });
+		// The policy was served and parsed; a failed MX cross-check neither scores nor excludes.
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.score).toBe(100);
+		expect(r.findings.some((f) => /not covered|uncovered/i.test(f.title))).toBe(false);
+	});
+});

--- a/packages/dns-checks/src/__tests__/checks/check-mta-sts-not-assessed.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-mta-sts-not-assessed.test.ts
@@ -246,3 +246,69 @@ describe('checkMTASTS — a DEFINITE negative answer is still evidence (#889 bou
 		expect(r.findings.some((f) => /not covered|uncovered/i.test(f.title))).toBe(false);
 	});
 });
+
+describe('checkMTASTS — a TLS-RPT sub-probe failure must not blank a DEFINITE MTA-STS measurement (#889 review)', () => {
+	const policy404: FetchFunction = async () => new Response('Not Found', { status: 404 });
+
+	it('404 policy + _smtp._tls throws → category MEASURED, the high is retained and scores, TLS-RPT rides along as an unscored info', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_smtp._tls.example.com': new Error('SERVFAIL') }), { fetchFn: policy404 });
+
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.partial).toBeUndefined();
+		expect(r.findings.some((f) => f.title === 'MTA-STS policy file not accessible' && f.severity === 'high')).toBe(true);
+		// The high (−25) scores; the TLS-RPT abstention costs nothing (was −5 pre-PR, would have
+		// been a whole-category blank after the first cut of this PR).
+		expect(r.score).toBe(75);
+		expect(r.passed).toBe(true);
+
+		const tls = r.findings.find((f) => f.metadata?.notAssessedReason === 'dns_query_failed');
+		expect(tls?.severity).toBe('info');
+		expect(tls?.metadata?.inconclusive).toBe(true);
+		// Never recorded as a measured absence.
+		expect(r.findings.some((f) => f.title === 'TLS-RPT record missing')).toBe(false);
+		expect(r.controlPresent).toBe(true);
+		expect(r.recordPresent).toBe(true);
+	});
+
+	it('missing _mta-sts record (definite absence) + _smtp._tls throws → measured, graded absence retained', async () => {
+		const r = await checkMTASTS(
+			'example.com',
+			healthyDNS({ '_mta-sts.example.com': [], '_smtp._tls.example.com': new Error('SERVFAIL') }),
+			{
+				fetchFn: okPolicy,
+			},
+		);
+		expect(r.checkStatus).toBeUndefined();
+		expect(r.findings.some((f) => f.title === 'No MTA-STS record found' && f.severity === 'medium')).toBe(true);
+		expect(r.score).toBe(85);
+		expect(r.recordPresent).toBe(false);
+		// The both-missing summary needs a MEASURED TLS-RPT absence; a failed lookup is not one.
+		expect(r.findings.some((f) => f.title === 'No MTA-STS or TLS-RPT records found')).toBe(false);
+	});
+
+	it('record present + policy fetch throws + TLS-RPT ok → whole-check abstention (unchanged)', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS(), { fetchFn: throwing(new Error('ECONNRESET')) });
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.partial).toBe(true);
+	});
+
+	it('record present + healthy policy (no graded finding) + _smtp._tls throws → whole-check abstention (nothing definite to keep)', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_smtp._tls.example.com': new Error('SERVFAIL') }), { fetchFn: okPolicy });
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.findings.some((f) => f.title === 'MTA-STS properly configured')).toBe(false);
+	});
+
+	it('both the policy fetch and _smtp._tls throw → abstention carrying both reasons', async () => {
+		const r = await checkMTASTS('example.com', healthyDNS({ '_smtp._tls.example.com': named('TimeoutError') }), {
+			fetchFn: throwing(new Error('ECONNRESET')),
+		});
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.partial).toBe(true);
+		const reasons = r.findings.filter((f) => f.metadata?.inconclusive === true).map((f) => f.metadata?.notAssessedReason);
+		expect(reasons).toEqual(expect.arrayContaining(['policy_fetch_failed', 'dns_query_failed']));
+		expect(hasScoredDeficiency(r.findings)).toBe(false);
+	});
+});

--- a/packages/dns-checks/src/checks/check-mta-sts.ts
+++ b/packages/dns-checks/src/checks/check-mta-sts.ts
@@ -8,9 +8,10 @@
  * Licensed under BUSL-1.1
  */
 
-import type { CheckResult, DNSQueryFunction, FetchFunction, Finding, ZoneContext } from '../types';
+import type { CheckResult, CheckStatus, DNSQueryFunction, FetchFunction, Finding, ZoneContext } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
 import { readResponseTextCapped } from '../response-body';
+import { RobotsDisallowedError, describeRobotsScope, robotsAbstentionMetadata } from '../robots-gate';
 import { isNullMxRecord, parseMxRecords } from './mx-analysis';
 import {
 	finalizeMissingMtaStsRecordFinding,
@@ -27,6 +28,21 @@ import {
 const HTTPS_TIMEOUT_MS = 4_000;
 
 /**
+ * Why an `mta_sts` result was NOT assessed (issue #889), carried additively in the
+ * not-assessed finding's `metadata.notAssessedReason`. `checkStatus` alone cannot say
+ * this — its union is deliberately `'completed' | 'timeout' | 'error'` (#743) — so the
+ * reason travels here, the same way `robotsAbstentionMetadata` already does for the
+ * robots case in `ssl` / `http_security` / `bimi`.
+ *
+ * - `robots_disallowed`   — the `mta-sts.<domain>` host's robots.txt disallowed the policy fetch.
+ * - `policy_fetch_failed` — the policy fetch THREW (transport error, TLS/egress failure, the
+ *                            package's own `AbortSignal.timeout`, a resolver failure for the
+ *                            `mta-sts.` host) before any HTTP response was received.
+ * - `dns_query_failed`    — the `_mta-sts` or `_smtp._tls` TXT lookup rejected.
+ */
+export type MtaStsNotAssessedReason = 'robots_disallowed' | 'policy_fetch_failed' | 'dns_query_failed';
+
+/**
  * Parse MX records from raw DNS response strings.
  * MX data format: "priority exchange"
  */
@@ -39,8 +55,62 @@ function parseMxFromRaw(answers: string[]): Array<{ exchange: string }> {
 }
 
 /**
+ * Classify a thrown fetch / resolver call by the ONLY signal that distinguishes a stall from
+ * a refusal: the error's `name`. `AbortSignal.timeout` rejects with a DOMException named
+ * `TimeoutError` (workerd, Node ≥ 17.3) or `AbortError` (older runtimes / composed signals);
+ * everything else — ECONNRESET, TLS failure, SERVFAIL, an egress refusal — is `'error'`.
+ * `'error'` is also the class `scan_domain`'s transient-zero retry fires on.
+ */
+function classifyTransportFailure(err: unknown): CheckStatus {
+	const name = (err as { name?: unknown } | null)?.name;
+	return name === 'AbortError' || name === 'TimeoutError' ? 'timeout' : 'error';
+}
+
+/**
+ * The not-assessed shape (issue #889): `checkStatus` is what EXCLUDES the category from the
+ * profile score (renormalised, shown n/a — never zeroed, never penalised); `score: 0` +
+ * `passed: false` because an unmeasured check did not pass; `partial: true` keeps the
+ * transient outcome OUT of the result cache so the next call re-measures.
+ *
+ * `controlPresent` / `recordPresent` are passed through ONLY when the `_mta-sts` record was
+ * actually observed (`true`); a lookup that never answered leaves them `undefined` (unknown).
+ * They are never `false` on this path — that would assert an absence nobody measured.
+ */
+function buildNotAssessedResult(findings: Finding[], status: CheckStatus, txtRecordObserved: boolean): CheckResult {
+	const observed = txtRecordObserved ? true : undefined;
+	return {
+		...buildCheckResult('mta_sts', findings, observed, observed),
+		score: 0,
+		passed: false,
+		checkStatus: status,
+		partial: true,
+	};
+}
+
+/** The `info` finding documenting a rejected `_mta-sts` / `_smtp._tls` TXT lookup. */
+function buildDnsNotAssessedFinding(label: string, name: string, status: CheckStatus): Finding {
+	return createFinding(
+		'mta_sts',
+		`${label} not assessed (DNS lookup ${status === 'timeout' ? 'timed out' : 'failed'})`,
+		'info',
+		`The scanner's TXT lookup for ${name} did not complete, so ${label} could not be assessed on this run. ` +
+			`This is not evidence about the domain — an empty answer would have been graded as a missing record. Retry to re-measure.`,
+		// `errorKind: 'dns_error'` is the marker `isDnsErrorFinding` consumers filter on (no
+		// remediation, no compliance verdict, nothing to sell against an unmeasured category).
+		// Never `missingControl` alongside it (issue #638).
+		{ inconclusive: true, errorKind: 'dns_error', notAssessedReason: 'dns_query_failed' satisfies MtaStsNotAssessedReason },
+	);
+}
+
+/**
  * Check MTA-STS configuration for a domain.
  * Queries _mta-sts.<domain> TXT records and optionally fetches the policy file.
+ *
+ * Abstention doctrine (issue #889): only a DEFINITE answer from the domain is evidence —
+ * a non-ok HTTP status on the policy URL, or an empty TXT answer. A failure of the
+ * scanner's OWN I/O (a thrown fetch, a rejecting resolver, a robots.txt disallow) is
+ * returned as NOT ASSESSED via `checkStatus` + an `info` finding, never as a scored
+ * deficiency against the domain. See {@link MtaStsNotAssessedReason}.
  */
 export async function checkMTASTS(
 	domain: string,
@@ -53,24 +123,27 @@ export async function checkMTASTS(
 
 	// Check for _mta-sts TXT record
 	let hasTxtRecord = false;
-	// Read ONLY by `recordPresent` below: `hasTxtRecord` stays false on a lookup failure, which
-	// is the right conservative choice for `controlPresent` but would misreport publication.
-	let mtaStsQueryFailed = false;
 	try {
 		const txtRecords = await queryDNS(`_mta-sts.${domain}`, 'TXT', { timeout });
 		const txtAnalysis = getMtaStsTxtFindings(txtRecords);
 		hasTxtRecord = txtAnalysis.hasTxtRecord;
 		findings.push(...finalizeMissingMtaStsRecordFinding(txtAnalysis.findings, domain));
-	} catch {
-		findings = [];
-		mtaStsQueryFailed = true;
-		findings.push(createFinding('mta_sts', 'MTA-STS DNS query failed', 'low', `Could not query MTA-STS TXT record for ${domain}.`));
+	} catch (err) {
+		// The lookup that everything else hangs off never answered: nothing about MTA-STS was
+		// measured. Abstain outright (mirrors `checkMX`) — was a scored `low` "DNS query failed".
+		const status = classifyTransportFailure(err);
+		return buildNotAssessedResult([buildDnsNotAssessedFinding('MTA-STS', `_mta-sts.${domain}`, status)], status, false);
 	}
+
+	// A scanner-side failure observed below. The measured findings gathered so far are KEPT
+	// for display; the abstention decides the result shape at the end.
+	let notAssessedStatus: CheckStatus | null = null;
+	const notAssessedFindings: Finding[] = [];
 
 	// Try to fetch the MTA-STS policy file (only if fetch function provided)
 	if (hasTxtRecord && fetchFn) {
+		const policyUrl = `https://mta-sts.${domain}/.well-known/mta-sts.txt`;
 		try {
-			const policyUrl = `https://mta-sts.${domain}/.well-known/mta-sts.txt`;
 			const response = await fetchFn(policyUrl, {
 				method: 'GET',
 				redirect: 'manual',
@@ -89,6 +162,9 @@ export async function checkMTASTS(
 				// Body unread on this branch — release it so workerd doesn't cancel a stalled response.
 				void response.body?.cancel().catch(() => undefined);
 			} else if (!response.ok) {
+				// A DEFINITE HTTP answer (404/403/5xx) from the policy host IS evidence and stays
+				// scored. (A WAF challenge page is the one known exception — the bv-mcp wrapper
+				// fingerprints the response and excludes it; see issue #455.)
 				findings.push(
 					createFinding(
 						'mta_sts',
@@ -127,25 +203,57 @@ export async function checkMTASTS(
 								),
 							);
 						} catch {
-							// MX query failed; skip coverage cross-check.
+							// MX query failed; skip coverage cross-check. A sub-signal of an otherwise
+							// measured policy — silent abstention, neither scored nor excluding.
 						}
 					}
 				}
 			}
-		} catch {
-			findings.push(
-				createFinding(
-					'mta_sts',
-					'MTA-STS policy fetch failed',
-					'medium',
-					`Could not fetch MTA-STS policy file from https://mta-sts.${domain}/.well-known/mta-sts.txt`,
-				),
-			);
+		} catch (err) {
+			// Everything the fetch can THROW lands here: the scanner's own `AbortSignal.timeout`
+			// firing, a TLS/egress failure, a `RobotsDisallowedError` from a gate wrapped around
+			// `fetchFn`, a resolver failure for `mta-sts.<domain>`. None of these is an
+			// observation about the domain (issue #889) — was a scored `medium` "policy fetch
+			// failed" (category 85) indistinguishable from a domain that lacks the control.
+			if (err instanceof RobotsDisallowedError) {
+				notAssessedStatus = 'error';
+				notAssessedFindings.push(
+					createFinding(
+						'mta_sts',
+						'MTA-STS policy not independently verified (robots.txt)',
+						'info',
+						`${policyUrl} could not be fetched: the mta-sts.${domain} host's robots.txt ${describeRobotsScope(err.scope)}. ` +
+							`The _mta-sts DNS record itself was observed; only the policy file's own contents were not checked. Not scored — see https://www.blackveilsecurity.com/bot-policy.`,
+						{ ...robotsAbstentionMetadata(err.scope), inconclusive: true },
+					),
+				);
+			} else {
+				const status = classifyTransportFailure(err);
+				notAssessedStatus = status;
+				notAssessedFindings.push(
+					createFinding(
+						'mta_sts',
+						`MTA-STS policy not assessed (${status === 'timeout' ? 'scanner timeout' : 'transport error'})`,
+						'info',
+						`The scanner's fetch of ${policyUrl} did not complete (${status === 'timeout' ? 'the request timed out' : 'a transport error occurred'} before any HTTP response was received), ` +
+							`so policy accessibility could not be verified on this run. This is not evidence about ${domain}: the _mta-sts DNS record was observed, and a definite HTTP answer would have been graded. Retry to re-measure.`,
+						// No `missingControl` (issue #638): a fetch that never delivered a response
+						// established nothing about the policy. `checkStatus` below excludes the category.
+						{
+							inconclusive: true,
+							errorKind: status === 'timeout' ? 'timeout' : 'transport_error',
+							notAssessedReason: 'policy_fetch_failed' satisfies MtaStsNotAssessedReason,
+						},
+					),
+				);
+			}
 		}
 	}
 
 	// Check for TLSRPT record
 	let hasTlsRptRecord = false;
+	// True ONLY when the lookup ANSWERED (an empty answer is a measured absence). A rejected
+	// lookup must not read as "we looked" — that was the #889 `tlsRptChecked = true` defect.
 	let tlsRptChecked = false;
 	try {
 		const tlsrptRecords = await queryDNS(`_smtp._tls.${domain}`, 'TXT', { timeout });
@@ -153,9 +261,15 @@ export async function checkMTASTS(
 		const tlsRptAnalysis = getTlsRptRecordFindings(tlsrptRecords);
 		hasTlsRptRecord = tlsRptAnalysis.hasTlsRptRecord;
 		findings.push(...finalizeMissingTlsRptRecordFinding(tlsRptAnalysis.findings, domain));
-	} catch {
-		tlsRptChecked = true;
-		findings.push(createFinding('mta_sts', 'TLS-RPT DNS query failed', 'low', `Could not query TLS-RPT TXT record for ${domain}.`));
+	} catch (err) {
+		// Was a scored `low` "TLS-RPT DNS query failed" (category 95) recorded as measured.
+		const status = classifyTransportFailure(err);
+		notAssessedStatus ??= status;
+		notAssessedFindings.push(buildDnsNotAssessedFinding('TLS-RPT', `_smtp._tls.${domain}`, status));
+	}
+
+	if (notAssessedStatus) {
+		return buildNotAssessedResult([...findings, ...notAssessedFindings], notAssessedStatus, hasTxtRecord);
 	}
 
 	// If no issues found
@@ -226,16 +340,14 @@ export async function checkMTASTS(
 	}
 
 	// controlPresent: an MTA-STS policy record (_mta-sts TXT) was observed. TLS-RPT alone does not
-	// count as MTA-STS, and a failed lookup leaves hasTxtRecord false (conservative: not credited).
+	// count as MTA-STS.
 	//
 	// recordPresent asks the narrower question "was an `_mta-sts` TXT record published", so it
 	// tracks that SAME RRset — never the TLS-RPT one this check also reports on, and never the
-	// policy file (an unfetchable policy is still a published record). It diverges from
-	// `hasTxtRecord` on exactly one branch: a failed `_mta-sts` lookup, where false would assert
-	// an absence nobody observed.
-	const recordPresent = mtaStsQueryFailed ? undefined : hasTxtRecord;
-
-	return buildCheckResult('mta_sts', findings, hasTxtRecord, recordPresent);
+	// policy file (an unfetchable policy is still a published record). On this (measured) path
+	// the lookup answered, so `false` is a genuine observed absence; a lookup that never
+	// answered returned early above with both flags `undefined`.
+	return buildCheckResult('mta_sts', findings, hasTxtRecord, hasTxtRecord);
 }
 
 /**

--- a/packages/dns-checks/src/checks/check-mta-sts.ts
+++ b/packages/dns-checks/src/checks/check-mta-sts.ts
@@ -87,6 +87,15 @@ function buildNotAssessedResult(findings: Finding[], status: CheckStatus, txtRec
 	};
 }
 
+/**
+ * True when the findings gathered so far contain a DEFINITE MTA-STS measurement: a graded
+ * (non-`info`) finding that is not itself an abstention. Reads the `inconclusive` marker,
+ * never a title, so a copy edit cannot reclassify evidence.
+ */
+function hasDefiniteMtaStsMeasurement(findings: Finding[]): boolean {
+	return findings.some((f) => f.severity !== 'info' && f.metadata?.inconclusive !== true);
+}
+
 /** The `info` finding documenting a rejected `_mta-sts` / `_smtp._tls` TXT lookup. */
 function buildDnsNotAssessedFinding(label: string, name: string, status: CheckStatus): Finding {
 	return createFinding(
@@ -264,8 +273,20 @@ export async function checkMTASTS(
 	} catch (err) {
 		// Was a scored `low` "TLS-RPT DNS query failed" (category 95) recorded as measured.
 		const status = classifyTransportFailure(err);
-		notAssessedStatus ??= status;
-		notAssessedFindings.push(buildDnsNotAssessedFinding('TLS-RPT', `_smtp._tls.${domain}`, status));
+		const tlsRptNotAssessed = buildDnsNotAssessedFinding('TLS-RPT', `_smtp._tls.${domain}`, status);
+		if (notAssessedStatus === null && hasDefiniteMtaStsMeasurement(findings)) {
+			// TLS-RPT is a SUB-PROBE of this category. When MTA-STS itself already produced a
+			// definite measurement (a policy 404, a missing/duplicated record, a broken policy),
+			// a resolver hiccup on the sibling name must not blank that evidence: keep the
+			// result MEASURED, carry the sub-probe failure as an unscored `info` abstention
+			// (`tlsRptChecked` stays false — nothing was looked at), and let the graded
+			// findings score as they would have. Only when nothing definite was measured does
+			// the whole-check abstention below apply.
+			findings.push(tlsRptNotAssessed);
+		} else {
+			notAssessedStatus ??= status;
+			notAssessedFindings.push(tlsRptNotAssessed);
+		}
 	}
 
 	if (notAssessedStatus) {

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.32.0';
+export const PARITY_CORPUS_VERSION = '1.33.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -335,8 +335,30 @@
  *   protective; measured live anchor fundhaus.app 82/B → ≈76/NIST C). DOWNWARD for
  *   un-locked-down no-MX domains, UPWARD-neutral (unchanged 100) for locked-down
  *   ones; `non_mail` and every mail profile are bit-for-bit unchanged.
+ * - 1.21.0 — the SCANNER'S OWN I/O failure inside `checkMTASTS` no longer scores the
+ *   domain (issue #889, dns-checks 1.33.0). Three catch paths used to convert a thrown
+ *   policy fetch (ECONNRESET, TLS/egress failure, the package's own 4s
+ *   `AbortSignal.timeout`, a `RobotsDisallowedError` from the gate, a resolver failure
+ *   for `mta-sts.<domain>`) or a rejecting `_smtp._tls` / `_mta-sts` TXT lookup into a
+ *   SCORED finding with no `checkStatus` — `medium` "policy fetch failed" (category 85)
+ *   and `low` "DNS query failed" (category 95) — folded into the profile score as a
+ *   measured deficiency, byte-for-byte indistinguishable from a domain that lacks the
+ *   control. They now return the not-assessed shape the rest of the model already uses
+ *   (`checkMX`, `buildDnsErrorResult`): `checkStatus: 'timeout'` (AbortError /
+ *   TimeoutError) or `'error'`, `score: 0`, `passed: false`, `partial: true`, and an
+ *   `info` finding carrying `inconclusive: true` + `notAssessedReason`
+ *   (`policy_fetch_failed` | `dns_query_failed` | the existing `robots_disallowed`
+ *   vocabulary), so the category is EXCLUDED and renormalised (shown n/a) and the
+ *   scan-path transient-zero retry can fire. A DEFINITE answer is unchanged: a non-ok
+ *   HTTP status on the policy URL keeps its `high`, an empty TXT answer keeps its graded
+ *   absence finding, and the MX-coverage sub-check keeps its silent abstention.
+ *   Direction: UPWARD only, and only for scans whose MTA-STS probe failed on OUR side
+ *   (the −15 / −5 category penalty that was never evidence disappears); every measured
+ *   scan is bit-for-bit unchanged. No weight, tier, grade band, `SEVERITY_PENALTIES`
+ *   entry or profile-detection rule changed. Population UNMEASURED against the corpus
+ *   (a scanner-side transient by definition has no stable prevalence).
  */
-export const SCORING_MODEL_VERSION = '1.20.0';
+export const SCORING_MODEL_VERSION = '1.21.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -352,11 +352,17 @@
  *   scan-path transient-zero retry can fire. A DEFINITE answer is unchanged: a non-ok
  *   HTTP status on the policy URL keeps its `high`, an empty TXT answer keeps its graded
  *   absence finding, and the MX-coverage sub-check keeps its silent abstention.
- *   Direction: UPWARD only, and only for scans whose MTA-STS probe failed on OUR side
- *   (the −15 / −5 category penalty that was never evidence disappears); every measured
- *   scan is bit-for-bit unchanged. No weight, tier, grade band, `SEVERITY_PENALTIES`
- *   entry or profile-detection rule changed. Population UNMEASURED against the corpus
- *   (a scanner-side transient by definition has no stable prevalence).
+ *   A TLS-RPT lookup failure beside a DEFINITE MTA-STS measurement (a policy 404, a
+ *   missing record) does NOT abstain the category: the measured findings score as
+ *   before and the sub-probe failure rides along as an unscored `info` (was −5).
+ *   Direction: NOT one-way. The category is EXCLUDED and the profile weights are
+ *   renormalised over the remaining measured categories, so the overall score moves
+ *   toward the mean of those categories — UP when that mean exceeds the 85 / 95 the
+ *   failed probe used to contribute, DOWN when it is below. Only scans that hit the
+ *   failed-probe path are affected; every measured scan is bit-for-bit unchanged. No
+ *   weight, tier, grade band, `SEVERITY_PENALTIES` entry or profile-detection rule
+ *   changed. Population UNMEASURED against the corpus (a scanner-side transient by
+ *   definition has no stable prevalence).
  */
 export const SCORING_MODEL_VERSION = '1.21.0';
 

--- a/src/tools/check-mta-sts.ts
+++ b/src/tools/check-mta-sts.ts
@@ -11,11 +11,19 @@
  * from a probe that never reached the origin. We detect the interception from the policy
  * response (mirroring `check-http-security.ts`) and make the whole mta_sts category
  * INCONCLUSIVE — `checkStatus: 'error'` — so the scoring engine EXCLUDES it (neither
- * pass, fail, nor inflate). The same excluded shape is applied when the policy fetch
- * THROWS (a stall past the timeout → AbortError, or a network error), which the package
- * would otherwise surface as a confident `medium` "policy fetch failed". A policy fetch cut
- * short by the per-check fetch budget (#674) is routed into that SAME path — see `budgetMs`
- * on `checkMtaSts` — because it is the same claim: nothing was measured.
+ * pass, fail, nor inflate).
+ *
+ * A policy fetch that THROWS (a stall past the timeout → AbortError, a network error, a
+ * robots.txt disallow, a budget cut per #674) is handled by the PACKAGE since dns-checks
+ * 1.33.0 (issue #889): `checkMTASTS` itself returns the not-assessed shape (`checkStatus`
+ * `'timeout' | 'error'`, score 0, `partial: true`, an `info` finding carrying
+ * `notAssessedReason`) instead of the confident `medium` "policy fetch failed" it used to
+ * score. This wrapper no longer has to strip a scored finding; what it still owns on that
+ * path is (a) the WAF-aware prose of the inconclusive finding (#664) and (b) pinning the
+ * status to `'error'` — the package classifies a stall as `'timeout'`, which is faithful
+ * for direct package consumers but is NOT the class `scan_domain`'s transient-zero retry
+ * fires on (`shouldRetry` deliberately excludes `'timeout'`, the safeCheck-killed shape).
+ * See `excludeForPolicyThrow`.
  *
  * ⚠️ Exclusion is the whole remedy — the prose must not go on to reassure the reader that
  * real sending MTAs can fetch the policy anyway (issue #664). We have not measured that;
@@ -85,12 +93,13 @@ function resolveGatedFetch(budget: FetchBudget, budgeted: boolean): FetchFunctio
 const POLICY_FETCH_FALSE_POSITIVE_TITLES = new Set(['MTA-STS policy file not accessible', 'MTA-STS policy redirects']);
 
 /**
- * The package's transient finding (emitted from its own catch path) when the policy
- * fetch THROWS. Empirically a `medium` finding with NO `checkStatus`/`partial` flag,
- * so scoring would penalise it — we exclude the category when this is present together
- * with an observed policy-fetch throw. (Title confirmed against the built package.)
+ * The package's not-assessed finding for a THROWN policy fetch (dns-checks ≥ 1.33.0, issue
+ * #889) is identified by this `metadata.notAssessedReason` token — never by title, so a
+ * copy edit in the package cannot silently re-enable a scored finding here. A robots.txt
+ * abstention carries `'robots_disallowed'` instead and is left exactly as the package
+ * labelled it (same vocabulary as ssl / http_security / bimi).
  */
-const POLICY_FETCH_THROW_TITLE = 'MTA-STS policy fetch failed';
+const POLICY_FETCH_NOT_ASSESSED_REASON = 'policy_fetch_failed';
 
 /** True when this fetch is the MTA-STS policy-file fetch (the only thing fetchFn is used for). */
 function isPolicyFetch(url: string): boolean {
@@ -170,19 +179,33 @@ function excludeForWaf(result: CheckResult, domain: string, event: WafEvent, sta
 }
 
 /**
- * The policy fetch THREW (WAF stall → AbortError, or a network error) and the package
- * surfaced its transient `medium` "policy fetch failed" finding. Drop that finding,
- * add an inconclusive WAF-style `info` note, and EXCLUDE the category — same shape as
- * a Response-based WAF event. Conservative: only invoked when we actually observed a
- * policy-fetch throw, so a genuine deterministic "not accessible" (a real 404 Response)
- * is untouched and keeps the package's `high`.
+ * The policy fetch THREW (WAF stall → AbortError, a network error, or a budget cut) and the
+ * package returned its not-assessed shape (issue #889). Swap the package's generic
+ * not-assessed finding for the WAF-aware inconclusive `info` note, and pin the category to
+ * the EXCLUDED-and-RETRYABLE shape — `checkStatus: 'error'`, same as a Response-based WAF
+ * event. Conservative: only invoked when we actually observed a policy-fetch throw, so a
+ * genuine deterministic "not accessible" (a real 404 Response) is untouched and keeps the
+ * package's `high`.
+ *
+ * A robots.txt disallow is returned verbatim: the package labels it with the shared
+ * `robotsAbstentionMetadata` vocabulary (`notAssessedReason: 'robots_disallowed'`) and
+ * already uses `checkStatus: 'error'`; rewording it as a "stall" would misattribute a
+ * deliberate, polite abstention to a network fault.
+ *
+ * Why `'error'` and not the package's `'timeout'`: `scan_domain`'s `shouldRetry` fires on
+ * `checkStatus === 'error' && score === 0` ONLY — `'timeout'` is the safeCheck-killed shape
+ * and is deliberately never retried. A transient stall must get its second, unbudgeted
+ * attempt (test/mta-sts-fetch-budget.spec.ts drives that recovery), so the Worker path
+ * normalises to the retryable class. Direct package consumers keep the faithful `'timeout'`.
  */
-function excludeForPolicyThrow(result: CheckResult, domain: string): CheckResult {
-	const hasTransient = result.findings.some((f: Finding) => f.title === POLICY_FETCH_THROW_TITLE);
-	// The package emitted something other than its transient throw finding — don't touch it.
-	if (!hasTransient) return result;
+function excludeForPolicyThrow(result: CheckResult, domain: string, err: unknown): CheckResult {
+	if (err instanceof RobotsDisallowedError) return result;
 
-	const kept = result.findings.filter((f: Finding) => f.title !== POLICY_FETCH_THROW_TITLE);
+	const isPackageNotAssessed = (f: Finding) => f.metadata?.notAssessedReason === POLICY_FETCH_NOT_ASSESSED_REASON;
+	// The package emitted something other than its not-assessed shape — don't touch it.
+	if (!result.checkStatus && !result.findings.some(isPackageNotAssessed)) return result;
+
+	const kept = result.findings.filter((f: Finding) => !isPackageNotAssessed(f));
 	// Unlike a Response-based WAF event, a throw carries NO provider evidence — do NOT
 	// fabricate a `wafEvent` provider in the metadata (it would mislead analytics). Build a
 	// plain inconclusive transient finding; `checkStatus: 'error'` below is what excludes the
@@ -206,7 +229,15 @@ function excludeForPolicyThrow(result: CheckResult, domain: string): CheckResult
 			`would stall them too and leave MTA-STS unenforceable, while one keyed to this scanner's User-Agent would not. Retry, and review any edge rule covering mta-sts.${domain}.`,
 		{ inconclusive: true, errorKind: 'timeout' },
 	);
-	return { ...buildCheckResult('mta_sts', [...kept, inconclusive], result.controlPresent), score: 0, passed: false, checkStatus: 'error' };
+	// `partial: true` mirrors the package: a transient outcome must not be cached for the
+	// 5-min TTL on the direct registry path (handlers/tools.ts caches only `!r.partial`).
+	return {
+		...buildCheckResult('mta_sts', [...kept, inconclusive], result.controlPresent, result.recordPresent),
+		score: 0,
+		passed: false,
+		checkStatus: 'error',
+		partial: true,
+	};
 }
 
 /**
@@ -263,6 +294,7 @@ export async function checkMtaSts(
 	let policyWafEvent: WafEvent | null = null;
 	let policyWafStatus = 0;
 	let policyFetchThrew = false;
+	let policyFetchError: unknown = null;
 
 	const observingFetch = async (url: string, init?: RequestInit): Promise<Response> => {
 		const policy = isPolicyFetch(url);
@@ -272,19 +304,20 @@ export async function checkMtaSts(
 		} catch (err) {
 			// A policy-fetch rejection (AbortError from a stalled WAF challenge, or a network
 			// TypeError) is observed as inconclusive, then RE-THROWN so the package still runs
-			// its own catch path and emits its transient finding. Only the FIRST policy throw
-			// is recorded (single-fetch contract).
+			// its own catch path and returns its not-assessed shape (#889). Only the FIRST
+			// policy throw is recorded (single-fetch contract).
 			//
 			// The `!budget.canIssueRequest()` disjunct is what keeps a BUDGETED run honest
 			// (#674): when the budget is already spent, `wrap` rejects with a plain `Error`
 			// carrying neither the `AbortError` name nor `TypeError`, so `isObservableFetchThrow`
-			// alone would let the package's confident `medium` "policy fetch failed" stand and
-			// SCORE a penalty for a probe that was never issued. Reading the budget state instead
+			// alone would leave the wrapper's WAF-aware prose unapplied (the package still abstains,
+			// #889) for a probe that was never issued — pre-#889 it let a confident `medium` SCORE. Reading the budget state instead
 			// of the error's message keeps the sentinel string out of this file's contract.
 			// With no budget `remainingMs()` is Infinity, so this disjunct is constant-false and
 			// the direct-call path is unchanged.
 			if (policy && !policyFetchThrew && (isObservableFetchThrow(err) || !budget.canIssueRequest())) {
 				policyFetchThrew = true;
+				policyFetchError = err;
 			}
 			throw err;
 		}
@@ -323,7 +356,7 @@ export async function checkMtaSts(
 	})) as CheckResult;
 
 	if (policyWafEvent) return excludeForWaf(result, domain, policyWafEvent, policyWafStatus);
-	if (policyFetchThrew) return excludeForPolicyThrow(result, domain);
+	if (policyFetchThrew) return excludeForPolicyThrow(result, domain, policyFetchError);
 	return result;
 }
 

--- a/src/tools/validate-fix.ts
+++ b/src/tools/validate-fix.ts
@@ -4,7 +4,10 @@
  * Validate Fix tool.
  * Re-checks a specific DNS control after a user applies a fix.
  * Runs the single check function (always live, no cache), evaluates the result,
- * and returns a verdict: fixed, partial, or not_fixed.
+ * and returns a verdict: fixed, partial, not_fixed — or not_assessed when the check
+ * itself did not complete (`checkStatus` 'error' | 'timeout'), because `passed` is
+ * "did not penalize", NOT a verdict, and a transient scanner-side failure returns
+ * `passed: false, score: 0` (issue #889; the `passed`-as-verdict class of #705/#706/#725/#809).
  */
 
 import type { OutputFormat } from '../handlers/tool-args';
@@ -23,6 +26,7 @@ import { checkBimi } from './check-bimi';
 import { checkTlsrpt } from './check-tlsrpt';
 import { checkHttpSecurity } from './check-http-security';
 import { checkDane } from './check-dane';
+import { isCompletedCheck } from '../lib/ungraded-display';
 
 /** Map of check names to their check functions. */
 const CHECK_FUNCTIONS: Record<string, (domain: string, dnsOptions?: QueryDnsOptions) => Promise<CheckResult>> = {
@@ -40,8 +44,14 @@ const CHECK_FUNCTIONS: Record<string, (domain: string, dnsOptions?: QueryDnsOpti
 	dane: (d, o) => checkDane(d, o),
 };
 
-/** Verdict types for a validation check. */
-export type ValidateFixVerdict = 'fixed' | 'partial' | 'not_fixed';
+/**
+ * Verdict types for a validation check.
+ *
+ * `not_assessed` is NOT a soft `not_fixed` — it is the ABSENCE of a verdict (same vocabulary
+ * as map_compliance's `ComplianceStatus`): the live re-check never completed, so nothing
+ * about the fix was observed. The caller should retry, not remediate.
+ */
+export type ValidateFixVerdict = 'fixed' | 'partial' | 'not_fixed' | 'not_assessed';
 
 /** Result of validating a fix. */
 export interface ValidateFixResult {
@@ -109,6 +119,27 @@ export async function validateFix(
 	}
 
 	const result = await checkFn(domain, dnsOptions);
+
+	// The check did not COMPLETE (transient DNS/fetch failure, robots abstention, WAF stall →
+	// `checkStatus` 'error' | 'timeout'). Its `passed: false` / `score: 0` describe the
+	// abstention, not the fix, so reading them as a verdict would report a live-but-
+	// unmeasured control as `not_fixed`. Short-circuit to the absence-of-verdict value.
+	if (!isCompletedCheck(result)) {
+		const abstention = result.findings.find((f: Finding) => f.metadata?.inconclusive === true) ?? result.findings[0];
+		return {
+			domain,
+			check,
+			verdict: 'not_assessed',
+			liveRecord: null,
+			expectedMatch: null,
+			resolvedFindings: [],
+			remainingFindings: [],
+			newFindings: [],
+			hint: abstention
+				? `NOT ASSESSED: ${sanitizeOutputText(abstention.title, 200)} — ${sanitizeOutputText(abstention.detail, 300)} Retry to re-measure.`
+				: 'NOT ASSESSED: the live re-check did not complete. Retry to re-measure.',
+		};
+	}
 
 	// Classify findings by severity
 	const blockingFindings = result.findings.filter((f: Finding) => BLOCKING_SEVERITIES.has(f.severity));

--- a/test/check-mta-sts-robots.spec.ts
+++ b/test/check-mta-sts-robots.spec.ts
@@ -85,8 +85,21 @@ describe('checkMtaSts — robots.txt disallow on the policy fetch', () => {
 		expect(result.checkStatus).toBe('error');
 		expect(result.score).toBe(0);
 		expect(result.passed).toBe(false);
+		expect(result.partial).toBe(true);
 		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(true);
 		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		expect(result.findings.some((f) => f.severity === 'medium')).toBe(false);
+
+		// Since dns-checks 1.33.0 (#889) the package labels the abstention itself with the
+		// shared robots vocabulary (same as ssl / http_security / bimi), and the wrapper must
+		// pass it through VERBATIM — not reword a deliberate, polite abstention as a "stall".
+		const abstention = result.findings.find((f) => f.metadata?.notAssessedReason === 'robots_disallowed');
+		expect(abstention, 'the package robots abstention must survive the wrapper').toBeDefined();
+		expect(abstention!.severity).toBe('info');
+		expect(abstention!.metadata?.robotsScope).toBe('blanket');
+		expect(abstention!.metadata?.confidence).toBe('deterministic');
+		expect(abstention!.detail).toContain('robots.txt');
+		expect(result.findings.some((f) => f.title.includes('stalled'))).toBe(false);
 	});
 
 	it('does NOT exclude the category when robots.txt allows the policy fetch (control: unaffected happy path)', async () => {

--- a/test/check-mta-sts-waf.spec.ts
+++ b/test/check-mta-sts-waf.spec.ts
@@ -208,12 +208,12 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 		expect(result.checkStatus).not.toBe('error');
 	});
 
-	it('makes the category inconclusive when the policy fetch THROWS (AbortError / WAF stall) — excludes the package medium', async () => {
-		// Empirical: when the policy fetch rejects, the package emits a `medium`
-		// "MTA-STS policy fetch failed" finding with NO checkStatus/partial flag — so
-		// scoring would otherwise penalise it. The wrapper catches the throw for the
-		// policy fetch, re-throws (so the package still runs its catch path), then
-		// converts the result to the excluded/inconclusive shape.
+	it('makes the category inconclusive when the policy fetch THROWS (AbortError / WAF stall) — retryable error class', async () => {
+		// Since dns-checks 1.33.0 (#889) the package itself returns the not-assessed shape
+		// for a thrown policy fetch (`checkStatus: 'timeout'` for an AbortError). The
+		// wrapper observes the throw, re-throws (so the package runs its catch path), then
+		// swaps in its WAF-aware prose and pins `checkStatus: 'error'` — the class
+		// scan_domain's transient-zero retry fires on (`'timeout'` is never retried).
 		mockFetch({
 			mtaStsDns: validTxt('example.com'),
 			tlsrptDns: validTlsRpt('example.com'),
@@ -228,12 +228,18 @@ describe('checkMtaSts — WAF-challenged policy fetch (issue #455)', () => {
 
 		// No medium "fetch failed" left dragging the score down…
 		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
-		// …category excluded as inconclusive.
+		expect(result.findings.some((f) => f.severity === 'medium')).toBe(false);
+		expect(result.findings.some((f) => f.title === 'MTA-STS policy fetch failed')).toBe(false);
+		// …category excluded as inconclusive, in the RETRYABLE class, and kept out of the cache.
 		expect(result.checkStatus).toBe('error');
 		expect(result.score).toBe(0);
 		expect(result.passed).toBe(false);
-		// An inconclusive finding documents the stall.
-		expect(result.findings.some((f) => f.metadata?.inconclusive === true)).toBe(true);
+		expect(result.partial).toBe(true);
+		// Exactly ONE inconclusive finding documents the stall — the wrapper's WAF-aware note
+		// REPLACES the package's generic not-assessed finding rather than stacking on it.
+		expect(result.findings.filter((f) => f.metadata?.inconclusive === true)).toHaveLength(1);
+		// The observed _mta-sts record is still credited.
+		expect(result.controlPresent).toBe(true);
 	});
 });
 

--- a/test/check-mta-sts.spec.ts
+++ b/test/check-mta-sts.spec.ts
@@ -193,27 +193,65 @@ describe('checkMtaSts', () => {
 		expect(f!.severity).toBe('high');
 	});
 
-	it('returns low finding on DNS query failure', async () => {
+	it('a rejected _mta-sts DNS lookup is NOT ASSESSED (checkStatus error), not a scored low finding (#889)', async () => {
 		mockMultiFetch({
 			dnsError: new Error('DNS timeout'),
 			tlsrptDns: txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']),
 		});
 		const r = await run();
-		const f = r.findings.find((f) => f.title.includes('DNS query failed'));
-		expect(f).toBeDefined();
-		expect(f!.severity).toBe('low');
+		// Pre-#889: a `low` "MTA-STS DNS query failed" with no checkStatus → category 95, scored.
+		expect(r.findings.some((f) => f.title.includes('DNS query failed'))).toBe(false);
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.passed).toBe(false);
+		expect(r.partial).toBe(true);
+		const f = r.findings.find((f) => f.metadata?.inconclusive === true);
+		expect(f?.severity).toBe('info');
+		expect(f?.metadata?.notAssessedReason).toBe('dns_query_failed');
+		// Unknown, never a fabricated absence.
+		expect(r.recordPresent).toBeUndefined();
+		expect(r.controlPresent).toBeUndefined();
 	});
 
-	it('returns medium finding on policy fetch network error', async () => {
+	it('a policy fetch network error is NOT ASSESSED (checkStatus error, retryable), not a scored medium finding (#889)', async () => {
 		mockMultiFetch({
 			mtaStsDns: txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']),
-			policyError: new Error('Network error'),
+			policyError: Object.assign(new TypeError('Network error'), { name: 'TypeError' }),
 			tlsrptDns: txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']),
 		});
 		const r = await run();
-		const f = r.findings.find((f) => f.title.includes('fetch failed'));
-		expect(f).toBeDefined();
-		expect(f!.severity).toBe('medium');
+		// Pre-#889: a `medium` "MTA-STS policy fetch failed" with no checkStatus → category 85, scored.
+		expect(r.findings.some((f) => f.title.includes('fetch failed'))).toBe(false);
+		expect(r.findings.some((f) => f.severity === 'medium' || f.severity === 'high')).toBe(false);
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.partial).toBe(true);
+		expect(r.findings.find((f) => f.metadata?.inconclusive === true)?.severity).toBe('info');
+		// The _mta-sts record WAS observed — still credited.
+		expect(r.controlPresent).toBe(true);
+		expect(r.recordPresent).toBe(true);
+	});
+
+	it('a rejected _smtp._tls DNS lookup is NOT ASSESSED, never recorded as a measured TLS-RPT absence (#889)', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				if (url.includes('_mta-sts.')) return Promise.resolve(txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']));
+				if (url.includes('_smtp._tls.')) return Promise.reject(new Error('SERVFAIL'));
+				return Promise.resolve(createDohResponse([], []));
+			}
+			if (url.includes('mta-sts.') && url.includes('.well-known')) {
+				return Promise.resolve(policyResponse('version: STSv1\nmode: enforce\nmx: *.example.com\nmax_age: 86400'));
+			}
+			return Promise.resolve(policyResponse('', 404));
+		});
+		const r = await run();
+		expect(r.findings.some((f) => f.title === 'TLS-RPT DNS query failed')).toBe(false);
+		expect(r.findings.some((f) => f.title === 'TLS-RPT record missing')).toBe(false);
+		expect(r.checkStatus).toBe('error');
+		expect(r.score).toBe(0);
+		expect(r.partial).toBe(true);
+		expect(r.findings.find((f) => f.metadata?.inconclusive === true)?.metadata?.notAssessedReason).toBe('dns_query_failed');
 	});
 
 	it('returns low finding when no TLSRPT record exists', async () => {

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -1391,16 +1391,22 @@ describe('scanDomain — transient zero retry', () => {
 	});
 
 	it('fires retries for multiple simultaneously failing checks up to the cap', async () => {
-		// Throw on SPF, DMARC, TLSRPT, and BIMI TXT lookups on the first 2 fetches
-		// (DNS_RETRIES=1 means 2 fetches per query). Each subsequent fetch succeeds, so the
-		// retry pass can recover them. That's 4 qualifying retries; cap is MAX_RETRIES_PER_SCAN=3.
-		// The first 3 (by checkResults order: spf, dmarc, bimi) retry successfully; tlsrpt
-		// remains errored. (MTA-STS and DKIM are excluded because they swallow DNS errors
-		// internally and never propagate to safeCheck.)
+		// Throw on the SPF, DMARC and BIMI TXT lookups on the first 2 fetches (DNS_RETRIES=1
+		// means 2 fetches per query) and on EVERY `_smtp._tls` lookup. Each subsequent
+		// spf/dmarc/bimi fetch succeeds, so the retry pass can recover them.
+		//
+		// `_smtp._tls` is queried by TWO checks — tlsrpt AND mta_sts — and since #889
+		// (dns-checks 1.33.0) mta_sts no longer swallows a rejected lookup as a scored `low`:
+		// it returns the retryable `checkStatus: 'error'` + score 0 shape like everyone else.
+		// Failing that name permanently makes both of them deterministic candidates. That is
+		// 5 qualifying retries in checkResults order — spf, dmarc, mta_sts, bimi, tlsrpt — and
+		// the cap is MAX_RETRIES_PER_SCAN=3: spf and dmarc recover, mta_sts is retried but
+		// fails again, and bimi is NEVER retried (its lookup counter proves it), which is the
+		// cap doing its job. (DKIM is excluded because it swallows DNS errors internally.)
 		const counters: Record<string, number> = { spf: 0, dmarc: 0, tlsrpt: 0, bimi: 0 };
-		function shouldThrow(key: string): boolean {
+		function shouldThrow(key: string, limit = 2): boolean {
 			counters[key]++;
-			return counters[key] <= 2;
+			return counters[key] <= limit;
 		}
 		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
@@ -1415,7 +1421,7 @@ describe('scanDomain — transient zero retry', () => {
 						return Promise.resolve(txtResponse('_mta-sts.example.com', ['v=STSv1; id=20240101']));
 					}
 					if (url.includes('_smtp._tls.')) {
-						if (shouldThrow('tlsrpt')) return Promise.reject(new Error('DNS query failed'));
+						if (shouldThrow('tlsrpt', Number.POSITIVE_INFINITY)) return Promise.reject(new Error('DNS query failed'));
 						return Promise.resolve(txtResponse('_smtp._tls.example.com', ['v=TLSRPTv1; rua=mailto:tls@example.com']));
 					}
 					if (url.includes('default._bimi.')) {
@@ -1445,13 +1451,22 @@ describe('scanDomain — transient zero retry', () => {
 
 		const result = await run();
 
-		// Count how many of the 4 originally-failing checks ended up with a non-error result.
-		// With MAX_RETRIES_PER_SCAN=3, exactly 3 should have recovered via retry; the 4th stays errored.
-		const targets = ['spf', 'dmarc', 'tlsrpt', 'bimi'] as const;
-		const recovered = targets
-			.map((cat) => result.checks.find((c) => c.category === cat))
-			.filter((c) => c && c.checkStatus !== 'error' && c.score > 0);
-		expect(recovered.length).toBe(3);
+		const byCategory = (cat: string) => result.checks.find((c) => c.category === cat)!;
+		const recovered = (cat: string) => byCategory(cat).checkStatus !== 'error' && byCategory(cat).score > 0;
+
+		// Retry slots 1 and 2 (by checkResults order): recovered.
+		expect(recovered('spf')).toBe(true);
+		expect(recovered('dmarc')).toBe(true);
+		// Retry slot 3: mta_sts was retried (retryable class, #889) but its `_smtp._tls` lookup
+		// fails permanently, so it stays NOT ASSESSED — never a scored TLS-RPT finding.
+		expect(byCategory('mta_sts').checkStatus).toBe('error');
+		expect(byCategory('mta_sts').findings.some((f) => f.metadata?.notAssessedReason === 'dns_query_failed')).toBe(true);
+		expect(byCategory('mta_sts').findings.some((f) => f.title === 'TLS-RPT DNS query failed')).toBe(false);
+		// Beyond the cap: bimi and tlsrpt stay errored, and bimi's lookup counter proves it was
+		// never retried — exactly the 2 fetches of its first (failing) DNS attempt.
+		expect(recovered('bimi')).toBe(false);
+		expect(counters.bimi).toBe(2);
+		expect(recovered('tlsrpt')).toBe(false);
 	});
 });
 

--- a/test/scan-domain.spec.ts
+++ b/test/scan-domain.spec.ts
@@ -1395,14 +1395,15 @@ describe('scanDomain — transient zero retry', () => {
 		// means 2 fetches per query) and on EVERY `_smtp._tls` lookup. Each subsequent
 		// spf/dmarc/bimi fetch succeeds, so the retry pass can recover them.
 		//
-		// `_smtp._tls` is queried by TWO checks — tlsrpt AND mta_sts — and since #889
-		// (dns-checks 1.33.0) mta_sts no longer swallows a rejected lookup as a scored `low`:
-		// it returns the retryable `checkStatus: 'error'` + score 0 shape like everyone else.
-		// Failing that name permanently makes both of them deterministic candidates. That is
-		// 5 qualifying retries in checkResults order — spf, dmarc, mta_sts, bimi, tlsrpt — and
-		// the cap is MAX_RETRIES_PER_SCAN=3: spf and dmarc recover, mta_sts is retried but
-		// fails again, and bimi is NEVER retried (its lookup counter proves it), which is the
-		// cap doing its job. (DKIM is excluded because it swallows DNS errors internally.)
+		// `_smtp._tls` is queried by TWO checks — tlsrpt AND mta_sts. Since #889 (dns-checks
+		// 1.33.0) mta_sts no longer swallows a rejected lookup as a scored `low`; but a TLS-RPT
+		// sub-probe failure abstains the WHOLE category only when MTA-STS itself measured
+		// nothing definite. Here the policy fixture parses to graded findings, so mta_sts stays
+		// MEASURED (no checkStatus) with an unscored `info` TLS-RPT abstention and is NOT a
+		// retry candidate. Failing the name permanently keeps that deterministic. That leaves
+		// 4 qualifying retries in checkResults order — spf, dmarc, bimi, tlsrpt — against
+		// MAX_RETRIES_PER_SCAN=3: spf, dmarc and bimi recover; tlsrpt stays errored, which is
+		// the cap doing its job. (DKIM is excluded because it swallows DNS errors internally.)
 		const counters: Record<string, number> = { spf: 0, dmarc: 0, tlsrpt: 0, bimi: 0 };
 		function shouldThrow(key: string, limit = 2): boolean {
 			counters[key]++;
@@ -1454,19 +1455,20 @@ describe('scanDomain — transient zero retry', () => {
 		const byCategory = (cat: string) => result.checks.find((c) => c.category === cat)!;
 		const recovered = (cat: string) => byCategory(cat).checkStatus !== 'error' && byCategory(cat).score > 0;
 
-		// Retry slots 1 and 2 (by checkResults order): recovered.
+		// Retry slots 1–3 (by checkResults order): recovered. bimi's counter proves it was
+		// actually retried (more than the 2 fetches of its first, failing DNS attempt).
 		expect(recovered('spf')).toBe(true);
 		expect(recovered('dmarc')).toBe(true);
-		// Retry slot 3: mta_sts was retried (retryable class, #889) but its `_smtp._tls` lookup
-		// fails permanently, so it stays NOT ASSESSED — never a scored TLS-RPT finding.
-		expect(byCategory('mta_sts').checkStatus).toBe('error');
+		expect(recovered('bimi')).toBe(true);
+		expect(counters.bimi).toBeGreaterThan(2);
+		// Beyond the cap: tlsrpt stays errored.
+		expect(recovered('tlsrpt')).toBe(false);
+		// mta_sts: measured (definite policy findings), TLS-RPT sub-probe carried as an unscored
+		// info abstention — never the pre-#889 scored `low`, never a whole-category blank.
+		expect(byCategory('mta_sts').checkStatus).toBeUndefined();
 		expect(byCategory('mta_sts').findings.some((f) => f.metadata?.notAssessedReason === 'dns_query_failed')).toBe(true);
 		expect(byCategory('mta_sts').findings.some((f) => f.title === 'TLS-RPT DNS query failed')).toBe(false);
-		// Beyond the cap: bimi and tlsrpt stay errored, and bimi's lookup counter proves it was
-		// never retried — exactly the 2 fetches of its first (failing) DNS attempt.
-		expect(recovered('bimi')).toBe(false);
-		expect(counters.bimi).toBe(2);
-		expect(recovered('tlsrpt')).toBe(false);
+		expect(byCategory('mta_sts').findings.some((f) => f.title === 'TLS-RPT record missing')).toBe(false);
 	});
 });
 

--- a/test/validate-fix.spec.ts
+++ b/test/validate-fix.spec.ts
@@ -72,3 +72,68 @@ describe('validateFix', () => {
 		expect(result.liveRecord).toBeTruthy();
 	});
 });
+
+/**
+ * Issue #889 review — `validateFix` must not read a not-completed check's `passed: false`
+ * / `score: 0` as a `not_fixed` verdict. `passed` means "did not penalize", never a verdict
+ * (the #705/#706/#725/#809 class), and a scanner-side transient now returns exactly that
+ * shape with `checkStatus` set. The absence of a verdict is its own value.
+ */
+describe('validateFix — a check that did not complete is NOT ASSESSED, not not_fixed (#889)', () => {
+	async function run(domain: string, check: string) {
+		const { validateFix } = await import('../src/tools/validate-fix');
+		return validateFix(domain, check);
+	}
+
+	function txt(name: string, records: string[]) {
+		return createDohResponse(
+			[{ name, type: 16 }],
+			records.map((d) => ({ name, type: 16, TTL: 300, data: `"${d}"` })),
+		);
+	}
+
+	it('mta_sts with a policy fetch that throws → not_assessed, no remaining findings, hint says retry', async () => {
+		// Distinct domain: check-mta-sts.ts memoizes robots.txt per hostname for the isolate.
+		const domain = 'validate-not-assessed.example.com';
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+			const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+			if (url.includes('cloudflare-dns.com')) {
+				if (url.includes(`_mta-sts.${domain}`)) return Promise.resolve(txt(`_mta-sts.${domain}`, ['v=STSv1; id=20240101']));
+				if (url.includes(`_smtp._tls.${domain}`))
+					return Promise.resolve(txt(`_smtp._tls.${domain}`, ['v=TLSRPTv1; rua=mailto:tls@example.com']));
+				return Promise.resolve(createDohResponse([], []));
+			}
+			if (url.endsWith('/robots.txt')) return Promise.resolve(new Response(null, { status: 404 }));
+			if (url.includes('.well-known/mta-sts.txt')) return Promise.reject(new TypeError('Network connection lost'));
+			return Promise.resolve(new Response(null, { status: 404 }));
+		});
+
+		const result = await run(domain, 'mta_sts');
+
+		// Pre-fix: `passed: false` → 'not_fixed' for a control nobody measured.
+		expect(result.verdict).toBe('not_assessed');
+		expect(result.remainingFindings).toHaveLength(0);
+		expect(result.resolvedFindings).toHaveLength(0);
+		expect(result.liveRecord).toBeNull();
+		expect(result.expectedMatch).toBeNull();
+		expect(result.hint).toMatch(/NOT ASSESSED/);
+		expect(result.hint).toMatch(/retry/i);
+	});
+
+	it('formats the not_assessed verdict in both output formats', async () => {
+		const { formatValidateFix } = await import('../src/tools/validate-fix');
+		const base = {
+			domain: 'example.com',
+			check: 'mta_sts',
+			verdict: 'not_assessed' as const,
+			liveRecord: null,
+			expectedMatch: null,
+			resolvedFindings: [],
+			remainingFindings: [],
+			newFindings: [],
+			hint: 'NOT ASSESSED: the live re-check did not complete. Retry to re-measure.',
+		};
+		expect(formatValidateFix(base, 'compact')).toContain('NOT ASSESSED');
+		expect(formatValidateFix(base, 'full')).toContain('Verdict: NOT ASSESSED');
+	});
+});


### PR DESCRIPTION
## What happens

`@blackveil/dns-checks` `checkMTASTS` (`packages/dns-checks/src/checks/check-mta-sts.ts`) had three bare `catch` blocks that converted the **scanner's own** I/O failure into a **scored** finding with no `checkStatus`:

| path | thrown by | was |
|---|---|---|
| policy fetch | ECONNRESET / TLS-egress failure / the package's own 4s `AbortSignal.timeout` / `RobotsDisallowedError` from the gate / resolver failure for `mta-sts.<domain>` | `medium` "MTA-STS policy fetch failed" → category **85** |
| `_smtp._tls` TXT lookup | rejecting `queryDNS` | `low` "TLS-RPT DNS query failed" → **95**, and `tlsRptChecked = true` as if measured |
| `_mta-sts` TXT lookup | rejecting `queryDNS` | `low` "MTA-STS DNS query failed" |

Each folded into the profile score as a measured deficiency, byte-for-byte indistinguishable from a domain that lacks the control. bv-web-prod consumes the package export directly and publishes the grade on named third parties, so a 4s stall on **our** egress became a published claim about **them**. The bv-mcp Worker wrapper (`src/tools/check-mta-sts.ts`) already papered over the policy-fetch case by title-matching the scored finding after the fact — but only when its `observingFetch` recognised the error class (a plain `Error('ECONNRESET')` on a direct call slipped through), and never for the two DNS paths.

## Root cause

The package had the doctrine (`checkMX`, `checkCAA`, `checkNS` all abstain with `checkStatus: 'error'`; #455/#574/#664 all restated "an unmeasurable input produces an abstention, never a confident negative verdict") but `checkMTASTS` never received it. The MX-coverage sub-check nine lines above the policy catch abstains correctly; the three catches around it did not.

## Fix

**Package (`packages/dns-checks/src/checks/check-mta-sts.ts`)** — classify before scoring:

- A **definite** answer stays evidence and keeps its scored finding: non-`ok` HTTP on the policy URL (404/403/5xx → `high`, unchanged), an empty TXT answer for `_smtp._tls` / `_mta-sts` (graded absence, unchanged), the MX-coverage sub-check's silent abstention (unchanged).
- A **transport / timeout / robots / egress / transient-resolver** failure returns the not-assessed shape the rest of the model uses (`checkMX`, `buildDnsErrorResult`): `checkStatus: 'timeout'` when the error is an `AbortError` / `TimeoutError`, else `'error'`; `score: 0`; `passed: false`; `partial: true` (not cached); an `info` finding carrying `inconclusive: true` + `errorKind` + `notAssessedReason` (`policy_fetch_failed` | `dns_query_failed` | the existing `robots_disallowed` via `robotsAbstentionMetadata`, mirroring `ssl` / `http_security` / `bimi`). The `CheckStatus` union is **not** widened (#743).
- `controlPresent` / `recordPresent` are `true` when the `_mta-sts` record was actually observed (policy-fetch path — a real measurement is kept) and `undefined` when the lookup never answered. Never `false` on an abstention.
- Measured findings gathered before the failure are kept for display; `checkStatus` excludes the category regardless.
- Exported `MtaStsNotAssessedReason` type documents the vocabulary.

**Worker wrapper (`src/tools/check-mta-sts.ts`)** — no longer strips a scored finding; the package does not emit one. It still owns two things on the thrown-policy path and the code says why:
1. The WAF-aware prose of the inconclusive finding (#664) replaces the package's generic not-assessed finding, now identified by `metadata.notAssessedReason === 'policy_fetch_failed'` rather than by title (a copy edit can no longer re-enable a scored finding).
2. It pins `checkStatus: 'error'` where the package says `'timeout'`: `scan_domain`'s `shouldRetry` fires on `'error' && score === 0` only — `'timeout'` is the safeCheck-killed shape and is deliberately never retried, and `test/mta-sts-fetch-budget.spec.ts` drives exactly that recovery. Direct package consumers keep the faithful `'timeout'`. This is the one place the wrapper's token differs from the package's; it is deliberate and documented at `excludeForPolicyThrow`.
- A robots abstention is now passed through **verbatim** (it was previously reworded as a "stall" with `errorKind: 'timeout'`, which misattributed a polite abstention to a network fault).
- The wrapper's replacement result now also carries `partial: true` and passes `recordPresent` through.

**Deviation from the issue's proposal:** none in substance. The issue suggested `'error' | 'timeout'`; the package classifies by error name (the only signal that separates a stall from a refusal), and the wrapper normalises to the retryable class for the reason above.

## Scoring impact

Scoring model **1.20.0 → 1.21.0** (`src/lib/scoring-version.ts`, history entry added). Per #855's lockstep rule, `packages/dns-checks/package.json` **1.32.0 → 1.33.0** and `PARITY_CORPUS_VERSION` **1.32.0 → 1.33.0** (mirrors 627e9c899; `package-lock.json` was not touched by that commit either and its `packages/dns-checks` stanza already sat at 1.30.0 before this PR — the release commit owns it).

- **Direction: not one-way.** The category is excluded and the profile weights renormalise over the remaining measured categories, so the overall score moves toward the mean of those categories — up when that mean exceeds the 85/95 the failed probe used to contribute, down when it is below. Only scans that hit the failed-probe path are affected.
- A TLS-RPT lookup failure beside a **definite** MTA-STS measurement (policy 404, missing record) does not abstain the category: the graded findings score as before and the sub-probe failure rides along as an unscored `info` (was −5).
- Every measured scan is **bit-for-bit unchanged**. No weight, tier, grade band, `SEVERITY_PENALTIES` entry or profile-detection rule changed.
- **Parity corpus:** no fixture moved (all five `mta_sts` fixtures exercise measured answers; `parity-corpus.contract.test.ts` green at 1.33.0).
- Population unmeasured against the corpus — a scanner-side transient has no stable prevalence by definition.
- `scan_domain` retry: `mta_sts` is now a candidate for the transient-zero retry on a rejected `_smtp._tls` / `_mta-sts` lookup (it previously swallowed both). `test/scan-domain.spec.ts`'s cap test is updated for that — see Tests.

## Tests

New — `packages/dns-checks/src/__tests__/checks/check-mta-sts-not-assessed.test.ts` (16 cases, written first, 9 red on `main`): generic throw → `'error'`/0/partial/info + no medium; `AbortError` and `TimeoutError` → `'timeout'`; `RobotsDisallowedError` blanket/named → labelled abstention with the shared vocabulary; `_smtp._tls` rejects → not assessed, no "TLS-RPT record missing", no both-missing summary; `_mta-sts` rejects → `recordPresent`/`controlPresent` undefined; boundary: 404 keeps `high`, 5xx keeps `high`, empty `_smtp._tls` keeps the graded `low` (95), empty `_mta-sts` + MX keeps the graded `medium` (85), MX-coverage failure stays silent.

Updated:
- `test/check-mta-sts.spec.ts` — the two cases that pinned the scored `low`/`medium` now assert the not-assessed shape through the Worker wrapper; a third covers `_smtp._tls`.
- `test/check-mta-sts-waf.spec.ts` — stall case additionally asserts exactly one inconclusive finding, `partial`, no medium, `controlPresent` kept.
- `test/check-mta-sts-robots.spec.ts` — asserts the package's `robots_disallowed` abstention survives the wrapper verbatim.
- `test/scan-domain.spec.ts` "fires retries … up to the cap" — `_smtp._tls` is queried by BOTH `tlsrpt` and `mta_sts`, so `mta_sts` now legitimately joins the failing set (5 candidates, cap 3). The mock fails that name permanently; the test now asserts spf/dmarc recovered, `mta_sts` retried-but-still-not-assessed, and bimi never retried (its fetch counter = 2 proves the cap) instead of a bare count that the coupling made non-deterministic.

Commands and results:

```
npm -w packages/dns-checks test           # 55 files, 954 tests passed (incl. parity corpus, scoring contract)
npm -w packages/dns-checks run build      # rebuilt dist (root tests import it)
npx vitest run test/check-mta-sts*.spec.ts test/mta-sts-*.spec.ts test/audits/measured-vs-unmeasured-metadata.audit.test.ts
                                          # 7 files, 54 passed
npx vitest run test/scan-domain.spec.ts test/scan-version-stamps.spec.ts test/scoring-version.spec.ts test/cache-key-version.spec.ts
                                          # 4 files, 70 passed
npm run typecheck                         # clean
npm run lint                              # clean
npm test                                  # run 1 (load avg 42, four concurrent agent suites): 8401 passed, 1 failed + ~30 specs timing out at 15s (workerd-load signature);
                                          #   every timed-out spec re-run in isolation: 8 files 66 passed (--testTimeout=90000), 30 files re-run green
                                          # run 2 (after load dropped): 8402 passed, 13 skipped, 2 failed (15s timeouts in mcp-access-log.spec.ts +
                                          #   queue-batch-analytics.spec.ts, unrelated) -> re-run in isolation: 2 files, 17 passed.
                                          #   test/wasm-integration.test.ts suite-load error = the documented fresh-worktree signature (no wasm build), 0 test failures from it.
```

## Review fixes (second commit)

1. **TLS-RPT sub-probe failure no longer blanks a definite MTA-STS measurement.** `hasDefiniteMtaStsMeasurement()` (any non-`info`, non-`inconclusive` finding) gates the whole-check abstention: with a policy 404 / missing record already measured, the result stays completed, the `high`/`medium` scores, and the TLS-RPT failure is an unscored `info` abstention (`tlsRptChecked` stays false, so the both-missing summary cannot fire). Only when nothing definite was measured (healthy policy, or the policy fetch itself threw) does the category abstain. Tests: 404 + throw → measured at 75 with the high retained; missing record + throw → measured at 85; healthy policy + throw → abstention; policy throw + TLS-RPT ok → abstention; both throw → abstention carrying both reasons.
2. **`validate_fix` reads `checkStatus`.** A not-completed check short-circuits to a new `not_assessed` verdict (same absence-of-verdict vocabulary as `map_compliance`'s `ComplianceStatus`; type union widened, no schema/tool-count change — the verdict was never enumerated in a Zod schema) with empty finding lists and a "retry" hint, instead of reading `passed: false` as `not_fixed`. Spec: `test/validate-fix.spec.ts` (policy fetch throws → `not_assessed`; both output formats render it).
3. **Scoring-version 1.21.0 direction claim corrected** — excluded + renormalised, moves toward the mean of the remaining categories, so up or down; measured scans unchanged.

`test/scan-domain.spec.ts`'s retry-cap test was re-derived once more: with fix 1 the fixture's `mta_sts` (its policy body yields graded findings) stays **measured** and is no longer a retry candidate, so the classic 4-candidate / cap-3 shape returns (spf, dmarc, bimi recover; tlsrpt stays errored) and the test now also pins the `mta_sts` info abstention.

## Residuals

- `checkCAA` / `checkNS` / `checkMX` package abstentions keep `score: 100` beside `checkStatus: 'error'`, so on the scan path they are excluded but **not** retried (`shouldRetry` needs `score === 0`). Pre-existing, out of scope; noted because this PR made `mta_sts` retryable and the asymmetry is now visible.
- bv-web-prod still carries its `runOne` robots workaround around this check (`scan-engine.server.ts` ~338-361); with 1.33.0 vendored it becomes redundant and can be removed there.
- The `httpResponse` mock helper in `test/helpers/dns-mock.ts` has no `body` stream, so the package's `readResponseTextCapped` reads an empty policy and `mta_sts` scores 0 (four `high`s) in every `scan-domain.spec.ts` fixture that uses it. Harmless for those tests' assertions, but worth knowing before anyone asserts on `mta_sts` there.
- `package-lock.json`'s workspace stanza for `packages/dns-checks` reads 1.30.0 on `main` (stale since 1.31.0) — left for the release commit, as 627e9c899 did.

Closes #889

🤖 Generated with [Claude Code](https://claude.com/claude-code)
