### PR TITLE
fix(supply-chain): null MX and CAA issue ";" are directives, not providers (#932)

### DIFF
--- a/packages/dns-checks/src/checks/mx-analysis.ts
+++ b/packages/dns-checks/src/checks/mx-analysis.ts
@@ -26,7 +26,14 @@ export function parseMxRecords(answers: string[]): ParsedMxRecord[] {
 	});
 }
 
-export function isNullMxRecord(record: ParsedMxRecord): boolean {
+/**
+ * RFC 7505 null MX: priority 0 with a root (`.`) exchange, meaning the domain
+ * explicitly accepts NO inbound mail. Parsers strip the trailing dot, so the
+ * exchange arrives as `''` or `'.'` depending on the caller's normalisation.
+ * Accepts any object carrying an `exchange` so Worker-side MX shapes (which
+ * lack `raw`) can share the classification instead of re-deriving it.
+ */
+export function isNullMxRecord(record: Pick<ParsedMxRecord, 'exchange'>): boolean {
 	return record.exchange === '' || record.exchange === '.';
 }
 

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -110,7 +110,7 @@ export type {
 // RFC 8657 CAA parameter parsing (`accounturi` / `validationmethods`). Sourced
 // directly from the analysis module rather than the `./checks` barrel, which
 // re-exports only the record-level `parseCaaRecord`.
-export { parseCaaParameters } from './checks/caa-analysis';
+export { parseCaaParameters, MAX_CAA_ISSUERS, MAX_CAA_TOKEN_LENGTH, TRUNCATION_MARKER } from './checks/caa-analysis';
 export type { CaaParameters } from './checks/caa-analysis';
 
 // RFC 7505 null-MX classification, shared with Worker-side consumers (map_supply_chain)

--- a/packages/dns-checks/src/index.ts
+++ b/packages/dns-checks/src/index.ts
@@ -113,6 +113,10 @@ export type {
 export { parseCaaParameters } from './checks/caa-analysis';
 export type { CaaParameters } from './checks/caa-analysis';
 
+// RFC 7505 null-MX classification, shared with Worker-side consumers (map_supply_chain)
+// so a null MX is never re-parsed — and mis-rendered as a provider — outside check_mx.
+export { isNullMxRecord } from './checks/mx-analysis';
+
 // Scoring classifiers
 export { classifyDmarc, appendDmarcCleanInfo } from './scoring/classifiers/dmarc';
 export type { DmarcFacts } from './scoring/classifiers/dmarc';

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -10,6 +10,7 @@
 import type { OutputFormat } from '../handlers/tool-args';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { queryTxtRecords, queryDnsRecords, querySrvRecords, queryMxRecords } from '../lib/dns';
+import { isNullMxRecord, parseCaaRecord, parseCaaParameters } from '@blackveil/dns-checks';
 import { sanitizeOutputText } from '../lib/output-sanitize';
 import { detectProviders, matchProviderForNsHost, matchProviderForSpfInclude, matchProviderForMxHost } from './provider-guides';
 import { detectCdnFromAsn, detectHostingFromAsn } from '../lib/cdn-asn-detection';
@@ -38,8 +39,15 @@ export interface Signal {
 		| 'shadow_service'
 		| 'insecure_service'
 		| 'security_tooling_exposed'
-		| 'shared_hosting';
-	severity: 'low' | 'medium' | 'high';
+		| 'shared_hosting'
+		| 'null_mx'
+		| 'caa_no_issuance';
+	/**
+	 * `info` is a note, not a risk: it records a DNS directive that deliberately
+	 * REMOVES a dependency (RFC 7505 null MX, RFC 8659 `issue ";"`) so the absence
+	 * of a provider row is legible rather than silent.
+	 */
+	severity: 'info' | 'low' | 'medium' | 'high';
 	detail: string;
 }
 
@@ -78,14 +86,39 @@ function extractSpfIncludesFromRecord(spfRecord: string): string[] {
 	return domains;
 }
 
-/** Parse CAA record data string into tag and value. */
-function parseCaaIssuer(data: string): string | null {
-	// Human-readable format: "0 issue "letsencrypt.org""
-	const match = data.match(/^\d+\s+(issue|issuewild)\s+"?([^"]+)"?\s*$/i);
-	if (match) {
-		return match[2].toLowerCase().replace(/\.$/, '');
-	}
-	return null;
+/**
+ * Classify one CAA record for supply-chain purposes via the shared dns-checks
+ * parsers (`parseCaaRecord` + `parseCaaParameters`) rather than a local regex.
+ *
+ * Returns the issuer domain for an `issue` / `issuewild` grant (RFC 8657
+ * parameters stripped — `letsencrypt.org; validationmethods=dns-01` is a
+ * dependency on letsencrypt.org, not on that whole string), `noIssuance` for
+ * the RFC 8659 §4.2 deny-all form (`issue ";"`), which names NO provider, and
+ * `null` for every other tag or an empty value. Closes #932: the previous regex
+ * captured `;` as an issuer and rendered a CA called `;`.
+ */
+function classifyCaaRecord(data: string): { issuer: string } | { noIssuance: true; tag: string } | null {
+	const record = parseCaaRecord(data);
+	if (record === null) return null;
+	if (record.tag !== 'issue' && record.tag !== 'issuewild') return null;
+	const params = parseCaaParameters(record.value);
+	if (params.noIssuance) return { noIssuance: true, tag: record.tag };
+	const issuer = params.issuerDomain.replace(/\.$/, '');
+	return issuer.length > 0 ? { issuer } : null;
+}
+
+/**
+ * Whether a string can stand as a provider row name. Rejects empty, whitespace-only
+ * and punctuation-only strings (`''`, `';'`, `'.'`) — every degenerate name that
+ * has reached a row so far came from a DNS directive whose *value* is a symbol
+ * (RFC 7505 `0 .`, RFC 8659 `issue ";"`), and each source-specific classifier
+ * above should catch its own; this is the generic backstop so the next cousin of
+ * #286 / #932 cannot surface as a provider named `""`. Requires at least one
+ * letter or digit — the weakest test that still admits every legitimate name
+ * (hostnames, catalog names, `<domain> (self-hosted MX)` labels).
+ */
+export function isRenderableProviderName(name: string): boolean {
+	return /[\p{L}\p{N}]/u.test(name);
 }
 
 /** Determine the highest trust level for a dependency based on its sources. */
@@ -303,20 +336,33 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 	const rawNsRecords = nsSettled.status === 'fulfilled' ? nsSettled.value : [];
 	const nsHosts = rawNsRecords.map((r) => r.replace(/\.$/, '').toLowerCase());
 
-	// Extract MX exchange hosts (email-receiving providers)
+	// Extract MX exchange hosts (email-receiving providers). An RFC 7505 null MX
+	// (`0 .`) is a directive that the domain accepts NO mail — it names no
+	// provider, so it is split out here (shared `isNullMxRecord` classification
+	// from check_mx) and surfaced as a `null_mx` note below instead of a critical
+	// email-receiving row with an empty provider name (#932).
 	const rawMxRecords = mxSettled.status === 'fulfilled' ? mxSettled.value : [];
-	const mxHosts = rawMxRecords.map((r) => r.exchange.replace(/\.$/, '').toLowerCase());
+	const hasNullMx = rawMxRecords.some(isNullMxRecord);
+	const mxHosts = rawMxRecords.filter((r) => !isNullMxRecord(r)).map((r) => r.exchange.replace(/\.$/, '').toLowerCase());
 
 	// Apex A-records for the ASN-based CDN tier (resolved to origin ASN below)
 	const aRecords = aSettled.status === 'fulfilled' ? aSettled.value : [];
 
-	// Extract CAA issuers (only issue and issuewild tags)
+	// Extract CAA issuers (only issue and issuewild tags). The deny-all form
+	// (`issue ";"` / `issuewild ";"`) authorises NO CA and so yields no
+	// certificate-authority row; it is noted as `caa_no_issuance` below.
 	const rawCaaRecords = caaSettled.status === 'fulfilled' ? caaSettled.value : [];
 	const caaIssuers: string[] = [];
+	const caaNoIssuanceTags: string[] = [];
 	for (const record of rawCaaRecords) {
-		const issuer = parseCaaIssuer(record);
-		if (issuer && !caaIssuers.includes(issuer)) {
-			caaIssuers.push(issuer);
+		const classified = classifyCaaRecord(record);
+		if (classified === null) continue;
+		if ('noIssuance' in classified) {
+			if (!caaNoIssuanceTags.includes(classified.tag)) caaNoIssuanceTags.push(classified.tag);
+			continue;
+		}
+		if (!caaIssuers.includes(classified.issuer)) {
+			caaIssuers.push(classified.issuer);
 		}
 	}
 
@@ -345,6 +391,9 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 	const providerMap = new Map<string, { roles: Set<string>; sources: Set<string> }>();
 
 	function addDependency(providerName: string, source: string): void {
+		// Generic backstop (see isRenderableProviderName): a name with no letter or
+		// digit is a parsing artefact, never a vendor. Drop it rather than count it.
+		if (!isRenderableProviderName(providerName)) return;
 		const existing = providerMap.get(providerName);
 		if (existing) {
 			existing.roles.add(sourceToRole(source));
@@ -543,6 +592,28 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 		});
 	}
 
+	// Directive notes — a dependency that DNS explicitly says does not exist.
+	// Emitted as `info` so the missing row is legible, never as risk (#932).
+	if (hasNullMx) {
+		const conflict =
+			mxHosts.length > 0
+				? ` It is published alongside ${mxHosts.length} other MX record${mxHosts.length === 1 ? '' : 's'}, which RFC 7505 forbids — the null MX is dropped and the remaining exchanges are mapped as usual.`
+				: ' No email-receiving provider dependency exists.';
+		signals.push({
+			type: 'null_mx',
+			severity: 'info',
+			detail: `Null MX record (RFC 7505): the domain explicitly declares it accepts no inbound mail.${conflict}`,
+		});
+	}
+	if (caaNoIssuanceTags.length > 0) {
+		const scope = caaNoIssuanceTags.map((tag) => `${tag} ";"`).join(' and ');
+		signals.push({
+			type: 'caa_no_issuance',
+			severity: 'info',
+			detail: `CAA ${scope} (RFC 8659 §4.2): no certificate authority is authorised to issue for this scope. This is a deny-all directive, not a CA dependency.`,
+		});
+	}
+
 	// Concentration risk: provider appears in 3+ roles
 	for (const dep of dependencies) {
 		if (dep.roles.length >= 3) {
@@ -711,7 +782,7 @@ export function formatSupplyChain(result: SupplyChainMap, format: OutputFormat =
 	if (result.signals.length > 0) {
 		lines.push('## Risk Signals');
 		for (const signal of result.signals) {
-			const icon = signal.severity === 'high' ? '🔴' : signal.severity === 'medium' ? '🟠' : '🟡';
+			const icon = signal.severity === 'high' ? '🔴' : signal.severity === 'medium' ? '🟠' : signal.severity === 'low' ? '🟡' : 'ℹ️';
 			lines.push(`${icon} [${signal.severity.toUpperCase()}] ${sanitizeOutputText(signal.detail, 300)}`);
 		}
 	}

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -10,8 +10,16 @@
 import type { OutputFormat } from '../handlers/tool-args';
 import type { QueryDnsOptions } from '../lib/dns-types';
 import { queryTxtRecords, queryDnsRecords, querySrvRecords, queryMxRecords } from '../lib/dns';
-import { isNullMxRecord, parseCaaRecord, parseCaaParameters } from '@blackveil/dns-checks';
+import {
+	isNullMxRecord,
+	parseCaaRecord,
+	parseCaaParameters,
+	MAX_CAA_ISSUERS,
+	MAX_CAA_TOKEN_LENGTH,
+	TRUNCATION_MARKER,
+} from '@blackveil/dns-checks';
 import { sanitizeOutputText } from '../lib/output-sanitize';
+import { logEvent } from '../lib/log';
 import { detectProviders, matchProviderForNsHost, matchProviderForSpfInclude, matchProviderForMxHost } from './provider-guides';
 import { detectCdnFromAsn, detectHostingFromAsn } from '../lib/cdn-asn-detection';
 import { VERIFICATION_PATTERNS, SERVICE_SPF_DOMAINS } from './txt-hygiene-analysis';
@@ -97,14 +105,14 @@ function extractSpfIncludesFromRecord(spfRecord: string): string[] {
  * `null` for every other tag or an empty value. Closes #932: the previous regex
  * captured `;` as an issuer and rendered a CA called `;`.
  */
-function classifyCaaRecord(data: string): { issuer: string } | { noIssuance: true; tag: string } | null {
+function classifyCaaRecord(data: string): { issuer: string; tag: string } | { noIssuance: true; tag: string } | null {
 	const record = parseCaaRecord(data);
 	if (record === null) return null;
 	if (record.tag !== 'issue' && record.tag !== 'issuewild') return null;
 	const params = parseCaaParameters(record.value);
 	if (params.noIssuance) return { noIssuance: true, tag: record.tag };
 	const issuer = params.issuerDomain.replace(/\.$/, '');
-	return issuer.length > 0 ? { issuer } : null;
+	return issuer.length > 0 ? { issuer, tag: record.tag } : null;
 }
 
 /**
@@ -341,6 +349,10 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 	// provider, so it is split out here (shared `isNullMxRecord` classification
 	// from check_mx) and surfaced as a `null_mx` note below instead of a critical
 	// email-receiving row with an empty provider name (#932).
+	// Deliberate divergence from check_mx, which treats ANY null MX as "non-mail"
+	// and stops: the supply-chain map follows MTA behaviour (RFC 7505 §3 — skip
+	// the `.` exchange, try the next MX), so real exchanges published beside a
+	// null MX are still mapped as dependencies and the conflict is noted.
 	const rawMxRecords = mxSettled.status === 'fulfilled' ? mxSettled.value : [];
 	const hasNullMx = rawMxRecords.some(isNullMxRecord);
 	const mxHosts = rawMxRecords.filter((r) => !isNullMxRecord(r)).map((r) => r.exchange.replace(/\.$/, '').toLowerCase());
@@ -351,19 +363,30 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 	// Extract CAA issuers (only issue and issuewild tags). The deny-all form
 	// (`issue ";"` / `issuewild ";"`) authorises NO CA and so yields no
 	// certificate-authority row; it is noted as `caa_no_issuance` below.
+	// CAA values are attacker-authored DNS data: issuer names are clipped to
+	// MAX_CAA_TOKEN_LENGTH and the distinct set to MAX_CAA_ISSUERS (the same caps
+	// check_caa applies) so a hostile RRset cannot bloat `structuredContent`.
+	// Grants are counted per tag so a `;` entry beside a grant of the SAME tag is
+	// reported as a conflict, not as a denial (RFC 8659: a CA is authorised if it
+	// matches ANY `issue` record, so the empty entry simply matches no CA).
 	const rawCaaRecords = caaSettled.status === 'fulfilled' ? caaSettled.value : [];
-	const caaIssuers: string[] = [];
-	const caaNoIssuanceTags: string[] = [];
+	const caaIssuers = new Set<string>();
+	const caaGrantsByTag = new Map<string, number>();
+	const caaNoIssuanceTags = new Set<string>();
 	for (const record of rawCaaRecords) {
 		const classified = classifyCaaRecord(record);
 		if (classified === null) continue;
 		if ('noIssuance' in classified) {
-			if (!caaNoIssuanceTags.includes(classified.tag)) caaNoIssuanceTags.push(classified.tag);
+			caaNoIssuanceTags.add(classified.tag);
 			continue;
 		}
-		if (!caaIssuers.includes(classified.issuer)) {
-			caaIssuers.push(classified.issuer);
-		}
+		caaGrantsByTag.set(classified.tag, (caaGrantsByTag.get(classified.tag) ?? 0) + 1);
+		if (caaIssuers.size >= MAX_CAA_ISSUERS) continue;
+		const issuer =
+			classified.issuer.length > MAX_CAA_TOKEN_LENGTH
+				? `${classified.issuer.slice(0, MAX_CAA_TOKEN_LENGTH)}${TRUNCATION_MARKER}`
+				: classified.issuer;
+		caaIssuers.add(issuer);
 	}
 
 	// Extract SRV services
@@ -392,8 +415,21 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 
 	function addDependency(providerName: string, source: string): void {
 		// Generic backstop (see isRenderableProviderName): a name with no letter or
-		// digit is a parsing artefact, never a vendor. Drop it rather than count it.
-		if (!isRenderableProviderName(providerName)) return;
+		// digit is a parsing artefact, never a vendor. Drop it rather than count it,
+		// and say so in the tail log so the next cousin of #286 is visible instead
+		// of a quietly shorter provider list.
+		if (!isRenderableProviderName(providerName)) {
+			logEvent({
+				timestamp: new Date().toISOString(),
+				severity: 'warn',
+				category: 'supply-chain',
+				tool: 'map_supply_chain',
+				domain,
+				result: 'non_renderable_provider_dropped',
+				details: { source, name: providerName.slice(0, 32) },
+			});
+			return;
+		}
 		const existing = providerMap.get(providerName);
 		if (existing) {
 			existing.roles.add(sourceToRole(source));
@@ -594,24 +630,22 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 
 	// Directive notes — a dependency that DNS explicitly says does not exist.
 	// Emitted as `info` so the missing row is legible, never as risk (#932).
+	// Details stay under 200 characters: the compact formatter clamps signal text
+	// at 200 and a note truncated mid-sentence reads as a bug.
 	if (hasNullMx) {
-		const conflict =
+		const detail =
 			mxHosts.length > 0
-				? ` It is published alongside ${mxHosts.length} other MX record${mxHosts.length === 1 ? '' : 's'}, which RFC 7505 forbids — the null MX is dropped and the remaining exchanges are mapped as usual.`
-				: ' No email-receiving provider dependency exists.';
-		signals.push({
-			type: 'null_mx',
-			severity: 'info',
-			detail: `Null MX record (RFC 7505): the domain explicitly declares it accepts no inbound mail.${conflict}`,
-		});
+				? `Null MX (RFC 7505) declares no inbound mail, but it is published alongside ${mxHosts.length} other MX record${mxHosts.length === 1 ? '' : 's'}, which RFC 7505 forbids; the null MX is dropped and the rest are mapped.`
+				: 'Null MX record (RFC 7505): the domain explicitly declares it accepts no inbound mail. No email-receiving provider dependency exists.';
+		signals.push({ type: 'null_mx', severity: 'info', detail });
 	}
-	if (caaNoIssuanceTags.length > 0) {
-		const scope = caaNoIssuanceTags.map((tag) => `${tag} ";"`).join(' and ');
-		signals.push({
-			type: 'caa_no_issuance',
-			severity: 'info',
-			detail: `CAA ${scope} (RFC 8659 §4.2): no certificate authority is authorised to issue for this scope. This is a deny-all directive, not a CA dependency.`,
-		});
+	for (const tag of caaNoIssuanceTags) {
+		const grants = caaGrantsByTag.get(tag) ?? 0;
+		const detail =
+			grants > 0
+				? `CAA: a deny-all ${tag} ";" entry is published alongside ${grants} ${tag} grant${grants === 1 ? '' : 's'}; the grants take effect (RFC 8659) — the empty entry matches no CA and adds no dependency.`
+				: `CAA ${tag} ";" (RFC 8659 §4.2): no certificate authority is authorised to issue for this scope. This is a deny-all directive, not a CA dependency.`;
+		signals.push({ type: 'caa_no_issuance', severity: 'info', detail });
 	}
 
 	// Concentration risk: provider appears in 3+ roles

--- a/src/tools/map-supply-chain.ts
+++ b/src/tools/map-supply-chain.ts
@@ -382,6 +382,13 @@ export async function mapSupplyChain(domain: string, options: MapSupplyChainOpti
 		}
 		caaGrantsByTag.set(classified.tag, (caaGrantsByTag.get(classified.tag) ?? 0) + 1);
 		if (caaIssuers.size >= MAX_CAA_ISSUERS) continue;
+		// Backstop on the PRE-clip value: TRUNCATION_MARKER contains letters, so a
+		// clipped punctuation-only issuer would otherwise pass isRenderableProviderName.
+		// Routing it through addDependency unclipped keeps the drop logged.
+		if (!isRenderableProviderName(classified.issuer)) {
+			addDependency(classified.issuer, 'caa');
+			continue;
+		}
 		const issuer =
 			classified.issuer.length > MAX_CAA_TOKEN_LENGTH
 				? `${classified.issuer.slice(0, MAX_CAA_TOKEN_LENGTH)}${TRUNCATION_MARKER}`

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -1389,6 +1389,14 @@ describe('mapSupplyChain — null MX and CAA no-issuance are directives, not pro
 		expect(caRows.some((d) => d.provider === longIssuer)).toBe(false);
 	});
 
+	it('a long punctuation-only issuer is rejected on the pre-clip value, not rescued by the letters in TRUNCATION_MARKER', async () => {
+		mockDnsResponses({ domain: 'example.com', caaRecords: [`0 issue "${'.'.repeat(100)}"`, '0 issue "letsencrypt.org"'] });
+		const result = await run('example.com');
+		const caRows = result.dependencies.filter((d) => d.roles.includes('certificate-authority')).map((d) => d.provider);
+		expect(caRows).toEqual(['letsencrypt.org']);
+		expect(result.dependencies.some((d) => d.provider.includes('...(truncated)'))).toBe(false);
+	});
+
 	it('CAA RFC 8657 parameters are stripped from the CA provider name (shared parser, not a local regex)', async () => {
 		mockDnsResponses({
 			domain: 'example.com',

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -1282,3 +1282,161 @@ describe('mapSupplyChain — catalog batch v3.3.27 (G1/G2/G3)', () => {
 		});
 	});
 });
+
+describe('mapSupplyChain — null MX and CAA no-issuance are directives, not providers (#932)', () => {
+	async function run(domain: string) {
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		return mapSupplyChain(domain);
+	}
+
+	it('net-agents.dk shape: MX `0 .` + CAA `issue ";"` yield no "" / ";" provider rows and honest counts', async () => {
+		// Measured 2026-09-08 (engine 1.36.0): net-agents.dk publishes an RFC 7505 null
+		// MX and an RFC 8659 §4.2 deny-all CAA. The mock's `host: ''` renders as `0 .`,
+		// exactly the wire form DoH returns for a null MX.
+		mockDnsResponses({
+			domain: 'net-agents.dk',
+			mxRecords: [{ pref: 0, host: '' }],
+			caaRecords: ['0 issue ";"'],
+			nsHosts: ['ns01.one.com', 'ns02.one.com'],
+		});
+
+		const result = await run('net-agents.dk');
+
+		// No degenerate provider names, whatever the source.
+		expect(result.dependencies.find((d) => d.provider === '')).toBeUndefined();
+		expect(result.dependencies.find((d) => d.provider === ';')).toBeUndefined();
+		// The directives produce no dependency of their role at all.
+		expect(result.dependencies.some((d) => d.roles.includes('email-receiving'))).toBe(false);
+		expect(result.dependencies.some((d) => d.roles.includes('certificate-authority'))).toBe(false);
+		// Only the real (DNS-hosting) dependency survives, and the summary counts survivors only.
+		expect(result.dependencies.map((d) => d.provider)).toEqual(['one.com']);
+		expect(result.summary).toEqual({ totalProviders: 1, critical: 0, high: 1, medium: 0, low: 0 });
+
+		// Both directives are surfaced as informational notes, not as risk.
+		const nullMx = result.signals.find((s) => s.type === 'null_mx');
+		expect(nullMx).toBeDefined();
+		expect(nullMx!.severity).toBe('info');
+		expect(nullMx!.detail).toMatch(/RFC 7505/);
+		const noIssuance = result.signals.find((s) => s.type === 'caa_no_issuance');
+		expect(noIssuance).toBeDefined();
+		expect(noIssuance!.severity).toBe('info');
+		expect(noIssuance!.detail).toMatch(/RFC 8659/);
+	});
+
+	it('null MX published alongside a real MX drops the null row, keeps the provider, and notes the conflict', async () => {
+		mockDnsResponses({
+			domain: 'example.com',
+			mxRecords: [
+				{ pref: 0, host: '' },
+				{ pref: 10, host: 'aspmx.l.google.com' },
+			],
+		});
+		const result = await run('example.com');
+		expect(result.dependencies.find((d) => d.provider === '')).toBeUndefined();
+		const google = result.dependencies.find((d) => d.roles.includes('email-receiving'));
+		expect(google).toBeDefined();
+		expect(google!.provider).toBe('Google Workspace');
+		const nullMx = result.signals.find((s) => s.type === 'null_mx');
+		expect(nullMx).toBeDefined();
+		expect(nullMx!.detail).toMatch(/alongside 1 other MX record/);
+	});
+
+	it('issuewild ";" is a deny-all too; a grant in the same RRset still yields its CA row', async () => {
+		mockDnsResponses({
+			domain: 'example.com',
+			caaRecords: ['0 issue "letsencrypt.org"', '0 issuewild ";"'],
+		});
+		const result = await run('example.com');
+		expect(result.dependencies.find((d) => d.provider === ';')).toBeUndefined();
+		const caRows = result.dependencies.filter((d) => d.roles.includes('certificate-authority'));
+		expect(caRows.map((d) => d.provider)).toEqual(['letsencrypt.org']);
+		expect(result.signals.find((s) => s.type === 'caa_no_issuance')?.detail).toMatch(/issuewild/);
+	});
+
+	it('CAA RFC 8657 parameters are stripped from the CA provider name (shared parser, not a local regex)', async () => {
+		mockDnsResponses({
+			domain: 'example.com',
+			caaRecords: [
+				'0 issue "letsencrypt.org; validationmethods=dns-01"',
+				'0 issue "sectigo.com; accounturi=https://acme.sectigo.com/acct/123"',
+			],
+		});
+		const result = await run('example.com');
+		const caRows = result.dependencies.filter((d) => d.roles.includes('certificate-authority')).map((d) => d.provider);
+		expect(caRows.sort()).toEqual(['letsencrypt.org', 'sectigo.com']);
+	});
+
+	it('an empty CAA issue value (`issue ""`) is neither a provider nor a no-issuance directive', async () => {
+		mockDnsResponses({ domain: 'example.com', caaRecords: ['0 issue ""'] });
+		const result = await run('example.com');
+		expect(result.dependencies.some((d) => d.roles.includes('certificate-authority'))).toBe(false);
+		expect(result.signals.find((s) => s.type === 'caa_no_issuance')).toBeUndefined();
+	});
+
+	it('a clean zone emits neither note', async () => {
+		mockDnsResponses({
+			domain: 'example.com',
+			mxRecords: [{ pref: 10, host: 'aspmx.l.google.com' }],
+			caaRecords: ['0 issue "letsencrypt.org"'],
+		});
+		const result = await run('example.com');
+		expect(result.signals.find((s) => s.type === 'null_mx')).toBeUndefined();
+		expect(result.signals.find((s) => s.type === 'caa_no_issuance')).toBeUndefined();
+	});
+
+	describe('isRenderableProviderName — the generic guard every provider row passes through', () => {
+		it('rejects empty, whitespace-only, and punctuation-only names', async () => {
+			const { isRenderableProviderName } = await import('../src/tools/map-supply-chain');
+			for (const bad of ['', ' ', '\t', ';', '.', '..', '-', '";"', '. ;']) {
+				expect(isRenderableProviderName(bad), JSON.stringify(bad)).toBe(false);
+			}
+		});
+		it('accepts hostnames, catalog names, and labelled self-hosted rows', async () => {
+			const { isRenderableProviderName } = await import('../src/tools/map-supply-chain');
+			for (const good of ['one.com', 'Google Workspace', 'example.com (self-hosted MX)', 'ns1', 'Microsoft 365']) {
+				expect(isRenderableProviderName(good), good).toBe(true);
+			}
+		});
+	});
+
+	it('formatSupplyChain renders an info-severity note in both formats', async () => {
+		const { formatSupplyChain } = await import('../src/tools/map-supply-chain');
+		const result = {
+			domain: 'net-agents.dk',
+			dependencies: [],
+			signals: [{ type: 'null_mx' as const, severity: 'info' as const, detail: 'Null MX record (RFC 7505).' }],
+			summary: { totalProviders: 0, critical: 0, high: 0, medium: 0, low: 0 },
+		};
+		expect(formatSupplyChain(result, 'compact')).toContain('[INFO] Null MX record (RFC 7505).');
+		expect(formatSupplyChain(result, 'full')).toContain('[INFO] Null MX record (RFC 7505).');
+	});
+});
+
+describe('mapSupplyChain — self-hosted MX under a ccTLD-2LD is labelled, not dropped (#926, fixed by #927)', () => {
+	it('police.govt.nz shape: self-hosted MX row + M365 SPF row, both critical', async () => {
+		// #926 reported police.govt.nz's own mx1/mx2 vanishing from the map. #927 collapses
+		// them into an explicit self-hosted row; the existing pin covers only example.com,
+		// so this exercises the reported ccTLD-2LD shape (`govt.nz` is in PUBLIC_SUFFIX_SECOND_LEVEL).
+		mockDnsResponses({
+			domain: 'police.govt.nz',
+			mxRecords: [
+				{ pref: 10, host: 'mx1.police.govt.nz' },
+				{ pref: 20, host: 'mx2.police.govt.nz' },
+			],
+			spf: 'v=spf1 include:spf.protection.outlook.com -all',
+		});
+		const { mapSupplyChain } = await import('../src/tools/map-supply-chain');
+		const result = await mapSupplyChain('police.govt.nz');
+
+		const selfHosted = result.dependencies.filter((d) => d.provider === 'police.govt.nz (self-hosted MX)');
+		expect(selfHosted).toHaveLength(1);
+		expect(selfHosted[0].roles).toContain('email-receiving');
+		expect(selfHosted[0].sources).toEqual(['mx']);
+		expect(selfHosted[0].trustLevel).toBe('critical');
+		// Neither raw host nor the bare registrable parent may leak through as its own row.
+		expect(result.dependencies.find((d) => d.provider === 'police.govt.nz')).toBeUndefined();
+		expect(result.dependencies.find((d) => /^mx[12]\.police\.govt\.nz$/.test(d.provider))).toBeUndefined();
+		expect(result.dependencies.find((d) => d.provider === 'Microsoft 365')?.trustLevel).toBe('critical');
+		expect(result.summary.critical).toBe(2);
+	});
+});

--- a/test/map-supply-chain.spec.ts
+++ b/test/map-supply-chain.spec.ts
@@ -1321,6 +1321,9 @@ describe('mapSupplyChain — null MX and CAA no-issuance are directives, not pro
 		expect(noIssuance).toBeDefined();
 		expect(noIssuance!.severity).toBe('info');
 		expect(noIssuance!.detail).toMatch(/RFC 8659/);
+		expect(noIssuance!.detail).toMatch(/no certificate authority is authorised/);
+		// Compact format clamps signal text at 200 chars — a note must never be cut mid-sentence.
+		for (const note of [nullMx!, noIssuance!]) expect(note.detail.length).toBeLessThanOrEqual(200);
 	});
 
 	it('null MX published alongside a real MX drops the null row, keeps the provider, and notes the conflict', async () => {
@@ -1338,7 +1341,23 @@ describe('mapSupplyChain — null MX and CAA no-issuance are directives, not pro
 		expect(google!.provider).toBe('Google Workspace');
 		const nullMx = result.signals.find((s) => s.type === 'null_mx');
 		expect(nullMx).toBeDefined();
-		expect(nullMx!.detail).toMatch(/alongside 1 other MX record/);
+		expect(nullMx!.detail).toMatch(/alongside 1 other MX record, which RFC 7505 forbids/);
+		expect(nullMx!.detail.length).toBeLessThanOrEqual(200);
+	});
+
+	it('issue ";" beside an issue grant is a conflict, not a denial: the grant takes effect (RFC 8659 any-match)', async () => {
+		mockDnsResponses({
+			domain: 'example.com',
+			caaRecords: ['0 issue ";"', '0 issue "letsencrypt.org"'],
+		});
+		const result = await run('example.com');
+		expect(result.dependencies.find((d) => d.provider === ';')).toBeUndefined();
+		expect(result.dependencies.filter((d) => d.roles.includes('certificate-authority')).map((d) => d.provider)).toEqual(['letsencrypt.org']);
+		const notes = result.signals.filter((s) => s.type === 'caa_no_issuance');
+		expect(notes).toHaveLength(1);
+		expect(notes[0].detail).toMatch(/alongside 1 issue grant; the grants take effect/);
+		expect(notes[0].detail).not.toMatch(/no certificate authority is authorised/);
+		expect(notes[0].detail.length).toBeLessThanOrEqual(200);
 	});
 
 	it('issuewild ";" is a deny-all too; a grant in the same RRset still yields its CA row', async () => {
@@ -1350,7 +1369,24 @@ describe('mapSupplyChain — null MX and CAA no-issuance are directives, not pro
 		expect(result.dependencies.find((d) => d.provider === ';')).toBeUndefined();
 		const caRows = result.dependencies.filter((d) => d.roles.includes('certificate-authority'));
 		expect(caRows.map((d) => d.provider)).toEqual(['letsencrypt.org']);
-		expect(result.signals.find((s) => s.type === 'caa_no_issuance')?.detail).toMatch(/issuewild/);
+		// A grant under a DIFFERENT tag does not soften the wildcard denial.
+		const note = result.signals.find((s) => s.type === 'caa_no_issuance');
+		expect(note?.detail).toMatch(/issuewild ";"/);
+		expect(note?.detail).toMatch(/no certificate authority is authorised/);
+	});
+
+	it('caps attacker-authored CAA issuer names (MAX_CAA_ISSUERS distinct, MAX_CAA_TOKEN_LENGTH each) before they reach structuredContent', async () => {
+		const { MAX_CAA_ISSUERS, MAX_CAA_TOKEN_LENGTH, TRUNCATION_MARKER } = await import('@blackveil/dns-checks');
+		const longIssuer = `${'a'.repeat(200)}.example`;
+		const many = Array.from({ length: MAX_CAA_ISSUERS + 4 }, (_, i) => `0 issue "ca${i}.example"`);
+		mockDnsResponses({ domain: 'example.com', caaRecords: [`0 issue "${longIssuer}"`, ...many] });
+		const result = await run('example.com');
+		const caRows = result.dependencies.filter((d) => d.roles.includes('certificate-authority'));
+		expect(caRows).toHaveLength(MAX_CAA_ISSUERS);
+		const clipped = caRows.find((d) => d.provider.endsWith(TRUNCATION_MARKER));
+		expect(clipped).toBeDefined();
+		expect(clipped!.provider).toBe(`${longIssuer.slice(0, MAX_CAA_TOKEN_LENGTH)}${TRUNCATION_MARKER}`);
+		expect(caRows.some((d) => d.provider === longIssuer)).toBe(false);
 	});
 
 	it('CAA RFC 8657 parameters are stripped from the CA provider name (shared parser, not a local regex)', async () => {
@@ -1407,8 +1443,9 @@ describe('mapSupplyChain — null MX and CAA no-issuance are directives, not pro
 			signals: [{ type: 'null_mx' as const, severity: 'info' as const, detail: 'Null MX record (RFC 7505).' }],
 			summary: { totalProviders: 0, critical: 0, high: 0, medium: 0, low: 0 },
 		};
-		expect(formatSupplyChain(result, 'compact')).toContain('[INFO] Null MX record (RFC 7505).');
-		expect(formatSupplyChain(result, 'full')).toContain('[INFO] Null MX record (RFC 7505).');
+		expect(formatSupplyChain(result, 'compact')).toContain('- [INFO] Null MX record (RFC 7505).');
+		// The icon is the part that changed: pre-fix the fallthrough rendered 🟡 for anything not high/medium.
+		expect(formatSupplyChain(result, 'full')).toContain('ℹ️ [INFO] Null MX record (RFC 7505).');
 	});
 });
 


### PR DESCRIPTION
## Root cause

`map_supply_chain` re-parsed MX and CAA records locally instead of reusing the classifications `check_mx` / `check_caa` already carry, so two DNS directives that *remove* a dependency were rendered as providers:

- An RFC 7505 null MX (`0 .`) arrives from `queryMxRecords` with `exchange: ''`; `getEffectiveParentDomain('')` returns `''`, and `addDependency('', 'mx')` produced a **critical** `email-receiving` row named `""`.
- The local `parseCaaIssuer` regex captured everything between the quotes, so the RFC 8659 §4.2 deny-all form `issue ";"` produced a `certificate-authority` row named `";"` (and, as a bonus defect, `issue "letsencrypt.org; validationmethods=dns-01"` produced a CA named the whole string).

Both counted toward `summary`, so net-agents.dk — a domain that explicitly refuses mail and forbids all issuance — reported 3 providers, 1 critical. Cousin of #286 (raw hostnames as providers), fixed by #287.

## Changes

- **`packages/dns-checks`**: export `isNullMxRecord` from the package index and widen its parameter to `Pick<ParsedMxRecord, 'exchange'>` so the Worker's `{ priority, exchange }` MX shape qualifies. Additive; no behaviour change for existing callers.
- **`src/tools/map-supply-chain.ts`**
  - Null MX is split out before host grouping via the shared `isNullMxRecord` and surfaced as an `info` `null_mx` note. A null MX published alongside real MX records (forbidden by RFC 7505) drops the null, maps the rest, and the note names the conflict.
  - `parseCaaIssuer` replaced by `classifyCaaRecord`, built on the shared `parseCaaRecord` + `parseCaaParameters`. `issue ";"` / `issuewild ";"` yield no row and an `info` `caa_no_issuance` note (one per tag); RFC 8657 parameters are stripped from the issuer name. Grants are counted **per tag**: a `;` entry beside ≥1 grant of the same tag is worded as a conflict (RFC 8659 authorises a CA matching *any* `issue` record, so the grants take effect and the empty entry matches no CA) — `issuewild ";"` beside an `issue` grant remains a genuine wildcard denial.
  - Issuer names are clipped to `MAX_CAA_TOKEN_LENGTH` and the distinct set to `MAX_CAA_ISSUERS` (check_caa's own caps, now exported from the package index) before reaching `structuredContent`; dedupe is a `Set`.
  - The non-renderable-name backstop emits one `warn` log line (`category: 'supply-chain'`, `result: 'non_renderable_provider_dropped'`, source + 32-char name) when it fires, so a future cousin is visible in tail logs.
  - Both note details are kept ≤ 200 chars (the compact formatter clamps signal text at 200) and the spec pins that.
  - Generic backstop: `addDependency` rejects any name with no letter or digit (`isRenderableProviderName`, exported and pinned) so the next cousin cannot surface as `""` / `";"` / `"."`. `summary` counts survivors only because rejected names never enter the map.
  - `Signal.severity` gains `info`; `Signal.type` gains `null_mx` and `caa_no_issuance`. Additive — grepped `bv-web-prod` / `bv-app` / `bv-mobile`: nothing parses `signals[].type` or `severity`. There is no output Zod schema for this tool (`MapSupplyChainArgs` is input only), and no contract test pins the shape. The full formatter renders `info` with an ℹ️ icon; compact prints `[INFO]`.

## Test evidence

`test/map-supply-chain.spec.ts` — 11 new cases (73 → 83 passing, incl. the #926 addition):

- net-agents.dk shape (`MX 0 .` + `CAA 0 issue ";"` + `one.com` NS): no `""`/`";"` rows, no `email-receiving` / `certificate-authority` role at all, `dependencies == ['one.com']`, `summary == {1, 0 critical, 1 high, 0, 0}`, both `info` notes present.
- Null MX alongside a real MX: null dropped, Google Workspace kept, conflict noted.
- `issuewild ";"` with an `issue` grant in the same RRset: `letsencrypt.org` row survives, no `;` row, wildcard denial wording stands.
- `issue ";"` + `issue "letsencrypt.org"` (review finding): `letsencrypt.org` row survives; note is the **conflict** wording, not "no CA is authorised".
- CAA caps: `MAX_CAA_ISSUERS + 4` grants plus a 200-char issuer → exactly `MAX_CAA_ISSUERS` CA rows, the long name clipped to `MAX_CAA_TOKEN_LENGTH` + `TRUNCATION_MARKER`.
- RFC 8657 parameters stripped (`letsencrypt.org; validationmethods=…`, `sectigo.com; accounturi=…`).
- Empty `issue ""` is neither a provider nor a no-issuance directive (matches `parseCaaParameters` semantics).
- Clean zone emits neither note.
- `isRenderableProviderName` rule pinned on 9 bad / 5 good inputs.
- `formatSupplyChain` renders an `info` note in both formats, asserting the full-format `ℹ️ [INFO]` icon (the part that changed).
- **#926 regression** (coordinator request): `police.govt.nz` with `mx1`/`mx2.police.govt.nz` + M365 SPF → exactly one `police.govt.nz (self-hosted MX)` row (`email-receiving`, `sources: ['mx']`, `critical`), no raw-host or bare-parent leak, `summary.critical === 2`. Passes on the base as-is — #927's fix already covers the ccTLD-2LD shape; this pins it.

TDD: 6 of the #932 cases were red before the fix (`""`/`";"` rows present, `isRenderableProviderName` undefined), green after.

Gates (worktree on f4fc873fd, fresh `npm ci`):
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm test` — **8784 passed, 0 failed**, 14 skipped, 716/721 files (re-run after the review fixes). The single "failed" file is the documented fresh-worktree `test/wasm-integration.test.ts` suite-load error (`No such module …bv_wasm_core_bg.wasm`; wasm-pack artefact not built locally), not a test failure. No teardown flake this run.

## Explicitly not handled here

- **`MX 10 localhost`** (from the issue's suggested-fix list) is **not** treated as a null MX. This matches `check_mx` / `isNullMxRecord`, which recognise only the RFC 7505 form (`0 .`); `localhost` would map to a `localhost` row today. Widening the classification is a shared-package decision for both checks, not a supply-chain-only patch.
- **`src/tools/mx-analysis.ts:21`** is a now-dead Worker-side duplicate of the package's `isNullMxRecord` (the whole file is a duplicate of `packages/dns-checks/src/checks/mx-analysis.ts`). It is imported only by `test/mx-analysis.spec.ts`, but that spec also imports sibling finding helpers the package index does not export, so repointing it needs a deep import — left for a follow-up to keep this diff small.
- Supply chain deliberately diverges from `check_mx` on a null MX published beside real MX records: `check_mx` treats any null MX as non-mail and stops; the map follows MTA behaviour (RFC 7505 §3: skip `.`, try the next MX), maps the remaining exchanges, and notes the conflict. Recorded in a code comment at the drop site.
- `CHANGELOG.md` (release flow writes it) and no version bump (the dns-checks exports are additive; ship with the next release bump).

Closes #932
Refs #926

🤖 Generated with [Claude Code](https://claude.com/claude-code)
