### PR TITLE
ci(hygiene): advisory check that Claude trailers parse, never that they exist

### DIFF
--- a/.github/workflows/repo-hygiene.yml
+++ b/.github/workflows/repo-hygiene.yml
@@ -279,3 +279,95 @@ jobs:
       - name: Run public source safety audits
         if: steps.npm.outputs.lockfile == 'true' && steps.npm.outputs.oss_safety == 'true'
         run: npm run audit:oss-safety
+
+  # ---------------------------------------------------------------------------
+  # Agent-attribution trailer integrity — ADVISORY BY CONTRACT, exits 0 always.
+  #
+  # WHAT THIS DOES NOT DO: it never requires a Co-Authored-By trailer to be
+  # present. That is deliberate and load-bearing. macrohard.nz publishes an
+  # "agent-authored share" computed from these repos, and the trailer is only a
+  # meaningful signal while it stays OPTIONAL — measured 2026-09-12, 109 of 230
+  # human-authored commits in this repo's last 250 correctly carry no trailer.
+  # Mandating it would turn the published figure into a compliance counter that
+  # trends to 100% and measures nothing. Do not "upgrade" this into a gate.
+  #
+  # WHAT IT DOES: when a trailer IS present, assert it parses under the exact
+  # regex macrohard uses (parseAgentTrailers, src/receipts.ts). A trailer that
+  # names Claude but is missing its <email> is silently invisible to that
+  # parser, so the published number would UNDERCOUNT with nothing to say so.
+  # Measured at adoption: 0 malformed across 625 trailers in the four tracked
+  # repos. This step's job is to keep that zero honest.
+  #
+  # Advisory because the fleet's standing rule for telemetry-derived checks
+  # (FA-13) is that they ship fail-soft and are falsified before they ever gate.
+  trailer-integrity:
+    name: Agent-attribution trailer integrity (advisory)
+    runs-on: ubuntu-latest
+    steps:
+      # fetch-depth: 0 so a base..head range resolves. Kept in its own job so the
+      # file-hygiene job above keeps its fast depth-1 checkout.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check Co-Authored-By trailers parse
+        # Commit messages are attacker-controlled on a fork PR, so they are NEVER
+        # interpolated into this script — not through ${{ }}, not through the
+        # shell. The only ${{ }} values are event metadata passed via env, and
+        # every message is read from git inside python.
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+          PUSH_BEFORE: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, re, subprocess, sys
+
+          # Character-for-character the regex in macrohard src/receipts.ts.
+          STRICT = re.compile(r'^co-authored-by:\s*(claude[^<\n]*?)\s*<[^>]*>\s*$', re.I)
+          LOOSE = re.compile(r'^co-authored-by:.*claude', re.I)
+
+          def git(*args):
+              return subprocess.run(['git', *args], capture_output=True, text=True).stdout
+
+          event = os.environ.get('EVENT_NAME', '')
+          base = os.environ.get('BASE_REF', '')
+          before = os.environ.get('PUSH_BEFORE', '')
+
+          if event == 'pull_request' and base:
+              shas = git('rev-list', f'origin/{base}..HEAD').split()
+          elif before and not re.fullmatch(r'0+', before):
+              shas = git('rev-list', f'{before}..HEAD').split()
+          else:
+              # First push on a branch, or no usable range: check the tip only.
+              shas = git('rev-list', '-1', 'HEAD').split()
+
+          if not shas:
+              print('No commits in range - nothing to check.')
+              sys.exit(0)
+
+          malformed = []
+          with_trailer = 0
+          for sha in shas:
+              msg = git('log', '-1', '--format=%B', sha)
+              hits = [l.strip() for l in msg.splitlines() if LOOSE.match(l.strip())]
+              if hits:
+                  with_trailer += 1
+              malformed += [(sha, l) for l in hits if not STRICT.match(l)]
+
+          print('Commits checked: %d' % len(shas))
+          print('Commits carrying a Claude trailer: %d '
+                '(absence is expected and is never reported)' % with_trailer)
+
+          for sha, line in malformed:
+              print('::warning::Malformed Claude trailer in %s: %r - macrohard '
+                    'parseAgentTrailers will NOT count this commit. Expected form: '
+                    '"Co-Authored-By: Claude <model> <email@host>"' % (sha[:9], line))
+
+          if malformed:
+              print('%d malformed trailer(s). Advisory only - not failing the build.'
+                    % len(malformed))
+          else:
+              print('All Claude trailers in this range parse correctly.')
+          PY


### PR DESCRIPTION
macrohard.nz computes a published "agent-authored share" from this repo and three siblings using one mechanical rule: a `Co-Authored-By: Claude …` trailer, parsed by `parseAgentTrailers` in macrohard's `src/receipts.ts`. A trailer that names Claude but omits its `<email>` does not match that regex — so it would silently **undercount**, with nothing to say so.

This adds one advisory job that re-checks well-formedness with a character-for-character copy of that regex.

## It deliberately does NOT require a trailer

This is the load-bearing part, and the part most likely to get "fixed" later, so the rationale is in the job header as well as here.

Measured 2026-09-12: **109 of the 230** human-authored commits in this repo's last 250 correctly carry no trailer, because no agent co-authored them. Mandating one would drive macrohard's published share toward 100% and convert it from a measurement into a compliance counter.

Advisory placement also follows **FA-13**, the fleet's standing rule that telemetry-derived checks ship fail-soft and get falsified before they ever gate.

## Falsified, not just written

Against a purpose-built fixture repo the shipped script:

- flags a malformed trailer (`Co-Authored-By: Claude Opus 5`, no email) ✅
- counts a well-formed one ✅
- **does not flag a trailer-less human commit** ✅ — the Goodhart protection
- exits 0 either way ✅

Negative control across the four tracked repos — **0 malformed**:

| repo | commits checked | carrying a trailer | malformed |
| --- | --- | --- | --- |
| bv-mcp | 309 | 159 | 0 |
| macrohard | 14 | 13 | 0 |
| blackveil-dns-action | 20 | 13 | 0 |
| bv-claude-dns | 47 | 28 | 0 |

That zero is what the check exists to keep honest.

## Injection surface

The job reads commit messages, which are attacker-controlled on a fork PR.

- **No `${{ }}` anywhere in the `run` block** — verified by parsing the YAML
- The three interpolations are event metadata passed via `env:` — `github.event_name`, `github.base_ref`, `github.event.before`
- Uses `base_ref` (target branch, maintainer-controlled), **not** `head_ref`
- Trigger is `pull_request`, **not** `pull_request_target` → fork PRs get a read-only token and no secrets
- `permissions: contents: read`; git invoked as an argv list, no `shell=True`; messages never leave python

## Notes

- Runs as its **own job** so the file-hygiene job keeps its fast depth-1 checkout; this one needs `fetch-depth: 0` to resolve a commit range.
- The script is inline rather than a file in `scripts/`, because a `workflow_call` consumer checks out *its own* repo — a script here would not exist for `blackveil-dns-action`.
- Propagates automatically to `blackveil-dns-action` and `bv-claude-dns`, which consume this workflow `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)