### PR TITLE
feat(dane): verify TLSA pins against the served certificate via bv-tls-probe (#841, scoring model 1.22.0)

### DIFF
--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.33.0",
+	"version": "1.34.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts
@@ -6,18 +6,27 @@
  * the certificate the host actually serves. A stale DANE-EE pin (which actively
  * breaks every DANE-validating client, and is DNSSEC-enforced) read as a pass.
  *
- * Full pin verification needs the live leaf/SPKI. Until that probe output is wired
- * into this runtime-agnostic package, the finding must be HONEST:
- * state presence + syntactic validity, state that the certificate match was NOT
- * verified, and carry machine-readable metadata saying so.
+ * This file pins the NO-PROBE posture (scoring model 1.18.0): when no served
+ * certificate reaches the package — every BSL self-host, and every `check_dane`
+ * (SMTP, port 25) call, which a browser probe cannot serve — the finding must be
+ * HONEST: state presence + syntactic validity, state that the certificate match was
+ * NOT verified, and carry machine-readable metadata saying so.
+ *
+ * Real verification landed in scoring model 1.22.0: the bv-mcp wrapper captures the
+ * served leaf / SPKI over the operator-only bv-tls-probe binding (CDP
+ * `Security.visibleSecurityStateChanged` carries the DER chain) and passes it in as
+ * `ServedCertificate`; the verified / mismatch / unmeasured ladder is pinned by
+ * dane-pin-verification.test.ts. Nothing in this file is superseded by that — the
+ * posture it pins is exactly what a consumer WITHOUT the probe still gets.
  *
  * Pinned here:
  *  1. The low finding never uses the word "Valid" for an unverified pin.
  *  2. The detail states the certificate match was not verified.
  *  3. metadata.certificateMatchVerified === false (machine-readable marker).
  *  4. An unverified pin receives a small deduction instead of full marks.
- *  5. The load-bearing title "DANE TLSA configured for <name>" is unchanged —
- *     maturity staging regex-matches it.
+ *  5. The title "DANE TLSA configured for <name>" is unchanged. (Maturity staging no
+ *     longer regex-matches it — since 1.22.0 it counts a DANE pin toward Stage 4 only
+ *     when the finding carries `certificateMatchVerified: true`.)
  */
 
 import { describe, it, expect } from 'vitest';

--- a/packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts
@@ -116,6 +116,21 @@ describe('verifyTlsaAssociations — RFC 7671 usage × selector × matching type
 		expect(v.unmatched).toEqual([]);
 	});
 
+	it('chainTruncated: a TA pin matching no RETAINED entry is unverifiable (truncatedChain), a leaf pin is still unmatched', () => {
+		const truncated = servedCertificate('example.com', { chainTruncated: true, chainLength: 11 });
+		const ta = verifyTlsaAssociations([rec(2, 1, 1, STALE_SHA256), rec(0, 0, 1, STALE_SHA256)], truncated);
+		expect(ta.unmatched).toEqual([]);
+		expect(ta.unverifiable).toHaveLength(2);
+		expect(ta.truncatedChain).toHaveLength(2);
+		const ee = verifyTlsaAssociations([rec(3, 1, 1, STALE_SHA256), rec(1, 0, 1, STALE_SHA256)], truncated);
+		expect(ee.unmatched).toHaveLength(2);
+		expect(ee.truncatedChain).toEqual([]);
+		// A TA pin that DOES match a retained entry is still matched.
+		expect(verifyTlsaAssociations([rec(2, 0, 1, INTERMEDIATE_SHA256)], truncated).matched).toHaveLength(1);
+		// Without truncation the same TA pin is a plain mismatch.
+		expect(verifyTlsaAssociations([rec(2, 1, 1, STALE_SHA256)], servedCertificate()).unmatched).toHaveLength(1);
+	});
+
 	it('an empty chain falls back to the leaf for TA usages', () => {
 		const leafOnly = servedCertificate('example.com', { chain: [] });
 		expect(verifyTlsaAssociations([rec(2, 1, 1, LEAF_SPKI_SHA256)], leafOnly).matched).toHaveLength(1);
@@ -221,6 +236,39 @@ describe('analyzeTlsaRecords — verdict ladder with a served certificate', () =
 			);
 			expect(result.score).toBe(75);
 		}
+	});
+
+	it('chainTruncated + no TA match → info abstention (notAssessedReason chain_truncated), NOT a mismatch, no deduction', () => {
+		const truncated = servedCertificate('example.com', { chainTruncated: true, chainLength: 11 });
+		const findings = analyzeTlsaRecords([`2 1 1 ${STALE_SHA256}`], NAME, true, { servedCertificate: truncated });
+		expect(findings.some((f) => f.severity === 'high')).toBe(false);
+		const [f] = findings;
+		expect(f.severity).toBe('info');
+		expect(f.metadata).toMatchObject({
+			certificateMatchVerified: false,
+			inconclusive: true,
+			notAssessedReason: 'chain_truncated',
+			chainTruncated: true,
+			chainLength: 11,
+		});
+		// Not a probe outcome marker — the condition is persistent for the host, so the
+		// result must cache normally rather than re-try every scan.
+		expect(f.metadata?.certificateProbe).toBeUndefined();
+		expect(buildCheckResult('dane_https', [{ ...f, category: 'dane_https' }]).score).toBe(100);
+	});
+
+	it('chainTruncated with a stale LEAF pin beside an unverifiable TA pin → abstention (the set may still authenticate)', () => {
+		const truncated = servedCertificate('example.com', { chainTruncated: true });
+		const findings = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`, `2 1 1 ${STALE_SHA256}`], NAME, true, { servedCertificate: truncated });
+		expect(findings.some((f) => f.severity === 'high')).toBe(false);
+		expect(findings[0].metadata?.notAssessedReason).toBe('chain_truncated');
+		expect(findings[0].metadata?.unmatchedAssociations).toEqual([`3 1 1 ${STALE_SHA256}`]);
+	});
+
+	it('chainTruncated with a stale LEAF-only RRset → still a mismatch (truncation cannot hide an end-entity pin)', () => {
+		const truncated = servedCertificate('example.com', { chainTruncated: true });
+		const [f] = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true, { servedCertificate: truncated });
+		expect(f.severity).toBe('high');
 	});
 
 	it('a mixed unmatched + unverifiable set falls back to the honest "present, not verified" low (a broken pin is not established)', () => {
@@ -355,6 +403,17 @@ describe('checkDANEHTTPS — end state verified 100 > absent 95 > mismatch 75', 
 			expect(result.findings[0].metadata?.inconclusive).toBe(true);
 		},
 	);
+
+	it('chain_truncated abstention → 100, NOT partial (persistent condition, caches normally)', async () => {
+		const { queryDNS, rawQueryDNS } = dns([`2 1 1 ${STALE_SHA256}`]);
+		const result = await checkDANEHTTPS('example.com', queryDNS, {
+			rawQueryDNS,
+			servedCertificate: servedCertificate('example.com', { chainTruncated: true, chainLength: 9 }),
+		});
+		expect(result.score).toBe(100);
+		expect(result.partial).toBeUndefined();
+		expect(result.findings[0].metadata?.notAssessedReason).toBe('chain_truncated');
+	});
 
 	it('the lazy resolver is called ONLY when TLSA records exist', async () => {
 		let calls = 0;

--- a/packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts
@@ -7,7 +7,7 @@
  * the scoring was inverted: a stale DANE-EE pin (which breaks every DANE-validating
  * client) scored 100 while deleting it scored 95. With the served certificate in hand
  * (captured by bv-tls-probe, passed in as `ServedCertificate`) the end state is
- * monotone: verified 100 > absent 95 > mismatch 75.
+ * monotone: verified 100 > {absent, unverified — with or without a probe} 95 > mismatch 75.
  *
  * The digest vectors come from OpenSSL (see served-certificate.fixture.ts), so a green
  * run proves the comparison against an independent implementation.
@@ -238,29 +238,31 @@ describe('analyzeTlsaRecords — verdict ladder with a served certificate', () =
 		}
 	});
 
-	it('chainTruncated + no TA match → info abstention (notAssessedReason chain_truncated), NOT a mismatch, no deduction', () => {
+	it('chainTruncated + no TA match → the unverified low (95) with notAssessedReason chain_truncated, NOT a mismatch', () => {
 		const truncated = servedCertificate('example.com', { chainTruncated: true, chainLength: 11 });
 		const findings = analyzeTlsaRecords([`2 1 1 ${STALE_SHA256}`], NAME, true, { servedCertificate: truncated });
 		expect(findings.some((f) => f.severity === 'high')).toBe(false);
 		const [f] = findings;
-		expect(f.severity).toBe('info');
+		expect(f.severity).toBe('low');
+		expect(f.title).toBe(`DANE TLSA configured for ${NAME}`);
 		expect(f.metadata).toMatchObject({
 			certificateMatchVerified: false,
-			inconclusive: true,
 			notAssessedReason: 'chain_truncated',
 			chainTruncated: true,
 			chainLength: 11,
 		});
+		expect(f.metadata?.inconclusive).toBeUndefined();
 		// Not a probe outcome marker — the condition is persistent for the host, so the
 		// result must cache normally rather than re-try every scan.
 		expect(f.metadata?.certificateProbe).toBeUndefined();
-		expect(buildCheckResult('dane_https', [{ ...f, category: 'dane_https' }]).score).toBe(100);
+		expect(buildCheckResult('dane_https', [{ ...f, category: 'dane_https' }]).score).toBe(95);
 	});
 
 	it('chainTruncated with a stale LEAF pin beside an unverifiable TA pin → abstention (the set may still authenticate)', () => {
 		const truncated = servedCertificate('example.com', { chainTruncated: true });
 		const findings = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`, `2 1 1 ${STALE_SHA256}`], NAME, true, { servedCertificate: truncated });
 		expect(findings.some((f) => f.severity === 'high')).toBe(false);
+		expect(findings[0].severity).toBe('low');
 		expect(findings[0].metadata?.notAssessedReason).toBe('chain_truncated');
 		expect(findings[0].metadata?.unmatchedAssociations).toEqual([`3 1 1 ${STALE_SHA256}`]);
 	});
@@ -312,21 +314,21 @@ describe('analyzeTlsaRecords — probe outcomes without a certificate', () => {
 	});
 
 	it.each([
-		['pending', DANE_PIN_NOT_ASSESSED_REASONS.pending, /pending/],
-		['failed', DANE_PIN_NOT_ASSESSED_REASONS.failed, /inconclusive/],
-	] as const)('probe %s → info, inconclusive, notAssessedReason, NO deduction', (outcome, reason, titleRe) => {
+		['pending', DANE_PIN_NOT_ASSESSED_REASONS.pending],
+		['failed', DANE_PIN_NOT_ASSESSED_REASONS.captureFailed],
+	] as const)('probe %s → the SAME low "present, not verified" (95) with sub-state metadata, no inconclusive marker', (outcome, reason) => {
 		const [f] = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true, { certificateProbe: outcome });
-		expect(f.severity).toBe('info');
-		expect(f.title).toMatch(titleRe);
-		expect(f.metadata).toMatchObject({
-			certificateMatchVerified: false,
-			inconclusive: true,
-			notAssessedReason: reason,
-			certificateProbe: outcome,
-		});
+		const baseline = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true)[0];
+		expect(f.severity).toBe('low');
+		expect(f.title).toBe(baseline.title);
+		expect(f.detail).toBe(baseline.detail);
+		expect(f.metadata).toEqual({ ...baseline.metadata, certificateProbe: outcome, notAssessedReason: reason });
+		expect(f.metadata?.inconclusive).toBeUndefined();
 		expect(f.metadata?.missingControl).toBeUndefined();
-		const result = buildCheckResult('dane_https', [{ ...f, category: 'dane_https' }]);
-		expect(result.score).toBe(100);
+		// Never above the honest self-host disclosure: an attempted-but-unanswered
+		// comparison is not better evidence than no comparison.
+		expect(buildCheckResult('dane_https', [{ ...f, category: 'dane_https' }]).score).toBe(95);
+		expect(buildCheckResult('dane_https', [{ ...baseline, category: 'dane_https' }]).score).toBe(95);
 	});
 
 	it('a caller-supplied reason token becomes the notAssessedReason', () => {
@@ -335,7 +337,7 @@ describe('analyzeTlsaRecords — probe outcomes without a certificate', () => {
 			certificateProbeReason: 'off_host_redirect',
 		});
 		expect(f.metadata?.notAssessedReason).toBe('off_host_redirect');
-		expect(f.detail).toContain('off host redirect');
+		expect(f.severity).toBe('low');
 	});
 
 	it('a served certificate wins over a stale probe outcome', () => {
@@ -393,24 +395,46 @@ describe('checkDANEHTTPS — end state verified 100 > absent 95 > mismatch 75', 
 	});
 
 	it.each(['pending', 'failed'] as const)(
-		'probe %s → 100, partial: true, checkStatus untouched (category stays completed)',
+		'probe %s (default transient reason) → 95, partial: true, checkStatus untouched',
 		async (outcome) => {
 			const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
 			const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS, certificateProbe: outcome });
-			expect(result.score).toBe(100);
+			expect(result.score).toBe(95);
+			expect(result.passed).toBe(true);
 			expect(result.partial).toBe(true);
 			expect(result.checkStatus).toBeUndefined();
-			expect(result.findings[0].metadata?.inconclusive).toBe(true);
+			expect(result.findings[0].severity).toBe('low');
+			expect(result.findings[0].metadata?.certificateProbe).toBe(outcome);
 		},
 	);
 
