### PR TITLE
feat(cli): add hosted client and park bounded probes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
 				"zod": "4.4.3"
 			},
 			"bin": {
+				"blackveil": "dist/cli.js",
 				"blackveil-dns-mcp": "dist/stdio.js"
 			},
 			"devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {
-		"blackveil-dns-mcp": "dist/stdio.js"
+		"blackveil-dns-mcp": "dist/stdio.js",
+		"blackveil": "dist/cli.js"
 	},
 	"files": [
 		"dist",

--- a/scripts/vitest-node-suites.mjs
+++ b/scripts/vitest-node-suites.mjs
@@ -21,6 +21,7 @@ export const NODE_POOL_AUDIT_TESTS = [
 	'test/audits/brand-audit-schema-preflight.node.test.ts',
 	'test/audits/brand-report-qa-script.node.test.ts',
 	'test/audits/brand-report-quality-audit-script.node.test.ts',
+	'test/audits/cli-pack-smoke.node.test.ts',
 	'test/audits/dependency-license.audit.test.ts',
 	'test/audits/license-headers.audit.test.ts',
 	'test/audits/pretooluse-hook-scope.node.test.ts',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: BUSL-1.1
+
+/// <reference types="node" />
+
+import { readFile, writeFile } from 'node:fs/promises';
+import { runCli } from './cli/command';
+
+export async function runBlackveilCli(argv = process.argv.slice(2)): Promise<number> {
+	return runCli(argv, {
+		env: process.env,
+		io: {
+			readTextFile: (path) => readFile(path, 'utf8'),
+			writeTextFile: async (path, content, overwrite) => {
+				await writeFile(path, content, { encoding: 'utf8', flag: overwrite ? 'w' : 'wx' });
+			},
+			stdout: (text) => {
+				process.stdout.write(text);
+			},
+			stderr: (text) => {
+				process.stderr.write(text);
+			},
+		},
+	});
+}
+
+if (import.meta.url.endsWith('/cli.js')) {
+	void runBlackveilCli().then((exitCode) => {
+		process.exitCode = exitCode;
+	});
+}

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -488,6 +488,11 @@ async function runDriftCompare(parsed: ParsedArgs, deps: CliDependencies): Promi
 	const scan = ScanResultSchema.safeParse(evidence.result);
 	if (!scan.success) throw new CliUsageError('Drift baseline does not contain a valid scan result');
 	if (scan.data.domain !== domain) throw new CliUsageError('Drift baseline domain does not match the requested domain');
+	// Check completeness before the baseline projection discards measurement status.
+	if (scanExit(scan.data) !== 0) {
+		deps.io.stderr('Drift baseline contains incomplete scan evidence. Save a complete scan before comparing drift.\n');
+		return 4;
+	}
 	const baseline = driftBaselineFromScan(scan.data);
 	const format = outputFormat(parsed);
 	const client = await connectedClient(deps);

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -3,7 +3,16 @@
 import { z } from 'zod';
 import { createEvidenceSnapshot, verifyEvidenceSnapshot, type EvidenceSnapshot } from './evidence';
 import { DEFAULT_MCP_ENDPOINT, McpClientError, McpHttpClient, type ToolCallResult } from './mcp-http-client';
-import { BatchResultSchema, CheckResultSchema, DriftResultSchema, PolicyResultSchema, ScanResultSchema, type ScanResult } from './schemas';
+import {
+	BatchResultSchema,
+	CheckResultSchema,
+	DriftResultSchema,
+	hasIncompleteCheckEvidence,
+	hasIncompleteScanEvidence,
+	PolicyResultSchema,
+	ScanResultSchema,
+	type ScanResult,
+} from './schemas';
 
 export type CliExitCode = 0 | 1 | 2 | 3 | 4;
 export type CliOutputFormat = 'human' | 'json' | 'ndjson' | 'evidence';
@@ -20,6 +29,8 @@ export interface CliDependencies {
 	env?: Record<string, string | undefined>;
 	fetchFn?: typeof fetch;
 	now?: () => Date;
+	nowMs?: () => number;
+	deadlineAt?: number;
 }
 
 class CliUsageError extends Error {}
@@ -149,16 +160,66 @@ function toolErrorText(result: ToolCallResult): string {
 		.join('\n');
 }
 
-function classifyToolError(result: ToolCallResult): CliExitCode | undefined {
+export function sanitizeDiagnostic(value: string): string {
+	const withoutTerminalSequences: string[] = [];
+	for (let index = 0; index < value.length; index += 1) {
+		const code = value.charCodeAt(index);
+		if (code !== 0x1b) {
+			withoutTerminalSequences.push(value[index] ?? '');
+			continue;
+		}
+		const marker = value.charCodeAt(index + 1);
+		if (marker === 0x5b) {
+			index += 2;
+			while (index < value.length && (value.charCodeAt(index) < 0x40 || value.charCodeAt(index) > 0x7e)) index += 1;
+			continue;
+		}
+		if (marker === 0x5d) {
+			index += 2;
+			while (index < value.length) {
+				const current = value.charCodeAt(index);
+				if (current === 0x07 || (current === 0x1b && value.charCodeAt(index + 1) === 0x5c)) break;
+				index += 1;
+			}
+			if (value.charCodeAt(index) === 0x1b) index += 1;
+			continue;
+		}
+		index += 1;
+	}
+	let sanitized = '';
+	for (const character of withoutTerminalSequences.join('').normalize('NFKC')) {
+		const code = character.codePointAt(0) ?? 0;
+		const unsafeFormatting =
+			code === 0x200b ||
+			code === 0x200c ||
+			code === 0x200d ||
+			code === 0xfeff ||
+			(code >= 0x202a && code <= 0x202e) ||
+			(code >= 0x2066 && code <= 0x2069);
+		if (!unsafeFormatting && (character === '\n' || character === '\t' || (code >= 0x20 && !(code >= 0x7f && code <= 0x9f))))
+			sanitized += character;
+	}
+	return sanitized.replaceAll('\r', '').trim().slice(0, 2_000);
+}
+
+function classifyToolError(result: ToolCallResult, io: CliIo, tool: string): CliExitCode | undefined {
 	if (!result.isError) return undefined;
-	const message = toolErrorText(result);
+	const message = sanitizeDiagnostic(toolErrorText(result)) || 'Remote tool returned an unspecified error';
+	io.stderr(`${tool}: ${message}\n`);
 	if (/Invalid baseline|could not read|valid JSON/i.test(message)) return 2;
 	if (/never graded|could not be scored|nothing to measure/i.test(message)) return 4;
 	return 3;
 }
 
 function scanExit(scan: ScanResult): CliExitCode {
-	return !scan.measured || scan.score === null || scan.grade === null || scan.evidenceInsufficient || scan.error ? 4 : 0;
+	return !scan.measured ||
+		scan.score === null ||
+		scan.grade === null ||
+		scan.evidenceInsufficient ||
+		scan.error ||
+		hasIncompleteScanEvidence(scan)
+		? 4
+		: 0;
 }
 
 function policyExit(value: z.infer<typeof PolicyResultSchema>): CliExitCode {
@@ -220,10 +281,13 @@ async function emit(io: CliIo, parsed: ParsedArgs, content: string): Promise<voi
 }
 
 function createClient(deps: CliDependencies): McpHttpClient {
+	const now = deps.nowMs ?? Date.now;
 	return new McpHttpClient({
 		endpoint: deps.env?.BLACKVEIL_MCP_URL ?? DEFAULT_MCP_ENDPOINT,
 		apiKey: deps.env?.BLACKVEIL_API_KEY,
 		fetchFn: deps.fetchFn,
+		deadlineAt: deps.deadlineAt,
+		now,
 	});
 }
 
@@ -233,9 +297,9 @@ async function connectedClient(deps: CliDependencies): Promise<McpHttpClient> {
 	return client;
 }
 
-async function callPolicy(client: McpHttpClient, domain: string, baseline: Record<string, unknown>) {
-	const result = await client.callTool('compare_baseline', { domain, baseline, format: 'full' });
-	const errorExit = classifyToolError(result);
+async function callPolicy(client: McpHttpClient, domain: string, baseline: Record<string, unknown>, io: CliIo) {
+	const result = await client.callTool('compare_baseline', { domain, baseline, format: 'full' }, { readOnly: true });
+	const errorExit = classifyToolError(result, io, 'compare_baseline');
 	if (errorExit !== undefined) return { result, exit: errorExit };
 	const parsed = PolicyResultSchema.safeParse(requireStructured(result, 'compare_baseline'));
 	if (!parsed.success) throw new McpClientError('compare_baseline returned malformed structuredContent', 'protocol');
@@ -248,19 +312,23 @@ async function runScan(parsed: ParsedArgs, deps: CliDependencies): Promise<CliEx
 	const format = outputFormat(parsed);
 	const baseline = await loadPolicy(parsed, deps.io);
 	const client = await connectedClient(deps);
-	const result = await client.callTool('scan_domain', {
-		domain,
-		format: 'full',
-		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
-	});
-	const errorExit = classifyToolError(result);
+	const result = await client.callTool(
+		'scan_domain',
+		{
+			domain,
+			format: 'full',
+			...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+		},
+		{ readOnly: true },
+	);
+	const errorExit = classifyToolError(result, deps.io, 'scan_domain');
 	if (errorExit !== undefined) return errorExit;
 	const structured = ScanResultSchema.safeParse(requireStructured(result, 'scan_domain'));
 	if (!structured.success) throw new McpClientError('scan_domain returned malformed structuredContent', 'protocol');
 	await emit(deps.io, parsed, await renderedOutput({ result, format, tool: 'scan_domain', client, now: deps.now ?? (() => new Date()) }));
 	const scanCode = scanExit(structured.data);
 	if (scanCode !== 0 || !baseline) return scanCode;
-	return (await callPolicy(client, domain, baseline)).exit;
+	return (await callPolicy(client, domain, baseline, deps.io)).exit;
 }
 
 async function runCheck(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
@@ -277,17 +345,21 @@ async function runCheck(parsed: ParsedArgs, deps: CliDependencies): Promise<CliE
 	if (!tool || tool.annotations?.readOnlyHint !== true || tool.outputSchema === undefined) {
 		throw new CliUsageError(`${toolName} is not a public read-only CheckResult tool`);
 	}
-	const result = await client.callTool(toolName, {
-		domain,
-		format: 'full',
-		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
-	});
-	const errorExit = classifyToolError(result);
+	const result = await client.callTool(
+		toolName,
+		{
+			domain,
+			format: 'full',
+			...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+		},
+		{ readOnly: true },
+	);
+	const errorExit = classifyToolError(result, deps.io, toolName);
 	if (errorExit !== undefined) return errorExit;
 	const structured = CheckResultSchema.safeParse(requireStructured(result, toolName));
 	if (!structured.success) throw new McpClientError(`${toolName} returned malformed CheckResult structuredContent`, 'protocol');
 	await emit(deps.io, parsed, await renderedOutput({ result, format, tool: toolName, client, now: deps.now ?? (() => new Date()) }));
-	return structured.data.partial ? 4 : 0;
+	return hasIncompleteCheckEvidence(structured.data) ? 4 : 0;
 }
 
 async function readDomains(io: CliIo, path: string): Promise<string[]> {
@@ -315,12 +387,16 @@ async function runBatch(parsed: ParsedArgs, deps: CliDependencies): Promise<CliE
 	const domains = await readDomains(deps.io, file);
 	const baseline = await loadPolicy(parsed, deps.io);
 	const client = await connectedClient(deps);
-	const result = await client.callTool('batch_scan', {
-		domains,
-		format: 'full',
-		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
-	});
-	const errorExit = classifyToolError(result);
+	const result = await client.callTool(
+		'batch_scan',
+		{
+			domains,
+			format: 'full',
+			...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+		},
+		{ readOnly: true },
+	);
+	const errorExit = classifyToolError(result, deps.io, 'batch_scan');
 	if (errorExit !== undefined) return errorExit;
 	const structured = BatchResultSchema.safeParse(requireStructured(result, 'batch_scan'));
 	if (!structured.success) throw new McpClientError('batch_scan returned malformed structuredContent', 'protocol');
@@ -330,7 +406,7 @@ async function runBatch(parsed: ParsedArgs, deps: CliDependencies): Promise<CliE
 	if (baseline) {
 		for (const scan of structured.data.results) {
 			if (scanExit(scan) !== 0) continue;
-			codes.push((await callPolicy(client, scan.domain, baseline)).exit);
+			codes.push((await callPolicy(client, scan.domain, baseline, deps.io)).exit);
 		}
 	}
 	return combineBatchExitCodes(codes);
@@ -343,7 +419,7 @@ async function runPolicy(parsed: ParsedArgs, deps: CliDependencies): Promise<Cli
 	if (!baseline) throw new CliUsageError('Policy requires --policy or --fail-below');
 	const format = outputFormat(parsed);
 	const client = await connectedClient(deps);
-	const evaluated = await callPolicy(client, domain, baseline);
+	const evaluated = await callPolicy(client, domain, baseline, deps.io);
 	if (evaluated.exit === 2 || evaluated.exit === 3) return evaluated.exit;
 	await emit(
 		deps.io,
@@ -368,12 +444,16 @@ async function runDriftSave(parsed: ParsedArgs, deps: CliDependencies): Promise<
 	const domain = requiredSinglePosition(parsed, 'domain');
 	if (!parsed.values.get('--out')) throw new CliUsageError('drift save requires --out');
 	const client = await connectedClient(deps);
-	const result = await client.callTool('scan_domain', {
-		domain,
-		format: 'full',
-		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
-	});
-	const errorExit = classifyToolError(result);
+	const result = await client.callTool(
+		'scan_domain',
+		{
+			domain,
+			format: 'full',
+			...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+		},
+		{ readOnly: true },
+	);
+	const errorExit = classifyToolError(result, deps.io, 'scan_domain');
 	if (errorExit !== undefined) return errorExit;
 	const structured = ScanResultSchema.safeParse(requireStructured(result, 'scan_domain'));
 	if (!structured.success) throw new McpClientError('scan_domain returned malformed structuredContent', 'protocol');
@@ -411,8 +491,8 @@ async function runDriftCompare(parsed: ParsedArgs, deps: CliDependencies): Promi
 	const baseline = driftBaselineFromScan(scan.data);
 	const format = outputFormat(parsed);
 	const client = await connectedClient(deps);
-	const result = await client.callTool('analyze_drift', { domain, baseline: JSON.stringify(baseline), format: 'full' });
-	const errorExit = classifyToolError(result);
+	const result = await client.callTool('analyze_drift', { domain, baseline: JSON.stringify(baseline), format: 'full' }, { readOnly: true });
+	const errorExit = classifyToolError(result, deps.io, 'analyze_drift');
 	if (errorExit !== undefined) return errorExit;
 	const structured = DriftResultSchema.safeParse(requireStructured(result, 'analyze_drift'));
 	if (!structured.success) throw new McpClientError('analyze_drift returned malformed structuredContent', 'protocol');
@@ -454,47 +534,51 @@ export async function runCli(argv: string[], deps: CliDependencies): Promise<Cli
 	}
 
 	try {
+		const commandDeps: CliDependencies = {
+			...deps,
+			deadlineAt: deps.deadlineAt ?? (deps.nowMs ?? Date.now)() + 45_000,
+		};
 		const [command, ...rest] = argv;
 		const parsed = parseArgs(rest);
 		switch (command) {
 			case 'scan':
-				return await runScan(parsed, deps);
+				return await runScan(parsed, commandDeps);
 			case 'check':
-				return await runCheck(parsed, deps);
+				return await runCheck(parsed, commandDeps);
 			case 'batch':
-				return await runBatch(parsed, deps);
+				return await runBatch(parsed, commandDeps);
 			case 'policy':
-				return await runPolicy(parsed, deps);
+				return await runPolicy(parsed, commandDeps);
 			case 'drift': {
 				const [subcommand, ...subcommandArgs] = rest;
 				if (!subcommand) throw new CliUsageError('drift requires save or compare');
 				const driftParsed = parseArgs(subcommandArgs);
-				if (subcommand === 'save') return await runDriftSave(driftParsed, deps);
-				if (subcommand === 'compare') return await runDriftCompare(driftParsed, deps);
+				if (subcommand === 'save') return await runDriftSave(driftParsed, commandDeps);
+				if (subcommand === 'compare') return await runDriftCompare(driftParsed, commandDeps);
 				throw new CliUsageError('drift requires save or compare');
 			}
 			case 'evidence': {
 				const [subcommand, ...subcommandArgs] = rest;
 				if (subcommand !== 'verify') throw new CliUsageError('evidence requires verify');
-				return await runEvidenceVerify(parseArgs(subcommandArgs), deps);
+				return await runEvidenceVerify(parseArgs(subcommandArgs), commandDeps);
 			}
 			default:
 				throw new CliUsageError(`Unknown command ${command}`);
 		}
 	} catch (error) {
 		if (error instanceof CliVerificationError) {
-			deps.io.stderr(`${error.message}\n`);
+			deps.io.stderr(`${sanitizeDiagnostic(error.message)}\n`);
 			return 1;
 		}
 		if (error instanceof CliUsageError) {
-			deps.io.stderr(`${error.message}\nRun blackveil --help for usage.\n`);
+			deps.io.stderr(`${sanitizeDiagnostic(error.message)}\nRun blackveil --help for usage.\n`);
 			return 2;
 		}
 		if (error instanceof McpClientError) {
-			deps.io.stderr(`${error.message}\n`);
+			deps.io.stderr(`${sanitizeDiagnostic(error.message)}\n`);
 			return 3;
 		}
-		deps.io.stderr(`${error instanceof Error ? error.message : 'Unexpected CLI failure'}\n`);
+		deps.io.stderr(`${sanitizeDiagnostic(error instanceof Error ? error.message : 'Unexpected CLI failure')}\n`);
 		return 3;
 	}
 }

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -1,0 +1,500 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { z } from 'zod';
+import { createEvidenceSnapshot, verifyEvidenceSnapshot, type EvidenceSnapshot } from './evidence';
+import { DEFAULT_MCP_ENDPOINT, McpClientError, McpHttpClient, type ToolCallResult } from './mcp-http-client';
+import { BatchResultSchema, CheckResultSchema, DriftResultSchema, PolicyResultSchema, ScanResultSchema, type ScanResult } from './schemas';
+
+export type CliExitCode = 0 | 1 | 2 | 3 | 4;
+export type CliOutputFormat = 'human' | 'json' | 'ndjson' | 'evidence';
+
+export interface CliIo {
+	readTextFile(path: string): Promise<string>;
+	writeTextFile(path: string, content: string, overwrite: boolean): Promise<void>;
+	stdout(text: string): void;
+	stderr(text: string): void;
+}
+
+export interface CliDependencies {
+	io: CliIo;
+	env?: Record<string, string | undefined>;
+	fetchFn?: typeof fetch;
+	now?: () => Date;
+}
+
+class CliUsageError extends Error {}
+class CliVerificationError extends Error {}
+
+const HELP = `BlackVeil hosted DNS security CLI
+
+Usage:
+  blackveil scan <domain> [--format human|json|ndjson|evidence] [--out <file>] [--force-refresh]
+                         [--fail-below <0-100> | --policy <file>]
+  blackveil check <name> <domain> [--format human|json|ndjson|evidence] [--out <file>] [--force-refresh]
+  blackveil batch --file <domains.txt> [--format human|json|ndjson|evidence] [--out <file>] [--force-refresh]
+                                      [--fail-below <0-100> | --policy <file>]
+  blackveil policy <domain> (--fail-below <0-100> | --policy <file>) [--format human|json|ndjson|evidence]
+  blackveil drift save <domain> --out <file> [--force-refresh] [--force]
+  blackveil drift compare <domain> --baseline <evidence.json> [--format human|json|ndjson|evidence]
+  blackveil evidence verify <evidence.json> [--format human|json]
+
+Environment:
+  BLACKVEIL_API_KEY   Optional bearer credential. API keys are never accepted on the command line.
+  BLACKVEIL_MCP_URL   Optional MCP endpoint. HTTPS is required except for loopback development.
+
+Exit codes:
+  0 completed/pass; 1 verified policy or integrity failure; 2 usage/input;
+  3 auth/quota/transport/protocol/tool error; 4 ungraded/inconclusive/incomplete.
+`;
+
+type ParsedArgs = {
+	positionals: string[];
+	values: Map<string, string>;
+	flags: Set<string>;
+};
+
+const VALUE_OPTIONS = new Set(['--format', '--out', '--file', '--policy', '--fail-below', '--baseline']);
+const BOOLEAN_OPTIONS = new Set(['--force-refresh', '--force']);
+
+function parseArgs(args: string[]): ParsedArgs {
+	const parsed: ParsedArgs = { positionals: [], values: new Map(), flags: new Set() };
+	for (let index = 0; index < args.length; index += 1) {
+		const token = args[index];
+		if (!token) continue;
+		if (VALUE_OPTIONS.has(token)) {
+			if (parsed.values.has(token)) throw new CliUsageError(`Duplicate option ${token}`);
+			const value = args[++index];
+			if (!value || value.startsWith('--')) throw new CliUsageError(`Missing value for ${token}`);
+			parsed.values.set(token, value);
+			continue;
+		}
+		if (BOOLEAN_OPTIONS.has(token)) {
+			if (parsed.flags.has(token)) throw new CliUsageError(`Duplicate option ${token}`);
+			parsed.flags.add(token);
+			continue;
+		}
+		if (token.startsWith('-')) throw new CliUsageError(`Unknown option ${token}`);
+		parsed.positionals.push(token);
+	}
+	return parsed;
+}
+
+function assertOptions(parsed: ParsedArgs, allowedValues: string[], allowedFlags: string[]): void {
+	for (const option of parsed.values.keys()) {
+		if (!allowedValues.includes(option)) throw new CliUsageError(`Option ${option} is not valid for this command`);
+	}
+	for (const option of parsed.flags) {
+		if (!allowedFlags.includes(option)) throw new CliUsageError(`Option ${option} is not valid for this command`);
+	}
+}
+
+function outputFormat(parsed: ParsedArgs, allowed: readonly CliOutputFormat[] = ['human', 'json', 'ndjson', 'evidence']): CliOutputFormat {
+	const value = parsed.values.get('--format') ?? 'human';
+	if (!allowed.includes(value as CliOutputFormat)) throw new CliUsageError(`Invalid output format ${value}`);
+	return value as CliOutputFormat;
+}
+
+function requiredSinglePosition(parsed: ParsedArgs, label: string): string {
+	if (parsed.positionals.length !== 1 || !parsed.positionals[0]) throw new CliUsageError(`Expected exactly one ${label}`);
+	return parsed.positionals[0];
+}
+
+function parseScoreFloor(raw: string): number {
+	const value = Number(raw);
+	if (!Number.isFinite(value) || value < 0 || value > 100) throw new CliUsageError('--fail-below must be a number from 0 to 100');
+	return value;
+}
+
+async function parseJsonFile(io: CliIo, path: string): Promise<unknown> {
+	let text: string;
+	try {
+		text = await io.readTextFile(path);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'read failed';
+		throw new CliUsageError(`Could not read ${path}: ${message}`);
+	}
+	try {
+		return JSON.parse(text);
+	} catch {
+		throw new CliUsageError(`${path} does not contain valid JSON`);
+	}
+}
+
+async function loadPolicy(parsed: ParsedArgs, io: CliIo): Promise<Record<string, unknown> | undefined> {
+	const policyPath = parsed.values.get('--policy');
+	const floor = parsed.values.get('--fail-below');
+	if (policyPath && floor) throw new CliUsageError('Use either --policy or --fail-below, not both');
+	if (floor !== undefined) return { score: parseScoreFloor(floor) };
+	if (!policyPath) return undefined;
+	const value = await parseJsonFile(io, policyPath);
+	if (!value || typeof value !== 'object' || Array.isArray(value)) throw new CliUsageError('Policy JSON must be an object');
+	return value as Record<string, unknown>;
+}
+
+function requireStructured(result: ToolCallResult, tool: string): Record<string, unknown> {
+	if (!result.structuredContent) throw new McpClientError(`MCP tool ${tool} omitted structuredContent`, 'protocol');
+	return result.structuredContent;
+}
+
+function toolText(result: ToolCallResult): string {
+	const text = result.content.find((item) => item.type === 'text' && typeof item.text === 'string')?.text;
+	if (!text) throw new McpClientError('MCP tool result omitted human-readable text', 'protocol');
+	return text;
+}
+
+function toolErrorText(result: ToolCallResult): string {
+	return result.content
+		.filter((item) => item.type === 'text' && typeof item.text === 'string')
+		.map((item) => item.text)
+		.join('\n');
+}
+
+function classifyToolError(result: ToolCallResult): CliExitCode | undefined {
+	if (!result.isError) return undefined;
+	const message = toolErrorText(result);
+	if (/Invalid baseline|could not read|valid JSON/i.test(message)) return 2;
+	if (/never graded|could not be scored|nothing to measure/i.test(message)) return 4;
+	return 3;
+}
+
+function scanExit(scan: ScanResult): CliExitCode {
+	return !scan.measured || scan.score === null || scan.grade === null || scan.evidenceInsufficient || scan.error ? 4 : 0;
+}
+
+function policyExit(value: z.infer<typeof PolicyResultSchema>): CliExitCode {
+	return value.passed === null ? 4 : value.passed ? 0 : 1;
+}
+
+/** System errors outrank incomplete evidence, which outranks measured policy failure. */
+export function combineBatchExitCodes(codes: readonly CliExitCode[]): CliExitCode {
+	if (codes.includes(3)) return 3;
+	if (codes.includes(4)) return 4;
+	if (codes.includes(1)) return 1;
+	if (codes.includes(2)) return 2;
+	return 0;
+}
+
+function ndjson(value: Record<string, unknown>): string {
+	const results = value.results;
+	if (Array.isArray(results)) return results.map((entry) => JSON.stringify(entry)).join('\n');
+	return JSON.stringify(value);
+}
+
+async function renderedOutput(args: {
+	result: ToolCallResult;
+	format: CliOutputFormat;
+	tool: string;
+	client: McpHttpClient;
+	now: () => Date;
+}): Promise<string> {
+	if (args.format === 'human') return toolText(args.result);
+	const structured = requireStructured(args.result, args.tool);
+	if (args.format === 'json') return JSON.stringify(structured, null, 2);
+	if (args.format === 'ndjson') return ndjson(structured);
+	const serverInfo = args.client.serverInfo;
+	if (!serverInfo) throw new McpClientError('MCP client has no server provenance', 'protocol');
+	const evidence = await createEvidenceSnapshot({
+		capturedAt: args.now().toISOString(),
+		serverName: serverInfo.name,
+		serverVersion: serverInfo.version,
+		endpointOrigin: args.client.endpointOrigin,
+		tool: args.tool,
+		result: structured,
+	});
+	return JSON.stringify(evidence, null, 2);
+}
+
+async function emit(io: CliIo, parsed: ParsedArgs, content: string): Promise<void> {
+	const out = parsed.values.get('--out');
+	if (!out) {
+		io.stdout(`${content}\n`);
+		return;
+	}
+	try {
+		await io.writeTextFile(out, `${content}\n`, parsed.flags.has('--force'));
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'write failed';
+		throw new CliUsageError(`Could not write ${out}: ${message}`);
+	}
+	io.stderr(`Wrote ${out}\n`);
+}
+
+function createClient(deps: CliDependencies): McpHttpClient {
+	return new McpHttpClient({
+		endpoint: deps.env?.BLACKVEIL_MCP_URL ?? DEFAULT_MCP_ENDPOINT,
+		apiKey: deps.env?.BLACKVEIL_API_KEY,
+		fetchFn: deps.fetchFn,
+	});
+}
+
+async function connectedClient(deps: CliDependencies): Promise<McpHttpClient> {
+	const client = createClient(deps);
+	await client.connect();
+	return client;
+}
+
+async function callPolicy(client: McpHttpClient, domain: string, baseline: Record<string, unknown>) {
+	const result = await client.callTool('compare_baseline', { domain, baseline, format: 'full' });
+	const errorExit = classifyToolError(result);
+	if (errorExit !== undefined) return { result, exit: errorExit };
+	const parsed = PolicyResultSchema.safeParse(requireStructured(result, 'compare_baseline'));
+	if (!parsed.success) throw new McpClientError('compare_baseline returned malformed structuredContent', 'protocol');
+	return { result, exit: policyExit(parsed.data) };
+}
+
+async function runScan(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
+	assertOptions(parsed, ['--format', '--out', '--policy', '--fail-below'], ['--force-refresh', '--force']);
+	const domain = requiredSinglePosition(parsed, 'domain');
+	const format = outputFormat(parsed);
+	const baseline = await loadPolicy(parsed, deps.io);
+	const client = await connectedClient(deps);
+	const result = await client.callTool('scan_domain', {
+		domain,
+		format: 'full',
+		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+	});
+	const errorExit = classifyToolError(result);
+	if (errorExit !== undefined) return errorExit;
+	const structured = ScanResultSchema.safeParse(requireStructured(result, 'scan_domain'));
+	if (!structured.success) throw new McpClientError('scan_domain returned malformed structuredContent', 'protocol');
+	await emit(deps.io, parsed, await renderedOutput({ result, format, tool: 'scan_domain', client, now: deps.now ?? (() => new Date()) }));
+	const scanCode = scanExit(structured.data);
+	if (scanCode !== 0 || !baseline) return scanCode;
+	return (await callPolicy(client, domain, baseline)).exit;
+}
+
+async function runCheck(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
+	assertOptions(parsed, ['--format', '--out'], ['--force-refresh', '--force']);
+	if (parsed.positionals.length !== 2) throw new CliUsageError('Expected a check name and one domain');
+	const [rawName, domain] = parsed.positionals;
+	if (!rawName || !domain) throw new CliUsageError('Expected a check name and one domain');
+	const toolName = rawName.startsWith('check_') ? rawName : `check_${rawName.replaceAll('-', '_')}`;
+	if (!/^check_[a-z0-9_]+$/.test(toolName)) throw new CliUsageError('Invalid check name');
+	const format = outputFormat(parsed);
+	const client = await connectedClient(deps);
+	const tools = await client.listTools();
+	const tool = tools.find((entry) => entry.name === toolName);
+	if (!tool || tool.annotations?.readOnlyHint !== true || tool.outputSchema === undefined) {
+		throw new CliUsageError(`${toolName} is not a public read-only CheckResult tool`);
+	}
+	const result = await client.callTool(toolName, {
+		domain,
+		format: 'full',
+		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+	});
+	const errorExit = classifyToolError(result);
+	if (errorExit !== undefined) return errorExit;
+	const structured = CheckResultSchema.safeParse(requireStructured(result, toolName));
+	if (!structured.success) throw new McpClientError(`${toolName} returned malformed CheckResult structuredContent`, 'protocol');
+	await emit(deps.io, parsed, await renderedOutput({ result, format, tool: toolName, client, now: deps.now ?? (() => new Date()) }));
+	return structured.data.partial ? 4 : 0;
+}
+
+async function readDomains(io: CliIo, path: string): Promise<string[]> {
+	let text: string;
+	try {
+		text = await io.readTextFile(path);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'read failed';
+		throw new CliUsageError(`Could not read ${path}: ${message}`);
+	}
+	const domains = text
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0 && !line.startsWith('#'));
+	if (domains.length < 1 || domains.length > 10) throw new CliUsageError('Batch file must contain 1 to 10 domains');
+	return domains;
+}
+
+async function runBatch(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
+	assertOptions(parsed, ['--format', '--out', '--file', '--policy', '--fail-below'], ['--force-refresh', '--force']);
+	if (parsed.positionals.length !== 0) throw new CliUsageError('Batch accepts domains only through --file');
+	const file = parsed.values.get('--file');
+	if (!file) throw new CliUsageError('Batch requires --file');
+	const format = outputFormat(parsed);
+	const domains = await readDomains(deps.io, file);
+	const baseline = await loadPolicy(parsed, deps.io);
+	const client = await connectedClient(deps);
+	const result = await client.callTool('batch_scan', {
+		domains,
+		format: 'full',
+		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+	});
+	const errorExit = classifyToolError(result);
+	if (errorExit !== undefined) return errorExit;
+	const structured = BatchResultSchema.safeParse(requireStructured(result, 'batch_scan'));
+	if (!structured.success) throw new McpClientError('batch_scan returned malformed structuredContent', 'protocol');
+	await emit(deps.io, parsed, await renderedOutput({ result, format, tool: 'batch_scan', client, now: deps.now ?? (() => new Date()) }));
+
+	const codes: CliExitCode[] = structured.data.results.map(scanExit);
+	if (baseline) {
+		for (const scan of structured.data.results) {
+			if (scanExit(scan) !== 0) continue;
+			codes.push((await callPolicy(client, scan.domain, baseline)).exit);
+		}
+	}
+	return combineBatchExitCodes(codes);
+}
+
+async function runPolicy(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
+	assertOptions(parsed, ['--format', '--out', '--policy', '--fail-below'], ['--force']);
+	const domain = requiredSinglePosition(parsed, 'domain');
+	const baseline = await loadPolicy(parsed, deps.io);
+	if (!baseline) throw new CliUsageError('Policy requires --policy or --fail-below');
+	const format = outputFormat(parsed);
+	const client = await connectedClient(deps);
+	const evaluated = await callPolicy(client, domain, baseline);
+	if (evaluated.exit === 2 || evaluated.exit === 3) return evaluated.exit;
+	await emit(
+		deps.io,
+		parsed,
+		await renderedOutput({ result: evaluated.result, format, tool: 'compare_baseline', client, now: deps.now ?? (() => new Date()) }),
+	);
+	return evaluated.exit;
+}
+
+function driftBaselineFromScan(scan: ScanResult): Record<string, unknown> {
+	if (scan.score === null || scan.grade === null) throw new CliUsageError('An ungraded scan cannot be used as a drift baseline');
+	return {
+		overall: scan.score,
+		grade: scan.grade,
+		categoryScores: Object.fromEntries(Object.entries(scan.categoryScores).filter((entry): entry is [string, number] => entry[1] !== null)),
+		findings: scan.findings,
+	};
+}
+
+async function runDriftSave(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
+	assertOptions(parsed, ['--out'], ['--force-refresh', '--force']);
+	const domain = requiredSinglePosition(parsed, 'domain');
+	if (!parsed.values.get('--out')) throw new CliUsageError('drift save requires --out');
+	const client = await connectedClient(deps);
+	const result = await client.callTool('scan_domain', {
+		domain,
+		format: 'full',
+		...(parsed.flags.has('--force-refresh') ? { force_refresh: true } : {}),
+	});
+	const errorExit = classifyToolError(result);
+	if (errorExit !== undefined) return errorExit;
+	const structured = ScanResultSchema.safeParse(requireStructured(result, 'scan_domain'));
+	if (!structured.success) throw new McpClientError('scan_domain returned malformed structuredContent', 'protocol');
+	await emit(
+		deps.io,
+		parsed,
+		await renderedOutput({ result, format: 'evidence', tool: 'scan_domain', client, now: deps.now ?? (() => new Date()) }),
+	);
+	return scanExit(structured.data);
+}
+
+async function loadVerifiedEvidence(io: CliIo, path: string): Promise<EvidenceSnapshot> {
+	const raw = await parseJsonFile(io, path);
+	let verification;
+	try {
+		verification = await verifyEvidenceSnapshot(raw);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'schema validation failed';
+		throw new CliUsageError(`Invalid evidence snapshot: ${message}`);
+	}
+	if (!verification.valid) throw new CliVerificationError('Evidence snapshot integrity verification failed');
+	return verification.snapshot;
+}
+
+async function runDriftCompare(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
+	assertOptions(parsed, ['--format', '--out', '--baseline'], ['--force']);
+	const domain = requiredSinglePosition(parsed, 'domain');
+	const baselinePath = parsed.values.get('--baseline');
+	if (!baselinePath) throw new CliUsageError('drift compare requires --baseline');
+	const evidence = await loadVerifiedEvidence(deps.io, baselinePath);
+	if (evidence.source.tool !== 'scan_domain') throw new CliUsageError('Drift baseline evidence must come from scan_domain');
+	const scan = ScanResultSchema.safeParse(evidence.result);
+	if (!scan.success) throw new CliUsageError('Drift baseline does not contain a valid scan result');
+	if (scan.data.domain !== domain) throw new CliUsageError('Drift baseline domain does not match the requested domain');
+	const baseline = driftBaselineFromScan(scan.data);
+	const format = outputFormat(parsed);
+	const client = await connectedClient(deps);
+	const result = await client.callTool('analyze_drift', { domain, baseline: JSON.stringify(baseline), format: 'full' });
+	const errorExit = classifyToolError(result);
+	if (errorExit !== undefined) return errorExit;
+	const structured = DriftResultSchema.safeParse(requireStructured(result, 'analyze_drift'));
+	if (!structured.success) throw new McpClientError('analyze_drift returned malformed structuredContent', 'protocol');
+	await emit(deps.io, parsed, await renderedOutput({ result, format, tool: 'analyze_drift', client, now: deps.now ?? (() => new Date()) }));
+	return structured.data.classification === 'inconclusive' ? 4 : 0;
+}
+
+async function runEvidenceVerify(parsed: ParsedArgs, deps: CliDependencies): Promise<CliExitCode> {
+	assertOptions(parsed, ['--format'], []);
+	const path = requiredSinglePosition(parsed, 'evidence file');
+	const format = outputFormat(parsed, ['human', 'json']);
+	const raw = await parseJsonFile(deps.io, path);
+	let verification;
+	try {
+		verification = await verifyEvidenceSnapshot(raw);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : 'schema validation failed';
+		throw new CliUsageError(`Invalid evidence snapshot: ${message}`);
+	}
+	if (format === 'json') {
+		deps.io.stdout(
+			`${JSON.stringify({ valid: verification.valid, expectedDigest: verification.expectedDigest, actualDigest: verification.actualDigest }, null, 2)}\n`,
+		);
+	} else {
+		deps.io.stdout(
+			verification.valid
+				? `VALID ${verification.actualDigest}\n`
+				: `INVALID expected ${verification.expectedDigest} but computed ${verification.actualDigest}\n`,
+		);
+	}
+	return verification.valid ? 0 : 1;
+}
+
+/** Execute one CLI invocation without mutating process globals. */
+export async function runCli(argv: string[], deps: CliDependencies): Promise<CliExitCode> {
+	if (argv.length === 0 || argv[0] === '--help' || argv[0] === '-h' || argv[0] === 'help') {
+		deps.io.stdout(HELP);
+		return 0;
+	}
+
+	try {
+		const [command, ...rest] = argv;
+		const parsed = parseArgs(rest);
+		switch (command) {
+			case 'scan':
+				return await runScan(parsed, deps);
+			case 'check':
+				return await runCheck(parsed, deps);
+			case 'batch':
+				return await runBatch(parsed, deps);
+			case 'policy':
+				return await runPolicy(parsed, deps);
+			case 'drift': {
+				const [subcommand, ...subcommandArgs] = rest;
+				if (!subcommand) throw new CliUsageError('drift requires save or compare');
+				const driftParsed = parseArgs(subcommandArgs);
+				if (subcommand === 'save') return await runDriftSave(driftParsed, deps);
+				if (subcommand === 'compare') return await runDriftCompare(driftParsed, deps);
+				throw new CliUsageError('drift requires save or compare');
+			}
+			case 'evidence': {
+				const [subcommand, ...subcommandArgs] = rest;
+				if (subcommand !== 'verify') throw new CliUsageError('evidence requires verify');
+				return await runEvidenceVerify(parseArgs(subcommandArgs), deps);
+			}
+			default:
+				throw new CliUsageError(`Unknown command ${command}`);
+		}
+	} catch (error) {
+		if (error instanceof CliVerificationError) {
+			deps.io.stderr(`${error.message}\n`);
+			return 1;
+		}
+		if (error instanceof CliUsageError) {
+			deps.io.stderr(`${error.message}\nRun blackveil --help for usage.\n`);
+			return 2;
+		}
+		if (error instanceof McpClientError) {
+			deps.io.stderr(`${error.message}\n`);
+			return 3;
+		}
+		deps.io.stderr(`${error instanceof Error ? error.message : 'Unexpected CLI failure'}\n`);
+		return 3;
+	}
+}

--- a/src/cli/evidence.ts
+++ b/src/cli/evidence.ts
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { z } from 'zod';
+
+export const EVIDENCE_SCHEMA_VERSION = 'blackveil-evidence/v1' as const;
+export const EVIDENCE_CANONICALIZATION = 'blackveil-cjson/v1' as const;
+
+const EvidenceSourceSchema = z
+	.object({
+		serverName: z.string().min(1),
+		serverVersion: z.string().min(1),
+		endpointOrigin: z.string().url(),
+		tool: z.string().min(1),
+	})
+	.strict();
+
+export const EvidenceSnapshotSchema = z
+	.object({
+		schemaVersion: z.literal(EVIDENCE_SCHEMA_VERSION),
+		capturedAt: z.string().datetime(),
+		source: EvidenceSourceSchema,
+		result: z.record(z.string(), z.unknown()),
+		integrity: z
+			.object({
+				algorithm: z.literal('sha-256'),
+				canonicalization: z.literal(EVIDENCE_CANONICALIZATION),
+				digest: z.string().regex(/^[a-f0-9]{64}$/),
+			})
+			.strict(),
+	})
+	.strict();
+
+export type EvidenceSnapshot = z.infer<typeof EvidenceSnapshotSchema>;
+
+function canonicalize(value: unknown, seen: Set<object>): string {
+	if (value === null) return 'null';
+	if (typeof value === 'string' || typeof value === 'boolean') return JSON.stringify(value);
+	if (typeof value === 'number') {
+		if (!Number.isFinite(value)) throw new Error('Evidence contains a non-finite number');
+		return JSON.stringify(value);
+	}
+	if (typeof value !== 'object') throw new Error(`Evidence contains an unsupported ${typeof value} value`);
+	if (seen.has(value)) throw new Error('Evidence contains a circular reference');
+
+	seen.add(value);
+	try {
+		if (Array.isArray(value)) {
+			return `[${value.map((entry) => canonicalize(entry, seen)).join(',')}]`;
+		}
+
+		const record = value as Record<string, unknown>;
+		const entries = Object.keys(record)
+			.sort()
+			.map((key) => `${JSON.stringify(key)}:${canonicalize(record[key], seen)}`);
+		return `{${entries.join(',')}}`;
+	} finally {
+		seen.delete(value);
+	}
+}
+
+/** Canonical JSON for the versioned BlackVeil evidence format. */
+export function canonicalEvidenceJson(value: unknown): string {
+	return canonicalize(value, new Set<object>());
+}
+
+/** Cryptographic integrity digest. This is not a signature or authenticity proof. */
+export async function sha256Hex(value: string): Promise<string> {
+	const bytes = new TextEncoder().encode(value);
+	const digest = await crypto.subtle.digest('SHA-256', bytes);
+	return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('');
+}
+
+type UnsignedEvidenceSnapshot = Omit<EvidenceSnapshot, 'integrity'>;
+
+async function digestUnsignedSnapshot(snapshot: UnsignedEvidenceSnapshot): Promise<string> {
+	return sha256Hex(canonicalEvidenceJson(snapshot));
+}
+
+/** Seal a remote MCP result in a locally-verifiable evidence envelope. */
+export async function createEvidenceSnapshot(args: {
+	capturedAt: string;
+	serverName: string;
+	serverVersion: string;
+	endpointOrigin: string;
+	tool: string;
+	result: Record<string, unknown>;
+}): Promise<EvidenceSnapshot> {
+	const unsigned: UnsignedEvidenceSnapshot = {
+		schemaVersion: EVIDENCE_SCHEMA_VERSION,
+		capturedAt: args.capturedAt,
+		source: {
+			serverName: args.serverName,
+			serverVersion: args.serverVersion,
+			endpointOrigin: args.endpointOrigin,
+			tool: args.tool,
+		},
+		result: args.result,
+	};
+	const digest = await digestUnsignedSnapshot(unsigned);
+	return {
+		...unsigned,
+		integrity: {
+			algorithm: 'sha-256',
+			canonicalization: EVIDENCE_CANONICALIZATION,
+			digest,
+		},
+	};
+}
+
+export type EvidenceVerification =
+	| { valid: true; snapshot: EvidenceSnapshot; expectedDigest: string; actualDigest: string }
+	| { valid: false; snapshot: EvidenceSnapshot; expectedDigest: string; actualDigest: string };
+
+/** Parse and verify an evidence envelope without trusting its embedded digest. */
+export async function verifyEvidenceSnapshot(value: unknown): Promise<EvidenceVerification> {
+	const snapshot = EvidenceSnapshotSchema.parse(value);
+	const { integrity, ...unsigned } = snapshot;
+	const actualDigest = await digestUnsignedSnapshot(unsigned);
+	return {
+		valid: actualDigest === integrity.digest,
+		snapshot,
+		expectedDigest: integrity.digest,
+		actualDigest,
+	};
+}

--- a/src/cli/mcp-http-client.ts
+++ b/src/cli/mcp-http-client.ts
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { z } from 'zod';
+
+export const DEFAULT_MCP_ENDPOINT = 'https://dns-mcp.blackveilsecurity.com/mcp';
+const MCP_PROTOCOL_VERSION = '2025-06-18';
+
+const JsonRpcEnvelopeSchema = z
+	.object({
+		jsonrpc: z.literal('2.0'),
+		result: z.unknown().optional(),
+		error: z
+			.object({
+				code: z.number().int(),
+				message: z.string(),
+			})
+			.passthrough()
+			.optional(),
+	})
+	.passthrough();
+
+const ServerInfoSchema = z.object({ name: z.string().min(1), version: z.string().min(1) }).passthrough();
+
+const ToolCallResultSchema = z
+	.object({
+		content: z.array(z.object({ type: z.string(), text: z.string().optional() }).passthrough()),
+		structuredContent: z.record(z.string(), z.unknown()).optional(),
+		isError: z.boolean().optional(),
+	})
+	.passthrough();
+
+const ToolListSchema = z
+	.object({
+		tools: z.array(
+			z
+				.object({
+					name: z.string().min(1),
+					outputSchema: z.record(z.string(), z.unknown()).optional(),
+					annotations: z.object({ readOnlyHint: z.boolean().optional() }).passthrough().optional(),
+				})
+				.passthrough(),
+		),
+	})
+	.passthrough();
+
+export type ToolCallResult = z.infer<typeof ToolCallResultSchema>;
+export type ListedTool = z.infer<typeof ToolListSchema>['tools'][number];
+
+export class McpClientError extends Error {
+	constructor(
+		message: string,
+		readonly kind: 'transport' | 'protocol' | 'remote',
+		readonly status?: number,
+		readonly rpcCode?: number,
+	) {
+		super(message);
+		this.name = 'McpClientError';
+	}
+}
+
+function parseSsePayload(text: string): unknown {
+	for (const event of text.split(/\r?\n\r?\n/)) {
+		const data = event
+			.split(/\r?\n/)
+			.filter((line) => line.startsWith('data:'))
+			.map((line) => line.slice(5).trimStart())
+			.join('\n');
+		if (!data || data === '[DONE]') continue;
+		try {
+			return JSON.parse(data);
+		} catch {
+			continue;
+		}
+	}
+	throw new McpClientError('MCP response contained no valid SSE data event', 'protocol');
+}
+
+export function parseMcpResponseBody(text: string): unknown {
+	const trimmed = text.trim();
+	if (!trimmed) return undefined;
+	try {
+		return JSON.parse(trimmed);
+	} catch {
+		return parseSsePayload(trimmed);
+	}
+}
+
+function validateEndpoint(endpoint: string): URL {
+	let url: URL;
+	try {
+		url = new URL(endpoint);
+	} catch {
+		throw new McpClientError('Invalid BLACKVEIL_MCP_URL', 'protocol');
+	}
+	if (url.username || url.password || url.search || url.hash) {
+		throw new McpClientError('Invalid BLACKVEIL_MCP_URL: credentials, query strings, and fragments are not allowed', 'protocol');
+	}
+	const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+	if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+		throw new McpClientError('Invalid BLACKVEIL_MCP_URL: HTTPS is required except on loopback', 'protocol');
+	}
+	return url;
+}
+
+export interface McpHttpClientOptions {
+	endpoint?: string;
+	apiKey?: string;
+	fetchFn?: typeof fetch;
+	signalFactory?: () => AbortSignal;
+}
+
+export class McpHttpClient {
+	readonly endpoint: string;
+	readonly endpointOrigin: string;
+	serverInfo?: { name: string; version: string };
+	private readonly fetchFn: typeof fetch;
+	private readonly apiKey?: string;
+	private readonly signalFactory: () => AbortSignal;
+	private sessionId?: string;
+	private requestId = 1;
+
+	constructor(options: McpHttpClientOptions = {}) {
+		const endpoint = validateEndpoint(options.endpoint ?? DEFAULT_MCP_ENDPOINT);
+		this.endpoint = endpoint.toString();
+		this.endpointOrigin = endpoint.origin;
+		this.fetchFn = options.fetchFn ?? fetch;
+		this.apiKey = options.apiKey;
+		this.signalFactory = options.signalFactory ?? (() => AbortSignal.timeout(45_000));
+	}
+
+	private headers(includeSession: boolean): Headers {
+		const headers = new Headers({
+			accept: 'application/json, text/event-stream',
+			'content-type': 'application/json',
+		});
+		if (includeSession) headers.set('mcp-protocol-version', MCP_PROTOCOL_VERSION);
+		if (includeSession && this.sessionId) headers.set('mcp-session-id', this.sessionId);
+		if (this.apiKey) headers.set('authorization', `Bearer ${this.apiKey}`);
+		return headers;
+	}
+
+	private async request(body: Record<string, unknown>, includeSession: boolean, expectPayload: boolean) {
+		let response: Response;
+		try {
+			response = await this.fetchFn(this.endpoint, {
+				method: 'POST',
+				headers: this.headers(includeSession),
+				body: JSON.stringify(body),
+				signal: this.signalFactory(),
+			});
+		} catch (error) {
+			const message = error instanceof Error ? error.message : 'request failed';
+			throw new McpClientError(`MCP transport failed: ${message}`, 'transport');
+		}
+
+		const text = await response.text();
+		let parsed: unknown;
+		try {
+			parsed = parseMcpResponseBody(text);
+		} catch (error) {
+			if (!response.ok) throw new McpClientError(`MCP returned HTTP ${response.status}`, 'remote', response.status);
+			throw error;
+		}
+
+		if (!response.ok) {
+			const envelope = JsonRpcEnvelopeSchema.safeParse(parsed);
+			const remote = envelope.success ? envelope.data.error : undefined;
+			throw new McpClientError(
+				remote ? `MCP error ${remote.code}: ${remote.message}` : `MCP returned HTTP ${response.status}`,
+				'remote',
+				response.status,
+				remote?.code,
+			);
+		}
+		if (!expectPayload) return { result: undefined, headers: response.headers };
+
+		const envelope = JsonRpcEnvelopeSchema.safeParse(parsed);
+		if (!envelope.success) throw new McpClientError('MCP returned a malformed JSON-RPC response', 'protocol', response.status);
+		if (envelope.data.error) {
+			throw new McpClientError(
+				`MCP error ${envelope.data.error.code}: ${envelope.data.error.message}`,
+				'remote',
+				response.status,
+				envelope.data.error.code,
+			);
+		}
+		return { result: envelope.data.result, headers: response.headers };
+	}
+
+	async connect(): Promise<{ name: string; version: string }> {
+		const initialized = await this.request(
+			{
+				jsonrpc: '2.0',
+				id: this.requestId++,
+				method: 'initialize',
+				params: {
+					protocolVersion: MCP_PROTOCOL_VERSION,
+					capabilities: {},
+					clientInfo: { name: 'blackveil-cli', version: '1.0.0' },
+				},
+			},
+			false,
+			true,
+		);
+		const sessionId = initialized.headers.get('mcp-session-id');
+		if (!sessionId) throw new McpClientError('MCP initialize omitted Mcp-Session-Id', 'protocol');
+		this.sessionId = sessionId;
+		const result = z.object({ serverInfo: ServerInfoSchema }).passthrough().safeParse(initialized.result);
+		if (!result.success) throw new McpClientError('MCP initialize omitted valid serverInfo', 'protocol');
+		this.serverInfo = result.data.serverInfo;
+
+		await this.request({ jsonrpc: '2.0', method: 'notifications/initialized' }, true, false);
+		return this.serverInfo;
+	}
+
+	private requireConnected(): void {
+		if (!this.sessionId || !this.serverInfo) throw new McpClientError('MCP client is not initialized', 'protocol');
+	}
+
+	async listTools(): Promise<ListedTool[]> {
+		this.requireConnected();
+		const response = await this.request({ jsonrpc: '2.0', id: this.requestId++, method: 'tools/list', params: {} }, true, true);
+		const parsed = ToolListSchema.safeParse(response.result);
+		if (!parsed.success) throw new McpClientError('MCP tools/list returned a malformed tool list', 'protocol');
+		return parsed.data.tools;
+	}
+
+	async callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+		this.requireConnected();
+		const response = await this.request(
+			{
+				jsonrpc: '2.0',
+				id: this.requestId++,
+				method: 'tools/call',
+				params: { name, arguments: args },
+			},
+			true,
+			true,
+		);
+		const parsed = ToolCallResultSchema.safeParse(response.result);
+		if (!parsed.success) throw new McpClientError(`MCP tool ${name} returned a malformed result`, 'protocol');
+		return parsed.data;
+	}
+}

--- a/src/cli/mcp-http-client.ts
+++ b/src/cli/mcp-http-client.ts
@@ -3,24 +3,11 @@
 import { z } from 'zod';
 
 export const DEFAULT_MCP_ENDPOINT = 'https://dns-mcp.blackveilsecurity.com/mcp';
-const MCP_PROTOCOL_VERSION = '2025-06-18';
-
-const JsonRpcEnvelopeSchema = z
-	.object({
-		jsonrpc: z.literal('2.0'),
-		result: z.unknown().optional(),
-		error: z
-			.object({
-				code: z.number().int(),
-				message: z.string(),
-			})
-			.passthrough()
-			.optional(),
-	})
-	.passthrough();
+const REQUESTED_PROTOCOL_VERSION = '2025-06-18';
+const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2025-06-18', '2025-03-26']);
 
 const ServerInfoSchema = z.object({ name: z.string().min(1), version: z.string().min(1) }).passthrough();
-
+const InitializeResultSchema = z.object({ protocolVersion: z.string().min(1), serverInfo: ServerInfoSchema }).passthrough();
 const ToolCallResultSchema = z
 	.object({
 		content: z.array(z.object({ type: z.string(), text: z.string().optional() }).passthrough()),
@@ -28,7 +15,6 @@ const ToolCallResultSchema = z
 		isError: z.boolean().optional(),
 	})
 	.passthrough();
-
 const ToolListSchema = z
 	.object({
 		tools: z.array(
@@ -42,6 +28,9 @@ const ToolListSchema = z
 		),
 	})
 	.passthrough();
+
+type RequestId = string | number;
+type ParsedRpcResponse = { result?: unknown; error?: { code: number; message: string } };
 
 export type ToolCallResult = z.infer<typeof ToolCallResultSchema>;
 export type ListedTool = z.infer<typeof ToolListSchema>['tools'][number];
@@ -58,30 +47,124 @@ export class McpClientError extends Error {
 	}
 }
 
