### PR TITLE
chore(gitleaks): defuse two latent phone-number findings on a mandated path

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -168,6 +168,24 @@ path = '''enterprise-architecture\.md$'''
 
 # ─── Global Allowlists ───────────────────────────────────────────────
 
+# Digit runs that are phone-SHAPED but structurally cannot be a phone number.
+# Scoped to `phone-number` via targetRules, so every other rule still inspects
+# these lines -- a 64-hex string, for instance, is still examined by the
+# Cloudflare-ID and generic-api-key rules.
+#
+# Pattern-scoped on purpose rather than path-scoped: parity-fixtures.ts is a file
+# the release flow REQUIRES touching on every scoring change (PARITY_CORPUS_VERSION),
+# so a latent finding there is a landmine on a mandated path -- but exempting the
+# whole file would stop it being scanned for real secrets. Verified reachable before
+# this was added: a commit range touching these two files produced 7 findings.
+[[allowlists]]
+targetRules = ["phone-number"]
+regexTarget = "line"
+regexes = [
+  '''\b[0-9a-f]{64}\b''',   # 64-hex digests (the all-zero SHA256 sentinel in parity-fixtures.ts)
+  '''\d+\.\d{12,}''',        # IEEE-754 artifacts quoted in comments (scoring/config.ts tier-split sum)
+]
+
 # DKIM test fixtures (base64 public keys) and env-var-NAME literals trip the
 # built-in `generic-api-key` rule. Scoped to that rule with `targetRules` so the
 # BUILT-IN rule stays active and keeps its own upstream regex and stopword


### PR DESCRIPTION
## The problem

The tracked tree carried **7 dormant `phone-number` findings** — 6 on one line of `packages/dns-checks/src/parity-fixtures.ts`, 1 in `packages/dns-checks/src/scoring/config.ts`.

They were invisible day to day because both live gates are **incremental**: CI scans a commit range (`--log-opts=base..head`), the pre-commit hook scans staged content only. Nothing scans the whole tree, so a finding can sit in a tracked file indefinitely and surface only when a PR happens to touch its line.

**Reachability verified before changing anything**, not assumed: a throwaway repo holding just those two files plus the config, scanned with the same `--log-opts=HEAD~1..HEAD` form CI uses, reported all 7.

## Why it mattered

It sits on a path the release flow **mandates** touching. Per the `bv-mcp-release` skill, any scoring-behaviour change must bump `PARITY_CORPUS_VERSION` in `parity-fixtures.ts` — enforced by `parity-corpus.contract.test.ts` and `check:scoring-contract-change`. The required **Secret & PII scan** would therefore have fired on a scoring PR for a reason having nothing to do with that PR, exactly when the author is least expecting it.

## Why not fix it at the source

| File | Content | Why it stays |
|---|---|---|
| `parity-fixtures.ts` | synthetic all-zero SHA256 sentinel (63 zeros + 1); the regex finds 6 overlapping phone-shaped runs inside the zero run | it's a parity fixture — changing its value is a corpus change |
| `scoring/config.ts` | an IEEE-754 sum quoted in a **comment** explaining why strict equality was replaced with a tolerance | the long decimal *is* the evidence for the fix; rewording degrades the comment into an assertion |

## The fix

A `[[allowlists]]` block scoped by `targetRules = ["phone-number"]` with two narrow line patterns: a 64-hex digest, and a decimal with 12+ fractional digits.

**Pattern-scoped, deliberately not path-scoped.** Exempting `parity-fixtures.ts` wholesale would stop scanning a real file for real secrets in order to silence a regex artifact — and it would decay, outliving the line that motivated it. A pattern exemption states the actual invariant: digits inside a hex digest, or trailing float noise, are never a phone number in any file.

## Verification

- Full tracked tree (`git archive HEAD` → clean tree): **7 findings → 0**
- Same commit-range harness that proved reachability: **7 → 0**
- **Control A** — `phone-number` still fires on a genuine phone-shaped value with a proximity keyword. The rule is narrowed, not disabled.
- **Control B** — a high-entropy 64-hex digest on a line this allowlist covers still trips `generic-api-key`, while `phone-number` is correctly silent on it. `targetRules` scopes the exemption to one rule rather than blanketing the line.
- Audits reading this config: `gitleaks-policy` + `no-tracked-secrets`, **6/6**

Control B needed a second attempt worth recording: the first used the **all-zero** digest and nothing fired. That reads as *"the allowlist is too broad"* but was really *"gitleaks' `generic-api-key` has an entropy floor and an all-zeros string has almost none"* — the fixture was invalid, not the config. A control that fires nothing proves nothing until you've shown it *can* fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)