-	it('chain_truncated abstention → 100, NOT partial (persistent condition, caches normally)', async () => {
+	it.each([
+		[DANE_PIN_NOT_ASSESSED_REASONS.pending, true],
+		[DANE_PIN_NOT_ASSESSED_REASONS.captureFailed, true],
+		[DANE_PIN_NOT_ASSESSED_REASONS.unreachable, true],
+		[DANE_PIN_NOT_ASSESSED_REASONS.probeUnavailable, true],
+		[DANE_PIN_NOT_ASSESSED_REASONS.offHostRedirect, false],
+		[DANE_PIN_NOT_ASSESSED_REASONS.hostMismatch, false],
+		['some_unknown_reason', false],
+	])('reason %s → partial %s (transient reasons re-try, permanent ones cache normally)', async (reason, partial) => {
+		const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
+		const result = await checkDANEHTTPS('example.com', queryDNS, {
+			rawQueryDNS,
+			certificateProbe: 'failed',
+			certificateProbeReason: reason,
+		});
+		expect(result.score).toBe(95);
+		expect(result.partial).toBe(partial ? true : undefined);
+		expect(result.findings[0].metadata?.notAssessedReason).toBe(reason);
+	});
+
+	it('chain_truncated → 95, NOT partial (persistent condition, caches normally)', async () => {
 		const { queryDNS, rawQueryDNS } = dns([`2 1 1 ${STALE_SHA256}`]);
 		const result = await checkDANEHTTPS('example.com', queryDNS, {
 			rawQueryDNS,
 			servedCertificate: servedCertificate('example.com', { chainTruncated: true, chainLength: 9 }),
 		});
-		expect(result.score).toBe(100);
+		expect(result.score).toBe(95);
 		expect(result.partial).toBeUndefined();
 		expect(result.findings[0].metadata?.notAssessedReason).toBe('chain_truncated');
 	});
@@ -430,7 +454,7 @@ describe('checkDANEHTTPS — end state verified 100 > absent 95 > mismatch 75', 
 		expect(result.score).toBe(100);
 	});
 
-	it('a throwing resolver is a failed probe (unmeasured, partial), never a verdict', async () => {
+	it('a throwing resolver is a failed probe (probe_unavailable: 95, partial), never a verdict', async () => {
 		const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
 		const result = await checkDANEHTTPS('example.com', queryDNS, {
 			rawQueryDNS,
@@ -438,9 +462,9 @@ describe('checkDANEHTTPS — end state verified 100 > absent 95 > mismatch 75', 
 				throw new Error('binding exploded');
 			},
 		});
-		expect(result.score).toBe(100);
+		expect(result.score).toBe(95);
 		expect(result.partial).toBe(true);
-		expect(result.findings[0].metadata?.notAssessedReason).toBe(DANE_PIN_NOT_ASSESSED_REASONS.failed);
+		expect(result.findings[0].metadata?.notAssessedReason).toBe(DANE_PIN_NOT_ASSESSED_REASONS.probeUnavailable);
 	});
 
 	it('the critical-gap ceiling does not arm on a mismatch in the web_only profile', async () => {

--- a/packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts
@@ -1,0 +1,406 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Issue #841 — DANE TLSA pins are VERIFIED against the certificate the host serves.
+ *
+ * Before scoring model 1.22.0 the check could only say "present and well-formed", and
+ * the scoring was inverted: a stale DANE-EE pin (which breaks every DANE-validating
+ * client) scored 100 while deleting it scored 95. With the served certificate in hand
+ * (captured by bv-tls-probe, passed in as `ServedCertificate`) the end state is
+ * monotone: verified 100 > absent 95 > mismatch 75.
+ *
+ * The digest vectors come from OpenSSL (see served-certificate.fixture.ts), so a green
+ * run proves the comparison against an independent implementation.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { analyzeTlsaRecords, parseTlsaRecord, verifyTlsaAssociations, DANE_PIN_NOT_ASSESSED_REASONS } from '../../checks/dane-analysis';
+import { checkDANEHTTPS } from '../../checks/check-dane-https';
+import {
+	buildCheckResult,
+	computeScanScore,
+	findingsIndicateMissingControl,
+	getProfileWeights,
+	scoreIndicatesMissingControl,
+} from '../../scoring';
+import type { CheckResult, DNSQueryFunction, RawDNSQueryFunction } from '../../types';
+import {
+	servedCertificate,
+	LEAF_SHA256,
+	LEAF_SHA512,
+	LEAF_SPKI_SHA256,
+	LEAF_SPKI_SHA512,
+	LEAF_DER_HEX,
+	LEAF_SPKI_DER_HEX,
+	STALE_SHA256,
+	INTERMEDIATE_SHA256,
+	INTERMEDIATE_SHA512,
+	INTERMEDIATE_SPKI_SHA256,
+	INTERMEDIATE_SPKI_SHA512,
+	INTERMEDIATE_DER_HEX,
+} from './served-certificate.fixture';
+
+const NAME = '_443._tcp.example.com';
+
+function rec(usage: number, selector: number, matchingType: number, certData: string) {
+	return { usage, selector, matchingType, certData };
+}
+
+describe('verifyTlsaAssociations — RFC 7671 usage × selector × matching type', () => {
+	const cert = servedCertificate();
+
+	it.each([
+		// usage 3 DANE-EE and 1 PKIX-EE bind the LEAF
+		['3 0 1 leaf cert sha256', rec(3, 0, 1, LEAF_SHA256)],
+		['3 0 2 leaf cert sha512', rec(3, 0, 2, LEAF_SHA512)],
+		['3 1 1 leaf SPKI sha256 (the recommended form)', rec(3, 1, 1, LEAF_SPKI_SHA256)],
+		['3 1 2 leaf SPKI sha512', rec(3, 1, 2, LEAF_SPKI_SHA512)],
+		['3 0 0 full leaf DER', rec(3, 0, 0, LEAF_DER_HEX)],
+		['3 1 0 full leaf SPKI DER', rec(3, 1, 0, LEAF_SPKI_DER_HEX)],
+		['1 1 1 PKIX-EE leaf SPKI sha256', rec(1, 1, 1, LEAF_SPKI_SHA256)],
+		['1 0 1 PKIX-EE leaf cert sha256', rec(1, 0, 1, LEAF_SHA256)],
+		// usage 2 DANE-TA and 0 PKIX-TA match ANY chain entry
+		['2 0 1 DANE-TA intermediate cert sha256', rec(2, 0, 1, INTERMEDIATE_SHA256)],
+		['2 0 2 DANE-TA intermediate cert sha512', rec(2, 0, 2, INTERMEDIATE_SHA512)],
+		['2 1 1 DANE-TA intermediate SPKI sha256', rec(2, 1, 1, INTERMEDIATE_SPKI_SHA256)],
+		['2 1 2 DANE-TA intermediate SPKI sha512', rec(2, 1, 2, INTERMEDIATE_SPKI_SHA512)],
+		['2 0 0 DANE-TA intermediate full DER', rec(2, 0, 0, INTERMEDIATE_DER_HEX)],
+		['2 1 1 DANE-TA where the TA IS the leaf (RFC 7671 §5.2)', rec(2, 1, 1, LEAF_SPKI_SHA256)],
+		['0 0 1 PKIX-TA intermediate cert sha256', rec(0, 0, 1, INTERMEDIATE_SHA256)],
+		['0 1 0 PKIX-TA leaf SPKI full DER (TA == EE)', rec(0, 1, 0, LEAF_SPKI_DER_HEX)],
+	])('%s → matched', (_label, record) => {
+		const v = verifyTlsaAssociations([record], cert);
+		expect(v.matched).toEqual([record]);
+		expect(v.unmatched).toEqual([]);
+		expect(v.unverifiable).toEqual([]);
+	});
+
+	it.each([
+		['3 1 1 stale SPKI pin (the #841 repro shape)', rec(3, 1, 1, STALE_SHA256)],
+		['3 0 1 wrong object: SPKI digest pinned under selector 0', rec(3, 0, 1, LEAF_SPKI_SHA256)],
+		['3 1 2 wrong algorithm: sha256 pinned as matching type 2', rec(3, 1, 2, LEAF_SPKI_SHA256)],
+		['3 1 1 intermediate SPKI pinned as DANE-EE (EE binds the leaf only)', rec(3, 1, 1, INTERMEDIATE_SPKI_SHA256)],
+		['1 0 1 PKIX-EE intermediate cert pinned (EE binds the leaf only)', rec(1, 0, 1, INTERMEDIATE_SHA256)],
+		['2 1 1 DANE-TA digest absent from the whole chain', rec(2, 1, 1, STALE_SHA256)],
+		['3 0 0 full DER off by one byte', rec(3, 0, 0, LEAF_DER_HEX.slice(0, -2) + '00')],
+	])('%s → unmatched', (_label, record) => {
+		const v = verifyTlsaAssociations([record], cert);
+		expect(v.unmatched).toEqual([record]);
+		expect(v.matched).toEqual([]);
+		expect(v.unverifiable).toEqual([]);
+	});
+
+	it.each([
+		['usage 4 (outside 0–3)', rec(4, 1, 1, LEAF_SPKI_SHA256)],
+		['selector 2 (outside 0–1)', rec(3, 2, 1, LEAF_SPKI_SHA256)],
+		['matching type 3 (outside 0–2)', rec(3, 1, 3, LEAF_SPKI_SHA256)],
+		['empty certData', rec(3, 1, 1, '')],
+	])('%s → unverifiable, never unmatched', (_label, record) => {
+		const v = verifyTlsaAssociations([record], cert);
+		expect(v.unverifiable).toEqual([record]);
+		expect(v.unmatched).toEqual([]);
+	});
+
+	it('a TA selector-1 full-data pin against a non-leaf entry is unverifiable (the contract carries no SPKI DER there)', () => {
+		const v = verifyTlsaAssociations([rec(2, 1, 0, INTERMEDIATE_DER_HEX)], cert);
+		// The leaf entry IS comparable (leafSpkiDer) and differs; the intermediate is not.
+		// A record with an uncomparable member is unverifiable, not a broken pin.
+		expect(v.unverifiable).toHaveLength(1);
+		expect(v.unmatched).toEqual([]);
+	});
+
+	it('probe material a comparison needs but lacks → unverifiable, not unmatched', () => {
+		const bare = servedCertificate('example.com', { leafSha512: undefined, chain: [] });
+		const v = verifyTlsaAssociations([rec(3, 0, 2, LEAF_SHA512)], bare);
+		expect(v.unverifiable).toHaveLength(1);
+		expect(v.unmatched).toEqual([]);
+	});
+
+	it('an empty chain falls back to the leaf for TA usages', () => {
+		const leafOnly = servedCertificate('example.com', { chain: [] });
+		expect(verifyTlsaAssociations([rec(2, 1, 1, LEAF_SPKI_SHA256)], leafOnly).matched).toHaveLength(1);
+		expect(verifyTlsaAssociations([rec(2, 1, 1, INTERMEDIATE_SPKI_SHA256)], leafOnly).unmatched).toHaveLength(1);
+	});
+
+	it('comparison is case-insensitive and whitespace-tolerant on both sides', () => {
+		const shouty = servedCertificate('example.com', { leafSpkiSha256: LEAF_SPKI_SHA256.toUpperCase() });
+		const spaced = `${LEAF_SPKI_SHA256.slice(0, 32)} ${LEAF_SPKI_SHA256.slice(32).toUpperCase()}`;
+		expect(verifyTlsaAssociations([rec(3, 1, 1, spaced)], shouty).matched).toHaveLength(1);
+	});
+
+	it('accepts presentation strings, parsing them; unparseable strings are dropped', () => {
+		const v = verifyTlsaAssociations([`3 1 1 ${LEAF_SPKI_SHA256}`, `3 1 1 ${STALE_SHA256}`, 'garbage'], cert);
+		expect(v.matched).toEqual([parseTlsaRecord(`3 1 1 ${LEAF_SPKI_SHA256}`)]);
+		expect(v.unmatched).toEqual([parseTlsaRecord(`3 1 1 ${STALE_SHA256}`)]);
+		expect(v.unverifiable).toEqual([]);
+	});
+});
+
+describe('analyzeTlsaRecords — verdict ladder with a served certificate', () => {
+	const cert = servedCertificate();
+
+	it('a matching association → info, certificateMatchVerified: true, matched digests in metadata', () => {
+		const findings = analyzeTlsaRecords([`3 1 1 ${LEAF_SPKI_SHA256}`], NAME, true);
+		expect(findings).toHaveLength(1);
+		const verified = analyzeTlsaRecords([`3 1 1 ${LEAF_SPKI_SHA256}`], NAME, true, { servedCertificate: cert });
+		expect(verified).toHaveLength(1);
+		const f = verified[0];
+		expect(f.severity).toBe('info');
+		expect(f.title).toBe(`DANE TLSA verified against the served certificate for ${NAME}`);
+		expect(f.metadata).toMatchObject({
+			certificateMatchVerified: true,
+			matchedUsage: 3,
+			matchedSelector: 1,
+			matchedMatchingType: 1,
+			matchedCertData: LEAF_SPKI_SHA256,
+			matchedAssociations: [`3 1 1 ${LEAF_SPKI_SHA256}`],
+			servedLeafSpkiSha256: LEAF_SPKI_SHA256,
+			servedLeafSha256: LEAF_SHA256,
+			servedHost: 'example.com',
+			servedPort: 443,
+		});
+		expect(f.metadata?.inconclusive).toBeUndefined();
+	});
+
+	it('a rollover RRset (one stale + one current) → verified, with the stale member listed as unmatched', () => {
+		const [f] = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`, `3 1 1 ${LEAF_SPKI_SHA256}`], NAME, true, { servedCertificate: cert });
+		expect(f.severity).toBe('info');
+		expect(f.metadata?.certificateMatchVerified).toBe(true);
+		expect(f.metadata?.unmatchedAssociations).toEqual([`3 1 1 ${STALE_SHA256}`]);
+		expect(f.detail).toMatch(/rollover/i);
+	});
+
+	it('no association matches → high "pin does not match", certificateMatchVerified: false, served SPKI + pinned list', () => {
+		const [f] = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true, { servedCertificate: cert });
+		expect(f.severity).toBe('high');
+		expect(f.title).toBe(`DANE TLSA pin does not match the served certificate for ${NAME}`);
+		expect(f.metadata).toMatchObject({
+			certificateMatchVerified: false,
+			servedLeafSpkiSha256: LEAF_SPKI_SHA256,
+			pinned: [`3 1 1 ${STALE_SHA256}`],
+		});
+		expect(f.detail).toMatch(/DNSSEC-authenticated, DANE-validating clients reject the connection/);
+		expect(f.detail).toContain(LEAF_SPKI_SHA256);
+	});
+
+	it('the mismatch finding is NOT a missing control — it must never arm the critical-gap ceiling', () => {
+		const findings = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`, `2 0 1 ${STALE_SHA256}`], NAME, true, { servedCertificate: cert });
+		const high = findings.filter((f) => f.severity === 'high');
+		expect(high).toHaveLength(1);
+		// Both the canonical predicate and the legacy prose predicate must decline.
+		expect(findingsIndicateMissingControl(high)).toBe(false);
+		expect(scoreIndicatesMissingControl(high)).toBe(false);
+		// The words the prose regex keys on are absent from title AND detail.
+		const text = `${high[0].title} ${high[0].detail}`;
+		expect(text).not.toMatch(/missing|required|not\s+found/i);
+		expect(text).not.toMatch(/no\s+[^\r\n]{1,64}\srecord/i);
+		expect(high[0].metadata?.missingControl).toBeUndefined();
+		// And the category scores 75 (ordinary −25), not 0.
+		const result = buildCheckResult(
+			'dane_https',
+			findings.map((f) => ({ ...f, category: 'dane_https' as const })),
+		);
+		expect(result.score).toBe(75);
+		expect(result.passed).toBe(true);
+	});
+
+	it('a zone owner cannot smuggle a regex trigger through the pinned data (subject-data redaction)', () => {
+		// `3 1 1 missing` parses: certData = "missing". It matches no digest → high mismatch
+		// whose prose interpolates the pin. The predicate must test the prose WITHOUT it.
+		for (const token of ['missing', 'required', 'not found', 'no tlsa record']) {
+			const findings = analyzeTlsaRecords([`3 1 1 ${token}`], NAME, true, { servedCertificate: cert });
+			const high = findings.filter((f) => f.severity === 'high');
+			expect(high).toHaveLength(1);
+			// parseTlsaRecord joins the data parts without a separator, so a spaced token collapses.
+			expect(high[0].detail).toContain(token.replace(/\s+/g, ''));
+			expect(scoreIndicatesMissingControl(high)).toBe(false);
+			expect(findingsIndicateMissingControl(high)).toBe(false);
+			const result = buildCheckResult(
+				'dane_https',
+				findings.map((f) => ({ ...f, category: 'dane_https' as const })),
+			);
+			expect(result.score).toBe(75);
+		}
+	});
+
+	it('a mixed unmatched + unverifiable set falls back to the honest "present, not verified" low (a broken pin is not established)', () => {
+		const findings = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`, `2 1 0 ${INTERMEDIATE_DER_HEX}`], NAME, true, {
+			servedCertificate: cert,
+		});
+		// The `2 1 0` record also earns its own "full certificate matching" low; the verdict is the consolidated one.
+		expect(findings.some((x) => x.severity === 'high')).toBe(false);
+		const f = findings.find((x) => x.title.startsWith('DANE TLSA configured'))!;
+		expect(f).toBeDefined();
+		expect(f.severity).toBe('low');
+		expect(f.title).toBe(`DANE TLSA configured for ${NAME}`);
+		expect(f.metadata?.certificateMatchVerified).toBe(false);
+		expect(f.metadata?.unverifiableAssociations).toEqual([`2 1 0 ${INTERMEDIATE_DER_HEX}`]);
+	});
+
+	it('DNSSEC-absent + mismatch: both the DANE-without-DNSSEC high and the mismatch high fire (additive, not zeroing)', () => {
+		const findings = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, false, { servedCertificate: cert });
+		expect(findings.map((f) => f.title)).toEqual([
+			'DANE without DNSSEC',
+			`DANE TLSA pin does not match the served certificate for ${NAME}`,
+		]);
+		const result = buildCheckResult(
+			'dane_https',
+			findings.map((f) => ({ ...f, category: 'dane_https' as const })),
+		);
+		expect(result.score).toBe(50);
+	});
+});
+
+describe('analyzeTlsaRecords — probe outcomes without a certificate', () => {
+	it('no probe capability (default) → the 1.18.0 low finding, byte-identical to before', () => {
+		const before = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true);
+		const explicit = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true, { certificateProbe: 'unavailable' });
+		const empty = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true, {});
+		expect(explicit).toEqual(before);
+		expect(empty).toEqual(before);
+		expect(before[0].severity).toBe('low');
+		expect(before[0].title).toBe(`DANE TLSA configured for ${NAME}`);
+		expect(before[0].metadata).toEqual({ name: NAME, validRecordCount: 1, certificateMatchVerified: false });
+	});
+
+	it.each([
+		['pending', DANE_PIN_NOT_ASSESSED_REASONS.pending, /pending/],
+		['failed', DANE_PIN_NOT_ASSESSED_REASONS.failed, /inconclusive/],
+	] as const)('probe %s → info, inconclusive, notAssessedReason, NO deduction', (outcome, reason, titleRe) => {
+		const [f] = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true, { certificateProbe: outcome });
+		expect(f.severity).toBe('info');
+		expect(f.title).toMatch(titleRe);
+		expect(f.metadata).toMatchObject({
+			certificateMatchVerified: false,
+			inconclusive: true,
+			notAssessedReason: reason,
+			certificateProbe: outcome,
+		});
+		expect(f.metadata?.missingControl).toBeUndefined();
+		const result = buildCheckResult('dane_https', [{ ...f, category: 'dane_https' }]);
+		expect(result.score).toBe(100);
+	});
+
+	it('a caller-supplied reason token becomes the notAssessedReason', () => {
+		const [f] = analyzeTlsaRecords([`3 1 1 ${STALE_SHA256}`], NAME, true, {
+			certificateProbe: 'failed',
+			certificateProbeReason: 'off_host_redirect',
+		});
+		expect(f.metadata?.notAssessedReason).toBe('off_host_redirect');
+		expect(f.detail).toContain('off host redirect');
+	});
+
+	it('a served certificate wins over a stale probe outcome', () => {
+		const [f] = analyzeTlsaRecords([`3 1 1 ${LEAF_SPKI_SHA256}`], NAME, true, {
+			servedCertificate: servedCertificate(),
+			certificateProbe: 'failed',
+		});
+		expect(f.metadata?.certificateMatchVerified).toBe(true);
+	});
+});
+
+describe('checkDANEHTTPS — end state verified 100 > absent 95 > mismatch 75', () => {
+	function dns(tlsa: string[]): { queryDNS: DNSQueryFunction; rawQueryDNS: RawDNSQueryFunction } {
+		return {
+			queryDNS: async (name, type) => (type === 'TLSA' && name === NAME ? tlsa : []),
+			rawQueryDNS: async () => ({ AD: true, Answer: [] }),
+		};
+	}
+
+	it('verified pin → 100, passed, not partial', async () => {
+		const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${LEAF_SPKI_SHA256}`]);
+		const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS, servedCertificate: servedCertificate() });
+		expect(result.score).toBe(100);
+		expect(result.passed).toBe(true);
+		expect(result.partial).toBeUndefined();
+		expect(result.checkStatus).toBeUndefined();
+		expect(result.recordPresent).toBe(true);
+		expect(result.findings[0].category).toBe('dane_https');
+		expect(result.findings[0].metadata?.certificateMatchVerified).toBe(true);
+	});
+
+	it('absent TLSA → 95 (unchanged), even with a served certificate in hand', async () => {
+		const { queryDNS, rawQueryDNS } = dns([]);
+		const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS, servedCertificate: servedCertificate() });
+		expect(result.score).toBe(95);
+		expect(result.findings[0].title).toBe('No DANE TLSA for HTTPS');
+		expect(result.partial).toBeUndefined();
+	});
+
+	it('stale pin → 75, and the category is still scored (passed, no missing control)', async () => {
+		const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
+		const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS, servedCertificate: servedCertificate() });
+		expect(result.score).toBe(75);
+		expect(result.passed).toBe(true);
+		expect(result.partial).toBeUndefined();
+		expect(result.findings[0].severity).toBe('high');
+	});
+
+	it('no probe capability → 95 with the unverified low (self-host posture, bit-for-bit unchanged)', async () => {
+		const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
+		const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS });
+		expect(result.score).toBe(95);
+		expect(result.partial).toBeUndefined();
+		expect(result.findings[0].severity).toBe('low');
+	});
+
+	it.each(['pending', 'failed'] as const)(
+		'probe %s → 100, partial: true, checkStatus untouched (category stays completed)',
+		async (outcome) => {
+			const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
+			const result = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS, certificateProbe: outcome });
+			expect(result.score).toBe(100);
+			expect(result.partial).toBe(true);
+			expect(result.checkStatus).toBeUndefined();
+			expect(result.findings[0].metadata?.inconclusive).toBe(true);
+		},
+	);
+
+	it('the lazy resolver is called ONLY when TLSA records exist', async () => {
+		let calls = 0;
+		const resolve = async () => {
+			calls++;
+			return { servedCertificate: servedCertificate() };
+		};
+		const none = dns([]);
+		await checkDANEHTTPS('example.com', none.queryDNS, { rawQueryDNS: none.rawQueryDNS, resolveServedCertificate: resolve });
+		expect(calls).toBe(0);
+		const some = dns([`3 1 1 ${LEAF_SPKI_SHA256}`]);
+		const result = await checkDANEHTTPS('example.com', some.queryDNS, { rawQueryDNS: some.rawQueryDNS, resolveServedCertificate: resolve });
+		expect(calls).toBe(1);
+		expect(result.score).toBe(100);
+	});
+
+	it('a throwing resolver is a failed probe (unmeasured, partial), never a verdict', async () => {
+		const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
+		const result = await checkDANEHTTPS('example.com', queryDNS, {
+			rawQueryDNS,
+			resolveServedCertificate: async () => {
+				throw new Error('binding exploded');
+			},
+		});
+		expect(result.score).toBe(100);
+		expect(result.partial).toBe(true);
+		expect(result.findings[0].metadata?.notAssessedReason).toBe(DANE_PIN_NOT_ASSESSED_REASONS.failed);
+	});
+
+	it('the critical-gap ceiling does not arm on a mismatch in the web_only profile', async () => {
+		const { queryDNS, rawQueryDNS } = dns([`3 1 1 ${STALE_SHA256}`]);
+		const dane = await checkDANEHTTPS('example.com', queryDNS, { rawQueryDNS, servedCertificate: servedCertificate() });
+		// A clean web-only roster; dane_https is CRITICAL for web_only, so a missing-control
+		// reading here would cap the whole scan at 64.
+		const clean = (category: CheckResult['category']) =>
+			buildCheckResult(category, [{ category, title: 'ok', severity: 'info', detail: 'ok' }], true, true);
+		const noMx = buildCheckResult('mx', [{ category: 'mx', title: 'No MX records', severity: 'info', detail: 'web-only' }], false, false);
+		const checks: CheckResult[] = [noMx, clean('ssl'), clean('http_security'), clean('dnssec'), clean('caa'), clean('ns'), dane];
+		const score = computeScanScore(checks, {
+			profile: 'web_only',
+			signals: [],
+			weights: getProfileWeights('web_only'),
+			detectedProvider: null,
+		});
+		expect(score.categoryScores.dane_https).toBe(75);
+		expect(score.overall).not.toBeNull();
+		expect(score.overall!).toBeGreaterThan(64);
+	});
+});

