### PR TITLE
fix: preserve tenant monitoring state and static-key authentication

### DIFF
--- a/scripts/vitest-node-suites.mjs
+++ b/scripts/vitest-node-suites.mjs
@@ -17,6 +17,7 @@
  * `node` project in vitest.config.ts). Governance gates — they must always run.
  */
 export const NODE_POOL_AUDIT_TESTS = [
+	'test/tenants/cycle-alerts-d1.node.test.ts',
 	'test/scheduled/brand-audit-cron-d1.node.test.ts',
 	'test/audits/brand-audit-schema-preflight.node.test.ts',
 	'test/audits/brand-report-qa-script.node.test.ts',

--- a/src/lib/tier-auth.ts
+++ b/src/lib/tier-auth.ts
@@ -4,10 +4,10 @@
  * Tier-based API key authentication.
  *
  * Resolves a bearer token to its tier via:
+ * 0. OAuth JWT verification, then configured static credentials
  * 1. KV cache (sub-ms, 5-min TTL)
  * 2. Trial key lookup (KV `trial:` prefix, 60s cache TTL)
  * 3. bv-web service binding (cache miss fallback)
- * 4. Static BV_API_KEY comparison (self-hosted fallback)
  */
 
 import type { McpApiKeyTier } from './config';
@@ -119,12 +119,12 @@ async function hashTokenRaw(token: string): Promise<Uint8Array> {
  * constant-time XOR over the digests (never short-circuits on first mismatch)
  * so it cannot leak the secret via timing.
  */
-async function matchesStaticDevKey(tokenRaw: Uint8Array, candidate: string | undefined): Promise<boolean> {
+async function matchesStaticKey(tokenRaw: Uint8Array, candidate: string | undefined): Promise<boolean> {
 	if (!candidate) return false;
 	const b = await hashTokenRaw(candidate);
 	// Both operands are fixed-length 32-byte SHA-256 digests, so iterate the
-	// full digest with no length term (matches auth.ts and the step-4 fallback
-	// compare below). Never short-circuits on first mismatch → no timing leak.
+	// full digest with no length term (matches auth.ts). Never short-circuits
+	// on first mismatch → no timing leak.
 	let mismatch = 0;
 	for (let i = 0; i < tokenRaw.byteLength; i++) {
 		mismatch |= tokenRaw[i] ^ b[i];
@@ -145,10 +145,10 @@ function applyOwnerIpGate(tier: McpApiKeyTier, ownerAllowIps: string | undefined
  * Resolve a bearer token to its API key tier.
  *
  * Resolution order:
+ * 0. OAuth JWT verification, then load-test, internal-dev, and BV_API_KEY credentials
  * 1. KV cache lookup (`tier:{hash}`)
  * 2. Trial key lookup (`trial:{hash}` in KV — time + usage limits)
  * 3. Service binding to companion app (validate-key endpoint)
- * 4. Static BV_API_KEY comparison (self-hosted fallback → owner tier)
  *
  * Owner tier requires IP allowlist (OWNER_ALLOW_IPS env var, comma-separated).
  * If the key matches BV_API_KEY but the IP is not in the allowlist,
@@ -271,7 +271,7 @@ export async function resolveTier(
 	// source-IP allowlist is configured and the Cloudflare-observed client IP is
 	// present. This prevents a leaked test key from degrading into another
 	// authenticated tier or reaching the normal key-resolution fallbacks.
-	if (await matchesStaticDevKey(tokenRaw, env.BV_LOAD_TEST_KEY)) {
+	if (await matchesStaticKey(tokenRaw, env.BV_LOAD_TEST_KEY)) {
 		const allowedIps = parseOwnerAllowIps(env.BV_LOAD_TEST_ALLOW_IPS);
 		if (allowedIps.length === 0 || !clientIp || !allowedIps.includes(clientIp)) {
 			return { authenticated: false };
@@ -287,7 +287,17 @@ export async function resolveTier(
 	// Two independent slots (BV_INTERNAL_DEV_KEY + BV_INTERNAL_DEV_KEY_2) allow
 	// adding a per-machine key without rotating the shared one out from under
 	// other consumers. Both resolve to owner tier and remain OWNER_ALLOW_IPS-gated.
-	if ((await matchesStaticDevKey(tokenRaw, env.BV_INTERNAL_DEV_KEY)) || (await matchesStaticDevKey(tokenRaw, env.BV_INTERNAL_DEV_KEY_2))) {
+	if ((await matchesStaticKey(tokenRaw, env.BV_INTERNAL_DEV_KEY)) || (await matchesStaticKey(tokenRaw, env.BV_INTERNAL_DEV_KEY_2))) {
+		const resolvedTier = applyOwnerIpGate('owner', env.OWNER_ALLOW_IPS, clientIp);
+		return { authenticated: true, tier: resolvedTier, keyHash, legacyOwnerId: keyHash.slice(0, 16), credentialHash: keyHash };
+	}
+
+	// The configured static key is authoritative independently of remote
+	// entitlements. Resolve it before the cache so a remote negative entry cannot
+	// reject it on the next request, and a stale positive tier cannot demote it.
+	// Keep the dedicated load-test denial above and apply the owner IP gate on
+	// every request; static credentials never populate the entitlement cache.
+	if (await matchesStaticKey(tokenRaw, env.BV_API_KEY)) {
 		const resolvedTier = applyOwnerIpGate('owner', env.OWNER_ALLOW_IPS, clientIp);
 		return { authenticated: true, tier: resolvedTier, keyHash, legacyOwnerId: keyHash.slice(0, 16), credentialHash: keyHash };
 	}
@@ -395,27 +405,6 @@ export async function resolveTier(
 			// Entitlement validation is an authorization boundary. Network failures,
 			// timeouts, malformed bodies, and 5xx responses all fail closed. Serving a
 			// stale positive result here would let a revoked bearer survive an outage.
-		}
-	}
-
-	// 4. Fallback: compare against static BV_API_KEY (self-hosted/dev)
-	if (env.BV_API_KEY) {
-		// Constant-time comparison: XOR raw SHA-256 digests byte-by-byte
-		// (same pattern as auth.ts — avoids timing side-channels from === on strings)
-		const a = tokenRaw;
-		const b = await hashTokenRaw(env.BV_API_KEY);
-		let mismatch = 0;
-		for (let i = 0; i < a.byteLength; i++) {
-			mismatch |= a[i] ^ b[i];
-		}
-		if (mismatch === 0) {
-			// Owner tier requires IP allowlist. If OWNER_ALLOW_IPS is set and non-empty
-			// and the client IP is not in the list, downgrade to partner (still high
-			// limits but not unlimited). If OWNER_ALLOW_IPS is unset, empty, or whitespace-
-			// only, owner is unrestricted (backward compat for self-hosted/dev where
-			// there's no IP filtering).
-			const resolvedTier = applyOwnerIpGate('owner', env.OWNER_ALLOW_IPS, clientIp);
-			return { authenticated: true, tier: resolvedTier, keyHash, legacyOwnerId: keyHash.slice(0, 16), credentialHash: keyHash };
 		}
 	}
 

--- a/src/tenants/alerts/diff.ts
+++ b/src/tenants/alerts/diff.ts
@@ -18,10 +18,12 @@ import {
  * unit-testable.
  *
  * Key behaviours:
- *   - Findings are grouped by (domain, category). Within a group, an entry that
- *     exists in both arrays at different severity counts as `severity_changed`;
- *     an entry that exists only in current is `gained`; only in baseline is
- *     `lost`.
+ *   - Findings are matched by (domain, category, title), preserving duplicate
+ *     occurrence counts. Equal-severity occurrences match first; remaining
+ *     occurrences pair by severity descending as `severity_changed`, with
+ *     unmatched current/baseline occurrences counted as `gained`/`lost`.
+ *     Persisted rows have no stable cross-scan finding code, so a title change
+ *     is a loss plus a gain, not a severity transition.
  *   - `highlights` is a top-N list ordered by severity desc then by domain for
  *     stability, capped at MAX_HIGHLIGHTS = 20 (the schema also enforces this).
  *   - `totals.by_severity` counts each individual delta (not just highlights)
@@ -63,7 +65,7 @@ const SEVERITY_RANK: Record<TenantSeverity, number> = {
 const MAX_HIGHLIGHTS = 20;
 
 function findingKey(row: FindingRow): string {
-	return `${row.domain}\x00${row.category}`;
+	return JSON.stringify([row.domain, row.category, row.title]);
 }
 
 function emptySeverityCounts(): Record<TenantSeverity, number> {
@@ -79,48 +81,48 @@ interface DiffEntry {
 	title: string;
 }
 
+function groupFindings(rows: FindingRow[]): Map<string, { row: FindingRow; counts: Record<TenantSeverity, number> }> {
+	const groups = new Map<string, { row: FindingRow; counts: Record<TenantSeverity, number> }>();
+	for (const row of rows) {
+		const key = findingKey(row);
+		let group = groups.get(key);
+		if (!group) {
+			group = { row, counts: emptySeverityCounts() };
+			groups.set(key, group);
+		}
+		group.counts[row.severity] += 1;
+	}
+	return groups;
+}
+
 function buildDiffEntries(current: FindingRow[], baseline: FindingRow[]): DiffEntry[] {
-	const baselineMap = new Map<string, FindingRow>();
-	for (const row of baseline) baselineMap.set(findingKey(row), row);
-
+	const currentGroups = groupFindings(current);
+	const baselineGroups = groupFindings(baseline);
 	const entries: DiffEntry[] = [];
-	const currentSeen = new Set<string>();
-
-	for (const cur of current) {
-		const key = findingKey(cur);
-		currentSeen.add(key);
-		const prev = baselineMap.get(key);
-		if (!prev) {
+	for (const key of new Set([...currentGroups.keys(), ...baselineGroups.keys()])) {
+		const cur = currentGroups.get(key);
+		const prev = baselineGroups.get(key);
+		const row = (cur ?? prev)!.row;
+		const gained: TenantSeverity[] = [];
+		const lost: TenantSeverity[] = [];
+		for (const severity of TENANT_SEVERITY_LEVELS) {
+			const difference = (cur?.counts[severity] ?? 0) - (prev?.counts[severity] ?? 0);
+			for (let i = 0; i < Math.abs(difference); i++) {
+				(difference > 0 ? gained : lost).push(severity);
+			}
+		}
+		for (let i = 0; i < Math.max(gained.length, lost.length); i++) {
+			const severity = gained[i];
+			const previousSeverity = lost[i];
 			entries.push({
-				domain: cur.domain,
-				category: cur.category,
-				delta: 'gained',
-				severity: cur.severity,
-				title: cur.title,
-			});
-		} else if (prev.severity !== cur.severity) {
-			entries.push({
-				domain: cur.domain,
-				category: cur.category,
-				delta: 'severity_changed',
-				severity: cur.severity,
-				previousSeverity: prev.severity,
-				title: cur.title,
+				domain: row.domain,
+				category: row.category,
+				title: row.title,
+				delta: severity === undefined ? 'lost' : previousSeverity === undefined ? 'gained' : 'severity_changed',
+				severity: severity ?? previousSeverity,
+				...(severity !== undefined && previousSeverity !== undefined ? { previousSeverity } : {}),
 			});
 		}
-		// same severity → not a delta
-	}
-
-	for (const prev of baseline) {
-		const key = findingKey(prev);
-		if (currentSeen.has(key)) continue;
-		entries.push({
-			domain: prev.domain,
-			category: prev.category,
-			delta: 'lost',
-			severity: prev.severity,
-			title: prev.title,
-		});
 	}
 
 	return entries;
@@ -132,7 +134,8 @@ function compareEntries(a: DiffEntry, b: DiffEntry): number {
 	if (a.domain !== b.domain) return a.domain < b.domain ? -1 : 1;
 	if (a.category !== b.category) return a.category < b.category ? -1 : 1;
 	if (a.delta !== b.delta) return a.delta < b.delta ? -1 : 1;
-	return 0;
+	if (a.title !== b.title) return a.title < b.title ? -1 : 1;
+	return (b.previousSeverity ? SEVERITY_RANK[b.previousSeverity] : 0) - (a.previousSeverity ? SEVERITY_RANK[a.previousSeverity] : 0);
 }
 
 function toFindingDelta(entry: DiffEntry, opts: ComputeCycleDiffOptions): TenantFindingDelta {
@@ -157,11 +160,7 @@ function toFindingDelta(entry: DiffEntry, opts: ComputeCycleDiffOptions): Tenant
  * Pure function — throws only if the resulting payload fails schema validation
  * (defensive, indicates a producer bug rather than a runtime/env issue).
  */
-export function computeCycleDiff(
-	current: FindingRow[],
-	baseline: FindingRow[],
-	opts: ComputeCycleDiffOptions,
-): TenantCycleAlert {
+export function computeCycleDiff(current: FindingRow[], baseline: FindingRow[], opts: ComputeCycleDiffOptions): TenantCycleAlert {
 	const entries = buildDiffEntries(current, baseline);
 	entries.sort(compareEntries);
 

--- a/src/tenants/cycle-progress.ts
+++ b/src/tenants/cycle-progress.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import type { TenantDbHandle } from './tenant-resolver';
+
+/** Count durable completions, including DLQ markers but excluding partial writes. */
+const COMPLETED_SCANS_SQL = `
+	SELECT COUNT(*) AS completed_total FROM scans s
+	WHERE s.cycle_id = ?
+	  AND (SELECT COUNT(*) FROM findings f WHERE f.scan_id = s.id) >= COALESCE(s.finding_count, 0)
+`;
+const SYNC_COMPLETED_SQL = 'UPDATE tenant_cycles SET completed_total = MAX(completed_total, ?) WHERE id = ?';
+
+/**
+ * Synchronize instead of incrementing so redelivery and an ambiguous registry
+ * write cannot count a domain twice. MAX prevents an older concurrent snapshot
+ * from reducing progress. Missing cycles (ad hoc scans) remain a harmless no-op.
+ * Errors propagate: queue redelivery or the scheduled sweep will retry safely.
+ */
+export async function synchronizeCycleProgress(registry: D1Database | undefined, tenantDb: TenantDbHandle, cycleId: string): Promise<void> {
+	if (!registry) return;
+	const row = await tenantDb.prepare(COMPLETED_SCANS_SQL).bind(cycleId).first<{ completed_total: number }>();
+	await registry
+		.prepare(SYNC_COMPLETED_SQL)
+		.bind(row?.completed_total ?? 0, cycleId)
+		.run();
+}

--- a/src/tenants/queue-consumer.ts
+++ b/src/tenants/queue-consumer.ts
@@ -31,6 +31,7 @@ import { parseScoringConfigCached } from '../lib/scoring-config';
 import { parseCacheTtl, parsePerCheckTimeout, parseScanTimeout } from '../lib/config';
 import { ScanQueueMessageSchema, type ScanQueueMessage } from '../schemas/tenant-internal';
 import { streamScanResult } from '../lib/hooks/analytics-stream';
+import { synchronizeCycleProgress } from './cycle-progress';
 import { resolveTenant, type ResolverEnv, type TenantDbHandle } from './tenant-resolver';
 import { resolveAccumulatorShardModeFromEnv } from '../lib/profile-accumulator';
 import { parseTenantScanSnapshot, toTenantScanSnapshot, type TenantScanSnapshot } from './scan-snapshot';
@@ -123,32 +124,6 @@ export type ScanQueueConsumerEnv = ResolverEnv & {
 	BV_DOH_TOKEN?: string;
 };
 
-/**
- * Phase 3 cycle-progress hook. After persistScan succeeds (or after a DLQ row
- * is written) we increment tenant_cycles.completed_total so the alert sweep can
- * tell when a cycle has settled.
- *
- * Fail-soft: 0 rows affected when there's no matching tenant_cycles entry (e.g.
- * the cycle was driven by /internal/tenants/scan rather than the weekly rescan).
- * Registry D1 errors are swallowed — the scan itself already landed in the
- * tenant DB so we MUST NOT cause a queue retry on a registry hiccup.
- */
-const INCREMENT_COMPLETED_SQL =
-	'UPDATE tenant_cycles SET completed_total = completed_total + 1 WHERE id = ?';
-
-async function incrementCompletedTotalIfTracked(
-	env: ScanQueueConsumerEnv,
-	cycleId: string,
-): Promise<void> {
-	const registry = env.TENANT_REGISTRY_DB;
-	if (!registry) return;
-	try {
-		await registry.prepare(INCREMENT_COMPLETED_SQL).bind(cycleId).run();
-	} catch {
-		// Registry write failed — ignored intentionally.
-	}
-}
-
 /** Generate a per-row id (scans, findings). */
 function newRowId(): string {
 	return crypto.randomUUID();
@@ -181,19 +156,14 @@ async function writeDlqRow(
 	reason: string,
 ): Promise<void> {
 	const scanId = newRowId();
-	try {
-		await tenantDb
-			.prepare(SCANS_INSERT_SQL)
-			.bind(scanId, msg.domain, Date.now(), null, null, null, 1, JSON.stringify({ error: reason }), msg.cycle_id)
-			.run();
-		await tenantDb
-			.prepare(FINDINGS_INSERT_SQL)
-			.bind(newRowId(), scanId, msg.domain, 'queue', 'high', 'queue_dlq', reason, JSON.stringify({ source: 'queue_dlq', reason }))
-			.run();
-	} catch {
-		// If even the DLQ write fails, swallow — we've exhausted retries; better
-		// to drop than to wedge the queue.
-	}
+	await tenantDb
+		.prepare(SCANS_INSERT_SQL)
+		.bind(scanId, msg.domain, Date.now(), null, null, null, 1, JSON.stringify({ error: reason }), msg.cycle_id)
+		.run();
+	await tenantDb
+		.prepare(FINDINGS_INSERT_SQL)
+		.bind(newRowId(), scanId, msg.domain, 'queue', 'high', 'queue_dlq', reason, JSON.stringify({ source: 'queue_dlq', reason }))
+		.run();
 }
 
 /** Persist a successful scan + its findings to the per-tenant D1. */
@@ -239,15 +209,44 @@ async function repairPartialScanIfNeeded(tenantDb: TenantDbHandle, cycleId: stri
 	return 'repaired';
 }
 
+/** Registry writes are retryable even after the scan's attempt budget is spent. */
+async function finishMessage(env: ScanQueueConsumerEnv, tenantDb: TenantDbHandle, msg: ScanQueueMessage): Promise<'ack' | 'retry'> {
+	try {
+		await synchronizeCycleProgress(env.TENANT_REGISTRY_DB, tenantDb, msg.cycle_id);
+		return 'ack';
+	} catch {
+		return 'retry';
+	}
+}
+
+async function deadLetterMessage(
+	env: ScanQueueConsumerEnv,
+	tenantDb: TenantDbHandle,
+	msg: ScanQueueMessage,
+	reason: string,
+): Promise<'ack' | 'retry'> {
+	try {
+		// Persistence may have failed after creating a partial scan. Repair it
+		// before inserting the marker, while preserving a concurrently completed scan.
+		if ((await repairPartialScanIfNeeded(tenantDb, msg.cycle_id, msg.domain)) !== 'complete') {
+			await writeDlqRow(tenantDb, msg, reason);
+		}
+		return finishMessage(env, tenantDb, msg);
+	} catch {
+		// Never acknowledge work whose scan and DLQ marker both failed to persist.
+		return 'retry';
+	}
+}
+
 /**
  * Process one message. Returns:
  *   - `'ack'`     → caller should `message.ack()`
  *   - `'retry'`   → caller should rethrow to trigger Cloudflare retry
  *
- * Idempotency: a duplicate `(cycle_id, domain)` row short-circuits with `'ack'`.
+ * Idempotency: a completed `(cycle_id, domain)` repairs progress before acking.
  * DLQ: when `attempts >= MAX_ATTEMPTS`, writes a marker row and returns `'ack'`
- * so the queue drains. The cycle report will surface it via the high-severity
- * `queue_dlq` finding.
+ * after durable persistence and progress synchronization. The cycle report
+ * surfaces it via the high-severity `queue_dlq` finding.
  */
 export async function processScanMessage(
 	rawBody: unknown,
@@ -287,11 +286,13 @@ export async function processScanMessage(
 	// the expected findings are present; retry repairs the stale row first.
 	try {
 		const status = await repairPartialScanIfNeeded(tenantDb, parsed.cycle_id, parsed.domain);
-		if (status === 'complete') return 'ack';
+		if (status === 'complete') {
+			return finishMessage(env, tenantDb, parsed);
+		}
 	} catch {
 		// Probe/repair failed — retry rather than risk UNIQUE conflicts or silently
 		// accepting an incomplete scan.
-		return attempts >= MAX_ATTEMPTS ? 'ack' : 'retry';
+		return 'retry';
 	}
 
 	// On the LAST allowed attempt the budget can still time out — record a DLQ
@@ -375,9 +376,7 @@ export async function processScanMessage(
 			);
 			if (result.isError) {
 				if (isLastAttempt) {
-					await writeDlqRow(tenantDb, parsed, 'queue_dlq');
-					await incrementCompletedTotalIfTracked(env, parsed.cycle_id);
-					return 'ack';
+					return deadLetterMessage(env, tenantDb, parsed, 'queue_dlq');
 				}
 				return 'retry';
 			}
@@ -385,9 +384,7 @@ export async function processScanMessage(
 	} catch (err) {
 		const reason = err instanceof Error ? err.message : 'queue_error';
 		if (isLastAttempt) {
-			await writeDlqRow(tenantDb, parsed, reason === 'queue_timeout' ? 'queue_timeout' : 'queue_dlq');
-			await incrementCompletedTotalIfTracked(env, parsed.cycle_id);
-			return 'ack';
+			return deadLetterMessage(env, tenantDb, parsed, reason === 'queue_timeout' ? 'queue_timeout' : 'queue_dlq');
 		}
 		return 'retry';
 	}
@@ -405,19 +402,14 @@ export async function processScanMessage(
 	} catch {
 		// Persistence failure is transient (D1 contention, throttling). Retry.
 		if (isLastAttempt) {
-			await writeDlqRow(tenantDb, parsed, 'persist_failed');
-			// Even DLQ counts toward completed_total — otherwise a cycle with N
-			// permanently-stuck domains never settles and the alert never fires.
-			await incrementCompletedTotalIfTracked(env, parsed.cycle_id);
-			return 'ack';
+			return deadLetterMessage(env, tenantDb, parsed, 'persist_failed');
 		}
 		return 'retry';
 	}
 
-	// Phase 3 cycle-progress hook. Fail-soft: a registry hiccup must NOT cause
-	// a redelivery, so this swallows its own errors.
-	await incrementCompletedTotalIfTracked(env, parsed.cycle_id);
-	return 'ack';
+	// Completion is durable only after registry synchronization. Redelivery can
+	// repair a failed registry write without scanning or counting the domain twice.
+	return finishMessage(env, tenantDb, parsed);
 }
 
 /**

--- a/src/tenants/scheduled-handlers.ts
+++ b/src/tenants/scheduled-handlers.ts
@@ -22,6 +22,7 @@
  * sharing the same trigger). Errors are logged via `logError`.
  */
 
+import { synchronizeCycleProgress } from './cycle-progress';
 import { computeFingerprint, fingerprintsDiffer, type DnsQueryFn } from './dns-fingerprint';
 import {
 	computeCycleDiff,
@@ -71,9 +72,14 @@ const UPDATE_FINGERPRINT_SQL =
 	'UPDATE domains SET fingerprint = ?, fingerprint_at = ? WHERE domain = ?';
 const INSERT_CYCLE_SQL =
 	'INSERT INTO tenant_cycles (id, super_tenant_id, sub_tenant_id, started_at, expected_total, completed_total, errored_total, baseline_cycle_id) ' +
-	'VALUES (?, ?, ?, ?, ?, 0, 0, ?)';
+	'VALUES (?, ?, ?, ?, ?, 0, ?, ?)';
 const INCREMENT_ERRORED_SQL =
 	'UPDATE tenant_cycles SET errored_total = errored_total + ? WHERE id = ?';
+const UNSETTLED_CYCLES_SQL = `
+	SELECT id, sub_tenant_id FROM tenant_cycles
+	WHERE alert_sent_at IS NULL AND completed_total + errored_total < expected_total
+	ORDER BY started_at DESC LIMIT ?
+`;
 const FIND_BASELINE_CYCLE_SQL =
 	'SELECT id FROM tenant_cycles WHERE sub_tenant_id = ? AND alert_sent_at IS NOT NULL ORDER BY started_at DESC LIMIT 1';
 const PENDING_CYCLES_SQL = `
@@ -86,10 +92,36 @@ const PENDING_CYCLES_SQL = `
 `;
 const STAMP_ALERT_SQL =
 	'UPDATE tenant_cycles SET alert_sent_at = ?, alert_outcome = ? WHERE id = ?';
+// Preserve durable queue failure markers as operational alerts while excluding
+// unmeasured security findings from posture comparisons.
 const FINDINGS_FOR_CYCLE_SQL = `
 	SELECT f.domain, f.category, f.severity, f.title
 	FROM findings f
-	WHERE f.scan_id IN (SELECT id FROM scans WHERE cycle_id = ?)
+	WHERE f.scan_id IN (
+		SELECT s.id FROM scans s WHERE s.cycle_id = ?
+		AND (s.score IS NOT NULL OR (f.category = 'queue' AND f.title = 'queue_dlq'))
+		AND (SELECT COUNT(*) FROM findings measured WHERE measured.scan_id = s.id) >= COALESCE(s.finding_count, 0)
+	)
+`;
+
+// A cycle measures only selected domains. Find each measured domain's latest
+// complete, successful observation before this cycle, even when an intervening
+// partial cycle skipped that domain. Failed/partial rows never replace knowledge.
+const BASELINE_FINDINGS_SQL = `
+	SELECT f.domain, f.category, f.severity, f.title
+	FROM findings f
+	WHERE f.scan_id IN (
+		SELECT (
+			SELECT prior.id FROM scans prior
+			WHERE prior.domain = current.domain AND prior.scan_at < ?
+			  AND prior.cycle_id IS NOT current.cycle_id AND prior.score IS NOT NULL
+			  AND (SELECT COUNT(*) FROM findings pf WHERE pf.scan_id = prior.id) >= COALESCE(prior.finding_count, 0)
+			ORDER BY prior.scan_at DESC, prior.id DESC LIMIT 1
+		)
+		FROM scans current
+		WHERE current.cycle_id = ? AND current.score IS NOT NULL
+		  AND (SELECT COUNT(*) FROM findings cf WHERE cf.scan_id = current.id) >= COALESCE(current.finding_count, 0)
+	)
 `;
 
 interface ActiveTenantRow {
@@ -160,8 +192,8 @@ function toFindingRow(row: FindingRowDb): FindingRow {
  *      - now - last_scanned_at > 2 * interval → enqueue (stale-rescan bypass)
  *      - otherwise → update fingerprint_at and skip
  *   6. Insert one `tenant_cycles` row per sub-tenant with `expected_total`
- *      = enqueued domains. DNS-failed domains are recorded immediately as
- *      `errored_total` so the cycle can settle.
+ *      = selected domains + DNS errors, then publish the selected scans.
+ *      DNS errors initialize `errored_total` so the cycle can settle.
  *
  * Fail-soft: missing TENANT_REGISTRY_DB or BV_SCANNER_QUEUE → return early.
  * Per-domain or per-tenant errors are logged and the loop continues.
@@ -275,7 +307,7 @@ async function rescanTenant(
 	const cycleId = deps.newCycleId();
 	let queuedCount = 0;
 	let erroredCount = 0;
-	const queueErrors: string[] = [];
+	const selectedDomains: string[] = [];
 
 	for (const row of dueDomains) {
 		try {
@@ -285,49 +317,22 @@ async function rescanTenant(
 				continue;
 			}
 
-			const intervalMs =
-				(row.watch_interval_hours ?? DEFAULT_WATCH_INTERVAL_HOURS) * 3600 * 1000;
-			const stale =
-				row.last_scanned_at !== null &&
-				tNow - row.last_scanned_at > intervalMs * STALE_RESCAN_MULTIPLIER;
+			const intervalMs = (row.watch_interval_hours ?? DEFAULT_WATCH_INTERVAL_HOURS) * 3600 * 1000;
+			const stale = row.last_scanned_at !== null && tNow - row.last_scanned_at > intervalMs * STALE_RESCAN_MULTIPLIER;
 
-			const shouldEnqueue =
-				row.last_scanned_at === null ||
-				fingerprintsDiffer(fp.fingerprint, row.fingerprint) ||
-				stale;
+			const shouldEnqueue = row.last_scanned_at === null || fingerprintsDiffer(fp.fingerprint, row.fingerprint) || stale;
 
 			// Always refresh the cached fingerprint so silent drift is captured even
 			// when we skip the scan.
 			try {
-				await tenantDb
-					.prepare(UPDATE_FINGERPRINT_SQL)
-					.bind(fp.fingerprint, fp.capturedAt, row.domain)
-					.run();
+				await tenantDb.prepare(UPDATE_FINGERPRINT_SQL).bind(fp.fingerprint, fp.capturedAt, row.domain).run();
 			} catch {
 				// Best-effort cache refresh — don't surface as cycle error.
 			}
 
 			if (!shouldEnqueue) continue;
 
-			try {
-				await env.BV_SCANNER_QUEUE!.send(
-					{ cycle_id: cycleId, sub_tenant_id: tenant.id, domain: row.domain },
-					{ contentType: 'json' },
-				);
-				queuedCount += 1;
-			} catch (err) {
-				queueErrors.push(row.domain);
-				erroredCount += 1;
-				logError(err instanceof Error ? err : String(err), {
-					severity: 'warn',
-					category: 'tenant.scheduled',
-					details: {
-						message: 'tenant_weekly_rescan_queue_send_failed',
-						subTenantId: tenant.id,
-						cycleId,
-					},
-				});
-			}
+			selectedDomains.push(row.domain);
 		} catch (err) {
 			erroredCount += 1;
 			logError(err instanceof Error ? err : String(err), {
@@ -342,15 +347,12 @@ async function rescanTenant(
 		}
 	}
 
-	const expectedTotal = queuedCount + erroredCount;
+	const expectedTotal = selectedDomains.length + erroredCount;
 	if (expectedTotal === 0) return;
 
 	let baselineCycleId: string | null = null;
 	try {
-		const baselineRow = await env
-			.TENANT_REGISTRY_DB!.prepare(FIND_BASELINE_CYCLE_SQL)
-			.bind(tenant.id)
-			.first<{ id: string }>();
+		const baselineRow = await env.TENANT_REGISTRY_DB!.prepare(FIND_BASELINE_CYCLE_SQL).bind(tenant.id).first<{ id: string }>();
 		baselineCycleId = baselineRow?.id ?? null;
 	} catch {
 		// Baseline lookup is best-effort — alert sweep falls back to
@@ -358,8 +360,9 @@ async function rescanTenant(
 	}
 
 	try {
-		await env.TENANT_REGISTRY_DB!.prepare(INSERT_CYCLE_SQL)
-			.bind(cycleId, tenant.super_tenant_id, tenant.id, tNow, expectedTotal, baselineCycleId)
+		await env
+			.TENANT_REGISTRY_DB!.prepare(INSERT_CYCLE_SQL)
+			.bind(cycleId, tenant.super_tenant_id, tenant.id, tNow, expectedTotal, erroredCount, baselineCycleId)
 			.run();
 	} catch (err) {
 		logError(err instanceof Error ? err : String(err), {
@@ -374,14 +377,25 @@ async function rescanTenant(
 		return;
 	}
 
-	if (erroredCount > 0) {
+	// The complete expected count and fingerprint errors must exist before any
+	// consumer can run. A failed insert above publishes no work.
+	let sendErrors = 0;
+	for (const domain of selectedDomains) {
 		try {
-			await env.TENANT_REGISTRY_DB!.prepare(INCREMENT_ERRORED_SQL)
-				.bind(erroredCount, cycleId)
-				.run();
-		} catch {
-			// Log only; the cycle is still tracked, just with errored_total stuck at 0.
+			await env.BV_SCANNER_QUEUE!.send({ cycle_id: cycleId, sub_tenant_id: tenant.id, domain }, { contentType: 'json' });
+			queuedCount += 1;
+		} catch (err) {
+			sendErrors += 1;
+			logError(err instanceof Error ? err : String(err), {
+				severity: 'warn',
+				category: 'tenant.scheduled',
+				details: { message: 'tenant_weekly_rescan_queue_send_failed', subTenantId: tenant.id, cycleId },
+			});
 		}
+	}
+	if (sendErrors > 0) {
+		await env.TENANT_REGISTRY_DB!.prepare(INCREMENT_ERRORED_SQL).bind(sendErrors, cycleId).run();
+		erroredCount += sendErrors;
 	}
 
 	logEvent({
@@ -404,7 +418,8 @@ async function rescanTenant(
  *
  * For each settled cycle without an alert:
  *   1. Pull current findings (`scan_id IN (SELECT id FROM scans WHERE cycle_id = ?)`)
- *   2. Pull baseline findings if `baseline_cycle_id` is set.
+ *   2. Pull each measured domain's latest successful prior findings when a
+ *      baseline exists; skipped and failed domains retain their prior knowledge.
  *   3. `computeCycleDiff` produces a `TenantCycleAlert` payload.
  *   4. If totals.deltas === 0 → mark `'no_diff'`, no webhook call.
  *   5. Else `sendTenantAlert(payload, env)`. On `delivered: false` mark
@@ -428,6 +443,32 @@ export async function handleTenantCycleAlerts(
 
 	const now = options.now ?? (() => Date.now());
 	const send = options.sendAlert ?? sendTenantAlert;
+
+	// Recover completion writes lost during a registry outage, including when the
+	// queue exhausted delivery retries after the tenant scan was already durable.
+	try {
+		const unsettled = await env.TENANT_REGISTRY_DB.prepare(UNSETTLED_CYCLES_SQL)
+			.bind(MAX_CYCLES_PER_ALERT_TICK)
+			.all<{ id: string; sub_tenant_id: string }>();
+		for (const cycle of unsettled.results ?? []) {
+			try {
+				const { db } = await resolveTenantUncached(env, cycle.sub_tenant_id);
+				await synchronizeCycleProgress(env.TENANT_REGISTRY_DB, db, cycle.id);
+			} catch (err) {
+				logError(err instanceof Error ? err : String(err), {
+					severity: 'warn',
+					category: 'tenant.scheduled',
+					details: { message: 'tenant_cycle_reconcile_failed', cycleId: cycle.id },
+				});
+			}
+		}
+	} catch (err) {
+		logError(err instanceof Error ? err : String(err), {
+			severity: 'warn',
+			category: 'tenant.scheduled',
+			details: { message: 'tenant_cycle_reconcile_query_failed' },
+		});
+	}
 
 	let pending: PendingCycleRow[];
 	try {
@@ -522,7 +563,7 @@ async function processCycleAlert(
 	try {
 		const [curr, base] = await Promise.all([
 			tenantDb.prepare(FINDINGS_FOR_CYCLE_SQL).bind(cycle.id).all<FindingRowDb>(),
-			tenantDb.prepare(FINDINGS_FOR_CYCLE_SQL).bind(cycle.baseline_cycle_id).all<FindingRowDb>(),
+			tenantDb.prepare(BASELINE_FINDINGS_SQL).bind(cycle.started_at, cycle.id).all<FindingRowDb>(),
 		]);
 		currentFindings = (curr.results ?? []).map(toFindingRow);
 		baselineFindings = (base.results ?? []).map(toFindingRow);
@@ -535,8 +576,7 @@ async function processCycleAlert(
 				cycleId: cycle.id,
 			},
 		});
-		// Mark as webhook_failed-equivalent so we don't loop on a permanently-broken cycle.
-		await stamp('findings_query_failed');
+		// Leave the cycle retryable: a transient read must not permanently lose its alert.
 		return;
 	}
 

--- a/test/tenants/alerts/diff.test.ts
+++ b/test/tenants/alerts/diff.test.ts
@@ -115,6 +115,75 @@ describe('computeCycleDiff', () => {
 		expect(out.totals.deltas).toBe(0);
 	});
 
+	it('unchanged findings in one category do not produce drift in either input order', () => {
+		const findings = [row('example.com', 'spf', 'high', 'Permissive policy'), row('example.com', 'spf', 'low', 'Redundant include')];
+		for (const current of [findings, [...findings].reverse()]) {
+			for (const baseline of [findings, [...findings].reverse()]) {
+				expect(computeCycleDiff(current, baseline, baseOpts).totals.deltas).toBe(0);
+			}
+		}
+	});
+
+	it('detects a gain and loss within a category that still has another finding', () => {
+		const unchanged = row('example.com', 'spf', 'high', 'Permissive policy');
+		const out = computeCycleDiff(
+			[unchanged, row('example.com', 'spf', 'low', 'New include issue')],
+			[unchanged, row('example.com', 'spf', 'low', 'Old include issue')],
+			baseOpts,
+		);
+		expect(out.totals.deltas).toBe(2);
+		expect(out.highlights).toEqual([
+			expect.objectContaining({ delta: 'gained', title: 'New include issue', severity: 'low' }),
+			expect.objectContaining({ delta: 'lost', title: 'Old include issue', severity: 'low' }),
+		]);
+	});
+
+	it('attributes a severity transition to its finding within a shared category', () => {
+		const unchanged = row('example.com', 'spf', 'high', 'Permissive policy');
+		const out = computeCycleDiff(
+			[row('example.com', 'spf', 'medium', 'Include issue'), unchanged],
+			[unchanged, row('example.com', 'spf', 'low', 'Include issue')],
+			baseOpts,
+		);
+		expect(out.totals.deltas).toBe(1);
+		expect(out.highlights[0]).toMatchObject({
+			delta: 'severity_changed',
+			title: 'Include issue',
+			severity: 'medium',
+			previous_severity: 'low',
+		});
+	});
+
+	it('matches duplicate occurrences at equal severity before pairing severity transitions', () => {
+		const high = row('example.com', 'spf', 'high', 'Include issue');
+		const low = row('example.com', 'spf', 'low', 'Include issue');
+		const medium = row('example.com', 'spf', 'medium', 'Include issue');
+		const baseline = [high, low, low];
+		expect(computeCycleDiff([low, high, low], baseline, baseOpts).totals.deltas).toBe(0);
+
+		const out = computeCycleDiff([medium, low, high], baseline, baseOpts);
+		expect(out.totals.deltas).toBe(1);
+		expect(out.highlights[0]).toMatchObject({ delta: 'severity_changed', severity: 'medium', previous_severity: 'low' });
+		expect(computeCycleDiff([high, low, medium], [...baseline].reverse(), baseOpts)).toEqual(out);
+	});
+
+	it('counts gained and lost duplicate occurrences individually', () => {
+		const finding = row('example.com', 'spf', 'low', 'Include issue');
+		const gained = computeCycleDiff([finding, finding, finding], [finding], baseOpts);
+		const lost = computeCycleDiff([finding], [finding, finding, finding], baseOpts);
+		expect(gained.totals.deltas).toBe(2);
+		expect(gained.highlights.every((entry) => entry.delta === 'gained')).toBe(true);
+		expect(lost.totals.deltas).toBe(2);
+		expect(lost.highlights.every((entry) => entry.delta === 'lost')).toBe(true);
+	});
+
+	it('orders highlights deterministically when findings share domain, category, severity and delta', () => {
+		const findings = [row('example.com', 'spf', 'high', 'Zulu issue'), row('example.com', 'spf', 'high', 'Alpha issue')];
+		const out = computeCycleDiff(findings, [], baseOpts);
+		expect(out.highlights.map((entry) => entry.title)).toEqual(['Alpha issue', 'Zulu issue']);
+		expect(computeCycleDiff([...findings].reverse(), [], baseOpts)).toEqual(out);
+	});
+
 	it('null baseline_cycle_id passes through (first-ever cycle)', () => {
 		const out = computeCycleDiff([], [], { ...baseOpts, baselineCycleId: null });
 		expect(out.baseline_cycle_id).toBeNull();

--- a/test/tenants/cycle-alerts-d1.node.test.ts
+++ b/test/tenants/cycle-alerts-d1.node.test.ts
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { Miniflare, convertV4MiniflareOptions } from 'miniflare';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleTenantCycleAlerts, handleTenantWeeklyRescan } from '../../src/tenants/scheduled-handlers';
+import { synchronizeCycleProgress } from '../../src/tenants/cycle-progress';
+import { resolveTenantUncached } from '../../src/tenants/tenant-resolver';
+import type { TenantCycleAlert } from '../../src/schemas/tenant-alerts';
+
+let runtime: Miniflare;
+let registry: D1Database;
+let tenant: D1Database;
+const ctx = { waitUntil: (_promise: Promise<unknown>) => undefined };
+
+async function migrate(db: D1Database, kind: 'registry' | 'tenant') {
+	const directory = new URL(`../../src/tenants/db/migrations/${kind}/`, import.meta.url);
+	for (const file of readdirSync(directory)
+		.filter((name) => name.endsWith('.sql'))
+		.sort()) {
+		await db.exec(
+			readFileSync(new URL(file, directory), 'utf8')
+				.replace(/--[^\n]*/g, '')
+				.replace(/\s+/g, ' ')
+				.trim(),
+		);
+	}
+}
+
+function environment() {
+	return { TENANT_REGISTRY_DB: registry, TENANT_DB_TENANT_1: tenant, ALERT_WEBHOOK_URL: 'https://example.com/webhook' };
+}
+
+async function cycle(id: string, startedAt: number, expected: number, baseline: string | null = 'cycle-baseline') {
+	await registry
+		.prepare(
+			'INSERT INTO tenant_cycles (id, super_tenant_id, sub_tenant_id, started_at, expected_total, baseline_cycle_id) VALUES (?, ?, ?, ?, ?, ?)',
+		)
+		.bind(id, 'super-1', 'tenant-1', startedAt, expected, baseline)
+		.run();
+}
+
+async function scan(
+	id: string,
+	domain: string,
+	cycleId: string,
+	at: number,
+	titles: string[],
+	score: number | null = 70,
+	expected = titles.length,
+) {
+	await tenant.prepare('INSERT OR IGNORE INTO domains (domain, source, added_at) VALUES (?, ?, ?)').bind(domain, 'seed', 1).run();
+	await tenant
+		.prepare('INSERT INTO scans (id, domain, scan_at, score, finding_count, cycle_id) VALUES (?, ?, ?, ?, ?, ?)')
+		.bind(id, domain, at, score, expected, cycleId)
+		.run();
+	for (const [index, title] of titles.entries()) {
+		await tenant
+			.prepare('INSERT INTO findings (id, scan_id, domain, category, severity, title) VALUES (?, ?, ?, ?, ?, ?)')
+			.bind(`${id}-${index}`, id, domain, 'spf', 'high', title)
+			.run();
+	}
+}
+
+beforeEach(async () => {
+	runtime = new Miniflare(
+		convertV4MiniflareOptions({
+			modules: true,
+			script: 'export default { fetch() { return new Response("ok") } }',
+			d1Databases: { REGISTRY: `registry-${crypto.randomUUID()}`, TENANT: `tenant-${crypto.randomUUID()}` },
+		}),
+	);
+	registry = (await runtime.getD1Database('REGISTRY')) as unknown as D1Database;
+	tenant = (await runtime.getD1Database('TENANT')) as unknown as D1Database;
+	await migrate(registry, 'registry');
+	await migrate(tenant, 'tenant');
+	await registry
+		.prepare('INSERT INTO super_tenants (id, name, api_key_hash, d1_binding_prefix, created_at) VALUES (?, ?, ?, ?, ?)')
+		.bind('super-1', 'Synthetic super tenant', 'synthetic-key-hash', 'TENANT_DB_', 1)
+		.run();
+	await registry
+		.prepare('INSERT INTO sub_tenants (id, super_tenant_id, name, d1_db_id, created_at) VALUES (?, ?, ?, ?, ?)')
+		.bind('tenant-1', 'super-1', 'Synthetic tenant', 'synthetic-db', 1)
+		.run();
+});
+
+afterEach(async () => {
+	await runtime?.dispose();
+});
+
+describe('Tenant cycle lifecycle against real D1', () => {
+	it('persists the full cycle before immediate completions and does not double-count replay', async () => {
+		for (const domain of ['a.example.com', 'b.example.com']) {
+			await tenant.prepare('INSERT INTO domains (domain, source, added_at) VALUES (?, ?, ?)').bind(domain, 'seed', 1).run();
+		}
+		const env = environment();
+		const handle = (await resolveTenantUncached(env, 'tenant-1')).db;
+		const expectedCounts: number[] = [];
+		await handleTenantWeeklyRescan(
+			{
+				...env,
+				BV_SCANNER_QUEUE: {
+					send: async (message) => {
+						const persisted = await registry
+							.prepare('SELECT expected_total FROM tenant_cycles WHERE id = ?')
+							.bind(message.cycle_id)
+							.first<{ expected_total: number }>();
+						expectedCounts.push(persisted?.expected_total ?? -1);
+						await scan(`scan-${message.domain}`, message.domain, message.cycle_id, 1001, []);
+						await synchronizeCycleProgress(registry, handle, message.cycle_id);
+						await synchronizeCycleProgress(registry, handle, message.cycle_id);
+					},
+				},
+			},
+			ctx,
+			{
+				now: () => 1000,
+				newCycleId: () => 'cycle-fast',
+				dnsQuery: async () => ({ Status: 0, TC: false, RD: true, RA: true, AD: false, CD: false, Question: [], Answer: [] }),
+			},
+		);
+		expect(expectedCounts).toEqual([2, 2]);
+		expect(
+			await registry.prepare('SELECT expected_total, completed_total FROM tenant_cycles WHERE id = ?').bind('cycle-fast').first(),
+		).toEqual({ expected_total: 2, completed_total: 2 });
+	});
+
+	it('compares only measured domains with their latest complete pre-cycle observations', async () => {
+		await cycle('cycle-current', 1000, 4);
+		await scan('a-old', 'a.example.com', 'cycle-baseline', 100, ['Old finding']);
+		await scan('a-latest', 'a.example.com', 'cycle-intermediate', 500, ['Current finding']);
+		await scan('a-failed', 'a.example.com', 'cycle-failed', 700, ['Failure'], null);
+		await scan('a-partial', 'a.example.com', 'cycle-partial', 800, ['Partial finding'], 70, 2);
+		await scan('a-future', 'a.example.com', 'cycle-future', 2000, ['Future finding']);
+		await scan('a-current', 'a.example.com', 'cycle-current', 1001, ['Current finding']);
+		await scan('b-old', 'b.example.com', 'cycle-baseline', 100, ['Unscanned finding']);
+		await scan('c-old', 'c.example.com', 'cycle-baseline', 100, ['Resolved finding']);
+		await scan('c-current', 'c.example.com', 'cycle-current', 1001, []);
+		await scan('d-old', 'd.example.com', 'cycle-baseline', 100, ['Unmeasured finding']);
+		await scan('d-current', 'd.example.com', 'cycle-current', 1001, ['queue_dlq'], null);
+		await tenant.prepare('UPDATE findings SET category = ? WHERE scan_id = ?').bind('queue', 'd-current').run();
+		await scan('e-old', 'e.example.com', 'cycle-baseline', 100, ['Incomplete finding']);
+		await scan('e-current', 'e.example.com', 'cycle-current', 1001, [], 70, 1);
+		// Exercise the read predicates independently of progress; an already-settled
+		// legacy cycle may contain an incomplete row, which must still be excluded.
+		await registry.prepare('UPDATE tenant_cycles SET completed_total = 4 WHERE id = ?').bind('cycle-current').run();
+		const alerts: TenantCycleAlert[] = [];
+		await handleTenantCycleAlerts(environment(), ctx, {
+			now: () => 3000,
+			sendAlert: async (payload) => {
+				alerts.push(payload);
+				return { delivered: true };
+			},
+		});
+		expect(alerts).toHaveLength(1);
+		expect(alerts[0].highlights).toEqual([
+			expect.objectContaining({ domain: 'c.example.com', title: 'Resolved finding', delta: 'lost' }),
+			expect.objectContaining({ domain: 'd.example.com', title: 'queue_dlq', delta: 'gained' }),
+		]);
+	});
+
+	it('recovers lost registry progress without counting incomplete writes or duplicating completions', async () => {
+		await cycle('cycle-recover', 1000, 3, null);
+		await scan('complete', 'a.example.com', 'cycle-recover', 1001, ['Measured finding']);
+		await scan('dlq', 'b.example.com', 'cycle-recover', 1001, ['queue_dlq'], null);
+		await scan('partial', 'c.example.com', 'cycle-recover', 1001, [], 70, 1);
+		await handleTenantCycleAlerts(environment(), ctx);
+		expect(
+			await registry.prepare('SELECT completed_total, alert_sent_at FROM tenant_cycles WHERE id = ?').bind('cycle-recover').first(),
+		).toEqual({ completed_total: 2, alert_sent_at: null });
+		await tenant
+			.prepare('INSERT INTO findings (id, scan_id, domain, category, severity, title) VALUES (?, ?, ?, ?, ?, ?)')
+			.bind('repaired', 'partial', 'c.example.com', 'spf', 'high', 'Measured finding')
+			.run();
+		await handleTenantCycleAlerts(environment(), ctx, { now: () => 3000 });
+		await handleTenantCycleAlerts(environment(), ctx, { now: () => 4000 });
+		expect(
+			await registry.prepare('SELECT completed_total, alert_sent_at FROM tenant_cycles WHERE id = ?').bind('cycle-recover').first(),
+		).toEqual({ completed_total: 3, alert_sent_at: 3000 });
+	});
+});

--- a/test/tenants/queue-consumer.integration.test.ts
+++ b/test/tenants/queue-consumer.integration.test.ts
@@ -41,6 +41,12 @@ const SCAN_COMPLETION_PROBE_SQL =
 	'WHERE s.cycle_id = ? AND s.domain = ? ' +
 	'GROUP BY s.id, s.finding_count ' +
 	'LIMIT 1';
+const COMPLETED_SCANS_SQL = `
+	SELECT COUNT(*) AS completed_total FROM scans s
+	WHERE s.cycle_id = ?
+	  AND (SELECT COUNT(*) FROM findings f WHERE f.scan_id = s.id) >= COALESCE(s.finding_count, 0)
+`;
+const SYNC_COMPLETED_SQL = 'UPDATE tenant_cycles SET completed_total = MAX(completed_total, ?) WHERE id = ?';
 const SCANS_INSERT_SQL =
 	'INSERT INTO scans (id, domain, scan_at, score, grade, maturity_stage, finding_count, result_json, cycle_id) ' +
 	'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)';
@@ -240,6 +246,37 @@ describe('processScanMessage', () => {
 		expect(handleToolsCallMock).not.toHaveBeenCalled();
 	});
 
+	it('retries a registry write failure after persistence, then repairs progress without rescanning or double counting', async () => {
+		const { processScanMessage, MAX_ATTEMPTS } = await import('../../src/tenants/queue-consumer');
+		const failures = new Set([SYNC_COMPLETED_SQL]);
+		const registry = makeMockD1({
+			throwOnSql: failures,
+			rowsBySql: {
+				'SELECT active FROM sub_tenants WHERE id = ? LIMIT 1': [{ active: 1 }],
+				[REGISTRY_LOOKUP_SQL]: [{ id: TEST_TENANT_ID, super_tenant_id: 'super-tenant-1', d1_db_id: 'x', active: 1 }],
+			},
+		});
+		const rows: Record<string, unknown[]> = { [COMPLETED_SCANS_SQL]: [{ completed_total: 1 }] };
+		const tenant = makeMockD1({ rowsBySql: rows });
+		const customEnv = { ...env, TENANT_REGISTRY_DB: registry.db, [TEST_TENANT_BINDING]: tenant.db };
+		handleToolsCallMock.mockImplementation(async (_call, _kv, options) => {
+			emitScanCapture(options, validMsg.domain, { score: 90, grade: 'A', findings: [] });
+			return { isError: false, content: [] };
+		});
+		expect(await processScanMessage(validMsg, 1, customEnv, makeCtx())).toBe('retry');
+		rows[SCAN_COMPLETION_PROBE_SQL] = [{ id: 'durable-scan', finding_count: 0, persisted_findings: 0 }];
+		// Even the final scan attempt cannot silently acknowledge lost progress.
+		expect(await processScanMessage(validMsg, MAX_ATTEMPTS, customEnv, makeCtx())).toBe('retry');
+		failures.clear();
+		expect(await processScanMessage(validMsg, MAX_ATTEMPTS, customEnv, makeCtx())).toBe('ack');
+		expect(await processScanMessage(validMsg, MAX_ATTEMPTS + 1, customEnv, makeCtx())).toBe('ack');
+		expect(handleToolsCallMock).toHaveBeenCalledTimes(1);
+		expect(tenant.calls.filter((c) => c.sql === SCANS_INSERT_SQL)).toHaveLength(1);
+		expect(registry.calls.filter((c) => c.sql === SYNC_COMPLETED_SQL).map((c) => c.binds)).toEqual(
+			Array.from({ length: 4 }, () => [1, validMsg.cycle_id]),
+		);
+	});
+
 	it('returns ack and drops a malformed message (Zod failure, no retry)', async () => {
 		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
 		const { customEnv, tenantCalls } = buildEnv();
@@ -345,6 +382,29 @@ describe('processScanMessage', () => {
 		expect(dlqScan.binds[4]).toBeNull();
 	});
 
+	it('retries failed DLQ progress without creating another marker or rerunning the failed scan', async () => {
+		const { processScanMessage, MAX_ATTEMPTS } = await import('../../src/tenants/queue-consumer');
+		const failures = new Set([SYNC_COMPLETED_SQL]);
+		const registry = makeMockD1({
+			throwOnSql: failures,
+			rowsBySql: {
+				'SELECT active FROM sub_tenants WHERE id = ? LIMIT 1': [{ active: 1 }],
+				[REGISTRY_LOOKUP_SQL]: [{ id: TEST_TENANT_ID, super_tenant_id: 'super-tenant-1', d1_db_id: 'x', active: 1 }],
+			},
+		});
+		const rows: Record<string, unknown[]> = { [COMPLETED_SCANS_SQL]: [{ completed_total: 1 }] };
+		const tenant = makeMockD1({ rowsBySql: rows });
+		const customEnv = { ...env, TENANT_REGISTRY_DB: registry.db, [TEST_TENANT_BINDING]: tenant.db };
+		handleToolsCallMock.mockResolvedValue({ isError: true, content: [] });
+		expect(await processScanMessage(validMsg, MAX_ATTEMPTS, customEnv, makeCtx())).toBe('retry');
+		rows[SCAN_COMPLETION_PROBE_SQL] = [{ id: 'durable-dlq', finding_count: 1, persisted_findings: 1 }];
+		failures.clear();
+		expect(await processScanMessage(validMsg, MAX_ATTEMPTS + 1, customEnv, makeCtx())).toBe('ack');
+		expect(handleToolsCallMock).toHaveBeenCalledTimes(1);
+		expect(tenant.calls.filter((c) => c.sql === SCANS_INSERT_SQL)).toHaveLength(1);
+		expect(tenant.calls.filter((c) => c.sql === FINDINGS_INSERT_SQL)).toHaveLength(1);
+	});
+
 	it('returns retry when handleToolsCall throws on a non-final attempt', async () => {
 		handleToolsCallMock.mockRejectedValue(new Error('upstream_500'));
 		const { processScanMessage } = await import('../../src/tenants/queue-consumer');
@@ -354,7 +414,7 @@ describe('processScanMessage', () => {
 		expect(outcome).toBe('retry');
 	});
 
-	it('returns ack and writes DLQ persist_failed when D1 insert throws on the last attempt', async () => {
+	it('retries when both the scan and DLQ marker fail to persist on the last attempt', async () => {
 		handleToolsCallMock.mockImplementation(async (_call, _kv, runtimeOptions) => {
 			emitScanCapture(runtimeOptions, 'example.com', { score: 90, grade: 'A' });
 			return { isError: false, content: [{ type: 'text', text: 'ok' }] };
@@ -375,7 +435,7 @@ describe('processScanMessage', () => {
 		};
 
 		const outcome = await processScanMessage(validMsg, MAX_ATTEMPTS, customEnv, makeCtx());
-		expect(outcome).toBe('ack');
+		expect(outcome).toBe('retry');
 		expect(tenant.calls.filter((c) => c.sql === SCANS_INSERT_SQL).length).toBeGreaterThanOrEqual(1);
 	});
 

--- a/test/tenants/scheduled-handlers.integration.test.ts
+++ b/test/tenants/scheduled-handlers.integration.test.ts
@@ -411,9 +411,9 @@ describe('handleTenantWeeklyRescan', () => {
 		expect(cycleInserts).toHaveLength(1);
 		// expected_total bind position 5 (zero-indexed 4) of INSERT_CYCLE_SQL.
 		expect(cycleInserts[0].binds[4]).toBe(3);
-		const errIncs = registry.calls.filter((c) => callMatches(c.sql, INCREMENT_ERRORED_SQL));
-		expect(errIncs).toHaveLength(1);
-		expect(errIncs[0].binds[0]).toBe(1);
+		// Fingerprint errors are initialized atomically before the first send.
+		expect(cycleInserts[0].binds[5]).toBe(1);
+		expect(registry.calls.filter((c) => callMatches(c.sql, INCREMENT_ERRORED_SQL))).toHaveLength(0);
 	});
 
 	it('g. BV_SCANNER_QUEUE unbound → fail-soft, no throw', async () => {
@@ -431,6 +431,63 @@ describe('handleTenantWeeklyRescan', () => {
 		).resolves.toBeUndefined();
 		// Active-tenants enumeration NOT run — handler returns before that step.
 		expect(registry.calls.filter((c) => callMatches(c.sql, ACTIVE_TENANTS_SQL))).toHaveLength(0);
+	});
+
+	it('creates the full cycle before a fast consumer can finish the first queued domain', async () => {
+		const { handleTenantWeeklyRescan } = await import('../../src/tenants/scheduled-handlers');
+		const registry = makeMockD1({ rowsBySql: { [ACTIVE_TENANTS_SQL]: [{ id: TENANT_A, super_tenant_id: SUPER }] } });
+		const tenant = makeMockD1({
+			rowsBySql: {
+				[DUE_DOMAINS_SQL]: ['a.example.com', 'b.example.com'].map((domain) => ({
+					domain,
+					last_scanned_at: null,
+					watch_interval_hours: 168,
+					fingerprint: null,
+				})),
+			},
+		});
+		const observedCycleCounts: unknown[][] = [];
+		const queue = {
+			send: vi.fn(async () => {
+				const insert = registry.calls.find((c) => callMatches(c.sql, INSERT_CYCLE_SQL));
+				observedCycleCounts.push(insert?.binds.slice(4, 6) ?? []);
+			}),
+		};
+		await handleTenantWeeklyRescan(
+			{ ...env, TENANT_REGISTRY_DB: registry.db, [TENANT_A_BINDING]: tenant.db, BV_SCANNER_QUEUE: queue } as TenantScheduledEnv,
+			makeCtx(),
+			{
+				now: () => 1000,
+				newCycleId: () => 'cycle-fast',
+				dnsQuery: makeDnsQuery({}),
+			},
+		);
+		expect(observedCycleCounts).toEqual([
+			[2, 0],
+			[2, 0],
+		]);
+	});
+
+	it('publishes no scan work when the cycle insert fails', async () => {
+		const { handleTenantWeeklyRescan } = await import('../../src/tenants/scheduled-handlers');
+		const registry = makeMockD1({
+			rowsBySql: { [ACTIVE_TENANTS_SQL]: [{ id: TENANT_A, super_tenant_id: SUPER }] },
+			throwOnSql: new Set([INSERT_CYCLE_SQL]),
+		});
+		const tenant = makeMockD1({
+			rowsBySql: { [DUE_DOMAINS_SQL]: [{ domain: 'a.example.com', last_scanned_at: null, watch_interval_hours: 168, fingerprint: null }] },
+		});
+		const queue = makeMockQueue();
+		await handleTenantWeeklyRescan(
+			{ ...env, TENANT_REGISTRY_DB: registry.db, [TENANT_A_BINDING]: tenant.db, BV_SCANNER_QUEUE: queue } as TenantScheduledEnv,
+			makeCtx(),
+			{
+				now: () => 1000,
+				newCycleId: () => 'cycle-failed',
+				dnsQuery: makeDnsQuery({}),
+			},
+		);
+		expect(queue.sends).toHaveLength(0);
 	});
 
 	it('passes baseline_cycle_id from registry to the cycle insert when one exists', async () => {
@@ -464,8 +521,8 @@ describe('handleTenantWeeklyRescan', () => {
 
 		const inserts = registry.calls.filter((c) => callMatches(c.sql, INSERT_CYCLE_SQL));
 		expect(inserts).toHaveLength(1);
-		// baseline_cycle_id is the 6th bind (zero-indexed 5).
-		expect(inserts[0].binds[5]).toBe('baseline-cycle-7');
+		// baseline_cycle_id follows the initial errored count.
+		expect(inserts[0].binds[6]).toBe('baseline-cycle-7');
 	});
 
 	it('bounds active-tenant and due-domain enumeration per weekly tick', async () => {
@@ -517,7 +574,7 @@ function makeFindingsTenantDb(rowsByCycleId: Record<string, unknown[]>): D1Datab
 				},
 				async all<T = unknown>() {
 					if (sql.includes(FINDINGS_FOR_CYCLE_SQL)) {
-						const cycleId = binds[0] as string;
+						const cycleId = sql.includes('prior.scan_at < ?') ? 'cycle-base' : binds[0] as string;
 						const rows = rowsByCycleId[cycleId] ?? [];
 						return { results: rows as T[], success: true, meta: {} } as unknown as D1Result<T>;
 					}

--- a/test/tier-auth.spec.ts
+++ b/test/tier-auth.spec.ts
@@ -308,8 +308,7 @@ describe('tier-auth KV cache validation', () => {
 		expect(bvWeb.fetch).not.toHaveBeenCalled();
 	});
 
-	it('keeps BV_API_KEY (customer-facing) IP-gated to partner when client IP is outside OWNER_ALLOW_IPS', async () => {
-		// Regression guard: dev-key bypass must NOT extend to BV_API_KEY.
+	it('keeps BV_API_KEY IP-gated to partner when client IP is outside OWNER_ALLOW_IPS', async () => {
 		const { resolveTier } = await import('../src/lib/tier-auth');
 
 		const kv = {
@@ -443,6 +442,83 @@ describe('tier-auth KV cache validation', () => {
 	});
 });
 
+describe('tier-auth configured static API key', () => {
+	function statefulKv() {
+		const entries = new Map<string, string>();
+		const kv = {
+			get: vi.fn(async (key: string) => entries.get(key) ?? null),
+			put: vi.fn(async (key: string, value: string) => {
+				entries.set(key, value);
+			}),
+			delete: vi.fn(async (key: string) => {
+				entries.delete(key);
+			}),
+		} as unknown as KVNamespace;
+		return { kv, entries };
+	}
+
+	it('authenticates consecutive requests without caching a remote rejection of the static key', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+		const { kv } = statefulKv();
+		const bvWeb = { fetch: vi.fn(async () => Response.json({ tier: null })) } as unknown as Fetcher;
+		const env = { BV_API_KEY: 'static-api-key', RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' };
+
+		const first = await resolveTier('static-api-key', env, '192.0.2.10', 'https://example.com/mcp');
+		const second = await resolveTier('static-api-key', env, '192.0.2.10', 'https://example.com/mcp');
+
+		expect(first).toMatchObject({ authenticated: true, tier: 'owner' });
+		expect(second).toEqual(first);
+		expect(first.keyHash).toMatch(/^[a-f0-9]{64}$/);
+		expect(first.credentialHash).toBe(first.keyHash);
+		expect(first.legacyOwnerId).toBe(first.keyHash?.slice(0, 16));
+		expect(bvWeb.fetch).not.toHaveBeenCalled();
+		expect(kv.put).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		['negative', { tier: 'free', revokedAt: 1 }],
+		['positive', { tier: 'developer', revokedAt: null }],
+	])('ignores a stale %s entitlement cache and rechecks the owner IP gate on every request', async (_label, cached) => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+		const token = 'static-api-key';
+		const keyHash = Array.from(new Uint8Array(await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token))))
+			.map((byte) => byte.toString(16).padStart(2, '0'))
+			.join('');
+		const { kv, entries } = statefulKv();
+		entries.set(`tier:${keyHash}`, JSON.stringify(cached));
+		const bvWeb = { fetch: vi.fn(async () => Response.json({ tier: null })) } as unknown as Fetcher;
+		const env = {
+			BV_API_KEY: token,
+			RATE_LIMIT: kv,
+			BV_WEB: bvWeb,
+			BV_WEB_INTERNAL_KEY: 'internal-key',
+			OWNER_ALLOW_IPS: '192.0.2.10',
+		};
+
+		for (const [clientIp, tier] of [
+			['192.0.2.10', 'owner'],
+			['198.51.100.20', 'partner'],
+			[undefined, 'partner'],
+			['192.0.2.10', 'owner'],
+		]) {
+			expect(await resolveTier(token, env, clientIp, 'https://example.com/mcp')).toMatchObject({ authenticated: true, tier, keyHash });
+		}
+		expect(bvWeb.fetch).not.toHaveBeenCalled();
+		expect(kv.get).not.toHaveBeenCalled();
+	});
+
+	it('continues to reject and negative-cache unrelated credentials with a static key configured', async () => {
+		const { resolveTier } = await import('../src/lib/tier-auth');
+		const { kv } = statefulKv();
+		const bvWeb = { fetch: vi.fn(async () => Response.json({ tier: null })) } as unknown as Fetcher;
+		const env = { BV_API_KEY: 'static-api-key', RATE_LIMIT: kv, BV_WEB: bvWeb, BV_WEB_INTERNAL_KEY: 'internal-key' };
+
+		expect(await resolveTier('unrelated-api-key', env, '192.0.2.10', 'https://example.com/mcp')).toEqual({ authenticated: false });
+		expect(await resolveTier('unrelated-api-key', env, '192.0.2.10', 'https://example.com/mcp')).toEqual({ authenticated: false });
+		expect(bvWeb.fetch).toHaveBeenCalledOnce();
+	});
+});
+
 describe('tier-auth fail-closed entitlement validation', () => {
 	// ─── Successful validation only writes the bounded positive cache ───────────
 
@@ -534,7 +610,7 @@ describe('tier-auth fail-closed entitlement validation', () => {
 		expect(vi.mocked(kv.get).mock.calls.some(([key]) => String(key) === `tier:lkg:${keyHash}`)).toBe(false);
 	});
 
-	it('falls through to BV_API_KEY when bv-web throws and no LKG entry exists', async () => {
+	it('rejects an unmatched credential when bv-web throws and no LKG entry exists', async () => {
 		const { resolveTier } = await import('../src/lib/tier-auth');
 
 		const kv = {


### PR DESCRIPTION
Tenant monitoring could lose queue completion counts, treat unscanned domains as cleared findings, and emit severity changes for unchanged findings in the same category. A configured static API key could also authenticate once, then fail against a negative entitlement cache entry.

This change fixes all four behaviors:

- Create the complete cycle record before publishing queue messages. Synchronize completion from fully persisted scans so redelivery cannot double-count; retry failed persistence and reconcile missed completion writes during the alert sweep.
- Compare successfully measured domains with their latest complete observation before the current cycle. Skipped, failed, and incomplete scans retain prior security knowledge; clean scans can clear findings, and durable queue failure markers still generate operational alerts.
- Match findings by domain, category, and title, preserving duplicate occurrences and deterministic severity transitions. Since persisted findings have no stable cross-scan code, a title change is represented as a loss and a gain.
- Resolve the configured static API key before entitlement caching, preserving constant-time comparison, owner IP restrictions, and dedicated load-test credential denial precedence.

Regression coverage includes real Miniflare D1 databases initialized with the repository migrations, immediate queue completion, idempotent replay, registry recovery, partial-cycle SQL selection, and stateful authentication caches. No database migration or configuration change is required.

Validation:

- `npm test -- run`: 715 test files passed, 4 skipped; 8,728 tests passed, 13 skipped.
- `npm run typecheck`, `npm run lint`, `npm run build`, and `npm run build:wasm` passed.
- `npm run typecheck:tests` passed the existing per-file ratchet (737 errors against the existing 739 baseline; no new errors).
- `npm run validate:internal-deps`, `npm run audit:repo-safety`, staged secret scanning, and `git diff --check` passed.

Existing queue-send error accounting still has no crash recovery if publishing fails and the subsequent registry error-count update also fails; this change addresses durable scan completion recovery without introducing a new queue ledger.
