### PR TITLE
refactor(dispatch): retire blackveil_dns_action from the legacy STRUCTURED_RESULT allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ _Entries for released versions below were edited on 2026-09-09 to remove a third
 
 ## [Unreleased]
 
+### Changed
+
+- **`blackveil_dns_action` retired from `STRUCTURED_COMMENT_LEGACY_CLIENTS`.** blackveil-dns-action v1.4.0 (2026-09-10) negotiates protocol `2025-06-18`, sends the `MCP-Protocol-Version` header and reads the MCP-standard `structuredContent` field first, so the ~20 KB `<!-- STRUCTURED_RESULT … -->` comment it was allowlisted to receive is now dropped for it like any other modern client. Older action versions (`<= 1.3.0`) negotiate `2025-03-26` and send no version header, so the existing protocol gate in `stripRedundantStructuredComment()` still serves them the comment — no compatibility window needed. The allowlist set stays (empty) as the mechanism for any future comment-only client. Not score-affecting.
+
 ## [3.78.0] - 2026-09-09
 
 Scoring model 1.25.0, `@blackveil/dns-checks` 1.37.0 (parity corpus 1.37.0). No category weights, grade bands or severity penalties change.

--- a/src/handlers/tool-formatters.ts
+++ b/src/handlers/tool-formatters.ts
@@ -27,7 +27,7 @@ export function mcpText(text: string): McpContent {
  * Emission is format-driven here; whether a given client still *needs* this backward-compat comment
  * is decided downstream at the dispatch boundary — `stripRedundantStructuredComment` in `mcp/dispatch.ts`
  * removes it for clients that read the MCP-standard `structuredContent` field (protocol >= 2025-06-18,
- * excluding known comment-parsers like `blackveil_dns_action`).
+ * excluding any client listed in `STRUCTURED_COMMENT_LEGACY_CLIENTS` — currently none).
  */
 export function buildToolContent(text: string, structuredData: unknown, format: OutputFormat): McpContent[] {
 	const content: McpContent[] = [mcpText(text)];

--- a/src/mcp/dispatch.ts
+++ b/src/mcp/dispatch.ts
@@ -66,12 +66,14 @@ const STRUCTURED_CONTENT_MIN_VERSION = '2025-06-18';
 /**
  * Client types known to parse the embedded `<!-- STRUCTURED_RESULT … -->` comment instead of
  * the MCP-standard `structuredContent` field. The comment is preserved for these regardless of
- * protocol version. `blackveil_dns_action` (its `scan.mjs`) regex-extracts the comment for
- * `score`/`grade`/`categoryScores` and does not read `structuredContent`; it also negotiates
- * `2025-03-26`, so it would be protected by the version gate anyway — the allowlist is
- * belt-and-suspenders against a future protocol bump on that client.
+ * protocol version. EMPTY as of blackveil-dns-action v1.4.0 (2026-09-10): that action now
+ * negotiates `2025-06-18`, sends the `MCP-Protocol-Version` header, and reads `structuredContent`
+ * first (comment second, text third). Older action versions (`<= 1.3.0`, protocol `2025-03-26`,
+ * no version header) are still served the comment by the protocol gate below, which is why the
+ * allowlist entry could be retired without a compatibility window. The set stays as the
+ * mechanism for any future comment-only client.
  */
-export const STRUCTURED_COMMENT_LEGACY_CLIENTS: ReadonlySet<string> = new Set(['blackveil_dns_action']);
+export const STRUCTURED_COMMENT_LEGACY_CLIENTS: ReadonlySet<string> = new Set<string>([]);
 
 /**
  * Client types verified to NOT consume the embedded comment, for which it is dropped regardless of

--- a/test/protocol-version-negotiation.spec.ts
+++ b/test/protocol-version-negotiation.spec.ts
@@ -108,10 +108,16 @@ describe('stripRedundantStructuredComment (#363 follow-up — "Both (conservativ
 		expect(out.structuredContent).toEqual({ score: 80 });
 	});
 
-	it('KEEPS the comment for the legacy comment-parsing client even on modern protocol', () => {
+	it('DROPS the comment for blackveil_dns_action on modern protocol (v1.4.0+ reads structuredContent; allowlist retired)', () => {
 		const out = stripRedundantStructuredComment(make(), { clientType: 'blackveil_dns_action', protocolVersionHeader: '2025-06-18' });
+		expect(hasComment(out)).toBe(false);
+		expect(out.structuredContent).toEqual({ score: 80 });
+		expect(STRUCTURED_COMMENT_LEGACY_CLIENTS.has('blackveil_dns_action')).toBe(false);
+	});
+
+	it('KEEPS the comment for blackveil_dns_action on the older 2025-03-26 protocol (action <= 1.3.0)', () => {
+		const out = stripRedundantStructuredComment(make(), { clientType: 'blackveil_dns_action', protocolVersionHeader: '2025-03-26' });
 		expect(hasComment(out)).toBe(true);
-		expect(STRUCTURED_COMMENT_LEGACY_CLIENTS.has('blackveil_dns_action')).toBe(true);
 	});
 
 	it('KEEPS the comment when the protocol header is absent (most clients omit it)', () => {
@@ -286,8 +292,14 @@ describe('redundant STRUCTURED_RESULT comment stripping (#363 follow-up, end-to-
 		expect(out.hasStructured).toBe(true);
 	});
 
-	it('keeps the comment for the blackveil_dns_action client even on protocol 2025-06-18', async () => {
-		const out = await explainFinding(await initSession(), { protocolHeader: '2025-06-18', userAgent: 'blackveil-dns-action/1.0' });
+	it('drops the comment for blackveil-dns-action >= 1.4.0 (protocol 2025-06-18, reads structuredContent)', async () => {
+		const out = await explainFinding(await initSession(), { protocolHeader: '2025-06-18', userAgent: 'blackveil-dns-action/1.4.0' });
+		expect(out.hasComment).toBe(false);
+		expect(out.hasStructured).toBe(true);
+	});
+
+	it('keeps the comment for blackveil-dns-action <= 1.3.0 (protocol 2025-03-26, comment parser)', async () => {
+		const out = await explainFinding(await initSession(), { protocolHeader: '2025-03-26', userAgent: 'blackveil-dns-action/1.3.0' });
 		expect(out.hasComment).toBe(true);
 	});
 


### PR DESCRIPTION
## Summary

[blackveil-dns-action v1.4.0](https://github.com/MadaBurns/blackveil-dns-action/releases/tag/v1.4.0) (released today; `v1` tag moved) negotiates protocol `2025-06-18`, sends the `MCP-Protocol-Version` header, and reads `structuredContent` first — comment second, text third. The `<!-- STRUCTURED_RESULT … -->` comment it was allowlisted in `STRUCTURED_COMMENT_LEGACY_CLIENTS` to receive (~20 KB per `scan_domain` response) is now redundant for it, so the entry is retired.

**Backward compatibility:** action versions `<= 1.3.0` negotiate `2025-03-26` and send no version header. `clientSupportsStructuredContent()` returns `false` for them, so the existing protocol gate keeps serving the comment. No compatibility window is needed. The set stays as an (empty) mechanism for any future comment-only client.

## Changes
- `src/mcp/dispatch.ts` — allowlist emptied; doc comment rewritten (it previously described the action as regex-extracting the comment on `2025-03-26`, which is no longer true).
- `src/handlers/tool-formatters.ts` — comment no longer names the action.
- `test/protocol-version-negotiation.spec.ts` — flipped in both directions at the pure-function and dispatch levels: DROP on `2025-06-18` with UA `blackveil-dns-action/1.4.0`; KEEP on `2025-03-26` with UA `blackveil-dns-action/1.3.0`.
- `CHANGELOG.md` — Unreleased / Changed entry. Not score-affecting; no version bump in this PR.

## Verification
- `protocol-version-negotiation.spec.ts`: 33/33 pass.
- `tsc --noEmit`: 0 errors (with generated `worker-configuration.d.ts`).
- Pre-commit gates (gitleaks, repo-safety scanners) passed on commit.

Class B (internal platform behaviour). Companion CI PR: #969.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
