### PR TITLE
fix(lookalikes): a shared-platform NS pair is not ownership evidence (#929)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/), and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`check_lookalikes` / `check_shadow_domains` / `discover_brand_domains` attributed every tenant of a shared hosting platform to the seed.** A candidate on the same one.com nameserver pair as the seed (`ns01.one.com` / `ns02.one.com`, which one.com assigns to every customer) was reported `owned_by_seed` / `strong` / confidence 1.00 on `ns_set_match` alone and worded as "shares 2/2 dedicated nameservers" — the mirror image of #263/#864, and a squatter hosting a lookalike at one.com would have earned the seed's `info` severity ceiling for free. one.com joins `SHARED_NS_APEXES`; the complete-match shared-provider arm now credits only POOLED providers (Akamai — `POOLED_SHARED_NS_APEXES`, injected as `isPooledSharedNsHost`, defaults closed), so a complete match on a uniform platform is `third_party` with the new `ns_shared_platform` signal and a rationale naming the platform hosts; the `ns_set_match` rationale no longer says "dedicated". `discover_brand_domains` already dropped shared-apex overlap, so listing one.com fixes it outright. Not `scan_domain`-score-affecting (both checks are `scanIncluded: false`; no model bump). (Closes #929)
+
 ## [3.77.0] - 2026-09-08
 
 Scoring model 1.24.0, `@blackveil/dns-checks` 1.36.0. No category weights, grade bands or severity penalties change; several finding severities do, so scores move for affected domains.

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -403,8 +403,8 @@ export function isInBailiwick(nsHost: string, seedApex: string): boolean {
  *  5. Any other overlap confined to shared-provider hosts → not evidence. A partial overlap is
  *     the ANZ/Westpac 1/6-Akamai trap (a single pooled host in common is operational plumbing);
  *     a complete match on a NON-pooled platform (one.com `ns01`/`ns02`, #929) is what every
- *     tenant of that platform looks like. Falls through to 5b; if 5b declines: identical whole
- *     sets on a non-pooled platform → `unattributed` (no distinct infrastructure was observed),
+ *     tenant of that platform looks like. Falls through to 5b; if 5b declines: the candidate's
+ *     WHOLE set is platform hosts the seed uses → `unattributed` (nothing distinct observed),
  *     any other platform-confined overlap → `third_party` — both carrying `ns_shared_platform`.
  *  5b. (#864) SEED-AUTHORISED convergence — pre-filter: every real MX exchange inside the seed
  *     apex (attacker-free, no weight); verdict: the seed publishes the RFC 7489 §7.1 DMARC
@@ -537,26 +537,29 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 	// Neither verdict below moves severity (the third_party / unattributed
 	// split is wording only — see the file header); the choice is about what
 	// was OBSERVED:
-	//  - the candidate's WHOLE set is the seed's whole set, on a non-pooled
-	//    platform (one.com `ns01`/`ns02`): the hosts are the platform's,
-	//    assigned to every tenant, and NO distinct infrastructure was seen. That
-	//    is `unattributed` — "no ownership or third-party signal" — not
-	//    `third_party`, whose report wording ("registered to a different
-	//    organisation") would be a false claim about the customer's own alias
-	//    hosted on the same platform (PR #937 review).
+	//  - the candidate's WHOLE set is shared-platform hosts the seed also uses
+	//    (one.com `ns01`/`ns02`; or a candidate that carries only the platform
+	//    half of a seed that ALSO has its own hosts): the hosts are the
+	//    platform's, assigned to every tenant, and NO distinct infrastructure
+	//    was seen on the candidate. That is `unattributed` — "no ownership or
+	//    third-party signal" — not `third_party`, whose report wording
+	//    ("registered to a different organisation") would be a false claim
+	//    about the customer's own alias hosted on the same platform (PR #937
+	//    review, both rounds). The seed's total does NOT enter this test: the
+	//    `third_party` sentence below must be literally true of the CANDIDATE.
 	//  - anything else (the 1/6 Akamai partial; a one.com pair PLUS the
 	//    squatter's own `ns1.attacker.example`): the candidate's REMAINING
 	//    nameservers are distinct from the seed's, so `third_party` is what
 	//    was measured, worded for the platform overlap rather than as
 	//    "distinct infrastructure".
 	if (candidateNs.length > 0 && sharedNs.length > 0 && dedicatedShared.length === 0) {
-		const identicalSets = sharedNs.length === seedTotal && sharedNs.length === candidateNs.length;
-		if (identicalSets) {
+		const candidateWhollyOnPlatform = sharedNs.length === candidateNs.length;
+		if (candidateWhollyOnPlatform) {
 			return {
 				verdict: 'unattributed',
 				strength: 'none',
 				signals: ['ns_shared_platform'],
-				rationale: `${candidateDomain} and ${seedApex} delegate to the same shared-tenant DNS platform hosts (${sharedNs.join(', ')}), which that platform assigns to every customer — platform plumbing, not ownership evidence either way.`,
+				rationale: `${candidateDomain} delegates only to shared-tenant DNS platform hosts that ${seedApex} also uses (${sharedNs.join(', ')}), which that platform assigns to every customer — platform plumbing, not ownership evidence either way.`,
 			};
 		}
 		return {

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -124,6 +124,34 @@
  * apex would attribute — the same provider-class residual the NS
  * in-bailiwick arm already carries for DNS providers. Strength is `medium`
  * and `evidence[]` names every record so a consumer can audit the match.
+ *
+ * AMENDMENT — SHARED-PLATFORM NS PAIRS (2026-09-09, #929, the mirror image of
+ * #263/#864). The seed-side NS arms assumed that any nameserver NOT on a
+ * known shared provider is "dedicated", and that a COMPLETE match on a
+ * shared provider is medium evidence. Both assumptions fail on a platform
+ * that hands EVERY tenant the identical set: `net-agents.dk`, `net-agent.dk`
+ * and `net-agents.com` all delegate to `ns01.one.com` / `ns02.one.com`
+ * (one.com shared hosting, DoH 2026-09-09) and were attributed to each other
+ * at `strong` / confidence 1.00 on `ns_set_match` — a test that would also
+ * attribute every other one.com customer, and that a squatter satisfies by
+ * hosting the lookalike at one.com (earning the `info` ceiling the D4 gate
+ * reserves for the seed's own domains). Ruling A's bar applies to NS too: a
+ * verdict rests only on what the SEED alone can publish, and a
+ * platform-assigned NS set is not that.
+ *
+ * Fix: (1) one.com joins `SHARED_NS_APEXES`, so its hosts never count as
+ * dedicated; (2) the complete-match arm (step 4) now requires the injected
+ * `isPooledSharedNsHost` predicate to accept EVERY matched host — only a
+ * provider that draws hostnames per zone from a large pool (Akamai) makes an
+ * identical complete set per-account evidence. The predicate is optional and
+ * DEFAULTS CLOSED (nothing is pooled): a caller that omits it can never
+ * credit a platform. (3) An overlap confined to shared-provider hosts that
+ * does not earn step 4 now returns `third_party` with the `ns_shared_platform`
+ * signal and a rationale naming the platform hosts — it is the same
+ * `third_party` ceiling as before, worded for what was measured, and step 5b
+ * (the seed-published DMARC grant) keeps precedence over it. (4) The dedicated
+ * arm's rationale no longer says "dedicated"; it says the hosts are on no
+ * known shared-tenant provider, which is what was actually checked.
  */
 
 import type { CheckCategory, Finding, Severity } from '@blackveil/dns-checks/scoring';
@@ -156,6 +184,7 @@ export type OwnershipSignal =
 	| 'ns_in_bailiwick'
 	| 'ns_set_match'
 	| 'ns_shared_provider_complete'
+	| 'ns_shared_platform'
 	| 'mx_in_bailiwick'
 	| 'dmarc_report_authorised_by_seed'
 	| 'soa_in_bailiwick'
@@ -236,6 +265,17 @@ export interface ClassifyOwnershipInput {
 	 * never imports from `src/tenants/discovery/` (see file header).
 	 */
 	isSharedNsHost: (nsHost: string) => boolean;
+	/**
+	 * #929 — injected POOLED-shared-provider predicate (`isPooledSharedNsHost`
+	 * from `src/tenants/discovery/shared-ns-hosts.ts`): true for a shared
+	 * provider that assigns hostnames per zone from a pool large enough that
+	 * an identical COMPLETE set implies one account (Akamai). Step 4 credits a
+	 * complete shared-provider match ONLY when every matched host passes this.
+	 * OPTIONAL and DEFAULTS CLOSED — absent, no shared provider is pooled and
+	 * step 4 can never fire — so a caller that forgets it fails safe (no
+	 * platform is credited), never open. Must imply `isSharedNsHost`.
+	 */
+	isPooledSharedNsHost?: (nsHost: string) => boolean;
 	/**
 	 * True when the SEED's own NS lookup REJECTED (timeout / throttling), so
 	 * `seedNs` is empty because it was UNFETCHED, not because the seed has no
@@ -355,10 +395,13 @@ export function isInBailiwick(nsHost: string, seedApex: string): boolean {
  *     resolution and never reaches this arm with a matching host (Ruling B:
  *     "in-bailiwick NS requires resolution evidence").
  *  3. NS set match on hosts NOT flagged shared, >=50% AND >=2 shared → `owned_by_seed`, strong.
- *  4. Complete (100%) NS set match where every shared host is on a SHARED provider → `owned_by_seed`, medium.
- *  5. Partial overlap confined to shared-provider hosts → not evidence (falls through silently —
- *     this is the ANZ/Westpac 1/6-Akamai trap: a single shared-provider NS host in common is
- *     operational plumbing, not ownership evidence).
+ *  4. Complete (100%) NS set match where every shared host is on a POOLED shared provider
+ *     (`isPooledSharedNsHost`, #929 — Akamai; defaults closed) → `owned_by_seed`, medium.
+ *  5. Any other overlap confined to shared-provider hosts → not evidence. A partial overlap is
+ *     the ANZ/Westpac 1/6-Akamai trap (a single pooled host in common is operational plumbing);
+ *     a complete match on a NON-pooled platform (one.com `ns01`/`ns02`, #929) is what every
+ *     tenant of that platform looks like. Falls through to 5b; if 5b declines, step 6 words the
+ *     `third_party` verdict as `ns_shared_platform` rather than "distinct infrastructure".
  *  5b. (#864) SEED-AUTHORISED convergence — pre-filter: every real MX exchange inside the seed
  *     apex (attacker-free, no weight); verdict: the seed publishes the RFC 7489 §7.1 DMARC
  *     report authorisation `<candidate>._report._dmarc.<receiver-under-seed>` → `owned_by_seed`,
@@ -447,26 +490,37 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 	const sharedNs = candidateNs.filter((ns) => seedNs.includes(ns));
 	const dedicatedShared = sharedNs.filter((ns) => !input.isSharedNsHost(ns));
 	const seedTotal = seedNs.length;
+	// #929 — defaults CLOSED: with no predicate injected, no shared provider is
+	// pooled and the complete-match arm below is unreachable.
+	const isPooled = input.isPooledSharedNsHost ?? (() => false);
 
 	if (
 		seedTotal > 0 &&
 		dedicatedShared.length >= DEDICATED_NS_MATCH_MIN_COUNT &&
 		dedicatedShared.length / seedTotal >= DEDICATED_NS_MATCH_RATIO
 	) {
+		// #929 — "dedicated" was the old word here. What is actually checked is
+		// that none of the matched hosts sits on a KNOWN shared-tenant provider;
+		// say that, not more.
 		return {
 			verdict: 'owned_by_seed',
 			strength: 'strong',
 			signals: ['ns_set_match'],
-			rationale: `${candidateDomain} shares ${dedicatedShared.length}/${seedTotal} dedicated nameservers with ${seedApex}.`,
+			rationale: `${candidateDomain} shares ${dedicatedShared.length}/${seedTotal} nameservers with ${seedApex} (${dedicatedShared.join(', ')}), none on a known shared-tenant provider.`,
 		};
 	}
 
-	if (seedTotal > 0 && sharedNs.length === seedTotal && sharedNs.every((ns) => input.isSharedNsHost(ns))) {
+	if (
+		seedTotal > 0 &&
+		sharedNs.length === seedTotal &&
+		sharedNs.every((ns) => input.isSharedNsHost(ns)) &&
+		sharedNs.every((ns) => isPooled(ns))
+	) {
 		return {
 			verdict: 'owned_by_seed',
 			strength: 'medium',
 			signals: ['ns_shared_provider_complete'],
-			rationale: `${candidateDomain} matches the complete ${seedTotal}/${seedTotal} nameserver set on a shared provider. A full match is evidence; a partial match on the same provider would not be.`,
+			rationale: `${candidateDomain} matches the complete ${seedTotal}/${seedTotal} nameserver set on a pooled shared provider (${sharedNs.join(', ')}). A full match is evidence there; a partial match on the same provider would not be.`,
 		};
 	}
 
@@ -474,6 +528,22 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 	// a strong NS match is never displaced by this medium-strength verdict. Also
 	// carries the `unmeasured` outcome for an asked-but-unanswered seed probe.
 	if (convergence !== null) return convergence;
+
+	// #929 — an overlap that exists but is confined to shared-provider hosts
+	// (a complete match on a non-pooled platform such as one.com, or the 1/6
+	// Akamai partial). Same `third_party` ceiling as the arm below — a
+	// misclassification between third_party and unattributed never moves
+	// severity — but worded for what was measured: the hosts are the
+	// platform's, assigned to every tenant, and say nothing about who
+	// registered the candidate.
+	if (candidateNs.length > 0 && sharedNs.length > 0 && dedicatedShared.length === 0) {
+		return {
+			verdict: 'third_party',
+			strength: 'none',
+			signals: ['ns_shared_platform'],
+			rationale: `${candidateDomain} shares ${sharedNs.length}/${seedTotal} nameservers with ${seedApex} (${sharedNs.join(', ')}), all on a shared-tenant DNS platform that assigns the same hostnames to unrelated customers — platform plumbing, not ownership evidence.`,
+		};
+	}
 
 	if (candidateNs.length > 0) {
 		return {

--- a/src/lib/ownership-attribution.ts
+++ b/src/lib/ownership-attribution.ts
@@ -146,10 +146,13 @@
  * identical complete set per-account evidence. The predicate is optional and
  * DEFAULTS CLOSED (nothing is pooled): a caller that omits it can never
  * credit a platform. (3) An overlap confined to shared-provider hosts that
- * does not earn step 4 now returns `third_party` with the `ns_shared_platform`
- * signal and a rationale naming the platform hosts — it is the same
- * `third_party` ceiling as before, worded for what was measured, and step 5b
- * (the seed-published DMARC grant) keeps precedence over it. (4) The dedicated
+ * does not earn step 4 now carries the `ns_shared_platform` signal and a
+ * rationale naming the platform hosts: identical whole sets on a non-pooled
+ * platform → `unattributed` (nothing distinct was observed, so the report
+ * must not say "registered to a different organisation" about what may be
+ * the customer's own alias), any other platform-confined overlap →
+ * `third_party`. Same `info` ceiling either way; step 5b (the seed-published
+ * DMARC grant) keeps precedence. (4) The dedicated
  * arm's rationale no longer says "dedicated"; it says the hosts are on no
  * known shared-tenant provider, which is what was actually checked.
  */
@@ -400,8 +403,9 @@ export function isInBailiwick(nsHost: string, seedApex: string): boolean {
  *  5. Any other overlap confined to shared-provider hosts → not evidence. A partial overlap is
  *     the ANZ/Westpac 1/6-Akamai trap (a single pooled host in common is operational plumbing);
  *     a complete match on a NON-pooled platform (one.com `ns01`/`ns02`, #929) is what every
- *     tenant of that platform looks like. Falls through to 5b; if 5b declines, step 6 words the
- *     `third_party` verdict as `ns_shared_platform` rather than "distinct infrastructure".
+ *     tenant of that platform looks like. Falls through to 5b; if 5b declines: identical whole
+ *     sets on a non-pooled platform → `unattributed` (no distinct infrastructure was observed),
+ *     any other platform-confined overlap → `third_party` — both carrying `ns_shared_platform`.
  *  5b. (#864) SEED-AUTHORISED convergence — pre-filter: every real MX exchange inside the seed
  *     apex (attacker-free, no weight); verdict: the seed publishes the RFC 7489 §7.1 DMARC
  *     report authorisation `<candidate>._report._dmarc.<receiver-under-seed>` → `owned_by_seed`,
@@ -529,19 +533,37 @@ export function classifyOwnership(input: ClassifyOwnershipInput): OwnershipAsses
 	// carries the `unmeasured` outcome for an asked-but-unanswered seed probe.
 	if (convergence !== null) return convergence;
 
-	// #929 — an overlap that exists but is confined to shared-provider hosts
-	// (a complete match on a non-pooled platform such as one.com, or the 1/6
-	// Akamai partial). Same `third_party` ceiling as the arm below — a
-	// misclassification between third_party and unattributed never moves
-	// severity — but worded for what was measured: the hosts are the
-	// platform's, assigned to every tenant, and say nothing about who
-	// registered the candidate.
+	// #929 — an overlap that exists but is confined to shared-provider hosts.
+	// Neither verdict below moves severity (the third_party / unattributed
+	// split is wording only — see the file header); the choice is about what
+	// was OBSERVED:
+	//  - the candidate's WHOLE set is the seed's whole set, on a non-pooled
+	//    platform (one.com `ns01`/`ns02`): the hosts are the platform's,
+	//    assigned to every tenant, and NO distinct infrastructure was seen. That
+	//    is `unattributed` — "no ownership or third-party signal" — not
+	//    `third_party`, whose report wording ("registered to a different
+	//    organisation") would be a false claim about the customer's own alias
+	//    hosted on the same platform (PR #937 review).
+	//  - anything else (the 1/6 Akamai partial; a one.com pair PLUS the
+	//    squatter's own `ns1.attacker.example`): the candidate's REMAINING
+	//    nameservers are distinct from the seed's, so `third_party` is what
+	//    was measured, worded for the platform overlap rather than as
+	//    "distinct infrastructure".
 	if (candidateNs.length > 0 && sharedNs.length > 0 && dedicatedShared.length === 0) {
+		const identicalSets = sharedNs.length === seedTotal && sharedNs.length === candidateNs.length;
+		if (identicalSets) {
+			return {
+				verdict: 'unattributed',
+				strength: 'none',
+				signals: ['ns_shared_platform'],
+				rationale: `${candidateDomain} and ${seedApex} delegate to the same shared-tenant DNS platform hosts (${sharedNs.join(', ')}), which that platform assigns to every customer — platform plumbing, not ownership evidence either way.`,
+			};
+		}
 		return {
 			verdict: 'third_party',
 			strength: 'none',
 			signals: ['ns_shared_platform'],
-			rationale: `${candidateDomain} shares ${sharedNs.length}/${seedTotal} nameservers with ${seedApex} (${sharedNs.join(', ')}), all on a shared-tenant DNS platform that assigns the same hostnames to unrelated customers — platform plumbing, not ownership evidence.`,
+			rationale: `${candidateDomain} shares ${sharedNs.length}/${seedTotal} nameservers with ${seedApex} (${sharedNs.join(', ')}), all on a shared-tenant DNS platform that assigns the same hostnames to unrelated customers; its remaining nameservers are distinct from ${seedApex}'s — platform plumbing, not ownership evidence.`,
 		};
 	}
 
@@ -845,10 +867,14 @@ export function buildNonOwnedGateFinding(
 			: '';
 	// #832: an `unmeasured` verdict must not be TITLED "Unrelated domain" — that
 	// is the very third-party claim the degraded comparison failed to earn.
+	// #929 (PR #937 review): `unattributed` earns no "Unrelated" title either —
+	// nothing was measured that says the domain is anyone else's.
 	const title =
 		ownership.verdict === 'unmeasured'
 			? `Confusable label, ownership unmeasured this run: ${domain}`
-			: `Unrelated domain, confusable label: ${domain}`;
+			: ownership.verdict === 'unattributed'
+				? `Confusable label, ownership not established: ${domain}`
+				: `Unrelated domain, confusable label: ${domain}`;
 	return createFinding(
 		options.category,
 		title,

--- a/src/tenants/discovery/ns-correlator.ts
+++ b/src/tenants/discovery/ns-correlator.ts
@@ -185,8 +185,11 @@ export async function correlateNs(seedDomain: string, options: NsCorrelationOpti
 		// Parking services / shared-tenant DNS providers publish the same NS
 		// hostnames across many unrelated customers. Their overlap is operational
 		// plumbing, not ownership evidence — exclude them from the confidence
-		// math. Hyperscale managed DNS (Cloudflare, Route 53, GCP) assigns unique
-		// NS per account, so those remain ownership-bearing.
+		// math. Providers NOT in `SHARED_NS_APEXES` remain ownership-bearing by
+		// omission, not by proof: Route 53 draws four hosts from a large pool,
+		// but Cloud DNS hands out one of a handful of fixed
+		// `ns-cloud-*.googledomains.com` sets, so a full match there is weaker
+		// than this math credits (#929 follow-up issue, linked from PR #937).
 		const ownershipBearingShared = shared.filter((ns) => !isSharedNsHost(ns));
 		if (ownershipBearingShared.length === 0) return { candidate: null, failed: false };
 

--- a/src/tenants/discovery/shared-ns-hosts.ts
+++ b/src/tenants/discovery/shared-ns-hosts.ts
@@ -48,10 +48,16 @@ import { registeredApex } from './infrastructure-providers';
 
 /**
  * Apex-form (2-label) domains of NS providers that assign shared NS
- * hostnames across many unrelated customers. Add conservatively — false
- * negatives (missing a provider) just mean the existing orchestrator gate
- * handles it; false positives (suppressing a real Cloudflare-style signal)
- * would erase legitimate ownership evidence.
+ * hostnames across many unrelated customers.
+ *
+ * Membership bar (rewritten 2026-09-09, #929): list a provider when two
+ * UNRELATED tenants can be observed sharing NS hostnames. The cost of a
+ * missing entry is a manufacturable `owned_by_seed` — a squatter hosting a
+ * lookalike on the seed's platform earns the seed's severity ceiling — which
+ * is worse than the cost of an extra entry (an ownership lead that must be
+ * corroborated some other way). Verify with two tenants over DoH before
+ * adding; record the measurement in the entry's comment. Providers not yet
+ * verified either way are tracked in the follow-up issue linked from PR #937.
  */
 export const SHARED_NS_APEXES: ReadonlySet<string> = new Set([
 	// Parking services

--- a/src/tenants/discovery/shared-ns-hosts.ts
+++ b/src/tenants/discovery/shared-ns-hosts.ts
@@ -19,6 +19,25 @@
  * from its `confidence` math; if ALL shared NS land here, the candidate is
  * skipped entirely (no signal contribution).
  *
+ * TWO CLASSES OF SHARED PROVIDER (#929, 2026-09-09). `classifyOwnership()`
+ * (`src/lib/ownership-attribution.ts`) credits a COMPLETE NS-set match on a
+ * shared provider as medium ownership evidence — but that is only true where
+ * the provider draws hostnames per zone from a large POOL (Akamai: six from
+ * ~128 `a*-*.akam.net` hosts, so an identical 6/6 set means one account).
+ * A platform that hands EVERY tenant the same set — one.com's `ns01`/`ns02`,
+ * a parking service's `ns1`/`ns2`, a registrar default — makes a complete
+ * match the DEFAULT relationship between two unrelated customers, and a
+ * squatter who hosts a lookalike on the same platform would earn the seed's
+ * `owned_by_seed` (and its `info` severity ceiling) for free. Measured live
+ * 2026-09-09: `net-agents.dk`, `net-agent.dk` and `net-agents.com` all
+ * delegate to `ns01.one.com` / `ns02.one.com`, and were attributed to each
+ * other at confidence 1.00. So membership here is split: every apex in
+ * `SHARED_NS_APEXES` is excluded from the dedicated-NS arm, and ONLY the
+ * `POOLED_SHARED_NS_APEXES` subset may earn the complete-match arm. The
+ * default for a new shared platform is therefore the safe one — add it to
+ * `SHARED_NS_APEXES` and it can never attribute; promote it to the pooled
+ * subset only with evidence that its complete sets are per-account.
+ *
  * Ref: v2.14.0 audit, leakage risk LR-2 (defense-in-depth at the correlator
  * layer; the orchestrator's corroboration gate already filters single-signal
  * NS, this covers two-signal scenarios where parking-NS would otherwise
@@ -51,14 +70,34 @@ export const SHARED_NS_APEXES: ReadonlySet<string> = new Set([
 	'secureserver.net',
 	// Namecheap registrar-default
 	'registrar-servers.com',
+	// one.com shared hosting — every tenant delegates to the identical
+	// `ns01.one.com` / `ns02.one.com` pair (#929; verified live 2026-09-09 on
+	// net-agents.dk, net-agent.dk, net-agents.com). NOT pooled: a complete
+	// 2/2 match is what any two one.com customers look like.
+	'one.com',
 	// Akamai — assigns NS hostnames from a shared pool reused across unrelated
 	// customer zones (2026-07-26 correctness-defects design §3.3, verified
 	// live: bnz.co.nz shares a9-65.akam.net with anz.co.nz and a3-67.akam.net
 	// with westpac.co.nz). Overlap on an Akamai hostname alone is NOT
 	// ownership evidence; only a complete NS-set match is (see
-	// `classifyOwnership()` in `src/lib/ownership-attribution.ts`).
+	// `classifyOwnership()` in `src/lib/ownership-attribution.ts`) — which is
+	// why it is ALSO in `POOLED_SHARED_NS_APEXES` below.
 	'akam.net',
 ]);
+
+/**
+ * The subset of `SHARED_NS_APEXES` whose hostnames are assigned PER ZONE from
+ * a pool large enough that an identical COMPLETE set implies one account
+ * (#929). Only these may satisfy `classifyOwnership()`'s
+ * `ns_shared_provider_complete` arm; every other shared apex hands each
+ * tenant the same set, so a complete match there is not evidence.
+ *
+ * Membership is an evidence decision, not a convenience: promote an apex here
+ * only after measuring that unrelated tenants receive DIFFERENT complete sets
+ * (the Akamai measurement is in the `SHARED_NS_APEXES` comment above). The
+ * `shared-ns-hosts` audit pins that this set stays a subset of the shared set.
+ */
+export const POOLED_SHARED_NS_APEXES: ReadonlySet<string> = new Set(['akam.net']);
 
 /**
  * True if `nsHost` (a nameserver hostname like `ns1.sedoparking.com`) is
@@ -69,4 +108,15 @@ export function isSharedNsHost(nsHost: string): boolean {
 	if (!nsHost) return false;
 	const apex = registeredApex(nsHost);
 	return SHARED_NS_APEXES.has(apex);
+}
+
+/**
+ * True if `nsHost` is served by a POOLED shared-tenant provider — one whose
+ * complete NS set is per-account evidence (see `POOLED_SHARED_NS_APEXES`).
+ * Always implies `isSharedNsHost(nsHost)`.
+ */
+export function isPooledSharedNsHost(nsHost: string): boolean {
+	if (!nsHost) return false;
+	const apex = registeredApex(nsHost);
+	return POOLED_SHARED_NS_APEXES.has(apex);
 }

--- a/src/tools/check-lookalikes.ts
+++ b/src/tools/check-lookalikes.ts
@@ -36,7 +36,7 @@ import { buildCheckResult } from '../lib/scoring';
 import { generateCognitiveLookalikes, generateCombosquats, generateLookalikes } from './lookalike-analysis';
 import { calibrateLookalikeSeverity, type LookalikeSignals } from './lookalike-severity';
 import { attributionConfidence, classifyOwnership, type OwnershipAssessment } from '../lib/ownership-attribution';
-import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
+import { isPooledSharedNsHost, isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 import { extractBrandName } from '../lib/public-suffix';
 import {
 	detectWildcardParents,
@@ -336,6 +336,7 @@ async function checkLookalikesCore(
 				candidateDomain: perm,
 				registration: { state: 'registered', ns: candidateNs, evidence: candidateNs.length > 0 ? ['ns'] : ['a'] },
 				isSharedNsHost,
+				isPooledSharedNsHost,
 				seedNsUnresolved: seedNsUnmeasured,
 			}),
 		);
@@ -408,6 +409,7 @@ async function checkLookalikesCore(
 		nsByDomain: lookalikeNsMap,
 		ownershipByDomain,
 		isSharedNsHost,
+		isPooledSharedNsHost,
 		probeAuthorisation: probeDmarcReportAuthorisation,
 	});
 

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -605,13 +605,19 @@ function detectSharedNs(probes: VariantProbeResult[]): Finding[] {
 	const findings: Finding[] = [];
 	for (const [nsKey, variants] of nsMap) {
 		if (variants.length >= 2) {
+			// #929 — a pair every tenant of a shared platform receives (one.com
+			// `ns01`/`ns02`) says nothing about ownership; say so rather than
+			// "suggesting common ownership".
+			const allShared = nsKey.split(',').every((host) => isSharedNsHost(host));
 			findings.push(
 				createFinding(
 					'shadow_domains',
 					'Shared NS across shadow domains',
 					'info',
-					`${variants.join(', ')} share the same nameserver pair (${nsKey}), suggesting common ownership or registrar.`,
-					{ variants, nameservers: nsKey },
+					allShared
+						? `${variants.join(', ')} share the same nameserver pair (${nsKey}) on a shared-tenant DNS platform that assigns it to every customer — a hosting choice in common, not evidence of common ownership.`
+						: `${variants.join(', ')} share the same nameserver pair (${nsKey}), suggesting common ownership or registrar.`,
+					{ variants, nameservers: nsKey, sharedPlatform: allShared },
 				),
 			);
 		}

--- a/src/tools/check-shadow-domains.ts
+++ b/src/tools/check-shadow-domains.ts
@@ -27,7 +27,7 @@ import {
 	classifyOwnership,
 	type OwnershipAssessment,
 } from '../lib/ownership-attribution';
-import { isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
+import { isPooledSharedNsHost, isSharedNsHost } from '../tenants/discovery/shared-ns-hosts';
 
 /** Wall-clock timeout for the entire shadow domain check (ms). */
 const SHADOW_TIMEOUT_MS = 20_000;
@@ -573,6 +573,7 @@ function classifyAndGate(probe: VariantProbeResult, seedDomain: string, seedNs: 
 		candidateDomain: probe.variant,
 		registration: { state: 'registered', ns: probe.ns, evidence },
 		isSharedNsHost,
+		isPooledSharedNsHost,
 	});
 
 	// Shared mail infrastructure with the primary is the one corroborating

--- a/src/tools/lookalike-attribution.ts
+++ b/src/tools/lookalike-attribution.ts
@@ -266,6 +266,8 @@ export interface SeedAuthorisationRefinementInput {
 	/** The run's ownership map — updated IN PLACE for every probed candidate. */
 	ownershipByDomain: Map<string, OwnershipAssessment>;
 	isSharedNsHost: (nsHost: string) => boolean;
+	/** #929 — pooled-shared-provider predicate, threaded through unchanged; defaults closed inside `classifyOwnership()`. */
+	isPooledSharedNsHost?: (nsHost: string) => boolean;
 	/** Injected seed-side probe (`probeDmarcReportAuthorisation` in production; a stub in tests). */
 	probeAuthorisation: (candidate: string, seedDomain: string) => Promise<DmarcReportAuthorisation>;
 }
@@ -325,6 +327,7 @@ export async function refineOwnershipBySeedAuthorisation(
 			candidateDomain: result.domain,
 			registration: { state: 'registered', ns: candidateNs, evidence: candidateNs.length > 0 ? ['ns'] : ['a'] },
 			isSharedNsHost: input.isSharedNsHost,
+			isPooledSharedNsHost: input.isPooledSharedNsHost,
 			seedNsUnresolved: input.seedNsUnresolved,
 			candidateMx: result.mxExchanges,
 			dmarcReportAuthorisation: authorisations[index],

--- a/src/tools/lookalike-summary-findings.ts
+++ b/src/tools/lookalike-summary-findings.ts
@@ -483,8 +483,8 @@ export function buildStagingSummaryFinding(input: {
 			// lookup was dropped is whether the SET is complete — and this
 			// finding is the one making a claim about the set.
 			confidence: enumeration.complete ? 'deterministic' : 'heuristic',
-			// Present whenever the counted set shares one verdict (the realistic
-			// case — a non-owned registered candidate is always `third_party`).
+			// Present whenever the counted set shares one verdict (usually
+			// `third_party`; `unattributed` for a same-platform pair, #929).
 			// Omitted rather than fabricated for a mixed set; either way it can
 			// never be `owned_by_seed`, since owned candidates never reach here.
 			...(highVerdicts.size === 1 ? { ownershipVerdict: [...highVerdicts][0] } : {}),

--- a/test/audits/shared-ns-hosts.audit.test.ts
+++ b/test/audits/shared-ns-hosts.audit.test.ts
@@ -14,7 +14,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { isSharedNsHost } from '../../src/tenants/discovery/shared-ns-hosts';
+import {
+	isPooledSharedNsHost,
+	isSharedNsHost,
+	POOLED_SHARED_NS_APEXES,
+	SHARED_NS_APEXES,
+} from '../../src/tenants/discovery/shared-ns-hosts';
 
 const SHARED_NS_MUST_MATCH: ReadonlyArray<readonly [string, string]> = [
 	// Parking services
@@ -31,6 +36,9 @@ const SHARED_NS_MUST_MATCH: ReadonlyArray<readonly [string, string]> = [
 	['ns1.secureserver.net', 'GoDaddy secureserver'],
 	// Namecheap registrar default
 	['dns1.registrar-servers.com', 'Namecheap registrar-default NS'],
+	// one.com shared hosting — identical pair for every tenant (#929, live 2026-09-09)
+	['ns01.one.com', 'one.com shared hosting — every tenant gets ns01/ns02'],
+	['ns02.one.com', 'one.com shared hosting — every tenant gets ns01/ns02'],
 	// Akamai — hostnames are shared across unrelated customers (2026-07-26
 	// correctness-defects design §3.3: bnz.co.nz shares a9-65.akam.net with
 	// anz.co.nz and a3-67.akam.net with westpac.co.nz — three competing banks).
@@ -68,4 +76,23 @@ describe('SHARED_NS_APEXES non-coverage — hyperscale DNS must remain ownership
 		expect(isSharedNsHost('')).toBe(false);
 		expect(isSharedNsHost('   ')).toBe(false);
 	});
+});
+
+describe('POOLED_SHARED_NS_APEXES — the only shared providers a complete NS-set match may credit (#929)', () => {
+	it('is a strict subset of SHARED_NS_APEXES (a pooled host must also be excluded from the dedicated arm)', () => {
+		expect(POOLED_SHARED_NS_APEXES.size).toBeGreaterThan(0);
+		expect(POOLED_SHARED_NS_APEXES.size).toBeLessThan(SHARED_NS_APEXES.size);
+		for (const apex of POOLED_SHARED_NS_APEXES) expect(SHARED_NS_APEXES.has(apex)).toBe(true);
+	});
+
+	it('classes Akamai as pooled (six hosts per zone from a large pool — a 6/6 match is one account)', () => {
+		expect(isPooledSharedNsHost('a1-97.akam.net')).toBe(true);
+	});
+
+	for (const [ns] of SHARED_NS_MUST_MATCH) {
+		if (ns.endsWith('.akam.net')) continue;
+		it(`does NOT class ${ns} as pooled — every tenant of that platform receives the same set`, () => {
+			expect(isPooledSharedNsHost(ns)).toBe(false);
+		});
+	}
 });

--- a/test/audits/shared-ns-hosts.audit.test.ts
+++ b/test/audits/shared-ns-hosts.audit.test.ts
@@ -5,10 +5,11 @@
  *
  * The well-known parking services and registrar-default NS hosts MUST be
  * classified as shared-tenant so an overlap on their hostnames doesn't
- * inflate brand-discovery confidence. Conversely, hyperscale managed DNS
- * (Cloudflare, Route 53, GCP) MUST NOT be classified as shared-tenant —
- * those providers assign unique NS hostnames per account, so an overlap
- * there is genuine ownership evidence.
+ * inflate brand-discovery confidence. Cloudflare and Route 53 are pinned as
+ * NOT shared-tenant: they draw per-account / per-zone hostnames from a large
+ * pool, so an overlap there is ownership evidence. Cloud DNS is pinned as
+ * not-listed too, but only as the CURRENT state (see the entry's comment) —
+ * membership is an evidence decision (#929), never an assumption.
  *
  * Ref: v2.14.0 audit, LR-2 (Slice 6 defense-in-depth).
  */
@@ -51,7 +52,10 @@ const SHARED_NS_MUST_NOT_MATCH: ReadonlyArray<readonly [string, string]> = [
 	['alice.ns.cloudflare.com', 'Cloudflare assigns unique NS per account'],
 	['bob.ns.cloudflare.com', 'Cloudflare assigns unique NS per account'],
 	['ns-1234.awsdns-56.com', 'AWS Route 53 assigns unique NS per hosted zone'],
-	['ns-cloud-a1.googledomains.com', 'GCP Cloud DNS unique-per-zone'],
+	// Cloud DNS assigns one of a handful of FIXED `ns-cloud-{a..e}{1..4}` sets, so
+	// a full match there is manufacturable; it stays out of the shared set only
+	// because two unrelated tenants have not been measured yet (#929 follow-up).
+	['ns-cloud-a1.googledomains.com', 'GCP Cloud DNS — not yet verified as shared; pinned as-is, not as unique-per-zone'],
 	// User-controlled / clearly unrelated
 	['ns1.example.com', 'Generic example domain'],
 	['blackveilsecurity.com', 'Our own apex (defensive)'],

--- a/test/check-lookalikes-shared-platform-ns.spec.ts
+++ b/test/check-lookalikes-shared-platform-ns.spec.ts
@@ -122,6 +122,26 @@ describe('classifyOwnership — a complete match on a shared PLATFORM pair is no
 		expect(result.rationale).not.toContain('no ownership signal links it');
 	});
 
+	it('a candidate carrying ONLY the platform half of a seed that also has its own hosts is unattributed (candidate ⊂ seed)', async () => {
+		// Seed = 2 own hosts + the one.com pair; candidate = the one.com pair
+		// alone. The candidate has NO remaining nameservers, so the `third_party`
+		// sentence ("its remaining nameservers are distinct") would be false and
+		// the gate would call a possible alias "a different organisation"
+		// (PR #937 re-verification). The seed's total must not enter the test.
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: ['ns1.net-agents.dk', 'ns2.net-agents.dk', ...ONE_COM_NS],
+			candidateDomain: 'net-agent.dk',
+			registration: registered(ONE_COM_NS.slice()),
+			isSharedNsHost,
+			isPooledSharedNsHost,
+		});
+		expect(result.verdict).toBe('unattributed');
+		expect(result.signals).toEqual(['ns_shared_platform']);
+		expect(result.rationale).not.toContain('remaining nameservers');
+	});
+
 	it("the squatter's cheapest shape — the seed's one.com pair PLUS its own ns1.attacker host — is third_party, never owned", async () => {
 		// Step 4 used to accept this: `sharedNs.length === seedTotal` held and
 		// every shared host was on a shared provider, so the extra attacker host

--- a/test/check-lookalikes-shared-platform-ns.spec.ts
+++ b/test/check-lookalikes-shared-platform-ns.spec.ts
@@ -27,9 +27,12 @@
  *     COMPLETE set match still implies one account (design §3.3, 2026-07-26;
  *     `ns_shared_provider_complete`, medium). The only members that earn that.
  *   - everything else (parking, registrar defaults, one.com): every tenant
- *     receives the same set, so a complete match declines to `third_party`
- *     with the new `ns_shared_platform` signal — wording that names the
- *     platform, severity ceiling unchanged (D4: non-owned → `info`).
+ *     receives the same set, so a complete match declines with the new
+ *     `ns_shared_platform` signal — `unattributed` when the two whole sets
+ *     are identical (nothing distinct was observed, so the report must not
+ *     call the customer's own alias "a different organisation"), `third_party`
+ *     when the candidate also carries its own distinct hosts (the squatter's
+ *     cheapest shape). Severity ceiling unchanged (D4: non-owned → `info`).
  *
  * `classifyOwnership()` takes the pooled predicate as an OPTIONAL injected
  * input and defaults it to "nothing is pooled": a caller that forgets it
@@ -97,7 +100,7 @@ describe('shared-ns-hosts — one.com is a shared platform, and pooled ⊆ share
 // ---------------------------------------------------------------------------
 
 describe('classifyOwnership — a complete match on a shared PLATFORM pair is not ownership (#929)', () => {
-	it('net-agent.dk on the same one.com pair as the seed is third_party, never owned_by_seed / strong', async () => {
+	it('net-agent.dk on the same one.com pair as the seed is unattributed, never owned_by_seed / strong', async () => {
 		const { classifyOwnership } = await loadAttribution();
 		const result = classifyOwnership({
 			seedDomain: SEED,
@@ -107,12 +110,35 @@ describe('classifyOwnership — a complete match on a shared PLATFORM pair is no
 			isSharedNsHost,
 			isPooledSharedNsHost,
 		});
-		expect(result.verdict).toBe('third_party');
+		// `unattributed`, not `third_party`: identical whole sets on the platform
+		// observe NO distinct infrastructure, and the gate template words
+		// `third_party` as "registered to a different organisation" — false for
+		// the customer's own alias hosted at the same provider.
+		expect(result.verdict).toBe('unattributed');
 		expect(result.strength).toBe('none');
 		expect(result.signals).toEqual(['ns_shared_platform']);
 		expect(result.rationale).toContain('one.com');
 		expect(result.rationale).not.toContain('dedicated');
 		expect(result.rationale).not.toContain('no ownership signal links it');
+	});
+
+	it("the squatter's cheapest shape — the seed's one.com pair PLUS its own ns1.attacker host — is third_party, never owned", async () => {
+		// Step 4 used to accept this: `sharedNs.length === seedTotal` held and
+		// every shared host was on a shared provider, so the extra attacker host
+		// was invisible to the arm.
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: ONE_COM_NS,
+			candidateDomain: 'net-agent.dk',
+			registration: registered([...ONE_COM_NS, 'ns1.attacker.example']),
+			isSharedNsHost,
+			isPooledSharedNsHost,
+		});
+		expect(result.verdict).toBe('third_party');
+		expect(result.strength).toBe('none');
+		expect(result.signals).toEqual(['ns_shared_platform']);
+		expect(result.rationale).toContain('remaining nameservers are distinct');
 	});
 
 	it('the pooled predicate defaults CLOSED: without it even a complete 6/6 Akamai match declines', async () => {
@@ -124,7 +150,7 @@ describe('classifyOwnership — a complete match on a shared PLATFORM pair is no
 			registration: registered(AKAMAI_NS.slice()),
 			isSharedNsHost,
 		});
-		expect(result.verdict).toBe('third_party');
+		expect(result.verdict).toBe('unattributed');
 		expect(result.signals).toEqual(['ns_shared_platform']);
 	});
 
@@ -163,6 +189,7 @@ describe('classifyOwnership — a complete match on a shared PLATFORM pair is no
 		expect(result.verdict).toBe('third_party');
 		expect(result.signals).toEqual(['ns_shared_platform']);
 		expect(result.rationale).toContain('1/6');
+		expect(result.rationale).toContain('remaining nameservers are distinct');
 	});
 
 	it('a candidate on the same platform that ALSO holds the seed-published DMARC grant is still owned_by_seed via step 5b', async () => {
@@ -315,11 +342,17 @@ describe('checkLookalikes — net-agents.dk → net-agent.dk on the same one.com
 		expect(own.some((f) => f.metadata?.ownershipStrength === 'strong')).toBe(false);
 		const attribution = own.find((f) => f.metadata?.findingAxis === 'attribution');
 		expect(attribution).toBeDefined();
-		expect(attribution!.metadata?.ownershipVerdict).toBe('third_party');
+		expect(attribution!.metadata?.ownershipVerdict).toBe('unattributed');
 		// The attribution finding carries the verdict's rationale (the gate
-		// template does not surface `signals`): it must name the platform hosts.
+		// template does not surface `signals`): it must name the platform hosts,
+		// and neither its title nor its detail may claim the domain is someone
+		// else's — ground truth is unknown, and it may be the customer's own.
 		expect(attribution!.metadata?.ownershipRationale).toContain('ns01.one.com');
 		expect(attribution!.metadata?.ownershipRationale).toContain('shared-tenant DNS platform');
+		expect(attribution!.title).toBe('Confusable label, ownership not established: net-agent.dk');
+		expect(attribution!.detail).toContain('could not be attributed to the scanned organisation');
+		expect(attribution!.detail).not.toContain('registered to a different organisation');
+		expect(attribution!.title).not.toContain('Unrelated');
 		// D4 ceiling on the ATTRIBUTION axis: a non-owned candidate's attribution
 		// finding is capped at info. The observed-threat axis (Task 7b) is a
 		// separate, uncapped finding — it must still be emitted, and it must
@@ -327,7 +360,7 @@ describe('checkLookalikes — net-agents.dk → net-agent.dk on the same one.com
 		expect(attribution!.severity).toBe('info');
 		const threat = own.find((f) => f.metadata?.findingAxis === 'threat_observation');
 		expect(threat).toBeDefined();
-		expect(threat!.metadata?.ownershipVerdict).toBe('third_party');
+		expect(threat!.metadata?.ownershipVerdict).toBe('unattributed');
 
 		const serialised = JSON.stringify(result.findings);
 		expect(serialised).not.toContain('dedicated');
@@ -337,7 +370,7 @@ describe('checkLookalikes — net-agents.dk → net-agent.dk on the same one.com
 });
 
 describe('checkShadowDomains — net-agents.dk → net-agents.com on the same one.com pair (#929)', () => {
-	it('marks the .com variant third_party (info-capped), not owned_by_seed', async () => {
+	it('marks the .com variant unattributed (info-capped), not owned_by_seed', async () => {
 		installMock({
 			[SEED]: ONE_COM_ZONE,
 			[`_dmarc.${SEED}`]: DMARC_REJECT,
@@ -353,7 +386,32 @@ describe('checkShadowDomains — net-agents.dk → net-agents.com on the same on
 			expect(f.metadata?.ownershipVerdict).not.toBe('owned_by_seed');
 			expect(f.severity).toBe('info');
 		}
-		expect(com.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
-		expect(JSON.stringify(result.findings)).not.toContain('dedicated nameservers');
+		expect(com.some((f) => f.metadata?.ownershipVerdict === 'unattributed')).toBe(true);
+		const serialised = JSON.stringify(result.findings);
+		expect(serialised).not.toContain('dedicated nameservers');
+		expect(serialised).not.toContain('registered to a different organisation');
+		// Before the fix this variant took the OWNED ladder: `high` "Shadow domain
+		// fully spoofable … Likely same owner" for a squatter on the seed's
+		// platform. Now nothing above info is emitted about it.
+		expect(serialised).not.toContain('Likely same owner');
+	});
+
+	it('the "Shared NS across shadow domains" rollup does not suggest common ownership for a platform pair', async () => {
+		installMock({
+			[SEED]: ONE_COM_ZONE,
+			[`_dmarc.${SEED}`]: DMARC_REJECT,
+			'net-agents.com': ONE_COM_ZONE,
+			'_dmarc.net-agents.com': DMARC_REJECT,
+			'net-agents.org': ONE_COM_ZONE,
+			'_dmarc.net-agents.org': DMARC_REJECT,
+		});
+		const { checkShadowDomains } = await import('../src/tools/check-shadow-domains');
+		const result = await checkShadowDomains(SEED);
+		const rollup = result.findings.find((f) => f.title === 'Shared NS across shadow domains');
+		expect(rollup).toBeDefined();
+		expect(rollup!.severity).toBe('info');
+		expect(rollup!.metadata?.sharedPlatform).toBe(true);
+		expect(rollup!.detail).toContain('not evidence of common ownership');
+		expect(rollup!.detail).not.toContain('suggesting common ownership');
 	});
 });

--- a/test/check-lookalikes-shared-platform-ns.spec.ts
+++ b/test/check-lookalikes-shared-platform-ns.spec.ts
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * #929 (mirror of #263 / #864) — a SHARED-PLATFORM nameserver pair is not
+ * ownership evidence, in any quantity.
+ *
+ * `check_lookalikes`, `check_shadow_domains` and `discover_brand_domains` all
+ * attributed every one.com tenant to a one.com-hosted seed at
+ * `owned_by_seed` / `strong` / confidence 1 on `ns_set_match` alone, and
+ * worded it as "shares 2/2 DEDICATED nameservers". Live (DoH, 2026-09-09):
+ *
+ *   net-agents.dk   NS ns01.one.com, ns02.one.com   (seed, one.com shared hosting)
+ *   net-agent.dk    NS ns01.one.com, ns02.one.com   (lookalike permutation)
+ *   net-agents.com  NS ns01.one.com, ns02.one.com   (TLD shadow variant)
+ *   one.com         NS auth.g1-dns.com, auth.g1-dns.one
+ *
+ * one.com hands EVERY tenant the identical `ns01`/`ns02` pair, so a complete
+ * 2/2 match is the default relationship between any two unrelated one.com
+ * customers — and, worse, a squatter who hosts a lookalike at one.com would
+ * have its own threat finding capped at `info` by the seed's platform choice.
+ * `#897`'s rule applies: a verdict may rest only on something the SEED alone
+ * can publish. A platform-assigned NS set is not that.
+ *
+ * Two classes of shared-tenant provider now exist in
+ * `src/tenants/discovery/shared-ns-hosts.ts`:
+ *   - POOLED (`akam.net`): hostnames drawn per zone from a large pool, so a
+ *     COMPLETE set match still implies one account (design §3.3, 2026-07-26;
+ *     `ns_shared_provider_complete`, medium). The only members that earn that.
+ *   - everything else (parking, registrar defaults, one.com): every tenant
+ *     receives the same set, so a complete match declines to `third_party`
+ *     with the new `ns_shared_platform` signal — wording that names the
+ *     platform, severity ceiling unchanged (D4: non-owned → `info`).
+ *
+ * `classifyOwnership()` takes the pooled predicate as an OPTIONAL injected
+ * input and defaults it to "nothing is pooled": a caller that forgets it
+ * fails SAFE (no platform is credited), never open.
+ */
+
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { setupFetchMock, createDohResponse } from './helpers/dns-mock';
+import { isSharedNsHost, isPooledSharedNsHost, SHARED_NS_APEXES, POOLED_SHARED_NS_APEXES } from '../src/tenants/discovery/shared-ns-hosts';
+import type { RegistrationState } from '../src/lib/registration-state';
+import type { DmarcReportAuthorisation } from '../src/lib/ownership-attribution';
+import type { DohResponse } from '../src/lib/dns-types';
+
+const { restore } = setupFetchMock();
+afterEach(() => restore());
+
+// ---------------------------------------------------------------------------
+// Live-transcribed records (2026-09-09)
+// ---------------------------------------------------------------------------
+
+const SEED = 'net-agents.dk';
+const ONE_COM_NS = ['ns01.one.com', 'ns02.one.com'];
+const AKAMAI_NS = ['a1-97.akam.net', 'a3-67.akam.net', 'a8-66.akam.net', 'a9-65.akam.net', 'a16-65.akam.net', 'a24-64.akam.net'];
+
+function registered(ns: string[]): RegistrationState {
+	return { state: 'registered', ns, evidence: ['ns'] };
+}
+
+async function loadAttribution() {
+	return import('../src/lib/ownership-attribution');
+}
+
+// ---------------------------------------------------------------------------
+// Provider classification
+// ---------------------------------------------------------------------------
+
+describe('shared-ns-hosts — one.com is a shared platform, and pooled ⊆ shared (#929)', () => {
+	it('classifies ns01/ns02.one.com as shared-tenant hosts', () => {
+		for (const host of ONE_COM_NS) expect(isSharedNsHost(host)).toBe(true);
+		expect(isSharedNsHost('auth.g1-dns.com')).toBe(false);
+	});
+
+	it('does NOT class one.com as pooled — a complete pair match earns nothing', () => {
+		for (const host of ONE_COM_NS) expect(isPooledSharedNsHost(host)).toBe(false);
+	});
+
+	it('classes Akamai as pooled — the one shared provider where a complete set match is evidence', () => {
+		expect(isPooledSharedNsHost('a1-97.akam.net')).toBe(true);
+		expect(isSharedNsHost('a1-97.akam.net')).toBe(true);
+	});
+
+	it('every pooled apex is also a shared apex (a pooled host must never reach the dedicated arm)', () => {
+		for (const apex of POOLED_SHARED_NS_APEXES) expect(SHARED_NS_APEXES.has(apex)).toBe(true);
+	});
+
+	it('returns false for empty input and for hosts on no known provider', () => {
+		expect(isPooledSharedNsHost('')).toBe(false);
+		expect(isPooledSharedNsHost('ns1.example.com')).toBe(false);
+		expect(isPooledSharedNsHost('alice.ns.cloudflare.com')).toBe(false);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Unit — classifyOwnership()
+// ---------------------------------------------------------------------------
+
+describe('classifyOwnership — a complete match on a shared PLATFORM pair is not ownership (#929)', () => {
+	it('net-agent.dk on the same one.com pair as the seed is third_party, never owned_by_seed / strong', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: ONE_COM_NS,
+			candidateDomain: 'net-agent.dk',
+			registration: registered(ONE_COM_NS.slice()),
+			isSharedNsHost,
+			isPooledSharedNsHost,
+		});
+		expect(result.verdict).toBe('third_party');
+		expect(result.strength).toBe('none');
+		expect(result.signals).toEqual(['ns_shared_platform']);
+		expect(result.rationale).toContain('one.com');
+		expect(result.rationale).not.toContain('dedicated');
+		expect(result.rationale).not.toContain('no ownership signal links it');
+	});
+
+	it('the pooled predicate defaults CLOSED: without it even a complete 6/6 Akamai match declines', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'bnz.co.nz',
+			seedNs: AKAMAI_NS,
+			candidateDomain: 'bnzpartners.co.nz',
+			registration: registered(AKAMAI_NS.slice()),
+			isSharedNsHost,
+		});
+		expect(result.verdict).toBe('third_party');
+		expect(result.signals).toEqual(['ns_shared_platform']);
+	});
+
+	it('with the pooled predicate the Akamai 6/6 arm still yields owned_by_seed (medium) — unchanged behaviour', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'bnz.co.nz',
+			seedNs: AKAMAI_NS,
+			candidateDomain: 'bnzpartners.co.nz',
+			registration: registered(AKAMAI_NS.slice()),
+			isSharedNsHost,
+			isPooledSharedNsHost,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('medium');
+		expect(result.signals).toEqual(['ns_shared_provider_complete']);
+	});
+
+	it('a partial overlap confined to platform hosts is worded as platform plumbing, not "distinct infrastructure"', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const result = classifyOwnership({
+			seedDomain: 'bnz.co.nz',
+			seedNs: AKAMAI_NS,
+			candidateDomain: 'anz.co.nz',
+			registration: registered([
+				'a1-6.akam.net',
+				'a3-66.akam.net',
+				'a6-65.akam.net',
+				'a9-65.akam.net',
+				'a12-66.akam.net',
+				'a28-67.akam.net',
+			]),
+			isSharedNsHost,
+			isPooledSharedNsHost,
+		});
+		expect(result.verdict).toBe('third_party');
+		expect(result.signals).toEqual(['ns_shared_platform']);
+		expect(result.rationale).toContain('1/6');
+	});
+
+	it('a candidate on the same platform that ALSO holds the seed-published DMARC grant is still owned_by_seed via step 5b', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const authorised: DmarcReportAuthorisation = {
+			status: 'authorised',
+			seedReceivers: ['dmarc.net-agents.dk'],
+			receiverDomain: 'dmarc.net-agents.dk',
+			authorisationRecord: 'net-agents.com._report._dmarc.dmarc.net-agents.dk',
+		};
+		const result = classifyOwnership({
+			seedDomain: SEED,
+			seedNs: ONE_COM_NS,
+			candidateDomain: 'net-agents.com',
+			registration: registered(ONE_COM_NS.slice()),
+			isSharedNsHost,
+			isPooledSharedNsHost,
+			candidateMx: ['mail.net-agents.dk'],
+			dmarcReportAuthorisation: authorised,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('medium');
+		expect(result.signals).toEqual(['mx_in_bailiwick', 'dmarc_report_authorised_by_seed']);
+	});
+
+	it('the dedicated arm no longer claims "dedicated" — it says what was measured', async () => {
+		const { classifyOwnership } = await loadAttribution();
+		const dedicated = ['ns1.corp-dns.example', 'ns2.corp-dns.example'];
+		const result = classifyOwnership({
+			seedDomain: 'corp.example',
+			seedNs: dedicated,
+			candidateDomain: 'corp-sibling.example',
+			registration: registered(dedicated.slice()),
+			isSharedNsHost,
+			isPooledSharedNsHost,
+		});
+		expect(result.verdict).toBe('owned_by_seed');
+		expect(result.strength).toBe('strong');
+		expect(result.rationale).toContain('2/2 nameservers');
+		expect(result.rationale).toContain('none on a known shared-tenant provider');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// discover_brand_domains — the NS correlator
+// ---------------------------------------------------------------------------
+
+function nsResponse(name: string, hosts: string[]): DohResponse {
+	return {
+		Status: 0,
+		TC: false,
+		RD: true,
+		RA: true,
+		AD: false,
+		CD: false,
+		Question: [{ name, type: 2 }],
+		Answer: hosts.map((data) => ({ name, type: 2, TTL: 3600, data: `${data}.` })),
+	};
+}
+
+describe('correlateNs — a one.com pair contributes no co-ownership signal (#929)', () => {
+	it('drops net-agent.dk / net-agents.com entirely instead of reporting confidence 1 set_overlap', async () => {
+		const { correlateNs } = await import('../src/tenants/discovery/ns-correlator');
+		const zones: Record<string, string[]> = {
+			[SEED]: ONE_COM_NS,
+			'net-agent.dk': ONE_COM_NS,
+			'net-agents.com': ONE_COM_NS,
+		};
+		const dnsQuery = vi.fn(async (name: string) => {
+			const key = name.toLowerCase().replace(/\.$/, '');
+			const hosts = zones[key];
+			return hosts ? nsResponse(key, hosts) : { ...nsResponse(key, []), Answer: [] };
+		});
+		const result = await correlateNs(SEED, { dnsQuery, candidateDomains: ['net-agent.dk', 'net-agents.com'] });
+		expect(result.queryStatus).toBe('ok');
+		expect(result.coOwnedDomains).toEqual([]);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end — checkLookalikes() and checkShadowDomains()
+// ---------------------------------------------------------------------------
+
+type RecordName = 'NS' | 'A' | 'MX' | 'SOA' | 'TXT';
+const TYPE_CODE: Record<RecordName, number> = { NS: 2, A: 1, MX: 15, SOA: 6, TXT: 16 };
+const CODE_TYPE: Record<string, RecordName> = {
+	'2': 'NS',
+	NS: 'NS',
+	'1': 'A',
+	A: 'A',
+	'15': 'MX',
+	MX: 'MX',
+	'6': 'SOA',
+	SOA: 'SOA',
+	'16': 'TXT',
+	TXT: 'TXT',
+};
+type Zone = Partial<Record<RecordName, string[]>>;
+
+function dohAnswer(name: string, type: RecordName, records: string[]) {
+	return createDohResponse(
+		[{ name, type: TYPE_CODE[type] }],
+		records.map((data) => ({ name, type: TYPE_CODE[type], TTL: 300, data: type === 'TXT' ? `"${data}"` : data })),
+	);
+}
+
+/** DoH from `zones`; a registrar-only RDAP document (`.dk` has no RDAP live, so nothing is asserted on it); 200 for HEAD probes. */
+function installMock(zones: Record<string, Zone>): void {
+	globalThis.fetch = vi.fn().mockImplementation((input: string | URL | Request) => {
+		const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+		const parsed = new URL(url);
+		const qName = parsed.searchParams.get('name');
+		const qType = parsed.searchParams.get('type');
+		if (qName !== null && qType !== null) {
+			const name = qName.toLowerCase().replace(/\.$/, '');
+			const type = CODE_TYPE[qType.toUpperCase()];
+			const records = type ? zones[name]?.[type] : undefined;
+			if (records && type) return Promise.resolve(dohAnswer(name, type, records));
+			return Promise.resolve(createDohResponse([], []));
+		}
+		if (url.includes('rdap')) {
+			const body = {
+				objectClassName: 'domain',
+				entities: [{ roles: ['registrar'], vcardArray: ['vcard', [['fn', {}, 'text', 'Registrar Inc']]] }],
+			};
+			return Promise.resolve(new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/rdap+json' } }));
+		}
+		return Promise.resolve(new Response('', { status: 200 }));
+	});
+}
+
+/** The live shape: one.com pair, null MX, DMARC reject on both seed and candidates. */
+const ONE_COM_ZONE: Zone = { NS: ONE_COM_NS.map((h) => `${h}.`), A: ['46.30.211.1'], MX: ['0 .'] };
+const DMARC_REJECT: Zone = { TXT: ['v=DMARC1; p=reject'] };
+
+describe('checkLookalikes — net-agents.dk → net-agent.dk on the same one.com pair (#929)', () => {
+	it('does not attribute the candidate to the seed, and never says "dedicated"', async () => {
+		installMock({
+			[SEED]: ONE_COM_ZONE,
+			[`_dmarc.${SEED}`]: DMARC_REJECT,
+			'net-agent.dk': ONE_COM_ZONE,
+			'_dmarc.net-agent.dk': DMARC_REJECT,
+		});
+		const { checkLookalikes } = await import('../src/tools/check-lookalikes');
+		const result = await checkLookalikes(SEED);
+
+		const own = result.findings.filter((f) => f.metadata?.lookalikeDomain === 'net-agent.dk');
+		expect(own.length).toBeGreaterThan(0);
+		expect(own.some((f) => f.metadata?.ownershipVerdict === 'owned_by_seed')).toBe(false);
+		expect(own.some((f) => f.metadata?.ownershipStrength === 'strong')).toBe(false);
+		const attribution = own.find((f) => f.metadata?.findingAxis === 'attribution');
+		expect(attribution).toBeDefined();
+		expect(attribution!.metadata?.ownershipVerdict).toBe('third_party');
+		// The attribution finding carries the verdict's rationale (the gate
+		// template does not surface `signals`): it must name the platform hosts.
+		expect(attribution!.metadata?.ownershipRationale).toContain('ns01.one.com');
+		expect(attribution!.metadata?.ownershipRationale).toContain('shared-tenant DNS platform');
+		// D4 ceiling on the ATTRIBUTION axis: a non-owned candidate's attribution
+		// finding is capped at info. The observed-threat axis (Task 7b) is a
+		// separate, uncapped finding — it must still be emitted, and it must
+		// carry the same non-owned verdict.
+		expect(attribution!.severity).toBe('info');
+		const threat = own.find((f) => f.metadata?.findingAxis === 'threat_observation');
+		expect(threat).toBeDefined();
+		expect(threat!.metadata?.ownershipVerdict).toBe('third_party');
+
+		const serialised = JSON.stringify(result.findings);
+		expect(serialised).not.toContain('dedicated');
+		expect(serialised).not.toContain('likely owned by same entity');
+		expect(result.partial).not.toBe(true);
+	});
+});
+
+describe('checkShadowDomains — net-agents.dk → net-agents.com on the same one.com pair (#929)', () => {
+	it('marks the .com variant third_party (info-capped), not owned_by_seed', async () => {
+		installMock({
+			[SEED]: ONE_COM_ZONE,
+			[`_dmarc.${SEED}`]: DMARC_REJECT,
+			'net-agents.com': ONE_COM_ZONE,
+			'_dmarc.net-agents.com': DMARC_REJECT,
+		});
+		const { checkShadowDomains } = await import('../src/tools/check-shadow-domains');
+		const result = await checkShadowDomains(SEED);
+
+		const com = result.findings.filter((f) => (f.metadata as { variant?: string } | undefined)?.variant === 'net-agents.com');
+		expect(com.length).toBeGreaterThan(0);
+		for (const f of com) {
+			expect(f.metadata?.ownershipVerdict).not.toBe('owned_by_seed');
+			expect(f.severity).toBe('info');
+		}
+		expect(com.some((f) => f.metadata?.ownershipVerdict === 'third_party')).toBe(true);
+		expect(JSON.stringify(result.findings)).not.toContain('dedicated nameservers');
+	});
+});

--- a/test/check-lookalikes.spec.ts
+++ b/test/check-lookalikes.spec.ts
@@ -508,7 +508,7 @@ describe('checkLookalikes - shared nameserver detection', () => {
 		expect(tstFinding).toBeDefined();
 		expect(tstFinding!.severity).toBe('info');
 		expect(tstFinding!.title).toContain('likely owned by same entity');
-		expect(tstFinding!.detail).toContain('dedicated nameservers');
+		expect(tstFinding!.detail).toContain('none on a known shared-tenant provider');
 		expect(tstFinding!.detail).toContain('mail infrastructure');
 		expect(tstFinding!.metadata?.ownershipVerdict).toBe('owned_by_seed');
 

--- a/test/check-shadow-domains.spec.ts
+++ b/test/check-shadow-domains.spec.ts
@@ -878,7 +878,7 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 		const high = result.findings.find((f) => f.severity === 'high' && f.detail.includes('example.net') && /fully spoofable/i.test(f.title));
 		expect(high).toBeDefined();
-		expect(high!.detail).toContain('shares 2/2 dedicated nameservers');
+		expect(high!.detail).toContain('shares 2/2 nameservers');
 		expect((high!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 
@@ -916,7 +916,7 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 
 		const medium = result.findings.find((f) => f.severity === 'medium' && f.detail.includes('example.net') && /lacks DMARC/i.test(f.title));
 		expect(medium).toBeDefined();
-		expect(medium!.detail).toContain('shares 2/2 dedicated nameservers');
+		expect(medium!.detail).toContain('shares 2/2 nameservers');
 		expect((medium!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 
@@ -955,7 +955,7 @@ describe('checkShadowDomains — shared NS severity downgrade', () => {
 			(f) => f.severity === 'medium' && f.detail.includes('example.net') && /not enforcing/i.test(f.title),
 		);
 		expect(medium).toBeDefined();
-		expect(medium!.detail).toContain('shares 2/2 dedicated nameservers');
+		expect(medium!.detail).toContain('shares 2/2 nameservers');
 		expect((medium!.metadata as { ownershipVerdict?: string }).ownershipVerdict).toBe('owned_by_seed');
 	});
 

--- a/test/ownership-attribution.spec.ts
+++ b/test/ownership-attribution.spec.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 import { describe, it, expect, afterEach } from 'vitest';
-import { isSharedNsHost } from '../src/tenants/discovery/shared-ns-hosts';
+import { isPooledSharedNsHost, isSharedNsHost } from '../src/tenants/discovery/shared-ns-hosts';
 import { UNKNOWN_REASON_PHRASES } from '../src/lib/registration-state';
 import type { RegistrationState } from '../src/lib/registration-state';
 
@@ -59,6 +59,9 @@ describe('classifyOwnership — §4 fixture corpus (2026-07-26 correctness-defec
 			candidateDomain: 'bnzpartners.co.nz',
 			registration: registered(SEED_NS.slice()),
 			isSharedNsHost,
+			// #929 — Akamai is the POOLED shared provider; the complete-match arm
+			// needs this predicate (it defaults closed — see the #929 spec).
+			isPooledSharedNsHost,
 		});
 		expect(result.verdict).toBe('owned_by_seed');
 		expect(result.strength).toBe('medium');


### PR DESCRIPTION
## What happens

`check_lookalikes net-agents.dk` reported `net-agent.dk` as `owned_by_seed` / `ownershipStrength: strong` / `attributionConfidence: corroborated` on `ownershipSignals: ["ns_set_match"]` alone, worded "shares 2/2 **dedicated** nameservers". `check_shadow_domains` did the same for `net-agents.com/.eu/.org`, and `discover_brand_domains` surfaced all of them at `combinedConfidence: 1` on `signals: ["ns"]`. The only evidence was that both sides delegate to `ns01.one.com` / `ns02.one.com` (#929).

Live (`dns.google/resolve`, 2026-09-09):

| name | NS |
| --- | --- |
| `net-agents.dk` (seed) | `ns01.one.com`, `ns02.one.com` |
| `net-agent.dk` | `ns01.one.com`, `ns02.one.com` |
| `net-agents.com` | `ns01.one.com`, `ns02.one.com` |
| `one.com` itself | `auth.g1-dns.com`, `auth.g1-dns.one` |

one.com hands **every** tenant the identical pair, so a complete 2/2 match is the default relationship between any two unrelated one.com customers. This is the mirror image of #263/#864 (same entity MISSED because NS differ): here unrelated-until-proven domains are AFFIRMED on NS alone.

## Root cause

`classifyOwnership()` (`src/lib/ownership-attribution.ts`) carried two assumptions that both fail on a uniform-set platform:

1. Any nameserver not on a known shared provider is "dedicated" (step 3, `ns_set_match`, strong). one.com was not in `SHARED_NS_APEXES`, so its hosts counted as dedicated.
2. A **complete** NS-set match on a shared provider is medium evidence (step 4, `ns_shared_provider_complete`). That was designed for Akamai, which draws six hostnames per zone from a ~128-host pool — an identical 6/6 set really does mean one account. It is false for every platform that hands each tenant the same set (one.com, parking `ns1`/`ns2`, registrar defaults): there a complete match is what every tenant looks like.

Both matter for the safety property, not just wording: the D4 severity gate keys on `verdict === 'owned_by_seed'`, so a squatter who hosts a lookalike at the seed's shared platform would have its own threat finding capped at `info`. #897's rule applies to NS as it does to everything else: a verdict may rest only on what the **seed alone** can publish, and a platform-assigned NS set is not that.

## What changed

**`src/tenants/discovery/shared-ns-hosts.ts`**
- `one.com` added to `SHARED_NS_APEXES` (its hosts are never "dedicated"). This alone fixes `discover_brand_domains`: the ns-correlator already drops a candidate whose overlap is entirely shared-apex.
- New `POOLED_SHARED_NS_APEXES` (`akam.net` only) + `isPooledSharedNsHost()` — the subset whose complete NS set is per-account evidence. The default for a new shared platform is now the safe one: list it and it can never attribute; promote to pooled only with evidence.

**`src/lib/ownership-attribution.ts`**
- New optional input `isPooledSharedNsHost`. Step 4 now requires it to accept **every** matched host. Absent → defaults **closed** (nothing is pooled, step 4 unreachable) — a caller that forgets it fails safe, never open. Pinned by a test that runs the Akamai 6/6 fixture without the predicate and expects `third_party`.
- New arm after step 5b for an overlap confined to shared-provider hosts, carrying the new `ns_shared_platform` signal and a rationale naming the platform hosts. Two outcomes by what was **observed**: identical whole sets on a non-pooled platform → **`unattributed`** ("delegate to the same shared-tenant DNS platform hosts … not ownership evidence either way" — nothing distinct was seen); any other platform-confined overlap (the 1/6 Akamai partial, or the seed's one.com pair **plus** the squatter's own `ns1.attacker.example` — the cheapest forgery, which step 4 previously accepted) → `third_party` ("its remaining nameservers are distinct"). Neither moves severity (`capAttributionSeverity()` and `attributionConfidence()` branch only on `owned_by_seed`; verified by grep — no `src/` consumer distinguishes the two). Step 5b (the seed-published DMARC grant) keeps precedence, so a one.com candidate the seed has authorised still attributes at medium.
- `buildNonOwnedGateFinding()`: an `unattributed` verdict is now titled "Confusable label, ownership not established: X" instead of "Unrelated domain, confusable label: X" — the old title made the same false claim for the customer's own alias that the `third_party` relation sentence did (review finding 1).
- The `ns_set_match` rationale no longer says "dedicated"; it says the matched hosts are on no known shared-tenant provider, which is what is actually checked.
- Header amendment documents the ruling alongside the 2026-07-27 and 2026-09-04 ones.

**Callers** — `check-lookalikes.ts` (both `classifyOwnership()` sites via `lookalike-attribution.ts`) and `check-shadow-domains.ts` thread the pooled predicate. No signature changes; the field is optional.

## Verdict choice

`unattributed` for identical whole sets, `third_party` otherwise. The first revision returned `third_party` for the one.com pair; review caught that the D4 gate template words `third_party` as "is registered to a different organisation", which for seed `net-agents.dk` and the customer's own `net-agents.com` on one.com is a false factual claim sitting next to the new "not ownership evidence" sentence. The type's own definition settles it: `third_party` requires the full-set comparison to have found distinct infrastructure; a complete platform match found none. The ANZ/Westpac 1/6 Akamai fixture stays `third_party` (five distinct hosts were observed). `OwnershipStrength` gains no `weak` member — the issue's "lead" suggestion is served by the signal + rationale on a non-owned verdict.

`check_shadow_domains`' "Shared NS across shadow domains" rollup now says "a hosting choice in common, not evidence of common ownership" (with `sharedPlatform: true` metadata) when every host in the pair is on a shared provider, instead of "suggesting common ownership or registrar" (review finding 3).

## Scoring impact

**Not `scan_domain`-score-affecting.** Both `check_lookalikes` and `check_shadow_domains` are `scanIncluded: false`; `discover_brand_domains` is unscored. No `SCORING_MODEL_VERSION`, package or `PARITY_CORPUS_VERSION` bump — same posture as #897.

What does move, in the standalone tools, for a seed on a non-pooled shared platform — in **opposite directions** for the two checks:

- `check_lookalikes`: a same-platform candidate goes from an `info` `owned_by_seed` attribution to an `info` `unattributed` attribution **plus** the uncapped Task-7b threat observation it was previously spared (a mail-capable squatter on the seed's platform is now counted).
- `check_shadow_domains`: the false `owned_by_seed` **inflated** severity there — `classifyVariant()` emits `high` "Shadow domain fully spoofable … Likely same owner" only for owned candidates, and non-owned ones are gated to `info` — so a squatter's variant on the seed's platform drops from a wrong `high` (about a domain the customer may not control) to `info`. The new end-to-end case pins that "Likely same owner" no longer appears.

Both are the intended removal of the false attribution. Akamai behaviour is byte-identical (predicate threaded by every caller). Existing entries in `SHARED_NS_APEXES` (parking, GoDaddy, Namecheap) also lose the step-4 credit; a seed on those platforms is rare and a complete match there was never evidence.

## Tests

New `test/check-lookalikes-shared-platform-ns.spec.ts` (16), fixtures transcribed from the live records above:
- provider classification: one.com shared, not pooled; Akamai pooled; pooled ⊆ shared; empty/unknown → false
- `classifyOwnership()`: one.com 2/2 → `unattributed` / `none` / `['ns_shared_platform']`, rationale names one.com and never "dedicated"; one.com pair + `ns1.attacker.example` (the mixed squatter set step 4 used to accept) → `third_party`, never owned; predicate absent → Akamai 6/6 declines (closed default); predicate present → Akamai 6/6 still `owned_by_seed` medium; 1/6 partial → `third_party` worded as platform plumbing with distinct remainder; one.com pair + seed-published DMARC grant → `owned_by_seed` via step 5b; dedicated arm wording
- `correlateNs` (discover_brand_domains): one.com candidates dropped, `coOwnedDomains: []`
- end-to-end `checkLookalikes('net-agents.dk')` → `net-agent.dk`: no `owned_by_seed`, no `strong`, attribution `unattributed` at `info` titled "Confusable label, ownership not established", detail says "could not be attributed" and never "registered to a different organisation", threat observation retained, no "dedicated" / "likely owned by same entity" anywhere, not `partial`
- end-to-end `checkShadowDomains('net-agents.dk')` → `net-agents.com`: `unattributed`, `info`, no "Likely same owner", no "registered to a different organisation"; and the "Shared NS across shadow domains" rollup over `.com`/`.org` carries `sharedPlatform: true` and "not evidence of common ownership"

`test/audits/shared-ns-hosts.audit.test.ts` pins `ns01`/`ns02.one.com` as shared, `POOLED_SHARED_NS_APEXES` as a strict subset, Akamai pooled and every other listed host non-pooled. Four existing "dedicated nameservers" string pins updated; the Akamai 6/6 fixture in `ownership-attribution.spec.ts` now passes the predicate.

TDD: the new spec was run before the fix — 13 of 14 (then) failed (both tools emitting `owned_by_seed` on the one.com pair). Review round added the mixed-set and rollup cases (16 total).

## Verification

- `npm run typecheck` rc=0, `npm run lint` rc=0
- `npm test`: **8803 passed, 0 failed**, 14 skipped, 717 files passed. One file fails to *load* — `test/wasm-integration.test.ts` (`No such module …bv_wasm_core_bg.wasm`), the documented fresh-worktree shape (no `npm run build:wasm`), not a test failure.

## Residual — tracked in #939

- Only one.com was added: it is the measured instance. Other uniform-set platforms (Hostinger `dns-parking.com`, Wix `wixdns.net`, Google Cloud DNS's five fixed `ns-cloud-*` sets, further registrar defaults, `digital.govt.nz` — one data point) were not verified across two unrelated tenants this session, so they are not asserted here. Each is a single line in `SHARED_NS_APEXES` once measured and lands in the safe class automatically. **#939** (agent-filed) carries the reviewer's step-3 list and the DoH procedure. The comments that previously called Cloud DNS "unique-per-zone" (`shared-ns-hosts.ts`, `ns-correlator.ts`, the audit) now say what is actually known: it is *not listed*, not *proven unique* — and the `SHARED_NS_APEXES` doc now states the membership bar as "two unrelated tenants observed sharing", replacing the old "add conservatively, a false positive erases evidence" guidance that contradicted the default-safe doctrine.
- The D4 gate template's "is registered to a different organisation" wording for a genuine `third_party` verdict (distinct infrastructure observed) is pre-existing and unchanged.

Closes #929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
