### PR TITLE
chore: release 3.76.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.76.1] - 2026-09-06
+
+### Fixed
+
+- Create tenant monitoring cycles before publishing scan work, and recover completion counts from persisted scans without double-counting retries.
+- Compare partial monitoring cycles against each measured domain's latest complete prior observation. Preserve earlier findings for unmeasured domains and retain queue failure alerts.
+- Match individual findings within a category so unchanged findings do not emit false severity-change alerts.
+- Keep configured static API keys independent of stale entitlement cache entries while preserving owner IP restrictions.
+
 ## [3.76.0] - 2026-09-05
 
 - TODO: fill in release notes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.76.0",
+	"version": "3.76.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.76.0",
+			"version": "3.76.1",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.76.0",
+	"version": "3.76.1",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.76.0",
+	"version": "3.76.1",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Release the tenant monitoring and static-key authentication fixes merged in #918 as 3.76.1. Synchronizes package.json, package-lock.json, server.json, and the changelog so production can deploy from an exact release tag.

Validation: repository safety audit passed; all 49 focused versioning, release-integrity, npm publish-surface, and server-metadata tests passed. The underlying fixes passed the full suite (8,728 tests), typecheck, lint, build, and all hosted checks in #918.