--- a/packages/dns-checks/src/__tests__/checks/served-certificate.fixture.ts
+++ b/packages/dns-checks/src/__tests__/checks/served-certificate.fixture.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * A real served-certificate fixture for the DANE pin-verification tests (#841).
+ *
+ * Every value below was derived with OpenSSL from ONE throwaway self-signed P-256
+ * certificate (CN=example.test, 1-day validity, generated outside the repo), so the
+ * comparison logic is proven against an independent implementation rather than
+ * against itself:
+ *
+ *   openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:P-256 -nodes -days 1 \
+ *     -subj /CN=example.test -keyout /dev/null -out cert.pem
+ *   openssl x509 -in cert.pem -outform DER -out cert.der
+ *   openssl x509 -in cert.pem -pubkey -noout | openssl pkey -pubin -outform DER -out spki.der
+ *   openssl dgst -sha256 -r cert.der   # LEAF_SHA256      (TLSA selector 0, matching 1)
+ *   openssl dgst -sha512 -r cert.der   # LEAF_SHA512      (selector 0, matching 2)
+ *   openssl dgst -sha256 -r spki.der   # LEAF_SPKI_SHA256 (selector 1, matching 1)
+ *   openssl dgst -sha512 -r spki.der   # LEAF_SPKI_SHA512 (selector 1, matching 2)
+ *   base64 cert.der / spki.der         # LEAF_DER_B64 / LEAF_SPKI_DER_B64 (matching 0 inputs)
+ *   xxd -p cert.der / spki.der         # LEAF_DER_HEX / LEAF_SPKI_DER_HEX (matching 0 pins)
+ *
+ * The private key was discarded (`-keyout /dev/null`); nothing here is a secret.
+ */
+
+import type { ServedCertificate } from '../../checks/dane-analysis';
+
+export const LEAF_DER_B64 =
+	'MIIBgzCCASmgAwIBAgIUAU42LRqp7O5gToUGUj4O08EBkOMwCgYIKoZIzj0EAwIwFzEVMBMGA1UEAwwMZXhhbXBsZS50ZXN0MB4XDTI2MDkwMzIzNDUzMloXDTI2MDkwNDIzNDUzMlowFzEVMBMGA1UEAwwMZXhhbXBsZS50ZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2lPDQNRz6ePZ4OCkA3yAsY8tu0ttDIj6gyo0GDLxZDAHGk1NGS1vGlya395iEerZEGImLMb9pf/cysEjHjzSEKNTMFEwHQYDVR0OBBYEFATZ4DzM2/nMBVJCQgWbIThkBpGQMB8GA1UdIwQYMBaAFATZ4DzM2/nMBVJCQgWbIThkBpGQMA8GA1UdEwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSAAwRQIhAPzNiz2u+0aIJQlUNlRpHDN/wXI5FmR3nqMAvP9rjJ2QAiBDOuM+k5C7tGiagmlSOoqVJtNL2GteibqvHf8FTqfIfA==';
+export const LEAF_SPKI_DER_B64 =
+	'MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2lPDQNRz6ePZ4OCkA3yAsY8tu0ttDIj6gyo0GDLxZDAHGk1NGS1vGlya395iEerZEGImLMb9pf/cysEjHjzSEA==';
+
+export const LEAF_SHA256 = '7a9bcc4b1bc7d041e4a9a4165792c51ba980ee1fe649206b62ee03e36c9d3b6d';
+export const LEAF_SHA512 =
+	'3f073ff1e8be79dac7f333f4e55a8c1dc114a034fb597a9e17e6f1e1f4a1c9b66c5a64d0481bc8f350ca2c015e09efafe28f118f5848db1fe311d97e134c04c5';
+export const LEAF_SPKI_SHA256 = '94b19b8aa7a903c5aaec27633d30f44ba3be5d3da686337f062830efcdd1db56';
+export const LEAF_SPKI_SHA512 =
+	'e7e28199c4b3df9fdab90e08267cd6be504935d4b44a8a2dde36636549cc01280bd54d9cae7299d45ce1fb2671528978f74d7d83423fc520107c23b3e58c2312';
+
+/** Full-data (matching type 0) pins: hex of the DER, as TLSA presentation carries them. */
+export const LEAF_DER_HEX =
+	'3082018330820129a0030201020214014e362d1aa9ecee604e8506523e0ed3c10190e3300a06082a8648ce3d04030230173115301306035504030c0c6578616d706c652e74657374301e170d3236303930333233343533325a170d3236303930343233343533325a30173115301306035504030c0c6578616d706c652e746573743059301306072a8648ce3d020106082a8648ce3d03010703420004da53c340d473e9e3d9e0e0a4037c80b18f2dbb4b6d0c88fa832a341832f16430071a4d4d192d6f1a5c9adfde6211ead91062262cc6fda5ffdccac1231e3cd210a3533051301d0603551d0e0416041404d9e03cccdbf9cc05524242059b213864069190301f0603551d2304183016801404d9e03cccdbf9cc05524242059b213864069190300f0603551d130101ff040530030101ff300a06082a8648ce3d0403020348003045022100fccd8b3daefb46882509543654691c337fc172391664779ea300bcff6b8c9d900220433ae33e9390bbb4689a8269523a8a9526d34bd86b5e89baaf1dff054ea7c87c';
+export const LEAF_SPKI_DER_HEX =
+	'3059301306072a8648ce3d020106082a8648ce3d03010703420004da53c340d473e9e3d9e0e0a4037c80b18f2dbb4b6d0c88fa832a341832f16430071a4d4d192d6f1a5c9adfde6211ead91062262cc6fda5ffdccac1231e3cd210';
+
+/** A digest that matches nothing — the "stale pin" of issue #841. */
+export const STALE_SHA256 = 'b5d294f0346bc9b8b1d9396e93537b750784fa385d514c1bcb7f3b7a606a432a';
+
+/**
+ * A synthetic intermediate for the DANE-TA / PKIX-TA chain paths. Its digests are
+ * arbitrary distinct values (they need only be findable in the chain, not derivable),
+ * and it deliberately carries NO `spkiDer` — the probe contract has none for non-leaf
+ * entries — so a selector-1 / matching-0 TA pin against it is UNVERIFIABLE.
+ */
+export const INTERMEDIATE_SHA256 = 'c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2';
+export const INTERMEDIATE_SHA512 =
+	'd2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5';
+export const INTERMEDIATE_SPKI_SHA256 = 'e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4';
+export const INTERMEDIATE_SPKI_SHA512 =
+	'f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7';
+/** base64 of the bytes 0x30 0x03 0x02 0x01 0x01 (a tiny stand-in DER; hex 3003020101). */
+export const INTERMEDIATE_DER_B64 = 'MAMCAQE=';
+export const INTERMEDIATE_DER_HEX = '3003020101';
+
+/** The served certificate exactly as bv-tls-probe reports it, host pinned to the scanned name. */
+export function servedCertificate(host = 'example.com', overrides: Partial<ServedCertificate> = {}): ServedCertificate {
+	return {
+		host,
+		port: 443,
+		capturedAt: '2026-09-04T00:00:00.000Z',
+		leafDer: LEAF_DER_B64,
+		leafSpkiDer: LEAF_SPKI_DER_B64,
+		leafSha256: LEAF_SHA256,
+		leafSha512: LEAF_SHA512,
+		leafSpkiSha256: LEAF_SPKI_SHA256,
+		leafSpkiSha512: LEAF_SPKI_SHA512,
+		chain: [
+			{ sha256: LEAF_SHA256, sha512: LEAF_SHA512, spkiSha256: LEAF_SPKI_SHA256, spkiSha512: LEAF_SPKI_SHA512, der: LEAF_DER_B64 },
+			{
+				sha256: INTERMEDIATE_SHA256,
+				sha512: INTERMEDIATE_SHA512,
+				spkiSha256: INTERMEDIATE_SPKI_SHA256,
+				spkiSha512: INTERMEDIATE_SPKI_SHA512,
+				der: INTERMEDIATE_DER_B64,
+			},
+		],
+		subjectName: 'example.test',
+		...overrides,
+	};
+}

--- a/packages/dns-checks/src/checks/check-dane-https.ts
+++ b/packages/dns-checks/src/checks/check-dane-https.ts
@@ -10,7 +10,7 @@
 
 import type { CheckResult, DNSQueryFunction, Finding, RawDNSQueryFunction } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
-import { analyzeTlsaRecords, DANE_PIN_NOT_ASSESSED_REASONS } from './dane-analysis';
+import { analyzeTlsaRecords, DANE_PIN_NOT_ASSESSED_REASONS, isTransientDanePinReason } from './dane-analysis';
 import type { TlsaVerificationContext } from './dane-analysis';
 
 /** Options for {@link checkDANEHTTPS}. */
@@ -21,7 +21,7 @@ export interface CheckDaneHttpsOptions extends TlsaVerificationContext {
 	 * Lazy certificate source (#841). Called ONLY when the TLSA lookup returned records —
 	 * DANE-for-HTTPS adoption is ~0%, so an eager probe would spend a Browser Rendering
 	 * session on every scan to verify nothing. A throwing resolver is a `failed` probe
-	 * (unmeasured), never a verdict. Takes precedence over the static `servedCertificate` /
+	 * (`probe_unavailable`, unverified at 95, re-tried), never a verdict. Takes precedence over the static `servedCertificate` /
 	 * `certificateProbe` fields when both are supplied.
 	 */
 	resolveServedCertificate?: () => Promise<TlsaVerificationContext>;
@@ -108,14 +108,19 @@ export async function checkDANEHTTPS(domain: string, queryDNS: DNSQueryFunction,
 	const recordPresent = tlsaQueryFailed ? undefined : hasHttpsTlsa;
 
 	const result = buildCheckResult('dane_https', remapped, undefined, recordPresent);
-	// An ATTEMPTED-but-unanswered pin verification is a transient outcome: `partial: true`
-	// keeps it out of the scan-TTL cache so the next scan re-tries (mirrors the MTA-STS
-	// not-assessed shape, #889). `checkStatus` is deliberately NOT set — the TLSA
-	// measurement itself is real, so the category stays completed and scored.
-	const verificationUnmeasured = remapped.some(
-		(f) => f.metadata?.certificateProbe === 'pending' || f.metadata?.certificateProbe === 'failed',
+	// An ATTEMPTED-but-unanswered pin verification with a TRANSIENT reason (cold-cache
+	// pending, host unreachable, probe 5xx/throw, capture hiccup) gets `partial: true`,
+	// which keeps it out of the scan-TTL cache so the next scan re-tries (mirrors the
+	// MTA-STS not-assessed shape, #889). Permanent reasons (off-host redirect, host
+	// mismatch, truncated chain) cache normally — no retry-forever. `checkStatus` is
+	// deliberately NOT set — the TLSA measurement itself is real, so the category stays
+	// completed and scored (at the unverified 95).
+	const retryable = remapped.some(
+		(f) =>
+			(f.metadata?.certificateProbe === 'pending' || f.metadata?.certificateProbe === 'failed') &&
+			isTransientDanePinReason(f.metadata?.notAssessedReason),
 	);
-	return verificationUnmeasured ? { ...result, partial: true } : result;
+	return retryable ? { ...result, partial: true } : result;
 }
 
 /**
@@ -128,7 +133,7 @@ async function resolveVerification(options: CheckDaneHttpsOptions | undefined): 
 		try {
 			return await options.resolveServedCertificate();
 		} catch {
-			return { certificateProbe: 'failed', certificateProbeReason: DANE_PIN_NOT_ASSESSED_REASONS.failed };
+			return { certificateProbe: 'failed', certificateProbeReason: DANE_PIN_NOT_ASSESSED_REASONS.probeUnavailable };
 		}
 	}
 	return {

--- a/packages/dns-checks/src/checks/check-dane-https.ts
+++ b/packages/dns-checks/src/checks/check-dane-https.ts
@@ -10,16 +10,31 @@
 
 import type { CheckResult, DNSQueryFunction, Finding, RawDNSQueryFunction } from '../types';
 import { buildCheckResult, createFinding } from '../check-utils';
-import { analyzeTlsaRecords } from './dane-analysis';
+import { analyzeTlsaRecords, DANE_PIN_NOT_ASSESSED_REASONS } from './dane-analysis';
+import type { TlsaVerificationContext } from './dane-analysis';
+
+/** Options for {@link checkDANEHTTPS}. */
+export interface CheckDaneHttpsOptions extends TlsaVerificationContext {
+	timeout?: number;
+	rawQueryDNS?: RawDNSQueryFunction;
+	/**
+	 * Lazy certificate source (#841). Called ONLY when the TLSA lookup returned records —
+	 * DANE-for-HTTPS adoption is ~0%, so an eager probe would spend a Browser Rendering
+	 * session on every scan to verify nothing. A throwing resolver is a `failed` probe
+	 * (unmeasured), never a verdict. Takes precedence over the static `servedCertificate` /
+	 * `certificateProbe` fields when both are supplied.
+	 */
+	resolveServedCertificate?: () => Promise<TlsaVerificationContext>;
+}
 
 /**
  * Check DANE TLSA records for a domain's HTTPS endpoint (_443._tcp.{domain}).
+ *
+ * With a served certificate (or a `resolveServedCertificate` source) the pinned data is
+ * VERIFIED against it — see `analyzeTlsaRecords` for the verdict ladder. Without one
+ * (every BSL self-host) the result is the 1.18.0 "present, not verified" posture.
  */
-export async function checkDANEHTTPS(
-	domain: string,
-	queryDNS: DNSQueryFunction,
-	options?: { timeout?: number; rawQueryDNS?: RawDNSQueryFunction },
-): Promise<CheckResult> {
+export async function checkDANEHTTPS(domain: string, queryDNS: DNSQueryFunction, options?: CheckDaneHttpsOptions): Promise<CheckResult> {
 	const timeout = options?.timeout ?? 5000;
 	const rawQueryDNS = options?.rawQueryDNS;
 	const findings: Finding[] = [];
@@ -45,7 +60,7 @@ export async function checkDANEHTTPS(
 		const tlsaRecords = await queryDNS(tlsaName, 'TLSA', { timeout });
 		if (tlsaRecords.length > 0) {
 			hasHttpsTlsa = true;
-			findings.push(...analyzeTlsaRecords(tlsaRecords, tlsaName, hasDnssec));
+			findings.push(...analyzeTlsaRecords(tlsaRecords, tlsaName, hasDnssec, await resolveVerification(options)));
 		}
 	} catch {
 		// TLSA query failed — report and continue
@@ -92,5 +107,33 @@ export async function checkDANEHTTPS(
 	// so that branch stays undefined rather than claiming absence.
 	const recordPresent = tlsaQueryFailed ? undefined : hasHttpsTlsa;
 
-	return buildCheckResult('dane_https', remapped, undefined, recordPresent);
+	const result = buildCheckResult('dane_https', remapped, undefined, recordPresent);
+	// An ATTEMPTED-but-unanswered pin verification is a transient outcome: `partial: true`
+	// keeps it out of the scan-TTL cache so the next scan re-tries (mirrors the MTA-STS
+	// not-assessed shape, #889). `checkStatus` is deliberately NOT set — the TLSA
+	// measurement itself is real, so the category stays completed and scored.
+	const verificationUnmeasured = remapped.some(
+		(f) => f.metadata?.certificateProbe === 'pending' || f.metadata?.certificateProbe === 'failed',
+	);
+	return verificationUnmeasured ? { ...result, partial: true } : result;
+}
+
+/**
+ * Resolve the verification context: the lazy source wins; a throw is a `failed` probe.
+ * Absent everything → `{}` → the analyzer's default `unavailable` posture.
+ */
+async function resolveVerification(options: CheckDaneHttpsOptions | undefined): Promise<TlsaVerificationContext> {
+	if (!options) return {};
+	if (options.resolveServedCertificate) {
+		try {
+			return await options.resolveServedCertificate();
+		} catch {
+			return { certificateProbe: 'failed', certificateProbeReason: DANE_PIN_NOT_ASSESSED_REASONS.failed };
+		}
+	}
+	return {
+		servedCertificate: options.servedCertificate,
+		certificateProbe: options.certificateProbe,
+		certificateProbeReason: options.certificateProbeReason,
+	};
 }

--- a/packages/dns-checks/src/checks/dane-analysis.ts
+++ b/packages/dns-checks/src/checks/dane-analysis.ts
@@ -10,6 +10,7 @@
 
 import type { Finding } from '../types';
 import { createFinding } from '../check-utils';
+import { SUBJECT_TERMS_METADATA_KEY } from '../scoring/model';
 
 /** Parsed TLSA record with usage, selector, matching type, and certificate data */
 export interface TlsaRecord {
@@ -61,13 +62,247 @@ const USAGE_LABELS: Record<number, string> = {
 };
 
 /**
+ * One member of the certificate chain a host served, as captured by an out-of-package
+ * probe (bv-tls-probe over the operator-only `BV_TLS_PROBE` binding). Digests are
+ * lowercase hex; DER is base64. Every field is optional so a probe that omits one
+ * makes the affected association UNVERIFIABLE rather than UNMATCHED — a dropped field
+ * must never read as a broken pin.
+ */
+export interface ServedCertificateChainEntry {
+	/** SHA-256 over the certificate DER (TLSA selector 0, matching type 1). */
+	sha256?: string;
+	/** SHA-512 over the certificate DER (selector 0, matching type 2). */
+	sha512?: string;
+	/** SHA-256 over the SubjectPublicKeyInfo DER (selector 1, matching type 1). */
+	spkiSha256?: string;
+	/** SHA-512 over the SubjectPublicKeyInfo DER (selector 1, matching type 2). */
+	spkiSha512?: string;
+	/** Base64 certificate DER (selector 0, matching type 0 — full data). */
+	der?: string;
+	/** Base64 SubjectPublicKeyInfo DER (selector 1, matching type 0). Not in the probe contract for non-leaf entries. */
+	spkiDer?: string;
+}
+
+/**
+ * The certificate a host served on a given port, captured by an external probe.
+ * Runtime-agnostic: this package never parses X.509 — every comparison is digest /
+ * hex equality against material the probe already derived. `chain[0]` is the leaf;
+ * the leaf-level fields duplicate it for the selector-0 / selector-1 end-entity paths.
+ */
+export interface ServedCertificate {
+	/** Exact host the probe pinned — DANE pins the TLSA owner's host, so this MUST equal the scanned name. */
+	host: string;
+	port: number;
+	/** ISO timestamp of the capture. */
+	capturedAt?: string;
+	leafDer?: string;
+	leafSpkiDer?: string;
+	leafSha256?: string;
+	leafSha512?: string;
+	leafSpkiSha256?: string;
+	leafSpkiSha512?: string;
+	/** Whole served chain, index 0 == leaf (DANE-TA usage 2 / PKIX-TA usage 0 search every entry). */
+	chain?: ServedCertificateChainEntry[];
+	subjectName?: string;
+	subjectAlternativeNames?: string[];
+	validFrom?: number;
+	validTo?: number;
+}
+
+/**
+ * What the certificate probe reported when no certificate is available.
+ * - `unavailable` — no probe capability at all (BSL self-hosts without the binding).
+ *   The pin stays "present, not verified" and keeps its small deduction.
+ * - `pending` — the probe was reached but is still warming its cache; the verdict
+ *   arrives on a later call. The pin is UNMEASURED this run: no deduction, `partial`.
+ * - `failed` — the probe was attempted and returned no usable certificate (capture
+ *   error, off-host redirect, host mismatch, transport failure). Also UNMEASURED.
+ */
+export type CertificateProbeOutcome = 'unavailable' | 'pending' | 'failed';
+
+/** Verification input for {@link analyzeTlsaRecords}: the served certificate, or why there is none. */
+export interface TlsaVerificationContext {
+	/** The certificate the host served. When present, every association is compared against it. */
+	servedCertificate?: ServedCertificate | null;
+	/** Why no certificate is available. Ignored when `servedCertificate` is set. Default `unavailable`. */
+	certificateProbe?: CertificateProbeOutcome;
+	/** Machine token explaining a `pending` / `failed` probe (surfaced as `notAssessedReason`). */
+	certificateProbeReason?: string;
+}
+
+/** Result of {@link verifyTlsaAssociations}. */
+export interface TlsaVerification {
+	/** Associations whose pinned data matches the served certificate (RFC 7671: one suffices). */
+	matched: TlsaRecord[];
+	/** Associations the served certificate could be compared against and does NOT match. */
+	unmatched: TlsaRecord[];
+	/** Associations that could not be compared (unknown field values, or probe material absent). */
+	unverifiable: TlsaRecord[];
+}
+
+/** Decode base64 to lowercase hex. Returns null when the input is not valid base64. */
+function base64ToHex(b64: string): string | null {
+	try {
+		const bin = atob(b64.replace(/\s+/g, ''));
+		let hex = '';
+		for (let i = 0; i < bin.length; i++) hex += bin.charCodeAt(i).toString(16).padStart(2, '0');
+		return hex;
+	} catch {
+		return null;
+	}
+}
+
+/** Canonical form for hex comparison: lowercase, whitespace stripped (TLSA presentation may split hex). */
+function canonicalHex(value: string): string {
+	return value.replace(/\s+/g, '').toLowerCase();
+}
+
+/** The material one chain member offers for a given selector. Absent fields are uncomparable. */
+interface AssociationCandidate {
+	sha256?: string;
+	sha512?: string;
+	/** Base64 DER of the selected object (certificate or SPKI). */
+	der?: string;
+}
+
+function leafCandidate(cert: ServedCertificate, selector: number): AssociationCandidate {
+	return selector === 0
+		? { sha256: cert.leafSha256, sha512: cert.leafSha512, der: cert.leafDer }
+		: { sha256: cert.leafSpkiSha256, sha512: cert.leafSpkiSha512, der: cert.leafSpkiDer };
+}
+
+function chainCandidate(
+	entry: ServedCertificateChainEntry,
+	selector: number,
+	isLeaf: boolean,
+	cert: ServedCertificate,
+): AssociationCandidate {
+	if (selector === 0) {
+		return {
+			sha256: entry.sha256 ?? (isLeaf ? cert.leafSha256 : undefined),
+			sha512: entry.sha512 ?? (isLeaf ? cert.leafSha512 : undefined),
+			der: entry.der ?? (isLeaf ? cert.leafDer : undefined),
+		};
+	}
+	return {
+		sha256: entry.spkiSha256 ?? (isLeaf ? cert.leafSpkiSha256 : undefined),
+		sha512: entry.spkiSha512 ?? (isLeaf ? cert.leafSpkiSha512 : undefined),
+		// The probe contract carries no SPKI DER for non-leaf entries; the leaf's is known.
+		der: entry.spkiDer ?? (isLeaf ? cert.leafSpkiDer : undefined),
+	};
+}
+
+/**
+ * The chain members a record's usage may match (RFC 7671 §5). End-entity usages (1, 3)
+ * bind the LEAF only; trust-anchor usages (0, 2) may match ANY served chain member —
+ * including the leaf, which §5.2 allows when the TA is also the EE. Returns null for a
+ * usage outside 0–3.
+ */
+function candidatesFor(record: TlsaRecord, cert: ServedCertificate): AssociationCandidate[] | null {
+	if (record.selector !== 0 && record.selector !== 1) return null;
+	switch (record.usage) {
+		case 1:
+		case 3:
+			return [leafCandidate(cert, record.selector)];
+		case 0:
+		case 2: {
+			const chain = cert.chain ?? [];
+			if (chain.length === 0) return [leafCandidate(cert, record.selector)];
+			return chain.map((entry, i) => chainCandidate(entry, record.selector, i === 0, cert));
+		}
+		default:
+			return null;
+	}
+}
+
+/** true = match, false = compared and differs, null = this candidate cannot be compared. */
+function compareCandidate(record: TlsaRecord, candidate: AssociationCandidate): boolean | null {
+	const pinned = canonicalHex(record.certData);
+	if (pinned.length === 0) return null;
+	switch (record.matchingType) {
+		case 1:
+			return candidate.sha256 === undefined ? null : canonicalHex(candidate.sha256) === pinned;
+		case 2:
+			return candidate.sha512 === undefined ? null : canonicalHex(candidate.sha512) === pinned;
+		case 0: {
+			if (candidate.der === undefined) return null;
+			const hex = base64ToHex(candidate.der);
+			return hex === null ? null : hex === pinned;
+		}
+		default:
+			return null;
+	}
+}
+
+/**
+ * Compare a TLSA RRset against the certificate the host served (RFC 7671 semantics).
+ *
+ * Pure and runtime-agnostic — digest / hex equality only, no X.509 parsing:
+ *
+ * | usage        | compared against              | selector 0 → | selector 1 → |
+ * | ------------ | ----------------------------- | ------------ | ------------ |
+ * | 3 DANE-EE    | the leaf                      | cert DER     | SPKI DER     |
+ * | 1 PKIX-EE    | the leaf                      | cert DER     | SPKI DER     |
+ * | 2 DANE-TA    | ANY served chain entry (incl. leaf, §5.2) | cert DER | SPKI DER |
+ * | 0 PKIX-TA    | ANY served chain entry (incl. leaf)       | cert DER | SPKI DER |
+ *
+ * matching type 1 = SHA-256 of the selected object, 2 = SHA-512, 0 = the full object
+ * (hex of the base64-decoded DER, compared case-insensitively). Any other usage /
+ * selector / matching type — or probe material the comparison needs but does not have
+ * — lands in `unverifiable`, never `unmatched`. Strings are parsed with
+ * {@link parseTlsaRecord}; unparseable strings are dropped (they carry their own
+ * "Malformed TLSA record" finding upstream).
+ */
+export function verifyTlsaAssociations(records: TlsaRecord[] | string[], cert: ServedCertificate): TlsaVerification {
+	const matched: TlsaRecord[] = [];
+	const unmatched: TlsaRecord[] = [];
+	const unverifiable: TlsaRecord[] = [];
+	for (const raw of records) {
+		const record = typeof raw === 'string' ? parseTlsaRecord(raw) : raw;
+		if (!record) continue;
+		const candidates = candidatesFor(record, cert);
+		if (!candidates) {
+			unverifiable.push(record);
+			continue;
+		}
+		// A record is UNMATCHED only when EVERY candidate it may match was compared and
+		// differs. One uncomparable candidate (a chain member the probe carried no material
+		// for) is enough to withhold that verdict — for a TA usage the pin may match that
+		// very member — so it lands in `unverifiable` instead.
+		let sawUncomparable = false;
+		let hit = false;
+		for (const candidate of candidates) {
+			const outcome = compareCandidate(record, candidate);
+			if (outcome === null) {
+				sawUncomparable = true;
+				continue;
+			}
+			if (outcome) {
+				hit = true;
+				break;
+			}
+		}
+		if (hit) matched.push(record);
+		else if (sawUncomparable) unverifiable.push(record);
+		else unmatched.push(record);
+	}
+	return { matched, unmatched, unverifiable };
+}
+
+/** Machine-readable `notAssessedReason` tokens for an unmeasured pin verification. */
+export const DANE_PIN_NOT_ASSESSED_REASONS = {
+	pending: 'certificate_probe_pending',
+	failed: 'certificate_probe_failed',
+} as const;
+
+/**
  * Analyze a set of TLSA records for a given DNS name.
  * Validates field ranges, checks DNSSEC dependency, and flags weak matching types.
  */
-export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: boolean): Finding[] {
+export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: boolean, verification?: TlsaVerificationContext): Finding[] {
 	const findings: Finding[] = [];
 	const seenDaneWithoutDnssec = new Set<string>();
-	let validRecordCount = 0;
+	const validRecords: TlsaRecord[] = [];
 
 	for (const record of records) {
 		const parsed = parseTlsaRecord(record);
@@ -146,34 +381,172 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 			);
 		}
 
-		// Count valid DANE records for consolidated info finding
-		validRecordCount++;
+		// Collect well-formed records for the consolidated verdict below
+		validRecords.push(parsed);
 	}
+	const validRecordCount = validRecords.length;
 
-	// Emit a single consolidated info finding for all well-formed TLSA records.
-	// HONESTY (#841): "well-formed" is a SYNTAX verdict only. This analyzer never
-	// fetches the certificate the host serves, so it cannot know whether the pinned
-	// data still matches — a stale DANE-EE pin (which breaks every DANE-validating
-	// client) parses identically to a correct one. The wording and the
-	// `certificateMatchVerified: false` marker must keep saying so until a live
-	// leaf/SPKI source is wired into this check. The upstream browser probe can expose
-	// certificate material, but this package does not receive it yet. Presence therefore
-	// earns a small deduction rather than the former unsupported perfect score.
+	// Consolidated verdict for the well-formed records (#841).
+	//
+	// HONESTY (#841): this analyzer parses DNS; it never fetches a certificate. A stale
+	// DANE-EE pin parses identically to a correct one, so "well-formed" is a SYNTAX
+	// verdict. Since scoring model 1.22.0 the served certificate CAN reach this function —
+	// the bv-mcp wrapper captures it over the operator-only bv-tls-probe binding and
+	// passes it in `verification` — and the verdict ladder is:
+	//   any association matches            → info, `certificateMatchVerified: true`   (100)
+	//   certificate served, none match     → high "pin does not match"                 (75)
+	//   probe attempted, no certificate    → info, `inconclusive` + `notAssessedReason` (unmeasured, no deduction)
+	//   no probe capability (self-hosts)   → low "present, not verified" — the 1.18.0 posture, unchanged (95)
+	// `certificateMatchVerified` is the machine-readable marker every consumer must read
+	// (maturity staging counts a DANE pin toward Stage 4 ONLY when it is `true`).
 	if (validRecordCount > 0) {
-		const detail =
-			validRecordCount === 1
-				? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection. Confirm the pin matches the live certificate after every certificate rotation.`
-				: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Authentication succeeds while any one association still matches, so a single superseded record during a rollover is not itself fatal; where the RRset is DNSSEC-authenticated and none match, DANE-validating clients reject the connection. Confirm each pin matches the live certificate after every certificate rotation.`;
-		findings.push(
-			createFinding('dane', `DANE TLSA configured for ${name}`, 'low', detail, {
-				name,
-				validRecordCount,
-				certificateMatchVerified: false,
-			}),
-		);
+		const cert = verification?.servedCertificate ?? null;
+		if (cert) {
+			findings.push(buildVerifiedVerdict(name, validRecords, cert));
+		} else if (verification?.certificateProbe === 'pending' || verification?.certificateProbe === 'failed') {
+			findings.push(buildUnmeasuredVerdict(name, validRecordCount, verification.certificateProbe, verification.certificateProbeReason));
+		} else {
+			findings.push(buildUnverifiedVerdict(name, validRecordCount));
+		}
 	}
 
 	return findings;
+}
+
+/** The 1.18.0 posture: present + well-formed, compared against nothing. Text is pinned by dane-honest-labeling.test.ts. */
+function buildUnverifiedVerdict(name: string, validRecordCount: number): Finding {
+	const detail =
+		validRecordCount === 1
+			? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection. Confirm the pin matches the live certificate after every certificate rotation.`
+			: `${validRecordCount} DANE TLSA records present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Authentication succeeds while any one association still matches, so a single superseded record during a rollover is not itself fatal; where the RRset is DNSSEC-authenticated and none match, DANE-validating clients reject the connection. Confirm each pin matches the live certificate after every certificate rotation.`;
+	return createFinding('dane', `DANE TLSA configured for ${name}`, 'low', detail, {
+		name,
+		validRecordCount,
+		certificateMatchVerified: false,
+	});
+}
+
+/**
+ * The probe was ATTEMPTED and returned no certificate: the pin is UNMEASURED this run.
+ * `info` with `inconclusive: true` — no deduction, no absence claim (#638: a probe that
+ * never produced an answer must not be scored as a measurement). The caller marks the
+ * result `partial` off `metadata.certificateProbe` so it is not cached and the next
+ * scan re-tries; the category itself stays COMPLETED because the TLSA measurement is
+ * real — only the comparison is outstanding.
+ */
+function buildUnmeasuredVerdict(
+	name: string,
+	validRecordCount: number,
+	outcome: 'pending' | 'failed',
+	reason: string | undefined,
+): Finding {
+	const notAssessedReason = reason ?? DANE_PIN_NOT_ASSESSED_REASONS[outcome];
+	const plural = validRecordCount === 1 ? 'TLSA record is' : `${validRecordCount} TLSA records are`;
+	const why =
+		outcome === 'pending'
+			? 'the certificate probe has not finished capturing the served certificate yet (its result arrives on a later scan)'
+			: `the certificate probe returned no usable certificate (${notAssessedReason.replace(/_/g, ' ')})`;
+	return createFinding(
+		'dane',
+		`DANE TLSA pin verification ${outcome === 'pending' ? 'pending' : 'inconclusive'} for ${name}`,
+		'info',
+		`${plural} present and syntactically well-formed for ${name}, but ${why}, so the pinned data was neither confirmed nor refuted against the certificate the server presents. This unverified state carries no deduction; the result is marked partial so the next scan re-attempts verification. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection — confirm the pin after every certificate rotation.`,
+		{
+			name,
+			validRecordCount,
+			certificateMatchVerified: false,
+			inconclusive: true,
+			notAssessedReason,
+			certificateProbe: outcome,
+		},
+	);
+}
+
+/** Compact presentation of an association for prose / metadata. */
+function describeAssociation(r: TlsaRecord): string {
+	return `${r.usage} ${r.selector} ${r.matchingType} ${canonicalHex(r.certData)}`;
+}
+
+/**
+ * A certificate WAS captured: compare and rule. The `high` mismatch wording is
+ * deliberately free of the `MISSING_CONTROL_REGEX` triggers ("missing", "required",
+ * "not found", "no … record") — `dane_https` sits in `PROFILE_CRITICAL_CATEGORIES`
+ * for `non_mail` / `web_only`, and a `high` that read as a missing control would arm
+ * the critical-gap ceiling and cap the whole scan at 64. A mismatch is a MEASURED
+ * defect (−25, category 75), not an absent control. Pinned by
+ * dane-pin-verification.test.ts.
+ */
+function buildVerifiedVerdict(name: string, validRecords: TlsaRecord[], cert: ServedCertificate): Finding {
+	const verification = verifyTlsaAssociations(validRecords, cert);
+	const served = {
+		servedHost: cert.host,
+		servedPort: cert.port,
+		...(cert.capturedAt ? { capturedAt: cert.capturedAt } : {}),
+		...(cert.leafSha256 ? { servedLeafSha256: canonicalHex(cert.leafSha256) } : {}),
+		...(cert.leafSpkiSha256 ? { servedLeafSpkiSha256: canonicalHex(cert.leafSpkiSha256) } : {}),
+	};
+
+	if (verification.matched.length > 0) {
+		const first = verification.matched[0];
+		const usageLabel = USAGE_LABELS[first.usage] ?? `usage ${first.usage}`;
+		const others = validRecords.length - verification.matched.length;
+		return createFinding(
+			'dane',
+			`DANE TLSA verified against the served certificate for ${name}`,
+			'info',
+			`The TLSA association ${describeAssociation(first)} (${usageLabel}) at ${name} matches the certificate ${cert.host} serves on port ${cert.port}${cert.capturedAt ? ` (captured ${cert.capturedAt})` : ''}.${others > 0 ? ` ${others} further association${others === 1 ? '' : 's'} in the RRset did not match — normal during a certificate rollover, harmless while one association matches.` : ''} Keep the RRset in step with certificate rotation; a CDN-managed certificate rotates on the provider's schedule.`,
+			{
+				...served,
+				name,
+				validRecordCount: validRecords.length,
+				certificateMatchVerified: true,
+				matchedAssociations: verification.matched.map(describeAssociation),
+				matchedUsage: first.usage,
+				matchedSelector: first.selector,
+				matchedMatchingType: first.matchingType,
+				matchedCertData: canonicalHex(first.certData),
+				...(verification.unmatched.length > 0 ? { unmatchedAssociations: verification.unmatched.map(describeAssociation) } : {}),
+				...(verification.unverifiable.length > 0 ? { unverifiableAssociations: verification.unverifiable.map(describeAssociation) } : {}),
+			},
+		);
+	}
+
+	if (verification.unverifiable.length > 0) {
+		// At least one association could not be compared, so "the pin is wrong" is not
+		// established — fall back to the honest present-not-verified posture.
+		const unverified = buildUnverifiedVerdict(name, validRecords.length);
+		return {
+			...unverified,
+			metadata: {
+				...unverified.metadata,
+				...served,
+				unmatchedAssociations: verification.unmatched.map(describeAssociation),
+				unverifiableAssociations: verification.unverifiable.map(describeAssociation),
+			},
+		};
+	}
+
+	const pinned = verification.unmatched.map(describeAssociation);
+	const count = pinned.length;
+	return createFinding(
+		'dane',
+		`DANE TLSA pin does not match the served certificate for ${name}`,
+		'high',
+		`${count === 1 ? 'The TLSA association' : `Each of the ${count} TLSA associations`} published at ${name} was compared against the certificate ${cert.host} serves on port ${cert.port}${cert.capturedAt ? ` (captured ${cert.capturedAt})` : ''} and none of them match it: pinned ${pinned.join('; ')}; served leaf SPKI SHA-256 ${served.servedLeafSpkiSha256 ?? 'unavailable'}, leaf SHA-256 ${served.servedLeafSha256 ?? 'unavailable'}. Where the RRset is DNSSEC-authenticated, DANE-validating clients reject the connection to this host. Republish the TLSA RRset from the current certificate (its issuer for DANE-TA) and automate the update on every rotation — a CDN-managed certificate rotates on the provider's schedule, so a hand-maintained DANE-EE pin drifts by default.`,
+		{
+			...served,
+			name,
+			validRecordCount: validRecords.length,
+			certificateMatchVerified: false,
+			pinned,
+			unmatchedAssociations: pinned,
+			// The pinned data is a raw DNS record token the zone owner controls. Declaring it
+			// as subject data has the missing-control predicate test the prose WITHOUT it, so
+			// a record such as `3 1 1 missing` cannot smuggle a regex trigger into a `high`
+			// finding and zero the category / arm the critical-gap ceiling.
+			[SUBJECT_TERMS_METADATA_KEY]: pinned,
+		},
+	);
 }
 
 /**

--- a/packages/dns-checks/src/checks/dane-analysis.ts
+++ b/packages/dns-checks/src/checks/dane-analysis.ts
@@ -309,11 +309,45 @@ export function verifyTlsaAssociations(records: TlsaRecord[] | string[], cert: S
 	return { matched, unmatched, unverifiable, truncatedChain };
 }
 
-/** Machine-readable `notAssessedReason` tokens for an unmeasured pin verification. */
+/**
+ * Machine-readable `notAssessedReason` tokens for a pin the probe could not verify.
+ * Every one of them scores the SAME `low` "present, not verified" finding (95) as a
+ * consumer with no probe at all — an attempted-but-unanswered comparison is not better
+ * evidence than no comparison. The token tells consumers WHICH sub-state applies.
+ */
 export const DANE_PIN_NOT_ASSESSED_REASONS = {
+	/** The probe's cold-cache verdict; the answer arrives on a later call. */
 	pending: 'certificate_probe_pending',
-	failed: 'certificate_probe_failed',
+	/** The probe reached the host but could not capture a usable certificate. */
+	captureFailed: 'capture_failed',
+	/** The probe followed a redirect off the TLSA owner's host (permanent for that host). */
+	offHostRedirect: 'off_host_redirect',
+	/** The capture describes a host other than the scanned one (permanent). */
+	hostMismatch: 'host_mismatch',
+	/** The host did not answer the probe. */
+	unreachable: 'unreachable',
+	/** The probe service itself failed (5xx, throw, timeout, budget cut). */
+	probeUnavailable: 'probe_unavailable',
+	/** A trust-anchor pin may sit in the chain tail the probe dropped (permanent). */
+	chainTruncated: 'chain_truncated',
 } as const;
+
+/**
+ * Reasons a later scan may resolve by itself. A result carrying one is marked `partial`
+ * (not cached for the scan TTL, re-tried next scan). The rest are permanent for the
+ * host and cache normally — no retry-forever.
+ */
+export const DANE_PIN_TRANSIENT_REASONS: ReadonlySet<string> = new Set([
+	DANE_PIN_NOT_ASSESSED_REASONS.pending,
+	DANE_PIN_NOT_ASSESSED_REASONS.captureFailed,
+	DANE_PIN_NOT_ASSESSED_REASONS.unreachable,
+	DANE_PIN_NOT_ASSESSED_REASONS.probeUnavailable,
+]);
+
+/** True when a `notAssessedReason` names a transient probe outcome worth re-trying. */
+export function isTransientDanePinReason(reason: unknown): boolean {
+	return typeof reason === 'string' && DANE_PIN_TRANSIENT_REASONS.has(reason);
+}
 
 /**
  * Analyze a set of TLSA records for a given DNS name.
@@ -415,8 +449,13 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 	// passes it in `verification` — and the verdict ladder is:
 	//   any association matches            → info, `certificateMatchVerified: true`   (100)
 	//   certificate served, none match     → high "pin does not match"                 (75)
-	//   probe attempted, no certificate    → info, `inconclusive` + `notAssessedReason` (unmeasured, no deduction)
+	//   probe attempted, no certificate    → the SAME low "present, not verified" (95) plus
+	//                                        `certificateProbe` + `notAssessedReason` metadata
 	//   no probe capability (self-hosts)   → low "present, not verified" — the 1.18.0 posture, unchanged (95)
+	// Every unverified state sits at 95 (operator-ratified 1.18.0 posture): an attempted
+	// comparison that produced no answer is not better evidence than no comparison, so it
+	// must never outscore the honest self-host disclosure. Only an ACTUAL comparison moves
+	// the score — up to 100 or down to 75.
 	// `certificateMatchVerified` is the machine-readable marker every consumer must read
 	// (maturity staging counts a DANE pin toward Stage 4 ONLY when it is `true`).
 	if (validRecordCount > 0) {
@@ -433,8 +472,13 @@ export function analyzeTlsaRecords(records: string[], name: string, hasDnssec: b
 	return findings;
 }
 
-/** The 1.18.0 posture: present + well-formed, compared against nothing. Text is pinned by dane-honest-labeling.test.ts. */
-function buildUnverifiedVerdict(name: string, validRecordCount: number): Finding {
+/**
+ * The 1.18.0 posture: present + well-formed, not confirmed against the served
+ * certificate. Text is pinned by dane-honest-labeling.test.ts. `extra` carries the
+ * sub-state metadata (`certificateProbe`, `notAssessedReason`, …) when a probe was
+ * attempted; the no-probe path passes nothing so its metadata is byte-identical.
+ */
+function buildUnverifiedVerdict(name: string, validRecordCount: number, extra: Record<string, unknown> = {}): Finding {
 	const detail =
 		validRecordCount === 1
 			? `TLSA record present and syntactically well-formed for ${name}. This check does not verify the pinned data against the certificate the server presents, so a stale pin is not detected here. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection. Confirm the pin matches the live certificate after every certificate rotation.`
@@ -443,16 +487,20 @@ function buildUnverifiedVerdict(name: string, validRecordCount: number): Finding
 		name,
 		validRecordCount,
 		certificateMatchVerified: false,
+		...extra,
 	});
 }
 
 /**
- * The probe was ATTEMPTED and returned no certificate: the pin is UNMEASURED this run.
- * `info` with `inconclusive: true` — no deduction, no absence claim (#638: a probe that
- * never produced an answer must not be scored as a measurement). The caller marks the
- * result `partial` off `metadata.certificateProbe` so it is not cached and the next
- * scan re-tries; the category itself stays COMPLETED because the TLSA measurement is
- * real — only the comparison is outstanding.
+ * The probe was ATTEMPTED and returned no certificate: the pin is still unverified, so
+ * the verdict is the SAME `low` as the no-probe path (95) — never `info`/100, which
+ * would rank "we tried and learned nothing" above the honest self-host disclosure.
+ * The metadata names the sub-state: `certificateProbe` (`pending` | `failed`) and a
+ * `notAssessedReason` token. `checkDANEHTTPS` marks the result `partial` only for the
+ * TRANSIENT reasons ({@link DANE_PIN_TRANSIENT_REASONS}) so a cold cache is re-tried and
+ * a permanently-failing host is not re-probed forever. No `inconclusive` marker: that
+ * vocabulary is reserved for no-penalty abstentions, and this finding carries a penalty
+ * because the TLSA measurement itself is real.
  */
 function buildUnmeasuredVerdict(
 	name: string,
@@ -460,26 +508,9 @@ function buildUnmeasuredVerdict(
 	outcome: 'pending' | 'failed',
 	reason: string | undefined,
 ): Finding {
-	const notAssessedReason = reason ?? DANE_PIN_NOT_ASSESSED_REASONS[outcome];
-	const plural = validRecordCount === 1 ? 'TLSA record is' : `${validRecordCount} TLSA records are`;
-	const why =
-		outcome === 'pending'
-			? 'the certificate probe has not finished capturing the served certificate yet (its result arrives on a later scan)'
-			: `the certificate probe returned no usable certificate (${notAssessedReason.replace(/_/g, ' ')})`;
-	return createFinding(
-		'dane',
-		`DANE TLSA pin verification ${outcome === 'pending' ? 'pending' : 'inconclusive'} for ${name}`,
-		'info',
-		`${plural} present and syntactically well-formed for ${name}, but ${why}, so the pinned data was neither confirmed nor refuted against the certificate the server presents. This unverified state carries no deduction; the result is marked partial so the next scan re-attempts verification. Where the RRset is DNSSEC-authenticated and no association matches the served certificate, DANE-validating clients reject the connection — confirm the pin after every certificate rotation.`,
-		{
-			name,
-			validRecordCount,
-			certificateMatchVerified: false,
-			inconclusive: true,
-			notAssessedReason,
-			certificateProbe: outcome,
-		},
-	);
+	const notAssessedReason =
+		reason ?? (outcome === 'pending' ? DANE_PIN_NOT_ASSESSED_REASONS.pending : DANE_PIN_NOT_ASSESSED_REASONS.captureFailed);
+	return buildUnverifiedVerdict(name, validRecordCount, { certificateProbe: outcome, notAssessedReason });
 }
 
 /** Compact presentation of an association for prose / metadata. */
@@ -532,28 +563,17 @@ function buildVerifiedVerdict(name: string, validRecords: TlsaRecord[], cert: Se
 	}
 
 	if (verification.truncatedChain.length > 0) {
-		// A trust-anchor pin may sit in the chain tail the probe dropped: an ABSTENTION
-		// (info, no deduction), not a mismatch. Persistent for that host, so no
-		// `certificateProbe` marker — the result is not `partial` and caches normally.
-		const affected = verification.truncatedChain.map(describeAssociation);
-		return createFinding(
-			'dane',
-			`DANE TLSA pin verification inconclusive for ${name}`,
-			'info',
-			`${affected.length === 1 ? 'A trust-anchor TLSA association' : `${affected.length} trust-anchor TLSA associations`} at ${name} matched none of the ${cert.chain?.length ?? 0} chain entries the certificate probe retained, but the chain ${cert.host} served${cert.chainLength ? ` (${cert.chainLength} entries)` : ''} exceeded the probe's cap and its tail was dropped, so the anchor may be among the entries that were not compared. The pin was neither confirmed nor refuted; this carries no deduction. Where the RRset is DNSSEC-authenticated and no association matches the served chain, DANE-validating clients reject the connection — confirm the anchor against the full chain.`,
-			{
-				...served,
-				name,
-				validRecordCount: validRecords.length,
-				certificateMatchVerified: false,
-				inconclusive: true,
-				notAssessedReason: 'chain_truncated',
-				chainTruncated: true,
-				...(cert.chainLength !== undefined ? { chainLength: cert.chainLength } : {}),
-				unverifiableAssociations: verification.unverifiable.map(describeAssociation),
-				...(verification.unmatched.length > 0 ? { unmatchedAssociations: verification.unmatched.map(describeAssociation) } : {}),
-			},
-		);
+		// A trust-anchor pin may sit in the chain tail the probe dropped: the pin is
+		// unverified (the same `low`, 95), never a mismatch. Permanent for that host, so
+		// no `certificateProbe` marker — the result is not `partial` and caches normally.
+		return buildUnverifiedVerdict(name, validRecords.length, {
+			...served,
+			notAssessedReason: DANE_PIN_NOT_ASSESSED_REASONS.chainTruncated,
+			chainTruncated: true,
+			...(cert.chainLength !== undefined ? { chainLength: cert.chainLength } : {}),
+			unverifiableAssociations: verification.unverifiable.map(describeAssociation),
+			...(verification.unmatched.length > 0 ? { unmatchedAssociations: verification.unmatched.map(describeAssociation) } : {}),
+		});
 	}
 
 	if (verification.unverifiable.length > 0) {

--- a/packages/dns-checks/src/checks/dane-analysis.ts
+++ b/packages/dns-checks/src/checks/dane-analysis.ts
@@ -103,6 +103,14 @@ export interface ServedCertificate {
 	leafSpkiSha512?: string;
 	/** Whole served chain, index 0 == leaf (DANE-TA usage 2 / PKIX-TA usage 0 search every entry). */
 	chain?: ServedCertificateChainEntry[];
+	/**
+	 * True when the served chain exceeded the probe's entry cap and trailing entries were
+	 * dropped. A trust-anchor usage (0 / 2) that matches no RETAINED entry is then
+	 * UNVERIFIABLE — the anchor may sit in the dropped tail — never a mismatch.
+	 */
+	chainTruncated?: boolean;
+	/** The chain's original length before truncation. */
+	chainLength?: number;
 	subjectName?: string;
 	subjectAlternativeNames?: string[];
 	validFrom?: number;
@@ -136,8 +144,14 @@ export interface TlsaVerification {
 	matched: TlsaRecord[];
 	/** Associations the served certificate could be compared against and does NOT match. */
 	unmatched: TlsaRecord[];
-	/** Associations that could not be compared (unknown field values, or probe material absent). */
+	/** Associations that could not be compared (unknown field values, probe material absent, or a truncated chain). */
 	unverifiable: TlsaRecord[];
+	/**
+	 * The subset of `unverifiable` whose verdict was withheld ONLY because the served chain
+	 * was truncated (`chainTruncated: true`): trust-anchor usages that matched no retained
+	 * entry. Empty unless the probe reported truncation.
+	 */
+	truncatedChain: TlsaRecord[];
 }
 
 /** Decode base64 to lowercase hex. Returns null when the input is not valid base64. */
@@ -257,6 +271,7 @@ export function verifyTlsaAssociations(records: TlsaRecord[] | string[], cert: S
 	const matched: TlsaRecord[] = [];
 	const unmatched: TlsaRecord[] = [];
 	const unverifiable: TlsaRecord[] = [];
+	const truncatedChain: TlsaRecord[] = [];
 	for (const raw of records) {
 		const record = typeof raw === 'string' ? parseTlsaRecord(raw) : raw;
 		if (!record) continue;
@@ -284,9 +299,14 @@ export function verifyTlsaAssociations(records: TlsaRecord[] | string[], cert: S
 		}
 		if (hit) matched.push(record);
 		else if (sawUncomparable) unverifiable.push(record);
-		else unmatched.push(record);
+		else if ((record.usage === 0 || record.usage === 2) && cert.chainTruncated === true) {
+			// Every RETAINED chain entry was compared and differs, but the probe dropped the
+			// chain's tail — the anchor may be there. Withhold the verdict.
+			unverifiable.push(record);
+			truncatedChain.push(record);
+		} else unmatched.push(record);
 	}
-	return { matched, unmatched, unverifiable };
+	return { matched, unmatched, unverifiable, truncatedChain };
 }
 
 /** Machine-readable `notAssessedReason` tokens for an unmeasured pin verification. */
@@ -507,6 +527,31 @@ function buildVerifiedVerdict(name: string, validRecords: TlsaRecord[], cert: Se
 				matchedCertData: canonicalHex(first.certData),
 				...(verification.unmatched.length > 0 ? { unmatchedAssociations: verification.unmatched.map(describeAssociation) } : {}),
 				...(verification.unverifiable.length > 0 ? { unverifiableAssociations: verification.unverifiable.map(describeAssociation) } : {}),
+			},
+		);
+	}
+
+	if (verification.truncatedChain.length > 0) {
+		// A trust-anchor pin may sit in the chain tail the probe dropped: an ABSTENTION
+		// (info, no deduction), not a mismatch. Persistent for that host, so no
+		// `certificateProbe` marker — the result is not `partial` and caches normally.
+		const affected = verification.truncatedChain.map(describeAssociation);
+		return createFinding(
+			'dane',
+			`DANE TLSA pin verification inconclusive for ${name}`,
+			'info',
+			`${affected.length === 1 ? 'A trust-anchor TLSA association' : `${affected.length} trust-anchor TLSA associations`} at ${name} matched none of the ${cert.chain?.length ?? 0} chain entries the certificate probe retained, but the chain ${cert.host} served${cert.chainLength ? ` (${cert.chainLength} entries)` : ''} exceeded the probe's cap and its tail was dropped, so the anchor may be among the entries that were not compared. The pin was neither confirmed nor refuted; this carries no deduction. Where the RRset is DNSSEC-authenticated and no association matches the served chain, DANE-validating clients reject the connection — confirm the anchor against the full chain.`,
+			{
+				...served,
+				name,
+				validRecordCount: validRecords.length,
+				certificateMatchVerified: false,
+				inconclusive: true,
+				notAssessedReason: 'chain_truncated',
+				chainTruncated: true,
+				...(cert.chainLength !== undefined ? { chainLength: cert.chainLength } : {}),
+				unverifiableAssociations: verification.unverifiable.map(describeAssociation),
+				...(verification.unmatched.length > 0 ? { unmatchedAssociations: verification.unmatched.map(describeAssociation) } : {}),
 			},
 		);
 	}

--- a/packages/dns-checks/src/checks/index.ts
+++ b/packages/dns-checks/src/checks/index.ts
@@ -29,7 +29,13 @@ export { checkHTTPSecurity } from './check-http-security';
 // ── Analysis utilities (re-exported for consumers) ───────────────────────────
 export { parseDmarcTags } from './dmarc-utils';
 export { parseDnskeyAlgorithm, parseDsRecord, parseDnssecAlgorithmToken } from './dnssec-analysis';
-export { parseTlsaRecord, verifyTlsaAssociations, DANE_PIN_NOT_ASSESSED_REASONS } from './dane-analysis';
+export {
+	parseTlsaRecord,
+	verifyTlsaAssociations,
+	DANE_PIN_NOT_ASSESSED_REASONS,
+	DANE_PIN_TRANSIENT_REASONS,
+	isTransientDanePinReason,
+} from './dane-analysis';
 export type { CaaRecord } from './caa-analysis';
 export { parseCaaRecord } from './caa-analysis';
 export type {

--- a/packages/dns-checks/src/checks/index.ts
+++ b/packages/dns-checks/src/checks/index.ts
@@ -29,9 +29,17 @@ export { checkHTTPSecurity } from './check-http-security';
 // ── Analysis utilities (re-exported for consumers) ───────────────────────────
 export { parseDmarcTags } from './dmarc-utils';
 export { parseDnskeyAlgorithm, parseDsRecord, parseDnssecAlgorithmToken } from './dnssec-analysis';
-export { parseTlsaRecord } from './dane-analysis';
+export { parseTlsaRecord, verifyTlsaAssociations, DANE_PIN_NOT_ASSESSED_REASONS } from './dane-analysis';
 export type { CaaRecord } from './caa-analysis';
 export { parseCaaRecord } from './caa-analysis';
-export type { TlsaRecord } from './dane-analysis';
+export type {
+	TlsaRecord,
+	ServedCertificate,
+	ServedCertificateChainEntry,
+	CertificateProbeOutcome,
+	TlsaVerificationContext,
+	TlsaVerification,
+} from './dane-analysis';
+export type { CheckDaneHttpsOptions } from './check-dane-https';
 export { analyzeSecurityHeaders } from './http-security-analysis';
 export { estimateTxtRrsetBytes } from './spf-analysis';

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -89,10 +89,21 @@ export {
 	parseDsRecord,
 	parseDnssecAlgorithmToken,
 	parseTlsaRecord,
+	verifyTlsaAssociations,
+	DANE_PIN_NOT_ASSESSED_REASONS,
 	parseCaaRecord,
 	analyzeSecurityHeaders,
 } from './checks';
-export type { CaaRecord, TlsaRecord } from './checks';
+export type {
+	CaaRecord,
+	TlsaRecord,
+	ServedCertificate,
+	ServedCertificateChainEntry,
+	CertificateProbeOutcome,
+	TlsaVerificationContext,
+	TlsaVerification,
+	CheckDaneHttpsOptions,
+} from './checks';
 
 // RFC 8657 CAA parameter parsing (`accounturi` / `validationmethods`). Sourced
 // directly from the analysis module rather than the `./checks` barrel, which

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -91,6 +91,8 @@ export {
 	parseTlsaRecord,
 	verifyTlsaAssociations,
 	DANE_PIN_NOT_ASSESSED_REASONS,
+	DANE_PIN_TRANSIENT_REASONS,
+	isTransientDanePinReason,
 	parseCaaRecord,
 	analyzeSecurityHeaders,
 } from './checks';

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.33.0';
+export const PARITY_CORPUS_VERSION = '1.34.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):

--- a/src/handlers/tools.ts
+++ b/src/handlers/tools.ts
@@ -312,7 +312,7 @@ interface ToolRuntimeOptions {
 	whoisBinding?: { fetch: typeof fetch };
 	/** Operator-only bv-recon service binding. Fail-soft; absent on BSL self-hosts. */
 	reconBinding?: { fetch: typeof fetch };
-	/** Operator-only bv-tls-probe service binding (negotiated-TLS-version detection). Fail-soft; absent on BSL self-hosts → SSL check gains no TLS-version finding. */
+	/** Operator-only bv-tls-probe service binding (negotiated-TLS-version detection for `ssl`; served-certificate capture for `dane_https` pin verification, #841). Fail-soft; absent on BSL self-hosts → no TLS-version finding, DANE pins reported present-not-verified. */
 	tlsProbeBinding?: { fetch: typeof fetch };
 	/** Bearer token forwarded to bv-tls-probe. */
 	tlsProbeAuthToken?: string;
@@ -528,7 +528,17 @@ export const TOOL_REGISTRY: Record<
 	check_http_security: { cacheKey: () => 'http_security', execute: (d) => checkHttpSecurity(d) },
 	check_dane: { cacheKey: () => 'dane', execute: (d, _args, ro) => checkDane(d, buildDnsOptions(ro)) },
 	check_ptr: { cacheKey: () => 'ptr', execute: (d, _args, ro) => dynamicCheckPtr(d, ro) },
-	check_dane_https: { cacheKey: () => 'dane_https', execute: (d, _args, ro) => checkDaneHttps(d, buildDnsOptions(ro)) },
+	check_dane_https: {
+		// #841: with the probe bound the result carries a verified/mismatch verdict the
+		// probe-less result cannot, so the two must not share a cache entry (as `ssl`).
+		cacheKey: (_a, ro) => (ro?.tlsProbeBinding ? 'dane_https:tls-probe' : 'dane_https'),
+		execute: (d, _args, ro) =>
+			checkDaneHttps(d, buildDnsOptions(ro), {
+				tlsProbeBinding: ro?.tlsProbeBinding,
+				tlsProbeAuthToken: ro?.tlsProbeAuthToken,
+				onBindingDegradation: ro?.onBindingDegradation,
+			}),
+	},
 	check_svcb_https: { cacheKey: () => 'svcb_https', execute: (d, _args, ro) => checkSvcbHttps(d, buildDnsOptions(ro)) },
 	check_mx_reputation: {
 		cacheKey: () => 'mx_reputation',

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -376,7 +376,10 @@
  *   off-host redirect, host mismatch) is UNMEASURED: an `info` with `inconclusive: true`
  *   + `notAssessedReason`, no deduction, `partial: true` (not cached, re-tried next scan)
  *   and NO `checkStatus` — the TLSA measurement itself is real, so the category stays
- *   completed. Direction: DOWNWARD only for domains whose DANE-HTTPS pin does not match
+ *   completed. A trust-anchor pin (usage 0 / 2) that matches no RETAINED chain entry
+ *   while the probe reports `chainTruncated` is likewise an `info` abstention
+ *   (`notAssessedReason: 'chain_truncated'`, cached normally — persistent for the host),
+ *   never a mismatch; leaf usages (1 / 3) are unaffected by truncation. Direction: DOWNWARD only for domains whose DANE-HTTPS pin does not match
  *   the served certificate (100 or 95 → 75, ≈0.09 overall points at protective weight 2);
  *   UPWARD 95 → 100 for verified pins on operator deploys. Absence is unchanged; every
  *   self-host without the binding (and `check_dane`, SMTP/25, which the HTTPS-only probe

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -373,17 +373,22 @@
  *   VERIFIED 100 (`info`, `certificateMatchVerified: true`) > ABSENT 95 (unchanged `low`)
  *   > MISMATCH 75 (`high` "pin does not match the served certificate", −25). A probe that
  *   was attempted but returned no certificate (cold-cache "pending", capture failure,
- *   off-host redirect, host mismatch) is UNMEASURED: an `info` with `inconclusive: true`
- *   + `notAssessedReason`, no deduction, `partial: true` (not cached, re-tried next scan)
- *   and NO `checkStatus` — the TLSA measurement itself is real, so the category stays
- *   completed. A trust-anchor pin (usage 0 / 2) that matches no RETAINED chain entry
- *   while the probe reports `chainTruncated` is likewise an `info` abstention
- *   (`notAssessedReason: 'chain_truncated'`, cached normally — persistent for the host),
- *   never a mismatch; leaf usages (1 / 3) are unaffected by truncation. Direction: DOWNWARD only for domains whose DANE-HTTPS pin does not match
- *   the served certificate (100 or 95 → 75, ≈0.09 overall points at protective weight 2);
- *   UPWARD 95 → 100 for verified pins on operator deploys. Absence is unchanged; every
- *   self-host without the binding (and `check_dane`, SMTP/25, which the HTTPS-only probe
- *   cannot serve) is bit-for-bit unchanged at the 1.18.0 posture. CEILING SAFETY:
+ *   off-host redirect, host mismatch, unreachable, probe 5xx) leaves the pin UNVERIFIED:
+ *   the SAME `low` 95 as the no-probe path (operator-ratified 1.18.0 posture — every
+ *   unverified state is 95, so "we tried and learned nothing" never outscores the honest
+ *   self-host disclosure), with `certificateProbe` + `notAssessedReason` metadata naming
+ *   the sub-state. `partial: true` (not cached, re-tried next scan) only for TRANSIENT
+ *   reasons (`certificate_probe_pending`, `capture_failed`, `unreachable`,
+ *   `probe_unavailable`); permanent ones (`off_host_redirect`, `host_mismatch`, and
+ *   `chain_truncated` — a trust-anchor pin matching no retained entry of a chain the
+ *   probe truncated; leaf usages 1 / 3 are unaffected) cache normally. NO `checkStatus`
+ *   and no `inconclusive` marker — the TLSA measurement itself is real, so the category
+ *   stays completed and scored. Direction: UPWARD 95 → 100 ONLY for pins verified against
+ *   the served certificate; DOWNWARD 95 → 75 ONLY for measured mismatches (≈0.09 overall
+ *   points either way at protective weight 2). Every unverified state is unchanged at
+ *   95, so self-hosts without the binding (and `check_dane`, SMTP/25, which the
+ *   HTTPS-only probe cannot serve) are bit-for-bit unchanged and operator deploys move
+ *   only on an actual comparison. Absence is unchanged. CEILING SAFETY:
  *   `dane_https` is in `PROFILE_CRITICAL_CATEGORIES` for `non_mail` / `web_only`, so a
  *   `high` that read as a missing control would cap the whole scan at 64; the mismatch
  *   prose is kept clear of the `MISSING_CONTROL_REGEX` triggers, declares no

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -363,8 +363,36 @@
  *   weight, tier, grade band, `SEVERITY_PENALTIES` entry or profile-detection rule
  *   changed. Population UNMEASURED against the corpus (a scanner-side transient by
  *   definition has no stable prevalence).
+ * - 1.22.0 — `check_dane_https` VERIFIES TLSA pins against the certificate the host
+ *   serves (issue #841, dns-checks 1.34.0). The served leaf / SPKI / chain digests are
+ *   captured by bv-tls-probe over the operator-only `BV_TLS_PROBE` binding (paid-tier
+ *   scans only, launched only when TLSA records exist) and compared per RFC 7671 —
+ *   DANE-EE / PKIX-EE against the leaf, DANE-TA / PKIX-TA against any served chain member,
+ *   matching types 0/1/2 as full data / SHA-256 / SHA-512. The scoring inversion this
+ *   issue measured (a stale pin at 100, its removal at 95) ends: the ladder is now
+ *   VERIFIED 100 (`info`, `certificateMatchVerified: true`) > ABSENT 95 (unchanged `low`)
+ *   > MISMATCH 75 (`high` "pin does not match the served certificate", −25). A probe that
+ *   was attempted but returned no certificate (cold-cache "pending", capture failure,
+ *   off-host redirect, host mismatch) is UNMEASURED: an `info` with `inconclusive: true`
+ *   + `notAssessedReason`, no deduction, `partial: true` (not cached, re-tried next scan)
+ *   and NO `checkStatus` — the TLSA measurement itself is real, so the category stays
+ *   completed. Direction: DOWNWARD only for domains whose DANE-HTTPS pin does not match
+ *   the served certificate (100 or 95 → 75, ≈0.09 overall points at protective weight 2);
+ *   UPWARD 95 → 100 for verified pins on operator deploys. Absence is unchanged; every
+ *   self-host without the binding (and `check_dane`, SMTP/25, which the HTTPS-only probe
+ *   cannot serve) is bit-for-bit unchanged at the 1.18.0 posture. CEILING SAFETY:
+ *   `dane_https` is in `PROFILE_CRITICAL_CATEGORIES` for `non_mail` / `web_only`, so a
+ *   `high` that read as a missing control would cap the whole scan at 64; the mismatch
+ *   prose is kept clear of the `MISSING_CONTROL_REGEX` triggers, declares no
+ *   `missingControl`, and the package test proves both predicates decline and a web_only
+ *   scan with a mismatch stays above 64. Also in this version: maturity staging counts a
+ *   DANE pin toward Stage 4 only when the finding carries `certificateMatchVerified:
+ *   true` (previously a title regex promoted unverified SMTP pins). No weight, tier, grade
+ *   band, `SEVERITY_PENALTIES` entry or profile-detection rule changed. Population
+ *   UNMEASURED against the corpus: DANE-for-HTTPS adoption is ≈0% and the mismatch rate
+ *   within it is unknown; the only measured instance is the issue's own repro domain.
  */
-export const SCORING_MODEL_VERSION = '1.21.0';
+export const SCORING_MODEL_VERSION = '1.22.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/src/lib/tls-probe-binding.ts
+++ b/src/lib/tls-probe-binding.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod';
 
 import type { CheckResult, Finding } from './scoring';
+import type { ServedCertificate, TlsaVerificationContext } from '@blackveil/dns-checks';
 import { buildCheckResult, createFinding } from './scoring';
 import { logEvent } from './log';
 import type { BindingDegradationKind, BindingDegradationSink } from './binding-degradation';
@@ -65,6 +66,45 @@ const DEFAULT_PROBE_PORT = 443;
 const TLS_PROBE_MAX_BODY_BYTES = 256 * 1024;
 const MIN_TLS_PROBE_CAPABILITY_BYTES = 32;
 
+/** One served-chain member as bv-tls-probe reports it (digests lowercase hex, DER base64). */
+const ServedChainEntrySchema = z
+	.object({
+		sha256: z.string().optional(),
+		sha512: z.string().optional(),
+		spkiSha256: z.string().optional(),
+		spkiSha512: z.string().optional(),
+		der: z.string().optional(),
+		spkiDer: z.string().optional(),
+	})
+	.passthrough();
+
+/**
+ * The served-certificate block bv-tls-probe adds to `/probe` for DANE pin verification
+ * (#841). Additive to the existing response; every field optional so a probe build that
+ * predates it, or omits a field, still validates. The block as a whole is `.catch`-ed:
+ * a malformed certificate object degrades to "no certificate" (the DANE check reports an
+ * unmeasured pin) instead of failing the whole response and taking the TLS-version
+ * enrichment down with it.
+ */
+const ServedCertificateSchema = z
+	.object({
+		host: z.string().optional(),
+		port: z.number().optional(),
+		capturedAt: z.string().optional(),
+		leafDer: z.string().optional(),
+		leafSpkiDer: z.string().optional(),
+		leafSha256: z.string().optional(),
+		leafSha512: z.string().optional(),
+		leafSpkiSha256: z.string().optional(),
+		leafSpkiSha512: z.string().optional(),
+		chain: z.array(ServedChainEntrySchema).optional(),
+		subjectName: z.string().optional(),
+		subjectAlternativeNames: z.array(z.string()).optional(),
+		validFrom: z.number().optional(),
+		validTo: z.number().optional(),
+	})
+	.passthrough();
+
 /** Defensive shape of a bv-tls-probe /probe response. All fields optional/lenient
  *  so unknown extras never fail validation. */
 const TlsProbeResponseSchema = z
@@ -78,6 +118,9 @@ const TlsProbeResponseSchema = z
 		cipher: z.object({ name: z.string().optional(), bits: z.number().optional() }).passthrough().optional(),
 		error: z.string().optional(),
 		probedAt: z.string().optional(),
+		certificate: ServedCertificateSchema.optional().catch(undefined),
+		/** Set when the capture failed ('off-host redirect', 'no security state', …). */
+		certificateError: z.string().optional(),
 	})
 	.passthrough();
 export type TlsProbeResult = z.infer<typeof TlsProbeResponseSchema>;
@@ -165,4 +208,91 @@ export function mergeTlsFinding(result: CheckResult, probe: TlsProbeResult): Che
 	// Preserve controlPresent — detectDomainContext reads it for profile detection,
 	// so dropping it here would flip sslPass to false for legacy-TLS-but-reachable hosts.
 	return buildCheckResult('ssl', [...result.findings, finding], result.controlPresent);
+}
+
+/**
+ * `notAssessedReason` vocabulary for a DANE pin the probe could not verify (#841).
+ * `pending` / `failed` are the package defaults; the rest name the specific cause.
+ */
+export const DANE_CERTIFICATE_PROBE_REASONS = {
+	pending: 'certificate_probe_pending',
+	failed: 'certificate_probe_failed',
+	offHostRedirect: 'off_host_redirect',
+	hostMismatch: 'certificate_host_mismatch',
+	unreachable: 'host_unreachable',
+} as const;
+
+/** A probe result that is still warming its cache (the DEFAULT path on a cold call). */
+const PROBE_PENDING_RE = /pending|warming/i;
+const OFF_HOST_REDIRECT_RE = /redirect/i;
+
+function normalizeHost(host: string): string {
+	return host.trim().toLowerCase().replace(/\.$/, '');
+}
+
+function unmeasured(outcome: 'pending' | 'failed', reason: string): TlsaVerificationContext {
+	return { servedCertificate: null, certificateProbe: outcome, certificateProbeReason: reason };
+}
+
+/**
+ * Project a `/probe` response onto the DANE check's verification input (#841).
+ *
+ * - `certificate` present AND its `host` equals the scanned name → the served certificate.
+ *   DANE pins the TLSA owner's EXACT host — apex and `www` can serve different
+ *   certificates — so a capture describing any other host (an off-host redirect the
+ *   probe followed, a missing host) is a FAILED verification, never a verdict.
+ * - `certificateError` → failed (`off_host_redirect` when the probe says so).
+ * - `error` matching the probe's "pending — cache warming" verdict → pending: the real
+ *   answer arrives on a later call, the check marks itself partial and re-tries.
+ * - `reachable: false`, a null result (binding failure), or a response with no
+ *   certificate block at all (a probe build predating the contract) → failed.
+ *
+ * Never throws; never fabricates material — a certificate block missing its leaf
+ * digests is treated as absent.
+ */
+export function servedCertificateFromProbe(probe: TlsProbeResult | null, expectedHost: string): TlsaVerificationContext {
+	if (!probe) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.failed);
+	const cert = probe.certificate;
+	if (cert) {
+		const host = cert.host ? normalizeHost(cert.host) : '';
+		if (host.length === 0 || host !== normalizeHost(expectedHost)) {
+			return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.hostMismatch);
+		}
+		if (!cert.leafSha256 || !cert.leafSpkiSha256) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.failed);
+		const served: ServedCertificate = {
+			host,
+			port: cert.port ?? DEFAULT_PROBE_PORT,
+			capturedAt: cert.capturedAt,
+			leafDer: cert.leafDer,
+			leafSpkiDer: cert.leafSpkiDer,
+			leafSha256: cert.leafSha256,
+			leafSha512: cert.leafSha512,
+			leafSpkiSha256: cert.leafSpkiSha256,
+			leafSpkiSha512: cert.leafSpkiSha512,
+			chain: (cert.chain ?? []).map((entry) => ({
+				sha256: entry.sha256,
+				sha512: entry.sha512,
+				spkiSha256: entry.spkiSha256,
+				spkiSha512: entry.spkiSha512,
+				der: entry.der,
+				spkiDer: entry.spkiDer,
+			})),
+			subjectName: cert.subjectName,
+			subjectAlternativeNames: cert.subjectAlternativeNames,
+			validFrom: cert.validFrom,
+			validTo: cert.validTo,
+		};
+		return { servedCertificate: served };
+	}
+	if (probe.certificateError) {
+		return unmeasured(
+			'failed',
+			OFF_HOST_REDIRECT_RE.test(probe.certificateError)
+				? DANE_CERTIFICATE_PROBE_REASONS.offHostRedirect
+				: DANE_CERTIFICATE_PROBE_REASONS.failed,
+		);
+	}
+	if (probe.error && PROBE_PENDING_RE.test(probe.error)) return unmeasured('pending', DANE_CERTIFICATE_PROBE_REASONS.pending);
+	if (probe.reachable === false) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.unreachable);
+	return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.failed);
 }

