### PR TITLE
fix(dns-checks): evidence-bound the RUA-authorization finding; cite RFC 9990

### DIFF
--- a/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
@@ -86,6 +86,39 @@ describe('checkDMARC', () => {
 		expect(result.findings.some((f) => f.title === 'Third-party aggregate reporting not authorized')).toBe(true);
 	});
 
+	// The RUA-authorization finding lands verbatim on the PUBLIC security-report page and
+	// names a real third party (the rua host). Two claim defects were measured 2026-09-04
+	// against meta.com -> dmarc.facebookmail.com (a TRUE finding: NXDOMAIN on 1.1.1.1 /
+	// 8.8.8.8 / 9.9.9.9, no wildcard, while Meta's ruf vendor datafeeds.phishlabs.com IS
+	// authorized — so the record construction is provably right):
+	//   1. "will be silently discarded" asserts a definite delivery outcome we cannot
+	//      observe. Receiver enforcement of external destination verification is uneven,
+	//      so the honest modal is "may be discarded by receivers that enforce" it.
+	//   2. RFC 7489 was obsoleted May 2026 by RFC 9989/9990/9991; external destination
+	//      verification now lives in RFC 9990 §4.
+	// The finding also carries confidence:'deterministic', which is only defensible for
+	// the DNS fact (the record is absent) — never for the downstream consequence.
+	it('states the RUA-authorization consequence as evidence-bounded, citing the current RFC', async () => {
+		const queryDNS = createMockDNS({
+			'_dmarc.example.com': ['v=DMARC1; p=reject; rua=mailto:dmarc@otherbrand.com'],
+			'example.com._report._dmarc.otherbrand.com': [], // missing auth
+		});
+		const result = await checkDMARC('example.com', queryDNS);
+		const finding = result.findings.find((f) => f.title === 'Third-party aggregate reporting not authorized');
+		expect(finding).toBeDefined();
+
+		// No unfalsifiable claim of a definite delivery outcome.
+		expect(finding!.detail).not.toMatch(/will be silently discarded/i);
+		expect(finding!.detail).toMatch(/may be discarded by receivers that enforce/i);
+
+		// Cite the standard that is actually in force.
+		expect(finding!.detail).toMatch(/RFC 9990/);
+
+		// The actionable part must survive the rewording: name the exact record to publish.
+		expect(finding!.detail).toContain('example.com._report._dmarc.otherbrand.com');
+		expect(finding!.detail).toContain('v=DMARC1');
+	});
+
 	describe('subdomain scanned directly against an enforcing parent (sp=none asymmetry)', () => {
 		// The org domain is locked down (p=reject) but hands this child sp=none, so the
 		// effective policy for the subdomain is "none". The tree walk resolves the record at

--- a/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
@@ -86,22 +86,13 @@ describe('checkDMARC', () => {
 		expect(result.findings.some((f) => f.title === 'Third-party aggregate reporting not authorized')).toBe(true);
 	});
 
-	// The RUA-authorization finding lands verbatim on the PUBLIC security-report page and
-	// names a real third party (the rua host). Two claim defects were measured 2026-09-04
-	// against meta.com -> dmarc.facebookmail.com (a TRUE finding: NXDOMAIN on 1.1.1.1 /
-	// 8.8.8.8 / 9.9.9.9, no wildcard, while Meta's ruf vendor datafeeds.phishlabs.com IS
-	// authorized — so the record construction is provably right):
-	//   1. "will be silently discarded" asserts a definite delivery outcome we cannot
-	//      observe. Receiver enforcement of external destination verification is uneven,
-	//      so the honest modal is "may be discarded by receivers that enforce" it.
-	//   2. RFC 7489 was obsoleted May 2026 by RFC 9989/9990/9991; external destination
-	//      verification now lives in RFC 9990 §4.
-	// The finding also carries confidence:'deterministic', which is only defensible for
-	// the DNS fact (the record is absent) — never for the downstream consequence.
+	// Authorization lookup establishes a DNS fact, not a report-delivery outcome.
+	// Keep the public consequence conditional, cite RFC 9990 §4, and retain the
+	// exact record the destination needs to publish. All evidence here is synthetic.
 	it('states the RUA-authorization consequence as evidence-bounded, citing the current RFC', async () => {
 		const queryDNS = createMockDNS({
-			'_dmarc.example.com': ['v=DMARC1; p=reject; rua=mailto:dmarc@otherbrand.com'],
-			'example.com._report._dmarc.otherbrand.com': [], // missing auth
+			'_dmarc.example.com': ['v=DMARC1; p=reject; rua=mailto:dmarc@reports.example.net'],
+			'example.com._report._dmarc.reports.example.net': [], // missing auth
 		});
 		const result = await checkDMARC('example.com', queryDNS);
 		const finding = result.findings.find((f) => f.title === 'Third-party aggregate reporting not authorized');
@@ -115,7 +106,7 @@ describe('checkDMARC', () => {
 		expect(finding!.detail).toMatch(/RFC 9990/);
 
 		// The actionable part must survive the rewording: name the exact record to publish.
-		expect(finding!.detail).toContain('example.com._report._dmarc.otherbrand.com');
+		expect(finding!.detail).toContain('example.com._report._dmarc.reports.example.net');
 		expect(finding!.detail).toContain('v=DMARC1');
 	});
 

--- a/packages/dns-checks/src/checks/dmarc-utils.ts
+++ b/packages/dns-checks/src/checks/dmarc-utils.ts
@@ -87,8 +87,15 @@ export function detectThirdPartyAggregators(uris: string[]): string[] {
 }
 
 /**
- * Check cross-domain RUA authorization per RFC 7489 §7.1.
+ * Check cross-domain RUA authorization per RFC 9990 §4 ("Verifying External
+ * Destinations"), which obsoleted RFC 7489 §7.1 in May 2026.
  * When rua= points to a third-party domain, verify authorization TXT records.
+ *
+ * The finding this emits is rendered verbatim on the PUBLIC security-report page and
+ * names a real third party, so its wording is evidence-bounded on purpose: the DNS
+ * fact (the authorization record is absent) is deterministic and ours to assert, but
+ * whether reports are actually dropped depends on each receiver's enforcement of
+ * external destination verification — which we cannot observe. Say "may", not "will".
  */
 export async function checkRuaAuthorization(
 	domain: string,
@@ -113,7 +120,7 @@ export async function checkRuaAuthorization(
 						'dmarc',
 						'Third-party aggregate reporting not authorized',
 						'medium',
-						`Aggregate reports sent to ${targetDomain} will be silently discarded. The authorization record ${domain}._report._dmarc.${targetDomain} must contain a TXT record with "v=DMARC1" (RFC 7489 §7.1).`,
+						`Aggregate reports sent to ${targetDomain} may be discarded by receivers that enforce external destination verification. The authorization record ${domain}._report._dmarc.${targetDomain} must contain a TXT record with "v=DMARC1" (RFC 9990 §4, which obsoletes RFC 7489 §7.1).`,
 					),
 				);
 			}


### PR DESCRIPTION
Addresses **#911**, defects 1 and 2. Defects 3 and 4 stay open there by design — see *Deliberately not in scope* below.

## Why

The `Third-party aggregate reporting not authorized` finding renders **verbatim on the public `/security-report/<domain>` page** and names a real third party (the `rua` host). Its detection is correct; its prose made two claims we cannot stand behind.

## The detection is correct and unchanged

Investigated as a suspected false positive on `meta.com` → `dmarc.facebookmail.com`. It is a **true** finding:

| Probe | Result |
|---|---|
| `meta.com._report._dmarc.dmarc.facebookmail.com` | **NXDOMAIN** across three independent public resolvers |
| wildcard at the destination | NXDOMAIN — no catch-all either |
| **Control (known-good):** same query shape against dmarcian / Postmark / emailauth.io | all return `"v=DMARC1;"` — the probe discriminates |
| **Control (Meta's own `ruf` vendor):** `meta.com._report._dmarc.datafeeds.phishlabs.com` | **NOERROR** — authorized |

The last row is decisive: Meta *does* authorize its forensic-report vendor, so the record construction is provably right and the omission is real and selective. `facebook.com`, `instagram.com` and `whatsapp.com` share the same unauthorized `rua` host, so one misconfiguration yields four findings.

**No detection logic changed in this PR.**

## What changed

```diff
- Aggregate reports sent to X will be silently discarded. The authorization record
-   <name> must contain a TXT record with "v=DMARC1" (RFC 7489 §7.1).
+ Aggregate reports sent to X may be discarded by receivers that enforce external
+   destination verification. The authorization record <name> must contain a TXT
+   record with "v=DMARC1" (RFC 9990 §4, which obsoletes RFC 7489 §7.1).
```

1. **Unfalsifiable consequence.** "will be silently discarded" asserted a delivery outcome we cannot observe, while the finding carries `confidence: 'deterministic'`. That confidence is defensible for the DNS fact (the record is absent), not for what receivers then do — enforcement of external destination verification is uneven in practice.
2. **Obsoleted citation.** RFC 7489 was obsoleted in May 2026 by RFC 9989/9990/9991; external destination verification now lives in **RFC 9990 §4**. The stale citation also contradicted bv-web-prod's own published DMARCbis guide. The new text names what it obsoletes so the old reference stays recognisable.

The docblock now records *why* the wording is bounded, so it does not regress.

## Deliberately not in scope

- **Defect 3 (#911):** the trigger uses `isSubdomainOf` where RFC 9990 §4 scopes the exemption to the **Organizational Domain on both sides**. Latent — a 45-domain sweep found **0** live false findings, because destinations publish the record anyway even when not required (`docs.google.com._report._dmarc.google.com` → `"v=DMARC1"`). A fix needs a PSL/org-domain helper; that is a behaviour change, not a copy change, and does not belong in the same commit.
- **Defect 4 (#911):** the bare `catch {}` erases not-assessed state on SERVFAIL/timeout. Direction is a false *negative*, so it is not this symptom.

## Downstream constraint — do not re-vendor into bv-web-prod yet

bv-web-prod pins `@blackveil/dns-checks` at **1.32.0** under an engine freeze: the 1 Oct NZ SGE measurement was pre-announced to press with a commitment to measure baseline and re-run on an **identical engine**. This may release in bv-mcp, but **must not be re-vendored into bv-web-prod between the baseline run and the 1 Oct post run**.

Blast radius is otherwise nil: only the finding **detail** changes. The **title** is untouched, so bv-web-prod's `estate-seed.sql` (10 occurrences) and the scoring parity fixtures are unaffected, and severity and score are unchanged.

## Verification

Test-first — the new test went red on the exact assertion before the fix, then green. It pins the modal, the citation, and that the actionable part (the exact record to publish) survives the rewording.

```
packages/dns-checks:  57 files | 1060 tests passed
```

Branched from verified base `2d6834061` in an isolated worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
