### PR TITLE
fix(lookalikes): bound the DNS-phase fan-out to the Workers connection cap so throttling stops being self-inflicted (#865 follow-up)

### DIFF
--- a/src/lib/dns-transport.ts
+++ b/src/lib/dns-transport.ts
@@ -49,11 +49,14 @@ function retryDelay(attempt: number): Promise<void> {
  *
  * @param token - Optional auth token sent as `X-BV-Token` (for custom secondary resolvers).
  * @param useEdgeCache - If true, attaches Cloudflare `cf` cache directive. Omit for external origins.
+ * @param signal - Optional caller abort signal, composed with the per-fetch
+ *   timeout exactly as `queryDns` composes it for the primary fetch, so a
+ *   caller deadline bounds this fetch too. Absent → timeout alone (unchanged).
  */
 export async function fetchDohOutcome(
 	url: string,
 	timeoutMs: number,
-	opts?: { token?: string; useEdgeCache?: boolean; semaphore?: Semaphore },
+	opts?: { token?: string; useEdgeCache?: boolean; semaphore?: Semaphore; signal?: AbortSignal },
 ): Promise<DohOutcome> {
 	try {
 		const headers: Record<string, string> = { Accept: 'application/dns-json' };
@@ -62,11 +65,11 @@ export async function fetchDohOutcome(
 			fetch(url, {
 				method: 'GET',
 				headers,
-				signal: AbortSignal.timeout(timeoutMs),
+				signal: opts?.signal ? AbortSignal.any([AbortSignal.timeout(timeoutMs), opts.signal]) : AbortSignal.timeout(timeoutMs),
 				redirect: 'manual',
 				...(opts?.useEdgeCache ? { cf: { cacheTtl: DOH_EDGE_CACHE_TTL, cacheEverything: true } } : {}),
 			});
-		const response = opts?.semaphore ? await opts.semaphore.run(doFetch) : await doFetch();
+		const response = opts?.semaphore ? await opts.semaphore.run(doFetch, opts.signal) : await doFetch();
 		if (!response.ok) {
 			const status = response.status;
 			await disposeUnreadResponseBody(response);
@@ -170,9 +173,7 @@ async function queryDnsUncached(domain: string, type: RecordTypeName, dnssecChec
 		// Either firing aborts the fetch. AbortSignal.any is a standard Web API
 		// available in workerd; falls back gracefully if the caller didn't pass
 		// a signal (timeout alone).
-		const fetchSignal = callerSignal
-			? AbortSignal.any([AbortSignal.timeout(timeoutMs), callerSignal])
-			: AbortSignal.timeout(timeoutMs);
+		const fetchSignal = callerSignal ? AbortSignal.any([AbortSignal.timeout(timeoutMs), callerSignal]) : AbortSignal.timeout(timeoutMs);
 
 		try {
 			response = await guardedFetch(url, {
@@ -226,10 +227,20 @@ async function queryDnsUncached(domain: string, type: RecordTypeName, dnssecChec
 		const data = validated.data as DohResponse;
 
 		if (confirmWithSecondaryOnEmpty && !opts?.skipSecondaryConfirmation && !hasTypedAnswers(data, type)) {
-			const secondaryOpts = opts?.secondaryDoh
-				? { secondaryDoh: { url: opts.secondaryDoh.endpoint, token: opts.secondaryDoh.token } }
-				: undefined;
+			// The caller's signal rides into the secondary fetches too (PR #903
+			// review): without it, an empty primary answer let the confirmation
+			// arm its own fresh timer and run up to `timeoutMs` PAST the caller's
+			// deadline while holding a connection slot.
+			const secondaryOpts = {
+				...(opts?.secondaryDoh ? { secondaryDoh: { url: opts.secondaryDoh.endpoint, token: opts.secondaryDoh.token } } : {}),
+				...(callerSignal ? { signal: callerSignal } : {}),
+			};
 			const secondaryResult = await confirmWithSecondaryResolvers(domain, type, dnssecCheck, timeoutMs, sem, secondaryOpts);
+			// An aborted confirmation is NOT a confirmed-empty answer: the caller
+			// stopped the measurement, so it must see the abort, never `data`.
+			if (callerSignal?.aborted) {
+				throw new DnsQueryError(`DNS query aborted by caller`, domain, type);
+			}
 			if ('kind' in secondaryResult && secondaryResult.kind === 'unconfirmed') {
 				// Secondary confirmation unavailable — keep the primary result as-is.
 				// (Do NOT change primary to empty; primary is authoritative when we can't verify.)
@@ -259,18 +270,19 @@ export async function confirmWithSecondaryResolvers(
 	dnssecCheck: boolean,
 	timeoutMs: number,
 	sem?: Semaphore,
-	opts?: { secondaryDoh?: { url: string; token?: string } },
+	opts?: { secondaryDoh?: { url: string; token?: string }; signal?: AbortSignal },
 ): Promise<DohResponse | { kind: 'unconfirmed' }> {
 	const bvDnsUrl = opts?.secondaryDoh ? buildDohUrl(opts.secondaryDoh.url, domain, type, dnssecCheck) : null;
 	const googleUrl = buildDohUrl(GOOGLE_DOH_ENDPOINT, domain, type, dnssecCheck);
+	const signal = opts?.signal;
 	const candidates = [
 		bvDnsUrl
-			? fetchDohOutcome(bvDnsUrl, timeoutMs, { token: opts!.secondaryDoh!.token, semaphore: sem })
+			? fetchDohOutcome(bvDnsUrl, timeoutMs, { token: opts!.secondaryDoh!.token, semaphore: sem, signal })
 			: Promise.resolve({ kind: 'error', reason: 'network' } as const),
 		// No edge cache on the secondary: it's the rare fallback used precisely when
 		// the primary missed, so caching its responses risks persisting a transient
 		// empty at the edge for the cache TTL (#199).
-		fetchDohOutcome(googleUrl, timeoutMs, { semaphore: sem }),
+		fetchDohOutcome(googleUrl, timeoutMs, { semaphore: sem, signal }),
 	];
 	const results = await Promise.allSettled(candidates);
 	for (const r of results) {

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -48,6 +48,7 @@ import {
 	queryPrimaryMx,
 	queryPrimaryNs,
 	type LookalikeResult,
+	type UnresolvedByReason,
 } from './lookalike-dns';
 import { EMPTY_RDAP_PROBE, enrichLookalikes, probePrimaryRegistration } from './lookalike-enrichment';
 import {
@@ -110,6 +111,49 @@ const LOOKALIKE_TIMEOUT_MS = 20_000;
  * set into explicit `not_attempted` ages instead of a timed-out check.
  */
 const ENRICHMENT_RESERVE_MS = 4_000;
+
+/**
+ * Smallest enrichment window the DNS phases must leave open before
+ * `enrichmentDeadlineMs`. Sized for the RDAP pool (4-wide, ~0.5s per lookup —
+ * #894): a 25-candidate set, the #867 shape, ages in ~3–4s. The DNS phases are
+ * cut before they can eat into it; their victims are counted as unresolved
+ * with reason `deadline` (`lookalike-dns.ts`).
+ */
+const ENRICHMENT_MIN_WINDOW_MS = 4_000;
+
+/**
+ * Wall-clock budget for the DNS phases (wildcard canary, seed NS/MX, NS
+ * existence, A/MX detail), measured from `startedAt`: what remains of the
+ * outer timeout once enrichment's window and its reserve are set aside.
+ * Both DNS pools run six queries wide (the platform cap — #865), so a
+ * 90-permutation seed with 11 hanging names (openai.com, measured) needs
+ * ~6s for NS existence and ~5s for the detail probe of 54 registered
+ * candidates; a seed larger than that degrades to explicit `deadline` cuts
+ * instead of tripping the outer race, which discards every finding.
+ */
+const DNS_PHASES_BUDGET_MS = LOOKALIKE_TIMEOUT_MS - ENRICHMENT_RESERVE_MS - ENRICHMENT_MIN_WINDOW_MS;
+
+/**
+ * Most of {@link DNS_PHASES_BUDGET_MS} the NS-existence phase may consume,
+ * counted from the moment IT starts — not from `startedAt`. The wildcard
+ * canaries and the seed's own NS/MX lookups run first, and the seed lookups
+ * are deliberately resilient (#853: 5s × up to three attempts), so anchoring
+ * this phase on `startedAt` let a slow seed zone hand phase 1 a budget that
+ * was already spent (measured on a local build: 6 resolved / 83 `deadline`
+ * from one run, 54 / 27 from the next, same seed, minutes apart). The
+ * absolute {@link DNS_PHASES_BUDGET_MS} boundary still caps it, so enrichment's
+ * window is never eaten; the detail probe gets whatever remains, so a fast
+ * phase 1 is never penalised and a slow one cannot starve phase 2 of the
+ * registered candidates it already found. Sized from measurement: 90
+ * permutations at six wide with 11 hanging names (openai.com) took 5.0s.
+ */
+const NS_PHASE_BUDGET_MS = 6_000;
+
+/** Attach the per-reason unresolved tally beside a scan_status finding's `enumeration` (see the comment at the enumeration site below). */
+function withUnresolvedReasons(finding: Finding, unresolvedByReason: UnresolvedByReason): Finding {
+	finding.metadata = { ...finding.metadata, unresolvedByReason: { ...unresolvedByReason } };
+	return finding;
+}
 
 /**
  * Extract a specific candidate domain bv-recon's CT_LOOKALIKE hit names, if
@@ -224,8 +268,11 @@ async function checkLookalikesCore(
 	// that already takes seconds; a voided attribution costs the whole result.
 	const [primaryNsProbe, primaryMx] = await Promise.all([queryPrimaryNs(domain), queryPrimaryMx(domain)]);
 
-	// Phase 1: Fast NS existence check — filter out unregistered domains.
-	const nsResult = await filterByNsExistence(permsToProbe);
+	// Phase 1: NS existence check — filter out unregistered domains. Pooled to
+	// the platform connection cap and deadline-cut (#865): see lookalike-dns.ts.
+	const dnsPhasesDeadlineMs = startedAt + DNS_PHASES_BUDGET_MS;
+	const nsPhaseDeadlineMs = Math.min(dnsPhasesDeadlineMs, Date.now() + NS_PHASE_BUDGET_MS);
+	const nsResult = await filterByNsExistence(permsToProbe, { deadlineMs: nsPhaseDeadlineMs });
 	const { registered: registeredPerms, nsMap: lookalikeNsMap, unresolved: nsUnresolved } = nsResult;
 	const primaryNs = primaryNsProbe.ns;
 	// #832 — the seed's own NS lookup failed, so the ownership comparison has
@@ -235,8 +282,35 @@ async function checkLookalikesCore(
 	const seedNsUnmeasured = !primaryNsProbe.resolved;
 
 	if (registeredPerms.length === 0) {
-		findings.push(buildNoRegisteredCandidatesFinding(domain, permutations.length));
-		return buildCheckResult('lookalikes', findings);
+		if (nsUnresolved === 0) {
+			findings.push(buildNoRegisteredCandidatesFinding(domain, permutations.length));
+			return buildCheckResult('lookalikes', findings);
+		}
+		// #865 follow-up — this return used to say "No active registrations
+		// detected", `deterministic`, even when EVERY lookup went unresolved: a
+		// run whose phase 1 was entirely cut reported a clean estate, and the
+		// unresolved count never reached the response (the enumeration contract
+		// below is only built once a candidate exists). Same law as #781: an
+		// unmeasured set is a SAMPLE, and a fully unmeasured one is no sample at
+		// all. Partial, so the non-answer is not cached for the TTL.
+		const nsOnlyEnumeration = {
+			permutationsGenerated: permutations.length,
+			permutationsProbed: permsToProbe.length,
+			candidatesResolved: 0,
+			unresolvedCount: nsUnresolved,
+			complete: false,
+		};
+		if (nsUnresolved < permsToProbe.length) {
+			// Some lookups DID measure an absence — say so, but not as a certainty
+			// about the set.
+			const none = buildNoRegisteredCandidatesFinding(domain, permutations.length);
+			none.metadata = { ...none.metadata, confidence: 'heuristic' };
+			findings.push(none);
+		}
+		findings.push(withUnresolvedReasons(buildIncompleteEnumerationFinding(domain, nsOnlyEnumeration), nsResult.unresolvedByReason));
+		const result = buildCheckResult('lookalikes', findings);
+		result.partial = true;
+		return result;
 	}
 
 	// D4 (2026-07-26 correctness-defects design) — classify every registered
@@ -267,8 +341,8 @@ async function checkLookalikesCore(
 		);
 	}
 
-	// Phase 2: Detail probe only registered domains
-	const probeResults = await probeWithAdaptiveBatching(registeredPerms);
+	// Phase 2: Detail probe only registered domains (pooled + deadline-cut, #865).
+	const probeResults = await probeWithAdaptiveBatching(registeredPerms, { deadlineMs: dnsPhasesDeadlineMs });
 	const results: LookalikeResult[] = [];
 	for (const result of probeResults) {
 		if (result.status === 'fulfilled') {
@@ -305,6 +379,18 @@ async function checkLookalikesCore(
 		unresolvedCount: nsUnresolved + probeUnresolved + infraUnknownCount,
 		complete: nsUnresolved + probeUnresolved + infraUnknownCount === 0,
 	};
+	// WHY the unresolved ones are unresolved (#865 follow-up): a resolver that
+	// never answered (`timeout`), a phase deadline cut (`deadline`), or a
+	// transport failure (`failed`). Kept BESIDE `enumeration`, not inside it —
+	// the five-key enumeration object is the contract #892's rollup reads and
+	// consumers diff — and attached to the scan_status findings below, whose
+	// builders live in `lookalike-summary-findings.ts` (owned by #865/#863;
+	// annotated here rather than there). Sums to `unresolvedCount`.
+	const unresolvedByReason: UnresolvedByReason = { ...nsResult.unresolvedByReason };
+	for (const r of results) {
+		if (r.probeDegraded) unresolvedByReason[r.probeDegradedReason ?? 'failed']++;
+	}
+	unresolvedByReason.failed += probeUnresolved;
 
 	// #864 — second attribution pass. The NS-only pass above cannot see a
 	// same-entity domain on a DIFFERENT DNS platform (amazon.com.au on amzndns.*
@@ -558,7 +644,11 @@ async function checkLookalikesCore(
 	// seed label permit a count; otherwise a not-assessed notice, never an
 	// integer.
 	const rollup = buildThreatRollupFinding({ seedDomain: domain, seedLabel: brand, members: rollupMembers, enumeration });
-	if (rollup.finding) findings.push(rollup.finding);
+	if (rollup.finding) {
+		findings.push(
+			rollup.notAssessedReason === 'enumeration_throttled' ? withUnresolvedReasons(rollup.finding, unresolvedByReason) : rollup.finding,
+		);
+	}
 
 	// If no active lookalikes found
 	if (findings.length === 0) {
@@ -579,7 +669,7 @@ async function checkLookalikesCore(
 	}
 
 	if (!enumeration.complete) {
-		findings.push(buildIncompleteEnumerationFinding(domain, enumeration));
+		findings.push(withUnresolvedReasons(buildIncompleteEnumerationFinding(domain, enumeration), unresolvedByReason));
 	}
 
 	// Recon enrichment: additive-only, fail-soft.

--- a/src/tools/lookalike-dns.ts
+++ b/src/tools/lookalike-dns.ts
@@ -3,22 +3,50 @@
 /**
  * DNS resolution layer for the lookalike check.
  *
- * Extracted VERBATIM from `check-lookalikes.ts` (pure split, no behaviour
- * change): everything here is the "does this candidate exist, and what
- * infrastructure does it carry" question — NS existence filtering, the
- * wildcard-parent canary probe, the adaptive-batching A/MX detail probe, and
- * the two seed-side queries (`NS` for the ownership verdict, `MX` for the D4
- * overlap corroboration signal).
+ * Extracted from `check-lookalikes.ts`: everything here is the "does this
+ * candidate exist, and what infrastructure does it carry" question — NS
+ * existence filtering, the wildcard-parent canary probe, the adaptive-batching
+ * A/MX detail probe, and the two seed-side queries (`NS` for the ownership
+ * verdict, `MX` for the D4 overlap corroboration signal).
  *
  * Nothing in this module builds a Finding, decides a severity, or makes an
  * ownership claim — it only measures. The tuning constants live here rather
  * than in the orchestrator because they are properties of the query plane, and
  * `test/check-lookalikes.spec.ts` pins their exact values through the tool's
  * re-export.
+ *
+ * ⚠️ FAN-OUT IS BOUNDED, AND THE BOUND IS THE PLATFORM'S (#865 — the DNS half
+ * of #867). A Worker invocation may hold at most SIX connections simultaneously
+ * (developers.cloudflare.com/workers/platform/limits/#simultaneous-open-connections);
+ * further `fetch()` calls QUEUE, with whatever timer the caller armed already
+ * running. Phase 1 used to dispatch every permutation's NS query at once
+ * (`Promise.allSettled(domains.map(...))`, ~90 fetches) and the detail probe
+ * 20 A/MX queries per batch, each arming `AbortSignal.timeout` at call time.
+ * Any permutation whose authoritative servers are lame or slow then holds its
+ * slot for the WHOLE timer window, so a handful of them parks every slot and
+ * the queue behind them aborts before a single byte is sent — and the tool
+ * reports the names it never asked about as "DNS timeout or rate limiting".
+ *
+ * Measured 2026-09-04: openai.com has 11 of 90 permutations whose NS lookup
+ * hangs to the 2s timer even when queried ALONE. Replaying the measured
+ * per-name latencies through a six-slot FIFO with pre-armed timers predicts
+ * 70 unresolved; production reported 76 (#865: 77). The same code on an
+ * uncapped local workerd against the same resolver: 12 unresolved, 54
+ * candidates. Ninety simultaneous queries from Node: zero HTTP 429. The
+ * resolver was never refusing the burst; the platform queue was — and #892's
+ * rollup then abstained at ≥ 50% unresolved, an abstention the tool inflicted
+ * on itself.
+ *
+ * Every DoH fan-out here now runs through a {@link LOOKALIKE_DNS_PROBE_CONCURRENCY}-
+ * wide pool, arms its timers when the query is actually dispatched, and is
+ * cut by a per-phase deadline whose victims are COUNTED, with a reason — never
+ * dropped, never recorded as "no NS". Do not re-introduce a
+ * `domains.map(queryDns...)` fan-out anywhere in this module.
  */
 
-import { queryDnsRecords, queryMxRecords, queryTxtRecords } from '../lib/dns';
+import { DnsQueryError, queryDnsRecords, queryMxRecords, queryTxtRecords } from '../lib/dns';
 import type { QueryDnsOptions } from '../lib/dns-types';
+import { mapConcurrent } from '../lib/map-concurrent';
 import { isInBailiwick, parseDmarcReportReceivers, type DmarcReportAuthorisation } from '../lib/ownership-attribution';
 import { getRegistrableDomain } from '../lib/public-suffix';
 
@@ -37,6 +65,110 @@ export const PHASE1_DNS_OPTS: QueryDnsOptions = {
 	retries: 0,
 	skipSecondaryConfirmation: true,
 };
+
+/**
+ * DNS options for the Phase 2 A/MX legs of a REGISTERED candidate. The default
+ * per-attempt timer and the secondary-resolver confirmation on an empty answer
+ * are kept (an empty A/MX is a measurement, and it is worth confirming), but
+ * there is NO retry: a candidate whose NS answered from the parent zone while
+ * its own servers are lame hangs BOTH legs, and with the default single retry
+ * each leg held one of the six connection slots for 3s + 3s. Eleven such
+ * candidates in a 54-candidate seed (openai.com, measured) spent the whole
+ * phase budget on names that were never going to answer, and the budget cuts
+ * landed on candidates that would have. #853's case for retries is the SEED's
+ * lookups, which gate every verdict; a candidate leg is one disposable
+ * permutation and its failure is COUNTED (`probeDegradedReason`), not lost.
+ */
+export const PHASE2_DNS_OPTS: QueryDnsOptions = {
+	retries: 0,
+};
+
+/**
+ * Width of every DoH pool in this module, counted in QUERIES in flight (not
+ * candidates): the Workers simultaneous-open-connection cap is six, and the
+ * DNS phases run alone — phase 0 (seed NS/MX) is awaited before phase 1, the
+ * detail probe follows phase 1, enrichment (`lookalike-enrichment.ts`, whose
+ * two pools also sum to six) follows the detail probe — so each phase owns
+ * the whole budget. Retries and the secondary-resolver confirmation happen
+ * SEQUENTIALLY inside one query, so a pooled query never holds more than one
+ * connection. Not `SCAN_DNS_CONCURRENCY` (12): `check_lookalikes` is
+ * `scanIncluded: false` and never competes with a scan.
+ *
+ * Do not widen past six: `test/check-lookalikes-dns-starvation.spec.ts` runs
+ * the pool against an emulated six-slot runtime and turns red the moment
+ * anything queues.
+ */
+export const LOOKALIKE_DNS_PROBE_CONCURRENCY = 6;
+
+/**
+ * Why a DNS probe did not produce a measurement.
+ *
+ *  - `timeout`  — the resolver never answered within the per-query timer
+ *                 (`PHASE1_DNS_OPTS.timeoutMs` / `DNS_TIMEOUT_MS`), the query
+ *                 having been dispatched with a free connection slot.
+ *  - `deadline` — the phase deadline cut it: either its turn came after the
+ *                 deadline (never issued) or it was aborted mid-flight.
+ *  - `failed`   — transport error, non-2xx DoH response, or unparseable body.
+ *
+ * Reported per phase so a consumer can tell "the resolver is slow for these
+ * names" from "this run was budget-cut" — the two need different responses
+ * (re-run vs. nothing to do) and #865's rollup abstention hides the difference.
+ */
+export type DnsProbeFailureReason = 'timeout' | 'deadline' | 'failed';
+
+/** Per-reason tally of unresolved probes for one phase. */
+export type UnresolvedByReason = Record<DnsProbeFailureReason, number>;
+
+/** A zeroed {@link UnresolvedByReason}. */
+export function emptyUnresolvedByReason(): UnresolvedByReason {
+	return { timeout: 0, deadline: 0, failed: 0 };
+}
+
+export interface DnsPhaseOptions {
+	/**
+	 * Wall-clock deadline (epoch ms) for the phase. A query whose turn comes
+	 * after it is NOT issued (`deadline`); a query dispatched before it carries
+	 * a caller-abort signal armed at dispatch, so the deadline bounds the whole
+	 * query including retries and secondary confirmation. Absent → each query
+	 * gets its full per-query budget (direct callers).
+	 */
+	deadlineMs?: number;
+}
+
+/** Milliseconds left before `deadlineMs`; +Infinity when there is no deadline. */
+function remainingMs(deadlineMs: number | undefined): number {
+	return typeof deadlineMs === 'number' ? deadlineMs - Date.now() : Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Caller-abort signal for ONE dispatched query, armed HERE — inside a pool
+ * worker, once a connection slot is free — never at enqueue. The transport
+ * composes it with its own per-attempt timer (`AbortSignal.any`) and a caller
+ * abort short-circuits its retry loop. `undefined` when there is no deadline.
+ */
+function deadlineSignal(deadlineMs: number | undefined): AbortSignal | undefined {
+	if (typeof deadlineMs !== 'number') return undefined;
+	return AbortSignal.timeout(Math.max(1, deadlineMs - Date.now()));
+}
+
+/**
+ * Classify a rejected query. The deadline signal is authoritative: a query it
+ * aborted is a budget cut, whatever the transport called it. A per-attempt
+ * timer expiry surfaces as `DNS query timed out after Nms` OR — because
+ * `AbortSignal.timeout()` rejects with a `TimeoutError`, not the `AbortError`
+ * the transport's retry branch tests for — as `DNS query failed: The operation
+ * was aborted due to timeout`; both are the resolver not answering.
+ */
+function classifyDnsFailure(err: unknown, deadline: AbortSignal | undefined): DnsProbeFailureReason {
+	if (deadline?.aborted) return 'deadline';
+	if (err instanceof DnsQueryError && /timed out|timeout/i.test(err.message)) return 'timeout';
+	return 'failed';
+}
+
+/** The "never measured" candidate shape: no positive signal, no measured absence, and the reason it is neither. */
+function unmeasuredResult(domain: string, reason: DnsProbeFailureReason): LookalikeResult {
+	return { domain, hasA: false, hasMX: false, mxExchanges: [], probeDegraded: true, probeDegradedReason: reason };
+}
 
 /**
  * Resilient DNS options for the SEED domain's own NS/MX lookups (#853).
@@ -69,6 +201,8 @@ export interface LookalikeResult {
 	 * compile a non-answer into a custody record.
 	 */
 	probeDegraded: boolean;
+	/** Why the probe is degraded (present iff `probeDegraded`). See {@link DnsProbeFailureReason}. */
+	probeDegradedReason?: DnsProbeFailureReason;
 }
 
 /**
@@ -106,23 +240,59 @@ function extractMxExchange(raw: string): string | null {
 	return target;
 }
 
+/** One leg of a candidate's detail probe, as the pool sees it. */
+type DetailLegOutcome = { ok: true; records: string[] } | { ok: false; reason: DnsProbeFailureReason };
+
+/** Worst-first precedence when both legs of a candidate degraded: a budget cut outranks a resolver timeout outranks a transport failure. */
+function worstReason(a: DnsProbeFailureReason | undefined, b: DnsProbeFailureReason | undefined): DnsProbeFailureReason | undefined {
+	const rank: Record<DnsProbeFailureReason, number> = { deadline: 3, timeout: 2, failed: 1 };
+	if (!a) return b;
+	if (!b) return a;
+	return rank[a] >= rank[b] ? a : b;
+}
+
 /**
- * Check a single lookalike domain for DNS and MX records.
- * Filters out null MX records (RFC 7505) to avoid false positives.
+ * Detail-probe one batch of registered candidates: A + MX per candidate,
+ * flattened to individual queries and run through the connection-cap pool
+ * (two candidate legs are independent, so flattening keeps every slot busy
+ * where a per-candidate pool of three would idle one whenever the legs finish
+ * apart). Filters out null MX records (RFC 7505) to avoid false positives.
+ *
+ * Both legs run on {@link PHASE2_DNS_OPTS}: the default per-attempt timer and
+ * the secondary confirmation on empty are kept, so the measurement semantics
+ * of `hasA` / `hasMX` are unchanged; the retry is dropped (see the preset).
  */
-async function probeLookalike(domain: string): Promise<LookalikeResult> {
-	const [aRecords, mxRecords] = await Promise.allSettled([queryDnsRecords(domain, 'A'), queryDnsRecords(domain, 'MX')]);
-
-	const realMxRecords = mxRecords.status === 'fulfilled' ? mxRecords.value.filter(isRealMxRecord) : [];
-	const mxExchanges = realMxRecords.map(extractMxExchange).filter((host): host is string => host !== null);
-
-	return {
-		domain,
-		hasA: aRecords.status === 'fulfilled' && aRecords.value.length > 0,
-		hasMX: realMxRecords.length > 0,
-		mxExchanges,
-		probeDegraded: aRecords.status === 'rejected' || mxRecords.status === 'rejected',
-	};
+async function probeDetailBatch(batch: string[], deadlineMs: number | undefined): Promise<LookalikeResult[]> {
+	const legs = batch.flatMap((domain) => [
+		{ domain, type: 'A' as const },
+		{ domain, type: 'MX' as const },
+	]);
+	const outcomes = await mapConcurrent(legs, LOOKALIKE_DNS_PROBE_CONCURRENCY, async (leg): Promise<DetailLegOutcome> => {
+		if (remainingMs(deadlineMs) <= 0) return { ok: false, reason: 'deadline' };
+		// Armed HERE, at dispatch — the pool guarantees a connection slot is free.
+		const deadline = deadlineSignal(deadlineMs);
+		try {
+			const records = await queryDnsRecords(leg.domain, leg.type, deadline ? { ...PHASE2_DNS_OPTS, signal: deadline } : PHASE2_DNS_OPTS);
+			return { ok: true, records };
+		} catch (err) {
+			return { ok: false, reason: classifyDnsFailure(err, deadline) };
+		}
+	});
+	return batch.map((domain, i) => {
+		const a = outcomes[2 * i];
+		const mx = outcomes[2 * i + 1];
+		const realMxRecords = mx.ok ? mx.records.filter(isRealMxRecord) : [];
+		const mxExchanges = realMxRecords.map(extractMxExchange).filter((host): host is string => host !== null);
+		const reason = worstReason(a.ok ? undefined : a.reason, mx.ok ? undefined : mx.reason);
+		return {
+			domain,
+			hasA: a.ok && a.records.length > 0,
+			hasMX: realMxRecords.length > 0,
+			mxExchanges,
+			probeDegraded: reason !== undefined,
+			...(reason !== undefined ? { probeDegradedReason: reason } : {}),
+		};
+	});
 }
 
 /**
@@ -147,10 +317,18 @@ export function getParentDomain(domain: string): string {
  */
 export async function detectWildcardParents(parentDomains: string[]): Promise<Set<string>> {
 	const wildcardParents = new Set<string>();
-	const probes = parentDomains.map(async (parent) => {
+	// A long brand yields one dot-insertion parent per label position, so this
+	// is pooled like every other fan-out here (a 16-label brand is 16 canaries),
+	// and it runs on the lean Phase-1 preset: it precedes the NS phase, whose
+	// budget it would otherwise eat — a canary under a lame parent zone used to
+	// cost 3s + one retry + a secondary-resolver confirmation, ~7s, before the
+	// first permutation was ever asked about. A canary that fails is "not a
+	// wildcard", which only means the parent's permutations get probed like any
+	// other; nothing is concluded from it.
+	await mapConcurrent(parentDomains, LOOKALIKE_DNS_PROBE_CONCURRENCY, async (parent) => {
 		try {
 			const canary = `${WILDCARD_CANARY_LABEL}.${parent}`;
-			const records = await queryDnsRecords(canary, 'A');
+			const records = await queryDnsRecords(canary, 'A', PHASE1_DNS_OPTS);
 			if (records.length > 0) {
 				wildcardParents.add(parent);
 			}
@@ -158,40 +336,60 @@ export async function detectWildcardParents(parentDomains: string[]): Promise<Se
 			// Query failed — not a wildcard
 		}
 	});
-	await Promise.allSettled(probes);
 	return wildcardParents;
 }
 
+/** Outcome of the pooled Phase 1 result: either a measured NS answer, or why there is none. */
+type NsExistenceOutcome =
+	{ domain: string; measured: true; ns: string[] } | { domain: string; measured: false; reason: DnsProbeFailureReason };
+
 /**
- * Phase 1: Fast NS existence check for all domains in parallel.
- * Returns only domains that have NS records (i.e., are registered),
- * along with their normalized NS record data for ownership comparison.
+ * Phase 1: NS existence check for all domains through the connection-cap
+ * pool. Returns only domains that have NS records (i.e., are registered),
+ * along with their normalized NS record data for ownership comparison, plus
+ * the count — and the reasons — of lookups that produced NO measurement.
+ *
+ * A REJECTED NS lookup is not "unregistered" — it is UNKNOWN, and dropping it
+ * silently is the primary source of run-to-run variance (#781). This phase
+ * gates everything downstream, so a timed-out NS query makes a registered
+ * domain vanish from the result set entirely, with nothing in the response
+ * distinguishing that from a deregistration. Measured on openclaw.ai: three
+ * `force_refresh` runs minutes apart returned 12, 10 and 13 candidates, with
+ * three names appearing only in the third. The same law applies to a lookup
+ * the phase deadline cut: counted, with reason `deadline`, never "no NS".
  */
 export async function filterByNsExistence(
 	domains: string[],
-): Promise<{ registered: string[]; nsMap: Map<string, Set<string>>; unresolved: number }> {
+	options: DnsPhaseOptions = {},
+): Promise<{ registered: string[]; nsMap: Map<string, Set<string>>; unresolved: number; unresolvedByReason: UnresolvedByReason }> {
 	const nsMap = new Map<string, Set<string>>();
-	const results = await Promise.allSettled(
-		domains.map(async (domain) => {
-			const ns = await queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS);
-			if (ns.length > 0) {
-				nsMap.set(domain, normalizeNsSet(ns));
-			}
-			return { domain, hasNs: ns.length > 0 };
-		}),
-	);
-	const registered = results
-		.filter((r): r is PromiseFulfilledResult<{ domain: string; hasNs: boolean }> => r.status === 'fulfilled' && r.value.hasNs)
-		.map((r) => r.value.domain);
-	// A REJECTED NS lookup is not "unregistered" — it is UNKNOWN, and dropping it
-	// silently is the primary source of run-to-run variance (#781). This phase
-	// gates everything downstream, so a timed-out NS query makes a registered
-	// domain vanish from the result set entirely, with nothing in the response
-	// distinguishing that from a deregistration. Measured on openclaw.ai: three
-	// `force_refresh` runs minutes apart returned 12, 10 and 13 candidates, with
-	// three names appearing only in the third.
-	const unresolved = results.filter((r) => r.status === 'rejected').length;
-	return { registered, nsMap, unresolved };
+	const outcomes = await mapConcurrent(domains, LOOKALIKE_DNS_PROBE_CONCURRENCY, async (domain): Promise<NsExistenceOutcome> => {
+		if (remainingMs(options.deadlineMs) <= 0) return { domain, measured: false, reason: 'deadline' };
+		// Armed HERE, at dispatch — the pool guarantees a connection slot is free,
+		// so both this signal and the transport's PHASE1 timer measure the
+		// resolver, not a queue.
+		const deadline = deadlineSignal(options.deadlineMs);
+		try {
+			const ns = await queryDnsRecords(domain, 'NS', deadline ? { ...PHASE1_DNS_OPTS, signal: deadline } : PHASE1_DNS_OPTS);
+			return { domain, measured: true, ns };
+		} catch (err) {
+			return { domain, measured: false, reason: classifyDnsFailure(err, deadline) };
+		}
+	});
+	const registered: string[] = [];
+	const unresolvedByReason = emptyUnresolvedByReason();
+	for (const outcome of outcomes) {
+		if (!outcome.measured) {
+			unresolvedByReason[outcome.reason]++;
+			continue;
+		}
+		if (outcome.ns.length > 0) {
+			nsMap.set(outcome.domain, normalizeNsSet(outcome.ns));
+			registered.push(outcome.domain);
+		}
+	}
+	const unresolved = unresolvedByReason.timeout + unresolvedByReason.deadline + unresolvedByReason.failed;
+	return { registered, nsMap, unresolved, unresolvedByReason };
 }
 
 /**
@@ -331,26 +529,52 @@ export async function queryPrimaryMx(domain: string): Promise<Set<string>> {
 }
 
 /**
- * Run permutation probes with adaptive batch sizing and backoff.
- * Starts at INITIAL_BATCH_SIZE, halves on repeated failures (floor at MIN_BATCH_SIZE),
- * recovers on clean batches.
+ * Phase 2: detail-probe (A + MX) the registered candidates in batches of up to
+ * INITIAL_BATCH_SIZE, each batch through the connection-cap pool. Halves the
+ * batch on repeated failures (floor at MIN_BATCH_SIZE) with a BACKOFF_DELAY_MS
+ * pause, and recovers on clean batches.
+ *
+ * "Failure" here is a candidate whose A or MX leg the resolver did not answer
+ * (`timeout` / `failed`). The pre-pool version counted REJECTED per-candidate
+ * promises — which could never occur, because the per-candidate probe settled
+ * both legs internally — so the backoff was unreachable, and it hid a second
+ * defect: the loop advanced by the NEW batch size after halving, so a live
+ * backoff would have re-probed half of the batch it had just finished. Both
+ * fixed here; a deadline cut is not a resolver failure and never triggers a
+ * backoff (there is nothing left to be polite about).
+ *
+ * Every candidate comes back FULFILLED — a degraded one carries
+ * `probeDegraded: true` + `probeDegradedReason`. The `PromiseSettledResult`
+ * return shape is kept for the orchestrator's existing accounting.
  */
-export async function probeWithAdaptiveBatching(permutations: string[]): Promise<PromiseSettledResult<LookalikeResult>[]> {
+export async function probeWithAdaptiveBatching(
+	permutations: string[],
+	options: DnsPhaseOptions = {},
+): Promise<PromiseSettledResult<LookalikeResult>[]> {
 	const allResults: PromiseSettledResult<LookalikeResult>[] = [];
 	let batchSize = INITIAL_BATCH_SIZE;
 	let delayMs = 0;
 
-	for (let i = 0; i < permutations.length; i += batchSize) {
+	let i = 0;
+	while (i < permutations.length) {
+		if (remainingMs(options.deadlineMs) <= 0) {
+			// Budget spent: everything left is UNMEASURED with a stated reason —
+			// never dropped, never reported as registered-but-dark.
+			for (const domain of permutations.slice(i)) {
+				allResults.push({ status: 'fulfilled', value: unmeasuredResult(domain, 'deadline') });
+			}
+			break;
+		}
 		if (delayMs > 0) {
 			await new Promise((resolve) => setTimeout(resolve, delayMs));
 		}
 
 		const batch = permutations.slice(i, i + batchSize);
-		const batchResults = await Promise.allSettled(batch.map((d) => probeLookalike(d)));
-		allResults.push(...batchResults);
+		i += batch.length;
+		const batchResults = await probeDetailBatch(batch, options.deadlineMs);
+		for (const value of batchResults) allResults.push({ status: 'fulfilled', value });
 
-		// Count failures in this batch
-		const failures = batchResults.filter((r) => r.status === 'rejected').length;
+		const failures = batchResults.filter((r) => r.probeDegraded && r.probeDegradedReason !== 'deadline').length;
 		if (failures > FAILURE_THRESHOLD) {
 			// Back off: halve batch size (floor to MIN_BATCH_SIZE) and add delay
 			batchSize = Math.max(MIN_BATCH_SIZE, Math.floor(batchSize / 2));

--- a/src/tools/lookalike-enrichment.ts
+++ b/src/tools/lookalike-enrichment.ts
@@ -362,10 +362,16 @@ export async function probePrimaryRegistration(domain: string, options: Enrichme
  *
  * A probe whose turn comes after `deadlineMs` is NOT issued and reports `true`
  * — "unknown" must fail toward the safe side, never toward the HIGH corroborator.
+ * The same law for a probe that TIMES OUT (#894 residual 2): a host that has
+ * not answered within the budget is unknown, not "no content" — a slow parked
+ * host and a slow real one look identical from here. Only a MEASURED refusal
+ * (reset, refused, TLS failure, no route) is the no-content signal.
  */
 export async function probeHasWebContent(domain: string, deadlineMs?: number): Promise<boolean> {
 	const budgetMs = remainingBudgetMs(WEB_PROBE_TIMEOUT_MS, deadlineMs);
 	if (budgetMs <= 0) return true;
+	// Armed HERE, at dispatch — the pool guarantees a connection slot is free (#867).
+	const signal = AbortSignal.timeout(budgetMs);
 	try {
 		// safeFetch + manual redirect: the candidate is attacker-influenced, so we
 		// MUST NOT auto-follow a 302 → internal/Cloudflare host (blind SSRF oracle,
@@ -375,12 +381,13 @@ export async function probeHasWebContent(domain: string, deadlineMs?: number): P
 		const resp = await safeFetch(`https://${domain}/`, {
 			method: 'HEAD',
 			redirect: 'manual',
-			signal: AbortSignal.timeout(budgetMs),
+			signal,
 		});
 		// Any HTTP response (incl. 3xx) means the host is reachable — content exists.
 		return Boolean(resp);
 	} catch {
-		// Transport failure (refused, timeout, DNS) — treat as no content (HIGH corroborator).
-		return false;
+		// Timed out → unknown → `true` (never the HIGH corroborator).
+		// Measured transport refusal (reset, refused, DNS/TLS failure) → no content.
+		return signal.aborted;
 	}
 }

--- a/test/check-lookalikes-dns-starvation.spec.ts
+++ b/test/check-lookalikes-dns-starvation.spec.ts
@@ -1,0 +1,494 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// Regression for the DNS-phase half of #867 / #865 (the residual PR #894 left).
+//
+// `filterByNsExistence` dispatched EVERY permutation's NS query at once
+// (`Promise.allSettled(domains.map(...))`) with `AbortSignal.timeout(2000)`
+// armed at call time, and `probeWithAdaptiveBatching` did the same for a
+// 10-candidate batch (20 A/MX queries plus their secondary confirmations). A
+// Worker invocation may hold at most SIX connections simultaneously
+// (developers.cloudflare.com/workers/platform/limits/#simultaneous-open-connections);
+// the rest queue with their timers already running. Any permutation whose
+// authoritative servers are lame or slow holds its slot for the WHOLE 2s
+// window, so a handful of them parks every slot and the queue behind them
+// aborts before a single byte is sent.
+//
+// Measured 2026-09-04 (the numbers in the PR): openai.com has 11 of 90
+// permutations whose NS lookup hangs to the 2s timer even when queried ALONE.
+// Replaying the measured per-name latencies through a six-slot FIFO with
+// pre-armed timers predicts 70 unresolved; production reported 76 (#865: 77).
+// The same code on an uncapped local workerd against the same resolver:
+// 12 unresolved, 54 candidates — so the resolver is not refusing the burst
+// (90 simultaneous queries from Node: zero HTTP 429); the platform queue is.
+// #892's rollup then abstains at >= 50% unresolved — an abstention the tool
+// inflicted on itself.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => {
+	restore();
+	vi.restoreAllMocks();
+});
+
+type FetchInput = string | URL | Request;
+
+function urlOf(input: FetchInput): string {
+	return typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+}
+
+function dohQuery(input: FetchInput): { name: string; type: string } {
+	const url = new URL(urlOf(input));
+	return { name: url.searchParams.get('name') ?? '', type: url.searchParams.get('type') ?? '' };
+}
+
+function nsAnswer(name: string): Response {
+	return createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: `ns1.${name}.` }]);
+}
+
+function typedAnswer(name: string, type: string): Response {
+	if (type === 'NS' || type === '2') return nsAnswer(name);
+	if (type === 'A' || type === '1') return createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.10' }]);
+	if (type === 'MX' || type === '15')
+		return createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mx.example.net.' }]);
+	return createDohResponse([], []);
+}
+
+/** Resolve after `ms`, or reject with an AbortError as soon as `signal` fires — the shape a real fetch has. */
+function delayHonouringSignal<T>(ms: number, value: () => T, signal: AbortSignal | null | undefined): Promise<T> {
+	return new Promise<T>((resolve, reject) => {
+		const abort = () => {
+			clearTimeout(timer);
+			reject(signal?.reason instanceof Error ? signal.reason : new DOMException('The operation was aborted', 'AbortError'));
+		};
+		if (signal?.aborted) {
+			abort();
+			return;
+		}
+		const timer = setTimeout(() => {
+			signal?.removeEventListener('abort', abort);
+			resolve(value());
+		}, ms);
+		signal?.addEventListener('abort', abort, { once: true });
+	});
+}
+
+/**
+ * Emulate the Workers runtime: at most `SLOTS` fetches are "connected" at a
+ * time; the rest wait in a FIFO queue with their AbortSignal already ticking,
+ * exactly as the real queue behaves. Same emulation as
+ * `test/check-lookalikes-registration-age.spec.ts` (#894), with a per-name
+ * hold: `holdFor(name)` returns how long a connected fetch occupies its slot,
+ * or `Infinity` for a name whose authoritative servers never answer — the
+ * measured openai.com shape (11 of 90 hang to the timer even queried alone).
+ * `peakWaiting` is the deterministic tell: it is > 0 iff something ever queued.
+ */
+function buildSixSlotDohRuntime(holdFor: (name: string) => number) {
+	const SLOTS = 6;
+	let active = 0;
+	const waiting: Array<() => void> = [];
+	const stats = { peakWaiting: 0, queuedThenAborted: 0, issued: 0, peakInFlight: 0 };
+	const releaseSlot = () => {
+		active--;
+		while (active < SLOTS && waiting.length > 0) {
+			const before = active;
+			waiting.shift()!();
+			if (active > before) break;
+		}
+	};
+	const fetchImpl = async (input: FetchInput, init?: RequestInit): Promise<Response> => {
+		const { name, type } = dohQuery(input);
+		const signal = init?.signal;
+		let wasQueued = false;
+		await new Promise<void>((resolve, reject) => {
+			const abortReason = () => signal?.reason ?? new DOMException('aborted', 'AbortError');
+			const grant = () => {
+				signal?.removeEventListener('abort', onAbort);
+				if (signal?.aborted) {
+					stats.queuedThenAborted++;
+					reject(abortReason());
+					return;
+				}
+				active++;
+				stats.peakInFlight = Math.max(stats.peakInFlight, active);
+				resolve();
+			};
+			const onAbort = () => {
+				const idx = waiting.indexOf(grant);
+				if (idx >= 0) {
+					waiting.splice(idx, 1);
+					stats.queuedThenAborted++;
+				}
+				reject(abortReason());
+			};
+			if (signal?.aborted) return onAbort();
+			signal?.addEventListener('abort', onAbort, { once: true });
+			if (active < SLOTS) {
+				grant();
+			} else {
+				wasQueued = true;
+				waiting.push(grant);
+				stats.peakWaiting = Math.max(stats.peakWaiting, waiting.length);
+			}
+		});
+		stats.issued++;
+		try {
+			const hold = holdFor(name);
+			if (!Number.isFinite(hold)) {
+				// Never answers: the slot is held until the caller's own timer fires.
+				return await delayHonouringSignal(60_000, () => typedAnswer(name, type), signal);
+			}
+			return await delayHonouringSignal(hold, () => typedAnswer(name, type), signal);
+		} catch (err) {
+			if (wasQueued) stats.queuedThenAborted++;
+			throw err;
+		} finally {
+			releaseSlot();
+		}
+	};
+	return { fetchImpl, stats };
+}
+
+/** 90 permutations, of which every 12th (7 in all) hangs — the openai.com shape at a slightly lower hang rate. */
+const HANG_EVERY = 12;
+const FAST_HOLD_MS = 50;
+function starvationSet(): { domains: string[]; hangs: Set<string> } {
+	const domains = Array.from({ length: 90 }, (_, i) => `perm${i}.com`);
+	const hangs = new Set(domains.filter((_, i) => i % HANG_EVERY === HANG_EVERY - 1));
+	return { domains, hangs };
+}
+const holdForStarvation = (hangs: Set<string>) => (name: string) => (hangs.has(name) ? Infinity : FAST_HOLD_MS);
+
+async function loadDns() {
+	return import('../src/tools/lookalike-dns');
+}
+
+// ---------------------------------------------------------------------------
+// Phase 1 — NS existence.
+// ---------------------------------------------------------------------------
+
+describe('filterByNsExistence — bounded to the Workers connection cap (#865 follow-up)', () => {
+	it('REPRODUCTION (pre-fix shape): the per-permutation fan-out queues behind six slots; a few hanging names park every slot and the queue aborts unsent', async () => {
+		const { domains, hangs } = starvationSet();
+		const { fetchImpl, stats } = buildSixSlotDohRuntime(holdForStarvation(hangs));
+		globalThis.fetch = vi.fn().mockImplementation(fetchImpl);
+		const { PHASE1_DNS_OPTS } = await loadDns();
+		const { queryDnsRecords } = await import('../src/lib/dns');
+
+		// EXACTLY the pre-fix `filterByNsExistence` body: every NS query at once,
+		// each arming its 2000ms timer (PHASE1_DNS_OPTS) at call time.
+		const results = await Promise.allSettled(domains.map((domain) => queryDnsRecords(domain, 'NS', PHASE1_DNS_OPTS)));
+		const rejected = results.filter((r) => r.status === 'rejected').length;
+
+		expect(stats.peakWaiting).toBeGreaterThan(0);
+		// Six hangs (positions 11..71) kill all six slots; everything queued
+		// behind position 71 — 18 names, 17 of them perfectly resolvable — aborts
+		// at 2000ms without ever being sent. Only `hangs.size` were ever unreachable.
+		expect(stats.queuedThenAborted).toBeGreaterThanOrEqual(15);
+		expect(rejected).toBeGreaterThanOrEqual(hangs.size + 15);
+	}, 15_000);
+
+	it('bounded pool: never queues behind the six slots, so only the names that genuinely never answer are unresolved — and they are counted with a reason', async () => {
+		const { domains, hangs } = starvationSet();
+		const { fetchImpl, stats } = buildSixSlotDohRuntime(holdForStarvation(hangs));
+		globalThis.fetch = vi.fn().mockImplementation(fetchImpl);
+		const { filterByNsExistence, LOOKALIKE_DNS_PROBE_CONCURRENCY } = await loadDns();
+
+		const result = await filterByNsExistence(domains, { deadlineMs: Date.now() + 14_000 });
+
+		// The load-bearing guard against a pool-width regression: with the pool at
+		// or under six nothing can ever wait for a slot. Any widening past six
+		// turns this red deterministically (mutation-checked in the PR).
+		expect(LOOKALIKE_DNS_PROBE_CONCURRENCY).toBeLessThanOrEqual(6);
+		expect(stats.peakInFlight).toBeLessThanOrEqual(6);
+		expect(stats.peakWaiting).toBe(0);
+		expect(stats.queuedThenAborted).toBe(0);
+
+		expect(result.registered.length).toBe(domains.length - hangs.size);
+		expect(result.unresolved).toBe(hangs.size);
+		expect(result.unresolvedByReason).toEqual({ timeout: hangs.size, deadline: 0, failed: 0 });
+		for (const hang of hangs) expect(result.registered).not.toContain(hang);
+	}, 15_000);
+
+	it('a permutation whose turn comes after the phase deadline is NOT issued, and is counted unresolved with reason `deadline` — never as "no NS"', async () => {
+		const domains = Array.from({ length: 30 }, (_, i) => `late${i}.com`);
+		const { fetchImpl, stats } = buildSixSlotDohRuntime(() => 100);
+		globalThis.fetch = vi.fn().mockImplementation(fetchImpl);
+		const { filterByNsExistence } = await loadDns();
+
+		// Two rounds of six fit; the rest find the deadline spent.
+		const result = await filterByNsExistence(domains, { deadlineMs: Date.now() + 230 });
+
+		expect(stats.issued).toBeLessThan(domains.length);
+		expect(result.unresolvedByReason.deadline).toBeGreaterThan(0);
+		// Every permutation that was never issued is a deadline cut (not a timeout,
+		// not a failure — nothing was measured).
+		expect(result.unresolvedByReason.deadline).toBeGreaterThanOrEqual(domains.length - stats.issued);
+		// Nothing is dropped silently: every permutation is either registered or unresolved.
+		expect(result.registered.length + result.unresolved).toBe(domains.length);
+		expect(result.unresolved).toBe(
+			result.unresolvedByReason.timeout + result.unresolvedByReason.deadline + result.unresolvedByReason.failed,
+		);
+		// Every name that WAS issued resolved (100ms hold, no hangs).
+		expect(result.registered.length).toBeGreaterThanOrEqual(12);
+		expect(result.registered.length).toBe(domains.length - result.unresolved);
+	});
+
+	it('a query cut mid-flight by the deadline is `deadline`, a query the resolver never answered is `timeout`, a transport failure is `failed`', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const { name } = dohQuery(input);
+			if (name === 'broken.com') return Promise.reject(new TypeError('connection reset'));
+			// Both remaining names hang; only the deadline distinguishes them.
+			return delayHonouringSignal(60_000, () => nsAnswer(name), init?.signal);
+		});
+		const { filterByNsExistence } = await loadDns();
+		const result = await filterByNsExistence(['broken.com', 'hang.com'], { deadlineMs: Date.now() + 300 });
+		expect(result.registered).toEqual([]);
+		expect(result.unresolved).toBe(2);
+		expect(result.unresolvedByReason).toEqual({ timeout: 0, deadline: 1, failed: 1 });
+	});
+
+	it('without a deadline (direct callers) behaves as before: a hang is a timeout after PHASE1_DNS_OPTS.timeoutMs', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const { name } = dohQuery(input);
+			if (name === 'hang.com') return delayHonouringSignal(60_000, () => nsAnswer(name), init?.signal);
+			return Promise.resolve(nsAnswer(name));
+		});
+		const { filterByNsExistence } = await loadDns();
+		const result = await filterByNsExistence(['ok.com', 'hang.com']);
+		expect(result.registered).toEqual(['ok.com']);
+		expect(result.unresolved).toBe(1);
+		expect(result.unresolvedByReason).toEqual({ timeout: 1, deadline: 0, failed: 0 });
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Phase 2 — A/MX detail probe.
+// ---------------------------------------------------------------------------
+
+describe('probeWithAdaptiveBatching — bounded to the Workers connection cap', () => {
+	it('candidate A/MX legs keep the default timer and secondary confirmation but never retry (a lame candidate must not hold a slot for two attempts)', async () => {
+		const { PHASE2_DNS_OPTS } = await loadDns();
+		expect(PHASE2_DNS_OPTS).toEqual({ retries: 0 });
+
+		let mxAttempts = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const { name, type } = dohQuery(input);
+			if (name === 'lame.com' && (type === 'MX' || type === '15')) {
+				mxAttempts++;
+				return delayHonouringSignal(60_000, () => typedAnswer(name, type), init?.signal);
+			}
+			return Promise.resolve(typedAnswer(name, type));
+		});
+		const { probeWithAdaptiveBatching } = await loadDns();
+		const [r] = await probeWithAdaptiveBatching(['lame.com']);
+		expect(r.status).toBe('fulfilled');
+		if (r.status === 'fulfilled') {
+			expect(r.value.probeDegraded).toBe(true);
+			expect(r.value.probeDegradedReason).toBe('timeout');
+			expect(r.value.hasA).toBe(true);
+		}
+		expect(mxAttempts).toBe(1);
+	}, 15_000);
+
+	it('a 10-candidate batch (20 queries) never has more than six DoH fetches in flight and every candidate is measured', async () => {
+		const { fetchImpl, stats } = buildSixSlotDohRuntime(() => 30);
+		globalThis.fetch = vi.fn().mockImplementation(fetchImpl);
+		const { probeWithAdaptiveBatching } = await loadDns();
+		const candidates = Array.from({ length: 25 }, (_, i) => `cand${i}.com`);
+
+		const results = await probeWithAdaptiveBatching(candidates, { deadlineMs: Date.now() + 14_000 });
+
+		expect(stats.peakInFlight).toBeLessThanOrEqual(6);
+		expect(stats.peakWaiting).toBe(0);
+		expect(results).toHaveLength(25);
+		for (const r of results) {
+			expect(r.status).toBe('fulfilled');
+			if (r.status === 'fulfilled') {
+				expect(r.value.probeDegraded).toBe(false);
+				expect(r.value.hasA).toBe(true);
+				expect(r.value.hasMX).toBe(true);
+			}
+		}
+	});
+
+	it('candidates whose turn comes after the deadline are returned DEGRADED with reason `deadline` (infrastructure unmeasured), never as registered-but-dark', async () => {
+		const fetchSpy = vi.fn().mockImplementation((input: FetchInput) => {
+			const { name, type } = dohQuery(input);
+			return Promise.resolve(typedAnswer(name, type));
+		});
+		globalThis.fetch = fetchSpy;
+		const { probeWithAdaptiveBatching } = await loadDns();
+		const candidates = Array.from({ length: 12 }, (_, i) => `cut${i}.com`);
+
+		const results = await probeWithAdaptiveBatching(candidates, { deadlineMs: Date.now() - 1 });
+
+		expect(fetchSpy).not.toHaveBeenCalled();
+		expect(results).toHaveLength(12);
+		for (const r of results) {
+			expect(r.status).toBe('fulfilled');
+			if (r.status === 'fulfilled') {
+				expect(r.value.probeDegraded).toBe(true);
+				expect(r.value.probeDegradedReason).toBe('deadline');
+				// UNFETCHED, not measured: no positive signal may be synthesised either way.
+				expect(r.value.hasA).toBe(false);
+				expect(r.value.hasMX).toBe(false);
+				expect(r.value.mxExchanges).toEqual([]);
+			}
+		}
+	});
+
+	it('a candidate whose A or MX query hung is degraded with reason `timeout`; a transport failure with `failed`', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const { name, type } = dohQuery(input);
+			if (name === 'slowmx.com' && (type === 'MX' || type === '15'))
+				return delayHonouringSignal(60_000, () => typedAnswer(name, type), init?.signal);
+			if (name === 'brokena.com' && (type === 'A' || type === '1')) return Promise.reject(new TypeError('connection reset'));
+			return Promise.resolve(typedAnswer(name, type));
+		});
+		const { probeWithAdaptiveBatching } = await loadDns();
+		const results = await probeWithAdaptiveBatching(['slowmx.com', 'brokena.com', 'fine.com'], { deadlineMs: Date.now() + 1_500 });
+		const byDomain = new Map(results.map((r) => (r.status === 'fulfilled' ? [r.value.domain, r.value] : ['?', undefined])));
+		// A hang past the deadline is a deadline cut, not a resolver timeout — the
+		// default per-attempt timer (3s) never got to fire.
+		expect(byDomain.get('slowmx.com')?.probeDegraded).toBe(true);
+		expect(byDomain.get('slowmx.com')?.probeDegradedReason).toBe('deadline');
+		expect(byDomain.get('slowmx.com')?.hasA).toBe(true);
+		expect(byDomain.get('brokena.com')?.probeDegraded).toBe(true);
+		expect(byDomain.get('brokena.com')?.probeDegradedReason).toBe('failed');
+		expect(byDomain.get('brokena.com')?.hasMX).toBe(true);
+		expect(byDomain.get('fine.com')?.probeDegraded).toBe(false);
+		expect(byDomain.get('fine.com')?.probeDegradedReason).toBeUndefined();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End to end through checkLookalikes — the enumeration contract #892 reads.
+// ---------------------------------------------------------------------------
+
+describe('checkLookalikes — DNS phases end to end', () => {
+	it('keeps the DoH fan-out at or under six for a 90-permutation seed, and the enumeration stats contract is byte-compatible', async () => {
+		let inFlight = 0;
+		let peakInFlight = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			if (url.pathname !== '/dns-query') return Promise.resolve(new Response(null, { status: 200 }));
+			const { name, type } = dohQuery(input);
+			inFlight++;
+			peakInFlight = Math.max(peakInFlight, inFlight);
+			const release = () => {
+				inFlight--;
+			};
+			// Non-seed .com names resolve fully; everything else is empty.
+			const answers = name !== 'example.com' && name.endsWith('.com') && name.split('.').length === 2;
+			return delayHonouringSignal(5, () => (answers ? typedAnswer(name, type) : createDohResponse([], [])), init?.signal).finally(release);
+		});
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('example.com');
+
+		expect(peakInFlight).toBeLessThanOrEqual(6);
+		const withEnum = result.findings.find((f) => f.metadata?.enumeration !== undefined);
+		expect(withEnum).toBeDefined();
+		const enumeration = withEnum!.metadata!.enumeration as Record<string, unknown>;
+		// Byte-compatible with what #892's rollup reads: exactly these five keys.
+		expect(Object.keys(enumeration).sort()).toEqual([
+			'candidatesResolved',
+			'complete',
+			'permutationsGenerated',
+			'permutationsProbed',
+			'unresolvedCount',
+		]);
+		expect(enumeration.complete).toBe(true);
+		expect(enumeration.unresolvedCount).toBe(0);
+		expect(result.findings.some((f) => /enumeration was incomplete/i.test(f.title))).toBe(false);
+	});
+
+	it('when NO candidate resolved because every lookup was unresolved, the run reports an incomplete enumeration (partial) — not a clean "no active registrations"', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput) => {
+			const url = new URL(urlOf(input));
+			if (url.pathname !== '/dns-query') return Promise.resolve(new Response(null, { status: 200 }));
+			const { name, type } = dohQuery(input);
+			if (name === 'example.com') return Promise.resolve(typedAnswer(name, type));
+			// Every permutation's lookup fails at the transport — the shape of a run
+			// whose phase 1 was entirely cut or refused.
+			return Promise.reject(new TypeError('connection reset'));
+		});
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('example.com');
+
+		expect(result.partial).toBe(true);
+		expect(result.findings.some((f) => /no active lookalike domains detected/i.test(f.title))).toBe(false);
+		const incomplete = result.findings.find((f) => /enumeration was incomplete/i.test(f.title));
+		expect(incomplete).toBeDefined();
+		const enumeration = incomplete!.metadata!.enumeration as Record<string, unknown>;
+		expect(Object.keys(enumeration).sort()).toEqual([
+			'candidatesResolved',
+			'complete',
+			'permutationsGenerated',
+			'permutationsProbed',
+			'unresolvedCount',
+		]);
+		expect(enumeration.candidatesResolved).toBe(0);
+		expect(enumeration.complete).toBe(false);
+		expect(enumeration.unresolvedCount).toBe(enumeration.permutationsProbed);
+		const reasons = incomplete!.metadata!.unresolvedByReason as { timeout: number; deadline: number; failed: number };
+		expect(reasons.failed).toBe(enumeration.permutationsProbed);
+		// Nothing in the run may claim determinism about the set.
+		for (const f of result.findings) expect(f.metadata?.confidence, f.title).not.toBe('deterministic');
+	});
+
+	it('when some lookups measured an absence and the rest were unresolved, "no registered candidates" is kept but demoted to heuristic, beside the incomplete notice', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput) => {
+			const url = new URL(urlOf(input));
+			if (url.pathname !== '/dns-query') return Promise.resolve(new Response(null, { status: 200 }));
+			const { name, type } = dohQuery(input);
+			if (name === 'example.com') return Promise.resolve(typedAnswer(name, type));
+			if (name === 'exampl.com') return Promise.reject(new TypeError('connection reset'));
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('example.com');
+
+		expect(result.partial).toBe(true);
+		const none = result.findings.find((f) => /no active lookalike domains detected/i.test(f.title));
+		expect(none).toBeDefined();
+		expect(none!.metadata?.confidence).toBe('heuristic');
+		const incomplete = result.findings.find((f) => /enumeration was incomplete/i.test(f.title));
+		expect(incomplete).toBeDefined();
+		expect((incomplete!.metadata!.enumeration as { unresolvedCount: number }).unresolvedCount).toBe(1);
+		expect(incomplete!.metadata!.unresolvedByReason).toEqual({ timeout: 0, deadline: 0, failed: 1 });
+	});
+
+	it('an incomplete run reports WHY on the scan_status finding, and the reasons sum to unresolvedCount', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			if (url.pathname !== '/dns-query') return Promise.resolve(new Response(null, { status: 200 }));
+			const { name, type } = dohQuery(input);
+			if (name === 'example.com') return Promise.resolve(typedAnswer(name, type));
+			if (name === 'exampl.com') return Promise.resolve(typedAnswer(name, type));
+			if (name === 'exmple.com') return Promise.reject(new TypeError('connection reset'));
+			if (name === 'examle.com') return delayHonouringSignal(60_000, () => typedAnswer(name, type), init?.signal);
+			return Promise.resolve(createDohResponse([], []));
+		});
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes('example.com');
+
+		const incomplete = result.findings.find((f) => /enumeration was incomplete/i.test(f.title));
+		expect(incomplete).toBeDefined();
+		const enumeration = incomplete!.metadata!.enumeration as { unresolvedCount: number; complete: boolean };
+		expect(enumeration.complete).toBe(false);
+		expect(enumeration.unresolvedCount).toBe(2);
+		expect(Object.keys(incomplete!.metadata!.enumeration as object).sort()).toEqual([
+			'candidatesResolved',
+			'complete',
+			'permutationsGenerated',
+			'permutationsProbed',
+			'unresolvedCount',
+		]);
+		const reasons = incomplete!.metadata!.unresolvedByReason as { timeout: number; deadline: number; failed: number };
+		expect(reasons).toEqual({ timeout: 1, deadline: 0, failed: 1 });
+		expect(reasons.timeout + reasons.deadline + reasons.failed).toBe(enumeration.unresolvedCount);
+	}, 15_000);
+});

--- a/test/check-lookalikes-dns-starvation.spec.ts
+++ b/test/check-lookalikes-dns-starvation.spec.ts
@@ -340,6 +340,41 @@ describe('probeWithAdaptiveBatching — bounded to the Workers connection cap', 
 		}
 	});
 
+	it('an empty-answer candidate whose SECONDARY confirmation hangs is cut at deadlineMs (not deadlineMs + DNS_TIMEOUT_MS), counted `deadline`, and the phase returns within budget', async () => {
+		// The PR #903 review case: typosquats holding NS only answer EMPTY for
+		// A/MX, which triggers the secondary-resolver confirmation — a fetch the
+		// caller's deadline used to have no reach into.
+		let secondaryCalls = 0;
+		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
+			const url = new URL(urlOf(input));
+			if (url.hostname === 'dns.google') {
+				secondaryCalls++;
+				return delayHonouringSignal(60_000, () => createDohResponse([], []), init?.signal);
+			}
+			const { name } = dohQuery(input);
+			return Promise.resolve(createDohResponse([{ name, type: 1 }], []));
+		});
+		const { probeWithAdaptiveBatching } = await loadDns();
+		const BUDGET_MS = 400;
+		const started = Date.now();
+		const results = await probeWithAdaptiveBatching(['nsonly.com'], { deadlineMs: started + BUDGET_MS });
+		const elapsed = Date.now() - started;
+
+		expect(secondaryCalls).toBeGreaterThan(0);
+		// Within budget (plus scheduling slack) — nowhere near the 3s the secondary's own timer would allow.
+		expect(elapsed).toBeLessThan(BUDGET_MS + 300);
+		expect(results).toHaveLength(1);
+		const r = results[0];
+		expect(r.status).toBe('fulfilled');
+		if (r.status === 'fulfilled') {
+			expect(r.value.probeDegraded).toBe(true);
+			expect(r.value.probeDegradedReason).toBe('deadline');
+			// An aborted confirmation is not a measured absence.
+			expect(r.value.hasA).toBe(false);
+			expect(r.value.hasMX).toBe(false);
+		}
+	});
+
 	it('a candidate whose A or MX query hung is degraded with reason `timeout`; a transport failure with `failed`', async () => {
 		globalThis.fetch = vi.fn().mockImplementation((input: FetchInput, init?: RequestInit) => {
 			const { name, type } = dohQuery(input);

--- a/test/check-lookalikes-registration-age.spec.ts
+++ b/test/check-lookalikes-registration-age.spec.ts
@@ -263,9 +263,12 @@ describe('enrichLookalikes — bounded fan-out (#867)', () => {
 		const starved = candidates.filter((c) => results.get(c.domain)?.registrationDays === null);
 		expect(starved.length).toBeGreaterThanOrEqual(10);
 		for (const c of starved) expect(results.get(c.domain)?.lookup, c.domain).toBe('timeout');
-		// And the same starvation manufactured the "no reachable web content"
-		// HIGH corroborator for HEAD probes that were never sent.
-		expect(candidates.some((c) => results.get(c.domain)?.hasWebContent === false)).toBe(true);
+		// The same starvation used to manufacture the "no reachable web content"
+		// HIGH corroborator for HEAD probes that were never sent (#894 residual
+		// 2, closed with the #865 follow-up): a HEAD probe that times out — in
+		// the queue or at the server — is UNKNOWN and fails toward `true`, so
+		// even this pre-fix fan-out shape can no longer synthesise it.
+		expect(candidates.every((c) => results.get(c.domain)?.hasWebContent === true)).toBe(true);
 	});
 
 	it('bounded fan-out never queues behind the six slots, so no timer runs while waiting and every candidate is populated', async () => {

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -161,10 +161,14 @@ describe('checkLookalikes', () => {
 		});
 		const result = await run('test.com');
 		expect(result.category).toBe('lookalikes');
-		// Should still produce a finding (info: no active lookalikes)
+		// Should still produce a finding — but NOT "no active lookalikes": every
+		// lookup was unresolved, so nothing about the estate was measured (#865
+		// follow-up; the same law as #781). The run says so and is partial.
 		expect(result.findings.length).toBeGreaterThan(0);
-		const info = result.findings.find((f) => /No active lookalike/i.test(f.title));
-		expect(info).toBeDefined();
+		expect(result.findings.find((f) => /No active lookalike/i.test(f.title))).toBeUndefined();
+		const incomplete = result.findings.find((f) => /enumeration was incomplete/i.test(f.title));
+		expect(incomplete).toBeDefined();
+		expect(result.partial).toBe(true);
 	});
 
 	it('exports adaptive batching constants', async () => {
@@ -1752,10 +1756,7 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 			const result = await run('testco.com');
 			const summary = result.findings.find((f) => f.metadata?.lookalikeDomainCount !== undefined);
 			expect(summary).toBeDefined();
-			expect(
-				summary!.title,
-				'the title must not name a wider set than the count applies',
-			).not.toMatch(/mail capability/i);
+			expect(summary!.title, 'the title must not name a wider set than the count applies').not.toMatch(/mail capability/i);
 			expect(summary!.title).toMatch(/pre-phishing staging signals/i);
 		});
 
@@ -1768,9 +1769,7 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 			// went unnoticed.
 			expect(summary!.metadata?.mailCapableCount).toBeDefined();
 			expect(summary!.metadata?.mailCapableDomains).toContain('twstco.com');
-			expect(summary!.metadata?.mailCapableCount as number).toBeGreaterThanOrEqual(
-				summary!.metadata?.lookalikeDomainCount as number,
-			);
+			expect(summary!.metadata?.mailCapableCount as number).toBeGreaterThanOrEqual(summary!.metadata?.lookalikeDomainCount as number);
 		});
 
 		it('a null-MX candidate is not counted as mail-capable', async () => {
@@ -1779,15 +1778,11 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 			globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 				const { name, type } = parseDohQuery(input);
 				if (name === 'testco.com' && (type === 'NS' || type === '2')) {
-					return Promise.resolve(
-						createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]),
-					);
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
 				}
 				if (name === 'twstco.com') {
 					if (type === 'NS' || type === '2') {
-						return Promise.resolve(
-							createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]),
-						);
+						return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]));
 					}
 					if (type === 'MX' || type === '15') {
 						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '0 .' }]));