--- a/src/lib/tls-probe-binding.ts
+++ b/src/lib/tls-probe-binding.ts
@@ -9,6 +9,7 @@
 import { z } from 'zod';
 
 import type { CheckResult, Finding } from './scoring';
+import { DANE_PIN_NOT_ASSESSED_REASONS } from '@blackveil/dns-checks';
 import type { ServedCertificate, TlsaVerificationContext } from '@blackveil/dns-checks';
 import { buildCheckResult, createFinding } from './scoring';
 import { logEvent } from './log';
@@ -215,16 +216,10 @@ export function mergeTlsFinding(result: CheckResult, probe: TlsProbeResult): Che
 }
 
 /**
- * `notAssessedReason` vocabulary for a DANE pin the probe could not verify (#841).
- * `pending` / `failed` are the package defaults; the rest name the specific cause.
+ * `notAssessedReason` vocabulary for a DANE pin the probe could not verify (#841) — the
+ * package's tokens, re-exported so the projection below and its consumers share one SSOT.
  */
-export const DANE_CERTIFICATE_PROBE_REASONS = {
-	pending: 'certificate_probe_pending',
-	failed: 'certificate_probe_failed',
-	offHostRedirect: 'off_host_redirect',
-	hostMismatch: 'certificate_host_mismatch',
-	unreachable: 'host_unreachable',
-} as const;
+export const DANE_CERTIFICATE_PROBE_REASONS = DANE_PIN_NOT_ASSESSED_REASONS;
 
 /** A probe result that is still warming its cache (the DEFAULT path on a cold call). */
 const PROBE_PENDING_RE = /pending|warming/i;
