### PR TITLE
fix(docs): correct CLAUDE.md tool counts (76/81 → 79/84) and gate them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ Guidance for Claude Code working in this repo. This file carries the big picture
 ## What is this?
 
 Blackveil DNS — source-available DNS & email security scanner, built as a Cloudflare Worker.
-76 public tools (81 registered in `TOOL_DEFS`; 5 internal-only via `INTERNAL_ONLY_TOOLS` — `map_csc_products` + the four `identity_secops` M365 tools, withdrawn 3.63.0) exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` is directly callable AND runs inside `scan_domain` (a `scanIncluded: false` special slot in `CHECK_DISPATCH`). Listed on the MCP Registry as `com.blackveilsecurity/dns`.
+79 public tools (84 registered in `TOOL_DEFS`; 5 internal-only via `INTERNAL_ONLY_TOOLS` — `map_csc_products` + the four `identity_secops` M365 tools, withdrawn 3.63.0) exposed via MCP Streamable HTTP (JSON-RPC 2.0) at `https://dns-mcp.blackveilsecurity.com/mcp`. Source of truth: `TOOL_DEFS` in `src/schemas/tool-definitions.ts`. `check_subdomain_takeover` is directly callable AND runs inside `scan_domain` (a `scanIncluded: false` special slot in `CHECK_DISPATCH`). Listed on the MCP Registry as `com.blackveilsecurity/dns`.
 
 **Version sync is automatic** — `npm version <X.Y.Z>` runs a lifecycle hook that syncs `server.json` + the `CHANGELOG.md` heading and stages them. Do not hand-edit those, `SERVER_VERSION`, or `package-lock.json` versions. Full surface list + release flow: **`bv-mcp-release` skill** (and `bv-mcp-operations` → "Version-sync surfaces").
 

--- a/scripts/tool-surface-tokens.ts
+++ b/scripts/tool-surface-tokens.ts
@@ -27,6 +27,13 @@ export const PUBLIC_TOOL_COUNT = PUBLIC_TOOLS.length;
  */
 export const CHECK_TOOL_COUNT = PUBLIC_TOOLS.filter((tool) => tool.name.startsWith('check_')).length;
 
+/**
+ * Every registered tool, public and internal-only. Only CLAUDE.md advertises
+ * this — customer-facing prose quotes the public count — but it drifted to 81
+ * against a real 84 precisely because nothing gated it.
+ */
+export const TOTAL_TOOL_COUNT = TOOLS.length;
+
 export interface ToolSurfaceToken {
 	/** Repo-relative path. */
 	file: string;
@@ -99,6 +106,23 @@ export const TOOL_SURFACE_TOKENS: ToolSurfaceToken[] = [
 		pattern: /DNS and email security scanner with (\d+) MCP tools\./,
 		expected: PUBLIC_TOOL_COUNT,
 		label: 'smithery.yaml description',
+	},
+	// CLAUDE.md was NOT covered until 2026-09-07 and had silently rotted to "76
+	// public tools (81 registered)" against a real surface of 79/84 — an agent
+	// reading it reported the (correct) server.json count as stale. It is the one
+	// file here read by an agent rather than a customer, so a wrong number
+	// propagates into reasoning rather than just into copy.
+	{
+		file: 'CLAUDE.md',
+		pattern: /^(\d+) public tools \(\d+ registered in `TOOL_DEFS`/m,
+		expected: PUBLIC_TOOL_COUNT,
+		label: 'CLAUDE.md public tool count',
+	},
+	{
+		file: 'CLAUDE.md',
+		pattern: /^\d+ public tools \((\d+) registered in `TOOL_DEFS`/m,
+		expected: TOTAL_TOOL_COUNT,
+		label: 'CLAUDE.md registered tool count',
 	},
 ];
 

--- a/test/audits/tool-surface-prose.audit.test.ts
+++ b/test/audits/tool-surface-prose.audit.test.ts
@@ -19,6 +19,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import claudeMd from '../../CLAUDE.md?raw';
 import githubSettings from '../../docs/github-settings.md?raw';
 import readme from '../../README.md?raw';
 import serverJson from '../../server.json?raw';
@@ -32,6 +33,7 @@ import { CHECK_TOOL_COUNT, PUBLIC_TOOL_COUNT, TOOL_SURFACE_TOKENS } from '../../
  * rather than being read by path. Keys must match `ToolSurfaceToken.file`.
  */
 const SOURCES: Record<string, string> = {
+	'CLAUDE.md': claudeMd,
 	'README.md': readme,
 	'docs/github-settings.md': githubSettings,
 	'extensions/vscode/README.md': vscodeReadme,


### PR DESCRIPTION
## What

CLAUDE.md advertised **"76 public tools (81 registered in `TOOL_DEFS`)"**. The real surface is **79 public / 84 registered** (5 internal-only, unchanged).

Measured from the SSOT rather than from prose:

```
TOOLS.length                                     = 84
INTERNAL_ONLY_TOOLS                              = 5
TOOLS.filter(t => !INTERNAL_ONLY_TOOLS.has(name)) = 79
```

`npm run check:tool-surface` independently reports `79 public tools, 35 check_* tools`.

## Why it rotted

Not a bad edit — a **missing gate**. `scripts/tool-surface-tokens.ts` propagates `PUBLIC_TOOL_COUNT` into six files (README ×4, `server.json`, `smithery.yaml`, `docs/github-settings.md`, vscode ×3) but **never covered CLAUDE.md**. Every customer-facing count stayed correct while the ungated one drifted.

That asymmetry had a real cost in the session that found this: an agent trusted CLAUDE.md's `76` and reported the registry's **correct** "79 MCP tools" as stale copy needing a republish. CLAUDE.md is the one file in this table's blast radius read by an *agent* rather than a customer, so a wrong number propagates into reasoning and recommendations — not just into marketing text.

## Change

- Correct the two numbers in CLAUDE.md.
- Add `TOTAL_TOOL_COUNT` (`TOOLS.length`) — CLAUDE.md is the only surface that quotes the registered total.
- Add two `CLAUDE.md` tokens, one per number, so both are now generated and gated.

## Verification

Positive control, because a passing check on a file I just edited proves nothing on its own — deliberately breaking the values must fail:

```
$ sed -i '' 's/^79 public tools (84 registered/77 public tools (99 registered/' CLAUDE.md
$ npm run check:tool-surface
  - CLAUDE.md: "CLAUDE.md public tool count" says 77, expected 79
  - CLAUDE.md: "CLAUDE.md registered tool count" says 99, expected 84
rc=1
```

Restored → `rc=0`, `Tool-surface prose is current: 79 public tools, 35 check_* tools`.

`EXPECTED_TOOL_COUNT` in `tool-count-ssot.audit.test.ts` is deliberately untouched — the generator's docblock calls it the one intentional human-acknowledgement gate.

No behaviour change: documentation plus a dev-only generator script that never ships to the Worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)