### PR TITLE
chore(gitleaks): drop the duplicated built-in rule, scope its allowlist instead

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -33,7 +33,8 @@ regexes = [
   '''mailto:[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]''', # mailto: in DMARC/TLSRPT test records
   '''support@smithery\.ai''',                                  # Smithery's public business contact
   '''support@github\.com''',                                   # GitHub's bot sign-off trailer, named in repo-safety allowlists
-  '''oldmail@retail\.com''',                                   # Fictional narrative example in older docs/MARKETING-BROCHURE.md commits
+  '''oldmail@retail\.com''',                                   # Fictional narrative example; originated in the deleted
+                                                               # docs/MARKETING-BROCHURE.md and still live in CHANGELOG.md
 ]
 
 [[rules]]
@@ -92,7 +93,6 @@ paths = [
   '''scripts/tranco-deep-.*\.json$''',     # Numeric IDs in scan artifacts
   '''scripts/phase\d+-.*\.json$''',
   '''scripts/chaos/''',                    # Test sentinels (e.g. 1234567890 placeholders)
-  '''^chaos-test-.*\.py$''',                # Old root-level path before scripts/chaos/ reshuffle
   '''crates/[^/]+/Cargo\.lock$''',         # Rust deps include numeric versions/hashes
   '''crates/[^/]+/target/''',              # Rust build artifacts (gitignored locally; safety net)
   '''docs/.*\.md$''',                      # Phone-number-shaped numerics in docs (timestamps, hashes)
@@ -166,34 +166,41 @@ id = "enterprise-architecture"
 description = "Enterprise architecture planning doc should not be committed"
 path = '''enterprise-architecture\.md$'''
 
-# ─── Built-in Rule Overrides ─────────────────────────────────────────
-# DKIM test fixtures contain base64-encoded public keys that trigger generic-api-key
+# ─── Global Allowlists ───────────────────────────────────────────────
 
-[[rules]]
-id = "generic-api-key"
-description = "Generic API Key (built-in override to allowlist test DKIM keys)"
-# Inherit the default generic-api-key pattern — override only adds allowlist
-regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:{1,3}=|\|\|:|<=|=>|:|\?=)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
-keywords = ["key","api","token","secret","client","passwd","password","auth","access"]
-[rules.allowlist]
+# DKIM test fixtures (base64 public keys) and env-var-NAME literals trip the
+# built-in `generic-api-key` rule. Scoped to that rule with `targetRules` so the
+# BUILT-IN rule stays active and keeps its own upstream regex and stopword
+# allowlists.
+#
+# This replaced a `[[rules]] id = "generic-api-key"` block that redefined the rule
+# wholesale. That is not additive: gitleaks skips a default rule whose ID the user
+# config already defines, so the block REPLACED the built-in and froze a
+# hand-copied copy of its regex, which could never track upstream fixes or inherit
+# its stopwords. Verified on gitleaks 8.30.1 by the `Description` field on the
+# emitted finding -- the RuleID is identical either way and cannot tell them apart.
+[[allowlists]]
+targetRules = ["generic-api-key"]
 paths = [
   '''test/''',                       # Test fixtures use dummy keys/tokens — never real secrets
   '''packages/[^/]+/test/''',
+  '''/__tests__/''',                  # Vitest-style colocated test dirs — the other custom
+                                      # rules already allowlist this; the replaced override
+                                      # did not, and only escaped notice because its frozen
+                                      # regex copy was narrower than upstream's current one.
 ]
 regexTarget = "match"
 # Env-var-default literals — these reference the env var name (or a placeholder
 # documented in shell-export form), not a real key. Cataloged by
 # test/audits/no-tracked-secrets.audit.test.ts (N5).
 regexes = [
-  '''process\.env\.BV_API_KEY''',           # scripts/tranco-scan.mjs:21, tranco-deep-scan.mjs:28
-  '''os\.getenv\(.{0,40}BV_API_KEY''',      # scripts/chaos/chaos-test-wasm.py:9
+  '''process\.env\.BV_API_KEY''',           # scripts/tranco-scan.mjs, tranco-deep-scan.mjs
+  '''os\.getenv\(.{0,40}BV_API_KEY''',      # scripts/chaos/chaos-test-wasm.py
   '''api_key=\$\{BV_API_KEY\}''',           # .mcp.json placeholder
-  '''bv_Kx8eZ2rdtUPfdzR8e_\.\.\.''',        # docs/client-setup.md:434 — truncated doc placeholder
+  '''bv_Kx8eZ2rdtUPfdzR8e_\.\.\.''',        # docs/client-setup.md — truncated doc placeholder
 ]
 