@@ -243,26 +238,30 @@ function unmeasured(outcome: 'pending' | 'failed', reason: string): TlsaVerifica
  *
  * - `certificate` present AND its `host` equals the scanned name → the served certificate.
  *   DANE pins the TLSA owner's EXACT host — apex and `www` can serve different
- *   certificates — so a capture describing any other host (an off-host redirect the
- *   probe followed, a missing host) is a FAILED verification, never a verdict.
- * - `certificateError` → failed (`off_host_redirect` when the probe says so).
- * - `error` matching the probe's "pending — cache warming" verdict → pending: the real
- *   answer arrives on a later call, the check marks itself partial and re-tries.
- * - `reachable: false`, a null result (binding failure), or a response with no
- *   certificate block at all (a probe build predating the contract) → failed.
+ *   certificates — so a capture describing any other host (or none) is `failed` /
+ *   `host_mismatch` (permanent), never a verdict.
+ * - `certificateError` → failed: `off_host_redirect` (permanent) when the probe says so,
+ *   else `capture_failed` (transient).
+ * - `error` matching the probe's "pending — cache warming" verdict → pending
+ *   (`certificate_probe_pending`, transient): the real answer arrives on a later call.
+ * - `reachable: false` → `unreachable` (transient); a null result (binding 5xx / throw /
+ *   timeout) → `probe_unavailable` (transient); a response with no certificate block at
+ *   all (a probe build predating the contract) → `capture_failed`.
  *
+ * Every outcome without a certificate scores the same unverified 95 in the package; the
+ * reason token only decides the sub-state metadata and whether the result is re-tried.
  * Never throws; never fabricates material — a certificate block missing its leaf
  * digests is treated as absent.
  */
 export function servedCertificateFromProbe(probe: TlsProbeResult | null, expectedHost: string): TlsaVerificationContext {
-	if (!probe) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.failed);
+	if (!probe) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.probeUnavailable);
 	const cert = probe.certificate;
 	if (cert) {
 		const host = cert.host ? normalizeHost(cert.host) : '';
 		if (host.length === 0 || host !== normalizeHost(expectedHost)) {
 			return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.hostMismatch);
 		}