@@ -1830,15 +1825,11 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 			globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
 				const { name, type } = parseDohQuery(input);
 				if (name === 'testco.com' && (type === 'NS' || type === '2')) {
-					return Promise.resolve(
-						createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]),
-					);
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.primary-dns.com.' }]));
 				}
 				if (name === 'twstco.com') {
 					if (type === 'NS' || type === '2') {
-						return Promise.resolve(
-							createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]),
-						);
+						return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.unrelated-dns.com.' }]));
 					}
 					if (type === 'MX' || type === '15') {
 						return Promise.resolve(createDohResponse([{ name, type: 15 }], [{ name, type: 15, TTL: 300, data: '10 mx.mailgun.org.' }]));
@@ -1919,9 +1910,7 @@ describe('checkLookalikes - Task 7b two-axis split (attribution vs threat observ
 		// Retitled by #779: it used to say "with mail capability detected", a
 		// strictly WIDER predicate than the mail-infra-PLUS-corroborator matrix it
 		// actually counts. The count is unchanged; only the claim is now honest.
-		const summary = result.findings.find((f) =>
-			/lookalike domains? showing pre-phishing staging signals/i.test(f.title),
-		);
+		const summary = result.findings.find((f) => /lookalike domains? showing pre-phishing staging signals/i.test(f.title));
 		expect(summary).toBeDefined();
 		expect(summary!.severity).toBe('high');
 		expect(summary!.metadata?.findingAxis).toBe('threat_observation');
@@ -2348,18 +2337,14 @@ describe('isSameEntityOrgMatch - fix round 2 residual (direct semantic pin)', ()
 			if (name === 'test.com' && isNs) {
 				seedNsAttempts += 1;
 				if (seedNsAttempts === 1) return Promise.reject(new Error('transient resolver throttle'));
-				return Promise.resolve(
-					createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.seedowner.com.' }]),
-				);
+				return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.seedowner.com.' }]));
 			}
 
 			// One registered candidate sharing the seed's nameservers — it can
 			// only be attributed if the seed NS resolved.
 			if (name === 'tes.com') {
 				if (isNs) {
-					return Promise.resolve(
-						createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.seedowner.com.' }]),
-					);
+					return Promise.resolve(createDohResponse([{ name, type: 2 }], [{ name, type: 2, TTL: 300, data: 'ns1.seedowner.com.' }]));
 				}
 				if (type === 'A' || type === '1') {
 					return Promise.resolve(createDohResponse([{ name, type: 1 }], [{ name, type: 1, TTL: 300, data: '192.0.2.1' }]));
@@ -2385,5 +2370,4 @@ describe('isSameEntityOrgMatch - fix round 2 residual (direct semantic pin)', ()
 		expect(attributedCandidate).toBeDefined();
 		expect(attributedCandidate?.metadata?.ownershipVerdict).not.toBe('unmeasured');
 	});
-
 });

--- a/test/dns-transport-signal.test.ts
+++ b/test/dns-transport-signal.test.ts
@@ -20,6 +20,71 @@ afterEach(() => {
 	restore();
 });
 
+describe('queryDns — AbortSignal propagation into the secondary confirmation (PR #903 review)', () => {
+	/** Primary (Cloudflare) answers EMPTY; the secondary (Google) hangs, honouring whatever signal it was given. */
+	function mockEmptyPrimaryHangingSecondary() {
+		const secondaryInits: RequestInit[] = [];
+		globalThis.fetch = vi.fn((url: string, init?: RequestInit) => {
+			const host = new URL(url).hostname;
+			if (host === 'dns.google') {
+				secondaryInits.push(init ?? {});
+				return new Promise<Response>((_resolve, reject) => {
+					const onAbort = () => reject(init?.signal?.reason ?? new DOMException('aborted', 'AbortError'));
+					if (init?.signal?.aborted) return onAbort();
+					init?.signal?.addEventListener('abort', onAbort, { once: true });
+				});
+			}
+			return Promise.resolve(
+				new Response(
+					JSON.stringify({
+						Status: 0,
+						TC: false,
+						RD: true,
+						RA: true,
+						AD: false,
+						CD: false,
+						Question: [{ name: 'example.com', type: 16 }],
+						Answer: [],
+					}),
+					{
+						status: 200,
+					},
+				),
+			);
+		}) as unknown as typeof globalThis.fetch;
+		return secondaryInits;
+	}
+
+	it('a caller signal aborts a hanging secondary confirmation, and the query REJECTS (never a confirmed-empty answer)', async () => {
+		const secondaryInits = mockEmptyPrimaryHangingSecondary();
+		const controller = new AbortController();
+		const started = Date.now();
+		const promise = queryDns('example.com', 'TXT', false, {
+			retries: 0,
+			timeoutMs: 3000,
+			confirmWithSecondaryOnEmpty: true,
+			signal: controller.signal,
+		});
+		setTimeout(() => controller.abort(), 30);
+
+		await expect(promise).rejects.toThrow(/aborted by caller/i);
+		// Cut by the caller, not by the secondary's own 3s timer.
+		expect(Date.now() - started).toBeLessThan(1000);
+		expect(secondaryInits.length).toBe(1);
+		expect(secondaryInits[0].signal?.aborted).toBe(true);
+	});
+
+	it('without a caller signal the secondary confirmation keeps its own timeout (behaviour preserved)', async () => {
+		const secondaryInits = mockEmptyPrimaryHangingSecondary();
+		const started = Date.now();
+		const result = await queryDns('example.com', 'TXT', false, { retries: 0, timeoutMs: 80, confirmWithSecondaryOnEmpty: true });
+		// Secondary timed out → unconfirmed → the primary's empty answer stands.
+		expect(result.Answer ?? []).toEqual([]);
+		expect(Date.now() - started).toBeGreaterThanOrEqual(60);
+		expect(secondaryInits.length).toBe(1);
+	});
+});
+
 describe('queryDns — AbortSignal propagation (Phase 1)', () => {
 	it('rejects when the caller-supplied AbortSignal aborts mid-fetch', async () => {
 		const controller = new AbortController();

--- a/test/lookalike-enrichment-web-content.spec.ts
+++ b/test/lookalike-enrichment-web-content.spec.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: BUSL-1.1
+//
+// PR #894 residual 2: `probeHasWebContent` mapped a genuine timeout to
+// `hasWebContent: false` — the "no reachable web content" HIGH corroborator in
+// the #264 severity matrix — contradicting the module doc ("a probe that never
+// ran cannot synthesise a HIGH"). A host that did not answer within the budget
+// is UNKNOWN, not "no content": unknown must fail toward `true`.
+//
+// A measured refusal (connection reset, TLS failure, NXDOMAIN at the socket)
+// stays `false` — that IS the "parked / unreachable" signal the corroborator
+// exists for.
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock } from './helpers/dns-mock';
+
+const { restore } = setupFetchMock();
+
+afterEach(() => {
+	restore();
+	vi.restoreAllMocks();
+});
+
+function hangHonouringSignal(signal: AbortSignal | null | undefined): Promise<Response> {
+	return new Promise<Response>((_, reject) => {
+		const abort = () =>
+			reject(signal?.reason instanceof Error ? signal.reason : new DOMException('The operation was aborted', 'AbortError'));
+		if (signal?.aborted) return abort();
+		signal?.addEventListener('abort', abort, { once: true });
+	});
+}
+
+async function load() {
+	return import('../src/tools/lookalike-enrichment');
+}
+
+describe('probeHasWebContent — failure direction (#894 residual 2)', () => {
+	it('a HEAD probe that times out reports true (unknown), never the no-content HIGH corroborator', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((_input: unknown, init?: RequestInit) => hangHonouringSignal(init?.signal));
+		const { probeHasWebContent } = await load();
+		// Deadline-clamped so the per-probe timer fires quickly.
+		const reachable = await probeHasWebContent('slow-parked.com', Date.now() + 150);
+		expect(reachable).toBe(true);
+	});
+
+	it('a measured transport refusal still reports false', async () => {
+		globalThis.fetch = vi.fn().mockImplementation(() => Promise.reject(new TypeError('connection refused')));
+		const { probeHasWebContent } = await load();
+		expect(await probeHasWebContent('dark.com')).toBe(false);
+	});
+
+	it('any HTTP response — 200, 3xx, 5xx — is reachable', async () => {
+		const { probeHasWebContent } = await load();
+		for (const status of [200, 302, 503]) {
+			globalThis.fetch = vi.fn().mockImplementation(() => Promise.resolve(new Response(null, { status })));
+			expect(await probeHasWebContent('live.com'), `status ${status}`).toBe(true);
+		}
+	});
+
+	it('a probe whose turn comes after the deadline is not issued and reports true', async () => {
+		const fetchSpy = vi.fn().mockImplementation(() => Promise.resolve(new Response(null, { status: 200 })));
+		globalThis.fetch = fetchSpy;
+		const { probeHasWebContent } = await load();
+		expect(await probeHasWebContent('late.com', Date.now() - 1)).toBe(true);
+		expect(fetchSpy).not.toHaveBeenCalled();
+	});
+
+	it('through enrichLookalikes: a hung HEAD probe cannot lift a candidate to the no-content corroborator', async () => {
+		globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request, init?: RequestInit) => {
+			const url = new URL(typeof input === 'string' ? input : input instanceof URL ? input.href : input.url);
+			if (url.pathname.includes('/domain/')) return Promise.resolve(new Response(JSON.stringify({ events: [] }), { status: 200 }));
+			return hangHonouringSignal(init?.signal);
+		});
+		const { enrichLookalikes } = await load();
+		const enrichment = await enrichLookalikes(
+			[{ domain: 'slow.com', hasA: true, hasMX: true, mxExchanges: ['mx.slow.com'], probeDegraded: false }],
+			{
+				deadlineMs: Date.now() + 200,
+			},
+		);
+		expect(enrichment.get('slow.com')?.hasWebContent).toBe(true);
+	});
+});


### PR DESCRIPTION
Follow-up to #865 / #867 / #894 / #892 (all closed — nothing here auto-closes).

## What happens

`check_lookalikes` reports most of its permutation space as unresolved on large seeds, and #892's rollup then abstains at ≥ 50 %. Measured live on prod 3.74.0 today (`force_refresh: true`):

| seed | probed | resolved | unresolved | rollup |
|---|---|---|---|---|
| openai.com | 90 | 13 | **76 (84 %)** | abstained (`enumeration_throttled`) — 4 threat observations at HIGH citing "no reachable web content" |
| cohere.com | 94 | 28 | **40 (43 %)** | published; 8 × `hasWebContent: false` |

#894 fixed the same mechanism in the enrichment phase and left this residual verbatim: *"The run's unresolvedCount … on the DNS phases is almost certainly the same mechanism."* This PR proves it, with a twist, and fixes it.

## Evidence

**Hypothesis: the DNS phases exceed the Workers six-connection cap with timers armed before dispatch. Verdict: PROVEN — with one refinement.**

1. **Code.** `filterByNsExistence` dispatched every permutation's NS query at once (`Promise.allSettled(domains.map(...))`, ~90 fetches, `PHASE1_DNS_OPTS` 2 s timer armed at call time, no semaphore). `probeWithAdaptiveBatching` dispatched 20 A/MX queries per batch (plus secondary confirmations). `dns-transport.ts` creates `AbortSignal.timeout()` *before* `guardedFetch`, so even a semaphore would not have helped — the timer runs in the queue.
2. **Resolver profile from this host (sequential, no concurrency at all).** openai.com: **11 of 90 permutations hang to the 2 s timer even queried alone** (lame/slow delegations: `oenai.com`, `oopenai.com`, `opebai.com`, …); the rest answer at p50 224 ms. cohere.com: 0 hangs. A burst of all 90 from Node: **zero HTTP 429**, the same 11 hangs. The resolver never refused the burst.
3. **Replay of the measured per-name latencies through a six-slot FIFO.** Pre-armed timers (current code): openai.com **70 unresolved** (prod 76, #865 77); cohere.com 23 (prod 40). Timers armed at dispatch: openai.com **11** (only the inherent hangs), cohere.com **0**. The refinement: it is not queue length alone — each hanging name parks one of the six slots for the *whole* 2 s window, so a dozen of them kill every slot and the queue behind them aborts unsent. That is why amazon.com (80 of 82 permutations registered, answering fast) sat at 1.2 % in #865's table while openai.com sat at 86 %.
4. **Same code on an uncapped local workerd against the same resolver:** openai.com 54 resolved / 12 unresolved (prod: 13 / 76). Local workerd does not enforce the cap; the 64-candidate gap is the platform queue.
5. **Emulation spec** (`test/check-lookalikes-dns-starvation.spec.ts`, the six-slot abortable FIFO from #894 with a per-name hold): the pre-fix fan-out shape against 90 names of which 7 hang → `peakWaiting > 0`, ≥ 15 fetches queued-then-aborted, ≥ 22 rejected. The bounded path on the same runtime → `peakWaiting === 0`, unresolved exactly 7, all `timeout`. **Mutation-checked:** `LOOKALIKE_DNS_PROBE_CONCURRENCY` 6 → 7 fails three assertions deterministically (`expected 1 to be +0`, `expected 7 to be less than or equal to 6`).
6. **Live, after** (local build via `wrangler dev`, same MCP handshake, `force_refresh: true`):

| seed | before (prod) | after, run 1 | after, run 2 |
|---|---|---|---|
| openai.com | 13 / 76 unresolved, rollup abstained | **54 / 23** (`timeout` 11, `deadline` 12), rollup published | **54 / 7** (`timeout` 7), rollup published |
| cohere.com | 28 / 40 | **39 / 0, `complete: true`** | — |
| openai `hasWebContent: false` | 4 | 2 (measured refusals) | 2 |

Caveat, stated plainly: local workerd does not enforce the six-connection cap, so the local "after" proves the pooled pipeline, the classifier and the deadlines against the real resolver; the cap behaviour is proven by the emulation spec. Prod verification after deploy is the acceptance step that remains (Residuals).

A second measurement in real workerd of the pooled phase 1 alone on the 90 openai.com names: wall **4.99 s**, 79 ok (p50 36 ms), 11 timeouts at exactly 2001 ms — the same 11 names as the host profile.

## Root cause

Unbounded DoH fan-out in `src/tools/lookalike-dns.ts` against a platform that serialises past six connections, with every timer armed at enqueue. Registered-but-lame permutations (NS answered from the parent zone, own servers dead) hold a slot for the full timer, which converts a 13 % inherent unresolved rate into 84 %. The adaptive-batching backoff could never fire (it counted rejected per-candidate promises, and the per-candidate probe settled both legs internally), and it carried a latent off-by-batch bug (advancing by the *new* size after halving, re-probing half a batch) — both now live and fixed.

Two silent-drop sites found on the way and closed: (a) the `registeredPerms.length === 0` early return reported **"No active lookalike domains detected", `deterministic`**, even when every lookup was unresolved — the enumeration stats never reached the response on that path; (b) `probeHasWebContent` mapped a timeout to `hasWebContent: false`, the HIGH corroborator (#894 residual 2).

## Fix

`src/tools/lookalike-dns.ts`
- `LOOKALIKE_DNS_PROBE_CONCURRENCY = 6` — one `mapConcurrent` pool per fan-out, counted in **queries** in flight (retries and secondary confirmation are sequential inside a query, so a pooled query never holds more than one connection). Not `SCAN_DNS_CONCURRENCY` (12): the tool is `scanIncluded: false` and the DNS phases run alone, so each owns the whole cap. Phase 2 flattens A/MX legs into the pool (a per-candidate pool of three would idle a slot whenever the legs finish apart).
- Timers armed at dispatch: the transport's per-query timer is created inside the pool worker; a per-phase caller-abort signal (`AbortSignal.timeout(remaining)`) is created at dispatch too and composed by the transport, so a deadline bounds the whole query including retries.
- `DnsPhaseOptions.deadlineMs` on `filterByNsExistence` / `probeWithAdaptiveBatching`. Victims are **counted with a reason** — `DnsProbeFailureReason = 'timeout' | 'deadline' | 'failed'` — never dropped, never "no NS". `filterByNsExistence` returns `unresolvedByReason`; a degraded `LookalikeResult` carries `probeDegradedReason`.
- `PHASE2_DNS_OPTS = { retries: 0 }` for candidate A/MX legs (default timer and secondary confirmation kept, so `hasA`/`hasMX` semantics are unchanged). A lame candidate hangs both legs; with the default retry each leg held a slot for 3 s + 3 s, and eleven such candidates spent the whole phase budget on names that would never answer. #853's case for retries is the seed's lookups, not disposable permutations.
- `detectWildcardParents` pooled and on the lean `PHASE1_DNS_OPTS` (it precedes phase 1 and used to cost up to ~7 s per lame parent zone; a failed canary only means "not a wildcard").
- `PHASE1_DNS_OPTS` and the four batching constants are byte-identical (pinned by `test/check-lookalikes.spec.ts`).

`src/tools/check-lookalikes.ts`
- Budget: `DNS_PHASES_BUDGET_MS = LOOKALIKE_TIMEOUT_MS − ENRICHMENT_RESERVE_MS − ENRICHMENT_MIN_WINDOW_MS (4 s)` = 12 s absolute from `startedAt`, so #894's enrichment window and reserve are untouchable. `NS_PHASE_BUDGET_MS = 6 s` counted from the moment phase 1 *starts* (min'd with the absolute boundary): anchoring it on `startedAt` let the seed's resilient lookups (#853, 5 s × 3) hand phase 1 an already-spent budget — measured locally as 6 resolved / 83 `deadline` one run and 54 / 27 the next. Phase 2 gets the remainder.
- `unresolvedByReason` is attached **beside** `enumeration` on the two scan_status findings (incomplete-enumeration notice; throttled rollup abstention). The five-key `enumeration` object #892 reads is byte-compatible (asserted). The builders live in `lookalike-summary-findings.ts` (not touched per the ownership brief), so the annotation is applied in the orchestrator.
- Early return with no registered candidate and unresolved lookups: emits the incomplete-enumeration notice (with `candidatesResolved: 0`), demotes "no registered candidates" to `heuristic` when some lookups did measure an absence and omits it when none did, and marks the result `partial` so the non-answer is not cached.

`src/tools/lookalike-enrichment.ts`
- `probeHasWebContent`: timeout → `true` (unknown); only a measured transport refusal → `false`. Module doc now matches behaviour.

`scan_domain`: `check_lookalikes` is a standalone intelligence tool outside the scored `CheckCategory` union and unreferenced by `scan-domain.ts`; no scan score can move and `SCORING_MODEL_VERSION` needs no bump. Not touched: `lookalike-summary-findings.ts`, `lib/ownership-attribution.ts`, `lib/maturity-staging.ts`, `packages/dns-checks`, `scan-domain.ts`, `scoring-version.ts`, `CHANGELOG.md`, version fields.

## Tests

New `test/check-lookalikes-dns-starvation.spec.ts` (13) and `test/lookalike-enrichment-web-content.spec.ts` (5), written red first (11 failed on the old code, the end-to-end guard with `expected 90 to be less than or equal to 6`):
- REPRODUCTION (pre-fix fan-out shape through the real transport) against the six-slot runtime; bounded `filterByNsExistence` on the same runtime (`peakWaiting === 0`, unresolved = exactly the hangs, all `timeout`) — the mutation guard; deadline: unissued tail counted `deadline`, `registered + unresolved === domains`; `deadline` vs `timeout` vs `failed` classification; no-deadline behaviour unchanged.
- `probeWithAdaptiveBatching`: ≤ 6 in flight for a 25-candidate set; deadline-spent → every candidate `probeDegraded` + `deadline`, no fetch issued, no synthesised `hasA`/`hasMX`; per-leg reasons; `PHASE2_DNS_OPTS` pinned with a single MX attempt for a hanging candidate.
- End to end through `checkLookalikes`: peak DoH in flight ≤ 6 on a 90-permutation seed; `enumeration` has exactly the five keys; `unresolvedByReason` sums to `unresolvedCount`; all-unresolved run → incomplete notice, `partial`, no "no active lookalikes", nothing `deterministic`; partially-unresolved run → "no registered" demoted to `heuristic` beside the notice.
- Web content: timeout → `true`; measured refusal → `false`; 200/3xx/5xx → `true`; deadline spent → `true` with no fetch; through `enrichLookalikes`, a hung HEAD cannot produce the corroborator.

Two existing assertions corrected because they pinned the defects: `test/check-lookalikes-registration-age.spec.ts` (the old fan-out shape can no longer manufacture `hasWebContent: false`) and `test/check-lookalikes.spec.ts › should handle all probe failures without crashing` (all-rejected lookups now yield the incomplete notice + `partial`, not "No active lookalike").

```
npm run typecheck                                       → 0 errors
npm run lint                                            → 0 errors (1 pre-existing warning)
npx vitest run test/check-lookalikes test/lookalike     → 11 files, 185 passed
node scripts/ci/typecheck-tests.mjs                     → OK, no test file exceeds its baseline
npm test                                                → see below
```

`npm test` (full suite, Workers pool): **8490 passed / 13 skipped / 14 failed**, 693 files passed, 6 files failed — none real:

- `test/wasm-integration.test.ts` — suite-load error `No such module …/crates/bv-wasm-core/pkg/bv_wasm_core_bg.wasm`; the documented fresh-worktree shape (`npm run build:wasm` is not run by `worktree-setup.sh`), 0 test failures inside it.
- 13 tests in `test/freemium-limits.spec.ts`, `test/index.spec.ts`, `test/oauth/{authorize-post,e2e,token}.spec.ts` — all auth/OAuth/API-key cases, none near the lookalike path. Cause: the throwaway `.dev.vars` (`BV_API_KEY`, `OWNER_ALLOW_IPS`) I had created for the local `wrangler dev` evidence run is read by vitest-pool-workers as bindings, so "OWNER_ALLOW_IPS unset" / "valid key" cases saw my values. Re-run in isolation after deleting it: **5 files, 127/127 passed**.

## Residuals

- **Prod verification.** Local workerd does not enforce the cap; the acceptance evidence for the cap itself is the emulation spec plus the prod re-run after deploy (`check_lookalikes openai.com force_refresh` — expect unresolved ≈ 11–25 of 90, `unresolvedByReason.timeout` ≈ 11, rollup published).
- **Inherent hangs.** ~11 openai.com permutations are lame delegations that hang the resolver for the full timer even when queried alone (13 %); they are now reported honestly as `timeout`, and nothing client-side can resolve them.
- **Large seeds still exhaust the 12 s DNS budget in phase 2** (0–12 `deadline` cuts per run for openai.com's 54 registered candidates) and enrichment's window (`not_attempted` tails). `LOOKALIKE_TIMEOUT_MS = 20 s` is the constraint; raising it, or leaning phase 2 further, is an operator call.
- `dns-transport.ts` arms `AbortSignal.timeout()` *before* `sem.run()`, so `scan_domain`'s semaphore path (`SCAN_DNS_CONCURRENCY = 12`, also > 6) still arms timers at enqueue — same defect class, out of scope here, worth its own issue. Also: its `AbortError` branch never matches `AbortSignal.timeout`'s `TimeoutError`, so real timeouts surface as `DNS query failed: The operation was aborted due to timeout` (retry still happens via the generic branch); the classifier here accepts both spellings.
- `check_lookalikes` is still declared `tier: 'protective'` + `scanIncluded: false` (pre-existing, noted in #894).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
