### PR TITLE
feat(scoring): DMARC partial enforcement is a gradient and caps the top letter (model 1.26.0, dns-checks 1.38.0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5297,7 +5297,7 @@
 		},
 		"packages/dns-checks": {
 			"name": "@blackveil/dns-checks",
-			"version": "1.37.0",
+			"version": "1.38.0",
 			"license": "BUSL-1.1",
 			"dependencies": {
 				"zod": "^4.5.4"

--- a/packages/dns-checks/package.json
+++ b/packages/dns-checks/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@blackveil/dns-checks",
-	"version": "1.37.0",
+	"version": "1.38.0",
 	"description": "Runtime-agnostic DNS and email security checks (16 checks + scoring engine) for BlackVeil Security",
 	"license": "BUSL-1.1",
 	"type": "module",

--- a/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
+++ b/packages/dns-checks/src/__tests__/checks/check-dmarc.test.ts
@@ -27,12 +27,18 @@ describe('checkDMARC', () => {
 		expect(result.findings.some((f) => f.title === 'DMARC policy set to none')).toBe(true);
 	});
 
-	it('flags p=quarantine as low', async () => {
+	it('flags p=quarantine as medium partial enforcement (scoring model 1.26.0), passing, not a missing control', async () => {
 		const queryDNS = createMockDNS({
 			'_dmarc.example.com': ['v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com'],
 		});
 		const result = await checkDMARC('example.com', queryDNS);
-		expect(result.findings.some((f) => f.title === 'DMARC policy set to quarantine')).toBe(true);
+		const quarantine = result.findings.find((f) => f.title === 'DMARC policy set to quarantine');
+		expect(quarantine).toBeDefined();
+		expect(quarantine?.severity).toBe('medium');
+		expect(quarantine?.metadata?.partialEnforcement).toBe(true);
+		// Enforcing → still an active control and a passing category (75 on this record).
+		expect(result.passed).toBe(true);
+		expect(result.controlPresent).toBe(true);
 	});
 
 	it('reports properly configured for p=reject with strict alignment', async () => {

--- a/packages/dns-checks/src/__tests__/scoring/dmarc-partial-enforcement-ceiling.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/dmarc-partial-enforcement-ceiling.spec.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BUSL-1.1
+
+/**
+ * Scoring model 1.26.0 — DMARC partial enforcement caps the top letter.
+ *
+ * THE DECISION THIS FILE PINS.
+ * Measured 2026-09-10 on the 1.25.0 package (mail_enabled, every other check perfect):
+ * absent 64 · p=none 64 · quarantine 100 · reject 100 · reject+strict 100. Quarantine
+ * and reject were score-IDENTICAL, so the model offered no gradient toward the
+ * mandated end state (NZ SGE Oct 2026, US BOD 18-01, BSI TR-03182 all name p=reject).
+ * Two things now move, both structurally declared and both DOWNWARD only:
+ *
+ *   1. `DMARC policy set to quarantine` is `medium` (was `low`) and carries
+ *      `metadata.partialEnforcement: true`; `DMARC not applied to all emails` (pct<100)
+ *      keeps `medium` and gains the same declaration. The category now sits BELOW reject.
+ *   2. The generic engine caps a scan at `partialEnforcementCeiling` (94 — the top of
+ *      NIST display A) when a CRITICAL category is partially enforced and not already a
+ *      critical gap. dmarc is critical in `mail_enabled` / `enterprise_mail` ONLY, so the
+ *      gate reaches no other profile by construction.
+ *
+ * The ordering this preserves: none/absent (64, D) < partial enforcement (≤94, A) <
+ * full reject (100, A+). The operator's "cannot pass D without p=reject" cap was
+ * adjudicated AGAINST (0 of 12 surveyed peer graders cap a composite on quarantine; it
+ * would flatten quarantine into the no-record bucket), and this file guards that
+ * boundary too: quarantine must never score like p=none.
+ *
+ * WHAT IS DELIBERATELY NOT CHANGED.
+ * The finding TITLES are load-bearing downstream (`assess_spoofability` derives posture
+ * from them; `generate_rollout_plan` / maturity staging match by substring) and stay
+ * exactly as they were. `sp=` / `t=y` semantics are settled DEFERs. The engine's INTERNAL
+ * 9-band `grade` still reads A+ at 94 — the customer-visible NIST letter is what moves.
+ *
+ * WHY THESE TESTS RUN THE REAL CHECK.
+ * `checkDMARC` (record → classifier → `buildCheckResult`) is what both repos consume, so
+ * the declaration is proven end-to-end through `computeProfileAwareScanScore`, not on a
+ * hand-built finding. The one synthetic finding here (the PROSE CONTROL) exists to prove
+ * the opposite: prose alone must NOT arm the ceiling.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { checkDMARC } from '../../checks/check-dmarc';
+import { buildCheckResult, computeProfileAwareScanScore, createFinding, DEFAULT_SCORING_CONFIG } from '../../scoring';
+import { classifyDmarc } from '../../scoring/classifiers/dmarc';
+import { findingsIndicatePartialEnforcement } from '../../scoring/model';
+import { nistScoreToGrade } from '../../scoring/engine';
+import type { DomainProfile, ScoringConfig } from '../../scoring';
+import type { CheckCategory, CheckResult, DNSQueryFunction } from '../../types';
+
+const DOMAIN = 'victim.example';
+const DMARC_NAME = `_dmarc.${DOMAIN}`;
+
+function ok(category: CheckCategory): CheckResult {
+	return buildCheckResult(category, [createFinding(category, `${category} OK`, 'info', 'Check passed')], true);
+}
+
+const NON_DMARC_CATEGORIES: CheckCategory[] = [
+	'spf',
+	'dkim',
+	'dnssec',
+	'ssl',
+	'mta_sts',
+	'caa',
+	'bimi',
+	'tlsrpt',
+	'subdomain_takeover',
+	'mx',
+	'ns',
+	'txt_hygiene',
+	'http_security',
+	'dane',
+	'mx_reputation',
+	'srv',
+	'zone_hygiene',
+	'dane_https',
+	'svcb_https',
+];
+
+/** An otherwise-clean roster with the given dmarc result. */
+function rosterWithDmarc(dmarcResult: CheckResult): CheckResult[] {
+	return [...NON_DMARC_CATEGORIES.map(ok), dmarcResult];
+}
+
+function mockDNS(record: string | null): DNSQueryFunction {
+	return async (name, type) => (type === 'TXT' && name === DMARC_NAME && record !== null ? [record] : []);
+}
+
+/** The REAL check: DNS → tree-walk → classifier → buildCheckResult. */
+async function realDmarc(record: string | null): Promise<CheckResult> {
+	return checkDMARC(DOMAIN, mockDNS(record));
+}
+
+async function scoreWith(record: string | null, profile: DomainProfile, config?: ScoringConfig) {
+	const dmarc = await realDmarc(record);
+	const { score } = computeProfileAwareScanScore(rosterWithDmarc(dmarc), { profile, config });
+	if (score.overall === null) throw new Error(`fixture ungraded: ${score.summary}`);
+	return { score, overall: score.overall, dmarc };
+}
+
+const QUARANTINE = 'v=DMARC1; p=quarantine; rua=mailto:d@victim.example';
+const REJECT = 'v=DMARC1; p=reject; rua=mailto:d@victim.example';
+const REJECT_PCT50 = 'v=DMARC1; p=reject; pct=50; rua=mailto:d@victim.example';
+const P_NONE = 'v=DMARC1; p=none; rua=mailto:d@victim.example';
+
+const CEILING = DEFAULT_SCORING_CONFIG.thresholds.partialEnforcementCeiling;
+
+describe('classifier: the partial-enforcement declaration is structural', () => {
+	it('quarantine is medium and declares partialEnforcement, keeps its title, and is NOT a missing control', () => {
+		const findings = classifyDmarc({ recordCount: 1, policy: 'quarantine', domain: DOMAIN, rua: 'mailto:d@victim.example' });
+		const quarantine = findings.find((f) => f.title === 'DMARC policy set to quarantine');
+		expect(quarantine).toBeDefined();
+		expect(quarantine?.severity).toBe('medium');
+		expect(quarantine?.metadata?.partialEnforcement).toBe(true);
+		expect(quarantine?.metadata?.missingControl).toBeUndefined();
+	});
+
+	it('pct<100 keeps medium and declares partialEnforcement whatever p= says', () => {
+		const findings = classifyDmarc({ recordCount: 1, policy: 'reject', domain: DOMAIN, pct: '50', rua: 'mailto:d@victim.example' });
+		const pct = findings.find((f) => f.title === 'DMARC not applied to all emails');
+		expect(pct?.severity).toBe('medium');
+		expect(pct?.metadata?.partialEnforcement).toBe(true);
+	});
+
+	it('the quarantine detail stays clear of every MISSING_CONTROL_REGEX trigger word', () => {
+		const findings = classifyDmarc({ recordCount: 1, policy: 'quarantine', domain: DOMAIN });
+		const quarantine = findings.find((f) => f.title === 'DMARC policy set to quarantine');
+		expect(quarantine?.detail).not.toMatch(/(no\s+[^\r\n]{1,64}\srecord|missing|required|not\s+found)/i);
+	});
+
+	it('findingsIndicatePartialEnforcement ignores a finding that is also a missing control', () => {
+		const both = createFinding('dmarc', 'x', 'high', 'y', { partialEnforcement: true, missingControl: true });
+		expect(findingsIndicatePartialEnforcement([both])).toBe(false);
+		const partialOnly = createFinding('dmarc', 'x', 'medium', 'y', { partialEnforcement: true });
+		expect(findingsIndicatePartialEnforcement([partialOnly])).toBe(true);
+	});
+});
+
+describe('mail_enabled: partial enforcement caps the top letter at 94 (NIST A, never A+)', () => {
+	it('1. p=quarantine + rua on an otherwise-perfect roster → exactly 94, partialEnforcementGaps [dmarc], criticalGaps []', async () => {
+		const { score, overall } = await scoreWith(QUARANTINE, 'mail_enabled');
+		expect(overall).toBe(94);
+		expect(score.partialEnforcementGaps).toEqual(['dmarc']);
+		expect(score.criticalGaps).toEqual([]);
+		expect(nistScoreToGrade(overall)).toBe('A');
+	});
+
+	it('2. POSITIVE CONTROL — p=reject + rua on the same roster → 100 with no gaps (the gate is off)', async () => {
+		const { score, overall } = await scoreWith(REJECT, 'mail_enabled');
+		expect(overall).toBe(100);
+		expect(score.partialEnforcementGaps).toEqual([]);
+		expect(score.criticalGaps).toEqual([]);
+		expect(nistScoreToGrade(overall)).toBe('A+');
+	});
+
+	it('3. p=reject; pct=50 + rua → capped at ≤94 with gaps [dmarc] (a staged pct is not full reject)', async () => {
+		const { score, overall } = await scoreWith(REJECT_PCT50, 'mail_enabled');
+		expect(overall).toBeLessThanOrEqual(94);
+		expect(score.partialEnforcementGaps).toEqual(['dmarc']);
+		expect(score.criticalGaps).toEqual([]);
+	});
+
+	it('4. p=none + rua → 64: missing beats partial, and partialEnforcementGaps stays empty', async () => {
+		const { score, overall } = await scoreWith(P_NONE, 'mail_enabled');
+		expect(overall).toBe(DEFAULT_SCORING_CONFIG.thresholds.criticalGapCeiling);
+		expect(overall).toBe(64);
+		expect(score.criticalGaps).toEqual(['dmarc']);
+		expect(score.partialEnforcementGaps).toEqual([]);
+	});
+
+	it('preserves the ordering none/absent (64) < partial (≤94) < full reject (100)', async () => {
+		const none = (await scoreWith(P_NONE, 'mail_enabled')).overall;
+		const absent = (await scoreWith(null, 'mail_enabled')).overall;
+		const quarantine = (await scoreWith(QUARANTINE, 'mail_enabled')).overall;
+		const staged = (await scoreWith(REJECT_PCT50, 'mail_enabled')).overall;
+		const reject = (await scoreWith(REJECT, 'mail_enabled')).overall;
+		expect(none).toBe(absent);
+		expect(none).toBeLessThan(quarantine);
+		expect(none).toBeLessThan(staged);
+		expect(quarantine).toBeLessThanOrEqual(CEILING);
+		expect(staged).toBeLessThanOrEqual(CEILING);
+		expect(quarantine).toBeLessThan(reject);
+		expect(staged).toBeLessThan(reject);
+	});
+
+	it('the gradient exists at the CATEGORY level too: quarantine scores below reject before any ceiling', async () => {
+		const quarantine = await realDmarc(QUARANTINE);
+		const reject = await realDmarc(REJECT);
+		expect(quarantine.score).toBeLessThan(reject.score);
+		expect(quarantine.passed).toBe(true);
+	});
+});
+
+describe('5. profile boundary: critical-category keyed, so only the mail profiles are capped', () => {
+	it('enterprise_mail + quarantine → capped', async () => {
+		const { score, overall } = await scoreWith(QUARANTINE, 'enterprise_mail');
+		expect(overall).toBeLessThanOrEqual(94);
+		expect(score.partialEnforcementGaps).toEqual(['dmarc']);
+	});
+
+	it('web_only + quarantine → NOT capped (dmarc weight 3, not critical)', async () => {
+		const { score } = await scoreWith(QUARANTINE, 'web_only');
+		expect(score.partialEnforcementGaps).toEqual([]);
+		expect(score.criticalGaps).toEqual([]);
+	});
+
+	it('non_mail + quarantine → NOT capped (dmarc weighted but not critical)', async () => {
+		const { score } = await scoreWith(QUARANTINE, 'non_mail');
+		expect(score.partialEnforcementGaps).toEqual([]);
+		expect(score.criticalGaps).toEqual([]);
+	});
+});
+
+describe('6. measurement gate: an unmeasured dmarc check cannot arm the ceiling', () => {
+	it('checkStatus: timeout carrying the real quarantine finding → no cap, no gap', async () => {
+		const measured = await realDmarc(QUARANTINE);
+		const timedOut: CheckResult = { ...measured, score: 0, passed: false, checkStatus: 'timeout' };
+		const { score } = computeProfileAwareScanScore(rosterWithDmarc(timedOut), { profile: 'mail_enabled' });
+		expect(score.overall).not.toBeNull();
+		expect(score.partialEnforcementGaps).toEqual([]);
+		expect(score.criticalGaps).toEqual([]);
+		// Excluded and renormalized — the remaining roster is perfect.
+		expect(score.overall).toBeGreaterThan(94);
+		expect(score.categoryScores.dmarc).toBeUndefined();
+	});
+});
+
+describe('7. PROSE CONTROL: the ceiling is structural-only', () => {
+	it('a dmarc finding whose detail reads "partial enforcement via quarantine" with NO metadata → no cap', () => {
+		const prose = buildCheckResult(
+			'dmarc',
+			[createFinding('dmarc', 'DMARC policy set to quarantine', 'medium', 'DMARC provides partial enforcement via quarantine on this domain.')],
+			true,
+			true,
+		);
+		expect(findingsIndicatePartialEnforcement(prose.findings)).toBe(false);
+		const { score } = computeProfileAwareScanScore(rosterWithDmarc(prose), { profile: 'mail_enabled' });
+		expect(score.partialEnforcementGaps).toEqual([]);
+		// The medium finding still costs its −15 on the category; only the CEILING is absent.
+		expect(score.overall).toBeGreaterThan(94);
+	});
+});
+
+describe('8. config: the ceiling is a threshold like criticalGapCeiling', () => {
+	it('thresholds.partialEnforcementCeiling: 89 → overall 89 on the quarantine roster', async () => {
+		const config: ScoringConfig = {
+			...DEFAULT_SCORING_CONFIG,
+			thresholds: { ...DEFAULT_SCORING_CONFIG.thresholds, partialEnforcementCeiling: 89 },
+		};
+		const { score, overall } = await scoreWith(QUARANTINE, 'mail_enabled', config);
+		expect(overall).toBe(89);
+		expect(score.partialEnforcementGaps).toEqual(['dmarc']);
+	});
+
+	it('a hand-built config that PREDATES the key falls back to the default 94 rather than disabling the ceiling', async () => {
+		const { partialEnforcementCeiling: _dropped, ...legacyThresholds } = DEFAULT_SCORING_CONFIG.thresholds;
+		const legacy = { ...DEFAULT_SCORING_CONFIG, thresholds: legacyThresholds } as unknown as ScoringConfig;
+		const { overall } = await scoreWith(QUARANTINE, 'mail_enabled', legacy);
+		expect(overall).toBe(94);
+	});
+});

--- a/packages/dns-checks/src/__tests__/scoring/dmarc-pnone-missing-control.spec.ts
+++ b/packages/dns-checks/src/__tests__/scoring/dmarc-pnone-missing-control.spec.ts
@@ -109,8 +109,13 @@ describe('classifier: p=none declares the missing enforcement control', () => {
 	it('does NOT extend the declaration to quarantine (discrimination control)', () => {
 		const findings = classifyDmarc({ recordCount: 1, policy: 'quarantine', domain: 'victim.example', rua: 'mailto:d@victim.example' });
 		const quarantine = findings.find((f) => f.title === 'DMARC policy set to quarantine');
-		expect(quarantine?.severity).toBe('low');
+		// Severity is `medium` since scoring model 1.26.0 (was `low`) and the finding declares
+		// `partialEnforcement` — a DIFFERENT, non-zeroing declaration. What this control pins is
+		// that quarantine never becomes a missing control: it must not collapse into the p=none
+		// / no-record bucket. See dmarc-partial-enforcement-ceiling.spec.ts for the 1.26.0 gate.
+		expect(quarantine?.severity).toBe('medium');
 		expect(quarantine?.metadata?.missingControl).toBeUndefined();
+		expect(quarantine?.metadata?.partialEnforcement).toBe(true);
 	});
 });
 

--- a/packages/dns-checks/src/parity-fixtures.ts
+++ b/packages/dns-checks/src/parity-fixtures.ts
@@ -40,7 +40,7 @@ export interface DmarcParityFixture {
 }
 
 /** Must equal the package version (asserted by both repos' version-lock). */
-export const PARITY_CORPUS_VERSION = '1.37.0';
+export const PARITY_CORPUS_VERSION = '1.38.0';
 
 /**
  * MX parity fixture. No-MX scoring is SPF-context (NIST SP 800-177r1 §4.4.2):
@@ -297,10 +297,40 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 	},
 	{
 		check: 'dmarc',
+		// Model 1.26.0: quarantine is PARTIAL enforcement — the finding moves low (−5) →
+		// medium (−15) and declares `metadata.partialEnforcement`, so the category now sits
+		// BELOW reject (was 85, score-identical to the p=reject+rua shape). Arithmetic:
+		// 100 − 15 (quarantine) − 5 (ruf absent) − 5 (relaxed adkim) = 75; aspf=r is
+		// advisory info (#842). NOT a missing control: quarantine must never collapse into
+		// the p=none / no-record bucket above.
 		name: 'p=quarantine + rua',
 		query: '_dmarc.example.com',
 		records: { '_dmarc.example.com': ['v=DMARC1; p=quarantine; rua=mailto:d@example.com'] },
-		expectedScore: 85,
+		expectedScore: 75,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dmarc',
+		// Model 1.26.0: a staged pct= is partial enforcement whatever p= says. Category
+		// arithmetic is UNCHANGED by 1.26.0 (the pct finding was already medium):
+		// 100 − 5 (no sp=) − 15 (pct<100) − 5 (ruf absent) − 5 (relaxed adkim) = 70. What the
+		// fixture pins is the `partialEnforcement` declaration riding on the pct finding — the
+		// engine's 94 ceiling arms on it, so p=reject;pct=50 can never print A+.
+		name: 'p=reject; pct=50; rua',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': ['v=DMARC1; p=reject; pct=50; rua=mailto:d@example.com'] },
+		expectedScore: 70,
+		expectedMissingControl: false,
+	},
+	{
+		check: 'dmarc',
+		// Model 1.26.0: both partial-enforcement shapes on one record — quarantine (−15,
+		// medium since 1.26.0) AND pct<100 (−15). 100 − 15 − 15 − 5 (ruf) − 5 (adkim) = 60
+		// (was 70 under 1.25.0). Two declarations on one category still arm the ceiling once.
+		name: 'p=quarantine; pct=50; rua',
+		query: '_dmarc.example.com',
+		records: { '_dmarc.example.com': ['v=DMARC1; p=quarantine; pct=50; rua=mailto:d@example.com'] },
+		expectedScore: 60,
 		expectedMissingControl: false,
 	},
 	{
@@ -346,6 +376,12 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 		// RFC 9989 §4.10 inheritance: the subdomain has no record, so the tree walk
 		// applies the org domain's sp (=quarantine). No rua here — this fixture
 		// isolates tree-walk inheritance from the (separately tested) RUA-auth path.
+		//
+		// Model 1.26.0: the EFFECTIVE policy is quarantine, so the inherited scan takes the
+		// same medium (−15, was low −5) and the same `partialEnforcement` declaration as a
+		// direct p=quarantine — a subdomain handed sp=quarantine is enforcing-but-not-reject
+		// exactly like its parent would be. 100 − 15 (quarantine) − 15 (no rua) − 5 (relaxed
+		// adkim) = 65 (was 75).
 		check: 'dmarc',
 		name: 'subdomain inherits parent sp=quarantine (tree-walk)',
 		query: '_dmarc.blog.example.com',
@@ -353,7 +389,7 @@ export const DMARC_PARITY_FIXTURES: DmarcParityFixture[] = [
 			'_dmarc.blog.example.com': [],
 			'_dmarc.example.com': ['v=DMARC1; p=reject; sp=quarantine'],
 		},
-		expectedScore: 75,
+		expectedScore: 65,
 		expectedMissingControl: false,
 		treeWalkOnly: true,
 	},

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.test.ts
@@ -24,9 +24,14 @@ describe('classifyDmarc', () => {
 		expect(none?.metadata?.missingControl).toBe(true);
 	});
 
-	it('flags p=quarantine as low', () => {
+	it('flags p=quarantine as medium partial enforcement, not a missing control (scoring model 1.26.0)', () => {
 		const f = classifyDmarc({ ...base, policy: 'quarantine', rua: 'mailto:dmarc@example.com' });
-		expect(f.find((x) => x.title === 'DMARC policy set to quarantine')?.severity).toBe('low');
+		const quarantine = f.find((x) => x.title === 'DMARC policy set to quarantine');
+		// Was `low` until 1.26.0, which left quarantine score-identical to reject at the
+		// category level. Declared structurally so the top-letter ceiling survives a reword.
+		expect(quarantine?.severity).toBe('medium');
+		expect(quarantine?.metadata?.partialEnforcement).toBe(true);
+		expect(quarantine?.metadata?.missingControl).toBeUndefined();
 	});
 
 	it('emits no significant finding for a clean p=reject record', () => {

--- a/packages/dns-checks/src/scoring/classifiers/dmarc.ts
+++ b/packages/dns-checks/src/scoring/classifiers/dmarc.ts
@@ -168,12 +168,43 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 			),
 		);
 	} else if (policy === 'quarantine') {
+		// Scoring model 1.26.0: quarantine is PARTIAL enforcement, one step below reject. Before
+		// this change quarantine and reject were score-IDENTICAL at the category level (both 85
+		// on the parity fixture: this finding cost `low` −5, and reject paid the same −5 via
+		// "No subdomain policy"), so the model offered no gradient toward reject at all. Two
+		// things move here, and only for the profiles where dmarc is a critical category
+		// (`mail_enabled` / `enterprise_mail` — the gate is keyed on `criticalCategories`, so
+		// non-mail profiles are untouched by construction):
+		//
+		//   1. severity `low` → `medium` (−5 → −15): quarantine now scores BELOW reject.
+		//   2. `partialEnforcement: true` — a STRUCTURAL declaration (never prose-inferred; the
+		//      2026-08-20 subject-data incident is why) consumed by
+		//      `findingsIndicatePartialEnforcement` → `partialEnforcementCeiling` (94). A mail
+		//      domain that is enforcing but not at full reject tops out at NIST display A,
+		//      never A+ ("Hardened across every dimension"). NZ SGE (Oct 2026), US BOD 18-01
+		//      and BSI TR-03182 all name p=reject as the end state.
+		//
+		// Deliberately NOT `missingControl`: quarantine IS enforcement (spoofed mail is
+		// diverted, not delivered as normal), so it must never collapse into the no-record /
+		// p=none bucket (64, D). The ordering the ceiling preserves is
+		// none/absent (64) < partial enforcement (≤94) < full reject (100). The operator's
+		// original "cannot pass D without p=reject" cap was adjudicated against: 0 of 12
+		// surveyed peer graders cap a composite on quarantine.
+		//
+		// The TITLE stays unchanged — `assess_spoofability` derives posture from it,
+		// `generate_rollout_plan` and maturity staging match it by substring.
+		//
+		// DETAIL wording is constrained twice over: it must stay clear of MISSING_CONTROL_REGEX
+		// (no "missing" / "required" / "not found" / "no … record" — say "needed"), and of
+		// every other DMARC explain_finding detail signature (`rua=` / "aggregate report" /
+		// `pct=` / `sp=` / "p=none") so `explain_finding` resolves it to its own signature.
 		findings.push(
 			createFinding(
 				'dmarc',
 				'DMARC policy set to quarantine',
-				'low',
-				`DMARC policy is "quarantine". Consider upgrading to "reject" for maximum protection once you've verified legitimate email flows.`,
+				'medium',
+				`DMARC policy is "quarantine": receivers deliver messages that fail authentication to spam or junk folders, where a recipient can still open and act on them. A "reject" policy bounces those messages at the SMTP gate before they reach any mailbox. Move to "reject" once reporting confirms every legitimate sender aligns — it is needed for the top grade and is the mandated end state (NZ Secure Government Email, US BOD 18-01).`,
+				{ partialEnforcement: true },
 			),
 		);
 	}
@@ -310,12 +341,19 @@ export function classifyDmarc(facts: DmarcFacts): Finding[] {
 				),
 			);
 		} else if (pctValue < 100) {
+			// Scoring model 1.26.0: a staged pct= is PARTIAL enforcement whatever the p= says —
+			// receivers apply the policy to only that fraction of failing mail and hand the rest
+			// the next-weaker action (RFC 7489 §6.6.4), so `p=reject; pct=50` is not full reject.
+			// Same structural declaration as the quarantine finding above, same ceiling (94),
+			// same critical-category gating. Severity is UNCHANGED (medium) — the category-level
+			// penalty already discriminated; only the top-letter gate is new.
 			findings.push(
 				createFinding(
 					'dmarc',
 					'DMARC not applied to all emails',
 					'medium',
 					`DMARC pct=${pctValue} means the policy only applies to ${pctValue}% of emails. Set pct=100 for full coverage.`,
+					{ partialEnforcement: true },
 				),
 			);
 		}

--- a/packages/dns-checks/src/scoring/config.ts
+++ b/packages/dns-checks/src/scoring/config.ts
@@ -80,6 +80,15 @@ export interface ScoringConfig {
 		criticalOverallPenalty: number;
 		criticalGapCeiling: number;
 		/**
+		 * Overall-score ceiling applied when a critical category is PARTIALLY enforced
+		 * (`metadata.partialEnforcement: true` on a measured finding — DMARC `p=quarantine`
+		 * or `pct<100`) and not already a critical gap. Default 94: the highest score that
+		 * still reads NIST display `A`, so a mail domain short of full `p=reject` can never
+		 * print `A+`. Scoring model 1.26.0. Like `criticalGapCeiling`, merged numerically
+		 * and unclamped; the engine falls back to the default if a hand-built config omits it.
+		 */
+		partialEnforcementCeiling: number;
+		/**
 		 * Minimum fraction of attempted checks that must COMPLETE for a scan to be
 		 * graded at all (0–1). Not a scoring cut-point: it never changes what a grade
 		 * means, only whether one is emitted. Clamped to [0, 1] on parse.
@@ -190,6 +199,7 @@ export const DEFAULT_SCORING_CONFIG: ScoringConfig = {
 		spfStrongThreshold: 57,
 		criticalOverallPenalty: 15,
 		criticalGapCeiling: 64,
+		partialEnforcementCeiling: 94,
 		evidenceSufficiency: EVIDENCE_SUFFICIENCY_THRESHOLD,
 	},
 	grades: {

--- a/packages/dns-checks/src/scoring/engine.ts
+++ b/packages/dns-checks/src/scoring/engine.ts
@@ -7,6 +7,7 @@ import {
 	type Finding,
 	inferFindingConfidence,
 	findingsIndicateMissingControl,
+	findingsIndicatePartialEnforcement,
 	type ScanScore,
 } from './model';
 import type { DomainContext } from './profiles';
@@ -227,6 +228,19 @@ function buildGenericContext(
 		}
 	}
 
+	// --- Build partialEnforcement map (scoring model 1.26.0) ---
+	// Same measurement gate as missingControls, for the same reason: a timed-out or errored
+	// check's synthetic findings must never arm a ceiling. The predicate is structural only
+	// (`metadata.partialEnforcement: true`, never prose), and a finding that is also a
+	// missing control does not count — the generic engine additionally skips any key the
+	// critical-gap ceiling already owns, so the two maps can never double-cap one category.
+	const partialEnforcement: Record<string, boolean> = {};
+	for (const result of results) {
+		if (isCheckMeasured(result.checkStatus) && findingsIndicatePartialEnforcement(result.findings)) {
+			partialEnforcement[result.category] = true;
+		}
+	}
+
 	// --- Build transientFailures map ---
 	// A check whose execution failed (checkStatus 'timeout'/'error', or any other non-measured
 	// status) is INCONCLUSIVE — we couldn't measure it. That is distinct from a genuinely-missing
@@ -314,6 +328,7 @@ function buildGenericContext(
 		tierMap: { ...CATEGORY_TIERS },
 		weights,
 		missingControls,
+		partialEnforcement,
 		transientFailures,
 		hardeningPassed,
 		criticalCategories: [...criticalCategories],
@@ -518,6 +533,12 @@ export function computeScanScore(
 		findings: allFindings,
 		summary,
 		tierBreakdown: genericResult.tierBreakdown,
+		// Which ceiling (if any) produced a capped `overall`. The generic engine keys these by
+		// string; every key it can emit came from `criticalCategories`, which this wrapper
+		// populates from `PROFILE_CRITICAL_CATEGORIES` / `DEFAULT_CRITICAL_CATEGORIES` — both
+		// typed `CheckCategory[]` — so the narrowing is sound.
+		criticalGaps: genericResult.criticalGaps as CheckCategory[],
+		partialEnforcementGaps: genericResult.partialEnforcementGaps as CheckCategory[],
 		evidence,
 	};
 }

--- a/packages/dns-checks/src/scoring/generic.ts
+++ b/packages/dns-checks/src/scoring/generic.ts
@@ -17,6 +17,11 @@
  * - **Critical penalty**: -criticalOverallPenalty (default 15) if findingSeverityCounts.critical > 0.
  * - **Critical gap ceiling**: If any non-transient criticalCategories key has missingControls=true,
  *   cap at criticalGapCeiling (default 64).
+ * - **Partial-enforcement ceiling**: If any non-transient criticalCategories key has
+ *   partialEnforcement=true and is NOT a missing control, cap at partialEnforcementCeiling
+ *   (default 94 — the top of NIST display A). Applied after the critical gap ceiling, so the
+ *   two compose as min(); a key the critical-gap ceiling already owns is never double-listed.
+ *   Ordering this preserves for a critical DMARC: absent/none (64) < partial (≤94) < full reject.
  */
 
 import type { CategoryTier } from '../types';
@@ -62,6 +67,14 @@ export interface GenericScoringContext {
 
 	/** Category key → true if the control is fundamentally missing (deterministic/verified). */
 	missingControls: Record<string, boolean>;
+
+	/**
+	 * Category key → true if the control is present and active but PARTIALLY enforced
+	 * (structurally declared via `metadata.partialEnforcement: true` on a measured finding;
+	 * never prose-inferred). Drives the partial-enforcement ceiling on criticalCategories
+	 * keys. Optional: absent means no key is partially enforced.
+	 */
+	partialEnforcement?: Record<string, boolean>;
 
 	/** Hardening category key → true if passed. Only submitted keys count. */
 	hardeningPassed: Record<string, boolean>;
@@ -109,6 +122,12 @@ export interface GenericScanScore {
 	/** Category keys that triggered the critical gap ceiling. */
 	criticalGaps: string[];
 
+	/**
+	 * Category keys that triggered the partial-enforcement ceiling. Disjoint from
+	 * `criticalGaps` by construction — a missing control is never also "partial".
+	 */
+	partialEnforcementGaps: string[];
+
 	/** Provider confidence modifier (-2 to +2). Reported for analytics; NOT applied to the overall score. */
 	providerModifier: number;
 
@@ -155,6 +174,7 @@ export function computeGenericScore(input: GenericScoringContext, config?: Scori
 	const thresholds = cfg.thresholds;
 
 	const transient = input.transientFailures ?? {};
+	const partial = input.partialEnforcement ?? {};
 	const emailKeys = input.emailBonusKeys ?? DEFAULT_EMAIL_BONUS_KEYS;
 
 	// --- Partition weights by tier, excluding transient failures ---
@@ -272,9 +292,37 @@ export function computeGenericScore(input: GenericScoringContext, config?: Scori
 			criticalGaps.push(key);
 		}
 	}
-	const overall = criticalGaps.length > 0
+	const afterCriticalCeiling = criticalGaps.length > 0
 		? Math.min(preCeiling, thresholds.criticalGapCeiling)
 		: preCeiling;
+
+	// --- Partial-enforcement ceiling (scoring model 1.26.0) ---
+	// A critical category whose control is PRESENT and ACTIVE but stops short of its full
+	// setting (DMARC p=quarantine, or any p= with pct<100) caps the overall at the top of
+	// NIST display A: enforcing-but-not-reject can never print A+. Three guards, same shape
+	// as the critical-gap loop above: transient wins (an unmeasured check cannot prove
+	// partiality), and a key the critical-gap ceiling already owns is skipped — missing beats
+	// partial, and listing it twice would misdescribe the evidence. Keyed on
+	// criticalCategories, so a profile where the category is not critical (dmarc in
+	// web_only / non_mail / minimal) is untouched by construction.
+	//
+	// `Number.isFinite` rather than `??`: `computeGenericScore` is a published API and a
+	// consumer can hand-build a `ScoringConfig` whose `thresholds` predates this key
+	// (undefined) or carries a coerced NaN — either must fall back to the default, not
+	// silently disable the ceiling (`Math.min(x, undefined)` is NaN, and NaN propagates into
+	// the grade).
+	const partialCeiling = Number.isFinite(thresholds.partialEnforcementCeiling)
+		? thresholds.partialEnforcementCeiling
+		: DEFAULT_SCORING_CONFIG.thresholds.partialEnforcementCeiling;
+	const partialEnforcementGaps: string[] = [];
+	for (const key of input.criticalCategories) {
+		if (partial[key] && !transient[key] && !input.missingControls[key]) {
+			partialEnforcementGaps.push(key);
+		}
+	}
+	const overall = partialEnforcementGaps.length > 0
+		? Math.min(afterCriticalCeiling, partialCeiling)
+		: afterCriticalCeiling;
 
 	// --- Grade ---
 	const grade = scoreToGrade(overall, config);
@@ -306,6 +354,7 @@ export function computeGenericScore(input: GenericScoringContext, config?: Scori
 		},
 		emailBonus,
 		criticalGaps,
+		partialEnforcementGaps,
 		providerModifier,
 		criticalPenalty,
 	};

--- a/packages/dns-checks/src/scoring/index.ts
+++ b/packages/dns-checks/src/scoring/index.ts
@@ -14,6 +14,7 @@ export {
 	inferFindingConfidence,
 	scoreIndicatesMissingControl,
 	findingsIndicateMissingControl,
+	findingsIndicatePartialEnforcement,
 	redactSubjectData,
 	SUBJECT_TERMS_METADATA_KEY,
 	computeCategoryScore,

--- a/packages/dns-checks/src/scoring/model.ts
+++ b/packages/dns-checks/src/scoring/model.ts
@@ -300,6 +300,30 @@ export function findingsIndicateMissingControl(findings: Finding[]): boolean {
 }
 
 /**
+ * Canonical partial-enforcement decision for a set of findings (scoring model 1.26.0).
+ *
+ * "Partial enforcement" means the control is PRESENT and ACTIVE but stops short of its
+ * full setting — DMARC `p=quarantine`, or any `p=` with `pct<100`. It is neither a missing
+ * control (the category is not zeroed) nor a clean pass: in the profiles where the category
+ * is critical, the generic engine caps the overall score at `partialEnforcementCeiling`
+ * (94 → NIST display A, never A+).
+ *
+ * STRUCTURAL ONLY, by design. Unlike {@link findingsIndicateMissingControl} there is no
+ * prose-inference leg: a check author declares the state with `metadata.partialEnforcement:
+ * true` or it does not exist. The 2026-08-20 incident (a scanned domain's own name supplying
+ * the substring "missing" and zeroing a category — see {@link redactSubjectData}) is the
+ * reason a second prose-driven gate is not being added.
+ *
+ * A finding that ALSO declares `missingControl: true` does not count: missing beats partial,
+ * and the engine's partial-enforcement ceiling is skipped for any category the critical-gap
+ * ceiling already owns. Measurement status is intentionally not accepted here: callers
+ * operating on whole check results must gate this predicate with `isCheckMeasured`.
+ */
+export function findingsIndicatePartialEnforcement(findings: Finding[]): boolean {
+	return findings.some((f) => f.metadata?.partialEnforcement === true && f.metadata?.missingControl !== true);
+}
+
+/**
  * Build a CheckResult from a category and its findings.
  * A check fails (passed=false) if the score is below 50, if findings indicate
  * a fundamentally missing security control (e.g., no SPF/DMARC record), or if

--- a/packages/dns-checks/src/types.ts
+++ b/packages/dns-checks/src/types.ts
@@ -226,6 +226,21 @@ export interface ScanScore {
 	 */
 	tierBreakdown?: { core: number; protective: number; hardening: number };
 	/**
+	 * Critical categories whose control was measured MISSING, arming the critical-gap
+	 * ceiling (64). Mirrors `GenericScanScore.criticalGaps`; surfaced here since scoring
+	 * model 1.26.0 so a consumer can tell WHICH ceiling produced a capped `overall`
+	 * rather than inferring it from the number. Optional: present only on a graded result
+	 * (additive — older results simply lack the key). Empty array when no ceiling armed.
+	 */
+	criticalGaps?: CheckCategory[];
+	/**
+	 * Critical categories whose control is present and active but PARTIALLY enforced
+	 * (DMARC `p=quarantine` / `pct<100`), arming the partial-enforcement ceiling (94 —
+	 * the top of NIST display A). Disjoint from `criticalGaps`: missing beats partial.
+	 * Same presence rule as `criticalGaps`. Scoring model 1.26.0.
+	 */
+	partialEnforcementGaps?: CheckCategory[];
+	/**
 	 * Coverage of this scan: how many checks were attempted and how many completed.
 	 * Present on EVERY result, graded or not, so a consumer can always judge the
 	 * scan's own reliability rather than inferring it from a missing grade.

--- a/src/lib/scoring-version.ts
+++ b/src/lib/scoring-version.ts
@@ -463,8 +463,57 @@
  *   No weight, tier, grade band, severity penalty or profile-detection rule changed;
  *   `@blackveil/dns-checks` is untouched (the check is worker-side), so the package /
  *   parity-corpus version stays at 1.36.0.
+ * - 1.26.0 — DMARC partial enforcement is a real gradient and gates the top letter
+ *   (`@blackveil/dns-checks` 1.37.0 → 1.38.0, parity corpus 1.38.0). Measured 2026-09-10
+ *   on the 1.25.0 package (mail_enabled, every other check perfect): absent 64 · p=none
+ *   64 · p=quarantine 100 · p=reject 100 · reject+strict 100 — quarantine and reject were
+ *   score-IDENTICAL, so the model offered no gradient toward the end state that NZ SGE
+ *   (Oct 2026), US BOD 18-01 and BSI TR-03182 all name: p=reject. Two coupled changes,
+ *   both declared STRUCTURALLY (`metadata.partialEnforcement: true`, consumed by the new
+ *   `findingsIndicatePartialEnforcement`; no prose regex — the 2026-08-20 subject-data
+ *   incident is why a second prose gate was not added): (1) `DMARC policy set to
+ *   quarantine` moves `low` → `medium` and declares partial enforcement, and `DMARC not
+ *   applied to all emails` (pct<100) keeps `medium` and gains the declaration; (2) the
+ *   generic engine caps the overall at a new `thresholds.partialEnforcementCeiling` (94,
+ *   the top of NIST display A) when a CRITICAL category is partially enforced and not
+ *   already a critical gap. The ceiling is critical-category-keyed, so dmarc arms it in
+ *   `mail_enabled` / `enterprise_mail` ONLY — the CEILING cannot arm in web_only /
+ *   non_mail / minimal / authoritative_dns_infra by construction. The SEVERITY step is
+ *   profile-independent: a p=quarantine domain in web_only / non_mail moves 99 → 98 on an
+ *   otherwise-perfect roster (dmarc weight 3 there), minimal 99 → 99 — so a non-mail
+ *   quarantine domain sitting exactly on a NIST boundary can drop a letter. Ordering
+ *   preserved: absent/none (64, D) < partial enforcement (≤94, A) < full reject (100, A+).
+ *   The operator's original "cannot pass D without p=reject" cap was adjudicated AGAINST
+ *   (none of the 12 peer graders surveyed in bv-web-prod's 2026-09-01 spec §3 caps a
+ *   composite grade even on p=none — two of the 12 were unverified displays — so a
+ *   fortiori none does on quarantine; it would also flatten quarantine into the
+ *   no-record bucket), and quarantine is deliberately NOT a missing control. DIRECTION:
+ *   DOWNWARD ONLY. Mail-profile domains at p=quarantine or pct<100 take the 94 ceiling
+ *   (including a subdomain inheriting sp=quarantine — the effective policy is what
+ *   scores); every quarantine domain in any profile takes the −10 category step (≈−1
+ *   overall in non-mail profiles). MAGNITUDE: dmarc category on the `p=quarantine + rua` parity fixture
+ *   85 → 75 (−5 → −15 on the one finding; the task brief's 85 → 70 assumed a −20 step
+ *   that `SEVERITY_PENALTIES` does not have), the inherited-sp=quarantine fixture 75 → 65,
+ *   `p=quarantine; pct=50` 70 → 60; a perfect quarantine mail domain 100 → 94 overall,
+ *   i.e. NIST display A+ → A. The engine's INTERNAL 9-band `grade` still reads A+ at 94
+ *   (`grades.aPlus` = 92) — it is the customer-visible NIST letter that moves; the
+ *   9-band is unchanged and non-display. POPULATION: 5.5% of a 1,953-domain GSI sample
+ *   (107 domains) sit at p=quarantine vs 120 at p=reject; the reject-with-pct<100 share is
+ *   UNMEASURED on our corpus (DMARCeye Q1 2026 reports ~6% of enforcing domains use a
+ *   staged pct). Absent / p=none / reject-at-pct=100 postures and every other category
+ *   are bit-for-bit unchanged. `ScanScore` gains optional `criticalGaps` /
+ *   `partialEnforcementGaps` (additive) so a consumer can read WHICH ceiling capped a
+ *   score. Finding TITLES are unchanged (assess_spoofability, generate_rollout_plan and
+ *   maturity staging match on them); `explain_finding` gains a `DMARC_POLICY_QUARANTINE`
+ *   detail signature so the reworded finding resolves to its own narrative rather than
+ *   the generic medium bucket. `sp=` and `t=y` classifier semantics are untouched. The
+ *   2026-08-26 twin DEFERs (`sp=none`, and `pct<100` read as enforcing) concern
+ *   bv-web-prod's consumer-side `dmarcEnforcing` boolean, not this engine's scoring; this
+ *   entry DOES change `pct<100` SCORING (flag + ceiling) and leaves `dmarcEnforcing`
+ *   alone. No weight, tier, grade band, `SEVERITY_PENALTIES` entry or profile-detection
+ *   rule changed.
  */
-export const SCORING_MODEL_VERSION = '1.25.0';
+export const SCORING_MODEL_VERSION = '1.26.0';
 
 /** Marker returned for an unset / default (un-overridden) scoring config. */
 const DEFAULT_CONFIG_MARKER = 'default';

--- a/src/tools/explain-finding-data.ts
+++ b/src/tools/explain-finding-data.ts
@@ -1502,6 +1502,28 @@ export const DETAIL_SIGNATURES: DetailSignatureRule[] = [
 		},
 	},
 	{
+		// Scoring model 1.26.0: the quarantine finding moved low → medium, which relocated
+		// it from the DMARC_LOW bucket ("Alignment / Reporting Refinement") into DMARC_MEDIUM
+		// ("Coverage Gap") — neither of which describes it. This signature gives it its own
+		// narrative. Ordered AFTER the subdomain-policy rule (whose "…domain policy is
+		// 'quarantine'" prose would otherwise match here) and BEFORE the rua= / pct= rules,
+		// so the classifier's quarantine detail — which avoids those tokens — lands here.
+		id: 'DMARC_POLICY_QUARANTINE',
+		checkType: 'DMARC',
+		pattern: /p=quarantine|policy (?:is |set to )?["']?quarantine/i,
+		template: {
+			title: 'DMARC Policy Is Quarantine, Not Reject (p=quarantine)',
+			explanation:
+				'A valid DMARC record is published and enforcing, but at p=quarantine: receivers divert messages that fail authentication to spam or junk, where a recipient can still open and act on them. A p=reject policy refuses those messages at the SMTP gate before they reach any mailbox. Quarantine is real enforcement one step short of the end state.',
+			impact: 'Spoofed mail is diverted rather than refused, so a share of it is still opened.',
+			adverseConsequences:
+				'Impersonation attempts that land in junk folders continue to succeed at the rate recipients rescue them, and the domain cannot reach the top grade or satisfy p=reject mandates (NZ SGE, US BOD 18-01, BSI TR-03182).',
+			recommendation:
+				'Confirm from DMARC reporting that every legitimate sender aligns, then move p=quarantine to p=reject (keeping pct=100). Tighten sp= to match so subdomains are covered.',
+			references: ['https://datatracker.ietf.org/doc/html/rfc7489#section-6.3'],
+		},
+	},
+	{
 		id: 'DMARC_NO_AGGREGATE_REPORTING',
 		checkType: 'DMARC',
 		pattern: /rua=|aggregate report/i,

--- a/test/check-dmarc.spec.ts
+++ b/test/check-dmarc.spec.ts
@@ -66,12 +66,14 @@ describe('checkDmarc', () => {
 		expect(finding!.metadata?.missingControl).toBe(true);
 	});
 
-	it('should return low finding for p=quarantine', async () => {
+	it('should return a medium partial-enforcement finding for p=quarantine (scoring model 1.26.0)', async () => {
 		mockTxtRecords(['v=DMARC1; p=quarantine; rua=mailto:dmarc@example.com']);
 		const result = await run();
 		const finding = result.findings.find((f) => /quarantine/i.test(f.title));
 		expect(finding).toBeDefined();
-		expect(finding!.severity).toBe('low');
+		expect(finding!.severity).toBe('medium');
+		expect(finding!.metadata?.partialEnforcement).toBe(true);
+		expect(finding!.metadata?.missingControl).toBeUndefined();
 	});
 
 	// controlPresent = "DMARC is an ACTIVE anti-spoofing control" = enforcing (p=quarantine|reject).

--- a/test/explain-finding.spec.ts
+++ b/test/explain-finding.spec.ts
@@ -283,6 +283,33 @@ describe('explainFinding', () => {
 		expect(result.title).toBe('DMARC Aggregate Reporting Not Configured');
 	});
 
+	it('returns the quarantine signature for the REAL classifier detail (scoring model 1.26.0: medium bucket)', async () => {
+		// Feed the classifier's own prose, not a paraphrase: the detail was reworded in 1.26.0
+		// and must resolve to its own signature rather than being swallowed by the broader
+		// rua= / pct= / sp= rules or falling to the generic DMARC_MEDIUM bucket text.
+		const { explainFinding } = await getModule();
+		const { classifyDmarc } = await import('@blackveil/dns-checks/scoring');
+		const quarantine = classifyDmarc({ recordCount: 1, policy: 'quarantine', domain: 'example.com', rua: 'mailto:d@example.com' }).find(
+			(f) => f.title === 'DMARC policy set to quarantine',
+		);
+		expect(quarantine?.severity).toBe('medium');
+		const result = explainFinding('DMARC', quarantine!.severity, quarantine!.detail);
+		expect(result.matchedSignature).toBe('DMARC_POLICY_QUARANTINE');
+		expect(result.title).toBe('DMARC Policy Is Quarantine, Not Reject (p=quarantine)');
+		expect(result.severity).toBe('medium');
+		expect(result.recommendation).toContain('p=reject');
+	});
+
+	it('does NOT let the quarantine signature steal the sp=none-under-quarantine subdomain finding', async () => {
+		const { explainFinding } = await getModule();
+		const result = explainFinding(
+			'DMARC',
+			'medium',
+			'Subdomain policy is set to "none" while domain policy is "quarantine". Subdomains are unprotected against spoofing.',
+		);
+		expect(result.matchedSignature).toBe('DMARC_SUBDOMAIN_POLICY');
+	});
+
 	// DNSSEC — only DNSSEC_PASS and DNSSEC_FAIL keys exist.
 	it('returns the unsigned-zone signature for a missing DNSKEY', async () => {
 		const { explainFinding } = await getModule();


### PR DESCRIPTION
## Why

Measured on the current package (1.37.0 / scoring model 1.25.0), `mail_enabled`, every other check perfect: `p=quarantine; rua` and `p=reject; rua` BOTH score dmarc **85** and overall **100 / A+**. The model offers no gradient toward reject. Meanwhile `p=none` and no-record both already cap at 64 / NIST D (model 1.19.0, #877).

Trigger: operator question 2026-09-10 — "should you be unable to pass D without `p=reject`?" Adjudicated against as literally asked (none of the 12 graders surveyed in the 2026-09-01 research spec §3 caps a composite grade even on `p=none` — two of the 12 were unverified displays — so a fortiori none does on quarantine; it would flatten quarantine into the no-record bucket; it hits the best-behaved cohort after reject — 107 of 1,953 sampled GSI domains at quarantine vs 120 at reject). The ratified shape is this PR. Research SSOT: bv-web-prod `docs/superpowers/specs/2026-09-01-dmarc-pnone-and-nonmail-grading-research.md` §11 — added by bv-web-prod PR #3081, OPEN/unmerged at time of writing.

## What (scoring model 1.25.0 → 1.26.0, package 1.37.0 → 1.38.0)

1. **Gradient.** `DMARC policy set to quarantine` moves `low` → `medium` (−5 → −15) and declares `metadata.partialEnforcement: true`. `DMARC not applied to all emails` (pct<100) declares the same flag; its severity is unchanged. Titles unchanged (`assess_spoofability`, `generate_rollout_plan` and maturity staging match on title; `dmarcIsWeak` matches only the none / no-record titles and is unaffected).
2. **Reject-only gate on the top letter.** New threshold `partialEnforcementCeiling: 94`. In `generic.ts`, after the critical-gap ceiling: any `criticalCategories` key that is partially enforced, measured, and NOT a missing control caps the overall at 94 → NIST display **A**, never A+. Keyed on `criticalCategories`, so the **ceiling** cannot arm in `web_only` / `non_mail` / `minimal` by construction (measured: every web_only row has `partialEnforcementGaps: []`). The **severity step** in (1) is profile-independent: a `p=quarantine` domain in `web_only` / `non_mail` moves 99 → 98 on an otherwise-perfect roster (dmarc weight 3), `minimal` 99 → 99; a non-mail quarantine domain sitting exactly on a NIST boundary would drop a letter.
3. **Structural only.** `findingsIndicatePartialEnforcement` reads `metadata.partialEnforcement === true` and excludes findings that also carry `missingControl`. No prose regex (the 2026-08-20 subject-data incident).
4. `ScanScore` gains optional `criticalGaps` / `partialEnforcementGaps` (additive; `criticalGaps` was previously only on `GenericScanScore`).
5. `explain_finding`: new `DMARC_POLICY_QUARANTINE` signature so the reworded medium finding resolves to its own remediation.

## Measured ladder (built `dist/`, `mail_enabled`, otherwise perfect)

| DMARC record | dmarc before → after | overall before → after | NIST after |
| --- | --- | --- | --- |
| no record | 0 → 0 | 64 → 64 | D |
| `p=none; rua` | 0 → 0 | 64 → 64 | D |
| `p=quarantine; pct=50; rua` | 70 → 60 | 97 → 94 | A |
| `p=quarantine; rua` | 85 → 75 | 100 → 94 | A |
| `p=reject; pct=50; rua` | 70 → 70 | 97 → 94 | A |
| `p=reject; rua` | 85 → 85 | 100 → 100 | A+ |
| `p=reject; sp=reject; adkim=s; aspf=s; rua` | 95 → 95 | 100 → 100 | A+ |

Ordering: none/absent 64 < partial ≤ 94 < full reject 100. Direction: DOWNWARD ONLY. Mail-profile domains at quarantine or pct<100 take the 94 ceiling; every quarantine domain in any profile takes the −10 category step (≈−1 overall in non-mail profiles). Population: 5.5% of the 1,953-domain sample at quarantine; reject-with-pct<100 share UNMEASURED (DMARCeye Q1 2026 reports ~6% of enforcing domains stage pct). Absent / none / reject-at-100 are bit-for-bit unchanged. No weight, tier, grade band or profile-detection rule changed. The engine's INTERNAL 9-band `grade` still reads A+ at 94; the customer-visible NIST letter is what moves.

## Parity fixtures moved

- `p=quarantine + rua` 85 → 75. New: `p=reject; pct=50; rua` (70, not missing), `p=quarantine; pct=50; rua` (60, not missing).
- `subdomain inherits parent sp=quarantine (tree-walk)` 75 → 65 — effective policy is quarantine, so it takes the medium.
- `PARITY_CORPUS_VERSION` and `packages/dns-checks/package.json` → 1.38.0 in lockstep (root `package.json` / `server.json` / `CHANGELOG.md` are release-time, per #877's footprint).

## Verification

- Claim-audited before posting (`claim-auditor`, 27 claims: 1 scope claim corrected — the non-mail severity step above — and 3 provenance claims tightened).

- Baseline before edits (reported by the implementing agent, arithmetic-consistent with the +1 file / +17 tests / +2 fixtures added): `npx vitest run packages/dns-checks` 60 files / 1129 tests, 0 failures.
- After: 61 files / 1148 tests green — **independently reproduced** by the claim audit. `npm test` (reported by implementer, not independently re-run): 720 files / 9324 passed; 3 failures not from this PR — `test/wasm-integration.test.ts` (gitignored `crates/bv-wasm-core/pkg` absent in a fresh worktree) and two 15 s timeouts (`queue-batch-analytics.spec.ts`, `streaming-sse.spec.ts`) that pass in isolation. `npm run lint` 0, `npm run typecheck` 0.
- New spec `dmarc-partial-enforcement-ceiling.spec.ts` (17 tests) runs the REAL `checkDMARC` through `computeProfileAwareScanScore`: exact 94 on quarantine, 100 on reject (positive control), pct<100 capped, p=none stays 64 with `partialEnforcementGaps: []`, enterprise_mail capped / web_only + non_mail not, timeout → no cap, prose-only finding → no cap, config override 89 honoured.
- Mutation-proven (reported by implementer; the 6/3 split matches the tests that depend on each flag): removing `partialEnforcement: true` from the quarantine finding → 6 failed (`expected 98 to be 94` …); removing it from the pct finding → 3 failed. Classifier restored byte-identical.
- Ladder independently re-measured in the main thread on the built package (both profiles) — reproduces the table above row for row.

## Reviewer notes

- The brief that produced this asked for quarantine at 70; the real step is −10 (`SEVERITY_PENALTIES` low −5 / medium −15) so it lands at 75. Left as the honest severity change rather than adding a `penaltyOverride` (DNSSEC precedent exists if a 20-point step is wanted). The 94 ceiling binds either way.
- `sp=` and `t=y` classifier semantics are untouched. The 2026-08-26 twin DEFERs (`sp=none`, and `pct<100` read as enforcing) concern bv-web-prod's consumer-side `dmarcEnforcing` boolean, not this engine's scoring; this PR **does** change `pct<100` scoring (flag + ceiling) and leaves `dmarcEnforcing` alone.
- Follow-on: bv-web-prod re-vendors the 1.38.0 tarball (both `VENDORED_VERSION` locks, sidecar, `vendor/README.md` entry naming the customer-visible movement) and adds the `/methodology` REVISIONS entry in the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