-		if (!cert.leafSha256 || !cert.leafSpkiSha256) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.failed);
+		if (!cert.leafSha256 || !cert.leafSpkiSha256) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.captureFailed);
 		const served: ServedCertificate = {
 			host,
 			port: cert.port ?? DEFAULT_PROBE_PORT,
@@ -295,10 +294,10 @@ export function servedCertificateFromProbe(probe: TlsProbeResult | null, expecte
 			'failed',
 			OFF_HOST_REDIRECT_RE.test(probe.certificateError)
 				? DANE_CERTIFICATE_PROBE_REASONS.offHostRedirect
-				: DANE_CERTIFICATE_PROBE_REASONS.failed,
+				: DANE_CERTIFICATE_PROBE_REASONS.captureFailed,
 		);
 	}
 	if (probe.error && PROBE_PENDING_RE.test(probe.error)) return unmeasured('pending', DANE_CERTIFICATE_PROBE_REASONS.pending);
 	if (probe.reachable === false) return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.unreachable);
-	return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.failed);
+	return unmeasured('failed', DANE_CERTIFICATE_PROBE_REASONS.captureFailed);
 }

--- a/src/lib/tls-probe-binding.ts
+++ b/src/lib/tls-probe-binding.ts
@@ -98,6 +98,10 @@ const ServedCertificateSchema = z
 		leafSpkiSha256: z.string().optional(),
 		leafSpkiSha512: z.string().optional(),
 		chain: z.array(ServedChainEntrySchema).optional(),
+		/** True when the served chain exceeded the probe's entry cap and its tail was dropped. */
+		chainTruncated: z.boolean().optional(),
+		/** The chain's original length before truncation. */
+		chainLength: z.number().optional(),
 		subjectName: z.string().optional(),
 		subjectAlternativeNames: z.array(z.string()).optional(),
 		validFrom: z.number().optional(),
@@ -277,6 +281,8 @@ export function servedCertificateFromProbe(probe: TlsProbeResult | null, expecte
 				der: entry.der,
 				spkiDer: entry.spkiDer,
 			})),
+			chainTruncated: cert.chainTruncated,
+			chainLength: cert.chainLength,
 			subjectName: cert.subjectName,
 			subjectAlternativeNames: cert.subjectAlternativeNames,
 			validFrom: cert.validFrom,

--- a/src/schemas/tool-definitions.ts
+++ b/src/schemas/tool-definitions.ts
@@ -311,7 +311,7 @@ const TOOL_DEFS: Record<string, ToolDef> = {
 	},
 	check_dane_https: {
 		description:
-			'Verify DANE certificate pinning for HTTPS connections. Looks up TLSA records at _443._tcp.{domain} (port 443) to confirm the web certificate is pinned in DNS. Distinct from check_dane which covers SMTP at port 25.',
+			'Verify DANE certificate pinning for HTTPS connections. Looks up TLSA records at _443._tcp.{domain} (port 443) and, when the operator certificate probe is bound, compares each pinned association against the certificate the host actually serves (RFC 7671: DANE-EE/PKIX-EE against the leaf, DANE-TA/PKIX-TA against the served chain) — a stale pin is reported as a mismatch, not a pass. Without the probe the record is reported as present but unverified. Distinct from check_dane which covers SMTP at port 25.',
 		schema: BaseDomainArgs,
 		group: 'infrastructure',
 		tier: 'protective',

--- a/src/tools/check-dane-https.ts
+++ b/src/tools/check-dane-https.ts
@@ -6,9 +6,10 @@
  *
  * Operator-only enrichment (#841): when a `tlsProbeBinding` is provided (the BV_TLS_PROBE
  * service binding), the certificate the host serves on :443 is captured and every TLSA
- * association is VERIFIED against it — a stale pin becomes a `high` mismatch, a matching
- * one a verified `info`. BSL self-hosts without the binding receive the unmodified base
- * result (present, not verified — the 1.18.0 posture).
+ * association is VERIFIED against it — a stale pin becomes a `high` mismatch (75), a
+ * matching one a verified `info` (100). A probe that produced no certificate leaves the
+ * pin at the unverified `low` (95) with sub-state metadata. BSL self-hosts without the
+ * binding receive the unmodified base result (present, not verified — the 1.18.0 posture).
  */
 
 import { checkDANEHTTPS } from '@blackveil/dns-checks';

--- a/src/tools/check-dane-https.ts
+++ b/src/tools/check-dane-https.ts
@@ -3,27 +3,76 @@
 /**
  * DANE-HTTPS check tool.
  * Thin wrapper around @blackveil/dns-checks — delegates all logic to the shared package.
+ *
+ * Operator-only enrichment (#841): when a `tlsProbeBinding` is provided (the BV_TLS_PROBE
+ * service binding), the certificate the host serves on :443 is captured and every TLSA
+ * association is VERIFIED against it — a stale pin becomes a `high` mismatch, a matching
+ * one a verified `info`. BSL self-hosts without the binding receive the unmodified base
+ * result (present, not verified — the 1.18.0 posture).
  */
 
 import { checkDANEHTTPS } from '@blackveil/dns-checks';
+import type { TlsaVerificationContext } from '@blackveil/dns-checks';
 import { queryDns } from '../lib/dns';
 import { makeQueryDNS } from '../lib/dns-query-adapter';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import type { CheckResult } from '../lib/scoring';
+import { callTlsProbe, servedCertificateFromProbe } from '../lib/tls-probe-binding';
+import type { TlsProbeBinding, BindingDegradationSink } from '../lib/tls-probe-binding';
+import { createFetchBudget } from '../lib/fetch-budget';
+
+/** Operator-only certificate-probe options for {@link checkDaneHttps}. Mirrors `checkSsl`'s. */
+export interface CheckDaneHttpsProbeOptions {
+	/** The BV_TLS_PROBE service binding (absent on all BSL self-hosts). */
+	tlsProbeBinding?: TlsProbeBinding;
+	/** Bearer token forwarded to the probe endpoint. */
+	tlsProbeAuthToken?: string;
+	onBindingDegradation?: BindingDegradationSink;
+	/** Caller-supplied abort signal (scan per-check / scan-level) — composed into the probe call. */
+	signal?: AbortSignal;
+	/**
+	 * Wall-clock this check may spend on the probe (issue #641 pattern). The probe is a
+	 * service binding, not a `fetch`, so a fetch-wrapper budget cannot meter it —
+	 * `budget.signal()` is what caps it at the shared deadline (the same lesson
+	 * `check_ssl` learned). Absent (every direct call) → the probe's own 8s timeout.
+	 */
+	budgetMs?: number;
+}
 
 /**
  * Check DANE TLSA records for a domain's HTTPS endpoint (_443._tcp.{domain}).
+ *
+ * The probe is LAZY: the package calls `resolveServedCertificate` only when the TLSA
+ * lookup returned records, so the ~100% of domains with no DANE never spend a Browser
+ * Rendering session. The probe host is EXACTLY `domain` — the TLSA owner is
+ * `_443._tcp.<domain>`, and DANE pins that host's certificate, not whatever an apex →
+ * `www` redirect lands on; `servedCertificateFromProbe` asserts the capture's host.
  */
-export async function checkDaneHttps(domain: string, dnsOptions?: QueryDnsOptions): Promise<CheckResult> {
-	return checkDANEHTTPS(
-		domain,
-		makeQueryDNS(dnsOptions),
-		{
-			timeout: dnsOptions?.timeoutMs ?? 5000,
-			rawQueryDNS: async (d, type, dnssecFlag) => {
-				const resp = await queryDns(d, type as Parameters<typeof queryDns>[1], dnssecFlag ?? false, dnsOptions);
-				return { AD: resp.AD, Answer: resp.Answer };
-			},
+export async function checkDaneHttps(
+	domain: string,
+	dnsOptions?: QueryDnsOptions,
+	probeOptions: CheckDaneHttpsProbeOptions = {},
+): Promise<CheckResult> {
+	const budget = createFetchBudget(probeOptions.budgetMs);
+	const binding = probeOptions.tlsProbeBinding;
+	// Fail-soft end to end: `callTlsProbe` returns null on any failure and the `.catch`
+	// is belt-and-braces; the package turns a throwing resolver into a `failed` probe
+	// (unmeasured), never into a verdict.
+	const resolveServedCertificate = binding
+		? async (): Promise<TlsaVerificationContext> => {
+				const probe = await callTlsProbe(binding, probeOptions.tlsProbeAuthToken, domain, {
+					telemetry: probeOptions.onBindingDegradation,
+					signal: budget.signal(probeOptions.signal),
+				}).catch(() => null);
+				return servedCertificateFromProbe(probe, domain);
+			}
+		: undefined;
+	return checkDANEHTTPS(domain, makeQueryDNS(dnsOptions), {
+		timeout: dnsOptions?.timeoutMs ?? 5000,
+		rawQueryDNS: async (d, type, dnssecFlag) => {
+			const resp = await queryDns(d, type as Parameters<typeof queryDns>[1], dnssecFlag ?? false, dnsOptions);
+			return { AD: resp.AD, Answer: resp.Answer };
 		},
-	) as Promise<CheckResult>;
+		resolveServedCertificate,
+	}) as Promise<CheckResult>;
 }

--- a/src/tools/scan-domain.ts
+++ b/src/tools/scan-domain.ts
@@ -91,10 +91,10 @@ const ADAPTIVE_WEIGHTS_MAX_BODY_BYTES = 128 * 1024;
 const PROBE_ELIGIBLE_TIERS = new Set(['developer', 'enterprise', 'partner', 'owner']);
 
 /**
- * Resolve the TLS-probe binding for the ssl check, gated on tier eligibility.
- * Paid-tier only — free/agent/anonymous scans skip Browser Rendering.
+ * Resolve the TLS-probe binding for the `ssl` and `dane_https` checks, gated on tier
+ * eligibility. Paid-tier only — free/agent/anonymous scans skip Browser Rendering.
  */
-function resolveSslOptions(rt?: ScanRuntimeOptions): { tlsProbeBinding?: { fetch: typeof fetch }; tlsProbeAuthToken?: string } {
+function resolveTlsProbeOptions(rt?: ScanRuntimeOptions): { tlsProbeBinding?: { fetch: typeof fetch }; tlsProbeAuthToken?: string } {
 	return {
 		tlsProbeBinding: PROBE_ELIGIBLE_TIERS.has(rt?.authTier ?? '') ? rt?.tlsProbeBinding : undefined,
 		tlsProbeAuthToken: rt?.tlsProbeAuthToken,
@@ -174,7 +174,7 @@ const CHECK_DISPATCH: Record<string, CheckRunner> = {
 	// per-check / scan-level timeout aborts their in-flight HTTPS subrequests.
 	// undefined outside scan context (direct calls / retry path) → unchanged.
 	ssl: (d, _dns, rt, sig, _zone, robots, budget) =>
-		checkSsl(d, { ...resolveSslOptions(rt), signal: sig, robotsMemo: robots, budgetMs: budget }),
+		checkSsl(d, { ...resolveTlsProbeOptions(rt), signal: sig, robotsMemo: robots, budgetMs: budget }),
 	// #674: `mta_sts` and `subdomain_takeover` are the remaining raw-HTTP checks whose
 	// fetches carry fixed timeouts the caller cannot lower (the package hardcodes the
 	// policy-fetch and fingerprint-probe timeouts), so they take the budget for the same
@@ -188,7 +188,12 @@ const CHECK_DISPATCH: Record<string, CheckRunner> = {
 	http_security: (d, _dns, _rt, sig, _zone, robots, budget) => checkHttpSecurity(d, { signal: sig, robotsMemo: robots, budgetMs: budget }),
 	dane: (d, dns) => checkDane(d, dns),
 	mx: (d, dns, rt) => checkMx(d, resolveProviderSignatureOptions(rt), dns),
-	dane_https: (d, dns) => checkDaneHttps(d, dns),
+	// #841: TLSA pin verification captures the served certificate over the same
+	// paid-tier-gated probe as `ssl`. The probe is a service binding the fetch budget
+	// cannot wrap, so the budget is threaded for its `signal()`; the wrapper launches it
+	// only when TLSA records exist, so a DANE-less domain (≈ all of them) pays nothing.
+	dane_https: (d, dns, rt, sig, _zone, _robots, budget) =>
+		checkDaneHttps(d, dns, { ...resolveTlsProbeOptions(rt), signal: sig, budgetMs: budget }),
 	svcb_https: (d, dns) => checkSvcbHttps(d, dns),
 	subdomailing: (d, dns) => checkSubdomailing(d, dns),
 	dnskey_strength: (d, dns) => checkDnskeyStrength(d, dns),
@@ -699,21 +704,22 @@ export async function scanDomain(domain: string, kv?: KVNamespace, runtimeOption
 	let scanTimeoutId: ReturnType<typeof setTimeout> | undefined;
 	const settled = await Promise.race([
 		Promise.allSettled(checkPromises),
-		new Promise<PromiseSettledResult<CheckResult>[]>((resolve) =>
-			(scanTimeoutId = setTimeout(() => {
-				timedOut = true;
-				// R7: abort the scan-level controller so EVERY still-in-flight subrequest
-				// (DoH via scanDns.signal + the raw HTTPS fetches via each composed
-				// per-check signal) is cancelled, not merely abandoned — the scan is over,
-				// so freeing the Workers subrequest budget is unambiguously correct here.
-				scanAbort.abort();
-				// Snapshot whatever has settled so far by racing each promise with an immediate rejection
-				resolve(
-					Promise.allSettled(
-						checkPromises.map((p) => Promise.race([p, new Promise<never>((_, reject) => reject(new Error('__check_pending__')))])),
-					),
-				);
-			}, timeoutBudget.scanTimeoutMs)),
+		new Promise<PromiseSettledResult<CheckResult>[]>(
+			(resolve) =>
+				(scanTimeoutId = setTimeout(() => {
+					timedOut = true;
+					// R7: abort the scan-level controller so EVERY still-in-flight subrequest
+					// (DoH via scanDns.signal + the raw HTTPS fetches via each composed
+					// per-check signal) is cancelled, not merely abandoned — the scan is over,
+					// so freeing the Workers subrequest budget is unambiguously correct here.
+					scanAbort.abort();
+					// Snapshot whatever has settled so far by racing each promise with an immediate rejection
+					resolve(
+						Promise.allSettled(
+							checkPromises.map((p) => Promise.race([p, new Promise<never>((_, reject) => reject(new Error('__check_pending__')))])),
+						),
+					);
+				}, timeoutBudget.scanTimeoutMs)),
 		),
 	]);
 	if (scanTimeoutId !== undefined) clearTimeout(scanTimeoutId);

--- a/src/tools/scan/maturity-staging.ts
+++ b/src/tools/scan/maturity-staging.ts
@@ -426,9 +426,15 @@ export function computeMaturityStage(checks: CheckResult[], profile?: DomainProf
 	const hasDnssec = measured(dnssecCheck) && (dnssecCheck?.passed ?? false);
 	const hasBimi = (measured(bimiCheck) && bimiCheck?.findings.some((f: Finding) => /BIMI record configured/i.test(f.title))) ?? false;
 
-	// DANE presence
-	const daneCheck = byCategory.get('dane');
-	const hasDane = (measured(daneCheck) && daneCheck?.findings.some((f: Finding) => /DANE TLSA configured/i.test(f.title))) ?? false;
+	// DANE presence — a pin counts ONLY when it was VERIFIED against the served certificate
+	// (#841, scoring model 1.22.0). Before, a title regex (`DANE TLSA configured`) matched the
+	// honest "present, not verified" finding too, so an unreadable or stale pin bought a
+	// Stage-4 promotion. `check_dane` (SMTP/25) is never verified today — the browser probe
+	// is HTTPS-only — so it contributes nothing here until a port-25 capture exists; a
+	// verified `dane_https` pin IS a DANE transport signal and does count.
+	const hasVerifiedDanePin = (check?: CheckResult): boolean =>
+		measured(check) && (check?.findings.some((f: Finding) => f.metadata?.certificateMatchVerified === true) ?? false);
+	const hasDane = hasVerifiedDanePin(byCategory.get('dane')) || hasVerifiedDanePin(byCategory.get('dane_https'));
 
 	// CAA presence (passed = CAA records found)
 	const caaCheck = byCategory.get('caa');

--- a/src/tools/scan/post-processing.ts
+++ b/src/tools/scan/post-processing.ts
@@ -54,7 +54,7 @@ export interface ScanRuntimeOptions {
 	secondaryDoh?: import('../../lib/dns-types').SecondaryDohConfig;
 	/** Optional service binding for raw DNS, routing, and vantage-point probes. */
 	infraProbe?: { fetch: typeof fetch };
-	/** Operator-only bv-tls-probe service binding (negotiated-TLS-version detection). Fail-soft; absent on BSL self-hosts → scan SSL score unchanged. */
+	/** Operator-only bv-tls-probe service binding (negotiated-TLS-version detection for `ssl`; served-certificate capture for `dane_https` pin verification, #841). Fail-soft; absent on BSL self-hosts → scan `ssl` / `dane_https` scores unchanged. */
 	tlsProbeBinding?: { fetch: typeof fetch };
 	/** Bearer token forwarded to bv-tls-probe. */
 	tlsProbeAuthToken?: string;

--- a/test/check-dane-https-pin-verification.spec.ts
+++ b/test/check-dane-https-pin-verification.spec.ts
@@ -1,0 +1,196 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * `check_dane_https` wrapper — TLSA pin verification over the operator-only
+ * BV_TLS_PROBE binding (#841). The package ladder (verified 100 > absent 95 >
+ * mismatch 75, unmeasured = info + partial) is pinned in
+ * packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts; THIS file
+ * pins the wrapper's contract with the probe: what it sends, how each probe outcome
+ * is projected, laziness, the budget signal, and the binding-absent identity.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse, dnssecResponse, tlsaResponse } from './helpers/dns-mock';
+import { LEAF_SPKI_SHA256, STALE_SHA256, servedCertificate } from '../packages/dns-checks/src/__tests__/checks/served-certificate.fixture';
+
+const { restore } = setupFetchMock();
+const TLS_PROBE_AUTH_TOKEN = 'tls-probe-dane-spec-key-32-bytes-minimum';
+
+afterEach(() => {
+	restore();
+	vi.restoreAllMocks();
+});
+
+/** DoH mock: DNSSEC on, and the given TLSA RRset at _443._tcp.example.com. */
+function mockDns(tlsa: Array<{ usage: number; selector: number; matchingType: number; certData: string }>) {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		if (url.includes('_443._tcp.example.com') && (url.includes('type=TLSA') || url.includes('type=52'))) {
+			return Promise.resolve(
+				tlsa.length > 0
+					? tlsaResponse('_443._tcp.example.com', tlsa)
+					: createDohResponse([{ name: '_443._tcp.example.com', type: 52 }], []),
+			);
+		}
+		if ((url.includes('type=A') || url.includes('type=1')) && !url.includes('_tcp')) {
+			return Promise.resolve(dnssecResponse('example.com', true));
+		}
+		return Promise.resolve(createDohResponse([], []));
+	});
+}
+
+function probeBinding(body: unknown, status = 200) {
+	return {
+		fetch: vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } }),
+		),
+	};
+}
+
+const PIN_CURRENT = { usage: 3, selector: 1, matchingType: 1, certData: LEAF_SPKI_SHA256 };
+const PIN_STALE = { usage: 3, selector: 1, matchingType: 1, certData: STALE_SHA256 };
+const PROBE_WITH_CERT = { reachable: true, minVersion: 'TLS1.2', maxVersion: 'TLS1.3', certificate: servedCertificate('example.com') };
+
+async function run(binding?: ReturnType<typeof probeBinding>, extra: Record<string, unknown> = {}) {
+	const { checkDaneHttps } = await import('../src/tools/check-dane-https');
+	return checkDaneHttps('example.com', undefined, { tlsProbeBinding: binding, tlsProbeAuthToken: TLS_PROBE_AUTH_TOKEN, ...extra });
+}
+
+describe('checkDaneHttps — pin verification over BV_TLS_PROBE (#841)', () => {
+	it('sends host=<domain>&port=443 with the bearer, and a matching pin → 100 verified', async () => {
+		mockDns([PIN_CURRENT]);
+		const binding = probeBinding(PROBE_WITH_CERT);
+		const result = await run(binding);
+		expect(binding.fetch).toHaveBeenCalledOnce();
+		const [url, init] = binding.fetch.mock.calls[0];
+		expect(String(url)).toContain('host=example.com');
+		expect(String(url)).toContain('port=443');
+		expect((init as RequestInit).headers).toMatchObject({ Authorization: `Bearer ${TLS_PROBE_AUTH_TOKEN}` });
+		expect(result.score).toBe(100);
+		expect(result.passed).toBe(true);
+		expect(result.partial).toBeUndefined();
+		const verdict = result.findings.find((f) => f.metadata?.certificateMatchVerified !== undefined)!;
+		expect(verdict.severity).toBe('info');
+		expect(verdict.category).toBe('dane_https');
+		expect(verdict.metadata?.certificateMatchVerified).toBe(true);
+		expect(verdict.metadata?.matchedCertData).toBe(LEAF_SPKI_SHA256);
+	});
+
+	it('a stale pin → 75 with a high mismatch, category still scored (not partial, no checkStatus)', async () => {
+		mockDns([PIN_STALE]);
+		const result = await run(probeBinding(PROBE_WITH_CERT));
+		expect(result.score).toBe(75);
+		expect(result.passed).toBe(true);
+		expect(result.partial).toBeUndefined();
+		expect(result.checkStatus).toBeUndefined();
+		const high = result.findings.find((f) => f.severity === 'high')!;
+		expect(high.title).toBe('DANE TLSA pin does not match the served certificate for _443._tcp.example.com');
+		expect(high.metadata?.certificateMatchVerified).toBe(false);
+		expect(high.metadata?.servedLeafSpkiSha256).toBe(LEAF_SPKI_SHA256);
+		expect(high.metadata?.pinned).toEqual([`3 1 1 ${STALE_SHA256}`]);
+	});
+
+	it.each([
+		['cold-cache pending verdict', { error: 'probe pending — cache warming, retry shortly' }, 'certificate_probe_pending'],
+		[
+			'capture failed: off-host redirect',
+			{ reachable: true, minVersion: 'TLS1.2', certificateError: 'off-host redirect to www.example.com' },
+			'off_host_redirect',
+		],
+		[
+			'capture failed: no security state',
+			{ reachable: true, minVersion: 'TLS1.2', certificateError: 'no security state' },
+			'certificate_probe_failed',
+		],
+		[
+			'certificate describes a different host',
+			{ reachable: true, certificate: servedCertificate('www.example.com') },
+			'certificate_host_mismatch',
+		],
+		['host unreachable', { reachable: false, error: 'connect timeout' }, 'host_unreachable'],
+		[
+			'probe predates the contract (no certificate block)',
+			{ reachable: true, minVersion: 'TLS1.2', maxVersion: 'TLS1.3' },
+			'certificate_probe_failed',
+		],
+	])('%s → unmeasured: info + inconclusive + notAssessedReason, no deduction, partial', async (_label, body, reason) => {
+		mockDns([PIN_STALE]);
+		const result = await run(probeBinding(body));
+		expect(result.score).toBe(100);
+		expect(result.partial).toBe(true);
+		expect(result.checkStatus).toBeUndefined();
+		const note = result.findings.find((f) => f.metadata?.inconclusive === true)!;
+		expect(note.severity).toBe('info');
+		expect(note.metadata?.notAssessedReason).toBe(reason);
+		expect(note.metadata?.certificateMatchVerified).toBe(false);
+		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+	});
+
+	it('binding present but failing (503) → unmeasured, never a verdict', async () => {
+		mockDns([PIN_STALE]);
+		const result = await run(probeBinding({ error: 'server error' }, 503));
+		expect(result.score).toBe(100);
+		expect(result.partial).toBe(true);
+		expect(result.findings.find((f) => f.metadata?.inconclusive === true)?.metadata?.notAssessedReason).toBe('certificate_probe_failed');
+	});
+
+	it('binding present but its fetch throws → unmeasured (fail-soft)', async () => {
+		mockDns([PIN_STALE]);
+		const binding = { fetch: vi.fn(async () => Promise.reject(new Error('binding exploded'))) };
+		const result = await run(binding);
+		expect(result.score).toBe(100);
+		expect(result.partial).toBe(true);
+	});
+
+	it('is LAZY: no TLSA record → the probe is never called, 95 unchanged', async () => {
+		mockDns([]);
+		const binding = probeBinding(PROBE_WITH_CERT);
+		const result = await run(binding);
+		expect(binding.fetch).not.toHaveBeenCalled();
+		expect(result.score).toBe(95);
+		expect(result.partial).toBeUndefined();
+		expect(result.findings[0].title).toBe('No DANE TLSA for HTTPS');
+	});
+
+	it('binding absent → identical to the two-argument call (self-host posture, 95 low, not partial)', async () => {
+		mockDns([PIN_STALE]);
+		const { checkDaneHttps } = await import('../src/tools/check-dane-https');
+		const plain = await checkDaneHttps('example.com');
+		mockDns([PIN_STALE]);
+		const emptyOpts = await run(undefined);
+		expect(emptyOpts).toEqual(plain);
+		expect(plain.score).toBe(95);
+		expect(plain.partial).toBeUndefined();
+		const low = plain.findings.find((f) => f.title.startsWith('DANE TLSA configured'))!;
+		expect(low.severity).toBe('low');
+		expect(low.metadata?.certificateMatchVerified).toBe(false);
+	});
+
+	it('a budget threads an AbortSignal into the binding call (a service binding is not fetch-wrapped)', async () => {
+		mockDns([PIN_CURRENT]);
+		const binding = probeBinding(PROBE_WITH_CERT);
+		await run(binding, { budgetMs: 5_000 });
+		const [, init] = binding.fetch.mock.calls[0];
+		expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
+	});
+
+	it('an already-exhausted budget aborts the probe → unmeasured, not a verdict', async () => {
+		mockDns([PIN_STALE]);
+		const binding = {
+			fetch: vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+				// Behave like a real binding: honour the signal.
+				if (init?.signal?.aborted) throw Object.assign(new Error('aborted'), { name: 'AbortError' });
+				await new Promise<void>((resolve, reject) => {
+					init?.signal?.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })));
+					setTimeout(resolve, 2_000);
+				});
+				return new Response(JSON.stringify(PROBE_WITH_CERT), { status: 200, headers: { 'Content-Type': 'application/json' } });
+			}),
+		};
+		const result = await run(binding, { budgetMs: 1 });
+		expect(result.score).toBe(100);
+		expect(result.partial).toBe(true);
+		expect(result.findings.find((f) => f.metadata?.inconclusive === true)?.metadata?.notAssessedReason).toBe('certificate_probe_failed');
+	});
+});