-# ─── Global Allowlists ───────────────────────────────────────────────
-
-[allowlist]
+[[allowlists]]
 # Threat-model report-folder timestamps (YYYYMMDD-HHMMSS, e.g. the `report_folder`
 # in threat-inventory.json) trip the default `phone-number` rule. Benign date-shaped
 # values — allow the specific pattern while keeping secret scanning active on the docs.


### PR DESCRIPTION
## What was dead

`.gitleaks.toml` declared `[[rules]] id = "generic-api-key"` alongside `[extend] useDefault = true`, with an in-file comment claiming it would *"inherit the default generic-api-key pattern — override only adds allowlist"*.

**It inherits nothing.** gitleaks' `extend()` adds a default rule only when the user config does *not* already define that ID, so a colliding ID **replaces** the built-in outright. The block was carrying a hand-copied, frozen snapshot of upstream's regex that could never track upstream fixes — and since replacing a rule also discards the built-in's own allowlists, it silently dropped upstream's stopword list too.

Replaced with a `[[allowlists]]` block carrying `targetRules = ["generic-api-key"]`, which attaches the same allowlist to the **maintained** built-in rule without redefining it. Net: ~20 lines of duplicated rule body gone, upstream's rule restored.

## Why this was invisible

Both rules emit findings under the identical `RuleID` `generic-api-key`. A finding **count**, or a check for whether the ID appears, cannot distinguish them — only the `Description` field can. Measured on gitleaks 8.30.1, one fixture tree, two configs:

| Config | `test/` | `src/` | `Description` on the finding |
|---|---|---|---|
| repo config | suppressed | fires | the repo's own text |
| override deleted | **fires** | fires | upstream's text |

That ambiguity had already produced one confident but wrong review conclusion ("the override is inert dead code" — it was live and load-bearing).

## Verification

**Differential over all 1462 tracked files** (`git archive HEAD` into a clean tree, so the scan universe is exactly what CI can ever see): **7 findings before, 7 after, zero new, zero gone.**

**Positive control on the final config** — a generic-key-shaped line under `src/` fires (with upstream's description, proving the built-in is what is active); the identical line under `test/` stays suppressed.

**Scoping control** (the security-relevant claim — the new allowlist must not blanket the path):

| Path | Rules that fire |
|---|---|
| `…/__tests__/` (newly allowlisted) | `github-pat`, `gitlab-pat` |
| non-allowlisted control, same content | `github-pat`, `gitlab-pat`, `generic-api-key` |

Only `generic-api-key` is suppressed; high-confidence credential rules still fire there.

**Repo audits that read this file**: `gitleaks-policy` + `no-tracked-secrets`, 6/6 pass.

## Three things the differential caught that inspection had not

1. **`[allowlist]` (legacy singular) cannot coexist with `[[allowlists]]`** — gitleaks refuses to load the config at all. It reports a FATAL and writes **no report file**, which reads downstream as *"0 findings"* — a clean pass. The trailing global block is migrated in the same change. Both live gates fail closed on it (CI `--exit-code 1`; the pre-commit hook checks `PIPESTATUS`), so it could not have shipped silently — but worth naming, because "scan found nothing" and "scan never ran" look identical.
2. **Restoring upstream's regex is stricter here**: it matches two DKIM *public* keys in `packages/dns-checks/src/__tests__/checks/check-dkim.test.ts` that the frozen copy did not. `/__tests__/` was missing from this rule's path allowlist while *every other custom rule in the file already had it* — a latent gap that stayed quiet only because the frozen regex was narrower. Added.
3. **One entry that looked dead was not.** The retail-example placeholder in the real-email allowlist has a deleted source file, and neither gate scans history (CI uses `--log-opts=base..head`; the hook uses `protect --staged`). Removing it regressed two findings in `CHANGELOG.md`, where the string still lives. Restored, comment corrected to name the file that actually keeps it alive.

## Also removed

The pre-reshuffle root-level chaos-test path from the `phone-number` allowlist — self-documented as legacy and superseded by the `scripts/chaos/` entry directly above it (10 tracked files). Parity re-verified after removal.

Incidental: dropped `:LINE` suffixes from four allowlist comments. Line numbers in comments rot silently; the filenames are the durable part.

🤖 Generated with [Claude Code](https://claude.com/claude-code)