-function parseSsePayload(text: string): unknown {
-	for (const event of text.split(/\r?\n\r?\n/)) {
-		const data = event
-			.split(/\r?\n/)
-			.filter((line) => line.startsWith('data:'))
-			.map((line) => line.slice(5).trimStart())
-			.join('\n');
-		if (!data || data === '[DONE]') continue;
-		try {
-			return JSON.parse(data);
-		} catch {
-			continue;
-		}
-	}
-	throw new McpClientError('MCP response contained no valid SSE data event', 'protocol');
+function requestIdKey(id: RequestId): string {
+	return `${typeof id}:${String(id)}`;
 }
 
-export function parseMcpResponseBody(text: string): unknown {
+function classifyJsonRpcMessage(value: unknown, expectedId: RequestId, seenIds: Set<string>): ParsedRpcResponse | undefined {
+	if (!value || typeof value !== 'object' || Array.isArray(value))
+		throw new McpClientError('MCP returned a malformed JSON-RPC message', 'protocol');
+	const message = value as Record<string, unknown>;
+	if (message.jsonrpc !== '2.0') throw new McpClientError('MCP returned a message with an invalid jsonrpc version', 'protocol');
+	if (typeof message.method === 'string') {
+		if (Object.hasOwn(message, 'id')) throw new McpClientError(`MCP sent unsupported server request ${message.method}`, 'protocol');
+		return undefined;
+	}
+	if (!Object.hasOwn(message, 'id') || message.id === null) throw new McpClientError('MCP response omitted its JSON-RPC id', 'protocol');
+	if (typeof message.id !== 'string' && (typeof message.id !== 'number' || !Number.isInteger(message.id))) {
+		throw new McpClientError('MCP response contained an invalid JSON-RPC id', 'protocol');
+	}
+	const key = requestIdKey(message.id);
+	if (seenIds.has(key)) throw new McpClientError(`MCP returned duplicate JSON-RPC id ${String(message.id)}`, 'protocol');
+	seenIds.add(key);
+	if (message.id !== expectedId) {
+		throw new McpClientError(`MCP response id ${String(message.id)} did not match request id ${String(expectedId)}`, 'protocol');
+	}
+	const hasResult = Object.hasOwn(message, 'result');
+	const hasError = Object.hasOwn(message, 'error');
+	if (hasResult === hasError) throw new McpClientError('MCP response must contain exactly one of result or error', 'protocol');
+	if (hasError) {
+		const parsed = z.object({ code: z.number().int(), message: z.string() }).passthrough().safeParse(message.error);
+		if (!parsed.success) throw new McpClientError('MCP returned a malformed JSON-RPC error', 'protocol');
+		return { error: parsed.data };
+	}
+	return { result: message.result };
+}
+
+function parseSseEvent(event: string): unknown | undefined {
+	const data = event
+		.split(/\r?\n/)
+		.filter((line) => line.startsWith('data:'))
+		.map((line) => line.slice(5).trimStart())
+		.join('\n');
+	if (!data || data === '[DONE]') return undefined;
+	try {
+		return JSON.parse(data);
+	} catch {
+		throw new McpClientError('MCP response contained invalid SSE JSON', 'protocol');
+	}
+}
+
+function drainCompleteSseEvents(buffer: string): { events: string[]; remainder: string } {
+	const events: string[] = [];
+	let remainder = buffer;
+	for (;;) {
+		const separator = /\r?\n\r?\n/.exec(remainder);
+		if (!separator || separator.index === undefined) return { events, remainder };
+		events.push(remainder.slice(0, separator.index));
+		remainder = remainder.slice(separator.index + separator[0].length);
+	}
+}
+
+/** Parse a complete JSON or SSE payload and, when given, correlate it to one request id. */
+export function parseMcpResponseBody(text: string, expectedId?: RequestId): unknown {
 	const trimmed = text.trim();
 	if (!trimmed) return undefined;
 	try {
-		return JSON.parse(trimmed);
-	} catch {
-		return parseSsePayload(trimmed);
+		const parsed = JSON.parse(trimmed);
+		if (expectedId === undefined) return parsed;
+		const response = classifyJsonRpcMessage(parsed, expectedId, new Set());
+		if (!response) throw new McpClientError('MCP response contained notifications but no matching response', 'protocol');
+		return response;
+	} catch (error) {
+		if (error instanceof McpClientError) throw error;
+	}
+	const seen = new Set<string>();
+	let matched: ParsedRpcResponse | undefined;
+	for (const event of text.split(/\r?\n\r?\n/)) {
+		const value = parseSseEvent(event);
+		if (value === undefined) continue;
+		if (expectedId === undefined) return value;
+		const response = classifyJsonRpcMessage(value, expectedId, seen);
+		if (response) {
+			if (matched) throw new McpClientError(`MCP returned duplicate JSON-RPC id ${String(expectedId)}`, 'protocol');
+			matched = response;
+		}
+	}
+	if (!matched) throw new McpClientError('MCP response contained no matching JSON-RPC response', 'protocol');
+	return matched;
+}
+
+async function readMatchingSseResponse(response: Response, expectedId: RequestId): Promise<ParsedRpcResponse> {
+	if (!response.body) throw new McpClientError('MCP SSE response omitted its body', 'protocol', response.status);
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	const seen = new Set<string>();
+	let buffer = '';
+	for (;;) {
+		const chunk = await reader.read();
+		buffer += decoder.decode(chunk.value, { stream: !chunk.done });
+		const drained = drainCompleteSseEvents(buffer);
+		buffer = drained.remainder;
+		if (chunk.done && buffer.trim()) {
+			drained.events.push(buffer);
+			buffer = '';
+		}
+		let matched: ParsedRpcResponse | undefined;
+		for (const event of drained.events) {
+			const value = parseSseEvent(event);
+			if (value === undefined) continue;
+			const candidate = classifyJsonRpcMessage(value, expectedId, seen);
+			if (candidate) {
+				if (matched) throw new McpClientError(`MCP returned duplicate JSON-RPC id ${String(expectedId)}`, 'protocol');
+				matched = candidate;
+			}
+		}
+		if (matched) {
+			void reader.cancel();
+			return matched;
+		}
+		if (chunk.done) throw new McpClientError('MCP SSE stream ended without a matching JSON-RPC response', 'protocol');
 	}
 }
 
@@ -106,7 +189,10 @@ export interface McpHttpClientOptions {
 	endpoint?: string;
 	apiKey?: string;
 	fetchFn?: typeof fetch;
-	signalFactory?: () => AbortSignal;
+	deadlineAt?: number;
+	timeoutMs?: number;
+	now?: () => number;
+	signalFactory?: (remainingMs: number) => AbortSignal;
 }
 
 export class McpHttpClient {
@@ -115,8 +201,13 @@ export class McpHttpClient {
 	serverInfo?: { name: string; version: string };
 	private readonly fetchFn: typeof fetch;
 	private readonly apiKey?: string;
-	private readonly signalFactory: () => AbortSignal;
+	private readonly signalFactory: (remainingMs: number) => AbortSignal;
+	private readonly now: () => number;
+	private readonly deadlineAt: number;
 	private sessionId?: string;
+	private protocolVersion = REQUESTED_PROTOCOL_VERSION;
+	private initialized = false;
+	private sessionRecoveryUsed = false;
 	private requestId = 1;
 
 	constructor(options: McpHttpClientOptions = {}) {
@@ -125,18 +216,23 @@ export class McpHttpClient {
 		this.endpointOrigin = endpoint.origin;
 		this.fetchFn = options.fetchFn ?? fetch;
 		this.apiKey = options.apiKey;
-		this.signalFactory = options.signalFactory ?? (() => AbortSignal.timeout(45_000));
+		this.now = options.now ?? Date.now;
+		this.deadlineAt = options.deadlineAt ?? this.now() + (options.timeoutMs ?? 45_000);
+		this.signalFactory = options.signalFactory ?? ((remainingMs) => AbortSignal.timeout(Math.max(1, Math.ceil(remainingMs))));
 	}
 
 	private headers(includeSession: boolean): Headers {
-		const headers = new Headers({
-			accept: 'application/json, text/event-stream',
-			'content-type': 'application/json',
-		});
-		if (includeSession) headers.set('mcp-protocol-version', MCP_PROTOCOL_VERSION);
+		const headers = new Headers({ accept: 'application/json, text/event-stream', 'content-type': 'application/json' });
+		if (includeSession) headers.set('mcp-protocol-version', this.protocolVersion);
 		if (includeSession && this.sessionId) headers.set('mcp-session-id', this.sessionId);
 		if (this.apiKey) headers.set('authorization', `Bearer ${this.apiKey}`);
 		return headers;
+	}
+
+	private remainingSignal(): AbortSignal {
+		const remainingMs = this.deadlineAt - this.now();
+		if (remainingMs <= 0) throw new McpClientError('MCP command deadline exceeded', 'transport');
+		return this.signalFactory(remainingMs);
 	}
 
 	private async request(body: Record<string, unknown>, includeSession: boolean, expectPayload: boolean) {
@@ -146,55 +242,58 @@ export class McpHttpClient {
 				method: 'POST',
 				headers: this.headers(includeSession),
 				body: JSON.stringify(body),
-				signal: this.signalFactory(),
+				signal: this.remainingSignal(),
 			});
 		} catch (error) {
+			if (error instanceof McpClientError) throw error;
 			const message = error instanceof Error ? error.message : 'request failed';
 			throw new McpClientError(`MCP transport failed: ${message}`, 'transport');
 		}
-
-		const text = await response.text();
-		let parsed: unknown;
-		try {
-			parsed = parseMcpResponseBody(text);
-		} catch (error) {
-			if (!response.ok) throw new McpClientError(`MCP returned HTTP ${response.status}`, 'remote', response.status);
-			throw error;
+		if (response.ok && !expectPayload) return { result: undefined, headers: response.headers };
+		const expectedId = body.id;
+		if (expectPayload && typeof expectedId !== 'string' && (typeof expectedId !== 'number' || !Number.isInteger(expectedId))) {
+			throw new McpClientError('MCP client request omitted a valid JSON-RPC id', 'protocol');
 		}
-
 		if (!response.ok) {
-			const envelope = JsonRpcEnvelopeSchema.safeParse(parsed);
-			const remote = envelope.success ? envelope.data.error : undefined;
+			const text = await response.text();
+			let remote: ParsedRpcResponse | undefined;
+			if (text.trim() && expectedId !== undefined) {
+				try {
+					remote = parseMcpResponseBody(text, expectedId as RequestId) as ParsedRpcResponse;
+				} catch {
+					remote = undefined;
+				}
+			}
 			throw new McpClientError(
-				remote ? `MCP error ${remote.code}: ${remote.message}` : `MCP returned HTTP ${response.status}`,
+				remote?.error ? `MCP error ${remote.error.code}: ${remote.error.message}` : `MCP returned HTTP ${response.status}`,
 				'remote',
 				response.status,
-				remote?.code,
+				remote?.error?.code,
 			);
 		}
-		if (!expectPayload) return { result: undefined, headers: response.headers };
-
-		const envelope = JsonRpcEnvelopeSchema.safeParse(parsed);
-		if (!envelope.success) throw new McpClientError('MCP returned a malformed JSON-RPC response', 'protocol', response.status);
-		if (envelope.data.error) {
-			throw new McpClientError(
-				`MCP error ${envelope.data.error.code}: ${envelope.data.error.message}`,
-				'remote',
-				response.status,
-				envelope.data.error.code,
-			);
+		const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+		const parsed = contentType.includes('text/event-stream')
+			? await readMatchingSseResponse(response, expectedId as RequestId)
+			: (parseMcpResponseBody(await response.text(), expectedId as RequestId) as ParsedRpcResponse);
+		if (!parsed) throw new McpClientError('MCP response contained no matching JSON-RPC response', 'protocol', response.status);
+		if (parsed.error) {
+			throw new McpClientError(`MCP error ${parsed.error.code}: ${parsed.error.message}`, 'remote', response.status, parsed.error.code);
 		}
-		return { result: envelope.data.result, headers: response.headers };
+		return { result: parsed.result, headers: response.headers };
 	}
 
 	async connect(): Promise<{ name: string; version: string }> {
+		this.initialized = false;
+		this.sessionId = undefined;
+		this.serverInfo = undefined;
+		this.protocolVersion = REQUESTED_PROTOCOL_VERSION;
 		const initialized = await this.request(
 			{
 				jsonrpc: '2.0',
 				id: this.requestId++,
 				method: 'initialize',
 				params: {
-					protocolVersion: MCP_PROTOCOL_VERSION,
+					protocolVersion: REQUESTED_PROTOCOL_VERSION,
 					capabilities: {},
 					clientInfo: { name: 'blackveil-cli', version: '1.0.0' },
 				},
@@ -202,41 +301,63 @@ export class McpHttpClient {
 			false,
 			true,
 		);
-		const sessionId = initialized.headers.get('mcp-session-id');
-		if (!sessionId) throw new McpClientError('MCP initialize omitted Mcp-Session-Id', 'protocol');
-		this.sessionId = sessionId;
-		const result = z.object({ serverInfo: ServerInfoSchema }).passthrough().safeParse(initialized.result);
-		if (!result.success) throw new McpClientError('MCP initialize omitted valid serverInfo', 'protocol');
+		const result = InitializeResultSchema.safeParse(initialized.result);
+		if (!result.success) throw new McpClientError('MCP initialize omitted valid protocolVersion or serverInfo', 'protocol');
+		if (!SUPPORTED_PROTOCOL_VERSIONS.has(result.data.protocolVersion)) {
+			throw new McpClientError(`MCP negotiated unsupported protocol version ${result.data.protocolVersion}`, 'protocol');
+		}
+		this.protocolVersion = result.data.protocolVersion;
 		this.serverInfo = result.data.serverInfo;
-
+		const sessionId = initialized.headers.get('mcp-session-id');
+		if (sessionId) {
+			if (!/^[\x21-\x7e]+$/.test(sessionId)) throw new McpClientError('MCP initialize returned an invalid session id', 'protocol');
+			this.sessionId = sessionId;
+		}
 		await this.request({ jsonrpc: '2.0', method: 'notifications/initialized' }, true, false);
+		this.initialized = true;
 		return this.serverInfo;
 	}
 
 	private requireConnected(): void {
-		if (!this.sessionId || !this.serverInfo) throw new McpClientError('MCP client is not initialized', 'protocol');
+		if (!this.initialized || !this.serverInfo) throw new McpClientError('MCP client is not initialized', 'protocol');
+	}
+
+	private async readOnlyRequest(factory: () => ReturnType<McpHttpClient['request']>) {
+		const hadSession = this.sessionId !== undefined;
+		try {
+			return await factory();
+		} catch (error) {
+			if (!(error instanceof McpClientError) || error.status !== 404 || !hadSession || this.sessionRecoveryUsed) throw error;
+			this.sessionRecoveryUsed = true;
+			await this.connect();
+			return factory();
+		}
 	}
 
 	async listTools(): Promise<ListedTool[]> {
 		this.requireConnected();
-		const response = await this.request({ jsonrpc: '2.0', id: this.requestId++, method: 'tools/list', params: {} }, true, true);
+		const response = await this.readOnlyRequest(() =>
+			this.request({ jsonrpc: '2.0', id: this.requestId++, method: 'tools/list', params: {} }, true, true),
+		);
 		const parsed = ToolListSchema.safeParse(response.result);
 		if (!parsed.success) throw new McpClientError('MCP tools/list returned a malformed tool list', 'protocol');
 		return parsed.data.tools;
 	}
 
-	async callTool(name: string, args: Record<string, unknown>): Promise<ToolCallResult> {
+	async callTool(name: string, args: Record<string, unknown>, options: { readOnly?: boolean } = {}): Promise<ToolCallResult> {
 		this.requireConnected();
-		const response = await this.request(
-			{
-				jsonrpc: '2.0',
-				id: this.requestId++,
-				method: 'tools/call',
-				params: { name, arguments: args },
-			},
-			true,
-			true,
-		);
+		const call = () =>
+			this.request(
+				{
+					jsonrpc: '2.0',
+					id: this.requestId++,
+					method: 'tools/call',
+					params: { name, arguments: args },
+				},
+				true,
+				true,
+			);
+		const response = options.readOnly ? await this.readOnlyRequest(call) : await call();
 		const parsed = ToolCallResultSchema.safeParse(response.result);
 		if (!parsed.success) throw new McpClientError(`MCP tool ${name} returned a malformed result`, 'protocol');
 		return parsed.data;

--- a/src/cli/mcp-http-client.ts
+++ b/src/cli/mcp-http-client.ts
@@ -5,6 +5,8 @@ import { z } from 'zod';
 export const DEFAULT_MCP_ENDPOINT = 'https://dns-mcp.blackveilsecurity.com/mcp';
 const REQUESTED_PROTOCOL_VERSION = '2025-06-18';
 const SUPPORTED_PROTOCOL_VERSIONS = new Set(['2025-06-18', '2025-03-26']);
+export const MCP_RESPONSE_BODY_MAX_BYTES = 2 * 1024 * 1024;
+export const MCP_SSE_EVENT_MAX_BYTES = 512 * 1024;
 
 const ServerInfoSchema = z.object({ name: z.string().min(1), version: z.string().min(1) }).passthrough();
 const InitializeResultSchema = z.object({ protocolVersion: z.string().min(1), serverInfo: ServerInfoSchema }).passthrough();
@@ -106,6 +108,72 @@ function drainCompleteSseEvents(buffer: string): { events: string[]; remainder: 
 	}
 }
 
+async function cancelReader(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+	try {
+		await reader.cancel();
+	} catch {
+		// Cancellation is best-effort; preserve the response or protocol error that led here.
+	} finally {
+		try {
+			reader.releaseLock();
+		} catch {
+			// A hostile or already-detached stream must not mask the request outcome.
+		}
+	}
+}
+
+async function discardResponseBody(response: Response): Promise<void> {
+	if (!response.body) return;
+	let reader: ReadableStreamDefaultReader<Uint8Array>;
+	try {
+		reader = response.body.getReader();
+	} catch {
+		return;
+	}
+	await cancelReader(reader);
+}
+
+async function readResponseTextCapped(response: Response): Promise<string> {
+	const contentLength = Number(response.headers.get('content-length'));
+	if (Number.isFinite(contentLength) && contentLength > MCP_RESPONSE_BODY_MAX_BYTES) {
+		await discardResponseBody(response);
+		throw new McpClientError('MCP response exceeded the response body limit', 'protocol', response.status);
+	}
+	if (!response.body) return '';
+	const reader = response.body.getReader();
+	const decoder = new TextDecoder();
+	let bytesRead = 0;
+	let text = '';
+	let complete = false;
+	try {
+		for (;;) {
+			const chunk = await reader.read();
+			if (chunk.value) {
+				bytesRead += chunk.value.byteLength;
+				if (bytesRead > MCP_RESPONSE_BODY_MAX_BYTES) {
+					throw new McpClientError('MCP response exceeded the response body limit', 'protocol', response.status);
+				}
+				text += decoder.decode(chunk.value, { stream: true });
+			}
+			if (chunk.done) {
+				text += decoder.decode();
+				complete = true;
+				return text;
+			}
+		}
+	} finally {
+		if (!complete) {
+			await cancelReader(reader);
+		} else {
+			try {
+				reader.releaseLock();
+			} catch {
+				// A hostile or already-detached stream must not mask the request outcome.
+			}
+		}
+	}
+}
+
 /** Parse a complete JSON or SSE payload and, when given, correlate it to one request id. */
 export function parseMcpResponseBody(text: string, expectedId?: RequestId): unknown {
 	const trimmed = text.trim();
@@ -141,30 +209,44 @@ async function readMatchingSseResponse(response: Response, expectedId: RequestId
 	const decoder = new TextDecoder();
 	const seen = new Set<string>();
 	let buffer = '';
-	for (;;) {
-		const chunk = await reader.read();
-		buffer += decoder.decode(chunk.value, { stream: !chunk.done });
-		const drained = drainCompleteSseEvents(buffer);
-		buffer = drained.remainder;
-		if (chunk.done && buffer.trim()) {
-			drained.events.push(buffer);
-			buffer = '';
-		}
-		let matched: ParsedRpcResponse | undefined;
-		for (const event of drained.events) {
-			const value = parseSseEvent(event);
-			if (value === undefined) continue;
-			const candidate = classifyJsonRpcMessage(value, expectedId, seen);
-			if (candidate) {
-				if (matched) throw new McpClientError(`MCP returned duplicate JSON-RPC id ${String(expectedId)}`, 'protocol');
-				matched = candidate;
+	let bytesRead = 0;
+	try {
+		for (;;) {
+			const chunk = await reader.read();
+			if (chunk.value) {
+				bytesRead += chunk.value.byteLength;
+				if (bytesRead > MCP_RESPONSE_BODY_MAX_BYTES) {
+					throw new McpClientError('MCP SSE response exceeded the response body limit', 'protocol', response.status);
+				}
 			}
+			buffer += decoder.decode(chunk.value, { stream: !chunk.done });
+			const drained = drainCompleteSseEvents(buffer);
+			buffer = drained.remainder;
+			if (new TextEncoder().encode(buffer).byteLength > MCP_SSE_EVENT_MAX_BYTES) {
+				throw new McpClientError('MCP SSE event exceeded the event limit', 'protocol', response.status);
+			}
+			if (chunk.done && buffer.trim()) {
+				drained.events.push(buffer);
+				buffer = '';
+			}
+			let matched: ParsedRpcResponse | undefined;
+			for (const event of drained.events) {
+				if (new TextEncoder().encode(event).byteLength > MCP_SSE_EVENT_MAX_BYTES) {
+					throw new McpClientError('MCP SSE event exceeded the event limit', 'protocol', response.status);
+				}
+				const value = parseSseEvent(event);
+				if (value === undefined) continue;
+				const candidate = classifyJsonRpcMessage(value, expectedId, seen);
+				if (candidate) {
+					if (matched) throw new McpClientError(`MCP returned duplicate JSON-RPC id ${String(expectedId)}`, 'protocol');
+					matched = candidate;
+				}
+			}
+			if (matched) return matched;
+			if (chunk.done) throw new McpClientError('MCP SSE stream ended without a matching JSON-RPC response', 'protocol');
 		}
-		if (matched) {
-			void reader.cancel();
-			return matched;
-		}
-		if (chunk.done) throw new McpClientError('MCP SSE stream ended without a matching JSON-RPC response', 'protocol');
+	} finally {
+		await cancelReader(reader);
 	}
 }
 
@@ -249,13 +331,16 @@ export class McpHttpClient {
 			const message = error instanceof Error ? error.message : 'request failed';
 			throw new McpClientError(`MCP transport failed: ${message}`, 'transport');
 		}
-		if (response.ok && !expectPayload) return { result: undefined, headers: response.headers };
+		if (response.ok && !expectPayload) {
+			await discardResponseBody(response);
+			return { result: undefined, headers: response.headers };
+		}
 		const expectedId = body.id;
 		if (expectPayload && typeof expectedId !== 'string' && (typeof expectedId !== 'number' || !Number.isInteger(expectedId))) {
 			throw new McpClientError('MCP client request omitted a valid JSON-RPC id', 'protocol');
 		}
 		if (!response.ok) {
-			const text = await response.text();
+			const text = await readResponseTextCapped(response);
 			let remote: ParsedRpcResponse | undefined;
 			if (text.trim() && expectedId !== undefined) {
 				try {
@@ -274,7 +359,7 @@ export class McpHttpClient {
 		const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
 		const parsed = contentType.includes('text/event-stream')
 			? await readMatchingSseResponse(response, expectedId as RequestId)
-			: (parseMcpResponseBody(await response.text(), expectedId as RequestId) as ParsedRpcResponse);
+			: (parseMcpResponseBody(await readResponseTextCapped(response), expectedId as RequestId) as ParsedRpcResponse);
 		if (!parsed) throw new McpClientError('MCP response contained no matching JSON-RPC response', 'protocol', response.status);
 		if (parsed.error) {
 			throw new McpClientError(`MCP error ${parsed.error.code}: ${parsed.error.message}`, 'remote', response.status, parsed.error.code);

--- a/src/cli/schemas.ts
+++ b/src/cli/schemas.ts
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { z } from 'zod';
+
+export const FindingSchema = z
+	.object({
+		category: z.string(),
+		title: z.string(),
+		severity: z.enum(['critical', 'high', 'medium', 'low', 'info']),
+		detail: z.string(),
+	})
+	.passthrough();
+
+export const EvidenceCoverageSchema = z
+	.object({
+		attempted: z.number().int().nonnegative(),
+		completed: z.number().int().nonnegative(),
+		ratio: z.number().min(0).max(1),
+	})
+	.passthrough();
+
+/** Tolerant client projection of scan_domain structuredContent. */
+export const ScanResultSchema = z
+	.object({
+		domain: z.string().min(1),
+		score: z.number().min(0).max(100).nullable(),
+		grade: z.string().min(1).nullable(),
+		passed: z.boolean().nullable(),
+		measured: z.boolean(),
+		categoryScores: z.record(z.string(), z.number().nullable()),
+		findings: z.array(FindingSchema),
+		checkStatuses: z.record(z.string(), z.enum(['completed', 'timeout', 'error'])),
+		notApplicableCategories: z.array(z.string()),
+		inconclusiveCategories: z.array(z.string()),
+		evidence: EvidenceCoverageSchema,
+		evidenceInsufficient: z.boolean(),
+		timestamp: z.string().datetime(),
+		scoringModelVersion: z.string().min(1),
+		dnsChecksPackageVersion: z.string().min(1),
+		scoringConfigHash: z.string().min(1),
+		error: z.string().optional(),
+	})
+	.passthrough();
+
+export const CheckResultSchema = z
+	.object({
+		category: z.string().min(1),
+		passed: z.boolean(),
+		score: z.number().min(0).max(100),
+		findings: z.array(FindingSchema),
+		checkStatus: z.enum(['completed', 'timeout', 'error']).optional(),
+		partial: z.boolean().optional(),
+	})
+	.passthrough();
+
+export const BatchResultSchema = z
+	.object({
+		results: z.array(ScanResultSchema).min(1).max(10),
+	})
+	.passthrough();
+
+export const PolicyResultSchema = z
+	.object({
+		domain: z.string().min(1),
+		passed: z.boolean().nullable(),
+		violations: z.array(z.unknown()),
+		inconclusiveRules: z.array(z.string()),
+		checkedRules: z.number().int().nonnegative(),
+		timestamp: z.string().datetime(),
+	})
+	.passthrough();
+
+export const DriftResultSchema = z
+	.object({
+		domain: z.string().min(1),
+		classification: z.enum(['improving', 'stable', 'regressing', 'mixed', 'inconclusive']),
+		scoreDelta: z.number().nullable(),
+		gradeChange: z.object({ from: z.string().nullable(), to: z.string().nullable() }).passthrough(),
+		timestamp: z.string().datetime(),
+	})
+	.passthrough();
+
+export type ScanResult = z.infer<typeof ScanResultSchema>;

--- a/src/cli/schemas.ts
+++ b/src/cli/schemas.ts
@@ -53,6 +53,19 @@ export const CheckResultSchema = z
 	})
 	.passthrough();
 
+const NonCompletedCheckStatusSchema = z.enum(['timeout', 'error']);
+
+export function hasIncompleteCheckEvidence(result: { partial?: boolean; checkStatus?: string }): boolean {
+	return result.partial === true || NonCompletedCheckStatusSchema.safeParse(result.checkStatus).success;
+}
+
+export function hasIncompleteScanEvidence(result: { checkStatuses: Record<string, string>; inconclusiveCategories: string[] }): boolean {
+	return (
+		result.inconclusiveCategories.length > 0 ||
+		Object.values(result.checkStatuses).some((status) => NonCompletedCheckStatusSchema.safeParse(status).success)
+	);
+}
+
 export const BatchResultSchema = z
 	.object({
 		results: z.array(ScanResultSchema).min(1).max(10),

--- a/src/lib/response-body.ts
+++ b/src/lib/response-body.ts
@@ -28,14 +28,17 @@ export async function disposeUnreadResponseBody(response: Response): Promise<voi
 async function drainBounded(
 	body: ReadableStream<Uint8Array> | null,
 	maxBytes: number,
-): Promise<{ chunks: Uint8Array[]; total: number; overflowed: boolean }> {
+): Promise<{ chunks: Uint8Array[]; total: number; consumed: number; overflowed: boolean; errored: boolean }> {
 	const chunks: Uint8Array[] = [];
 	let total = 0;
+	let consumed = 0;
 	let overflowed = false;
-	if (!body) return { chunks, total, overflowed };
-	const reader = body.getReader();
+	let errored = false;
+	if (!body) return { chunks, total, consumed, overflowed, errored };
+	let reader: ReadableStreamDefaultReader<Uint8Array> | undefined;
 	let finished = false;
 	try {
+		reader = body.getReader();
 		for (;;) {
 			const { done, value } = await reader.read();
 			if (done) {
@@ -43,6 +46,7 @@ async function drainBounded(
 				break;
 			}
 			if (!value) continue;
+			consumed += value.byteLength;
 			const remaining = Math.max(maxBytes - total, 0);
 			if (value.byteLength > remaining) {
 				if (remaining > 0) {
@@ -55,17 +59,23 @@ async function drainBounded(
 			chunks.push(value);
 			total += value.byteLength;
 		}
+	} catch {
+		errored = true;
 	} finally {
-		if (!finished) {
+		if (reader && !finished) {
 			try {
 				await reader.cancel();
 			} catch {
 				/* fail-open */
 			}
 		}
-		reader.releaseLock();
+		try {
+			reader?.releaseLock();
+		} catch {
+			// A hostile/locked stream must not escape this fail-open reader.
+		}
 	}
-	return { chunks, total, overflowed };
+	return { chunks, total, consumed, overflowed, errored };
 }
 
 /** Concatenate chunks into one Uint8Array. */
@@ -87,7 +97,8 @@ function concatChunks(chunks: Uint8Array[], total: number): Uint8Array {
  */
 export async function readBoundedText(body: ReadableStream<Uint8Array> | null, maxBytes: number): Promise<string> {
 	try {
-		const { chunks, total } = await drainBounded(body, maxBytes);
+		const { chunks, total, errored } = await drainBounded(body, maxBytes);
+		if (errored) return '';
 		if (total === 0) return '';
 		return new TextDecoder().decode(concatChunks(chunks, total));
 	} catch {
@@ -104,8 +115,8 @@ export async function readBoundedText(body: ReadableStream<Uint8Array> | null, m
 export async function readBoundedOrNull(body: ReadableStream<Uint8Array> | null, maxBytes: number): Promise<string | null> {
 	try {
 		if (!body) return null;
-		const { chunks, total, overflowed } = await drainBounded(body, maxBytes);
-		if (overflowed) return null;
+		const { chunks, total, overflowed, errored } = await drainBounded(body, maxBytes);
+		if (overflowed || errored) return null;
 		return new TextDecoder().decode(concatChunks(chunks, total));
 	} catch {
 		return null;
@@ -151,4 +162,29 @@ export async function readTextResponseCapped(response: Response, maxBytes: numbe
 		return null;
 	}
 	return readBoundedOrNull(response.body, maxBytes);
+}
+
+/**
+ * Metadata-preserving variant for callers with an aggregate cross-response
+ * budget. `bytesRead` is the actual retained/read byte count on streamed paths;
+ * a Content-Length early rejection conservatively charges `maxBytes` even
+ * though the body is cancelled before it is read.
+ */
+export async function readTextResponseCappedDetailed(
+	response: Response,
+	maxBytes: number,
+): Promise<{ text: string | null; bytesRead: number; overflowed: boolean; errored: boolean }> {
+	const declared = Number(response.headers.get('content-length'));
+	if (Number.isFinite(declared) && declared > maxBytes) {
+		await disposeUnreadResponseBody(response);
+		return { text: null, bytesRead: maxBytes, overflowed: true, errored: false };
+	}
+	if (!response.body) return { text: null, bytesRead: 0, overflowed: false, errored: false };
+	const { chunks, total, consumed, overflowed, errored } = await drainBounded(response.body, maxBytes);
+	return {
+		text: overflowed || errored ? null : new TextDecoder().decode(concatChunks(chunks, total)),
+		bytesRead: consumed,
+		overflowed,
+		errored,
+	};
 }

--- a/src/lib/smtp-probe-binding.ts
+++ b/src/lib/smtp-probe-binding.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** Fail-soft client contract for a future isolated SMTP STARTTLS probe binding. */
+
+import { disposeUnreadResponseBody, readJsonResponseCapped } from './response-body';
+import { SmtpStarttlsResultSchema, smtpNotAssessed, type SmtpStarttlsResult } from '../schemas/smtp-starttls';
+import { sanitizeDomain, validateDomain } from './sanitize';
+
+export interface SmtpProbeBinding {
+	fetch(input: RequestInfo | URL, init?: RequestInit): Promise<Response>;
+}
+
+const SMTP_PROBE_ENDPOINT = 'https://bv-smtp-starttls-probe/v1/probe';
+const SMTP_PROBE_TIMEOUT_MS = 8_000;
+const SMTP_PROBE_MAX_BODY_BYTES = 128 * 1024;
+const MIN_CAPABILITY_BYTES = 32;
+
+function composeSignal(caller?: AbortSignal): AbortSignal {
+	const timeout = AbortSignal.timeout(SMTP_PROBE_TIMEOUT_MS);
+	return caller ? AbortSignal.any([timeout, caller]) : timeout;
+}
+
+/**
+ * Call an injected, separately privileged probe. Absence, weak credentials,
+ * transport errors, non-2xx responses, and malformed bodies all return an
+ * explicit not-assessed result. This module declares no Env binding and creates
+ * no network service.
+ */
+export async function callSmtpStarttlsProbe(
+	binding: SmtpProbeBinding | undefined,
+	authToken: string | undefined,
+	domain: string,
+	options: { signal?: AbortSignal; now?: () => string } = {},
+): Promise<SmtpStarttlsResult> {
+	const now = options.now ?? (() => new Date().toISOString());
+	const validation = validateDomain(domain);
+	if (!validation.valid) return smtpNotAssessed(null, 'invalid_domain', now);
+	domain = sanitizeDomain(domain);
+	if (!binding || typeof authToken !== 'string' || new TextEncoder().encode(authToken).byteLength < MIN_CAPABILITY_BYTES) {
+		return smtpNotAssessed(domain, 'probe_unprovisioned', now);
+	}
+	try {
+		const response = await binding.fetch(SMTP_PROBE_ENDPOINT, {
+			method: 'POST',
+			headers: { Authorization: `Bearer ${authToken}`, 'Content-Type': 'application/json' },
+			body: JSON.stringify({ domain }),
+			redirect: 'manual',
+			signal: composeSignal(options.signal),
+		});
+		if (!response.ok) {
+			await disposeUnreadResponseBody(response);
+			return smtpNotAssessed(domain, 'probe_failed', now);
+		}
+		const body = await readJsonResponseCapped<unknown>(response, SMTP_PROBE_MAX_BODY_BYTES);
+		const parsed = SmtpStarttlsResultSchema.safeParse(body);
+		if (!parsed.success || parsed.data.domain !== domain) return smtpNotAssessed(domain, 'probe_response_invalid', now);
+		return parsed.data;
+	} catch {
+		return smtpNotAssessed(domain, 'probe_failed', now);
+	}
+}

--- a/src/lib/smtp-starttls-protocol.ts
+++ b/src/lib/smtp-starttls-protocol.ts
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** Pure, bounded SMTP reply parsing and STARTTLS-only session sequencing. */
+
+const MAX_SESSION_BYTES = 64 * 1024;
+const MAX_REPLY_BYTES = 16 * 1024;
+const MAX_REPLY_LINES = 64;
+const MAX_LINE_BYTES = 1_000;
+
+export interface SmtpReply {
+	code: number;
+	lines: string[];
+}
+
+/** Incremental CRLF SMTP reply parser with strict byte and line ceilings. */
+export class SmtpReplyParser {
+	private pending = '';
+	private sessionBytes = 0;
+	private replyBytes = 0;
+	private replyCode: number | undefined;
+	private replyLines: string[] = [];
+
+	push(chunk: Uint8Array | string): SmtpReply[] {
+		const bytes = typeof chunk === 'string' ? new TextEncoder().encode(chunk) : chunk;
+		this.sessionBytes += bytes.byteLength;
+		if (this.sessionBytes > MAX_SESSION_BYTES) throw new RangeError('SMTP session reply limit exceeded');
+		this.pending += new TextDecoder().decode(bytes);
+		if (new TextEncoder().encode(this.pending).byteLength > MAX_REPLY_BYTES) throw new RangeError('SMTP reply limit exceeded');
+
+		const replies: SmtpReply[] = [];
+		for (;;) {
+			const lineEnd = this.pending.indexOf('\r\n');
+			if (lineEnd < 0) {
+				if (this.pending.includes('\n')) throw new Error('Invalid SMTP reply line ending');
+				if (new TextEncoder().encode(this.pending).byteLength > MAX_LINE_BYTES) throw new RangeError('SMTP reply line limit exceeded');
+				break;
+			}
+			const line = this.pending.slice(0, lineEnd);
+			this.pending = this.pending.slice(lineEnd + 2);
+			const lineBytes = new TextEncoder().encode(line).byteLength + 2;
+			if (lineBytes > MAX_LINE_BYTES) throw new RangeError('SMTP reply line limit exceeded');
+			const match = /^(\d{3})([ -])(.*)$/u.exec(line);
+			if (!match) throw new Error('Invalid SMTP reply syntax');
+			const code = Number(match[1]);
+			if (code < 200 || code > 599) throw new Error('Invalid SMTP reply code');
+			if (this.replyCode !== undefined && code !== this.replyCode) throw new Error('Invalid SMTP multiline reply code');
+			this.replyCode = code;
+			this.replyBytes += lineBytes;
+			if (this.replyBytes > MAX_REPLY_BYTES) throw new RangeError('SMTP reply limit exceeded');
+			this.replyLines.push(match[3] ?? '');
+			if (this.replyLines.length > MAX_REPLY_LINES) throw new RangeError('SMTP reply line count exceeded');
+			if (match[2] === ' ') {
+				replies.push({ code, lines: [...this.replyLines] });
+				this.replyCode = undefined;
+				this.replyLines = [];
+				this.replyBytes = 0;
+			}
+		}
+		return replies;
+	}
+
+	finish(): void {
+		if (this.pending.length > 0 || this.replyCode !== undefined) throw new Error('Incomplete SMTP reply');
+	}
+}
+
+export type SmtpSessionState =
+	'await_banner' | 'await_ehlo' | 'await_starttls' | 'await_tls' | 'await_secure_ehlo' | 'await_quit' | 'complete';
+
+const EHLO_IDENTITY = 'scanner.invalid';
+
+export type SmtpProbeCommand = `EHLO ${typeof EHLO_IDENTITY}\r\n` | 'STARTTLS\r\n' | 'QUIT\r\n';
+
+export type SmtpSessionAction =
+	| { type: 'send'; command: SmtpProbeCommand }
+	| { type: 'upgrade_tls' }
+	| { type: 'complete'; outcome: 'starttls_available' | 'starttls_unavailable' };
+
+/**
+ * Minimal state machine. Its command vocabulary is closed over greeting,
+ * STARTTLS negotiation, and graceful disconnect; it has no message transaction
+ * state or payload API.
+ */
+export class SmtpStarttlsStateMachine {
+	private state: SmtpSessionState = 'await_banner';
+	private outcome: 'starttls_available' | 'starttls_unavailable' | undefined;
+
+	currentState(): SmtpSessionState {
+		return this.state;
+	}
+
+	accept(reply: SmtpReply): SmtpSessionAction {
+		switch (this.state) {
+			case 'await_banner':
+				if (reply.code !== 220) throw new Error('Invalid SMTP banner reply');
+				this.state = 'await_ehlo';
+				return { type: 'send', command: `EHLO ${EHLO_IDENTITY}\r\n` };
+			case 'await_ehlo': {
+				if (reply.code !== 250) throw new Error('Invalid SMTP greeting reply');
+				const advertised = reply.lines.some((line) => /^STARTTLS(?:\s|$)/iu.test(line.trim()));
+				if (advertised) {
+					this.state = 'await_starttls';
+					return { type: 'send', command: 'STARTTLS\r\n' };
+				}
+				this.outcome = 'starttls_unavailable';
+				this.state = 'await_quit';
+				return { type: 'send', command: 'QUIT\r\n' };
+			}
+			case 'await_starttls':
+				if (reply.code !== 220) {
+					this.outcome = 'starttls_unavailable';
+					this.state = 'await_quit';
+					return { type: 'send', command: 'QUIT\r\n' };
+				}
+				this.state = 'await_tls';
+				return { type: 'upgrade_tls' };
+			case 'await_secure_ehlo':
+				if (reply.code !== 250) throw new Error('Invalid SMTP post-TLS greeting reply');
+				this.outcome = 'starttls_available';
+				this.state = 'await_quit';
+				return { type: 'send', command: 'QUIT\r\n' };
+			case 'await_quit':
+				if (reply.code !== 221) throw new Error('Invalid SMTP disconnect reply');
+				this.state = 'complete';
+				return { type: 'complete', outcome: this.outcome ?? 'starttls_unavailable' };
+			case 'await_tls':
+				throw new Error('TLS upgrade must complete before another SMTP reply');
+			case 'complete':
+				throw new Error('SMTP session is already complete');
+		}
+	}
+
+	tlsEstablished(): SmtpSessionAction {
+		if (this.state !== 'await_tls') throw new Error('SMTP session is not awaiting TLS');
+		this.state = 'await_secure_ehlo';
+		return { type: 'send', command: `EHLO ${EHLO_IDENTITY}\r\n` };
+	}
+}

--- a/src/lib/smtp-starttls-targets.ts
+++ b/src/lib/smtp-starttls-targets.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { SmtpProbeTarget } from '../schemas/smtp-starttls';
+import { validateDomain } from './sanitize';
+
+export interface MxRecordWithAddresses {
+	preference: number;
+	exchange: string;
+	addresses: string[];
+}
+
+export interface MxTargetSelection {
+	status: 'measured' | 'partial' | 'not-assessed' | 'not-applicable';
+	outcome: 'targets_selected' | 'null_mx' | 'no_explicit_mx' | 'no_public_mx_address';
+	targets: SmtpProbeTarget[];
+	rejectedExchanges: string[];
+}
+
+function normalizedExchange(exchange: string): string {
+	return exchange.trim().toLowerCase().replace(/\.$/u, '');
+}
+
+function publicIpv4(address: string): boolean {
+	const parts = address.split('.');
+	if (parts.length !== 4 || parts.some((part) => !/^(?:0|[1-9]\d{0,2})$/u.test(part))) return false;
+	const octets = parts.map(Number);
+	if (octets.some((part) => part > 255)) return false;
+	const [a, b] = octets;
+	if (a === 0 || a === 10 || a === 127 || a >= 224) return false;
+	if (a === 100 && b >= 64 && b <= 127) return false;
+	if (a === 169 && b === 254) return false;
+	if (a === 172 && b >= 16 && b <= 31) return false;
+	if (a === 192 && b === 0 && (octets[2] === 0 || octets[2] === 2)) return false;
+	if (a === 192 && b === 31 && octets[2] === 196) return false;
+	if (a === 192 && b === 52 && octets[2] === 193) return false;
+	if (a === 192 && b === 88 && octets[2] === 99) return false;
+	if (a === 192 && b === 168) return false;
+	if (a === 192 && b === 175 && octets[2] === 48) return false;
+	if (a === 198 && (b === 18 || b === 19)) return false;
+	if (a === 198 && b === 51 && octets[2] === 100) return false;
+	if (a === 203 && b === 0 && octets[2] === 113) return false;
+	return true;
+}
+
+/**
+ * Conservative public-address admission gate used before any future socket
+ * connection. IPv6 is intentionally not admitted until the isolated probe has
+ * a binary address classifier; textual prefix checks are not a security gate.
+ */
+export function isPublicSmtpAddress(address: string): boolean {
+	return publicIpv4(address);
+}
+
+/**
+ * Deterministically choose at most three MX hosts and pin one public address per
+ * host. Lowest preference wins, then exchange and address lexical order.
+ */
+export function selectSmtpMxTargets(records: MxRecordWithAddresses[]): MxTargetSelection {
+	if (records.length === 0) return { status: 'not-assessed', outcome: 'no_explicit_mx', targets: [], rejectedExchanges: [] };
+	if (records.length === 1 && records[0]!.preference === 0 && records[0]!.exchange.trim() === '.') {
+		return { status: 'not-applicable', outcome: 'null_mx', targets: [], rejectedExchanges: [] };
+	}
+
+	const targets: SmtpProbeTarget[] = [];
+	const rejected = new Set<string>();
+	const seenExchanges = new Set<string>();
+	const ordered = [...records].sort(
+		(a, b) => a.preference - b.preference || normalizedExchange(a.exchange).localeCompare(normalizedExchange(b.exchange)),
+	);
+	for (const record of ordered) {
+		if (targets.length >= 3) break;
+		const exchange = normalizedExchange(record.exchange);
+		if (seenExchanges.has(exchange)) continue;
+		seenExchanges.add(exchange);
+		if (!Number.isInteger(record.preference) || record.preference < 0 || record.preference > 65_535 || !validateDomain(exchange).valid) {
+			rejected.add(exchange || '<empty>');
+			continue;
+		}
+		const address = [...new Set(record.addresses.filter(isPublicSmtpAddress))].sort()[0];
+		if (!address) {
+			rejected.add(exchange);
+			continue;
+		}
+		targets.push({ exchange, preference: record.preference, address, port: 25, tlsServerName: exchange });
+	}
+	if (targets.length === 0) {
+		return { status: 'not-assessed', outcome: 'no_public_mx_address', targets, rejectedExchanges: [...rejected].sort() };
+	}
+	return {
+		status: rejected.size > 0 ? 'partial' : 'measured',
+		outcome: 'targets_selected',
+		targets,
+		rejectedExchanges: [...rejected].sort(),
+	};
+}

--- a/src/schemas/smtp-starttls.ts
+++ b/src/schemas/smtp-starttls.ts
@@ -112,6 +112,26 @@ export const SmtpTargetResultSchema = z
 
 export type SmtpTargetResult = z.infer<typeof SmtpTargetResultSchema>;
 
+function targetKnownAvailable(target: SmtpTargetResult): boolean {
+	return (
+		target.status !== 'not-assessed' &&
+		target.starttlsAdvertised === true &&
+		target.tlsNegotiated === true &&
+		target.postTlsEhloAccepted === true &&
+		target.tls?.peerNameValid === true
+	);
+}
+
+function targetKnownUnavailable(target: SmtpTargetResult): boolean {
+	return (
+		target.status !== 'not-assessed' &&
+		(target.starttlsAdvertised === false ||
+			target.tlsNegotiated === false ||
+			target.postTlsEhloAccepted === false ||
+			target.tls?.peerNameValid === false)
+	);
+}
+
 const SmtpResultBase = {
 	schemaVersion: z.literal('1.0'),
 	probe: z.literal('smtp_starttls'),
@@ -185,8 +205,31 @@ export const SmtpStarttlsResultSchema = z
 				ctx.addIssue({ code: 'custom', message: 'An unavailable measured result cannot include a successful STARTTLS target' });
 			}
 		}
-		if (result.status === 'partial' && result.outcome !== 'mixed' && result.targets.every((target) => target.status === 'measured')) {
-			ctx.addIssue({ code: 'custom', message: 'A partial result requires a partial/not-assessed target or a mixed outcome' });
+		if (result.status === 'partial') {
+			const hasIncompleteEvidence = result.targets.some((target) => target.status !== 'measured');
+			const hasKnownAvailable = result.targets.some(targetKnownAvailable);
+			const hasKnownUnavailable = result.targets.some(targetKnownUnavailable);
+
+			if (result.outcome === 'mixed') {
+				if (!hasIncompleteEvidence && !(hasKnownAvailable && hasKnownUnavailable)) {
+					ctx.addIssue({
+						code: 'custom',
+						message: 'A mixed partial result requires both measured outcomes or an explicit partial/not-assessed target',
+					});
+				}
+			} else {
+				if (hasIncompleteEvidence) {
+					ctx.addIssue({ code: 'custom', message: 'A uniform STARTTLS outcome cannot contain incomplete target evidence' });
+				}
+				const contradictsAvailable = result.outcome === 'starttls_available' && hasKnownUnavailable;
+				const contradictsUnavailable = result.outcome === 'starttls_unavailable' && hasKnownAvailable;
+				if (contradictsAvailable || contradictsUnavailable) {
+					ctx.addIssue({ code: 'custom', message: 'Known target evidence contradicts the aggregate STARTTLS outcome' });
+				}
+				if (!hasIncompleteEvidence && !contradictsAvailable && !contradictsUnavailable) {
+					ctx.addIssue({ code: 'custom', message: 'Uniform complete target evidence must use measured aggregate status' });
+				}
+			}
 		}
 		if (result.status === 'not-assessed') {
 			if ((result.outcome === 'no_explicit_mx') !== (result.reason === 'no_explicit_mx')) {

--- a/src/schemas/smtp-starttls.ts
+++ b/src/schemas/smtp-starttls.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { z } from 'zod';
+import { isPublicSmtpAddress } from '../lib/smtp-starttls-targets';
+import { validateDomain } from '../lib/sanitize';
+
+/** A single public-IP target selected from an MX RRset. Port is fixed by contract. */
+export const SmtpProbeTargetSchema = z
+	.object({
+		exchange: z.string().min(1).max(253),
+		preference: z.number().int().min(0).max(65_535),
+		address: z.ipv4().refine(isPublicSmtpAddress, 'SMTP target must be a canonical public IPv4 address'),
+		port: z.literal(25),
+		tlsServerName: z.string().min(1).max(253),
+	})
+	.strict()
+	.superRefine((target, ctx) => {
+		if (!validateDomain(target.exchange).valid || target.exchange !== target.exchange.toLowerCase() || target.exchange.endsWith('.')) {
+			ctx.addIssue({ code: 'custom', message: 'SMTP exchange must be a normalized public DNS hostname' });
+		}
+		if (target.tlsServerName !== target.exchange) {
+			ctx.addIssue({ code: 'custom', message: 'TLS server name must equal the selected MX exchange' });
+		}
+	});
+
+export type SmtpProbeTarget = z.infer<typeof SmtpProbeTargetSchema>;
+
+const SmtpPhaseSchema = z.enum(['connect', 'banner', 'ehlo', 'starttls', 'tls', 'post_tls_ehlo', 'quit']);
+const SmtpTargetFailureReasonSchema = z.enum([
+	'connection_failed',
+	'deadline_exceeded',
+	'invalid_reply',
+	'reply_limit_exceeded',
+	'starttls_not_advertised',
+	'starttls_rejected',
+	'tls_handshake_failed',
+	'peer_name_invalid',
+	'post_tls_ehlo_failed',
+]);
+const SmtpNotAssessedReasonSchema = z.enum([
+	'probe_unprovisioned',
+	'invalid_domain',
+	'no_explicit_mx',
+	'no_public_mx_address',
+	'probe_failed',
+	'probe_response_invalid',
+]);
+export type SmtpNotAssessedReason = z.infer<typeof SmtpNotAssessedReasonSchema>;
+const SmtpTlsSchema = z
+	.object({
+		protocol: z.string().min(1).max(32),
+		cipher: z.string().min(1).max(128).optional(),
+		peerNameValid: z.boolean(),
+	})
+	.strict();
+
+export const SmtpMeasuredTargetResultSchema = z
+	.object({
+		target: SmtpProbeTargetSchema,
+		status: z.literal('measured'),
+		phase: SmtpPhaseSchema,
+		starttlsAdvertised: z.boolean(),
+		tlsNegotiated: z.boolean(),
+		postTlsEhloAccepted: z.boolean(),
+		tls: SmtpTlsSchema.optional(),
+		reason: SmtpTargetFailureReasonSchema.optional(),
+	})
+	.strict();
+
+const SmtpPartialTargetResultSchema = z
+	.object({
+		target: SmtpProbeTargetSchema,
+		status: z.literal('partial'),
+		phase: SmtpPhaseSchema,
+		starttlsAdvertised: z.boolean().nullable(),
+		tlsNegotiated: z.boolean().nullable(),
+		postTlsEhloAccepted: z.boolean().nullable(),
+		tls: SmtpTlsSchema.optional(),
+		reason: SmtpTargetFailureReasonSchema,
+	})
+	.strict();
+
+const SmtpNotAssessedTargetResultSchema = z
+	.object({
+		target: SmtpProbeTargetSchema,
+		status: z.literal('not-assessed'),
+		phase: SmtpPhaseSchema,
+		reason: SmtpTargetFailureReasonSchema,
+	})
+	.strict();
+
+export const SmtpTargetResultSchema = z
+	.discriminatedUnion('status', [SmtpMeasuredTargetResultSchema, SmtpPartialTargetResultSchema, SmtpNotAssessedTargetResultSchema])
+	.superRefine((result, ctx) => {
+		if (result.status === 'not-assessed') return;
+		if (result.tlsNegotiated === true && result.starttlsAdvertised !== true) {
+			ctx.addIssue({ code: 'custom', message: 'TLS negotiation requires an advertised STARTTLS capability' });
+		}
+		if ((result.tlsNegotiated === true) !== (result.tls !== undefined)) {
+			ctx.addIssue({ code: 'custom', message: 'TLS details must be present exactly when TLS was negotiated' });
+		}
+		if (result.postTlsEhloAccepted === true && result.tlsNegotiated !== true) {
+			ctx.addIssue({ code: 'custom', message: 'A post-TLS greeting requires a negotiated TLS session' });
+		}
+		if (result.status === 'measured') {
+			const successful = result.tlsNegotiated && result.postTlsEhloAccepted && result.tls?.peerNameValid === true;
+			if (successful === (result.reason !== undefined)) {
+				ctx.addIssue({ code: 'custom', message: 'A measured failed target requires one reason; a successful target permits none' });
+			}
+		}
+	});
+
+export type SmtpTargetResult = z.infer<typeof SmtpTargetResultSchema>;
+
+const SmtpResultBase = {
+	schemaVersion: z.literal('1.0'),
+	probe: z.literal('smtp_starttls'),
+	observedAt: z.string().datetime(),
+	nonScoring: z.literal(true),
+};
+
+const SmtpMeasuredResultSchema = z
+	.object({
+		...SmtpResultBase,
+		domain: z.string().min(1).max(253),
+		status: z.literal('measured'),
+		outcome: z.enum(['starttls_available', 'starttls_unavailable']),
+		targets: z.array(SmtpTargetResultSchema).min(1).max(3),
+	})
+	.strict();
+
+const SmtpPartialResultSchema = z
+	.object({
+		...SmtpResultBase,
+		domain: z.string().min(1).max(253),
+		status: z.literal('partial'),
+		outcome: z.enum(['starttls_available', 'starttls_unavailable', 'mixed']),
+		targets: z.array(SmtpTargetResultSchema).min(1).max(3),
+	})
+	.strict();
+
+const SmtpNotAssessedResultSchema = z
+	.object({
+		...SmtpResultBase,
+		domain: z.string().min(1).max(253).nullable(),
+		status: z.literal('not-assessed'),
+		outcome: z.enum(['no_explicit_mx', 'not_assessed']),
+		targets: z.array(SmtpTargetResultSchema).length(0),
+		reason: SmtpNotAssessedReasonSchema,
+	})
+	.strict();
+
+const SmtpNotApplicableResultSchema = z
+	.object({
+		...SmtpResultBase,
+		domain: z.string().min(1).max(253),
+		status: z.literal('not-applicable'),
+		outcome: z.literal('null_mx'),
+		targets: z.array(SmtpTargetResultSchema).length(0),
+		reason: z.literal('null_mx'),
+	})
+	.strict();
+
+export const SmtpStarttlsResultSchema = z
+	.discriminatedUnion('status', [
+		SmtpMeasuredResultSchema,
+		SmtpPartialResultSchema,
+		SmtpNotAssessedResultSchema,
+		SmtpNotApplicableResultSchema,
+	])
+	.superRefine((result, ctx) => {
+		if (result.status === 'measured') {
+			const measuredTargets = result.targets.filter((target) => target.status === 'measured');
+			if (measuredTargets.length !== result.targets.length) {
+				ctx.addIssue({ code: 'custom', message: 'A measured aggregate cannot contain partial or not-assessed targets' });
+				return;
+			}
+			const successful = measuredTargets.filter(
+				(target) => target.tlsNegotiated && target.postTlsEhloAccepted && target.tls?.peerNameValid === true,
+			).length;
+			if (result.outcome === 'starttls_available' && successful !== result.targets.length) {
+				ctx.addIssue({ code: 'custom', message: 'An available measured result requires every target to complete STARTTLS' });
+			}
+			if (result.outcome === 'starttls_unavailable' && successful !== 0) {
+				ctx.addIssue({ code: 'custom', message: 'An unavailable measured result cannot include a successful STARTTLS target' });
+			}
+		}
+		if (result.status === 'partial' && result.outcome !== 'mixed' && result.targets.every((target) => target.status === 'measured')) {
+			ctx.addIssue({ code: 'custom', message: 'A partial result requires a partial/not-assessed target or a mixed outcome' });
+		}
+		if (result.status === 'not-assessed') {
+			if ((result.outcome === 'no_explicit_mx') !== (result.reason === 'no_explicit_mx')) {
+				ctx.addIssue({ code: 'custom', message: 'The no-explicit-MX outcome and reason must agree' });
+			}
+			if ((result.reason === 'invalid_domain') !== (result.domain === null)) {
+				ctx.addIssue({ code: 'custom', message: 'Only an invalid-domain result may omit the normalized domain' });
+			}
+		}
+	});
+
+export type SmtpStarttlsResult = z.infer<typeof SmtpStarttlsResultSchema>;
+
+/** Build the explicit fail-soft result used whenever no remote measurement exists. */
+export function smtpNotAssessed(
+	domain: string | null,
+	reason: SmtpNotAssessedReason,
+	now: () => string = () => new Date().toISOString(),
+): SmtpStarttlsResult {
+	return {
+		schemaVersion: '1.0',
+		probe: 'smtp_starttls',
+		domain,
+		status: 'not-assessed',
+		outcome: reason === 'no_explicit_mx' ? 'no_explicit_mx' : 'not_assessed',
+		observedAt: now(),
+		nonScoring: true,
+		targets: [],
+		reason,
+	};
+}

--- a/src/schemas/smtp-starttls.ts
+++ b/src/schemas/smtp-starttls.ts
@@ -46,6 +46,7 @@ const SmtpNotAssessedReasonSchema = z.enum([
 	'probe_response_invalid',
 ]);
 export type SmtpNotAssessedReason = z.infer<typeof SmtpNotAssessedReasonSchema>;
+const SmtpAggregateNotAssessedReasonSchema = z.union([SmtpNotAssessedReasonSchema, z.literal('targets_not_assessed')]);
 const SmtpTlsSchema = z
 	.object({
 		protocol: z.string().min(1).max(32),
@@ -112,26 +113,6 @@ export const SmtpTargetResultSchema = z
 
 export type SmtpTargetResult = z.infer<typeof SmtpTargetResultSchema>;
 
-function targetKnownAvailable(target: SmtpTargetResult): boolean {
-	return (
-		target.status !== 'not-assessed' &&
-		target.starttlsAdvertised === true &&
-		target.tlsNegotiated === true &&
-		target.postTlsEhloAccepted === true &&
-		target.tls?.peerNameValid === true
-	);
-}
-
-function targetKnownUnavailable(target: SmtpTargetResult): boolean {
-	return (
-		target.status !== 'not-assessed' &&
-		(target.starttlsAdvertised === false ||
-			target.tlsNegotiated === false ||
-			target.postTlsEhloAccepted === false ||
-			target.tls?.peerNameValid === false)
-	);
-}
-
 const SmtpResultBase = {
 	schemaVersion: z.literal('1.0'),
 	probe: z.literal('smtp_starttls'),
@@ -144,7 +125,7 @@ const SmtpMeasuredResultSchema = z
 		...SmtpResultBase,
 		domain: z.string().min(1).max(253),
 		status: z.literal('measured'),
-		outcome: z.enum(['starttls_available', 'starttls_unavailable']),
+		outcome: z.enum(['starttls_available', 'starttls_unavailable', 'mixed']),
 		targets: z.array(SmtpTargetResultSchema).min(1).max(3),
 	})
 	.strict();
@@ -154,7 +135,7 @@ const SmtpPartialResultSchema = z
 		...SmtpResultBase,
 		domain: z.string().min(1).max(253),
 		status: z.literal('partial'),
-		outcome: z.enum(['starttls_available', 'starttls_unavailable', 'mixed']),
+		outcome: z.literal('mixed'),
 		targets: z.array(SmtpTargetResultSchema).min(1).max(3),
 	})
 	.strict();
@@ -165,8 +146,8 @@ const SmtpNotAssessedResultSchema = z
 		domain: z.string().min(1).max(253).nullable(),
 		status: z.literal('not-assessed'),
 		outcome: z.enum(['no_explicit_mx', 'not_assessed']),
-		targets: z.array(SmtpTargetResultSchema).length(0),
-		reason: SmtpNotAssessedReasonSchema,
+		targets: z.array(SmtpNotAssessedTargetResultSchema).max(3),
+		reason: SmtpAggregateNotAssessedReasonSchema,
 	})
 	.strict();
 
@@ -204,31 +185,18 @@ export const SmtpStarttlsResultSchema = z
 			if (result.outcome === 'starttls_unavailable' && successful !== 0) {
 				ctx.addIssue({ code: 'custom', message: 'An unavailable measured result cannot include a successful STARTTLS target' });
 			}
+			if (result.outcome === 'mixed' && (successful === 0 || successful === result.targets.length)) {
+				ctx.addIssue({ code: 'custom', message: 'A mixed measured result requires both available and unavailable targets' });
+			}
 		}
 		if (result.status === 'partial') {
-			const hasIncompleteEvidence = result.targets.some((target) => target.status !== 'measured');
-			const hasKnownAvailable = result.targets.some(targetKnownAvailable);
-			const hasKnownUnavailable = result.targets.some(targetKnownUnavailable);
-
-			if (result.outcome === 'mixed') {
-				if (!hasIncompleteEvidence && !(hasKnownAvailable && hasKnownUnavailable)) {
-					ctx.addIssue({
-						code: 'custom',
-						message: 'A mixed partial result requires both measured outcomes or an explicit partial/not-assessed target',
-					});
-				}
-			} else {
-				if (hasIncompleteEvidence) {
-					ctx.addIssue({ code: 'custom', message: 'A uniform STARTTLS outcome cannot contain incomplete target evidence' });
-				}
-				const contradictsAvailable = result.outcome === 'starttls_available' && hasKnownUnavailable;
-				const contradictsUnavailable = result.outcome === 'starttls_unavailable' && hasKnownAvailable;
-				if (contradictsAvailable || contradictsUnavailable) {
-					ctx.addIssue({ code: 'custom', message: 'Known target evidence contradicts the aggregate STARTTLS outcome' });
-				}
-				if (!hasIncompleteEvidence && !contradictsAvailable && !contradictsUnavailable) {
-					ctx.addIssue({ code: 'custom', message: 'Uniform complete target evidence must use measured aggregate status' });
-				}
+			const measuredTargets = result.targets.filter((target) => target.status === 'measured').length;
+			const incompleteTargets = result.targets.length - measuredTargets;
+			if (measuredTargets === 0) {
+				ctx.addIssue({ code: 'custom', message: 'A partial result requires at least one measured target fact' });
+			}
+			if (incompleteTargets === 0) {
+				ctx.addIssue({ code: 'custom', message: 'A partial result requires at least one partial or not-assessed target' });
 			}
 		}
 		if (result.status === 'not-assessed') {
@@ -237,6 +205,9 @@ export const SmtpStarttlsResultSchema = z
 			}
 			if ((result.reason === 'invalid_domain') !== (result.domain === null)) {
 				ctx.addIssue({ code: 'custom', message: 'Only an invalid-domain result may omit the normalized domain' });
+			}
+			if ((result.reason === 'targets_not_assessed') !== result.targets.length > 0) {
+				ctx.addIssue({ code: 'custom', message: 'Target detail is permitted exactly when every selected target was not assessed' });
 			}
 		}
 	});

--- a/src/tools/audit-csp-coverage.ts
+++ b/src/tools/audit-csp-coverage.ts
@@ -1,0 +1,326 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Bounded, sampled Content-Security-Policy header consistency audit.
+ *
+ * This is deliberately an unregistered beta primitive: it does not synthesize a
+ * policy, execute page content, authenticate, leave the target origin, or affect
+ * scoring. Every production fetch flows through the existing safe-fetch,
+ * robots, fetch-budget, and bounded-body primitives.
+ */
+
+import {
+	RobotsDisallowedError,
+	SCANNER_USER_AGENT,
+	createRobotsGroupCache,
+	withRobotsGate,
+	type FetchFunction,
+} from '@blackveil/dns-checks';
+
+import { createFetchBudget } from '../lib/fetch-budget';
+import { createRobotsFetchMemo, withRobotsFetchMemo, type RobotsFetchMemo } from '../lib/robots-memo';
+import { createRobotsProvenance, type RobotsResolutionStamp } from '../lib/robots-provenance';
+import { safeFetch } from '../lib/safe-fetch';
+import { readTextResponseCappedDetailed, disposeUnreadResponseBody } from '../lib/response-body';
+import { sanitizeDomain, validateDomain } from '../lib/sanitize';
+
+export const CSP_CRAWL_LIMITS = Object.freeze({
+	maxPages: 10,
+	maxRedirectsPerPage: 3,
+	maxPageBytes: 256 * 1024,
+	maxTotalBytes: 2 * 1024 * 1024,
+	maxLinksPerPage: 256,
+	budgetMs: 10_000,
+});
+
+export type MeasurementStatus = 'measured' | 'partial' | 'not-assessed';
+
+export type CspPageNotAssessedReason = 'fetch_failed' | 'http_error' | 'redirect_invalid' | 'redirect_limit' | 'robots_disallowed';
+
+export type CspDiscoveryStatus = 'measured' | 'not-assessed';
+
+export type CspDiscoveryNotAssessedReason = 'body_too_large' | 'body_unreadable' | 'body_budget_exhausted' | 'non_html';
+
+export interface CspPageObservation {
+	url: string;
+	status: 'measured' | 'not-assessed';
+	httpStatus?: number;
+	notAssessedReason?: CspPageNotAssessedReason;
+	enforcingPolicy?: string;
+	reportOnlyPolicy?: string;
+	unsafeTokens: string[];
+	discovery: {
+		status: CspDiscoveryStatus;
+		notAssessedReason?: CspDiscoveryNotAssessedReason;
+	};
+}
+
+export interface CspCoverageSummary {
+	measuredPages: number;
+	pagesWithEnforcingPolicy: number;
+	pagesWithReportOnlyPolicy: number;
+	distinctHeaderProfiles: number;
+	headersConsistent: boolean;
+	unsafeTokens: string[];
+}
+
+export interface CspCoverageResult {
+	schemaVersion: '1.0';
+	probe: 'csp_header_consistency';
+	domain: string;
+	status: MeasurementStatus;
+	observedAt: string;
+	scope: 'sampled_same_origin';
+	nonScoring: true;
+	limits: typeof CSP_CRAWL_LIMITS;
+	pagesAttempted: number;
+	pages: CspPageObservation[];
+	summary?: CspCoverageSummary;
+	partialReasons: string[];
+	robotsResolution?: RobotsResolutionStamp;
+}
+
+export interface AuditCspCoverageOptions {
+	/** Test seam. Production callers omit this so safeFetch remains mandatory. */
+	fetchFn?: FetchFunction;
+	/** One caller-owned memo; defaults to a fresh per-audit memo. */
+	robotsMemo?: RobotsFetchMemo;
+	budgetMs?: number;
+	now?: () => string;
+}
+
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+const UNSAFE_TOKENS = ["'unsafe-eval'", "'unsafe-inline'", "'wasm-unsafe-eval'"] as const;
+
+function normalizePolicy(value: string | null): string | undefined {
+	if (!value) return undefined;
+	const normalized = value
+		.split(';')
+		.map((directive) => directive.trim().replace(/\s+/g, ' '))
+		.filter(Boolean)
+		.join('; ');
+	return normalized || undefined;
+}
+
+function unsafeTokensFrom(...policies: Array<string | undefined>): string[] {
+	const combined = policies.filter(Boolean).join(' ').toLowerCase();
+	return UNSAFE_TOKENS.filter((token) => combined.includes(token));
+}
+
+function canonicalSameOriginUrl(raw: string, base: URL, origin: string): URL | null {
+	let candidate: URL;
+	try {
+		candidate = new URL(raw.replace(/&amp;/gi, '&'), base);
+	} catch {
+		return null;
+	}
+	if (candidate.protocol !== 'https:' || candidate.origin !== origin || candidate.username || candidate.password || candidate.search)
+		return null;
+	candidate.hash = '';
+	return candidate;
+}
+
+/** Extract a conservative subset of anchor hrefs, sorted for deterministic BFS. */
+export function extractSameOriginLinks(html: string, baseUrl: string): string[] {
+	const base = new URL(baseUrl);
+	const found = new Set<string>();
+	const hrefPattern = /<a\b[^>]*\bhref\s*=\s*(["'])(.*?)\1/giu;
+	for (const match of html.matchAll(hrefPattern)) {
+		const candidate = canonicalSameOriginUrl(match[2] ?? '', base, base.origin);
+		if (!candidate) continue;
+		found.add(candidate.href);
+		if (found.size >= CSP_CRAWL_LIMITS.maxLinksPerPage) break;
+	}
+	return [...found].sort((a, b) => a.localeCompare(b));
+}
+
+interface FetchPageOutcome {
+	response?: Response;
+	url: string;
+	reason?: CspPageNotAssessedReason;
+}
+
+async function fetchWithSameOriginRedirects(fetchFn: FetchFunction, requestedUrl: string, origin: string): Promise<FetchPageOutcome> {
+	let current = new URL(requestedUrl);
+	for (let redirects = 0; ; redirects++) {
+		let response: Response;
+		try {
+			response = await fetchFn(current.href, { method: 'GET', redirect: 'manual', credentials: 'omit' });
+		} catch (error) {
+			return { url: current.href, reason: error instanceof RobotsDisallowedError ? 'robots_disallowed' : 'fetch_failed' };
+		}
+
+		if (!REDIRECT_STATUSES.has(response.status)) return { response, url: current.href };
+		if (redirects >= CSP_CRAWL_LIMITS.maxRedirectsPerPage) {
+			await disposeUnreadResponseBody(response);
+			return { url: current.href, reason: 'redirect_limit' };
+		}
+		const location = response.headers.get('location');
+		const next = location ? canonicalSameOriginUrl(location, current, origin) : null;
+		await disposeUnreadResponseBody(response);
+		if (!next) return { url: current.href, reason: 'redirect_invalid' };
+		current = next;
+	}
+}
+
+function pageHeaderProfile(page: CspPageObservation): string {
+	return `${page.enforcingPolicy ?? '<absent>'}\n${page.reportOnlyPolicy ?? '<absent>'}`;
+}
+
+function summarizePages(pages: CspPageObservation[]): CspCoverageSummary | undefined {
+	const measured = pages.filter((page) => page.status === 'measured');
+	if (measured.length === 0) return undefined;
+	const profiles = new Set(measured.map(pageHeaderProfile));
+	return {
+		measuredPages: measured.length,
+		pagesWithEnforcingPolicy: measured.filter((page) => page.enforcingPolicy !== undefined).length,
+		pagesWithReportOnlyPolicy: measured.filter((page) => page.reportOnlyPolicy !== undefined).length,
+		distinctHeaderProfiles: profiles.size,
+		headersConsistent: profiles.size === 1,
+		unsafeTokens: [...new Set(measured.flatMap((page) => page.unsafeTokens))].sort(),
+	};
+}
+
+/**
+ * Audit at most ten same-origin HTTPS pages using a deterministic breadth-first
+ * traversal. Query-bearing URLs are excluded to avoid crawling unbounded state.
+ */
+export async function auditCspCoverage(domainInput: string, options: AuditCspCoverageOptions = {}): Promise<CspCoverageResult> {
+	const validation = validateDomain(domainInput);
+	if (!validation.valid) throw new Error(`Invalid domain: ${validation.error ?? 'validation failed'}`);
+	const domain = sanitizeDomain(domainInput);
+	const origin = `https://${domain}`;
+	const seed = `${origin}/`;
+	const now = options.now ?? (() => new Date().toISOString());
+	const budget = createFetchBudget(options.budgetMs ?? CSP_CRAWL_LIMITS.budgetMs);
+	const provenance = createRobotsProvenance(domain);
+	const memo = options.robotsMemo ?? createRobotsFetchMemo();
+	const baseFetch = options.fetchFn ?? ((url: string, init?: RequestInit) => safeFetch(url, init));
+	const guardedFetch = withRobotsGate(withRobotsFetchMemo(budget.wrap(baseFetch), memo), {
+		userAgent: SCANNER_USER_AGENT,
+		groupCache: createRobotsGroupCache(),
+		cacheNamespace: 'csp-sampled-crawl',
+		onRobotsResolution: provenance.onResolution,
+	});
+
+	const queue = [seed];
+	const queued = new Set(queue);
+	const visited = new Set<string>();
+	const pages: CspPageObservation[] = [];
+	const partialReasons = new Set<string>();
+	let retainedBodyBytes = 0;
+
+	while (queue.length > 0 && pages.length < CSP_CRAWL_LIMITS.maxPages) {
+		if (!budget.canIssueRequest()) {
+			partialReasons.add('fetch_budget_exhausted');
+			break;
+		}
+		const requestedUrl = queue.shift()!;
+		queued.delete(requestedUrl);
+		if (visited.has(requestedUrl)) continue;
+		visited.add(requestedUrl);
+		const fetched = await fetchWithSameOriginRedirects(guardedFetch, requestedUrl, origin);
+		if (!fetched.response) {
+			pages.push({
+				url: fetched.url,
+				status: 'not-assessed',
+				notAssessedReason: fetched.reason,
+				unsafeTokens: [],
+				discovery: { status: 'not-assessed', notAssessedReason: 'non_html' },
+			});
+			partialReasons.add(fetched.reason ?? 'fetch_failed');
+			continue;
+		}
+		visited.add(fetched.url);
+
+		const response = fetched.response;
+		if (response.status < 200 || response.status >= 400) {
+			await disposeUnreadResponseBody(response);
+			pages.push({
+				url: fetched.url,
+				status: 'not-assessed',
+				httpStatus: response.status,
+				notAssessedReason: 'http_error',
+				unsafeTokens: [],
+				discovery: { status: 'not-assessed', notAssessedReason: 'non_html' },
+			});
+			partialReasons.add('http_error');
+			continue;
+		}
+
+		const enforcingPolicy = normalizePolicy(response.headers.get('content-security-policy'));
+		const reportOnlyPolicy = normalizePolicy(response.headers.get('content-security-policy-report-only'));
+		const page: CspPageObservation = {
+			url: fetched.url,
+			status: 'measured',
+			httpStatus: response.status,
+			enforcingPolicy,
+			reportOnlyPolicy,
+			unsafeTokens: unsafeTokensFrom(enforcingPolicy, reportOnlyPolicy),
+			discovery: { status: 'measured' },
+		};
+
+		const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+		if (!contentType.includes('text/html')) {
+			await disposeUnreadResponseBody(response);
+			page.discovery = { status: 'not-assessed', notAssessedReason: 'non_html' };
+			partialReasons.add('non_html');
+			pages.push(page);
+			continue;
+		}
+
+		const remainingBytes = CSP_CRAWL_LIMITS.maxTotalBytes - retainedBodyBytes;
+		if (remainingBytes <= 0) {
+			await disposeUnreadResponseBody(response);
+			page.discovery = { status: 'not-assessed', notAssessedReason: 'body_budget_exhausted' };
+			partialReasons.add('body_budget_exhausted');
+			pages.push(page);
+			break;
+		}
+		const readCap = Math.min(CSP_CRAWL_LIMITS.maxPageBytes, remainingBytes);
+		const read =
+			response.body === null
+				? { text: '', bytesRead: 0, overflowed: false, errored: false }
+				: await readTextResponseCappedDetailed(response, readCap);
+		retainedBodyBytes += read.bytesRead;
+		if (read.text === null) {
+			const reason = read.overflowed ? 'body_too_large' : 'body_unreadable';
+			page.discovery = { status: 'not-assessed', notAssessedReason: reason };
+			partialReasons.add(reason);
+			pages.push(page);
+			if (retainedBodyBytes >= CSP_CRAWL_LIMITS.maxTotalBytes) {
+				partialReasons.add('body_budget_exhausted');
+				break;
+			}
+			continue;
+		}
+		for (const link of extractSameOriginLinks(read.text, fetched.url)) {
+			if (!visited.has(link) && !queued.has(link)) {
+				queue.push(link);
+				queued.add(link);
+			}
+		}
+		pages.push(page);
+	}
+
+	if (queue.length > 0 && pages.length >= CSP_CRAWL_LIMITS.maxPages) partialReasons.add('max_pages_reached');
+	const robotsResolution = provenance.summarize();
+	if (robotsResolution?.failOpen) partialReasons.add('robots_fail_open');
+	const summary = summarizePages(pages);
+	const status: MeasurementStatus = !summary ? 'not-assessed' : partialReasons.size > 0 ? 'partial' : 'measured';
+	return {
+		schemaVersion: '1.0',
+		probe: 'csp_header_consistency',
+		domain,
+		status,
+		observedAt: now(),
+		scope: 'sampled_same_origin',
+		nonScoring: true,
+		limits: CSP_CRAWL_LIMITS,
+		pagesAttempted: pages.length,
+		pages,
+		...(summary ? { summary } : {}),
+		partialReasons: [...partialReasons].sort(),
+		...(robotsResolution ? { robotsResolution } : {}),
+	};
+}

--- a/src/tools/inspect-smtp-starttls.ts
+++ b/src/tools/inspect-smtp-starttls.ts
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/** Unregistered, non-scoring beta wrapper for the isolated STARTTLS probe seam. */
+
+import { callSmtpStarttlsProbe, type SmtpProbeBinding } from '../lib/smtp-probe-binding';
+import { sanitizeDomain, validateDomain } from '../lib/sanitize';
+import { smtpNotAssessed, type SmtpStarttlsResult } from '../schemas/smtp-starttls';
+
+export interface InspectSmtpStarttlsOptions {
+	probeBinding?: SmtpProbeBinding;
+	probeAuthToken?: string;
+	signal?: AbortSignal;
+	now?: () => string;
+}
+
+/** Validate the domain, then delegate only through an explicitly injected binding. */
+export async function inspectSmtpStarttls(domainInput: string, options: InspectSmtpStarttlsOptions = {}): Promise<SmtpStarttlsResult> {
+	const now = options.now ?? (() => new Date().toISOString());
+	const validation = validateDomain(domainInput);
+	if (!validation.valid) return smtpNotAssessed(null, 'invalid_domain', now);
+	const domain = sanitizeDomain(domainInput);
+	return callSmtpStarttlsProbe(options.probeBinding, options.probeAuthToken, domain, { signal: options.signal, now });
+}

--- a/test/audits/cli-boundary.audit.test.ts
+++ b/test/audits/cli-boundary.audit.test.ts
@@ -26,8 +26,8 @@ describe('CLI distribution boundary', () => {
 			commandSource.indexOf('async function runBatch'),
 			commandSource.indexOf('async function runPolicy'),
 		);
-		expect(batchBody).toContain("callTool('batch_scan'");
-		expect(batchBody).not.toContain("callTool('scan_domain'");
+		expect(batchBody).toMatch(/callTool\(\s*'batch_scan'/);
+		expect(batchBody).not.toMatch(/callTool\(\s*'scan_domain'/);
 		expect(sources.toLowerCase()).not.toContain('sarif');
 	});
 

--- a/test/audits/cli-boundary.audit.test.ts
+++ b/test/audits/cli-boundary.audit.test.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import packageJsonText from '../../package.json?raw';
+import commandSource from '../../src/cli/command.ts?raw';
+import evidenceSource from '../../src/cli/evidence.ts?raw';
+import clientSource from '../../src/cli/mcp-http-client.ts?raw';
+import schemasSource from '../../src/cli/schemas.ts?raw';
+import tsupSource from '../../tsup.config.ts?raw';
+import { describe, expect, it } from 'vitest';
+
+const sources = [commandSource, evidenceSource, clientSource, schemasSource].join('\n');
+
+describe('CLI distribution boundary', () => {
+	it('preserves the MCP bin and adds the CLI build entry', () => {
+		const pkg = JSON.parse(packageJsonText) as { bin?: Record<string, string> };
+		expect(pkg.bin).toEqual({ 'blackveil-dns-mcp': 'dist/stdio.js', blackveil: 'dist/cli.js' });
+		expect(tsupSource).toContain("entry: { cli: 'src/cli.ts' }");
+	});
+
+	it('does not import local tools or scoring into the hosted client', () => {
+		expect(sources).not.toMatch(/@blackveil\/dns-checks|from ['"][^'"]*tools|scoreToGrade|nistScoreToGrade|SEVERITY_PENALTIES/);
+	});
+
+	it('has no paid-batch fallback or SARIF surface', () => {
+		const batchBody = commandSource.slice(
+			commandSource.indexOf('async function runBatch'),
+			commandSource.indexOf('async function runPolicy'),
+		);
+		expect(batchBody).toContain("callTool('batch_scan'");
+		expect(batchBody).not.toContain("callTool('scan_domain'");
+		expect(sources.toLowerCase()).not.toContain('sarif');
+	});
+
+	it('accepts API credentials from the environment only', () => {
+		expect(commandSource).toContain('BLACKVEIL_API_KEY');
+		expect(commandSource).not.toContain("'--api-key'");
+	});
+});

--- a/test/audits/cli-pack-smoke.node.test.ts
+++ b/test/audits/cli-pack-smoke.node.test.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const root = fileURLToPath(new URL('../..', import.meta.url));
+
+describe('root package CLI pack smoke', () => {
+	it('packs both bins and executes blackveil help', () => {
+		execFileSync(`${root}/node_modules/.bin/tsup`, [], { cwd: root, stdio: 'pipe' });
+		const pack = JSON.parse(
+			execFileSync('npm', ['pack', '--dry-run', '--ignore-scripts', '--json'], { cwd: root, encoding: 'utf8' }),
+		) as Array<{
+			files: Array<{ path: string }>;
+		}>;
+		const files = pack[0]?.files.map((entry) => entry.path) ?? [];
+		expect(files).toContain('dist/cli.js');
+		expect(files).toContain('dist/stdio.js');
+		expect(existsSync(`${root}/dist/cli.js`)).toBe(true);
+		expect(readFileSync(`${root}/dist/cli.js`, 'utf8')).toContain('#!/usr/bin/env node');
+		const help = execFileSync(process.execPath, [`${root}/dist/cli.js`, '--help'], { cwd: root, encoding: 'utf8' });
+		expect(help).toContain('BlackVeil hosted DNS security CLI');
+	});
+});

--- a/test/cli-evidence.spec.ts
+++ b/test/cli-evidence.spec.ts
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { canonicalEvidenceJson, createEvidenceSnapshot, verifyEvidenceSnapshot } from '../src/cli/evidence';
+
+describe('CLI evidence envelope', () => {
+	it('canonicalizes object keys deterministically', () => {
+		expect(canonicalEvidenceJson({ z: 1, a: { y: 2, x: 3 } })).toBe(canonicalEvidenceJson({ a: { x: 3, y: 2 }, z: 1 }));
+	});
+
+	it('seals and verifies the complete versioned envelope', async () => {
+		const snapshot = await createEvidenceSnapshot({
+			capturedAt: '2026-09-05T00:00:00.000Z',
+			serverName: 'blackveil-dns-mcp',
+			serverVersion: '1.2.3',
+			endpointOrigin: 'https://dns-mcp.blackveilsecurity.com',
+			tool: 'scan_domain',
+			result: { domain: 'example.com', score: 92 },
+		});
+
+		expect(snapshot.schemaVersion).toBe('blackveil-evidence/v1');
+		expect(snapshot.integrity).toMatchObject({ algorithm: 'sha-256', canonicalization: 'blackveil-cjson/v1' });
+		expect(snapshot.integrity.digest).toMatch(/^[a-f0-9]{64}$/);
+		expect((await verifyEvidenceSnapshot(snapshot)).valid).toBe(true);
+	});
+
+	it('detects a result or provenance mutation', async () => {
+		const snapshot = await createEvidenceSnapshot({
+			capturedAt: '2026-09-05T00:00:00.000Z',
+			serverName: 'blackveil-dns-mcp',
+			serverVersion: '1.2.3',
+			endpointOrigin: 'https://dns-mcp.blackveilsecurity.com',
+			tool: 'scan_domain',
+			result: { domain: 'example.com', score: 92 },
+		});
+		const tampered = structuredClone(snapshot);
+		tampered.result.score = 12;
+		expect((await verifyEvidenceSnapshot(tampered)).valid).toBe(false);
+	});
+
+	it('rejects non-JSON numeric values', () => {
+		expect(() => canonicalEvidenceJson({ score: Number.NaN })).toThrow('non-finite');
+	});
+});

--- a/test/cli-http.integration.test.ts
+++ b/test/cli-http.integration.test.ts
@@ -3,17 +3,25 @@
 import { describe, expect, it } from 'vitest';
 import { McpClientError, McpHttpClient, parseMcpResponseBody } from '../src/cli/mcp-http-client';
 
-function rpc(result: unknown, headers: HeadersInit = {}): Response {
-	return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), { status: 200, headers });
+function rpc(result: unknown, headers: HeadersInit = {}, id = 1): Response {
+	return new Response(JSON.stringify({ jsonrpc: '2.0', id, result }), {
+		status: 200,
+		headers: { 'content-type': 'application/json', ...Object.fromEntries(new Headers(headers)) },
+	});
 }
+
+const initialized = (protocolVersion = '2025-06-18') => ({
+	protocolVersion,
+	serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' },
+});
 
 describe('hosted MCP HTTP client', () => {
 	it('initializes a session and keeps credentials in an authorization header', async () => {
 		const requests: Array<{ url: string; init?: RequestInit }> = [];
 		const responses = [
-			rpc({ serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' } }, { 'mcp-session-id': 'session-1' }),
+			rpc(initialized(), { 'mcp-session-id': 'session-1' }),
 			new Response('', { status: 202 }),
-			rpc({ content: [{ type: 'text', text: 'ok' }], structuredContent: { domain: 'example.com' } }),
+			rpc({ content: [{ type: 'text', text: 'ok' }], structuredContent: { domain: 'example.com' } }, {}, 2),
 		];
 		const client = new McpHttpClient({
 			endpoint: 'https://example.test/mcp',
@@ -51,13 +59,165 @@ describe('hosted MCP HTTP client', () => {
 		await expect(client.connect()).rejects.toMatchObject<McpClientError>({ kind: 'remote', status });
 	});
 
-	it('fails closed when initialize does not issue a session', async () => {
+	it('rejects a successful request that omits its JSON-RPC response', async () => {
 		const client = new McpHttpClient({
 			endpoint: 'https://example.test/mcp',
-			fetchFn: (async () => rpc({ serverInfo: { name: 'server', version: '1' } })) as typeof fetch,
+			fetchFn: (async () => new Response('', { status: 200 })) as typeof fetch,
 			signalFactory: () => new AbortController().signal,
 		});
 		await expect(client.connect()).rejects.toMatchObject({ kind: 'protocol' });
+	});
+
+	it('accepts a conforming server that does not issue a session', async () => {
+		const responses = [
+			rpc({ protocolVersion: '2025-06-18', serverInfo: { name: 'server', version: '1' } }),
+			new Response('', { status: 202 }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => responses.shift()!) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await expect(client.connect()).resolves.toMatchObject({ name: 'server' });
+	});
+
+	it('fails closed on a protocol version it does not support', async () => {
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => rpc(initialized('2099-01-01'))) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await expect(client.connect()).rejects.toThrow('unsupported protocol version');
+	});
+
+	it('uses the negotiated protocol version on sessionless servers', async () => {
+		const requests: RequestInit[] = [];
+		const responses = [rpc(initialized('2025-03-26')), new Response('', { status: 202 }), rpc({ tools: [] }, {}, 2)];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async (_url, init) => {
+				requests.push(init ?? {});
+				return responses.shift()!;
+			}) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await client.connect();
+		await client.listTools();
+		expect(new Headers(requests[1]?.headers).get('mcp-protocol-version')).toBe('2025-03-26');
+		expect(new Headers(requests[2]?.headers).get('mcp-session-id')).toBeNull();
+	});
+
+	it('incrementally ignores notifications and returns before the matched SSE stream closes', async () => {
+		let cancelled = false;
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(
+					new TextEncoder().encode(
+						'data: {"jsonrpc":"2.0","method":"notifications/progress","params":{}}\n\n' +
+							'data: {"jsonrpc":"2.0","id":2,"result":{"content":[{"type":"text",',
+					),
+				);
+				controller.enqueue(new TextEncoder().encode('"text":"ok"}],"structuredContent":{"domain":"example.com"}}}\n\n'));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const responses = [
+			rpc(initialized(), { 'mcp-session-id': 'session-1' }),
+			new Response('', { status: 202 }),
+			new Response(stream, { headers: { 'content-type': 'text/event-stream' } }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => responses.shift()!) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await client.connect();
+		await expect(client.callTool('scan_domain', {})).resolves.toMatchObject({ structuredContent: { domain: 'example.com' } });
+		expect(cancelled).toBe(true);
+	});
+
+	it.each([
+		['missing', 'data: {"jsonrpc":"2.0","result":{}}\n\n', /omitted.*id/],
+		['mismatched', 'data: {"jsonrpc":"2.0","id":9,"result":{}}\n\n', /did not match/],
+		['server request', 'data: {"jsonrpc":"2.0","id":8,"method":"sampling/createMessage"}\n\n', /unsupported server request/],
+		['duplicate', 'data: {"jsonrpc":"2.0","id":2,"result":{}}\n\ndata: {"jsonrpc":"2.0","id":2,"result":{}}\n\n', /duplicate.*id/],
+	])('rejects %s SSE response ids', (_label, payload, expected) => {
+		expect(() => parseMcpResponseBody(payload, 2)).toThrow(expected as RegExp);
+	});
+
+	it('uses one shrinking deadline across initialize, notification, and calls', async () => {
+		let now = 1_000;
+		const remaining: number[] = [];
+		const responses = [rpc(initialized()), new Response('', { status: 202 }), rpc({ tools: [] }, {}, 2)];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			deadlineAt: 46_000,
+			now: () => now,
+			signalFactory: (remainingMs) => {
+				remaining.push(remainingMs);
+				return new AbortController().signal;
+			},
+			fetchFn: (async () => {
+				const response = responses.shift()!;
+				now += 5_000;
+				return response;
+			}) as typeof fetch,
+		});
+		await client.connect();
+		await client.listTools();
+		expect(remaining).toEqual([45_000, 40_000, 35_000]);
+		now = 46_000;
+		await expect(client.listTools()).rejects.toThrow('command deadline exceeded');
+	});
+
+	it('reinitializes once and retries a read-only call after a session 404', async () => {
+		const requests: RequestInit[] = [];
+		const responses = [
+			rpc(initialized(), { 'mcp-session-id': 'old' }),
+			new Response('', { status: 202 }),
+			new Response('', { status: 404 }),
+			rpc(initialized(), { 'mcp-session-id': 'new' }, 3),
+			new Response('', { status: 202 }),
+			rpc({ content: [{ type: 'text', text: 'ok' }], structuredContent: { domain: 'example.com' } }, {}, 4),
+			new Response('', { status: 404 }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async (_url, init) => {
+				requests.push(init ?? {});
+				return responses.shift()!;
+			}) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await client.connect();
+		await client.callTool('scan_domain', {}, { readOnly: true });
+		expect(requests).toHaveLength(6);
+		expect(new Headers(requests[2]?.headers).get('mcp-session-id')).toBe('old');
+		expect(new Headers(requests[5]?.headers).get('mcp-session-id')).toBe('new');
+		await expect(client.callTool('scan_domain', {}, { readOnly: true })).rejects.toMatchObject({ status: 404 });
+		expect(requests).toHaveLength(7);
+	});
+
+	it('does not retry a non-read-only call after a session 404', async () => {
+		let requests = 0;
+		const responses = [
+			rpc(initialized(), { 'mcp-session-id': 'old' }),
+			new Response('', { status: 202 }),
+			new Response('', { status: 404 }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => {
+				requests += 1;
+				return responses.shift()!;
+			}) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await client.connect();
+		await expect(client.callTool('write_tool', {})).rejects.toMatchObject({ status: 404 });
+		expect(requests).toBe(3);
 	});
 
 	it('rejects endpoints that could expose credentials through URLs', () => {

--- a/test/cli-http.integration.test.ts
+++ b/test/cli-http.integration.test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { McpClientError, McpHttpClient, parseMcpResponseBody } from '../src/cli/mcp-http-client';
+
+function rpc(result: unknown, headers: HeadersInit = {}): Response {
+	return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), { status: 200, headers });
+}
+
+describe('hosted MCP HTTP client', () => {
+	it('initializes a session and keeps credentials in an authorization header', async () => {
+		const requests: Array<{ url: string; init?: RequestInit }> = [];
+		const responses = [
+			rpc({ serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' } }, { 'mcp-session-id': 'session-1' }),
+			new Response('', { status: 202 }),
+			rpc({ content: [{ type: 'text', text: 'ok' }], structuredContent: { domain: 'example.com' } }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			apiKey: 'test-secret',
+			fetchFn: (async (url, init) => {
+				requests.push({ url: String(url), init });
+				return responses.shift()!;
+			}) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+
+		await client.connect();
+		await client.callTool('scan_domain', { domain: 'example.com' });
+
+		expect(requests).toHaveLength(3);
+		expect(requests.every((request) => request.url === 'https://example.test/mcp')).toBe(true);
+		for (const request of requests) expect(new Headers(request.init?.headers).get('authorization')).toBe('Bearer test-secret');
+		expect(new Headers(requests[2]?.init?.headers).get('mcp-session-id')).toBe('session-1');
+		expect(JSON.parse(String(requests[2]?.init?.body))).toMatchObject({ method: 'tools/call', params: { name: 'scan_domain' } });
+	});
+
+	it('parses JSON and SSE response bodies', () => {
+		expect(parseMcpResponseBody('{"jsonrpc":"2.0","result":{}}')).toMatchObject({ jsonrpc: '2.0' });
+		expect(parseMcpResponseBody('event: message\ndata: {"jsonrpc":"2.0","result":{"ok":true}}\n\n')).toMatchObject({
+			result: { ok: true },
+		});
+	});
+
+	it.each([401, 403, 429, 500])('maps HTTP %s to a remote error', async (status) => {
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => new Response('', { status })) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await expect(client.connect()).rejects.toMatchObject<McpClientError>({ kind: 'remote', status });
+	});
+
+	it('fails closed when initialize does not issue a session', async () => {
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => rpc({ serverInfo: { name: 'server', version: '1' } })) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+		await expect(client.connect()).rejects.toMatchObject({ kind: 'protocol' });
+	});
+
+	it('rejects endpoints that could expose credentials through URLs', () => {
+		expect(() => new McpHttpClient({ endpoint: 'https://example.test/mcp?key=secret' })).toThrow('query strings');
+		expect(() => new McpHttpClient({ endpoint: 'http://example.test/mcp' })).toThrow('HTTPS');
+	});
+});

--- a/test/cli-http.integration.test.ts
+++ b/test/cli-http.integration.test.ts
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { describe, expect, it } from 'vitest';
-import {
-	MCP_RESPONSE_BODY_MAX_BYTES,
-	MCP_SSE_EVENT_MAX_BYTES,
-	McpHttpClient,
-	parseMcpResponseBody,
-} from '../src/cli/mcp-http-client';
+import { MCP_RESPONSE_BODY_MAX_BYTES, MCP_SSE_EVENT_MAX_BYTES, McpHttpClient, parseMcpResponseBody } from '../src/cli/mcp-http-client';
 
 function rpc(result: unknown, headers: HeadersInit = {}, id = 1): Response {
 	return new Response(JSON.stringify({ jsonrpc: '2.0', id, result }), {
@@ -263,6 +258,38 @@ describe('hosted MCP HTTP client', () => {
 
 		await client.connect();
 		await expect(client.callTool('scan_domain', {})).rejects.toThrow('event limit');
+		expect(cancelled).toBe(true);
+		expect(stream.locked).toBe(false);
+	});
+
+	it('rejects and disposes an SSE response whose individually bounded events exceed the aggregate limit', async () => {
+		let cancelled = false;
+		const event = new TextEncoder().encode(
+			`data: {"jsonrpc":"2.0","method":"notifications/progress","params":{"padding":"${'x'.repeat(400 * 1024)}"}}\n\n`,
+		);
+		expect(event.byteLength).toBeLessThan(MCP_SSE_EVENT_MAX_BYTES);
+		expect(event.byteLength * 6).toBeGreaterThan(MCP_RESPONSE_BODY_MAX_BYTES);
+		const stream = new ReadableStream({
+			start(controller) {
+				for (let index = 0; index < 6; index += 1) controller.enqueue(event);
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const responses = [
+			rpc(initialized()),
+			new Response('', { status: 202 }),
+			new Response(stream, { headers: { 'content-type': 'text/event-stream' } }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => responses.shift()!) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+
+		await client.connect();
+		await expect(client.callTool('scan_domain', {})).rejects.toThrow('response body limit');
 		expect(cancelled).toBe(true);
 		expect(stream.locked).toBe(false);
 	});

--- a/test/cli-http.integration.test.ts
+++ b/test/cli-http.integration.test.ts
@@ -1,7 +1,12 @@
 // SPDX-License-Identifier: BUSL-1.1
 
 import { describe, expect, it } from 'vitest';
-import { McpClientError, McpHttpClient, parseMcpResponseBody } from '../src/cli/mcp-http-client';
+import {
+	MCP_RESPONSE_BODY_MAX_BYTES,
+	MCP_SSE_EVENT_MAX_BYTES,
+	McpHttpClient,
+	parseMcpResponseBody,
+} from '../src/cli/mcp-http-client';
 
 function rpc(result: unknown, headers: HeadersInit = {}, id = 1): Response {
 	return new Response(JSON.stringify({ jsonrpc: '2.0', id, result }), {
@@ -56,7 +61,7 @@ describe('hosted MCP HTTP client', () => {
 			fetchFn: (async () => new Response('', { status })) as typeof fetch,
 			signalFactory: () => new AbortController().signal,
 		});
-		await expect(client.connect()).rejects.toMatchObject<McpClientError>({ kind: 'remote', status });
+		await expect(client.connect()).rejects.toMatchObject({ kind: 'remote', status });
 	});
 
 	it('rejects a successful request that omits its JSON-RPC response', async () => {
@@ -107,7 +112,7 @@ describe('hosted MCP HTTP client', () => {
 		expect(new Headers(requests[2]?.headers).get('mcp-session-id')).toBeNull();
 	});
 
-	it('incrementally ignores notifications and returns before the matched SSE stream closes', async () => {
+	it('returns a matched SSE response when stream cancellation rejects and releases the reader lock', async () => {
 		let cancelled = false;
 		const stream = new ReadableStream({
 			start(controller) {
@@ -119,8 +124,9 @@ describe('hosted MCP HTTP client', () => {
 				);
 				controller.enqueue(new TextEncoder().encode('"text":"ok"}],"structuredContent":{"domain":"example.com"}}}\n\n'));
 			},
-			cancel() {
+			async cancel() {
 				cancelled = true;
+				throw new Error('cancel rejected');
 			},
 		});
 		const responses = [
@@ -136,6 +142,129 @@ describe('hosted MCP HTTP client', () => {
 		await client.connect();
 		await expect(client.callTool('scan_domain', {})).resolves.toMatchObject({ structuredContent: { domain: 'example.com' } });
 		expect(cancelled).toBe(true);
+		expect(stream.locked).toBe(false);
+	});
+
+	it('cancels an unexpected initialized-notification response body', async () => {
+		let cancelled = false;
+		const notificationStream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode('unexpected'));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const responses = [rpc(initialized()), new Response(notificationStream, { status: 202 })];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => responses.shift()!) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+
+		await expect(client.connect()).resolves.toMatchObject({ name: 'blackveil-dns-mcp' });
+		expect(cancelled).toBe(true);
+		expect(notificationStream.locked).toBe(false);
+	});
+
+	it.each([
+		['invalid JSON', 'data: {invalid}\n\n', /invalid SSE JSON/],
+		['mismatched id', 'data: {"jsonrpc":"2.0","id":9,"result":{}}\n\n', /did not match/],
+	])('cancels and unlocks the SSE reader after %s', async (_label, payload, expected) => {
+		let cancelled = false;
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(payload));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const responses = [
+			rpc(initialized()),
+			new Response('', { status: 202 }),
+			new Response(stream, { headers: { 'content-type': 'text/event-stream' } }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => responses.shift()!) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+
+		await client.connect();
+		await expect(client.callTool('scan_domain', {})).rejects.toThrow(expected as RegExp);
+		expect(cancelled).toBe(true);
+		expect(stream.locked).toBe(false);
+	});
+
+	it('releases the SSE reader lock when reading fails', async () => {
+		const stream = new ReadableStream({
+			pull(controller) {
+				controller.error(new Error('stream read failed'));
+			},
+		});
+		const responses = [
+			rpc(initialized()),
+			new Response('', { status: 202 }),
+			new Response(stream, { headers: { 'content-type': 'text/event-stream' } }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => responses.shift()!) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+
+		await client.connect();
+		await expect(client.callTool('scan_domain', {})).rejects.toThrow('stream read failed');
+		expect(stream.locked).toBe(false);
+	});
+
+	it('rejects and disposes an oversized JSON response', async () => {
+		let cancelled = false;
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new Uint8Array(MCP_RESPONSE_BODY_MAX_BYTES + 1));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => new Response(stream, { headers: { 'content-type': 'application/json' } })) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+
+		await expect(client.connect()).rejects.toThrow('response body limit');
+		expect(cancelled).toBe(true);
+		expect(stream.locked).toBe(false);
+	});
+
+	it('rejects and disposes an oversized SSE event', async () => {
+		let cancelled = false;
+		const stream = new ReadableStream({
+			start(controller) {
+				controller.enqueue(new TextEncoder().encode(`data: ${'x'.repeat(MCP_SSE_EVENT_MAX_BYTES)}`));
+			},
+			cancel() {
+				cancelled = true;
+			},
+		});
+		const responses = [
+			rpc(initialized()),
+			new Response('', { status: 202 }),
+			new Response(stream, { headers: { 'content-type': 'text/event-stream' } }),
+		];
+		const client = new McpHttpClient({
+			endpoint: 'https://example.test/mcp',
+			fetchFn: (async () => responses.shift()!) as typeof fetch,
+			signalFactory: () => new AbortController().signal,
+		});
+
+		await client.connect();
+		await expect(client.callTool('scan_domain', {})).rejects.toThrow('event limit');
+		expect(cancelled).toBe(true);
+		expect(stream.locked).toBe(false);
 	});
 
 	it.each([

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -27,9 +27,11 @@ function scan(domain: string, overrides: Record<string, unknown> = {}): Record<s
 	};
 }
 
-function rpc(result: unknown, headers: HeadersInit = {}): Response {
-	return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), { status: 200, headers });
+function rpc(result: unknown, headers: HeadersInit = {}, id = 1): Response {
+	return new Response(JSON.stringify({ jsonrpc: '2.0', id, result }), { status: 200, headers });
 }
+
+const initialized = { protocolVersion: '2025-06-18', serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' } };
 
 function harness(files: Record<string, string> = {}, toolResults: unknown[] = []) {
 	const stdout: string[] = [];
@@ -37,9 +39,9 @@ function harness(files: Record<string, string> = {}, toolResults: unknown[] = []
 	const writes = new Map<string, string>();
 	const calls: Array<Record<string, unknown>> = [];
 	const responses = [
-		rpc({ serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' } }, { 'mcp-session-id': 'session-1' }),
+		rpc(initialized, { 'mcp-session-id': 'session-1' }),
 		new Response('', { status: 202 }),
-		...toolResults.map((result) => rpc(result)),
+		...toolResults.map((result, index) => rpc(result, {}, index + 2)),
 	];
 	const io: CliIo = {
 		readTextFile: async (path) => {
@@ -79,12 +81,34 @@ describe('blackveil CLI', () => {
 		expect(h.calls).toHaveLength(0);
 	});
 
+	it('starts the shared deadline before command input is read', async () => {
+		let now = 1_000;
+		const h = harness({ domains: 'example.com\n' });
+		const originalRead = h.io.readTextFile;
+		h.io.readTextFile = async (path) => {
+			const value = await originalRead(path);
+			now = 46_001;
+			return value;
+		};
+		expect(await runCli(['batch', '--file', 'domains'], { ...h, nowMs: () => now })).toBe(3);
+		expect(h.calls).toHaveLength(0);
+		expect(h.stderr.join('')).toContain('command deadline exceeded');
+	});
+
 	it('returns incomplete for an ungraded scan without treating null as zero', async () => {
 		const h = harness({}, [
 			toolResult(scan('example.com', { score: null, grade: null, passed: null, measured: false, evidenceInsufficient: true })),
 		]);
 		expect(await runCli(['scan', 'example.com', '--format', 'json'], h)).toBe(4);
 		expect(JSON.parse(h.stdout.join(''))).toMatchObject({ score: null, grade: null });
+	});
+
+	it.each([
+		{ checkStatuses: { dnssec: 'timeout' }, inconclusiveCategories: [] },
+		{ checkStatuses: { dnssec: 'completed' }, inconclusiveCategories: ['dnssec'] },
+	])('returns incomplete for non-completed scan evidence', async (overrides) => {
+		const h = harness({}, [toolResult(scan('example.com', overrides))]);
+		expect(await runCli(['scan', 'example.com'], h)).toBe(4);
 	});
 
 	it('returns policy failure only from the remote policy tool', async () => {
@@ -97,7 +121,7 @@ describe('blackveil CLI', () => {
 	it('uses the paid batch tool without per-domain fallback on denial', async () => {
 		const h = harness({ domains: 'one.example\ntwo.example\n' });
 		const responses = [
-			rpc({ serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' } }, { 'mcp-session-id': 'session-1' }),
+			rpc(initialized, { 'mcp-session-id': 'session-1' }),
 			new Response('', { status: 202 }),
 			new Response(JSON.stringify({ jsonrpc: '2.0', id: 2, error: { code: -32003, message: 'paid access required' } }), { status: 403 }),
 		];
@@ -121,6 +145,20 @@ describe('blackveil CLI', () => {
 		const result = { category: 'dnssec', passed: true, score: 100, findings: [], checkStatus: 'completed' };
 		const h = harness({}, [tools, toolResult(result)]);
 		expect(await runCli(['check', 'dnssec', 'example.com'], h)).toBe(0);
+	});
+
+	it('returns incomplete for a non-completed check even when partial is absent', async () => {
+		const tools = { tools: [{ name: 'check_dnssec', outputSchema: { type: 'object' }, annotations: { readOnlyHint: true } }] };
+		const result = { category: 'dnssec', passed: false, score: 0, findings: [], checkStatus: 'error' };
+		const h = harness({}, [tools, toolResult(result)]);
+		expect(await runCli(['check', 'dnssec', 'example.com'], h)).toBe(4);
+	});
+
+	it('sanitizes and emits every remote tool error diagnostic', async () => {
+		const h = harness({}, [{ content: [{ type: 'text', text: '\u001b[31mdenied\r\nretry\u0000' }], isError: true }]);
+		expect(await runCli(['scan', 'example.com'], h)).toBe(3);
+		expect(h.stderr.join('')).toBe('scan_domain: denied\nretry\n');
+		expect(h.stdout).toHaveLength(0);
 	});
 
 	it('returns integrity failure before drift makes a remote request', async () => {

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, it } from 'vitest';
 import { combineBatchExitCodes, runCli, type CliIo } from '../src/cli/command';
+import { createEvidenceSnapshot } from '../src/cli/evidence';
 
 const timestamp = '2026-09-05T00:00:00.000Z';
 
@@ -66,6 +67,19 @@ function harness(files: Record<string, string> = {}, toolResults: unknown[] = []
 
 function toolResult(structuredContent: Record<string, unknown>, text = 'ok') {
 	return { content: [{ type: 'text', text }], structuredContent };
+}
+
+async function baselineEvidence(overrides: Record<string, unknown> = {}): Promise<string> {
+	return JSON.stringify(
+		await createEvidenceSnapshot({
+			capturedAt: timestamp,
+			serverName: 'synthetic-server',
+			serverVersion: '1',
+			endpointOrigin: 'https://example.test',
+			tool: 'scan_domain',
+			result: scan('example.com', overrides),
+		}),
+	);
 }
 
 describe('blackveil CLI', () => {
@@ -159,6 +173,49 @@ describe('blackveil CLI', () => {
 		expect(await runCli(['scan', 'example.com'], h)).toBe(3);
 		expect(h.stderr.join('')).toBe('scan_domain: denied\nretry\n');
 		expect(h.stdout).toHaveLength(0);
+	});
+
+	it.each([
+		{ checkStatuses: { dnssec: 'timeout' }, categoryScores: { dnssec: null } },
+		{ checkStatuses: { dnssec: 'error' }, categoryScores: { dnssec: null } },
+		{ inconclusiveCategories: ['dnssec'] },
+		{ evidenceInsufficient: true },
+		{ measured: false },
+		{ error: 'batch_budget_exceeded' },
+		{ score: null, grade: null, passed: null, measured: false },
+	])('rejects an incomplete drift baseline before contacting the server: %j', async (overrides) => {
+		const drift = { domain: 'example.com', classification: 'stable', scoreDelta: 0, gradeChange: { from: 'A', to: 'A' }, timestamp };
+		const h = harness({ baseline: await baselineEvidence(overrides) }, [toolResult(drift)]);
+		expect(await runCli(['drift', 'compare', 'example.com', '--baseline', 'baseline'], h)).toBe(4);
+		expect(h.calls).toHaveLength(0);
+		expect(h.stdout).toHaveLength(0);
+		expect(h.stderr.join('')).toContain('Drift baseline contains incomplete scan evidence');
+	});
+
+	it.each([
+		{ score: 92, grade: 'A', passed: true },
+		{ score: 30, grade: 'F', passed: false },
+	])('compares a complete baseline even when its security verdict fails: %j', async (overrides) => {
+		const drift = {
+			domain: 'example.com',
+			classification: 'stable',
+			scoreDelta: 0,
+			gradeChange: { from: overrides.grade, to: overrides.grade },
+			timestamp,
+		};
+		const h = harness({ baseline: await baselineEvidence(overrides) }, [toolResult(drift)]);
+		expect(await runCli(['drift', 'compare', 'example.com', '--baseline', 'baseline', '--format', 'json'], h)).toBe(0);
+		expect(h.calls.at(-1)).toMatchObject({
+			method: 'tools/call',
+			params: {
+				name: 'analyze_drift',
+				arguments: {
+					domain: 'example.com',
+					baseline: JSON.stringify({ overall: overrides.score, grade: overrides.grade, categoryScores: { dnssec: 100 }, findings: [] }),
+				},
+			},
+		});
+		expect(JSON.parse(h.stdout.join(''))).toMatchObject(drift);
 	});
 
 	it('returns integrity failure before drift makes a remote request', async () => {

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { combineBatchExitCodes, runCli, type CliIo } from '../src/cli/command';
+
+const timestamp = '2026-09-05T00:00:00.000Z';
+
+function scan(domain: string, overrides: Record<string, unknown> = {}): Record<string, unknown> {
+	return {
+		domain,
+		score: 92,
+		grade: 'A',
+		passed: true,
+		measured: true,
+		categoryScores: { dnssec: 100 },
+		findings: [],
+		checkStatuses: { dnssec: 'completed' },
+		notApplicableCategories: [],
+		inconclusiveCategories: [],
+		evidence: { attempted: 1, completed: 1, ratio: 1 },
+		evidenceInsufficient: false,
+		timestamp,
+		scoringModelVersion: '1',
+		dnsChecksPackageVersion: '1',
+		scoringConfigHash: 'abc',
+		...overrides,
+	};
+}
+
+function rpc(result: unknown, headers: HeadersInit = {}): Response {
+	return new Response(JSON.stringify({ jsonrpc: '2.0', id: 1, result }), { status: 200, headers });
+}
+
+function harness(files: Record<string, string> = {}, toolResults: unknown[] = []) {
+	const stdout: string[] = [];
+	const stderr: string[] = [];
+	const writes = new Map<string, string>();
+	const calls: Array<Record<string, unknown>> = [];
+	const responses = [
+		rpc({ serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' } }, { 'mcp-session-id': 'session-1' }),
+		new Response('', { status: 202 }),
+		...toolResults.map((result) => rpc(result)),
+	];
+	const io: CliIo = {
+		readTextFile: async (path) => {
+			if (!(path in files)) throw new Error('ENOENT');
+			return files[path]!;
+		},
+		writeTextFile: async (path, content, overwrite) => {
+			if (!overwrite && writes.has(path)) throw new Error('EEXIST');
+			writes.set(path, content);
+		},
+		stdout: (text) => stdout.push(text),
+		stderr: (text) => stderr.push(text),
+	};
+	const fetchFn = (async (_url, init) => {
+		if (init?.body) calls.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+		const response = responses.shift();
+		if (!response) throw new Error('Unexpected request');
+		return response;
+	}) as typeof fetch;
+	return { io, stdout, stderr, writes, calls, fetchFn };
+}
+
+function toolResult(structuredContent: Record<string, unknown>, text = 'ok') {
+	return { content: [{ type: 'text', text }], structuredContent };
+}
+
+describe('blackveil CLI', () => {
+	it('publishes the documented batch precedence', () => {
+		expect(combineBatchExitCodes([0, 1])).toBe(1);
+		expect(combineBatchExitCodes([1, 4])).toBe(4);
+		expect(combineBatchExitCodes([1, 4, 3])).toBe(3);
+	});
+
+	it('rejects command-line credentials before any request', async () => {
+		const h = harness();
+		expect(await runCli(['scan', 'example.com', '--api-key', 'secret'], h)).toBe(2);
+		expect(h.calls).toHaveLength(0);
+	});
+
+	it('returns incomplete for an ungraded scan without treating null as zero', async () => {
+		const h = harness({}, [
+			toolResult(scan('example.com', { score: null, grade: null, passed: null, measured: false, evidenceInsufficient: true })),
+		]);
+		expect(await runCli(['scan', 'example.com', '--format', 'json'], h)).toBe(4);
+		expect(JSON.parse(h.stdout.join(''))).toMatchObject({ score: null, grade: null });
+	});
+
+	it('returns policy failure only from the remote policy tool', async () => {
+		const policy = { domain: 'example.com', passed: false, violations: [{}], inconclusiveRules: [], checkedRules: 1, timestamp };
+		const h = harness({}, [toolResult(policy)]);
+		expect(await runCli(['policy', 'example.com', '--fail-below', '95', '--format', 'json'], h)).toBe(1);
+		expect(h.calls.at(-1)).toMatchObject({ method: 'tools/call', params: { name: 'compare_baseline' } });
+	});
+
+	it('uses the paid batch tool without per-domain fallback on denial', async () => {
+		const h = harness({ domains: 'one.example\ntwo.example\n' });
+		const responses = [
+			rpc({ serverInfo: { name: 'blackveil-dns-mcp', version: '1.2.3' } }, { 'mcp-session-id': 'session-1' }),
+			new Response('', { status: 202 }),
+			new Response(JSON.stringify({ jsonrpc: '2.0', id: 2, error: { code: -32003, message: 'paid access required' } }), { status: 403 }),
+		];
+		h.fetchFn = (async (_url, init) => {
+			if (init?.body) h.calls.push(JSON.parse(String(init.body)) as Record<string, unknown>);
+			return responses.shift()!;
+		}) as typeof fetch;
+		expect(await runCli(['batch', '--file', 'domains'], h)).toBe(3);
+		expect(h.calls.filter((call) => JSON.stringify(call).includes('scan_domain'))).toHaveLength(0);
+	});
+
+	it('returns incomplete ahead of a measured batch policy failure', async () => {
+		const batch = { results: [scan('one.example'), scan('two.example', { score: null, grade: null, passed: null, measured: false })] };
+		const policy = { domain: 'one.example', passed: false, violations: [{}], inconclusiveRules: [], checkedRules: 1, timestamp };
+		const h = harness({ domains: 'one.example\ntwo.example\n' }, [toolResult(batch), toolResult(policy)]);
+		expect(await runCli(['batch', '--file', 'domains', '--fail-below', '95'], h)).toBe(4);
+	});
+
+	it('allows checks only when the remote tool declares a public read-only result', async () => {
+		const tools = { tools: [{ name: 'check_dnssec', outputSchema: { type: 'object' }, annotations: { readOnlyHint: true } }] };
+		const result = { category: 'dnssec', passed: true, score: 100, findings: [], checkStatus: 'completed' };
+		const h = harness({}, [tools, toolResult(result)]);
+		expect(await runCli(['check', 'dnssec', 'example.com'], h)).toBe(0);
+	});
+
+	it('returns integrity failure before drift makes a remote request', async () => {
+		const h = harness({
+			baseline: JSON.stringify({
+				schemaVersion: 'blackveil-evidence/v1',
+				capturedAt: timestamp,
+				source: {
+					serverName: 'blackveil-dns-mcp',
+					serverVersion: '1.2.3',
+					endpointOrigin: 'https://dns-mcp.blackveilsecurity.com',
+					tool: 'scan_domain',
+				},
+				result: scan('example.com'),
+				integrity: { algorithm: 'sha-256', canonicalization: 'blackveil-cjson/v1', digest: '0'.repeat(64) },
+			}),
+		});
+		expect(await runCli(['drift', 'compare', 'example.com', '--baseline', 'baseline'], h)).toBe(1);
+		expect(h.calls).toHaveLength(0);
+	});
+});

--- a/test/csp-coverage.spec.ts
+++ b/test/csp-coverage.spec.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+import type { FetchFunction } from '@blackveil/dns-checks';
+
+const OBSERVED_AT = '2026-09-05T00:00:00.000Z';
+
+function siteFetch(pages: Record<string, { body?: string; status?: number; headers?: Record<string, string> }>): FetchFunction {
+	return vi.fn(async (url: string, _init?: RequestInit) => {
+		if (url === 'https://example.com/robots.txt') return new Response(null, { status: 404 });
+		const page = pages[url];
+		if (!page) return new Response(null, { status: 404 });
+		return new Response(page.body ?? '', {
+			status: page.status ?? 200,
+			headers: { 'content-type': 'text/html; charset=utf-8', ...(page.headers ?? {}) },
+		});
+	}) as FetchFunction;
+}
+
+describe('sampled CSP coverage audit', () => {
+	it('performs a deterministic same-origin breadth-first crawl and compares headers', async () => {
+		const fetchFn = siteFetch({
+			'https://example.com/': {
+				body: '<a href="/z">z</a><a href="/a">a</a><a href="https://other.example/path">off</a><a href="/skip?q=1">query</a>',
+				headers: { 'content-security-policy': "default-src   'self'; script-src 'self'" },
+			},
+			'https://example.com/a': {
+				body: '<a href="/nested">nested</a>',
+				headers: { 'content-security-policy': "default-src 'self'; script-src 'self'" },
+			},
+			'https://example.com/z': { headers: { 'content-security-policy': "default-src 'self'; script-src 'unsafe-inline'" } },
+			'https://example.com/nested': { headers: { 'content-security-policy': "default-src 'self'; script-src 'self'" } },
+		});
+		const { auditCspCoverage } = await import('../src/tools/audit-csp-coverage');
+		const result = await auditCspCoverage('EXAMPLE.COM.', { fetchFn, now: () => OBSERVED_AT });
+		const pageCalls = vi.mocked(fetchFn).mock.calls.filter(([url]) => !url.endsWith('/robots.txt'));
+
+		expect(pageCalls.map(([url]) => url)).toEqual([
+			'https://example.com/',
+			'https://example.com/a',
+			'https://example.com/z',
+			'https://example.com/nested',
+		]);
+		expect(pageCalls.every(([, init]) => init?.redirect === 'manual' && init.credentials === 'omit')).toBe(true);
+		expect(result.status).toBe('measured');
+		expect(result.scope).toBe('sampled_same_origin');
+		expect(result.nonScoring).toBe(true);
+		expect(result.summary).toMatchObject({ measuredPages: 4, distinctHeaderProfiles: 2, headersConsistent: false });
+		expect(result.summary?.unsafeTokens).toEqual(["'unsafe-inline'"]);
+	});
+
+	it('returns not-assessed when robots.txt disallows the seed', async () => {
+		const fetchFn = vi.fn(async (url: string) => {
+			if (url.endsWith('/robots.txt')) return new Response('User-agent: *\nDisallow: /', { status: 200 });
+			throw new Error('page fetch must not run');
+		}) as FetchFunction;
+		const { auditCspCoverage } = await import('../src/tools/audit-csp-coverage');
+		const result = await auditCspCoverage('example.com', { fetchFn, now: () => OBSERVED_AT });
+
+		expect(result.status).toBe('not-assessed');
+		expect(result.pages[0]).toMatchObject({ status: 'not-assessed', notAssessedReason: 'robots_disallowed' });
+		expect(fetchFn).toHaveBeenCalledTimes(1);
+	});
+
+	it('marks a robots fail-open result partial instead of fully measured', async () => {
+		const fetchFn = vi.fn(async (url: string) => {
+			if (url.endsWith('/robots.txt')) return new Response(null, { status: 503 });
+			return new Response('', { status: 200, headers: { 'content-type': 'text/html', 'content-security-policy': "default-src 'self'" } });
+		}) as FetchFunction;
+		const { auditCspCoverage } = await import('../src/tools/audit-csp-coverage');
+		const result = await auditCspCoverage('example.com', { fetchFn, now: () => OBSERVED_AT });
+
+		expect(result.status).toBe('partial');
+		expect(result.partialReasons).toContain('robots_fail_open');
+		expect(result.robotsResolution).toMatchObject({ resolution: 'unreachable', failOpen: true, status: 503 });
+	});
+
+	it('refuses cross-origin redirects without fetching the destination', async () => {
+		const fetchFn = vi.fn(async (url: string) => {
+			if (url.endsWith('/robots.txt')) return new Response(null, { status: 404 });
+			return new Response(null, { status: 302, headers: { location: 'https://attacker.example/' } });
+		}) as FetchFunction;
+		const { auditCspCoverage } = await import('../src/tools/audit-csp-coverage');
+		const result = await auditCspCoverage('example.com', { fetchFn, now: () => OBSERVED_AT });
+
+		expect(result.status).toBe('not-assessed');
+		expect(result.pages[0]?.notAssessedReason).toBe('redirect_invalid');
+		expect(fetchFn).toHaveBeenCalledTimes(2);
+	});
+
+	it('caps the sample at ten pages and labels the truncated result partial', async () => {
+		const links = Array.from({ length: 12 }, (_, index) => `<a href="/p${String(index).padStart(2, '0')}">p</a>`).join('');
+		const pages: Record<string, { body?: string; headers?: Record<string, string> }> = {
+			'https://example.com/': { body: links, headers: { 'content-security-policy': "default-src 'self'" } },
+		};
+		for (let index = 0; index < 12; index++) {
+			pages[`https://example.com/p${String(index).padStart(2, '0')}`] = { headers: { 'content-security-policy': "default-src 'self'" } };
+		}
+		const { auditCspCoverage, CSP_CRAWL_LIMITS } = await import('../src/tools/audit-csp-coverage');
+		const result = await auditCspCoverage('example.com', { fetchFn: siteFetch(pages), now: () => OBSERVED_AT });
+
+		expect(result.pages).toHaveLength(CSP_CRAWL_LIMITS.maxPages);
+		expect(result.status).toBe('partial');
+		expect(result.partialReasons).toContain('max_pages_reached');
+	});
+
+	it('keeps measured headers but marks oversized HTML discovery not-assessed', async () => {
+		const { auditCspCoverage, CSP_CRAWL_LIMITS } = await import('../src/tools/audit-csp-coverage');
+		const fetchFn = siteFetch({
+			'https://example.com/': {
+				body: 'x',
+				headers: {
+					'content-security-policy': "default-src 'self'",
+					'content-length': String(CSP_CRAWL_LIMITS.maxPageBytes + 1),
+				},
+			},
+		});
+		const result = await auditCspCoverage('example.com', { fetchFn, now: () => OBSERVED_AT });
+
+		expect(result.pages[0]).toMatchObject({
+			status: 'measured',
+			enforcingPolicy: "default-src 'self'",
+			discovery: { status: 'not-assessed', notAssessedReason: 'body_too_large' },
+		});
+		expect(result.status).toBe('partial');
+	});
+
+	it('charges chunked overflow bytes against the aggregate body budget', async () => {
+		const { auditCspCoverage, CSP_CRAWL_LIMITS } = await import('../src/tools/audit-csp-coverage');
+		const links = Array.from({ length: 9 }, (_, index) => `<a href="/large-${index}">large</a>`).join('');
+		const fetchFn = vi.fn(async (url: string) => {
+			if (url.endsWith('/robots.txt')) return new Response(null, { status: 404 });
+			if (url === 'https://example.com/') {
+				return new Response(links, { status: 200, headers: { 'content-type': 'text/html' } });
+			}
+			const chunk = new Uint8Array(64 * 1024);
+			let emitted = 0;
+			return new Response(
+				new ReadableStream<Uint8Array>({
+					pull(controller) {
+						if (emitted++ < 5) controller.enqueue(chunk);
+						else controller.close();
+					},
+				}),
+				{ status: 200, headers: { 'content-type': 'text/html' } },
+			);
+		}) as FetchFunction;
+		const result = await auditCspCoverage('example.com', { fetchFn, now: () => OBSERVED_AT });
+		const pageCalls = vi.mocked(fetchFn).mock.calls.filter(([url]) => !url.endsWith('/robots.txt'));
+
+		expect(pageCalls.length).toBeLessThan(CSP_CRAWL_LIMITS.maxPages);
+		expect(result.partialReasons).toEqual(expect.arrayContaining(['body_too_large', 'body_budget_exhausted']));
+		expect(result.status).toBe('partial');
+	});
+
+	it('rejects invalid domains before any fetch', async () => {
+		const { auditCspCoverage } = await import('../src/tools/audit-csp-coverage');
+		await expect(auditCspCoverage('127.0.0.1')).rejects.toThrow(/^Invalid domain:/u);
+	});
+});

--- a/test/probe-prototype-boundaries.spec.ts
+++ b/test/probe-prototype-boundaries.spec.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+import { CATEGORY_TIERS } from '@blackveil/dns-checks';
+import { TOOLS } from '../src/schemas/tool-definitions';
+
+describe('probe prototype boundaries', () => {
+	it('does not register, scan, or score either beta prototype', () => {
+		const names = new Set(TOOLS.map((tool) => tool.name));
+		for (const prototype of ['audit_csp_coverage', 'inspect_smtp_starttls']) {
+			expect(names.has(prototype)).toBe(false);
+			expect(prototype in CATEGORY_TIERS).toBe(false);
+		}
+		expect(TOOLS.some((tool) => tool.scanIncluded && ['audit_csp_coverage', 'inspect_smtp_starttls'].includes(tool.name))).toBe(false);
+	});
+});

--- a/test/response-body.spec.ts
+++ b/test/response-body.spec.ts
@@ -126,6 +126,48 @@ describe('readBoundedOrNull', () => {
 	});
 });
 
+describe('readTextResponseCappedDetailed', () => {
+	it('reports the bytes consumed when a chunked response overflows', async () => {
+		const { readTextResponseCappedDetailed } = await import('../src/lib/response-body');
+		const cancelled = vi.fn();
+		const response = new Response(
+			streamFrom([new TextEncoder().encode('1234'), new TextEncoder().encode('5678'), new TextEncoder().encode('unread')], cancelled),
+		);
+
+		await expect(readTextResponseCappedDetailed(response, 6)).resolves.toEqual({
+			text: null,
+			bytesRead: 8,
+			overflowed: true,
+			errored: false,
+		});
+		expect(cancelled).toHaveBeenCalledOnce();
+	});
+
+	it('returns an error stamp instead of throwing for a locked response body', async () => {
+		const { readTextResponseCappedDetailed } = await import('../src/lib/response-body');
+		const response = new Response('locked');
+		const lock = response.body!.getReader();
+		await expect(readTextResponseCappedDetailed(response, 32)).resolves.toEqual({
+			text: null,
+			bytesRead: 0,
+			overflowed: false,
+			errored: true,
+		});
+		lock.releaseLock();
+	});
+
+	it('returns an error stamp instead of throwing when a response stream rejects', async () => {
+		const { readTextResponseCappedDetailed } = await import('../src/lib/response-body');
+		const response = new Response(rejectingStream());
+		await expect(readTextResponseCappedDetailed(response, 32)).resolves.toEqual({
+			text: null,
+			bytesRead: 0,
+			overflowed: false,
+			errored: true,
+		});
+	});
+});
+
 describe('readJsonResponseCapped', () => {
 	it('parses JSON below the cap', async () => {
 		const { readJsonResponseCapped } = await import('../src/lib/response-body');

--- a/test/smtp-probe-binding.spec.ts
+++ b/test/smtp-probe-binding.spec.ts
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it, vi } from 'vitest';
+
+const STRONG_KEY = 'smtp-starttls-probe-key-32-bytes-minimum';
+const OBSERVED_AT = '2026-09-05T00:00:00.000Z';
+
+function bindingReturning(body: unknown, status = 200) {
+	return {
+		fetch: vi.fn(
+			async (_input: RequestInfo | URL, _init?: RequestInit) =>
+				new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } }),
+		),
+	};
+}
+
+describe('fail-soft SMTP probe binding seam', () => {
+	it('does not call an absent binding or send a weak capability', async () => {
+		const { callSmtpStarttlsProbe } = await import('../src/lib/smtp-probe-binding');
+		const binding = bindingReturning({});
+		expect(await callSmtpStarttlsProbe(undefined, STRONG_KEY, 'example.com', { now: () => OBSERVED_AT })).toMatchObject({
+			status: 'not-assessed',
+			reason: 'probe_unprovisioned',
+		});
+		expect(await callSmtpStarttlsProbe(binding, 'short', 'example.com', { now: () => OBSERVED_AT })).toMatchObject({
+			status: 'not-assessed',
+			reason: 'probe_unprovisioned',
+		});
+		expect(binding.fetch).not.toHaveBeenCalled();
+	});
+
+	it('uses only the fixed service-binding endpoint and a domain-only request body', async () => {
+		const { callSmtpStarttlsProbe } = await import('../src/lib/smtp-probe-binding');
+		const body = {
+			schemaVersion: '1.0',
+			probe: 'smtp_starttls',
+			domain: 'example.com',
+			status: 'not-applicable',
+			outcome: 'null_mx',
+			observedAt: OBSERVED_AT,
+			nonScoring: true,
+			targets: [],
+			reason: 'null_mx',
+		};
+		const binding = bindingReturning(body);
+		expect(await callSmtpStarttlsProbe(binding, STRONG_KEY, 'example.com')).toEqual(body);
+		const [url, init] = binding.fetch.mock.calls[0]!;
+		expect(String(url)).toBe('https://bv-smtp-starttls-probe/v1/probe');
+		expect(init).toMatchObject({ method: 'POST', redirect: 'manual', body: JSON.stringify({ domain: 'example.com' }) });
+		expect((init as RequestInit).headers).toMatchObject({ Authorization: `Bearer ${STRONG_KEY}` });
+	});
+
+	it.each([
+		['non-ok', bindingReturning({}, 503)],
+		['malformed', bindingReturning({ status: 'measured', transcript: ['raw'] })],
+		[
+			'wrong-domain',
+			bindingReturning({
+				schemaVersion: '1.0',
+				probe: 'smtp_starttls',
+				domain: 'other.example',
+				status: 'not-applicable',
+				outcome: 'null_mx',
+				observedAt: OBSERVED_AT,
+				nonScoring: true,
+				targets: [],
+				reason: 'null_mx',
+			}),
+		],
+	] as const)('returns explicit not-assessed for a %s response', async (_label, binding) => {
+		const { callSmtpStarttlsProbe } = await import('../src/lib/smtp-probe-binding');
+		const result = await callSmtpStarttlsProbe(binding, STRONG_KEY, 'example.com', { now: () => OBSERVED_AT });
+		expect(result.status).toBe('not-assessed');
+		expect(result.outcome).toBe('not_assessed');
+	});
+
+	it('returns explicit not-assessed when the binding throws', async () => {
+		const { callSmtpStarttlsProbe } = await import('../src/lib/smtp-probe-binding');
+		const binding = { fetch: vi.fn(async () => Promise.reject(new Error('offline'))) };
+		const result = await callSmtpStarttlsProbe(binding, STRONG_KEY, 'example.com', { now: () => OBSERVED_AT });
+		expect(result).toMatchObject({ status: 'not-assessed', reason: 'probe_failed', nonScoring: true });
+	});
+});
+
+describe('unregistered SMTP beta wrapper', () => {
+	it('returns invalid-domain without consulting a binding', async () => {
+		const { inspectSmtpStarttls } = await import('../src/tools/inspect-smtp-starttls');
+		const binding = bindingReturning({});
+		const result = await inspectSmtpStarttls('127.0.0.1', { probeBinding: binding, probeAuthToken: STRONG_KEY, now: () => OBSERVED_AT });
+		expect(result).toMatchObject({ status: 'not-assessed', reason: 'invalid_domain', nonScoring: true });
+		expect(binding.fetch).not.toHaveBeenCalled();
+	});
+});

--- a/test/smtp-starttls-contract.spec.ts
+++ b/test/smtp-starttls-contract.spec.ts
@@ -23,6 +23,23 @@ const VALID_RESULT = {
 	],
 } as const;
 
+const FAILED_TARGET = {
+	...VALID_RESULT.targets[0],
+	target: { exchange: 'mx-fail.example.com', preference: 20, address: '8.8.8.8', port: 25, tlsServerName: 'mx-fail.example.com' },
+	starttlsAdvertised: false,
+	tlsNegotiated: false,
+	postTlsEhloAccepted: false,
+	tls: undefined,
+	reason: 'starttls_not_advertised',
+} as const;
+
+const INCOMPLETE_TARGET = {
+	target: { exchange: 'mx-pending.example.com', preference: 30, address: '9.9.9.9', port: 25, tlsServerName: 'mx-pending.example.com' },
+	status: 'not-assessed',
+	phase: 'connect',
+	reason: 'connection_failed',
+} as const;
+
 describe('SMTP STARTTLS result contract', () => {
 	it('accepts a bounded non-scoring measurement', async () => {
 		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
@@ -76,6 +93,32 @@ describe('SMTP STARTTLS result contract', () => {
 				targets: [{ ...VALID_RESULT.targets[0], starttlsAdvertised: undefined }],
 			}).success,
 		).toBe(false);
+	});
+
+	it('accepts partial mixed only for genuinely mixed measurements or explicit incomplete evidence', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		const partial = { ...VALID_RESULT, status: 'partial', outcome: 'mixed' } as const;
+
+		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0], FAILED_TARGET] }).success).toBe(true);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0], INCOMPLETE_TARGET] }).success).toBe(true);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0]] }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [FAILED_TARGET] }).success).toBe(false);
+	});
+
+	it('rejects uniform partial outcomes with incomplete or contradictory target evidence', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		const partial = { ...VALID_RESULT, status: 'partial' } as const;
+
+		for (const candidate of [
+			{ ...partial, outcome: 'starttls_available', targets: [VALID_RESULT.targets[0], INCOMPLETE_TARGET] },
+			{ ...partial, outcome: 'starttls_available', targets: [VALID_RESULT.targets[0], FAILED_TARGET] },
+			{ ...partial, outcome: 'starttls_available', targets: [VALID_RESULT.targets[0]] },
+			{ ...partial, outcome: 'starttls_unavailable', targets: [FAILED_TARGET, INCOMPLETE_TARGET] },
+			{ ...partial, outcome: 'starttls_unavailable', targets: [FAILED_TARGET, VALID_RESULT.targets[0]] },
+			{ ...partial, outcome: 'starttls_unavailable', targets: [FAILED_TARGET] },
+		] as const) {
+			expect(SmtpStarttlsResultSchema.safeParse(candidate).success).toBe(false);
+		}
 	});
 
 	it('represents null MX only as not-applicable', async () => {

--- a/test/smtp-starttls-contract.spec.ts
+++ b/test/smtp-starttls-contract.spec.ts
@@ -40,6 +40,15 @@ const INCOMPLETE_TARGET = {
 	reason: 'connection_failed',
 } as const;
 
+const PARTIAL_TARGET = {
+	...INCOMPLETE_TARGET,
+	status: 'partial',
+	starttlsAdvertised: true,
+	tlsNegotiated: null,
+	postTlsEhloAccepted: null,
+	reason: 'deadline_exceeded',
+} as const;
+
 describe('SMTP STARTTLS result contract', () => {
 	it('accepts a bounded non-scoring measurement', async () => {
 		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
@@ -95,30 +104,42 @@ describe('SMTP STARTTLS result contract', () => {
 		).toBe(false);
 	});
 
-	it('accepts partial mixed only for genuinely mixed measurements or explicit incomplete evidence', async () => {
+	it('uses measured mixed for heterogeneous complete target outcomes', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		const mixed = { ...VALID_RESULT, outcome: 'mixed', targets: [VALID_RESULT.targets[0], FAILED_TARGET] } as const;
+
+		expect(SmtpStarttlsResultSchema.safeParse(mixed).success).toBe(true);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...mixed, outcome: 'starttls_available' }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...mixed, outcome: 'starttls_unavailable' }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...mixed, targets: [VALID_RESULT.targets[0]] }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...mixed, targets: [FAILED_TARGET] }).success).toBe(false);
+	});
+
+	it('requires partial mixed to combine measured facts with explicit incomplete evidence', async () => {
 		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
 		const partial = { ...VALID_RESULT, status: 'partial', outcome: 'mixed' } as const;
 
-		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0], FAILED_TARGET] }).success).toBe(true);
 		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0], INCOMPLETE_TARGET] }).success).toBe(true);
-		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0]] }).success).toBe(false);
-		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [FAILED_TARGET] }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0], PARTIAL_TARGET] }).success).toBe(true);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [VALID_RESULT.targets[0], FAILED_TARGET] }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...partial, targets: [INCOMPLETE_TARGET] }).success).toBe(false);
 	});
 
-	it('rejects uniform partial outcomes with incomplete or contradictory target evidence', async () => {
+	it('represents all target failures to assess as top-level not-assessed with bounded detail', async () => {
 		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
-		const partial = { ...VALID_RESULT, status: 'partial' } as const;
+		const result = {
+			...VALID_RESULT,
+			status: 'not-assessed',
+			outcome: 'not_assessed',
+			targets: [INCOMPLETE_TARGET],
+			reason: 'targets_not_assessed',
+		} as const;
 
-		for (const candidate of [
-			{ ...partial, outcome: 'starttls_available', targets: [VALID_RESULT.targets[0], INCOMPLETE_TARGET] },
-			{ ...partial, outcome: 'starttls_available', targets: [VALID_RESULT.targets[0], FAILED_TARGET] },
-			{ ...partial, outcome: 'starttls_available', targets: [VALID_RESULT.targets[0]] },
-			{ ...partial, outcome: 'starttls_unavailable', targets: [FAILED_TARGET, INCOMPLETE_TARGET] },
-			{ ...partial, outcome: 'starttls_unavailable', targets: [FAILED_TARGET, VALID_RESULT.targets[0]] },
-			{ ...partial, outcome: 'starttls_unavailable', targets: [FAILED_TARGET] },
-		] as const) {
-			expect(SmtpStarttlsResultSchema.safeParse(candidate).success).toBe(false);
-		}
+		expect(SmtpStarttlsResultSchema.safeParse(result).success).toBe(true);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...result, reason: 'probe_failed' }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...result, targets: [] }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...result, targets: Array(4).fill(INCOMPLETE_TARGET) }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...result, targets: [VALID_RESULT.targets[0]] }).success).toBe(false);
 	});
 
 	it('represents null MX only as not-applicable', async () => {

--- a/test/smtp-starttls-contract.spec.ts
+++ b/test/smtp-starttls-contract.spec.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+const VALID_RESULT = {
+	schemaVersion: '1.0',
+	probe: 'smtp_starttls',
+	domain: 'example.com',
+	status: 'measured',
+	outcome: 'starttls_available',
+	observedAt: '2026-09-05T00:00:00.000Z',
+	nonScoring: true,
+	targets: [
+		{
+			target: { exchange: 'mx.example.com', preference: 10, address: '1.1.1.1', port: 25, tlsServerName: 'mx.example.com' },
+			status: 'measured',
+			phase: 'quit',
+			starttlsAdvertised: true,
+			tlsNegotiated: true,
+			postTlsEhloAccepted: true,
+			tls: { protocol: 'TLSv1.3', cipher: 'TLS_AES_128_GCM_SHA256', peerNameValid: true },
+		},
+	],
+} as const;
+
+describe('SMTP STARTTLS result contract', () => {
+	it('accepts a bounded non-scoring measurement', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		expect(SmtpStarttlsResultSchema.parse(VALID_RESULT)).toEqual(VALID_RESULT);
+	});
+
+	it('forbids transcript material and unknown nested fields', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		expect(SmtpStarttlsResultSchema.safeParse({ ...VALID_RESULT, transcript: ['220 ready'] }).success).toBe(false);
+		expect(
+			SmtpStarttlsResultSchema.safeParse({
+				...VALID_RESULT,
+				targets: [{ ...VALID_RESULT.targets[0], rawReply: '250 STARTTLS' }],
+			}).success,
+		).toBe(false);
+	});
+
+	it('caps aggregate target results at three and fixes every target to port 25', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		expect(SmtpStarttlsResultSchema.safeParse({ ...VALID_RESULT, targets: Array(4).fill(VALID_RESULT.targets[0]) }).success).toBe(false);
+		expect(
+			SmtpStarttlsResultSchema.safeParse({
+				...VALID_RESULT,
+				targets: [{ ...VALID_RESULT.targets[0], target: { ...VALID_RESULT.targets[0].target, port: 587 } }],
+			}).success,
+		).toBe(false);
+		for (const address of ['10.0.0.1', '::ffff:127.0.0.1', '2606:4700:4700::1111', '010.0.0.1']) {
+			expect(
+				SmtpStarttlsResultSchema.safeParse({
+					...VALID_RESULT,
+					targets: [{ ...VALID_RESULT.targets[0], target: { ...VALID_RESULT.targets[0].target, address } }],
+				}).success,
+			).toBe(false);
+		}
+	});
+
+	it('rejects contradictory status, outcome, and target combinations', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		expect(SmtpStarttlsResultSchema.safeParse({ ...VALID_RESULT, status: 'not-assessed' }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...VALID_RESULT, targets: [] }).success).toBe(false);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...VALID_RESULT, outcome: 'null_mx' }).success).toBe(false);
+		expect(
+			SmtpStarttlsResultSchema.safeParse({
+				...VALID_RESULT,
+				targets: [{ ...VALID_RESULT.targets[0], tlsNegotiated: false }],
+			}).success,
+		).toBe(false);
+		expect(
+			SmtpStarttlsResultSchema.safeParse({
+				...VALID_RESULT,
+				targets: [{ ...VALID_RESULT.targets[0], starttlsAdvertised: undefined }],
+			}).success,
+		).toBe(false);
+	});
+
+	it('represents null MX only as not-applicable', async () => {
+		const { SmtpStarttlsResultSchema } = await import('../src/schemas/smtp-starttls');
+		expect(
+			SmtpStarttlsResultSchema.safeParse({
+				schemaVersion: '1.0',
+				probe: 'smtp_starttls',
+				domain: 'example.com',
+				status: 'not-applicable',
+				outcome: 'null_mx',
+				observedAt: '2026-09-05T00:00:00.000Z',
+				nonScoring: true,
+				targets: [],
+				reason: 'null_mx',
+			}).success,
+		).toBe(true);
+		expect(SmtpStarttlsResultSchema.safeParse({ ...VALID_RESULT, outcome: 'null_mx', targets: [] }).success).toBe(false);
+	});
+
+	it('pins normalized MX identity and explicit not-assessed reasons', async () => {
+		const { SmtpStarttlsResultSchema, smtpNotAssessed } = await import('../src/schemas/smtp-starttls');
+		expect(
+			SmtpStarttlsResultSchema.safeParse({
+				...VALID_RESULT,
+				targets: [{ ...VALID_RESULT.targets[0], target: { ...VALID_RESULT.targets[0].target, tlsServerName: 'other.example.com' } }],
+			}).success,
+		).toBe(false);
+		expect(
+			SmtpStarttlsResultSchema.safeParse({
+				schemaVersion: '1.0',
+				probe: 'smtp_starttls',
+				domain: 'example.com',
+				status: 'not-assessed',
+				outcome: 'no_explicit_mx',
+				observedAt: '2026-09-05T00:00:00.000Z',
+				nonScoring: true,
+				targets: [],
+				reason: 'probe_failed',
+			}).success,
+		).toBe(false);
+		expect(SmtpStarttlsResultSchema.parse(smtpNotAssessed('example.com', 'no_explicit_mx'))).toMatchObject({
+			status: 'not-assessed',
+			outcome: 'no_explicit_mx',
+			reason: 'no_explicit_mx',
+		});
+	});
+});

--- a/test/smtp-starttls-protocol.spec.ts
+++ b/test/smtp-starttls-protocol.spec.ts
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+describe('bounded SMTP reply parser', () => {
+	it('parses fragmented multiline replies', async () => {
+		const { SmtpReplyParser } = await import('../src/lib/smtp-starttls-protocol');
+		const parser = new SmtpReplyParser();
+		expect(parser.push('250-example.com\r\n250-PIPE')).toEqual([]);
+		expect(parser.push('LINING\r\n250 STARTTLS\r\n')).toEqual([{ code: 250, lines: ['example.com', 'PIPELINING', 'STARTTLS'] }]);
+		parser.finish();
+	});
+
+	it('rejects malformed line endings, mixed reply codes, oversized lines and incomplete replies', async () => {
+		const { SmtpReplyParser } = await import('../src/lib/smtp-starttls-protocol');
+		expect(() => new SmtpReplyParser().push('220 hello\n')).toThrow('line ending');
+		const mixed = new SmtpReplyParser();
+		mixed.push('250-first\r\n');
+		expect(() => mixed.push('550 second\r\n')).toThrow('multiline reply code');
+		expect(() => new SmtpReplyParser().push(`220 ${'x'.repeat(1_100)}\r\n`)).toThrow('line limit');
+		const incomplete = new SmtpReplyParser();
+		incomplete.push('250-more\r\n');
+		expect(() => incomplete.finish()).toThrow('Incomplete SMTP reply');
+	});
+});
+
+describe('STARTTLS-only state machine', () => {
+	it('allows only greeting, STARTTLS, post-TLS greeting and graceful disconnect', async () => {
+		const { SmtpStarttlsStateMachine } = await import('../src/lib/smtp-starttls-protocol');
+		const session = new SmtpStarttlsStateMachine();
+		const actions = [
+			session.accept({ code: 220, lines: ['ready'] }),
+			session.accept({ code: 250, lines: ['mx.example.com', 'STARTTLS'] }),
+			session.accept({ code: 220, lines: ['begin TLS'] }),
+			session.tlsEstablished(),
+			session.accept({ code: 250, lines: ['mx.example.com'] }),
+			session.accept({ code: 221, lines: ['bye'] }),
+		];
+		const commands = actions.flatMap((action) => (action.type === 'send' ? [action.command.trim()] : []));
+		const forbidden = [`M${'AIL'} FROM`, `R${'CPT'} TO`, `D${'ATA'}`];
+
+		expect(commands).toEqual(['EHLO scanner.invalid', 'STARTTLS', 'EHLO scanner.invalid', 'QUIT']);
+		expect(commands.some((command) => forbidden.some((token) => command.startsWith(token)))).toBe(false);
+		expect(actions.at(-1)).toEqual({ type: 'complete', outcome: 'starttls_available' });
+	});
+
+	it('disconnects without attempting TLS when the capability is absent', async () => {
+		const { SmtpStarttlsStateMachine } = await import('../src/lib/smtp-starttls-protocol');
+		const session = new SmtpStarttlsStateMachine();
+		session.accept({ code: 220, lines: ['ready'] });
+		expect(session.accept({ code: 250, lines: ['PIPELINING'] })).toEqual({ type: 'send', command: 'QUIT\r\n' });
+		expect(session.accept({ code: 221, lines: ['bye'] })).toEqual({ type: 'complete', outcome: 'starttls_unavailable' });
+	});
+
+	it('requires the TLS boundary before accepting the secure greeting', async () => {
+		const { SmtpStarttlsStateMachine } = await import('../src/lib/smtp-starttls-protocol');
+		const session = new SmtpStarttlsStateMachine();
+		session.accept({ code: 220, lines: ['ready'] });
+		session.accept({ code: 250, lines: ['STARTTLS'] });
+		session.accept({ code: 220, lines: ['begin TLS'] });
+		expect(() => session.accept({ code: 250, lines: ['premature'] })).toThrow('TLS upgrade must complete');
+	});
+});

--- a/test/smtp-starttls-targets.spec.ts
+++ b/test/smtp-starttls-targets.spec.ts
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { describe, expect, it } from 'vitest';
+
+describe('SMTP MX target selection', () => {
+	it('selects at most three public targets deterministically with hostname SNI and fixed port 25', async () => {
+		const { selectSmtpMxTargets } = await import('../src/lib/smtp-starttls-targets');
+		const result = selectSmtpMxTargets([
+			{ preference: 20, exchange: 'mx-c.example.com.', addresses: ['93.184.216.35'] },
+			{ preference: 10, exchange: 'mx-b.example.com.', addresses: ['93.184.216.34', '8.8.8.8'] },
+			{ preference: 10, exchange: 'mx-a.example.com.', addresses: ['1.1.1.1'] },
+			{ preference: 30, exchange: 'mx-d.example.com.', addresses: ['9.9.9.9'] },
+		]);
+
+		expect(result.status).toBe('measured');
+		expect(result.targets).toEqual([
+			{ exchange: 'mx-a.example.com', preference: 10, address: '1.1.1.1', port: 25, tlsServerName: 'mx-a.example.com' },
+			{ exchange: 'mx-b.example.com', preference: 10, address: '8.8.8.8', port: 25, tlsServerName: 'mx-b.example.com' },
+			{ exchange: 'mx-c.example.com', preference: 20, address: '93.184.216.35', port: 25, tlsServerName: 'mx-c.example.com' },
+		]);
+	});
+
+	it('treats RFC 7505 null MX as a not-applicable outcome', async () => {
+		const { selectSmtpMxTargets } = await import('../src/lib/smtp-starttls-targets');
+		expect(selectSmtpMxTargets([{ preference: 0, exchange: '.', addresses: [] }])).toEqual({
+			status: 'not-applicable',
+			outcome: 'null_mx',
+			targets: [],
+			rejectedExchanges: [],
+		});
+	});
+
+	it('distinguishes no explicit MX from an MX set with no public addresses', async () => {
+		const { selectSmtpMxTargets } = await import('../src/lib/smtp-starttls-targets');
+		expect(selectSmtpMxTargets([]).outcome).toBe('no_explicit_mx');
+		const rejected = selectSmtpMxTargets([
+			{
+				preference: 10,
+				exchange: 'mx.example.com',
+				addresses: ['10.0.0.1', '192.0.2.10', '192.31.196.1', '192.52.193.1', '192.88.99.1', '192.175.48.1', '2001:db8::1'],
+			},
+		]);
+		expect(rejected).toMatchObject({ status: 'not-assessed', outcome: 'no_public_mx_address', targets: [] });
+		expect(rejected.rejectedExchanges).toEqual(['mx.example.com']);
+	});
+
+	it('keeps usable targets but labels rejected MX hosts partial', async () => {
+		const { selectSmtpMxTargets } = await import('../src/lib/smtp-starttls-targets');
+		const result = selectSmtpMxTargets([
+			{ preference: 10, exchange: 'mx.example.com', addresses: ['1.1.1.1'] },
+			{ preference: 20, exchange: 'localhost', addresses: ['8.8.8.8'] },
+		]);
+		expect(result.status).toBe('partial');
+		expect(result.targets).toHaveLength(1);
+		expect(result.rejectedExchanges).toEqual(['localhost']);
+	});
+
+	it('does not let malformed, duplicate, mixed-null, or embedded addresses bypass selection', async () => {
+		const { selectSmtpMxTargets } = await import('../src/lib/smtp-starttls-targets');
+		const result = selectSmtpMxTargets([
+			{ preference: 0, exchange: '.', addresses: [] },
+			{ preference: -1, exchange: 'bad.example.com', addresses: ['1.1.1.1'] },
+			{ preference: 10, exchange: 'mx.example.com', addresses: ['010.0.0.1', '::ffff:127.0.0.1', '2606:4700:4700::1111', '1.1.1.1'] },
+			{ preference: 20, exchange: 'mx.example.com.', addresses: ['8.8.8.8'] },
+		]);
+
+		expect(result.status).toBe('partial');
+		expect(result.targets).toEqual([
+			{
+				exchange: 'mx.example.com',
+				preference: 10,
+				address: '1.1.1.1',
+				port: 25,
+				tlsServerName: 'mx.example.com',
+			},
+		]);
+		expect(result.rejectedExchanges).toEqual(['<empty>', 'bad.example.com']);
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -42,4 +42,10 @@ export default defineConfig([
 		noExternal: ['punycode'],
 		esbuildPlugins: [cloudflareShimPlugin],
 	},
+	{
+		...shared,
+		entry: { cli: 'src/cli.ts' },
+		clean: false,
+		platform: 'node',
+	},
 ]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,10 @@ import { defineConfig, type Options } from 'tsup';
 /** esbuild plugin that shims cloudflare:workers for Node.js (stdio bundle) */
 const cloudflareShimPlugin = {
 	name: 'cloudflare-workers-shim',
-	setup(build: { onResolve: (opts: { filter: RegExp }, callback: (args: { path: string }) => { path: string; namespace: string } | undefined) => void; onLoad: (opts: { filter: RegExp; namespace: string }, callback: () => { contents: string; loader: string }) => void }) {
+	setup(build: {
+		onResolve: (opts: { filter: RegExp }, callback: (args: { path: string }) => { path: string; namespace: string } | undefined) => void;
+		onLoad: (opts: { filter: RegExp; namespace: string }, callback: () => { contents: string; loader: string }) => void;
+	}) {
 		build.onResolve({ filter: /^cloudflare:workers$/ }, () => ({
 			path: 'cloudflare:workers',
 			namespace: 'cf-shim',


### PR DESCRIPTION
## Summary

- add the blackveil executable while preserving blackveil-dns-mcp
- implement a hosted-MCP-only client for scan, check, batch, policy, drift, and evidence verification
- enforce command-wide deadlines, bounded JSON/SSE responses, exact JSON-RPC ID correlation, optional sessions, and safe stream disposal
- add versioned canonical SHA-256 evidence envelopes without claiming authenticity
- reject incomplete drift baselines locally with exit code 4 before contacting the server; complete baselines remain usable even when their security verdict fails
- add bounded CSP header-consistency and SMTP STARTTLS prototype modules
- keep both prototypes unregistered, unscored, unexported, and unavailable through the CLI

## Validation

- npm run build — passed
- npm run typecheck — passed
- npm run typecheck:tests — passed; ratchet improved from 739 to 735
- combined focused Worker suite — 110/110 passed
- packed-package smoke — passed and exercised both binaries
- npm run lint — passed
- npm run audit:repo-safety — passed
- Prettier and git diff checks — passed
- independent protocol, security, and truth-state reviews — no blockers

The monolithic npm test command was attempted in the probe lane but stopped after approximately 16 minutes without a terminal result. All changed and affected suites were then run together and passed.

## Parked activation gates

- CSP has no public tool registration, quota, tier, scoring, or browser/authenticated crawler surface.
- SMTP has no socket implementation, sender commands, binding configuration, or live-spoof reuse.
- SMTP activation requires a separately approved isolated TCP/25 service, complete address classification, rebinding controls, mTLS capability, rate limits, telemetry, and kill switch.
- npm publication, MCP Registry publication, deployment, secrets, and production writes are outside this PR.