--- a/test/check-dane-https-pin-verification.spec.ts
+++ b/test/check-dane-https-pin-verification.spec.ts
@@ -2,8 +2,9 @@
 
 /**
  * `check_dane_https` wrapper — TLSA pin verification over the operator-only
- * BV_TLS_PROBE binding (#841). The package ladder (verified 100 > absent 95 >
- * mismatch 75, unmeasured = info + partial) is pinned in
+ * BV_TLS_PROBE binding (#841). The package ladder (verified 100 > absent / unverified 95 >
+ * mismatch 75; a probe with no certificate = the unverified low, partial only when
+ * transient) is pinned in
  * packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts; THIS file
  * pins the wrapper's contract with the probe: what it sends, how each probe outcome
  * is projected, laziness, the budget signal, and the binding-absent identity.
@@ -92,55 +93,66 @@ describe('checkDaneHttps — pin verification over BV_TLS_PROBE (#841)', () => {
 	});
 
 	it.each([
-		['cold-cache pending verdict', { error: 'probe pending — cache warming, retry shortly' }, 'certificate_probe_pending'],
+		['cold-cache pending verdict', { error: 'probe pending — cache warming, retry shortly' }, 'certificate_probe_pending', true],
 		[
 			'capture failed: off-host redirect',
 			{ reachable: true, minVersion: 'TLS1.2', certificateError: 'off-host redirect to www.example.com' },
 			'off_host_redirect',
+			false,
 		],
 		[
 			'capture failed: no security state',
 			{ reachable: true, minVersion: 'TLS1.2', certificateError: 'no security state' },
-			'certificate_probe_failed',
+			'capture_failed',
+			true,
 		],
 		[
 			'certificate describes a different host',
 			{ reachable: true, certificate: servedCertificate('www.example.com') },
-			'certificate_host_mismatch',
+			'host_mismatch',
+			false,
 		],
-		['host unreachable', { reachable: false, error: 'connect timeout' }, 'host_unreachable'],
+		['host unreachable', { reachable: false, error: 'connect timeout' }, 'unreachable', true],
 		[
 			'probe predates the contract (no certificate block)',
 			{ reachable: true, minVersion: 'TLS1.2', maxVersion: 'TLS1.3' },
-			'certificate_probe_failed',
+			'capture_failed',
+			true,
 		],
-	])('%s → unmeasured: info + inconclusive + notAssessedReason, no deduction, partial', async (_label, body, reason) => {
-		mockDns([PIN_STALE]);
-		const result = await run(probeBinding(body));
-		expect(result.score).toBe(100);
-		expect(result.partial).toBe(true);
-		expect(result.checkStatus).toBeUndefined();
-		const note = result.findings.find((f) => f.metadata?.inconclusive === true)!;
-		expect(note.severity).toBe('info');
-		expect(note.metadata?.notAssessedReason).toBe(reason);
-		expect(note.metadata?.certificateMatchVerified).toBe(false);
-		expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
-	});
+	])(
+		'%s → unverified 95 (the same low as no-probe) + sub-state metadata; partial only when transient',
+		async (_label, body, reason, partial) => {
+			mockDns([PIN_STALE]);
+			const result = await run(probeBinding(body));
+			expect(result.score).toBe(95);
+			expect(result.passed).toBe(true);
+			expect(result.partial).toBe(partial ? true : undefined);
+			expect(result.checkStatus).toBeUndefined();
+			const low = result.findings.find((f) => f.title.startsWith('DANE TLSA configured'))!;
+			expect(low.severity).toBe('low');
+			expect(low.metadata?.notAssessedReason).toBe(reason);
+			expect(low.metadata?.certificateProbe).toBe(reason === 'certificate_probe_pending' ? 'pending' : 'failed');
+			expect(low.metadata?.certificateMatchVerified).toBe(false);
+			expect(low.metadata?.inconclusive).toBeUndefined();
+			expect(result.findings.some((f) => f.severity === 'high')).toBe(false);
+		},
+	);
 
-	it('binding present but failing (503) → unmeasured, never a verdict', async () => {
+	it('binding present but failing (503) → probe_unavailable: 95, partial, never a verdict', async () => {
 		mockDns([PIN_STALE]);
 		const result = await run(probeBinding({ error: 'server error' }, 503));
-		expect(result.score).toBe(100);
+		expect(result.score).toBe(95);
 		expect(result.partial).toBe(true);
-		expect(result.findings.find((f) => f.metadata?.inconclusive === true)?.metadata?.notAssessedReason).toBe('certificate_probe_failed');
+		expect(result.findings.find((f) => f.title.startsWith('DANE TLSA configured'))?.metadata?.notAssessedReason).toBe('probe_unavailable');
 	});
 
-	it('binding present but its fetch throws → unmeasured (fail-soft)', async () => {
+	it('binding present but its fetch throws → probe_unavailable (fail-soft): 95, partial', async () => {
 		mockDns([PIN_STALE]);
 		const binding = { fetch: vi.fn(async () => Promise.reject(new Error('binding exploded'))) };
 		const result = await run(binding);
-		expect(result.score).toBe(100);
+		expect(result.score).toBe(95);
 		expect(result.partial).toBe(true);
+		expect(result.findings.find((f) => f.title.startsWith('DANE TLSA configured'))?.metadata?.notAssessedReason).toBe('probe_unavailable');
 	});
 
 	it('is LAZY: no TLSA record → the probe is never called, 95 unchanged', async () => {
@@ -175,7 +187,7 @@ describe('checkDaneHttps — pin verification over BV_TLS_PROBE (#841)', () => {
 		expect((init as RequestInit).signal).toBeInstanceOf(AbortSignal);
 	});
 
-	it('an already-exhausted budget aborts the probe → unmeasured, not a verdict', async () => {
+	it('an already-exhausted budget aborts the probe → probe_unavailable (95, partial), not a verdict', async () => {
 		mockDns([PIN_STALE]);
 		const binding = {
 			fetch: vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
@@ -189,8 +201,8 @@ describe('checkDaneHttps — pin verification over BV_TLS_PROBE (#841)', () => {
 			}),
 		};
 		const result = await run(binding, { budgetMs: 1 });
-		expect(result.score).toBe(100);
+		expect(result.score).toBe(95);
 		expect(result.partial).toBe(true);
-		expect(result.findings.find((f) => f.metadata?.inconclusive === true)?.metadata?.notAssessedReason).toBe('certificate_probe_failed');
+		expect(result.findings.find((f) => f.title.startsWith('DANE TLSA configured'))?.metadata?.notAssessedReason).toBe('probe_unavailable');
 	});
 });

--- a/test/maturity-staging-dane-verified.spec.ts
+++ b/test/maturity-staging-dane-verified.spec.ts
@@ -52,14 +52,14 @@ describe('maturity staging — DANE credit requires certificateMatchVerified (#8
 		expect(computeMaturityStage(checks, 'mail_enabled').stage).toBe(3);
 	});
 
-	it('a pending / unmeasured HTTPS pin verification does NOT promote', () => {
+	it('a pending HTTPS pin verification (unverified low with sub-state metadata) does NOT promote', () => {
 		const checks = [
 			...stage3Roster(),
 			dane(
 				'dane_https',
-				createFinding('dane_https', 'DANE TLSA pin verification pending for _443._tcp.example.com', 'info', 'unmeasured', {
+				createFinding('dane_https', 'DANE TLSA configured for _443._tcp.example.com', 'low', 'present, not verified', {
 					certificateMatchVerified: false,
-					inconclusive: true,
+					certificateProbe: 'pending',
 					notAssessedReason: 'certificate_probe_pending',
 				}),
 			),

--- a/test/maturity-staging-dane-verified.spec.ts
+++ b/test/maturity-staging-dane-verified.spec.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * #841 — maturity staging credits a DANE pin toward Stage 4 ONLY when the finding
+ * carries `certificateMatchVerified: true`. Before this, a title regex matched the
+ * honest "present, not verified" finding too, so an unreadable or stale SMTP pin
+ * bought a Stage-4 "Hardened" promotion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeMaturityStage } from '../src/tools/scan/maturity-staging';
+import { buildCheckResult, createFinding } from '../src/lib/scoring';
+import type { CheckResult, Finding } from '../src/lib/scoring';
+
+/**
+ * A Stage-3 mail roster with exactly ONE hardening signal (CAA — not a transport /
+ * integrity signal), so the DANE credit alone decides Stage 4: it supplies both the
+ * second hardening signal AND the required transport signal.
+ */
+function stage3Roster(): CheckResult[] {
+	return [
+		buildCheckResult('mx', [createFinding('mx', 'MX records found', 'info', '2 records')]),
+		buildCheckResult('spf', [createFinding('spf', 'SPF record configured', 'info', 'ok')]),
+		buildCheckResult('dmarc', [createFinding('dmarc', 'DMARC record found', 'info', 'p=reject')]),
+		buildCheckResult('dkim', [createFinding('dkim', 'DKIM configured', 'info', 'selectors', { detectionMethod: 'provider-implied' })]),
+		buildCheckResult('caa', [createFinding('caa', 'CAA records found', 'info', 'ok')]),
+	];
+}
+
+const dane = (category: 'dane' | 'dane_https', finding: Finding) => buildCheckResult(category, [{ ...finding, category }]);
+
+describe('maturity staging — DANE credit requires certificateMatchVerified (#841)', () => {
+	it('baseline: the roster is Stage 3 without DANE', () => {
+		expect(computeMaturityStage(stage3Roster(), 'mail_enabled').stage).toBe(3);
+	});
+
+	it('an unverified SMTP pin (present, not verified — title still "DANE TLSA configured") does NOT promote', () => {
+		const checks = [
+			...stage3Roster(),
+			dane(
+				'dane',
+				createFinding('dane', 'DANE TLSA configured for _25._tcp.mx.example.com', 'low', 'present, not verified', {
+					certificateMatchVerified: false,
+				}),
+			),
+		];
+		expect(computeMaturityStage(checks, 'mail_enabled').stage).toBe(3);
+	});
+
+	it('a legacy title-only finding with no marker does NOT promote either', () => {
+		const checks = [...stage3Roster(), dane('dane', createFinding('dane', 'DANE TLSA configured', 'info', 'ok'))];
+		expect(computeMaturityStage(checks, 'mail_enabled').stage).toBe(3);
+	});
+
+	it('a pending / unmeasured HTTPS pin verification does NOT promote', () => {
+		const checks = [
+			...stage3Roster(),
+			dane(
+				'dane_https',
+				createFinding('dane_https', 'DANE TLSA pin verification pending for _443._tcp.example.com', 'info', 'unmeasured', {
+					certificateMatchVerified: false,
+					inconclusive: true,
+					notAssessedReason: 'certificate_probe_pending',
+				}),
+			),
+		];
+		expect(computeMaturityStage(checks, 'mail_enabled').stage).toBe(3);
+	});
+
+	it('a VERIFIED HTTPS pin promotes to Stage 4', () => {
+		const checks = [
+			...stage3Roster(),
+			dane(
+				'dane_https',
+				createFinding('dane_https', 'DANE TLSA verified against the served certificate for _443._tcp.example.com', 'info', 'verified', {
+					certificateMatchVerified: true,
+				}),
+			),
+		];
+		const stage = computeMaturityStage(checks, 'mail_enabled');
+		expect(stage.stage).toBe(4);
+	});
+
+	it('a VERIFIED SMTP pin would promote too (the marker, not the category, is what counts)', () => {
+		const checks = [
+			...stage3Roster(),
+			dane(
+				'dane',
+				createFinding('dane', 'DANE TLSA verified against the served certificate for _25._tcp.mx.example.com', 'info', 'verified', {
+					certificateMatchVerified: true,
+				}),
+			),
+		];
+		expect(computeMaturityStage(checks, 'mail_enabled').stage).toBe(4);
+	});
+
+	it('a mismatched pin (high, certificateMatchVerified: false) does NOT promote', () => {
+		const checks = [
+			...stage3Roster(),
+			dane(
+				'dane_https',
+				createFinding('dane_https', 'DANE TLSA pin does not match the served certificate for _443._tcp.example.com', 'high', 'mismatch', {
+					certificateMatchVerified: false,
+				}),
+			),
+		];
+		expect(computeMaturityStage(checks, 'mail_enabled').stage).toBe(3);
+	});
+});

--- a/test/scan-domain-dane-pin.integration.test.ts
+++ b/test/scan-domain-dane-pin.integration.test.ts
@@ -8,7 +8,7 @@
  * threaded all the way into the scan's `dane_https` category, tier-gated exactly as
  * the `ssl` enrichment is, so a real scan's DANE score reflects the served certificate:
  *
- *   verified pin (100)  >  absent (95)  >  mismatch (75)
+ *   verified pin (100)  >  absent / unverified (95)  >  mismatch (75)
  *
  * Mirrors test/scan-domain-tls-probe.integration.test.ts's domain-agnostic harness.
  */
@@ -160,14 +160,25 @@ describe('scan_domain DANE-HTTPS pin-verification coherence (#841)', () => {
 		expect(categoryScore).toBe(95);
 	});
 
-	it('cold-cache pending probe → 100 unmeasured, check partial, category still completed', async () => {
+	it('cold-cache pending probe → 95 unverified (never above the no-probe posture), check partial, category still completed', async () => {
 		mockCleanScan(() => STALE_SHA256);
 		const pending = probeBinding(() => ({ error: 'probe pending — cache warming' }));
 		const { categoryScore, check } = await daneFor('danepending.com', withProbe(pending));
-		expect(categoryScore).toBe(100);
+		expect(categoryScore).toBe(95);
 		expect(check!.partial).toBe(true);
 		expect(check!.checkStatus).toBeUndefined();
-		expect(check!.findings.find((f) => f.metadata?.inconclusive === true)?.metadata?.notAssessedReason).toBe('certificate_probe_pending');
+		const low = check!.findings.find((f) => f.title.startsWith('DANE TLSA configured'))!;
+		expect(low.severity).toBe('low');
+		expect(low.metadata?.notAssessedReason).toBe('certificate_probe_pending');
+	});
+
+	it('permanent probe failure (off-host redirect) → 95, NOT partial (no retry-forever)', async () => {
+		mockCleanScan(() => STALE_SHA256);
+		const redirecting = probeBinding(() => ({ reachable: true, minVersion: 'TLS1.2', certificateError: 'off-host redirect' }));
+		const { categoryScore, check } = await daneFor('daneredirect.com', withProbe(redirecting));
+		expect(categoryScore).toBe(95);
+		expect(check!.partial).toBeUndefined();
+		expect(check!.findings.find((f) => f.title.startsWith('DANE TLSA configured'))?.metadata?.notAssessedReason).toBe('off_host_redirect');
 	});
 
 	it('no TLSA anywhere → the probe is only ever consulted by `ssl` (DANE stays lazy)', async () => {

--- a/test/scan-domain-dane-pin.integration.test.ts
+++ b/test/scan-domain-dane-pin.integration.test.ts
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Scan-path scoring-coherence guard for DANE-HTTPS pin verification (#841).
+ *
+ * `scan_domain` does NOT route through the tool registry — it invokes `checkDaneHttps`
+ * from its `CHECK_DISPATCH` table. These tests prove the BV_TLS_PROBE binding is
+ * threaded all the way into the scan's `dane_https` category, tier-gated exactly as
+ * the `ssl` enrichment is, so a real scan's DANE score reflects the served certificate:
+ *
+ *   verified pin (100)  >  absent (95)  >  mismatch (75)
+ *
+ * Mirrors test/scan-domain-tls-probe.integration.test.ts's domain-agnostic harness.
+ */
+
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse, txtResponse, nsResponse, caaResponse, dnssecResponse, tlsaResponse } from './helpers/dns-mock';
+import { IN_MEMORY_CACHE } from '../src/lib/cache';
+import { LEAF_SPKI_SHA256, STALE_SHA256, servedCertificate } from '../packages/dns-checks/src/__tests__/checks/served-certificate.fixture';
+
+const { restore } = setupFetchMock();
+const TLS_PROBE_AUTH_TOKEN = 'tls-probe-dane-scan-integration-key-32b';
+
+beforeEach(() => IN_MEMORY_CACHE.clear());
+afterEach(() => restore());
+
+function dohName(url: string): string {
+	return new URL(url).searchParams.get('name') ?? 'example.com';
+}
+
+/**
+ * Domain-agnostic clean scan; `tlsaFor` decides what `_443._tcp.<domain>` answers.
+ * The TLS probe is a SEPARATE binding object, never global fetch.
+ */
+function mockCleanScan(tlsaFor: (domain: string) => string | null) {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+
+		if (url.includes('cloudflare-dns.com')) {
+			const name = dohName(url);
+			const base = name.replace(/^_[^.]+\./, '').replace(/^[^.]+\._[^.]+\./, '');
+			if (url.includes('type=TLSA') || url.includes('type=52')) {
+				const m = /^_443\._tcp\.(.+)$/.exec(name);
+				const pin = m ? tlsaFor(m[1]) : null;
+				return Promise.resolve(
+					pin
+						? tlsaResponse(name, [{ usage: 3, selector: 1, matchingType: 1, certData: pin }])
+						: createDohResponse([{ name, type: 52 }], []),
+				);
+			}
+			if (url.includes('type=TXT') || url.includes('type=16')) {
+				if (name.includes('_dmarc.')) return Promise.resolve(txtResponse(name, ['v=DMARC1; p=reject']));
+				if (name.includes('_domainkey.')) return Promise.resolve(txtResponse(name, ['v=DKIM1; k=rsa; p=MIGf']));
+				if (name.includes('_mta-sts.')) return Promise.resolve(txtResponse(name, ['v=STSv1; id=20240101']));
+				if (name.includes('_smtp._tls.')) return Promise.resolve(txtResponse(name, ['v=TLSRPTv1; rua=mailto:tls@' + base]));
+				if (name.includes('_bimi.')) return Promise.resolve(txtResponse(name, ['v=BIMI1; l=https://' + base + '/logo.svg']));
+				return Promise.resolve(txtResponse(name, ['v=spf1 include:_spf.google.com -all']));
+			}
+			if (url.includes('type=NS') || url.includes('type=2'))
+				return Promise.resolve(nsResponse(name, ['ns1.' + base + '.', 'ns2.' + base + '.']));
+			if (url.includes('type=CAA') || url.includes('type=257')) return Promise.resolve(caaResponse(name, ['0 issue "letsencrypt.org"']));
+			if (url.includes('type=A') || url.includes('type=1')) return Promise.resolve(dnssecResponse(name, true));
+			return Promise.resolve(createDohResponse([], []));
+		}
+
+		if (url.startsWith('https://')) {
+			return Promise.resolve({
+				url,
+				ok: true,
+				status: 200,
+				headers: new Headers({ 'strict-transport-security': 'max-age=31536000; includeSubDomains' }),
+			} as unknown as Response);
+		}
+		if (url.startsWith('http://')) {
+			return Promise.resolve({
+				ok: false,
+				status: 301,
+				headers: new Headers({ location: url.replace('http://', 'https://') }),
+			} as unknown as Response);
+		}
+		return Promise.resolve(createDohResponse([], []));
+	});
+}
+
+/** A bv-tls-probe binding that answers with the served certificate for whatever host was asked. */
+function probeBinding(bodyFor: (host: string) => unknown, status = 200) {
+	return {
+		fetch: vi.fn(async (input: RequestInfo | URL) => {
+			const host = new URL(String(input)).searchParams.get('host') ?? '';
+			return new Response(JSON.stringify(bodyFor(host)), { status, headers: { 'Content-Type': 'application/json' } });
+		}),
+	};
+}
+
+const certProbe = () =>
+	probeBinding((host) => ({ reachable: true, minVersion: 'TLS1.2', maxVersion: 'TLS1.3', certificate: servedCertificate(host) }));
+
+async function daneFor(domain: string, runtimeOptions?: Record<string, unknown>) {
+	const { scanDomain } = await import('../src/tools/scan-domain');
+	IN_MEMORY_CACHE.clear();
+	const result = await scanDomain(domain, undefined, { forceRefresh: true, ...runtimeOptions });
+	const check = result.checks.find((c) => c.category === 'dane_https');
+	return { categoryScore: result.score.categoryScores.dane_https, check, result };
+}
+
+const withProbe = (binding: ReturnType<typeof probeBinding>, authTier = 'enterprise') => ({
+	tlsProbeBinding: binding,
+	tlsProbeAuthToken: TLS_PROBE_AUTH_TOKEN,
+	authTier,
+});
+
+describe('scan_domain DANE-HTTPS pin-verification coherence (#841)', () => {
+	it('verified 100 > absent 95 > mismatch 75 — the end state, measured through the scan path', async () => {
+		mockCleanScan(() => null);
+		const absent = await daneFor('daneabsent.com', withProbe(certProbe()));
+
+		mockCleanScan(() => LEAF_SPKI_SHA256);
+		const verified = await daneFor('daneverified.com', withProbe(certProbe()));
+
+		mockCleanScan(() => STALE_SHA256);
+		const stale = await daneFor('danestale.com', withProbe(certProbe()));
+
+		expect(absent.categoryScore).toBe(95);
+		expect(verified.categoryScore).toBe(100);
+		expect(stale.categoryScore).toBe(75);
+		expect(verified.categoryScore).toBeGreaterThan(absent.categoryScore);
+		expect(absent.categoryScore).toBeGreaterThan(stale.categoryScore);
+
+		expect(verified.check!.findings.some((f) => f.metadata?.certificateMatchVerified === true)).toBe(true);
+		expect(stale.check!.findings.some((f) => f.severity === 'high' && f.metadata?.certificateMatchVerified === false)).toBe(true);
+		// A mismatch is a MEASURED defect, not a missing control — the web-only critical-gap
+		// ceiling (64) must not arm on it.
+		expect(stale.result.score.overall).not.toBeNull();
+		expect(stale.result.score.overall!).toBeGreaterThan(64);
+	});
+
+	it('the probe is asked for the EXACT scanned host (the TLSA owner), port 443', async () => {
+		mockCleanScan(() => LEAF_SPKI_SHA256);
+		const binding = certProbe();
+		await daneFor('danehost.com', withProbe(binding));
+		const hosts = binding.fetch.mock.calls.map(([input]) => new URL(String(input)).searchParams.get('host'));
+		// Both `ssl` and `dane_https` consult the probe; every call pins the scanned host itself.
+		expect(hosts.length).toBeGreaterThanOrEqual(2);
+		expect(new Set(hosts)).toEqual(new Set(['danehost.com']));
+	});
+
+	it('binding absent → 95 present-not-verified (self-host posture), no probe involved', async () => {
+		mockCleanScan(() => STALE_SHA256);
+		const { categoryScore, check } = await daneFor('danenoprobe.com');
+		expect(categoryScore).toBe(95);
+		expect(check!.partial).toBeUndefined();
+		expect(check!.findings.find((f) => f.title.startsWith('DANE TLSA configured'))?.severity).toBe('low');
+	});
+
+	it('free tier → the paid-tier gate withholds the binding: no probe call, 95 unchanged', async () => {
+		mockCleanScan(() => STALE_SHA256);
+		const binding = certProbe();
+		const { categoryScore } = await daneFor('danefree.com', withProbe(binding, 'free'));
+		expect(binding.fetch).not.toHaveBeenCalled();
+		expect(categoryScore).toBe(95);
+	});
+
+	it('cold-cache pending probe → 100 unmeasured, check partial, category still completed', async () => {
+		mockCleanScan(() => STALE_SHA256);
+		const pending = probeBinding(() => ({ error: 'probe pending — cache warming' }));
+		const { categoryScore, check } = await daneFor('danepending.com', withProbe(pending));
+		expect(categoryScore).toBe(100);
+		expect(check!.partial).toBe(true);
+		expect(check!.checkStatus).toBeUndefined();
+		expect(check!.findings.find((f) => f.metadata?.inconclusive === true)?.metadata?.notAssessedReason).toBe('certificate_probe_pending');
+	});
+
+	it('no TLSA anywhere → the probe is only ever consulted by `ssl` (DANE stays lazy)', async () => {
+		mockCleanScan(() => null);
+		const binding = certProbe();
+		await daneFor('danelazy.com', withProbe(binding));
+		expect(binding.fetch).toHaveBeenCalledOnce();
+	});
+});

--- a/test/tls-probe-binding.spec.ts
+++ b/test/tls-probe-binding.spec.ts
@@ -287,3 +287,97 @@ describe('mergeTlsFinding', () => {
 		expect(merged.controlPresent).toBe(true);
 	});
 });
