### PR TITLE
chore: release 3.77.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.77.0] - 2026-09-08
+
+Scoring model 1.24.0, `@blackveil/dns-checks` 1.36.0. No category weights, grade bands or severity penalties change; several finding severities do, so scores move for affected domains.
+
+### Changed
+
+- DKIM key strength: a 1024-bit RSA key is now `medium` rather than `high`. RFC 8301 §3.2 permits 1024 bits and recommends 2048, so a conforming key was being reported as a serious deficiency. Revoked and truncated keys rise to `high` — a truncated key cannot verify a signature at all.
+- A set of revoked DKIM selectors no longer reports the domain as non-sending. Selector probing cannot rule out active keys under names that were never probed, so the finding now states what was observed instead of inferring intent.
+- SPF soft fail (`~all`) is `info` when DMARC is explicitly in monitoring (`p=none`), which is the correct posture while a sender inventory is being built, and `low` under DMARC enforcement. Unknown or missing DMARC remains `low`.
+- `check_ssl` no longer reports origin TLS protocol versions or legacy-TLS findings. The browser-based probe observes its own TLS-terminating proxy handshake rather than the origin's, so the signal described the probe rather than the scanned host. Scans now report the assessment as not performed.
+
+### Fixed
+
+- DMARC external aggregate reporting authorization (RFC 9990 §4) now compares organizational domains discovered by DNS tree walk and builds the authorization record from the policy owner. A subdomain inheriting an organization-level DMARC record previously probed the wrong name and could be reported as unauthorized when it was correctly configured.
+- A DNS failure while checking reporting authorization records an explicit not-assessed result instead of passing silently, and marks the check partial so it is not cached.
+- Bounded the DNS fan-out of reporting-authorization checks. An unbounded `rua=` destination list combined with per-destination organizational lookups could expand a single DNS record into a large number of subrequests.
+- Transient DNS failures in the nameserver, MX and CAA checks are no longer written to the five-minute result cache, so a resolver blip is retried on the next scan rather than pinned. Scores are unaffected — these categories were already excluded from scoring when a check could not complete.
+- DNS-over-HTTPS queries now start each attempt's timeout when the request is dispatched rather than while it waits for a connection slot, so a queued query no longer spends its allowance waiting. Timeout errors are retried alongside aborts.
+- `map_supply_chain` labels self-hosted nameserver and mail-exchange infrastructure explicitly instead of omitting it, matching how self-hosted SPF is already reported.
+
+### Added
+
+- `npm run audit:client-ip-headers` — a read-only aggregate audit of client-IP header presence on the public request path that reports an unknown result rather than a healthy one when there is insufficient evidence.
+
 ## [3.76.1] - 2026-09-06
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.76.1",
+	"version": "3.77.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "blackveil-dns",
-			"version": "3.76.1",
+			"version": "3.77.0",
 			"license": "BUSL-1.1",
 			"workspaces": [
 				"packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "blackveil-dns",
-	"version": "3.76.1",
+	"version": "3.77.0",
 	"license": "BUSL-1.1",
 	"type": "module",
 	"bin": {

--- a/server.json
+++ b/server.json
@@ -8,7 +8,7 @@
 		"url": "https://github.com/MadaBurns/bv-mcp",
 		"source": "github"
 	},
-	"version": "3.76.1",
+	"version": "3.77.0",
 	"remotes": [
 		{
 			"type": "streamable-http",


### PR DESCRIPTION
Release commit for **3.77.0**. Version surfaces only — no code changes.

Carries the scoring work merged in #927: `SCORING_MODEL_VERSION` **1.24.0**, `@blackveil/dns-checks` **1.36.0** (both bumped in that PR, per the per-behaviour-change rule; the release commit does not touch them).

## Version surfaces — all four synced to 3.77.0

| Surface | Value |
|---|---|
| `package.json` | 3.77.0 |
| `package-lock.json` (root + `packages[""]`) | 3.77.0 |
| `server.json` (top-level; remotes-only, no `packages` stanza) | 3.77.0 |
| `CHANGELOG.md` heading | `## [3.77.0]` |

`SERVER_VERSION` auto-derives from `pkg.version` and is deliberately not hand-edited.

`server.json` is a **1-line** diff — the indentation is untouched, avoiding the re-serialization shape that silently broke releases 3.40.0–3.42.0.

## Why minor, not patch

Scoring model 1.24.0 changes several finding severities (DKIM 1024-bit `high`→`medium`, revoked/truncated → `high`, SPF `~all` by DMARC posture), so scores move for affected domains. No category weights, grade bands or `SEVERITY_PENALTIES` entries change.

## Not in this PR

Deploy and MCP Registry publish are separate operator-run steps. Per the release skill's ordering rule the registry publish must come **after** `npm run deploy:prod`, never before — publishing first would advertise a version prod isn't serving.

## Known pre-existing gap

The `## [3.76.0]` section still reads `TODO: fill in release notes` from an earlier release. Left as-is rather than reconstructing what shipped in that version after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
