### PR TITLE
ci(hygiene): skip npm-backed audits in consumers that lack them

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -239,15 +239,43 @@ jobs:
             echo "✓ No large tracked files found."
           fi
 
+      # The npm-backed audits below are bv-mcp's own scripts. This workflow is
+      # also consumed by sibling repos (workflow_call) that have no package.json,
+      # or a package.json without these scripts — for them the file-level checks
+      # above are the whole contract. Detect what exists and SAY what is skipped,
+      # so a green run in a consumer never silently implies the audits ran.
+      - name: Detect npm audit surface
+        id: npm
+        run: |
+          set -euo pipefail
+          lockfile=false; repo_safety=false; oss_safety=false
+          if [ -f package.json ]; then
+            if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then lockfile=true; fi
+            if [ "$(jq -r '.scripts["audit:repo-safety"] // empty' package.json)" != "" ]; then repo_safety=true; fi
+            if [ "$(jq -r '.scripts["audit:oss-safety"] // empty' package.json)" != "" ]; then oss_safety=true; fi
+          fi
+          {
+            echo "lockfile=$lockfile"
+            echo "repo_safety=$repo_safety"
+            echo "oss_safety=$oss_safety"
+          } >> "$GITHUB_OUTPUT"
+          [ "$lockfile" = true ] || echo "::notice::No package-lock.json — skipping npm install and npm-backed audits."
+          [ "$repo_safety" = true ] || echo "::notice::No audit:repo-safety script in package.json — repo safety scanner skipped."
+          [ "$oss_safety" = true ] || echo "::notice::No audit:oss-safety script in package.json — public source safety audits skipped."
+
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: steps.npm.outputs.lockfile == 'true'
         with:
           node-version: 22
           cache: npm
 
       - run: npm ci
+        if: steps.npm.outputs.lockfile == 'true'
 
       - name: Run repo safety scanner
+        if: steps.npm.outputs.lockfile == 'true' && steps.npm.outputs.repo_safety == 'true'
         run: npm run audit:repo-safety
 
       - name: Run public source safety audits
+        if: steps.npm.outputs.lockfile == 'true' && steps.npm.outputs.oss_safety == 'true'
         run: npm run audit:oss-safety


### PR DESCRIPTION
## Summary

The reusable `repo-hygiene.yml` (consumed via `workflow_call` by sibling repos) unconditionally runs `setup-node` with `cache: npm`, `npm ci`, `npm run audit:repo-safety` and `npm run audit:oss-safety`. Those scripts exist only in bv-mcp, so consumers go red after every file-level check has passed:

- `MadaBurns/blackveil-dns-action` has failed `hygiene / File hygiene check` on `main` since 2026-07-10 (`f05878b`).
- A consumer with a `package.json` but no lockfile fails even earlier, inside `setup-node`'s cache lookup ("Dependencies lock file is not found").

This adds a `Detect npm audit surface` step (jq over `package.json`, lockfile presence) and gates each npm step on its outputs. Every skip is announced with `::notice::` so a green consumer run never silently implies the audits ran.

**bv-mcp's own gate is unchanged** — all three detections resolve to `true` here (verified locally), so `npm ci` and both audits still run and `File hygiene check` remains a meaningful required check.

## Verification
- Simulated the detect step locally: bv-mcp → `lockfile=true repo_safety=true oss_safety=true`; blackveil-dns-action → `lockfile=true repo_safety=false` (audits skipped with notice).
- `workflow-safety-gates.audit.test.ts` and `repo-safety-policy.audit.test.ts` pass (10/10) — both `npm run audit:…` strings are still present.
- Class C (CI-only, non-runtime); no public contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