+
+// ---------------------------------------------------------------------------
+// servedCertificateFromProbe (#841) — projecting /probe onto the DANE check's input
+// ---------------------------------------------------------------------------
+describe('servedCertificateFromProbe', () => {
+	const cert = () => ({
+		host: 'example.com',
+		port: 443,
+		capturedAt: '2026-09-04T00:00:00.000Z',
+		leafDer: 'MAMCAQE=',
+		leafSpkiDer: 'MAMCAQE=',
+		leafSha256: 'aa'.repeat(32),
+		leafSha512: 'bb'.repeat(64),
+		leafSpkiSha256: 'cc'.repeat(32),
+		leafSpkiSha512: 'dd'.repeat(64),
+		chain: [
+			{ sha256: 'aa'.repeat(32), sha512: 'bb'.repeat(64), spkiSha256: 'cc'.repeat(32), spkiSha512: 'dd'.repeat(64), der: 'MAMCAQE=' },
+		],
+		subjectName: 'example.com',
+		subjectAlternativeNames: ['example.com', 'www.example.com'],
+	});
+
+	it('a certificate for the scanned host → the served certificate, chain projected verbatim', async () => {
+		const { servedCertificateFromProbe } = await fresh();
+		const out = servedCertificateFromProbe({ reachable: true, certificate: cert() }, 'example.com');
+		expect(out.certificateProbe).toBeUndefined();
+		expect(out.servedCertificate).toMatchObject({
+			host: 'example.com',
+			port: 443,
+			leafSha256: 'aa'.repeat(32),
+			leafSpkiSha256: 'cc'.repeat(32),
+			chain: [{ sha256: 'aa'.repeat(32), spkiSha256: 'cc'.repeat(32) }],
+			subjectAlternativeNames: ['example.com', 'www.example.com'],
+		});
+	});
+
+	it('host comparison is case-insensitive and ignores a trailing dot', async () => {
+		const { servedCertificateFromProbe } = await fresh();
+		const out = servedCertificateFromProbe({ certificate: { ...cert(), host: 'Example.COM.' } }, 'example.com');
+		expect(out.servedCertificate?.host).toBe('example.com');
+	});
+
+	it.each([
+		['a different host (www vs apex)', { certificate: { ...cert(), host: 'www.example.com' } }, 'certificate_host_mismatch'],
+		['a certificate with no host', { certificate: { ...cert(), host: undefined } }, 'certificate_host_mismatch'],
+		['a certificate block missing its leaf digests', { certificate: { host: 'example.com', port: 443 } }, 'certificate_probe_failed'],
+		['certificateError: off-host redirect', { certificateError: 'off-host redirect' }, 'off_host_redirect'],
+		['certificateError: anything else', { certificateError: 'no security state' }, 'certificate_probe_failed'],
+		['reachable: false', { reachable: false, error: 'connect timeout' }, 'host_unreachable'],
+		['no certificate block at all', { reachable: true, minVersion: 'TLS1.2' }, 'certificate_probe_failed'],
+	])('%s → failed, reason %s', async (_label, probe, reason) => {
+		const { servedCertificateFromProbe } = await fresh();
+		const out = servedCertificateFromProbe(probe as never, 'example.com');
+		expect(out.servedCertificate).toBeNull();
+		expect(out.certificateProbe).toBe('failed');
+		expect(out.certificateProbeReason).toBe(reason);
+	});
+
+	it('the cold-cache "pending" verdict → pending', async () => {
+		const { servedCertificateFromProbe } = await fresh();
+		const out = servedCertificateFromProbe({ error: 'probe pending — cache warming…' }, 'example.com');
+		expect(out.certificateProbe).toBe('pending');
+		expect(out.certificateProbeReason).toBe('certificate_probe_pending');
+	});
+
+	it('a null probe (binding failure) → failed', async () => {
+		const { servedCertificateFromProbe } = await fresh();
+		expect(servedCertificateFromProbe(null, 'example.com')).toEqual({
+			servedCertificate: null,
+			certificateProbe: 'failed',
+			certificateProbeReason: 'certificate_probe_failed',
+		});
+	});
+
+	it('callTlsProbe: a MALFORMED certificate block degrades to "no certificate" without losing the TLS-version fields', async () => {
+		const { callTlsProbe } = await fresh();
+		const binding = bindingReturning({
+			reachable: true,
+			minVersion: 'TLS1.2',
+			certificate: { host: 'example.com', port: '443', chain: 'nope' },
+		});
+		const out = await callTlsProbe(binding, STRONG_TLS_KEY, 'example.com');
+		expect(out).not.toBeNull();
+		expect(out!.minVersion).toBe('TLS1.2');
+		expect(out!.certificate).toBeUndefined();
+	});
+
+	it('callTlsProbe: a well-formed certificate block survives validation', async () => {
+		const { callTlsProbe } = await fresh();
+		const binding = bindingReturning({ reachable: true, minVersion: 'TLS1.2', certificate: cert(), certificateError: undefined });
+		const out = await callTlsProbe(binding, STRONG_TLS_KEY, 'example.com');
+		expect(out!.certificate?.leafSpkiSha256).toBe('cc'.repeat(32));
+	});
+});

--- a/test/tls-probe-binding.spec.ts
+++ b/test/tls-probe-binding.spec.ts
@@ -323,6 +323,14 @@ describe('servedCertificateFromProbe', () => {
 		});
 	});
 
+	it('projects chainTruncated / chainLength from the probe contract', async () => {
+		const { servedCertificateFromProbe } = await fresh();
+		const out = servedCertificateFromProbe({ certificate: { ...cert(), chainTruncated: true, chainLength: 11 } }, 'example.com');
+		expect(out.servedCertificate).toMatchObject({ chainTruncated: true, chainLength: 11 });
+		const plain = servedCertificateFromProbe({ certificate: cert() }, 'example.com');
+		expect(plain.servedCertificate?.chainTruncated).toBeUndefined();
+	});
+
 	it('host comparison is case-insensitive and ignores a trailing dot', async () => {
 		const { servedCertificateFromProbe } = await fresh();
 		const out = servedCertificateFromProbe({ certificate: { ...cert(), host: 'Example.COM.' } }, 'example.com');

--- a/test/tls-probe-binding.spec.ts
+++ b/test/tls-probe-binding.spec.ts
@@ -338,13 +338,13 @@ describe('servedCertificateFromProbe', () => {
 	});
 
 	it.each([
-		['a different host (www vs apex)', { certificate: { ...cert(), host: 'www.example.com' } }, 'certificate_host_mismatch'],
-		['a certificate with no host', { certificate: { ...cert(), host: undefined } }, 'certificate_host_mismatch'],
-		['a certificate block missing its leaf digests', { certificate: { host: 'example.com', port: 443 } }, 'certificate_probe_failed'],
+		['a different host (www vs apex)', { certificate: { ...cert(), host: 'www.example.com' } }, 'host_mismatch'],
+		['a certificate with no host', { certificate: { ...cert(), host: undefined } }, 'host_mismatch'],
+		['a certificate block missing its leaf digests', { certificate: { host: 'example.com', port: 443 } }, 'capture_failed'],
 		['certificateError: off-host redirect', { certificateError: 'off-host redirect' }, 'off_host_redirect'],
-		['certificateError: anything else', { certificateError: 'no security state' }, 'certificate_probe_failed'],
-		['reachable: false', { reachable: false, error: 'connect timeout' }, 'host_unreachable'],
-		['no certificate block at all', { reachable: true, minVersion: 'TLS1.2' }, 'certificate_probe_failed'],
+		['certificateError: anything else', { certificateError: 'no security state' }, 'capture_failed'],
+		['reachable: false', { reachable: false, error: 'connect timeout' }, 'unreachable'],
+		['no certificate block at all', { reachable: true, minVersion: 'TLS1.2' }, 'capture_failed'],
 	])('%s → failed, reason %s', async (_label, probe, reason) => {
 		const { servedCertificateFromProbe } = await fresh();
 		const out = servedCertificateFromProbe(probe as never, 'example.com');
@@ -360,12 +360,12 @@ describe('servedCertificateFromProbe', () => {
 		expect(out.certificateProbeReason).toBe('certificate_probe_pending');
 	});
 
-	it('a null probe (binding failure) → failed', async () => {
+	it('a null probe (binding failure) → failed, probe_unavailable', async () => {
 		const { servedCertificateFromProbe } = await fresh();
 		expect(servedCertificateFromProbe(null, 'example.com')).toEqual({
 			servedCertificate: null,
 			certificateProbe: 'failed',
-			certificateProbeReason: 'certificate_probe_failed',
+			certificateProbeReason: 'probe_unavailable',
 		});
 	});
 


### PR DESCRIPTION
Closes #841

## What happens

`check_dane_https` now **verifies** every TLSA association against the certificate the host actually serves, captured by bv-tls-probe over the operator-only `BV_TLS_PROBE` binding (paid-tier scans, launched only when TLSA records exist). The scoring inversion #841 measured — a stale DANE-EE pin at **100**, its removal at **95** — ends. The ladder is now monotone:

| state | before | after | finding |
| --- | ---: | ---: | --- |
| pin **verified** against the served certificate | 95 (1.18.0) | **100** | `info` "DANE TLSA verified against the served certificate", `certificateMatchVerified: true` |
| no TLSA record | 95 | **95** | unchanged `low` |
| pin **does not match** the served certificate | 95 (1.18.0) / 100 (pre-1.18) | **75** | `high` "DANE TLSA pin does not match the served certificate", `certificateMatchVerified: false`, `servedLeafSpkiSha256`, `pinned[]` |
| probe attempted, no certificate — **transient** (`certificate_probe_pending` cold cache, `capture_failed`, `unreachable`, `probe_unavailable` = binding 5xx/throw/timeout) | 95 | **95** | the SAME `low` "present, not verified" + `certificateProbe: 'pending' \| 'failed'` + `notAssessedReason`; `partial: true` (not cached, re-tried next scan); **no `checkStatus`, no `inconclusive`** |
| probe attempted, no certificate — **permanent** (`off_host_redirect`, `host_mismatch`) | 95 | **95** | same `low` + sub-state metadata; cached normally (no retry-forever) |
| TA pin (usage 0/2) absent from a **truncated** chain | — | **95** | same `low`, `notAssessedReason: 'chain_truncated'`, `chainTruncated: true`; cached normally |
| no probe capability (BSL self-hosts) / `check_dane` (SMTP/25) | 95 | **95** | bit-for-bit the 1.18.0 "present, not verified" `low` |

Every **unverified** state sits at 95 (the operator-ratified 1.18.0 posture): an attempted comparison that produced no answer is not better evidence than no comparison, so it never outranks the honest self-host disclosure. Only an actual comparison moves the score.

Direct bv-mcp callers see the same verdicts; the registry cache key splits on the binding (`dane_https:tls-probe`) exactly as `ssl` does.

## Contract (bv-tls-probe `/probe`, additive; sibling PR in bv-web-prod #2843)

```ts
certificate?: {
  host: string; port: number; capturedAt: string;
  leafDer: string; leafSpkiDer: string;                       // base64 DER
  leafSha256: string; leafSha512: string;                     // hex over leaf DER  (selector 0)
  leafSpkiSha256: string; leafSpkiSha512: string;             // hex over leaf SPKI (selector 1)
  chain: Array<{ sha256; sha512; spkiSha256; spkiSha512; der }>; // index 0 == leaf, whole served chain
  chainTruncated?: boolean; chainLength?: number;             // tail dropped past the probe's cap
  subjectName?; subjectAlternativeNames?; validFrom?; validTo?;
};
certificateError?: string; // 'off-host redirect', 'no security state', …
```

Every field is optional in the Zod schema (`.passthrough()`); a malformed `certificate` block is `.catch`-ed to "no certificate" so the TLS-version enrichment survives. `servedCertificateFromProbe` asserts `certificate.host === <scanned domain>` (apex and `www` can serve different certificates — the TLSA owner is `_443._tcp.<domain>`, so the probe host is exactly `<domain>`) and treats anything else as `failed`. bv-mcp never parses X.509: every comparison is digest / hex equality.

## Verification semantics (RFC 7671) — `verifyTlsaAssociations`

| usage | compared against | selector 0 | selector 1 | matching 0 | matching 1 | matching 2 |
| --- | --- | --- | --- | --- | --- | --- |
| 3 DANE-EE | the leaf | cert DER | SPKI DER | hex(base64→DER) == certData | SHA-256 | SHA-512 |
| 1 PKIX-EE | the leaf | cert DER | SPKI DER | same | SHA-256 | SHA-512 |
| 2 DANE-TA | **any** served chain entry (incl. leaf, §5.2) | cert DER | SPKI DER | same | SHA-256 | SHA-512 |
| 0 PKIX-TA | **any** served chain entry (incl. leaf) | cert DER | SPKI DER | same | SHA-256 | SHA-512 |

Comparison is case-insensitive and whitespace-tolerant. A record is **unmatched** only when every candidate it may match was compared and differs; one uncomparable candidate (out-of-range field, probe material absent, a non-leaf `spkiDer` for matching type 0, or a TA usage against a truncated chain) makes it **unverifiable** — never a broken pin. One matching association verifies the RRset (rollover sets list the stale members as `unmatchedAssociations`). Vectors were derived with OpenSSL from a throwaway P-256 certificate, so the comparison is proven against an independent implementation.

## Scoring impact + ceiling safety

`SCORING_MODEL_VERSION` 1.21.0 → **1.22.0** (history entry in `src/lib/scoring-version.ts`); `@blackveil/dns-checks` + `PARITY_CORPUS_VERSION` 1.33.0 → **1.34.0** (lock file untouched, as in #898). **No parity fixture moves** — the fixtures run without a probe and land on the unchanged 1.18.0 posture (verified locally, `parity-corpus.contract.test.ts` green).

- UPWARD 95 → 100 **only** for pins verified against the served certificate; DOWNWARD 95 → 75 **only** for measured mismatches (≈0.09 overall points either way at protective weight 2). Every unverified state is unchanged at 95, so self-hosts without the binding, and `check_dane` (port 25, which the HTTPS-only browser probe cannot serve), are bit-for-bit unchanged, and operator deploys move only on an actual comparison. Absence unchanged.
- **Ceiling safety.** `dane_https` is in `PROFILE_CRITICAL_CATEGORIES` for `non_mail` / `web_only`; a `high` that read as a missing control would cap the whole scan at 64. The mismatch prose is kept clear of the `MISSING_CONTROL_REGEX` triggers, declares no `missingControl`, and the pinned data (a zone-owner-controlled record token) is declared as `subjectTerms` so a record like `3 1 1 missing` cannot smuggle a trigger into the prose. Tests prove `findingsIndicateMissingControl` and `scoreIndicatesMissingControl` both decline, the category scores 75 / `passed: true`, and a `web_only` scan with a mismatch stays above 64 — at the package level and through the real scan path.
- No weight, tier, grade band, `SEVERITY_PENALTIES` entry or profile-detection rule changed. Population unmeasured against the corpus (DANE-for-HTTPS adoption ≈0%; the only measured instance is the issue's repro domain).
- **Maturity staging**: a DANE pin counts toward Stage 4 only when the finding carries `certificateMatchVerified: true` (`dane` or `dane_https`). The title regex that promoted unverified SMTP pins is gone.

## Scan wiring (every call site)

- `src/handlers/tools.ts` — `check_dane_https` registry entry: binding + token + telemetry, cache key split on the binding.
- `src/tools/scan-domain.ts` — `CHECK_DISPATCH.dane_https` (the single dispatch site, also used by `runCheckRetry`): `resolveTlsProbeOptions(rt)` (renamed from `resolveSslOptions`, same paid-tier gate as `ssl`) + per-check `signal` + `budgetMs`. The probe is a service binding the fetch budget cannot wrap, so `budget.signal()` caps it (the `check_ssl` lesson).
- `src/tools/scan/post-processing.ts` — `ScanRuntimeOptions.tlsProbeBinding` doc updated; `src/mcp/execute.ts` and `src/index.ts` already thread `tlsProbeBinding`/`tlsProbeAuthToken` through both passthroughs (no change needed — `scan_domain` spreads `runtimeOptions`).
- `src/tools/check-dane-https.ts` — the lazy `resolveServedCertificate` is handed to the package, which calls it only when TLSA records exist, so DANE-less domains (≈ all) never spend a Browser Rendering session.

## Tests

- `packages/dns-checks/src/__tests__/checks/dane-pin-verification.test.ts` (65) — the usage × selector × matching table (16 matched / 7 unmatched / 4 unverifiable vectors), rollover, truncation, subject-term smuggling, the ladder through `checkDANEHTTPS`, the `web_only` ceiling proof. `served-certificate.fixture.ts` carries the OpenSSL-derived material and the recipe.
- `packages/dns-checks/src/__tests__/checks/dane-honest-labeling.test.ts` — stale header corrected (the blocker it recorded was overturned on the issue); still pins the no-probe posture.
- `test/check-dane-https-pin-verification.spec.ts` (14) — wrapper ↔ probe contract: request shape, every outcome projection, laziness, binding-absent identity, budget signal, exhausted-budget abort.
- `test/scan-domain-dane-pin.integration.test.ts` (7) — verified 100 > absent 95 > mismatch 75 through the real scan path, exact-host probing, tier gate, pending → 95 + partial, off-host redirect → 95 not partial, laziness.
- `test/maturity-staging-dane-verified.spec.ts` (7) — the Stage-4 credit requires the marker.
- `test/tls-probe-binding.spec.ts` (+11) — `servedCertificateFromProbe`, schema leniency.
- Gates run: `npm run typecheck`, `npm run typecheck:tests` (ratchet OK), `npm run lint`, `npm run check:tool-surface` (counts unchanged), `npm -w packages/dns-checks test` (1017), `test/audits` + `test/contracts` (794), full `npm test` once — 8578 passed, 0 failed; the only red is the known fresh-worktree `wasm-integration` load artefact.

## Residuals

- **Probe contract**: non-leaf chain entries carry no `spkiDer`, so a TA pin with selector 1 + matching type 0 (full SPKI) against an intermediate is unverifiable (rare in practice — matching type 0 is already flagged `low`). Adding `spkiDer` per chain entry would close it.
- A transient probe outcome (the DEFAULT cold-cache "pending" path, unreachable, probe 5xx) marks the check `partial`, which also keeps the whole scan result out of the 5-min cache for that domain — bounded to paid-tier scans of TLSA-publishing domains, and the probe's own 60-min cache makes the re-try cheap. Permanent outcomes cache normally.
- `check_dane` (SMTP/25) stays "present, not verified" — a port-25 capture is a different probe.
- `src/tools/dane-analysis.ts` is a dead worker-side duplicate of the package analyzer (imported only by `test/dane-analysis.spec.ts`, still emitting the pre-1.18.0 `info`); untouched here, worth deleting separately per the duplicate-analyzer rule in `bv-mcp-scoring`.
- The maturity contract fixtures (`maturity-evidence-gating`, `maturity-staging-profile`, `cluster-3-canary`) still carry a marker-less `DANE TLSA configured` finding; they stay green because DANE was never the deciding signal in them, but they now exercise a credit that no longer exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
